### PR TITLE
chore(profile): re_export entry 3-way decomposition (M7)

### DIFF
--- a/src/bundler/bundler_test/incremental_bench_v4.zig
+++ b/src/bundler/bundler_test/incremental_bench_v4.zig
@@ -54,6 +54,9 @@ const WarmResult = struct {
     incr_req_inner_contains_ns: u64,
     incr_req_inner_put_ns: u64,
     incr_re_export_entry_ns: u64,
+    incr_re_export_entry_get_ns: u64,
+    incr_re_export_entry_copy_ns: u64,
+    incr_re_export_entry_star_scan_ns: u64,
     incr_re_export_outer_ns: u64,
     incr_miss_resolve_ns: u64,
 };
@@ -107,6 +110,9 @@ fn measureWarm(allocator: std.mem.Allocator, store: *PersistentModuleStore, entr
         .incr_req_inner_contains_ns = profile.totalNs(.graph_discover_incr_req_inner_contains),
         .incr_req_inner_put_ns = profile.totalNs(.graph_discover_incr_req_inner_put),
         .incr_re_export_entry_ns = profile.totalNs(.graph_discover_incr_re_export_entry),
+        .incr_re_export_entry_get_ns = profile.totalNs(.graph_discover_incr_re_export_entry_get),
+        .incr_re_export_entry_copy_ns = profile.totalNs(.graph_discover_incr_re_export_entry_copy),
+        .incr_re_export_entry_star_scan_ns = profile.totalNs(.graph_discover_incr_re_export_entry_star_scan),
         .incr_re_export_outer_ns = profile.totalNs(.graph_discover_incr_re_export_outer),
         .incr_miss_resolve_ns = profile.totalNs(.graph_discover_incr_miss_resolve),
     };
@@ -165,6 +171,9 @@ fn printSubPhase(label: []const u8, r: WarmResult) void {
         \\      inner_put     = {d:>7}us ({d:>3}%)
         \\    re_export caller side (us, % of re_export):
         \\      entry         = {d:>7}us ({d:>3}%)
+        \\        get         = {d:>7}us ({d:>3}% of entry)
+        \\        copy        = {d:>7}us ({d:>3}% of entry)
+        \\        star_scan   = {d:>7}us ({d:>3}% of entry)
         \\      outer_loop    = {d:>7}us ({d:>3}%)
         \\
     , .{
@@ -184,6 +193,12 @@ fn printSubPhase(label: []const u8, r: WarmResult) void {
         if (req == 0) @as(u64, 0) else r.incr_req_inner_put_ns * 100 / req,
         r.incr_re_export_entry_ns / 1000,
         if (r.incr_req_re_export_ns == 0) @as(u64, 0) else r.incr_re_export_entry_ns * 100 / r.incr_req_re_export_ns,
+        r.incr_re_export_entry_get_ns / 1000,
+        if (r.incr_re_export_entry_ns == 0) @as(u64, 0) else r.incr_re_export_entry_get_ns * 100 / r.incr_re_export_entry_ns,
+        r.incr_re_export_entry_copy_ns / 1000,
+        if (r.incr_re_export_entry_ns == 0) @as(u64, 0) else r.incr_re_export_entry_copy_ns * 100 / r.incr_re_export_entry_ns,
+        r.incr_re_export_entry_star_scan_ns / 1000,
+        if (r.incr_re_export_entry_ns == 0) @as(u64, 0) else r.incr_re_export_entry_star_scan_ns * 100 / r.incr_re_export_entry_ns,
         r.incr_re_export_outer_ns / 1000,
         if (r.incr_req_re_export_ns == 0) @as(u64, 0) else r.incr_re_export_outer_ns * 100 / r.incr_req_re_export_ns,
     });
@@ -213,6 +228,9 @@ test "incremental bench v4: changed_files null/empty/single comparison" {
         "graph_discover_incr_req_inner_contains",
         "graph_discover_incr_req_inner_put",
         "graph_discover_incr_re_export_entry",
+        "graph_discover_incr_re_export_entry_get",
+        "graph_discover_incr_re_export_entry_copy",
+        "graph_discover_incr_re_export_entry_star_scan",
         "graph_discover_incr_re_export_outer",
         "graph_discover_incr_miss_resolve",
     });

