### PR TITLE
feat(core): esbuild-style build({output:[]}) sugar

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -853,6 +853,12 @@ interface BuildOptionsCommon {
   outdir?: string;
   /** Output file path (for a single entry, used when write: true). */
   outfile?: string;
+  /**
+   * Multi-format emit (rolldown-style). 배열 길이 >= 2 시 같은 entry 로 각 format 별
+   * build() 호출 후 BuildResult.outputsByFormat 에 결과 묶음. 사용자가 한 호출로
+   * ESM+CJS 동시 출력. graph 재사용은 현재 미지원 (각 format 마다 graph 재빌드).
+   */
+  output?: OutputOptions[];
   /** Whether to write to disk (default: false, automatically true when outdir/outfile is set). */
   write?: boolean;
   /** Allow output files to overwrite input files. */
@@ -1385,6 +1391,12 @@ export interface BuildResult {
   metafile?: string;
   outputCount?: number;
   rnAssetMetadata?: RnAssetMetadata[];
+  /// Multi-format emit (`BuildOptions.output: OutputOptions[]`) 결과 — format 별로 묶음.
+  /// 단일 build/format 모드에서는 undefined.
+  outputsByFormat?: Array<{
+    format: 'esm' | 'cjs' | 'iife' | 'umd' | 'amd';
+    outputFiles: OutputFile[];
+  }>;
 }
 
 /**
@@ -2321,6 +2333,10 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
   if (!options.entryPoints?.length) throw new Error('@zntc/core: entryPoints is required');
   validateTsConfigRaw(options.tsconfigRaw);
 
+  if (options.output && options.output.length >= 2) {
+    return buildMultiFormat(options);
+  }
+
   const { napiOptions, cleanup } = prepareNapiOptions(options);
   const dispatcher = resolveDispatcher(options);
   if (dispatcher) napiOptions._pluginDispatcher = dispatcher;
@@ -2442,6 +2458,37 @@ export async function zntc(options: BuildOptions): Promise<BuildInstance> {
   if (!options.entryPoints?.length) throw new Error('@zntc/core: entryPoints is required');
   validateTsConfigRaw(options.tsconfigRaw);
   return new BuildInstance(options);
+}
+
+/// esbuild-style `build({output:[...]})` sugar — internal 으로 format 별 build() N회 호출 후
+/// outputsByFormat 으로 묶음. PR-I (#3561) 진입점. graph 재사용은 별도 epic.
+async function buildMultiFormat(options: BuildOptions): Promise<BuildResult> {
+  const outputs = options.output!;
+  const { output: _omit, ...baseOpts } = options as BuildOptions & { output?: OutputOptions[] };
+
+  const aggregated: BuildResult = {
+    outputFiles: [],
+    errors: [],
+    warnings: [],
+    outputsByFormat: [],
+  };
+
+  for (const cfg of outputs) {
+    const r = await build(mergeOutput(baseOpts as BuildOptions, cfg));
+    aggregated.errors.push(...r.errors);
+    aggregated.warnings.push(...r.warnings);
+    aggregated.outputsByFormat!.push({
+      format: cfg.format ?? 'esm',
+      outputFiles: r.outputFiles,
+    });
+  }
+
+  // backward-compat: 첫 entry 의 결과를 outputFiles 에 alias.
+  if (aggregated.outputsByFormat!.length > 0) {
+    aggregated.outputFiles = aggregated.outputsByFormat![0].outputFiles;
+  }
+
+  return aggregated;
 }
 
 export function buildAppSync(options: AppBuildOptions = {}): BuildResult {

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -190,6 +190,8 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "outdir", // CLI -o/--outdir
     "outfile",
     "outbase",
+    "output", // multi-format sugar (PR-I) — JS-level dispatch, native 로 전달 안 함
+    "outputsByFormat", // BuildResult only — write 시점에 BundleResult 안 가지만 schema test 가 BuildOptions 만 검사
     "globalName", // IIFE/UMD only
     "publicPath",
     "splitting", // bundler 옵션, DTO 에 모음

--- a/tests/integration/tests/multi-format.test.ts
+++ b/tests/integration/tests/multi-format.test.ts
@@ -5,7 +5,7 @@ import { describe, test, expect } from 'bun:test';
 import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { zntc, type BuildOptions } from '@zntc/core';
+import { build, zntc, type BuildOptions } from '@zntc/core';
 
 async function createFixture(files: Record<string, string>): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'zntc-multi-format-'));
@@ -19,6 +19,35 @@ async function createFixture(files: Record<string, string>): Promise<string> {
 }
 
 describe('multi-format JS API (#3561)', () => {
+  test('esbuild-style build({output:[esm,cjs]}) returns outputsByFormat', async () => {
+    const dir = await createFixture({
+      'index.ts': 'export const greet = (n: string) => `hello ${n}`;\nconsole.log(greet("b"));',
+    });
+    try {
+      const result = await build({
+        entryPoints: [join(dir, 'index.ts')],
+        output: [
+          { format: 'esm', dir: join(dir, 'dist-esm') },
+          { format: 'cjs', dir: join(dir, 'dist-cjs') },
+        ],
+      } as BuildOptions);
+      expect(result.errors.length).toBe(0);
+      expect(result.outputsByFormat).toBeDefined();
+      expect(result.outputsByFormat!.length).toBe(2);
+      expect(result.outputsByFormat![0].format).toBe('esm');
+      expect(result.outputsByFormat![1].format).toBe('cjs');
+      expect(result.outputsByFormat![0].outputFiles.length).toBeGreaterThan(0);
+      expect(result.outputsByFormat![1].outputFiles.length).toBeGreaterThan(0);
+      const esmText = result.outputsByFormat![0].outputFiles.map((f) => f.text).join('\n');
+      const cjsText = result.outputsByFormat![1].outputFiles.map((f) => f.text).join('\n');
+      expect(esmText).not.toBe(cjsText);
+      // backward-compat: outputFiles 가 첫 format 의 alias
+      expect(result.outputFiles).toEqual(result.outputsByFormat![0].outputFiles);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test('zntc(input).write(esm) + write(cjs) produces both outputs', async () => {
     const dir = await createFixture({
       'index.ts': 'export const greet = (n: string) => `hi ${n}`;\nconsole.log(greet("a"));',


### PR DESCRIPTION
epic #3561 PR-I/10 (마지막). PR-E 의 rollup-style 위에 **esbuild-style 단일 호출 sugar**.

## 변경 (3 파일, +79)

- `packages/core/index.ts`:
  - `BuildOptionsCommon.output?: OutputOptions[]` 필드 추가 (PR-E 의 `OutputOptions` 재사용)
  - `BuildResult.outputsByFormat?: Array<{format, outputFiles}>` 노출 (backward-compat: 첫 entry 의 outputFiles 가 `result.outputFiles` alias)
  - `build()` 진입에 `output.length >= 2` 분기 → `buildMultiFormat(options)` 위임
  - `buildMultiFormat(options)`: 각 OutputConfig 별 build() N회 호출 → errors/warnings/outputsByFormat 누적
- `tests/integration/tests/multi-format.test.ts` — "esbuild-style build({output:[esm,cjs]}) returns outputsByFormat" smoke test 추가
- `src/config_options_dto_test.zig` — `output` / `outputsByFormat` 을 `ts_buildoptions_only_allowlist` 에 추가 (JS-level dispatch, native 로 전달 안 함)

## 사용 패턴

```ts
import { build } from '@zntc/core';

const r = await build({
  entryPoints: ['src/main.ts'],
  output: [
    { format: 'esm', dir: 'dist/esm' },
    { format: 'cjs', dir: 'dist/cjs' },
  ],
});

r.outputsByFormat![0].format === 'esm';
r.outputsByFormat![1].outputFiles; // CJS 결과
```

## API 표면 — 두 패턴 다 노출

- **rollup-style** (PR-E): `await zntc(input)` → `.write(output)` → `.close()` — lifecycle 훅
- **esbuild-style** (PR-I): `await build({output: [...]})` — 단일 호출, 한 번에 다중 format

rolldown 의 실제 API 패턴과 동일 (둘 다 제공, 사용자 선택).

## 검증

- `bun run --cwd packages/core build:dts` 통과
- `zig build test` 통과 (schema drift gate 포함)
- `bun test multi-format + determinism + lodash-es` **11 pass / 0 fail**

## 후속 / 제한

- **graph 재사용 미지원**: 두 API 모두 매 호출/format 마다 graph 재빌드. native multi-emit 도 *각 build() 호출 1회* (graph 재사용 X). 진짜 *한 graph N format emit* 은 별도 epic (incremental rebuild 재설계 epic 의 일부)

Refs #3561