### PR TITLE
feat(emit): document multi-format shared-asset policy + CSS test gate

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1605,6 +1605,13 @@ pub const Bundler = struct {
             // Multi-format single-path emit. 매 OutputConfig 마다 linker setEmitFormat 으로
             // format-dependent state 갱신, emit 결과 누적. 첫 entry 의 결과를 `output` /
             // `dev_sourcemap` 에 alias 로 노출 (backward-compat).
+            //
+            // 산출물 정책 (PR-H):
+            //   - bundle.js 본문 = format 별 (outputs_by_format[*].output)
+            //   - CSS / worker / asset = graph 기반이라 *format 무관, 공유*. result.asset_outputs
+            //     가 모든 OutputConfig 와 공유 (한 번만 emit). 사용자가 per-format CSS 원하면
+            //     build() 를 두 번 호출.
+            //   - mf_manifest = MF + multi-format 거부 (위 validation) 라 항상 null.
             const by = try self.allocator.alloc(types.FormatOutput, self.options.output.len);
             errdefer self.allocator.free(by);
             const mf_opt2 = self.options.mf;

--- a/src/bundler/bundler_test/multi_format.zig
+++ b/src/bundler/bundler_test/multi_format.zig
@@ -183,3 +183,40 @@ test "multi-format: dev_mode rejected" {
     const result = b.bundle();
     try std.testing.expectError(error.MultiFormatRequiresSinglePath, result);
 }
+
+test "multi-format: CSS import yields shared CSS output across formats" {
+    // multi-format 의 CSS/worker/asset 산출물은 *format 무관* — graph 에서 추출되어
+    // 모든 OutputConfig 가 공유. result.asset_outputs 가 *한 번만* CSS 포함하는지 검증.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "style.css", ".a { color: red; }\n");
+    try writeFile(tmp.dir, "index.ts", "import './style.css';\nexport const x = 42;\n");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .output = &.{
+            .{ .format = .esm },
+            .{ .format = .cjs },
+        },
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.outputs_by_format != null);
+    try std.testing.expectEqual(@as(usize, 2), result.outputs_by_format.?.len);
+    // CSS 는 asset_outputs 에 정확히 1개 (format 무관 공유) — multi-emit N회 호출에도 중복 emit 없음.
+    if (result.asset_outputs) |assets| {
+        var css_count: usize = 0;
+        for (assets) |a| {
+            if (std.mem.endsWith(u8, a.path, ".css")) css_count += 1;
+        }
+        try std.testing.expectEqual(@as(usize, 1), css_count);
+    } else {
+        return error.NoCssOutput;
+    }
+}


### PR DESCRIPTION
epic #3561 PR-H/10. CSS/Worker/Asset 산출물 multi-format 정책 **명시화** + 검증.

## 정책

multi-format 의 산출물 분리:
- **bundle.js 본문**: format 별 (`outputs_by_format[*].output`)
- **CSS / worker / asset / mf-manifest**: 모듈 graph 에서 추출 → **format-invariant, 공유**
- `result.asset_outputs` 가 모든 OutputConfig 와 공유 (한 번만 emit, per-format 분리 안 함)
- 사용자가 per-format CSS 원하면 `build()` 두 번 호출 권장 (rspack MultiCompiler 식)

## 변경 (2 파일, +44)

- `src/bundler/bundler.zig` — multi_format 분기에 산출물 정책 doc 추가
- `src/bundler/bundler_test/multi_format.zig` — "CSS import yields shared CSS output across formats" unit test: multi-format + `.css import` → `asset_outputs` 에 CSS **정확히 1개** emit 검증 (중복/누락 없음)

## 검증

- `zig build test` 통과
- `bun test` (determinism + multi-format + lodash-es) **10 pass / 0 fail**

## 후속

per-format CSS split (rollup `output.assetFileNames` 호환) 은 별도 epic 가치. 현재 multi-format 의 핵심 use-case (ESM/CJS 동시 출력 + 공통 CSS) 는 본 정책으로 정의됨.

Refs #3561