### PR TITLE
chore(profile): split requestDependencyExports into 3 branches (M4)

### DIFF
--- a/src/bundler/bundler_test/incremental_bench_v4.zig
+++ b/src/bundler/bundler_test/incremental_bench_v4.zig
@@ -46,6 +46,9 @@ const WarmResult = struct {
     incr_replay_request_exports_ns: u64,
     incr_replay_record_dep_ns: u64,
     incr_replay_other_ns: u64,
+    incr_req_static_import_ns: u64,
+    incr_req_re_export_ns: u64,
+    incr_req_simple_ns: u64,
     incr_miss_resolve_ns: u64,
 };
 
@@ -90,6 +93,9 @@ fn measureWarm(allocator: std.mem.Allocator, store: *PersistentModuleStore, entr
         .incr_replay_request_exports_ns = profile.totalNs(.graph_discover_incr_replay_request_exports),
         .incr_replay_record_dep_ns = profile.totalNs(.graph_discover_incr_replay_record_dep),
         .incr_replay_other_ns = profile.totalNs(.graph_discover_incr_replay_other),
+        .incr_req_static_import_ns = profile.totalNs(.graph_discover_incr_req_static_import),
+        .incr_req_re_export_ns = profile.totalNs(.graph_discover_incr_req_re_export),
+        .incr_req_simple_ns = profile.totalNs(.graph_discover_incr_req_simple),
         .incr_miss_resolve_ns = profile.totalNs(.graph_discover_incr_miss_resolve),
     };
 }
