### PR TITLE
chore(bench): production-realistic incremental rebuild measurement (M0)

### DIFF
--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -39,5 +39,7 @@ comptime {
     _ = @import("bundler_test/runtime_helper_shadow.zig");
     _ = @import("bundler_test/multi_format.zig");
     _ = @import("bundler_test/incremental_bench.zig");
+    _ = @import("bundler_test/incremental_bench_v2.zig");
+    _ = @import("bundler_test/incremental_bench_v4.zig");
     _ = @import("namespace_access_test.zig");
 }

--- a/src/bundler/bundler_test/incremental_bench_v2.zig
+++ b/src/bundler/bundler_test/incremental_bench_v2.zig
@@ -1,0 +1,93 @@
+//! Production-realistic measurement: React-style 컴포넌트 fixture + cold/warm rebuild.
+//! module_store 로 cache hit 률 + parse/semantic phase ns 측정.
+
+const std = @import("std");
+const Bundler = @import("../bundler.zig").Bundler;
+const ModuleGraph = @import("../graph.zig").ModuleGraph;
+const PersistentModuleStore = @import("../module_store.zig").PersistentModuleStore;
+const ResolveCache = @import("../resolve_cache.zig").ResolveCache;
+const test_helpers = @import("../test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+const absPath = test_helpers.absPath;
+const profile = @import("../../profile.zig");
+
+test "incremental bench: react-style 10 components, cache hit on no-change" {
+    profile.resetForTest();
+    profile.setLevel(.summary);
+    // graph_build / graph_finalize 는 enable 만 하고 read 하지 않으면 dead — 측정하는 3 category 만.
+    profile.addCategories(&.{ "parse", "semantic", "graph_discover" });
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // 10 React-style components + index entry
+    try writeFile(tmp.dir, "Button.tsx", "import { Card } from './Card';\nexport function Button(p: {label: string}) { return null as any; }\n");
+    try writeFile(tmp.dir, "Card.tsx", "export function Card(p: {title: string}) { return null as any; }\n");
+    try writeFile(tmp.dir, "Header.tsx", "import { Button } from './Button';\nexport function Header() { return null as any; }\n");
+    try writeFile(tmp.dir, "Footer.tsx", "import { Card } from './Card';\nexport function Footer() { return null as any; }\n");
+    try writeFile(tmp.dir, "Sidebar.tsx", "import { Button } from './Button';\nimport { Card } from './Card';\nexport function Sidebar() { return null as any; }\n");
+    try writeFile(tmp.dir, "Modal.tsx", "import { Card } from './Card';\nexport function Modal() { return null as any; }\n");
+    try writeFile(tmp.dir, "Form.tsx", "import { Button } from './Button';\nexport function Form() { return null as any; }\n");
+    try writeFile(tmp.dir, "Table.tsx", "import { Card } from './Card';\nexport function Table() { return null as any; }\n");
+    try writeFile(tmp.dir, "Layout.tsx", "import { Header } from './Header';\nimport { Sidebar } from './Sidebar';\nimport { Footer } from './Footer';\nexport function Layout() { return null as any; }\n");
+    try writeFile(tmp.dir, "App.tsx", "import { Layout } from './Layout';\nimport { Modal } from './Modal';\nimport { Form } from './Form';\nimport { Table } from './Table';\nexport function App() { return null as any; }\n");
+    try writeFile(tmp.dir, "index.tsx", "import { App } from './App';\nconsole.log(App);\n");
+
+    const entry = try absPath(&tmp, "index.tsx");
+    defer std.testing.allocator.free(entry);
+
+    var store = PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+
+    // ─── Cold build (store empty) ──────────────────────────────
+    {
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .module_store = &store,
+        });
+        defer b.deinit();
+        const r = try b.bundle();
+        defer r.deinit(std.testing.allocator);
+        try std.testing.expect(r.output.len > 0);
+    }
+    const cold_parse = profile.totalNs(.parse);
+    const cold_semantic = profile.totalNs(.semantic);
+    const cold_discover = profile.totalNs(.graph_discover);
+    const cold_total = cold_parse + cold_semantic + cold_discover;
+
+    profile.resetCounters();
+
+    // ─── Warm build (no source change, store hit) ──────────────
+    {
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .module_store = &store,
+        });
+        defer b.deinit();
+        const r = try b.bundle();
+        defer r.deinit(std.testing.allocator);
+        try std.testing.expect(r.output.len > 0);
+    }
+    const warm_parse = profile.totalNs(.parse);
+    const warm_semantic = profile.totalNs(.semantic);
+    const warm_discover = profile.totalNs(.graph_discover);
+    const warm_total = warm_parse + warm_semantic + warm_discover;
+
+    const parse_savings_pct = if (cold_parse == 0) @as(u64, 0) else 100 - (warm_parse * 100 / cold_parse);
+    const sem_savings_pct = if (cold_semantic == 0) @as(u64, 0) else 100 - (warm_semantic * 100 / cold_semantic);
+    const total_savings_pct = if (cold_total == 0) @as(u64, 0) else 100 - (warm_total * 100 / cold_total);
+
+    std.debug.print(
+        \\
+        \\[incremental-bench v2] React 10-component fixture, no-change warm:
+        \\  cold:  parse={d}ns semantic={d}ns discover={d}ns total={d}ns
+        \\  warm:  parse={d}ns semantic={d}ns discover={d}ns total={d}ns
+        \\  savings: parse={d}% semantic={d}% total={d}%
+        \\  parse+sem / total cold = {d}%
+        \\
+    , .{
+        cold_parse,        cold_semantic,   cold_discover,     cold_total,
+        warm_parse,        warm_semantic,   warm_discover,     warm_total,
+        parse_savings_pct, sem_savings_pct, total_savings_pct, if (cold_total == 0) @as(u64, 0) else (cold_parse + cold_semantic) * 100 / cold_total,
+    });
+}

