### PR TITLE
chore(bench): sub-phase µs output for incremental bench (M2)

### DIFF
--- a/src/bundler/bundler_test/incremental_bench_v2.zig
+++ b/src/bundler/bundler_test/incremental_bench_v2.zig
@@ -14,8 +14,15 @@ const profile = @import("../../profile.zig");
 test "incremental bench: react-style 10 components, cache hit on no-change" {
     profile.resetForTest();
     profile.setLevel(.summary);
-    // graph_build / graph_finalize 는 enable 만 하고 read 하지 않으면 dead — 측정하는 3 category 만.
-    profile.addCategories(&.{ "parse", "semantic", "graph_discover" });
+    profile.addCategories(&.{
+        "parse",
+        "semantic",
+        "graph_discover",
+        "graph_discover_incr_mtime",
+        "graph_discover_incr_cache_lookup",
+        "graph_discover_incr_cache_hit_assign",
+        "graph_discover_incr_replay",
+    });
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -89,5 +96,23 @@ test "incremental bench: react-style 10 components, cache hit on no-change" {
         cold_parse,        cold_semantic,   cold_discover,     cold_total,
         warm_parse,        warm_semantic,   warm_discover,     warm_total,
         parse_savings_pct, sem_savings_pct, total_savings_pct, if (cold_total == 0) @as(u64, 0) else (cold_parse + cold_semantic) * 100 / cold_total,
+    });
+
+    const w_mtime = profile.totalNs(.graph_discover_incr_mtime);
+    const w_cl = profile.totalNs(.graph_discover_incr_cache_lookup);
+    const w_ha = profile.totalNs(.graph_discover_incr_cache_hit_assign);
+    const w_rp = profile.totalNs(.graph_discover_incr_replay);
+    std.debug.print(
+        \\  warm sub-phase (ns, % of discover):
+        \\    mtime           = {d}ns ({d}%)
+        \\    cache_lookup    = {d}ns ({d}%)
+        \\    cache_hit_assign= {d}ns ({d}%)
+        \\    replay          = {d}ns ({d}%)
+        \\
+    , .{
+        w_mtime, if (warm_discover == 0) @as(u64, 0) else w_mtime * 100 / warm_discover,
+        w_cl,    if (warm_discover == 0) @as(u64, 0) else w_cl * 100 / warm_discover,
+        w_ha,    if (warm_discover == 0) @as(u64, 0) else w_ha * 100 / warm_discover,
+        w_rp,    if (warm_discover == 0) @as(u64, 0) else w_rp * 100 / warm_discover,
     });
 }

