### PR TITLE
fix(graph): remap SymbolRef.module in renumber (cross-module resolution hotfix)

### DIFF
--- a/src/bundler/graph/renumber.zig
+++ b/src/bundler/graph/renumber.zig
@@ -15,6 +15,7 @@ const ModuleIndex = types.ModuleIndex;
 const ModuleGraph = @import("../graph.zig").ModuleGraph;
 const ModuleList = ModuleGraph.ModuleList;
 const RequestedExports = @import("state.zig").RequestedExports;
+const bundler_symbol = @import("../symbol.zig");
 const profile = @import("../../profile.zig");
 
 pub const RenumberError = error{ RenumberIncomplete, OutOfMemory };
@@ -100,6 +101,16 @@ pub fn renumberModulesDeterministically(
             if (rec.resolved.isNone()) continue;
             rec.resolved = @enumFromInt(old_to_new[rec.resolved.toU32()]);
         }
+        // binding_scanner 가 scan 시점 (renumber 전) module_index 를 SymbolRef 에 박음.
+        // ImportBinding.symbol/local_symbol + ExportBinding.symbol 의 .semantic.module / .alias.module
+        // 필드를 renumber 후 새 idx 로 일괄 치환 — cross-module symbol resolution 정확성 보장.
+        for (m.import_bindings) |*ib| {
+            ib.symbol = remapSymbolRef(ib.symbol, old_to_new);
+            ib.local_symbol = remapSymbolRef(ib.local_symbol, old_to_new);
+        }
+        for (m.export_bindings) |*eb| {
+            eb.symbol = remapSymbolRef(eb.symbol, old_to_new);
+        }
     }
 
     var p_it = self.path_to_module.iterator();
@@ -161,6 +172,19 @@ inline fn remapList(list: *std.ArrayList(ModuleIndex), old_to_new: []const u32) 
     for (list.items) |*idx| {
         idx.* = @enumFromInt(old_to_new[idx.toU32()]);
     }
+}
+
+fn remapSymbolRef(ref: bundler_symbol.SymbolRef, old_to_new: []const u32) bundler_symbol.SymbolRef {
+    return switch (ref) {
+        .semantic => |s| if (s.module.isNone()) ref else .{ .semantic = .{
+            .module = @enumFromInt(old_to_new[s.module.toU32()]),
+            .symbol = s.symbol,
+        } },
+        .alias => |a| if (a.module.isNone()) ref else .{ .alias = .{
+            .module = @enumFromInt(old_to_new[a.module.toU32()]),
+            .symbol = a.symbol,
+        } },
+    };
 }
 
 fn lessThanByPath(graph: *const ModuleGraph, a: u32, b: u32) bool {


### PR DESCRIPTION
**Hotfix** — 결정성 epic #3564 PR-1 (graph renumber) 의 remap 누락 → cross-module symbol resolution 깨짐 → 실제 lib (cheerio/effect/zod 등) e2e 회귀.

## 회귀 격리

bisect (gh run list 의 e2e 결과):
- `test/determinism-infra-3564` (PR-0): ✅ success
- **`fix/graph-deterministic-module-index-3564` (PR-1): ❌ failure** — 회귀 시작점
- 그 이후 8 PR 모두 e2e failure (같은 fail signature)

회귀 신호:
- `browser: effect` → `symbol is not defined`, `Hash$1 is not defined`
- `browser: cheerio` → `Cannot access 'Tokenizer$1' before initialization`, `test is not a function`
- `D1_validation_serialize_combo` → zod runtime crash

cheerio bundle diff (pre-epic vs main):
- `adapter: index_ns_2` (큰 함수 set) → `adapter: index_ns` (작은 set)
- `getDocumentMode(token)` → `isWhitespace$1(token)` (완전 다른 함수)
- `REPLACEMENT_CHARACTER` → `boolbase$5` (상수 → 모듈 변수)

renumber 임시 비활성 binary 로 cheerio runtime 정상 (`hi`) → **PR-1 의 remap 누락 확정**.

## Root cause

`binding_scanner.zig` 가 scan 시점에 `SymbolRef.makeSemantic(module_index, sym_idx)` 호출 → `ExportBinding.symbol` / `ImportBinding.symbol` / `.local_symbol` 의 `SymbolRef.semantic.module` 또는 `SymbolRef.alias.module` 에 **module_index 영구 baked**.

PR-1 의 renumber 는:
- ✓ `Module.index`
- ✓ `Module.dependencies / importers / dynamic_*`
- ✓ `Module.import_records[*].resolved`
- ✓ `graph.path_to_module`
- ✓ `graph.requested_exports`
- ✓ `graph.worker_entries[*].source_module`
- **✗ `Module.import_bindings[*].symbol / local_symbol.{semantic,alias}.module`**
- **✗ `Module.export_bindings[*].symbol.{semantic,alias}.module`**

→ stale module_index 가 linker 의 `populateImportSymbols` / `resolveExportChain` 등에서 **잘못된 모듈의 symbol** 참조.

## Fix (1 파일, +24 LOC)

`src/bundler/graph/renumber.zig`:
- `remapSymbolRef(ref, old_to_new)` helper 추가
- new_list iter 안에서 module 별 `import_bindings[*].symbol` + `.local_symbol` + `export_bindings[*].symbol` 일괄 remap

## 검증

- `zig build test` 통과
- `bun test determinism + multi-format + lodash-es` **10 pass / 0 fail**
- cheerio bundle node 실행 → `hi` 정상 (이전 `TypeError: test is not a function`)

Refs #3564