### PR TITLE
feat(core): rollup-style zntc(input).write(output).close() API

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -2386,6 +2386,64 @@ export function buildSync(options: BuildOptions): BuildResult {
   }
 }
 
+/// rollup-style per-output options. `BuildInstance.write/generate` 호출 시 input 옵션과
+/// merge 되어 native 호출. 미지정 필드는 base BuildOptions 의 값을 사용.
+export interface OutputOptions {
+  format?: 'esm' | 'cjs' | 'iife' | 'umd' | 'amd';
+  dir?: string;
+  file?: string;
+  /// IIFE/UMD/AMD external → factory param 이름. rollup `output.globals` 호환.
+  globals?: Record<string, string>;
+}
+
+/// rollup/rolldown 스타일 build instance. `await zntc(options)` 로 생성, `.write(output)` /
+/// `.generate(output)` 다회 호출 후 `.close()`. multi-format 빌드 패턴 우선, lifecycle
+/// 훅 (watch/incremental 후속) 의 anchor.
+///
+/// 주의: 현재 native 측 graph cache 미보유 — `.write()` 매 호출이 graph 재빌드. multi-format
+/// 효율 우선이면 `build({ output: [...] })` (esbuild-style) 사용.
+export class BuildInstance {
+  #base: BuildOptions;
+  #closed: boolean = false;
+  constructor(base: BuildOptions) {
+    this.#base = base;
+  }
+  get closed(): boolean {
+    return this.#closed;
+  }
+  async write(output: OutputOptions = {}): Promise<BuildResult> {
+    this.#assertOpen();
+    return build(mergeOutput(this.#base, output));
+  }
+  async generate(output: OutputOptions = {}): Promise<BuildResult> {
+    this.#assertOpen();
+    return build({ ...mergeOutput(this.#base, output), write: false } as BuildOptions);
+  }
+  async close(): Promise<void> {
+    this.#closed = true;
+  }
+  #assertOpen(): void {
+    if (this.#closed) throw new Error('@zntc/core: BuildInstance is closed');
+  }
+}
+
+function mergeOutput(base: BuildOptions, out: OutputOptions): BuildOptions {
+  const merged: any = { ...base };
+  if (out.format !== undefined) merged.format = out.format;
+  if (out.dir !== undefined) merged.outdir = out.dir;
+  if (out.file !== undefined) merged.outfile = out.file;
+  if (out.globals !== undefined) merged.globals = out.globals;
+  return merged as BuildOptions;
+}
+
+/// rollup/rolldown 스타일 entry — `zntc(input).write(output).close()`. Graph 재사용은
+/// 향후 native ScanStageCache 도입 시 추가 (현재는 매 write 가 graph 재빌드).
+export async function zntc(options: BuildOptions): Promise<BuildInstance> {
+  if (!options.entryPoints?.length) throw new Error('@zntc/core: entryPoints is required');
+  validateTsConfigRaw(options.tsconfigRaw);
+  return new BuildInstance(options);
+}
+
 export function buildAppSync(options: AppBuildOptions = {}): BuildResult {
   const n = ensureNative();
   const { publicDir, compiler, ...rest } = options;


### PR DESCRIPTION
epic #3561 PR-E/10. **rollup/rolldown 스타일 lifecycle API**. 사용자 우선 디자인 선택.

## 변경 (1 파일, +58)

`packages/core/index.ts`:
- `OutputOptions { format, dir, file, globals }` interface — per-output 옵션
- `BuildInstance` class — `write/generate/close`, `closed` getter
- `zntc(options): Promise<BuildInstance>` entry — input 옵션 받아 instance 반환
- `mergeOutput(base, out)` — base + per-output 옵션 merge

## 사용 패턴

```ts
import { zntc } from '@zntc/core';

const bundle = await zntc({ entryPoints: ['src/main.ts'] });
const esm = await bundle.write({ format: 'esm', dir: 'dist/esm' });
const cjs = await bundle.write({ format: 'cjs', dir: 'dist/cjs' });
await bundle.close();
```

기존 `build(options)` / `buildSync(options)` 와 공존. esbuild-style 단일 호출 `build({output:[]})` 은 후속 PR-I 에서 sugar 로 추가.

## 주의 (성능 단점 명시)

현재 native 측 graph cache 미보유 — **`.write()` 매 호출이 graph 재빌드**. multi-format 효율 우선이면 PR-I 의 `build({output:[]})` 사용 (native 1회 호출 + multi-emit). rolldown 의 `RolldownBuild` 도 동일 패턴이지만 native ScanStageCache 가 graph 재사용 — zntc 는 별도 epic 으로 추후.

rollup-style 의 진짜 가치 = **lifecycle 훅** (close, 향후 watch/incremental). API 표면 + 패턴 친숙도.

## 검증

- `bun run --cwd packages/core build:dts` 통과
- `bun run lint` 무변경 (내 코드 외 5 warnings 사전 존재)

Refs #3561