--- a/src/bundler/bundler_test/incremental_bench_v4.zig
+++ b/src/bundler/bundler_test/incremental_bench_v4.zig
@@ -1,0 +1,171 @@
+//! Incremental bench v4 — production-realistic invocation pattern.
+//! v3 는 changed_files=null 로 호출해 watcher-skip path 우회 (641 stat syscall 발생).
+//! v4 는 changed_files 의 3가지 case 를 측정해 stat skip ratio 를 격리.
+//!
+//! case A: changed_files = empty HashMap   — watcher 가 변경 0 보고 (no-change rebuild)
+//! case B: changed_files = {entry.ts}      — watcher 가 1 file 변경 보고 (single-file edit)
+//! case C: changed_files = null            — watcher 미통합 (=v3 baseline)
+//!
+//! lodash-es 641 module fixture 로 측정.
+
+const std = @import("std");
+const Bundler = @import("../bundler.zig").Bundler;
+const PersistentModuleStore = @import("../module_store.zig").PersistentModuleStore;
+const test_helpers = @import("../test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+const absPath = test_helpers.absPath;
+const profile = @import("../../profile.zig");
+
+const LODASH_ENTRY =
+    \\import {
+    \\  uniq, chunk, compact, drop, dropRight, fill, findIndex, flatten,
+    \\  flattenDeep, head, indexOf, initial, intersection, last, nth, pull,
+    \\  pullAll, remove, slice, sortedIndex, take, takeRight, union, uniqBy,
+    \\  without, xor, zip, zipObject, countBy, every, filter, find, forEach,
+    \\  groupBy, includes, keyBy, map, orderBy, partition, reduce, reject,
+    \\  sample, shuffle, size, some, sortBy, debounce, throttle, memoize,
+    \\  once, defer, delay,
+    \\} from 'lodash-es';
+    \\console.log([uniq, chunk, compact].map(f => typeof f).join(','));
+    \\
+;
+
+const Case = enum { empty, single_entry, null_changed };
+
+const WarmResult = struct {
+    parse_ns: u64,
+    semantic_ns: u64,
+    discover_ns: u64,
+    total_ns: u64,
+};
+
+fn measureWarm(allocator: std.mem.Allocator, store: *PersistentModuleStore, entry: []const u8, case: Case) !WarmResult {
+    profile.resetCounters();
+
+    var changed_set: std.StringHashMap(void) = .init(allocator);
+    defer changed_set.deinit();
+    if (case == .single_entry) {
+        try changed_set.put(entry, {});
+    }
+
+    const changed_ptr: ?*const std.StringHashMap(void) = switch (case) {
+        .empty => &changed_set,
+        .single_entry => &changed_set,
+        .null_changed => null,
+    };
+
+    var b = Bundler.init(allocator, .{
+        .entry_points = &.{entry},
+        .module_store = store,
+        .changed_files = changed_ptr,
+    });
+    defer b.deinit();
+    const r = try b.bundle();
+    defer r.deinit(allocator);
+
+    const parse_ns = profile.totalNs(.parse);
+    const semantic_ns = profile.totalNs(.semantic);
+    const discover_ns = profile.totalNs(.graph_discover);
+    return .{
+        .parse_ns = parse_ns,
+        .semantic_ns = semantic_ns,
+        .discover_ns = discover_ns,
+        .total_ns = parse_ns + semantic_ns + discover_ns,
+    };
+}
+
+test "incremental bench v4: changed_files null/empty/single comparison" {
+    profile.resetForTest();
+    profile.setLevel(.summary);
+    profile.addCategories(&.{ "parse", "semantic", "graph_discover" });
+
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts", LODASH_ENTRY);
+
+    // node_modules symlink — lodash-es resolve 가능하게.
+    // cwd 가 repo root (zig build 의 실행 위치) → 그 안의 node_modules 를 symlink target.
+    const real_nm = std.fs.cwd().realpathAlloc(allocator, "node_modules") catch |err| {
+        std.debug.print("[bench v4] cwd node_modules absent ({}), skip\n", .{err});
+        return error.SkipZigTest;
+    };
+    defer allocator.free(real_nm);
+
+    const tmp_real = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_real);
+    const tmp_nm = try std.fs.path.join(allocator, &.{ tmp_real, "node_modules" });
+    defer allocator.free(tmp_nm);
+    std.posix.symlink(real_nm, tmp_nm) catch |err| {
+        std.debug.print("[bench v4] symlink skip: {}\n", .{err});
+        return error.SkipZigTest;
+    };
+
+    const entry = try std.fs.path.join(allocator, &.{ tmp_real, "entry.ts" });
+    defer allocator.free(entry);
+
+    var store: PersistentModuleStore = .init(allocator);
+    defer store.deinit();
+
+    // Cold build — store fill.
+    var cold_module_count: usize = 0;
+    {
+        var b = Bundler.init(allocator, .{
+            .entry_points = &.{entry},
+            .module_store = &store,
+        });
+        defer b.deinit();
+        const r = b.bundle() catch |err| {
+            std.debug.print("[bench v4] cold bundle fail: {}\n", .{err});
+            return error.SkipZigTest;
+        };
+        defer r.deinit(allocator);
+        cold_module_count = if (r.module_paths) |paths| paths.len else 0;
+    }
+    const cold_parse = profile.totalNs(.parse);
+    const cold_semantic = profile.totalNs(.semantic);
+    const cold_discover = profile.totalNs(.graph_discover);
+    const cold_total = cold_parse + cold_semantic + cold_discover;
+
+    // Warm 3 case — first run once and discard (dir-fd / inode cache warmup).
+    _ = try measureWarm(allocator, &store, entry, .null_changed);
+
+    const c_null = try measureWarm(allocator, &store, entry, .null_changed);
+    const c_empty = try measureWarm(allocator, &store, entry, .empty);
+    const c_single = try measureWarm(allocator, &store, entry, .single_entry);
+
+    std.debug.print(
+        \\
+        \\[incremental-bench v4] lodash-es {d} module, 3 case warm:
+        \\  cold        : parse={d}us semantic={d}us discover={d}us total={d}us
+        \\  warm null   : parse={d}us semantic={d}us discover={d}us total={d}us  (v3 baseline, 641 stat)
+        \\  warm empty  : parse={d}us semantic={d}us discover={d}us total={d}us  (no-change watcher)
+        \\  warm single : parse={d}us semantic={d}us discover={d}us total={d}us  (1-file watcher)
+        \\
+        \\  stat skip ratio (empty/null) = {d}%
+        \\  stat skip ratio (single/null) = {d}%
+        \\
+    , .{
+        cold_module_count,
+        cold_parse / 1000,
+        cold_semantic / 1000,
+        cold_discover / 1000,
+        cold_total / 1000,
+        c_null.parse_ns / 1000,
+        c_null.semantic_ns / 1000,
+        c_null.discover_ns / 1000,
+        c_null.total_ns / 1000,
+        c_empty.parse_ns / 1000,
+        c_empty.semantic_ns / 1000,
+        c_empty.discover_ns / 1000,
+        c_empty.total_ns / 1000,
+        c_single.parse_ns / 1000,
+        c_single.semantic_ns / 1000,
+        c_single.discover_ns / 1000,
+        c_single.total_ns / 1000,
+        if (c_null.total_ns == 0) @as(u64, 0) else c_empty.total_ns * 100 / c_null.total_ns,
+        if (c_null.total_ns == 0) @as(u64, 0) else c_single.total_ns * 100 / c_null.total_ns,
+    });
+}


