### PR TITLE
chore(profile): incremental rebuild sub-phase categories (M1)

### DIFF
--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -406,6 +406,8 @@ pub fn buildIncremental(
             // 그대로 쓴다. 수백 모듈 × ~100us stat 이 주 병목이었음. changed_files 가 null
             // 이거나 cache miss 인 경로는 기존처럼 stat.
             const mtime: i128 = blk: {
+                var s_mtime = profile.begin(.graph_discover_incr_mtime);
+                defer s_mtime.end();
                 if (changed_files) |cf| {
                     if (!cf.contains(mod_path)) {
                         if (store.modules.get(mod_path)) |cached_entry| {
@@ -416,8 +418,15 @@ pub fn buildIncremental(
                 break :blk getMtime(mod_path) catch 0;
             };
 
-            // 캐시 조회
-            if (store.getIfFresh(mod_path, mtime)) |cached| {
+            // 캐시 조회. `defer` 가 아닌 명시 `end()` — getIfFresh 호출 자체만 측정해야
+            // 하고, 뒤따르는 if/else 분기(cache_hit_assign / miss_parse) 시간이 섞이면
+            // 안 된다. 이 분기들은 각자 자기 scope 로 따로 측정한다.
+            var s_cl = profile.begin(.graph_discover_incr_cache_lookup);
+            const lookup_result = store.getIfFresh(mod_path, mtime);
+            s_cl.end();
+            if (lookup_result) |cached| {
+                var s_ha = profile.begin(.graph_discover_incr_cache_hit_assign);
+                defer s_ha.end();
                 // 캐시 히트: struct assign으로 전체 복원 후 graph-specific 필드만 override.
                 // Module에 새 필드가 추가되어도 누락 없이 복사됨.
                 const saved_index = mod.index;
@@ -457,6 +466,8 @@ pub fn buildIncremental(
                 }
                 mod.state = .ready;
             } else {
+                var s_mp = profile.begin(.graph_discover_incr_miss_parse);
+                defer s_mp.end();
                 // 캐시 미스: 정상 파싱
                 self.parseModule(@enumFromInt(@as(u32, @intCast(i))));
                 const m_ptr = self.modules.at(i);
@@ -470,9 +481,13 @@ pub fn buildIncremental(
         // resolve + addModule (새 의존성 등록)
         for (parse_start..parse_end) |i| {
             if (cache_hit_modules.contains(@intCast(i))) {
+                var s_rp = profile.begin(.graph_discover_incr_replay);
+                defer s_rp.end();
                 try graph_resolve_imports.replayCachedResolvedDeps(self, i);
                 try graph_resolve_imports.resolveDeferredRequestedImportsIfReady(self, ModuleIndex.fromUsize(i));
             } else {
+                var s_mr = profile.begin(.graph_discover_incr_miss_resolve);
+                defer s_mr.end();
                 try graph_resolve_imports.resolveModuleImports(self, @enumFromInt(@as(u32, @intCast(i))));
             }
         }

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -147,6 +147,15 @@ pub const Category = enum {
     graph_discover_pm_prepass_decision_unsupported_walk,
     graph_discover_pm_prepass_run,
     graph_discover_pm_is_pkg_type,
+    // Incremental rebuild hot path (build_flow.zig:buildIncremental).
+    // M0 측정값 (lodash-es 641 module warm) 의 47ms 를 sub-phase 로 분해해서
+    // 어느 단계가 dominant 인지 측정한다. graph_discover_pm_* 와 동위 prefix.
+    graph_discover_incr_mtime, // mtime 결정 (watcher skip → cached / fallback stat)
+    graph_discover_incr_cache_lookup, // store.getIfFresh — fresh 판정 (hash + mtime 비교)
+    graph_discover_incr_cache_hit_assign, // 캐시 히트 시 Module struct 복원 + ownership 이전
+    graph_discover_incr_miss_parse, // 캐시 미스 — parseModule + sideEffects 적용
+    graph_discover_incr_replay, // 히트 분기: replay cached resolved deps + deferred imports
+    graph_discover_incr_miss_resolve, // 미스 분기: resolveModuleImports (대칭 측정용)
     graph_finalize,
     graph_renumber,
     graph_resync,


### PR DESCRIPTION
## Summary

graph_discover 최적화 epic 의 **PR-M1** (sub-phase 측정). M0 (#3588) 의 lodash-es 641 module warm 47ms 를 6개 sub-phase 로 분해해 진짜 dominant 식별.

## 신규 카테고리 6개

`graph_discover_pm_*` 와 동위 prefix (`graph_discover_incr_*`):

| 카테고리 | 측정 범위 |
|---|---|
| `incr_mtime` | mtime 결정 (watcher skip → cached / fallback stat) |
| `incr_cache_lookup` | `store.getIfFresh` (fresh 판정 hash+mtime) |
| `incr_cache_hit_assign` | 캐시 히트 시 Module struct 복원 + ownership 이전 |
| `incr_miss_parse` | 캐시 미스 — `parseModule` + sideEffects |
| `incr_replay` | 히트 분기 `replayCachedResolvedDeps` + deferred imports |
| `incr_miss_resolve` | 미스 분기 `resolveModuleImports` (replay 대칭 측정) |

## Instrumentation

`build_flow.zig:buildIncremental` hot path 의 6개 위치에 begin/end 쌍. profile 비활성 시 `enabled()` 분기 1회만, `< 1% overhead` 약속 준수 (profile.zig 의 hot path 가정).

## 영향

- 코드 변경: enum 6개 추가 + begin/end 6쌍, behavioral change 없음
- 회귀 0 (`zig build test --summary all` — 5349/5353 통과 / 4 skipped, M0 baseline 동일)
- /simplify 3-agent review 에서 replay ↔ miss_resolve 대칭 측정 보강

## 다음 단계

- PR-M2 에서 v2/v4 bench 출력에 sub-phase µs 인쇄
- 측정 결과로 X2 (parallel replay) / X6 (renumber skip) 채택 여부 결정

## Test plan

- [x] `zig build test --summary all` — 5349/5353 통과 / 4 skipped (회귀 0)
- [x] /simplify 3-agent review 통과 (replay/miss 대칭 보강 반영)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)