@@ -97,6 +103,7 @@ fn measureWarm(allocator: std.mem.Allocator, store: *PersistentModuleStore, entr
 fn printSubPhase(label: []const u8, r: WarmResult) void {
     const d = r.discover_ns;
     const rep = r.incr_replay_ns;
+    const req = r.incr_req_static_import_ns + r.incr_req_re_export_ns + r.incr_req_simple_ns;
     std.debug.print(
         \\  {s} sub-phase (us, % of discover):
         \\    mtime           = {d:>7}us ({d:>3}%)
@@ -108,6 +115,10 @@ fn printSubPhase(label: []const u8, r: WarmResult) void {
         \\      request_export= {d:>7}us ({d:>3}% of replay)
         \\      record_dep    = {d:>7}us ({d:>3}% of replay)
         \\      other         = {d:>7}us ({d:>3}% of replay)
+        \\    request_exports breakdown (us, % of request_exports):
+        \\      static_import = {d:>7}us ({d:>3}%)
+        \\      re_export     = {d:>7}us ({d:>3}%)
+        \\      simple        = {d:>7}us ({d:>3}%)
         \\    miss_resolve    = {d:>7}us ({d:>3}%)
         \\
     , .{
@@ -130,6 +141,12 @@ fn printSubPhase(label: []const u8, r: WarmResult) void {
         if (rep == 0) @as(u64, 0) else r.incr_replay_record_dep_ns * 100 / rep,
         r.incr_replay_other_ns / 1000,
         if (rep == 0) @as(u64, 0) else r.incr_replay_other_ns * 100 / rep,
+        r.incr_req_static_import_ns / 1000,
+        if (req == 0) @as(u64, 0) else r.incr_req_static_import_ns * 100 / req,
+        r.incr_req_re_export_ns / 1000,
+        if (req == 0) @as(u64, 0) else r.incr_req_re_export_ns * 100 / req,
+        r.incr_req_simple_ns / 1000,
+        if (req == 0) @as(u64, 0) else r.incr_req_simple_ns * 100 / req,
         r.incr_miss_resolve_ns / 1000,
         if (d == 0) @as(u64, 0) else r.incr_miss_resolve_ns * 100 / d,
     });
@@ -151,6 +168,9 @@ test "incremental bench v4: changed_files null/empty/single comparison" {
         "graph_discover_incr_replay_request_exports",
         "graph_discover_incr_replay_record_dep",
         "graph_discover_incr_replay_other",
+        "graph_discover_incr_req_static_import",
+        "graph_discover_incr_req_re_export",
+        "graph_discover_incr_req_simple",
         "graph_discover_incr_miss_resolve",
     });
 

--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -4,6 +4,7 @@ const types = @import("../types.zig");
 const ImportRecord = types.ImportRecord;
 const ModuleIndex = types.ModuleIndex;
 const RequestedExports = @import("state.zig").RequestedExports;
+const profile = @import("../../profile.zig");
 
 pub fn requestAll(self: anytype, idx: ModuleIndex) !bool {
     if (idx.isNone()) return false;
@@ -200,6 +201,8 @@ pub fn requestDependencyExports(
     const importer = self.modules.at(importer_idx);
     switch (record.kind) {
         .static_import => {
+            var s = profile.begin(.graph_discover_incr_req_static_import);
+            defer s.end();
             var changed = false;
             var found_binding = false;
             for (importer.import_bindings) |ib| {
@@ -215,8 +218,16 @@ pub fn requestDependencyExports(
             }
             return changed;
         },
-        .re_export => return requestedExportsForReExportRecord(self, importer, rec_i, dep_idx),
-        .side_effect, .require, .dynamic_import, .worker, .glob, .require_context => return requestAll(self, dep_idx),
+        .re_export => {
+            var s = profile.begin(.graph_discover_incr_req_re_export);
+            defer s.end();
+            return requestedExportsForReExportRecord(self, importer, rec_i, dep_idx);
+        },
+        .side_effect, .require, .dynamic_import, .worker, .glob, .require_context => {
+            var s = profile.begin(.graph_discover_incr_req_simple);
+            defer s.end();
+            return requestAll(self, dep_idx);
+        },
     }
 }
 

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -161,6 +161,10 @@ pub const Category = enum {
     graph_discover_incr_replay_request_exports, // requestDependencyExports — requested_exports HashMap mutation
     graph_discover_incr_replay_record_dep, // recordResolvedDep — import_records write + linkDependency/linkDynamicImport
     graph_discover_incr_replay_other, // virtual/disabled/optional/external/worker 분기 + 부수 work
+    // requestDependencyExports 의 3 분기 (PR-M4). 37ms 단일 함수의 어느 분기가 dominant 인지.
+    graph_discover_incr_req_static_import, // static_import — import_bindings iterate + requestNamed/All
+    graph_discover_incr_req_re_export, // re_export — requestedExportsForReExportRecord (cross-product loop)
+    graph_discover_incr_req_simple, // side_effect/require/dyn/worker/glob/require_context — requestAll
     graph_discover_incr_miss_resolve, // 미스 분기: resolveModuleImports (대칭 측정용)
     graph_finalize,
     graph_renumber,


### PR DESCRIPTION
## Summary

graph_discover 최적화 epic 의 **PR-M4** (request_exports 내부 3-way 분해). #3591 M3 의 `request_exports = 74% of warm` 식별 후 *어느 분기가 dominant* 인지 격리.

## 신규 카테고리 3개

`graph_discover_incr_req_*`:

| 카테고리 | 측정 범위 |
|---|---|
| `req_static_import` | static_import 분기 (import_bindings iterate + requestNamed/All) |
| `req_re_export` | re_export 분기 (`requestedExportsForReExportRecord` 의 cross-product loop) |
| `req_simple` | side_effect/require/dynamic/worker/glob/require_context (requestAll) |

## 측정 결과 — 최종 dominant 격리

### lodash-es 641 module warm null (baseline 47.3 ms, request_exports 34.7 ms)

| Sub-step | µs | % of request_exports | % of warm |
|---|---|---|---|
| **re_export** | **31,201** | **90%** | **66%** |
| static_import | 3,255 | 9% | 7% |
| simple | 0 | 0% | 0% |

→ **warm 47 ms 의 66% = `requestedExportsForReExportRecord`** 단일 함수.

## 진짜 ROI 출처 확정

`requested_exports.zig:130-191` 의 cross-product loop:

- N=requested_names (평균 ~10) × M=export_bindings (평균 ~30) = 300 iter / dep
- `std.mem.eql(eb.exported_name, requested_name)` 매 iter — string compare
- 641 module × 평균 3 dep × 300 iter ≈ 580K iter / 31ms = 53ns/iter

**알고리즘 개선 명백**: `Module.export_bindings_by_name: StringHashMap(usize)` pre-compute → inner loop O(M) → O(1), 300 iter / dep → 10 iter / dep → **~10x 절감 가설** (31 ms → ~3 ms, warm 47 ms → ~19 ms = **60% 절감**).

## 다음 단계

- **PR-Y** 채택 (export_bindings_by_name index pre-compute, ~100 LOC) — 60% warm 절감 가설 검증
- 또는 RFC 자료로 보존 + epic close

## Test plan

- [x] `zig build test --summary all` — 5349/5353 통과 / 4 skipped (M3 baseline 동일)
- [x] /simplify 3-agent review — 모든 agent PASS, fix 0건
- [x] M0/M1/M2/M3/M4 누적 측정 일관 — re_export % stable across 3 case

🤖 Generated with [Claude Code](https://claude.com/claude-code)