--- a/src/bundler/bundler_test/incremental_bench_v4.zig
+++ b/src/bundler/bundler_test/incremental_bench_v4.zig
@@ -37,6 +37,12 @@ const WarmResult = struct {
     semantic_ns: u64,
     discover_ns: u64,
     total_ns: u64,
+    incr_mtime_ns: u64,
+    incr_cache_lookup_ns: u64,
+    incr_cache_hit_assign_ns: u64,
+    incr_miss_parse_ns: u64,
+    incr_replay_ns: u64,
+    incr_miss_resolve_ns: u64,
 };
 
 fn measureWarm(allocator: std.mem.Allocator, store: *PersistentModuleStore, entry: []const u8, case: Case) !WarmResult {
@@ -71,13 +77,57 @@ fn measureWarm(allocator: std.mem.Allocator, store: *PersistentModuleStore, entr
         .semantic_ns = semantic_ns,
         .discover_ns = discover_ns,
         .total_ns = parse_ns + semantic_ns + discover_ns,
+        .incr_mtime_ns = profile.totalNs(.graph_discover_incr_mtime),
+        .incr_cache_lookup_ns = profile.totalNs(.graph_discover_incr_cache_lookup),
+        .incr_cache_hit_assign_ns = profile.totalNs(.graph_discover_incr_cache_hit_assign),
+        .incr_miss_parse_ns = profile.totalNs(.graph_discover_incr_miss_parse),
+        .incr_replay_ns = profile.totalNs(.graph_discover_incr_replay),
+        .incr_miss_resolve_ns = profile.totalNs(.graph_discover_incr_miss_resolve),
     };
+}
+
+fn printSubPhase(label: []const u8, r: WarmResult) void {
+    const d = r.discover_ns;
+    std.debug.print(
+        \\  {s} sub-phase (us, % of discover):
+        \\    mtime           = {d:>7}us ({d:>3}%)
+        \\    cache_lookup    = {d:>7}us ({d:>3}%)
+        \\    cache_hit_assign= {d:>7}us ({d:>3}%)
+        \\    miss_parse      = {d:>7}us ({d:>3}%)
+        \\    replay          = {d:>7}us ({d:>3}%)
+        \\    miss_resolve    = {d:>7}us ({d:>3}%)
+        \\
+    , .{
+        label,
+        r.incr_mtime_ns / 1000,
+        if (d == 0) @as(u64, 0) else r.incr_mtime_ns * 100 / d,
+        r.incr_cache_lookup_ns / 1000,
+        if (d == 0) @as(u64, 0) else r.incr_cache_lookup_ns * 100 / d,
+        r.incr_cache_hit_assign_ns / 1000,
+        if (d == 0) @as(u64, 0) else r.incr_cache_hit_assign_ns * 100 / d,
+        r.incr_miss_parse_ns / 1000,
+        if (d == 0) @as(u64, 0) else r.incr_miss_parse_ns * 100 / d,
+        r.incr_replay_ns / 1000,
+        if (d == 0) @as(u64, 0) else r.incr_replay_ns * 100 / d,
+        r.incr_miss_resolve_ns / 1000,
+        if (d == 0) @as(u64, 0) else r.incr_miss_resolve_ns * 100 / d,
+    });
 }
 
 test "incremental bench v4: changed_files null/empty/single comparison" {
     profile.resetForTest();
     profile.setLevel(.summary);
-    profile.addCategories(&.{ "parse", "semantic", "graph_discover" });
+    profile.addCategories(&.{
+        "parse",
+        "semantic",
+        "graph_discover",
+        "graph_discover_incr_mtime",
+        "graph_discover_incr_cache_lookup",
+        "graph_discover_incr_cache_hit_assign",
+        "graph_discover_incr_miss_parse",
+        "graph_discover_incr_replay",
+        "graph_discover_incr_miss_resolve",
+    });
 
     const allocator = std.testing.allocator;
 
@@ -168,4 +218,8 @@ test "incremental bench v4: changed_files null/empty/single comparison" {
         if (c_null.total_ns == 0) @as(u64, 0) else c_empty.total_ns * 100 / c_null.total_ns,
         if (c_null.total_ns == 0) @as(u64, 0) else c_single.total_ns * 100 / c_null.total_ns,
     });
+
+    printSubPhase("null  ", c_null);
+    printSubPhase("empty ", c_empty);
+    printSubPhase("single", c_single);
 }


### PR DESCRIPTION
## Summary

graph_discover 최적화 epic 의 **PR-M2** (출력 확장). #3589 M1 의 6 sub-phase 카테고리를 v2/v4 bench 출력에 인쇄해 진짜 dominant 식별.

## 변경

- **v4** (lodash-es 641 module): `WarmResult` 에 6 ns 필드, `printSubPhase` helper, 3 case 별 6 sub-phase µs + % of discover
- **v2** (React 10-component): 단일 warm 측정의 4 sub-phase inline 출력

## 측정 결과 — 압도적 dominant

### lodash-es 641 module warm null (baseline 47 ms)

| Sub-phase | µs | % of discover |
|---|---|---|
| **replay** | **44,796** | **95%** |
| mtime | 1,505 | 3% |
| cache_hit_assign | 363 | 0% |
| cache_lookup | 190 | 0% |
| miss_parse / miss_resolve | 0 | 0% |

### React 10-component warm

| Sub-phase | ns | % of discover |
|---|---|---|
| **replay** | **243,293** | **85%** |
| mtime | 18,875 | 6% |
| cache_hit_assign | 17,083 | 5% |
| cache_lookup | 2,835 | 0% |

## 결론

**warm 47 ms 의 95% = `replayCachedResolvedDeps`** — 압도적 dominant.

- PR-X3 (mtime dir-fd cache) ROI **3% 만** → **drop 확정** (Plan 가설 반증 후속 확인)
- **PR-X2 (parallel replay) 가 epic 의 진짜 ROI 출처**: 44.8 ms / 4-core ≈ 11.2 ms → **33.6 ms 절감 (warm 의 71%)**

## 다음 단계

M0/M1/M2 측정 단계 완료. 사용자에게 결과 보고 + PR-X2 채택 또는 epic 종료 결정 (#23 분석 task).

## Test plan

- [x] `zig build test --summary all` — 5349/5353 통과 / 4 skipped (M1 baseline 동일)
- [x] /simplify 3-agent review (변경 0건 — yagni / 파일 내 일관성 / 컴파일 enum 검증)
- [x] v2/v4 출력 정상 (위 표 값 reproducible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)