### PR TITLE
feat(graph): export_index_by_name precompute (dormant Y1)

### DIFF
--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -457,6 +457,10 @@ pub fn buildIncremental(
                 // malloc abort. ownership 을 graph 로 이전해 graph.deinit
                 // 한 번만 free 되도록 한다.
                 cached.module.alias_table = null;
+                // export_index_by_name (PR-Y1) 도 동일 ownership 이전 패턴 — graph deinit
+                // 만 free, 다음 rebuild 의 populate 가 cached.module 의 export_bindings 로
+                // 재build. cached.module 쪽 stale 포인터 회피.
+                cached.module.export_index_by_name = null;
                 // canonical_name 은 이전 Build 의 Linker 가 소유한 문자열을
                 // 가리키는데, 그 Linker.deinit 이후 이미 freed 상태다.
                 // 다음 Linker 가 conflict 마다 새로 assign 하므로 stale 한

--- a/src/bundler/graph/json_module.zig
+++ b/src/bundler/graph/json_module.zig
@@ -90,6 +90,7 @@ pub fn parse(self: *ModuleGraph, module: *Module) void {
     module.export_bindings = binding_scanner_mod.extractExportBindings(arena_alloc, &(module.ast.?), scan_result.records, module.import_bindings) catch &.{};
     module.exported_names = projectExportedNames(arena_alloc, module.export_bindings);
     @import("requested_exports.zig").computeBarrelFlags(module);
+    @import("requested_exports.zig").populateExportIndexByName(module, self.allocator) catch {};
 
     // Phase 1 (#1328): 합성 심볼 테이블 초기화 + export default 등록.
     module.ensureAliasTable(self.allocator);

--- a/src/bundler/graph/parser_metadata.zig
+++ b/src/bundler/graph/parser_metadata.zig
@@ -85,6 +85,7 @@ pub fn materialize(
             module.exported_names = projectExportedNames(arena_alloc, ebindings);
             // barrel 분류 캐시 (export_bindings 가 final 인 시점에 한 번 계산).
             @import("requested_exports.zig").computeBarrelFlags(module);
+            @import("requested_exports.zig").populateExportIndexByName(module, self.allocator) catch {};
         } else |_| {}
     }
 

--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -87,6 +87,32 @@ pub fn computeBarrelFlags(m: *Module) void {
     m.default_export_named_local = default_named_local;
 }
 
+/// `exported_name → export_bindings idx` HashMap 을 build. PR-Y1.
+/// computeBarrelFlags 와 동일 시점 (parse 끝나 export_bindings final) 에 호출.
+///
+/// `resyncAfterAstMutation` 처럼 export_bindings 가 재생성되는 경로에서도 안전하도록,
+/// 기존 map 이 있으면 **deinit 후 재build** (stale idx 회피 + 누수 회피). cache-hit
+/// 경로는 build_flow 가 cached 쪽 포인터를 nullify 해 ownership 만 이전 (재build X).
+///
+/// ECMAScript spec: 같은 exported_name 의 중복 export 는 parse-time syntax error 라
+/// non-star eb 의 exported_name 은 unique 보장 → fallback 불필요. re_export_star
+/// (exported_name="") 는 *어떤* name 도 export 가능해 idx 등록 제외 (caller 가 별도 처리).
+pub fn populateExportIndexByName(m: *Module, allocator: std.mem.Allocator) !void {
+    if (m.export_index_by_name) |*old| {
+        old.deinit(allocator);
+        m.export_index_by_name = null;
+    }
+    if (m.export_bindings.len == 0) return;
+    var map: std.StringHashMapUnmanaged(u32) = .empty;
+    errdefer map.deinit(allocator);
+    try map.ensureTotalCapacity(allocator, @intCast(m.export_bindings.len));
+    for (m.export_bindings, 0..) |eb, i| {
+        if (eb.kind == .re_export_star) continue;
+        try map.put(allocator, eb.exported_name, @intCast(i));
+    }
+    m.export_index_by_name = map;
+}
+
 pub fn nameHasDirectNonStarExport(m: *const Module, name: []const u8) bool {
     for (m.export_bindings) |eb| {
         if (eb.kind == .re_export_star) continue;
@@ -252,4 +278,66 @@ pub fn reExportRecordMatchesRequest(m: *const Module, rec_i: usize, req: *const 
         }
     }
     return false;
+}
+
+// ── tests ─────────────────────────────────────────────────────
+
+const binding_scanner = @import("../binding_scanner.zig");
+const ExportBinding = binding_scanner.ExportBinding;
+const Span = @import("../../lexer/token.zig").Span;
+
+test "populateExportIndexByName: 빈 export_bindings 면 null" {
+    const testing = std.testing;
+    var module = Module.init(@enumFromInt(0), "empty.ts");
+    defer module.deinit(testing.allocator);
+
+    try populateExportIndexByName(&module, testing.allocator);
+    try testing.expect(module.export_index_by_name == null);
+}
+
+test "populateExportIndexByName: re_export_star 는 제외, 나머지는 idx 등록" {
+    const testing = std.testing;
+    var module = Module.init(@enumFromInt(0), "mix.ts");
+    defer module.deinit(testing.allocator);
+
+    const ebs = try testing.allocator.alloc(ExportBinding, 3);
+    defer testing.allocator.free(ebs);
+    ebs[0] = .{ .exported_name = "a", .local_name = "a", .local_span = Span.EMPTY, .kind = .local };
+    ebs[1] = .{ .exported_name = "", .local_name = "", .local_span = Span.EMPTY, .kind = .re_export_star };
+    ebs[2] = .{ .exported_name = "b", .local_name = "b_local", .local_span = Span.EMPTY, .kind = .local };
+    module.export_bindings = ebs;
+
+    try populateExportIndexByName(&module, testing.allocator);
+    const map = &module.export_index_by_name.?;
+    try testing.expectEqual(@as(u32, 2), map.count());
+    try testing.expectEqual(@as(u32, 0), map.get("a").?);
+    try testing.expectEqual(@as(u32, 2), map.get("b").?);
+    try testing.expect(map.get("") == null); // re_export_star 의 빈 이름은 등록 안 됨
+}
+
+test "populateExportIndexByName: resync 시 stale idx 회피 (재build, 누수 없음)" {
+    const testing = std.testing;
+    var module = Module.init(@enumFromInt(0), "resync.ts");
+    defer module.deinit(testing.allocator);
+
+    // build 1
+    var ebs1 = try testing.allocator.alloc(ExportBinding, 2);
+    defer testing.allocator.free(ebs1);
+    ebs1[0] = .{ .exported_name = "x", .local_name = "x", .local_span = Span.EMPTY, .kind = .local };
+    ebs1[1] = .{ .exported_name = "y", .local_name = "y", .local_span = Span.EMPTY, .kind = .local };
+    module.export_bindings = ebs1;
+    try populateExportIndexByName(&module, testing.allocator);
+    try testing.expectEqual(@as(u32, 0), module.export_index_by_name.?.get("x").?);
+    try testing.expectEqual(@as(u32, 1), module.export_index_by_name.?.get("y").?);
+
+    // resync: export_bindings 가 재생성돼 idx 가 바뀌었다고 가정 (x, y 의 순서 swap)
+    const ebs2 = try testing.allocator.alloc(ExportBinding, 2);
+    defer testing.allocator.free(ebs2);
+    ebs2[0] = .{ .exported_name = "y", .local_name = "y", .local_span = Span.EMPTY, .kind = .local };
+    ebs2[1] = .{ .exported_name = "x", .local_name = "x", .local_span = Span.EMPTY, .kind = .local };
+    module.export_bindings = ebs2;
+    try populateExportIndexByName(&module, testing.allocator);
+    // 재build 되어 새 idx 가 반영되어야 함 (stale 0/1 가 아닌 1/0).
+    try testing.expectEqual(@as(u32, 1), module.export_index_by_name.?.get("x").?);
+    try testing.expectEqual(@as(u32, 0), module.export_index_by_name.?.get("y").?);
 }

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -437,6 +437,7 @@ pub fn resyncAfterAstMutation(
         );
         module.exported_names = projectExportedNames(arena_alloc, module.export_bindings);
         @import("requested_exports.zig").computeBarrelFlags(module);
+        @import("requested_exports.zig").populateExportIndexByName(module, self.allocator) catch {};
     }
 
     const has_refreshed_cjs = scan_result.has_cjs_require or

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -208,6 +208,16 @@ pub const Module = struct {
     /// `export_bindings.exported_name` 의 평탄 slice 프리컴퓨트 (ModuleInfo 노출용 #1883).
     /// graph allocator 소유. 이름 자체는 source/AST text 의 borrow 라 별도 free 불필요.
     exported_names: []const []const u8 = &.{},
+    /// exported_name → export_bindings 의 idx. PR-Y1 (#3592 follow-up) — warm rebuild 의
+    /// `requestedExportsForReExportRecord` 가 cross-product O(N×M) loop 라 47ms warm 의
+    /// 66% 차지 (M4 측정). HashMap 으로 O(1) lookup.
+    ///
+    /// ECMAScript spec: 같은 exported_name 의 중복 export 는 parse-time syntax error 라
+    /// **non-star eb 의 exported_name 은 unique 보장** → caller fallback 불필요. re_export_star
+    /// (exported_name="") 는 *어떤* name 도 export 가능해 별도 path 로 처리 (caller).
+    ///
+    /// graph allocator 소유. PR-Y1 = populate 만 + caller 미사용 (dormant). PR-Y2 = caller 적용.
+    export_index_by_name: ?std.StringHashMapUnmanaged(u32) = null,
     /// Bundler-local 합성 심볼 테이블 (cross-module linking용). #1328 Phase 1.
     /// graph allocator 소유. null = 미초기화 (asset/disabled 모듈 등).
     alias_table: ?AliasTable = null,
@@ -632,6 +642,7 @@ pub const Module = struct {
         }
         self.resolved_deps.deinit(allocator);
         if (self.alias_table) |*t| t.deinit();
+        if (self.export_index_by_name) |*map| map.deinit(allocator);
         // require.context: plugin 이 채운 outer slice + 각 inner string free (#1579 Phase 2).
         // contract: plugin 이 allocator 로 dupe 한 상태로 반환 → graph 가 일괄 해제.
         for (self.import_records) |record| {

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -52,6 +52,7 @@ pub const PersistentModuleStore = struct {
         // parse_arena / alias_table 가 아직 store 에 있으면 해제.
         if (cached.module.parse_arena) |arena| Module_mod.destroyParseArena(self.allocator, arena);
         if (cached.module.alias_table) |*t| t.deinit();
+        if (cached.module.export_index_by_name) |*m| m.deinit(self.allocator);
         // dependencies/importers/dynamic_imports/dynamic_importers ArrayList 해제
         cached.module.dependencies.deinit(self.allocator);
         cached.module.importers.deinit(self.allocator);
@@ -107,6 +108,10 @@ pub const PersistentModuleStore = struct {
         module.parse_arena = null;
         module.resolve_dir = null;
         module.alias_table = null;
+        // export_index_by_name (PR-Y1) 도 alias_table 와 동일 ownership 이전 패턴 —
+        // shallow copy 라 양쪽이 같은 HashMap backing 가리킴, graph.deinit 이 free 하면
+        // store 쪽 dangling. ownership 을 store 로 이전 (graph 쪽 nullify).
+        module.export_index_by_name = null;
         module.import_records = &.{};
         module.resolved_deps = .empty;
 
@@ -120,6 +125,7 @@ pub const PersistentModuleStore = struct {
                 if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
                 if (cached_module.resolve_dir) |dir| self.allocator.free(dir);
                 if (cached_module.alias_table) |*t| t.deinit();
+                if (cached_module.export_index_by_name) |*m| m.deinit(self.allocator);
                 for (cached_module.resolved_deps.items) |dep| {
                     self.allocator.free(dep.path);
                     if (dep.resolve_dir) |dir| self.allocator.free(dir);
@@ -133,6 +139,7 @@ pub const PersistentModuleStore = struct {
                 if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
                 if (cached_module.resolve_dir) |dir| self.allocator.free(dir);
                 if (cached_module.alias_table) |*t| t.deinit();
+                if (cached_module.export_index_by_name) |*m| m.deinit(self.allocator);
                 for (cached_module.resolved_deps.items) |dep| {
                     self.allocator.free(dep.path);
                     if (dep.resolve_dir) |dir| self.allocator.free(dir);
@@ -152,6 +159,7 @@ pub const PersistentModuleStore = struct {
                 if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
                 if (cached_module.resolve_dir) |dir| self.allocator.free(dir);
                 if (cached_module.alias_table) |*t| t.deinit();
+                if (cached_module.export_index_by_name) |*m| m.deinit(self.allocator);
                 for (cached_module.resolved_deps.items) |dep| {
                     self.allocator.free(dep.path);
                     if (dep.resolve_dir) |dir| self.allocator.free(dir);


### PR DESCRIPTION
## Summary

graph_discover 최적화 epic 의 **PR-Y1** (#3592 follow-up). M4 measurement 결과 `requestedExportsForReExportRecord` 가 warm 47 ms 의 66% (lodash-es 641 module) 차지. cross-product O(N×M) loop 의 inner = `for eb in export_bindings: eql(...)`.

PR-Y1 = `Module.export_index_by_name` HashMap 자료구조 + populate 함수 추가. **caller 변경 없음 (dormant)**. PR-Y2 가 caller 를 lookup 으로 migrate.

## ECMAScript spec: non-star export unique 보장 → fallback 불필요

같은 exported_name 의 중복 export 는 parse-time syntax error. 따라서 non-star eb 의 exported_name 은 **unique** → HashMap 의 단일 idx 로 충분. **fallback linear scan 불필요**. re_export_star (exported_name="") 는 *어떤* name 도 export 가능 → idx 등록 제외.

## 변경

- `Module.export_index_by_name: ?StringHashMapUnmanaged(u32) = null` 신규 필드
- `populateExportIndexByName(m, allocator)` — non-star eb 만 등록. stale idx 회피 위해 기존 map 있으면 deinit 후 재build (resyncAfterAstMutation 안전)
- 3 call site (parser_metadata / json_module / transform_prepass) 의 computeBarrelFlags 옆에 populate 호출
- ownership: graph ↔ store 양방향 nullify (alias_table 와 동일 패턴)
  - `putModule` (graph → store): `module.export_index_by_name = null`
  - cache hit (store → graph): `cached.module.export_index_by_name = null`
- error cleanup + store deinit 3곳 + getOrPurge cleanup 의 map.deinit 추가
- **유닛 테스트 3건**: 빈 bindings / re_export_star 제외 / resync 재build (stale idx 회귀 가드)

## 영향

- caller 미사용 (dormant) → **동작 변경 없음**
- cold path populate cost ~3-6 ms 추가 (warm 영향 0)
- 회귀 0 (`zig build test --summary all` — 5349/5353 / 4 skipped)
- /simplify 3-agent review 에서 resync stale idx 버그 + 누수 회피 fix 반영

## 다음 PR-Y2

caller 3곳 변경 — `requestedExportsForReExportRecord` / `reExportRecordMatchesRequest` / `nameHasDirectNonStarExport`. cross-product O(N×M) → O(N) lookup. **47 ms warm → ~19 ms (60% 절감)** 가설 검증.

## Test plan

- [x] `zig build test --summary all` — 5349/5353 통과 / 4 skipped (회귀 0)
- [x] /simplify 3-agent review 통과 (B agent 적발 stale idx 버그 fix 반영 + 유닛 가드 3건)
- [x] dormant — caller 미사용 검증 (검색 시 export_index_by_name 의 reader 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)