### PR TITLE
feat(bundler): reject Module Federation + multi-format combination

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1450,6 +1450,12 @@ pub const Bundler = struct {
             if (self.options.dev_mode or self.options.code_splitting or self.options.preserve_modules) {
                 return error.MultiFormatRequiresSinglePath;
             }
+            // Module Federation 은 federation_emit.wrapContainer 가 splitting 경로 전용이라
+            // single multi-emit 에서 host/remote container 가 누락 (사일런트 깨짐). MF host 는
+            // 단일 IIFE/UMD/AMD 출력 한정.
+            if (self.options.mf != null) {
+                return error.MultiFormatNotSupportedWithModuleFederation;
+            }
         }
         // #3318 P1-5: MF remote 의 mf-manifest.json (wrapContainer 산출,
         // asset_outputs 로 편입). errdefer 로 부분실패 누수 방지.

--- a/src/bundler/bundler_test/multi_format.zig
+++ b/src/bundler/bundler_test/multi_format.zig
@@ -140,6 +140,28 @@ test "multi-format: memory safety — repeated multi-emit no leak" {
     }
 }
 
+test "multi-format: Module Federation rejected" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const x = 1;");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .mf = .{ .name = "host" },
+        .output = &.{
+            .{ .format = .esm },
+            .{ .format = .cjs },
+        },
+    });
+    defer b.deinit();
+
+    const result = b.bundle();
+    try std.testing.expectError(error.MultiFormatNotSupportedWithModuleFederation, result);
+}
+
 test "multi-format: dev_mode rejected" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
epic #3561 PR-G/10. MF + multi-format 명시 거부 정책.

## 변경 (2 파일, +28)

- `src/bundler/bundler.zig` — multi_format validation 에 MF 거부 추가
  - `error.MultiFormatNotSupportedWithModuleFederation`
- `src/bundler/bundler_test/multi_format.zig` — "Module Federation rejected" 단위테스트

## 근거

`federation_emit.wrapContainer` 가 splitting 경로 전용 (`bundler.zig:1579`). single multi-emit 경로에서 호출 안 됨 → MF host/remote container 누락 → **사일런트 깨짐**. 명시 error 로 디버깅 친화.

## rspack 패턴과 일관

rspack 의 multi-format = `MultiCompiler` (별도 compiler 배열). 각 config 가 자체 MF plugin 등록 + 독립 build. zntc 의 정책 = "MF 원하면 두 번 build" — 같은 패러다임.

향후 *graph 재사용 multi-format MF* 는 별도 epic (rspack 도 미구현).

## 검증

- `zig build test` 통과 (multi_format "Module Federation rejected" 포함)
- `bun test tests/determinism.test.ts + multi-format.test.ts` 6 pass / 0 fail

Refs #3561