--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -202,10 +202,14 @@ pub fn requestedExportsForReExportRecord(
     var overflowed = false;
 
     self.requested_exports_mutex.lock();
+    var s_get = profile.begin(.graph_discover_incr_re_export_entry_get);
     const maybe_req = self.requested_exports.get(importer_key);
+    s_get.end();
     const request_all = if (maybe_req) |req| req.all else true;
     if (!request_all) {
         if (maybe_req) |req| {
+            var s_copy = profile.begin(.graph_discover_incr_re_export_entry_copy);
+            defer s_copy.end();
             var it = req.names.keyIterator();
             while (it.next()) |name| {
                 if (!overflowed) {
@@ -245,6 +249,7 @@ pub fn requestedExportsForReExportRecord(
     // PR-Y2: 기존 cross-product O(N×M) 를 O(N) 으로. ECMAScript spec 의 non-star unique
     // 보장으로 (name → idx) HashMap lookup 1회 (M4 결과: 47ms warm 의 66% 차지하는 inner
     // loop). re_export_star 의 rec_i 매치는 outer 진입 전 1회 캐싱 후 outer 마다 boolean.
+    var s_star = profile.begin(.graph_discover_incr_re_export_entry_star_scan);
     const has_star_for_rec = blk: {
         for (importer.export_bindings) |eb| {
             if (eb.kind != .re_export_star) continue;
@@ -253,6 +258,7 @@ pub fn requestedExportsForReExportRecord(
         }
         break :blk false;
     };
+    s_star.end();
     s_entry.end();
 
     var s_outer = profile.begin(.graph_discover_incr_re_export_outer);

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -175,6 +175,10 @@ pub const Category = enum {
     // (caller) 의 진짜 dominant 찾기. entry setup (requested_names 복사 + has_star scan) 와
     // outer loop body (per-name lookup + branch) 분리.
     graph_discover_incr_re_export_entry, // 함수 진입 시 setup (requested_names 복사 + star scan)
+    // entry 내부 3-way (PR-M7). Z1 후 entry 5.6ms 의 진짜 dominant 식별.
+    graph_discover_incr_re_export_entry_get, // requested_exports.get (outer HashMap lookup)
+    graph_discover_incr_re_export_entry_copy, // names.keyIterator + stack/heap append (Z1 buffer)
+    graph_discover_incr_re_export_entry_star_scan, // has_star_for_rec scan (export_bindings 순회)
     graph_discover_incr_re_export_outer, // outer loop body (per-name index lookup + branch)
     graph_discover_incr_miss_resolve, // 미스 분기: resolveModuleImports (대칭 측정용)
     graph_finalize,
@@ -669,6 +673,7 @@ pub fn count(cat: Category) u32 {
 
 /// 지정한 format 으로 리포트 출력.
 pub fn report(writer: anytype, format: Format) !void {
+    @setEvalBranchQuota(20000);
     switch (format) {
         .table => try reportTable(writer),
         .tree => try reportTree(writer),


### PR DESCRIPTION
## Summary

graph_discover 잔여 epic 의 **PR-M7**. #3597 Z1 후 entry 5.6 ms 의 dominant 식별.

## 신규 카테고리 3개

- `re_export_entry_get` — `requested_exports.get` (outer HashMap lookup)
- `re_export_entry_copy` — `names.keyIterator` + stack/heap append
- `re_export_entry_star_scan` — `has_star_for_rec` scan

## 측정 결과

re_export entry 5.88 ms 분해 (lodash-es 641 module warm null):

| Sub-step | µs | % of entry |
|---|---|---|
| **copy** | **5,399** | **91%** |
| star_scan | 279 | 4% |
| get | 75 | 1% |

→ **copy 5.4 ms = 19,230 iters × 280 ns/iter**. measurement overhead 일부 포함 — 실제 copy 비용 ~2-3 ms 추정.

## 기타 fix

- `profile.report` 의 `@setEvalBranchQuota(20000)` — 카테고리 누적 증가

## Test plan

- [x] `zig build test --summary all` — 5352/5356 통과 / 4 skipped
- [x] warm null 26.1 ms baseline 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)