### PR DESCRIPTION
## Summary

graph_discover 최적화 epic 의 **PR-M0** (측정 infra). 이전 #3564 후속 (PR-0 가 4 module 합성 fixture 만 가졌고, 사용자 가설 \"react component cache hit 100%\" 검증 필요).

- v2: React 10-component fixture (작은 fixture, cache hit 100% 검증)
- v4: lodash-es 641 module fixture (production-realistic, watcher integration 3 case 측정)

## 측정 결과

### v2 — React 10-component, no-change warm

- cold: parse 83 µs / semantic 35 µs / discover 1.6 ms
- warm: parse **0** / semantic **0** / discover 270 µs
- → **cache hit 100% 확인** (사용자 기억 정확)
- parse + semantic / cold total = 6%

### v4 — lodash-es 641 module, changed_files 3 case

| Case | discover | (vs null) |
|---|---|---|
| warm null (641 stat)   | 47.6 ms | 100% baseline |
| warm empty (0 stat)    | 47.0 ms | **98%** |
| warm single (1 stat)   | 46.6 ms | **99%** |

→ **stat syscall 전체 비용 = 1-2 ms 만** (warm 의 2-4%). cold parse + semantic / total = 16%.

## 측정 결론

Plan 의 가설 *\"warm 47ms 의 dominant = 641 mtime stat\"* 가 **반증**. dir-fd cache 통합 (PR-X3 후보) 의 ROI ≈ 0 → drop. 진짜 dominant 는 sub-phase 측정 (PR-M1) 으로 격리해야 함.

## 영향

측정 infra 추가만, *코드 변경 없음*. 회귀 0. 실제 production lib (lodash-es) 사용해 bench timing 이 inode cache 의존적 — `--summary all` 통과 5349/5353 / 4 skipped (이전 대비 변화 없음).

## 다음 단계

- PR-M1: `build_flow.zig` hot path 에 5개 sub-phase 카테고리 추가 (mtime / cache lookup / cache_hit_assign / replay / miss_parse)
- PR-M2: bench v2/v4 출력에 sub-phase µs 인쇄
- 측정 결과 분석 → X2/X6 채택 또는 epic 종료 결정

## Test plan

- [x] `zig build test --summary all` — 5349/5353 통과 / 4 skipped (회귀 0)
- [x] v2 측정 결과 정상 출력
- [x] v4 측정 결과 정상 출력 (이전 commit 의 `@src().file` SKIP 이슈 → cwd 기반으로 수정)
- [x] memory leak 0 (v3 의 inline `realpathAlloc` leak fix 포함 — v3 폐기 + v4 가 strict superset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)