### PR TITLE
test(bundler): multi-format equivalence + order invariance + memory safety gates

### DIFF
--- a/src/bundler/bundler_test/multi_format.zig
+++ b/src/bundler/bundler_test/multi_format.zig
@@ -38,6 +38,108 @@ test "multi-format: esm + cjs single path produces both outputs" {
     try std.testing.expect(result.outputs_by_format.?[1].output.len > 0);
 }
 
+test "multi-format: single esm equals multi[esm,cjs].esm (byte-identical)" {
+    // 회귀 게이트: 동일 fixture 를 (1) single format=esm 으로 빌드 vs (2) multi
+    // output=[esm,cjs] 로 빌드 — ESM 결과가 byte-identical 이어야 함. multi-emit 의
+    // setEmitFormat/resetEmitTransients invariant 가 single 경로와 동등 동작 보장.
+    const source = "export const x = 42;\nexport function add(a, b) { return a + b; }\nconsole.log(x);";
+
+    var tmp_single = std.testing.tmpDir(.{});
+    defer tmp_single.cleanup();
+    try writeFile(tmp_single.dir, "index.ts", source);
+    const entry_single = try absPath(&tmp_single, "index.ts");
+    defer std.testing.allocator.free(entry_single);
+
+    var b_single = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry_single},
+        .format = .esm,
+    });
+    defer b_single.deinit();
+    const r_single = try b_single.bundle();
+    defer r_single.deinit(std.testing.allocator);
+
+    var tmp_multi = std.testing.tmpDir(.{});
+    defer tmp_multi.cleanup();
+    try writeFile(tmp_multi.dir, "index.ts", source);
+    const entry_multi = try absPath(&tmp_multi, "index.ts");
+    defer std.testing.allocator.free(entry_multi);
+
+    var b_multi = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry_multi},
+        .output = &.{
+            .{ .format = .esm },
+            .{ .format = .cjs },
+        },
+    });
+    defer b_multi.deinit();
+    const r_multi = try b_multi.bundle();
+    defer r_multi.deinit(std.testing.allocator);
+
+    // single 의 output == multi 의 ESM (첫 entry, result.output 으로 move 된 상태).
+    try std.testing.expectEqualStrings(r_single.output, r_multi.output);
+}
+
+test "multi-format: order invariant — [esm,cjs] vs [cjs,esm] produces same per-format outputs" {
+    // 순서 무관: output 배열의 순서만 바꿔도 각 format 의 결과는 동일.
+    // setEmitFormat 의 reset 이 transient state 를 정확히 cleanup 함을 보장.
+    const source = "export const greet = (n) => `hi ${n}`;\nconsole.log(greet('a'));";
+
+    var tmp_ab = std.testing.tmpDir(.{});
+    defer tmp_ab.cleanup();
+    try writeFile(tmp_ab.dir, "index.ts", source);
+    const entry_ab = try absPath(&tmp_ab, "index.ts");
+    defer std.testing.allocator.free(entry_ab);
+
+    var b_ab = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry_ab},
+        .output = &.{ .{ .format = .esm }, .{ .format = .cjs } },
+    });
+    defer b_ab.deinit();
+    const r_ab = try b_ab.bundle();
+    defer r_ab.deinit(std.testing.allocator);
+
+    var tmp_ba = std.testing.tmpDir(.{});
+    defer tmp_ba.cleanup();
+    try writeFile(tmp_ba.dir, "index.ts", source);
+    const entry_ba = try absPath(&tmp_ba, "index.ts");
+    defer std.testing.allocator.free(entry_ba);
+
+    var b_ba = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry_ba},
+        .output = &.{ .{ .format = .cjs }, .{ .format = .esm } },
+    });
+    defer b_ba.deinit();
+    const r_ba = try b_ba.bundle();
+    defer r_ba.deinit(std.testing.allocator);
+
+    // [esm,cjs] 의 esm (= r_ab.output, 첫 entry) == [cjs,esm] 의 esm (= r_ba.outputs_by_format[1].output, 두 번째 entry)
+    try std.testing.expectEqualStrings(r_ab.output, r_ba.outputs_by_format.?[1].output);
+    // [esm,cjs] 의 cjs (= r_ab.outputs_by_format[1].output, 두 번째 entry) == [cjs,esm] 의 cjs (= r_ba.output, 첫 entry)
+    try std.testing.expectEqualStrings(r_ab.outputs_by_format.?[1].output, r_ba.output);
+}
+
+test "multi-format: memory safety — repeated multi-emit no leak" {
+    // std.testing.allocator 는 leak 시 test fail. 3회 반복 multi-emit 후 누수 없음 검증.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const x = 1;\nexport default x;");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var i: usize = 0;
+    while (i < 3) : (i += 1) {
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .output = &.{ .{ .format = .esm }, .{ .format = .cjs } },
+        });
+        defer b.deinit();
+        const result = try b.bundle();
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(result.outputs_by_format != null);
+    }
+}
+
 test "multi-format: dev_mode rejected" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
epic #3561 PR-D/10. Multi-format 회귀 게이트 — **단일↔멀티 동등성 byte-identical** 보장.

## 변경 (1 파일, +102)

`src/bundler/bundler_test/multi_format.zig` 에 invariant test 3개 추가:

1. **단일↔멀티 동등성**: `single format=esm` 결과 `result.output` == `multi output=[esm,cjs]` 의 ESM (첫 entry, `result.output` move) byte-identical. multi-emit 의 setEmitFormat/resetEmitTransients 가 single 경로와 동등 동작 보장.

2. **순서 무관**: `[esm,cjs]` vs `[cjs,esm]` 의 각 format 결과 동일. transient state cleanup 정확성 검증.

3. **메모리 안전**: 3회 반복 multi-emit, `std.testing.allocator` leak 검출.

## 검증

- `zig build test` 통과 (5 multi_format test 전부)
- `bun test tests/determinism.test.ts` 5 pass / 0 fail

## 의미

multi-format 의 *진짜 contract* 가 자동 게이트로 보호됨. 후속 PR (JS API 추가, MF/CSS 정밀화) 가 이 invariant 깨지 않도록 강제.

Refs #3561