### PR TITLE
chore(bench): incremental rebuild measurement infra (ROI investigation)

### DIFF
--- a/documents/src/content/docs/reference/incremental-bench.md
+++ b/documents/src/content/docs/reference/incremental-bench.md
@@ -1,0 +1,68 @@
+---
+title: Incremental rebuild benchmark guide
+description: zntc 의 watch / HMR rebuild 측정 가이드. incremental rebuild 재설계 epic 의 ROI 입증용.
+---
+
+zntc 의 `--profile=*` 인프라로 watch mode rebuild 측정. 결과는 incremental rebuild
+재설계 epic 의 ROI 분기 결정에 사용.
+
+## 측정 명령
+
+### 1. cold + warm build phase 측정
+
+```sh
+ZNTC_PROFILE=parse,semantic,graph_discover,graph_build,graph_finalize \
+  zntc --bundle src/main.ts -o dist/bundle.js
+```
+
+stderr 로 phase 별 totalNs / count 출력. cold (첫 build) 의 parse + semantic 합계가
+total 의 몇 % 를 차지하는지 확인.
+
+### 2. watch mode 의 incremental rebuild 측정
+
+```sh
+ZNTC_PROFILE=parse,semantic,graph_discover \
+  zntc --watch --bundle src/main.ts -o dist/bundle.js
+```
+
+dev server 가 source 변경 감지하면 rebuild — 그 시점의 phase 별 ns 가 stderr 로
+출력. 다른 터미널에서 `touch src/some-file.ts` 또는 1-line 편집 후 측정.
+
+## ROI 분기 임계 (재설계 epic 진입 결정)
+
+| 메트릭 | 시나리오 A (재설계 진입) | 시나리오 B (epic 폐기) |
+|---|---|---|
+| cache hit률 = `(total_modules - reparsed) / total_modules` | ≥ 80% | < 50% |
+| parse + semantic ns 합 / total build ns | ≥ 20% | < 10% |
+| graph_discover ns / total build ns | ≥ 30% | < 15% |
+
+**시나리오 A**: incremental cache hit 률 높고 parse/semantic 이 dominant — *ModuleData path-keyed cache* 분리가 진짜 절감 효과.
+
+**시나리오 B**: cache miss 많거나 parse/semantic 비중 작음 — *재설계 ROI 부재*, 다른 병목 우선 (resolve, source read, applyScanResult).
+
+## 측정 보고 형식
+
+issue 또는 PR comment 에 다음 형식으로 보고:
+
+```
+Project: <name>
+Modules: <total>
+Cold build (ns):
+  parse:      <X>
+  semantic:   <Y>
+  discover:   <Z>
+  total:      <T>
+  parse+sem%: <(X+Y)/T*100>%
+
+Watch rebuild (1-line edit, leaf module):
+  reparsed modules: <N> / <total>
+  cache hit률: <100*(total-N)/total>%
+  parse:      <X'>
+  semantic:   <Y'>
+  discover:   <Z'>
+  total:      <T'>
+```
+
+## 본 가이드의 위치
+
+incremental rebuild 재설계 epic 의 PR-0 산출물. 데이터 수집 후 epic 진입/폐기 결정.

--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -38,5 +38,6 @@ comptime {
     _ = @import("bundler_test/manual_chunks.zig");
     _ = @import("bundler_test/runtime_helper_shadow.zig");
     _ = @import("bundler_test/multi_format.zig");
+    _ = @import("bundler_test/incremental_bench.zig");
     _ = @import("namespace_access_test.zig");
 }

--- a/src/bundler/bundler_test/incremental_bench.zig
+++ b/src/bundler/bundler_test/incremental_bench.zig
@@ -1,0 +1,45 @@
+//! Incremental rebuild bench (Plan #3564 redesign epic 진입 ROI 입증용).
+//! 작은 합성 fixture 로 cache hit rate + phase 별 ns 측정. production-realistic 측정은
+//! `documents/dist/reference/incremental-bench.md` 의 watch mode 가이드 따라 사용자 직접.
+
+const std = @import("std");
+const Bundler = @import("../bundler.zig").Bundler;
+const types = @import("../types.zig");
+const test_helpers = @import("../test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+const absPath = test_helpers.absPath;
+const profile = @import("../../profile.zig");
+
+test "incremental bench: cold vs warm rebuild parse savings" {
+    profile.resetForTest();
+    profile.setLevel(.summary);
+    profile.addCategories(&.{ "parse", "semantic", "graph_discover", "graph_build", "graph_finalize" });
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "export const a = 1;\nexport const a2 = 2;");
+    try writeFile(tmp.dir, "b.ts", "export const b = 1;");
+    try writeFile(tmp.dir, "c.ts", "export const c = 1;");
+    try writeFile(tmp.dir, "index.ts", "import { a } from './a';\nimport { b } from './b';\nimport { c } from './c';\nconsole.log(a, b, c);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const r1 = try b.bundle();
+    defer r1.deinit(std.testing.allocator);
+
+    const cold_parse = profile.totalNs(.parse);
+    const cold_semantic = profile.totalNs(.semantic);
+    const cold_discover = profile.totalNs(.graph_discover);
+
+    try std.testing.expect(cold_parse > 0);
+    try std.testing.expect(cold_semantic > 0);
+
+    // 측정 결과 stderr 출력 — CI artifact 캡처용 (assertion 약함, infra 입증 위주).
+    std.debug.print(
+        "\n[incremental-bench] cold build: parse={d}ns semantic={d}ns discover={d}ns\n",
+        .{ cold_parse, cold_semantic, cold_discover },
+    );
+}


### PR DESCRIPTION
incremental rebuild 재설계 epic 의 **PR-0 (측정 인프라)**. ROI 입증 후 본 epic 진입 결정.

## 변경 (3 파일, +114)

- `src/bundler/bundler_test/incremental_bench.zig` (신규): cold build phase ns 측정 zig 단위 test. infra 입증 — 작은 fixture (4 module) 의 stderr 출력
- `documents/src/content/docs/reference/incremental-bench.md` (신규): `ZNTC_PROFILE=parse,semantic,graph_discover ...` 명령 가이드 + ROI 분기 임계 표
- `src/bundler/bundler_test.zig`: incremental_bench aggregator 추가

## 측정 결과 (PR-0 시점 작은 fixture, 4 module)

```
parse=27333ns semantic=17751ns discover=571875ns
```

- (parse + semantic) / total ≈ **7.3%** (discover 가 92.7%, dominant)
- 작은 fixture 라 *production-realistic 아님*

## ROI 분기 룰 (가이드의 임계 표)

| 메트릭 | 시나리오 A (epic 진입) | 시나리오 B (epic 폐기) |
|---|---|---|
| cache hit률 | ≥ 80% | < 50% |
| parse + semantic % | ≥ 20% | < 10% |
| graph_discover % | ≥ 30% | < 15% |

## 다음 단계

**사용자가 production project watch mode 로 측정** → 결과 issue 에 보고 → epic 진입/폐기 결정.

문서 (`incremental-bench.md`) 의 측정 명령 + 보고 형식 따름.

Refs #3561 #3564 — incremental rebuild redesign epic 진입 결정용