### PR TITLE
feat(graph): migrate request_exports callers to index lookup (Y2)

### DIFF
--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -114,6 +114,10 @@ pub fn populateExportIndexByName(m: *Module, allocator: std.mem.Allocator) !void
 }
 
 pub fn nameHasDirectNonStarExport(m: *const Module, name: []const u8) bool {
+    // PR-Y2: index 가 있으면 O(1) lookup. map 은 non-star eb 만 포함하므로 hit 자체가
+    // "non-star export 존재" 증거. populate 안 된 edge (test fixture / asset module) 만
+    // linear fallback.
+    if (m.export_index_by_name) |map| return map.contains(name);
     for (m.export_bindings) |eb| {
         if (eb.kind == .re_export_star) continue;
         if (std.mem.eql(u8, eb.exported_name, name)) return true;
@@ -182,36 +186,64 @@ pub fn requestedExportsForReExportRecord(
     }
     self.requested_exports_mutex.unlock();
     if (request_all) return requestAll(self, dep_idx);
+    // requested_names 가 비어 있으면 outer 진입 자체가 no-op — star 캐시 계산 회피.
+    if (requested_names.items.len == 0) return changed;
+
+    // PR-Y2: 기존 cross-product O(N×M) 를 O(N) 으로. ECMAScript spec 의 non-star unique
+    // 보장으로 (name → idx) HashMap lookup 1회 (M4 결과: 47ms warm 의 66% 차지하는 inner
+    // loop). re_export_star 의 rec_i 매치는 outer 진입 전 1회 캐싱 후 outer 마다 boolean.
+    const has_star_for_rec = blk: {
+        for (importer.export_bindings) |eb| {
+            if (eb.kind != .re_export_star) continue;
+            const eb_rec = eb.import_record_index orelse continue;
+            if (eb_rec == rec_i) break :blk true;
+        }
+        break :blk false;
+    };
 
     for (requested_names.items) |requested_name| {
-        for (importer.export_bindings) |eb| {
-            const eb_rec = eb.import_record_index orelse continue;
-            if (eb_rec != rec_i) continue;
-            switch (eb.kind) {
-                .re_export => {
-                    if (std.mem.eql(u8, eb.exported_name, requested_name)) {
-                        changed = (try requestNamed(self, dep_idx, eb.local_name)) or changed;
+        // Non-star match: 단일 idx lookup. populate 안 된 edge 는 fallback linear.
+        if (importer.export_index_by_name) |map| {
+            if (map.get(requested_name)) |eb_idx| {
+                const eb = importer.export_bindings[eb_idx];
+                if (eb.import_record_index) |eb_rec| {
+                    if (eb_rec == rec_i) {
+                        switch (eb.kind) {
+                            .re_export => {
+                                changed = (try requestNamed(self, dep_idx, eb.local_name)) or changed;
+                            },
+                            .re_export_namespace => {
+                                return (try requestAll(self, dep_idx)) or changed;
+                            },
+                            .local => {},
+                            // map 은 non-star 만 포함 → 도달 불가.
+                            .re_export_star => unreachable,
+                        }
                     }
-                },
-                // namespace / star re-export 는 dep 전체를 요청한다 — 한 번 `.all` 이 되면
-                // 이후 requested_name 들의 작업은 전부 no-op 이므로 즉시 반환.
-                .re_export_namespace => {
-                    if (std.mem.eql(u8, eb.exported_name, requested_name)) {
-                        return (try requestAll(self, dep_idx)) or changed;
-                    }
-                },
-                .re_export_star => {
-                    // `export * from "./X"` 는 어느 source 가 이 이름을 제공하는지 정적으로
-                    // 알 수 없다 — 후보 source 의 namespace 전체를 요청해야 한다. 그러지
-                    // 않으면 X 가 이 이름을 안 가졌을 때 X 의 import record 가 deferred 인
-                    // 채로 (wrapped barrel 의 `init_*` 로 도달 가능해) 번들에 남아 raw
-                    // `require()` 가 출력된다 (#3136).
-                    if (!nameHasDirectNonStarExport(importer, requested_name)) {
-                        return (try requestAll(self, dep_idx)) or changed;
-                    }
-                },
-                .local => {},
+                }
             }
+        } else {
+            for (importer.export_bindings) |eb| {
+                if (eb.kind == .re_export_star) continue;
+                const eb_rec = eb.import_record_index orelse continue;
+                if (eb_rec != rec_i) continue;
+                if (!std.mem.eql(u8, eb.exported_name, requested_name)) continue;
+                switch (eb.kind) {
+                    .re_export => {
+                        changed = (try requestNamed(self, dep_idx, eb.local_name)) or changed;
+                    },
+                    .re_export_namespace => {
+                        return (try requestAll(self, dep_idx)) or changed;
+                    },
+                    .local, .re_export_star => {},
+                }
+            }
+        }
+
+        // Star match: `export * from "./X"` 는 어느 source 가 이 이름을 제공하는지 정적으로
+        // 알 수 없다 — name 이 non-star 로 직접 export 가 없으면 dep 전체 요청 (#3136).
+        if (has_star_for_rec and !nameHasDirectNonStarExport(importer, requested_name)) {
+            return (try requestAll(self, dep_idx)) or changed;
         }
     }
     return changed;
@@ -259,23 +291,45 @@ pub fn requestDependencyExports(
 
 pub fn reExportRecordMatchesRequest(m: *const Module, rec_i: usize, req: *const RequestedExports) bool {
     if (req.all) return true;
+    if (req.names.count() == 0) return false;
+    // PR-Y2: requestedExportsForReExportRecord 와 동일 패턴 — index lookup O(1) + star check.
+    const has_star_for_rec = blk: {
+        for (m.export_bindings) |eb| {
+            if (eb.kind != .re_export_star) continue;
+            const eb_rec = eb.import_record_index orelse continue;
+            if (eb_rec == rec_i) break :blk true;
+        }
+        break :blk false;
+    };
+
     var names = req.names.keyIterator();
     while (names.next()) |requested_name| {
-        for (m.export_bindings) |eb| {
-            const eb_rec = eb.import_record_index orelse continue;
-            if (eb_rec != rec_i) continue;
-            switch (eb.kind) {
-                .re_export,
-                .re_export_namespace,
-                => {
-                    if (std.mem.eql(u8, eb.exported_name, requested_name.*)) return true;
-                },
-                .re_export_star => {
-                    if (!nameHasDirectNonStarExport(m, requested_name.*)) return true;
-                },
-                .local => {},
+        if (m.export_index_by_name) |map| {
+            if (map.get(requested_name.*)) |eb_idx| {
+                const eb = m.export_bindings[eb_idx];
+                if (eb.import_record_index) |eb_rec| {
+                    if (eb_rec == rec_i) {
+                        switch (eb.kind) {
+                            .re_export, .re_export_namespace => return true,
+                            .local => {},
+                            .re_export_star => unreachable,
+                        }
+                    }
+                }
+            }
+        } else {
+            for (m.export_bindings) |eb| {
+                if (eb.kind == .re_export_star) continue;
+                const eb_rec = eb.import_record_index orelse continue;
+                if (eb_rec != rec_i) continue;
+                if (!std.mem.eql(u8, eb.exported_name, requested_name.*)) continue;
+                switch (eb.kind) {
+                    .re_export, .re_export_namespace => return true,
+                    .local, .re_export_star => {},
+                }
             }
         }
+        if (has_star_for_rec and !nameHasDirectNonStarExport(m, requested_name.*)) return true;
     }
     return false;
 }


### PR DESCRIPTION
## Summary

graph_discover 최적화 epic 의 **PR-Y2** (#3593 follow-up). PR-Y1 의 dormant `export_index_by_name` 을 caller 3 함수가 활용. cross-product O(N×M) → O(N) lookup.

## 변경

`requested_exports.zig` 의 3 caller:

1. **`nameHasDirectNonStarExport(m, name)`**: index 있으면 `map.contains(name)` O(1). map 이 non-star eb 만 포함 → hit = 직접 non-star export 존재. populate 안 된 edge 는 fallback linear.

2. **`requestedExportsForReExportRecord(self, importer, rec_i, dep_idx)`**: outer 진입 전 1회 `has_star_for_rec` 캐싱 — star 매치 outer×inner cross-product 회피. inner non-star lookup: `map.get(name)` 후 rec_i + kind switch. `re_export_star` arm 은 unreachable. star 처리: outer 마다 boolean.

3. **`reExportRecordMatchesRequest(m, rec_i, req)`**: 동일 패턴 (read-only bool).

**ECMAScript spec 의 non-star unique 보장으로 multi-match fallback 불필요.**

## 측정 결과 — lodash-es 641 module

| 항목 | M0~M4 baseline | PR-Y2 | 절감 |
|---|---|---|---|
| warm null  | 47.3 ms | **34.3 ms** | **27%** |
| warm empty | 47.0 ms | 32.4 ms | 31% |
| request_exports | 34.7 ms | 21.6 ms | 38% |
| **re_export 분기** | 31.2 ms | **18.2 ms** | **42%** |

가설 (60% 절감) 미달이지만 ROI 30% 임계 초과 → 채택 정당. 잔여 18.2 ms 는 `requestNamed`/`requestAll` 호출 자체 (mutex + HashMap put) — 알고리즘 개선 불가 영역.

## 영향

- 회귀 0 (`zig build test --summary all` — 5351/5356 / 4 skipped)
- /simplify 3-agent review 통과 — 잠재 엣지 검증 + 미세 fix `requested_names.len==0` 가드
- cold path: populate 비용 ~3-6 ms (PR-Y1 누적)

## 다음 단계

epic close — 진짜 dominant 격리 + 27% warm 절감 달성. 잔여 18.2 ms 의 `requestNamed`/`requestAll` mutex/HashMap 비용은 별도 큰 epic (graph 전체 lock-free 변환) 필요 — XL ROI, deferred.

## Test plan

- [x] `zig build test --summary all` — 5351/5356 통과 / 4 skipped (Y1 baseline 동일)
- [x] /simplify 3-agent review 통과
- [x] warm null 47.3 ms → 34.3 ms 실측 (27% 절감)

🤖 Generated with [Claude Code](https://claude.com/claude-code)