### PR TITLE
feat(graph): RequestedExports.names HashMap → flat array (Z2)

### DIFF
--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -26,7 +26,7 @@ pub fn requestAll(self: anytype, idx: ModuleIndex) !bool {
     }
     if (gop.value_ptr.all) return false;
     gop.value_ptr.names.deinit(self.allocator);
-    gop.value_ptr.names = .{};
+    gop.value_ptr.names = .empty;
     gop.value_ptr.all = true;
     return true;
 }
@@ -51,12 +51,12 @@ pub fn requestNamed(self: anytype, idx: ModuleIndex, name: []const u8) !bool {
     }
     if (gop.value_ptr.all) return false;
     var s_ic = profile.begin(.graph_discover_incr_req_inner_contains);
-    const already = gop.value_ptr.names.contains(name);
+    const already = gop.value_ptr.contains(name);
     s_ic.end();
     if (already) return false;
     var s_ip = profile.begin(.graph_discover_incr_req_inner_put);
     defer s_ip.end();
-    try gop.value_ptr.names.put(self.allocator, name, {});
+    try gop.value_ptr.names.append(self.allocator, name);
     return true;
 }
 
@@ -210,27 +210,19 @@ pub fn requestedExportsForReExportRecord(
         if (maybe_req) |req| {
             var s_copy = profile.begin(.graph_discover_incr_re_export_entry_copy);
             defer s_copy.end();
-            var it = req.names.keyIterator();
-            while (it.next()) |name| {
-                if (!overflowed) {
-                    if (stack_len < REQUESTED_NAMES_STACK_CAP) {
-                        stack_buf[stack_len] = name.*;
-                        stack_len += 1;
-                        continue;
-                    }
-                    // 첫 overflow: 누적된 32 개를 heap 으로 일괄 복사 후 분기 전환.
-                    heap_buf.appendSlice(self.allocator, stack_buf[0..REQUESTED_NAMES_STACK_CAP]) catch {
-                        self.requested_exports_mutex.unlock();
-                        s_entry.end();
-                        return error.OutOfMemory;
-                    };
-                    overflowed = true;
-                }
-                heap_buf.append(self.allocator, name.*) catch {
+            // PR-Z2: flat array iter — HashMap.keyIterator 의 bucket scan 회피.
+            // 작은 batch (≤ 32) 는 stack-only @memcpy, overflow 시 heap spillover.
+            const src = req.names.items;
+            if (src.len <= REQUESTED_NAMES_STACK_CAP) {
+                @memcpy(stack_buf[0..src.len], src);
+                stack_len = src.len;
+            } else {
+                heap_buf.appendSlice(self.allocator, src) catch {
                     self.requested_exports_mutex.unlock();
                     s_entry.end();
                     return error.OutOfMemory;
                 };
+                overflowed = true;
             }
         }
     }
@@ -353,7 +345,7 @@ pub fn requestDependencyExports(
 
 pub fn reExportRecordMatchesRequest(m: *const Module, rec_i: usize, req: *const RequestedExports) bool {
     if (req.all) return true;
-    if (req.names.count() == 0) return false;
+    if (req.names.items.len == 0) return false;
     // PR-Y2: requestedExportsForReExportRecord 와 동일 패턴 — index lookup O(1) + star check.
     const has_star_for_rec = blk: {
         for (m.export_bindings) |eb| {
@@ -364,10 +356,9 @@ pub fn reExportRecordMatchesRequest(m: *const Module, rec_i: usize, req: *const 
         break :blk false;
     };
 
-    var names = req.names.keyIterator();
-    while (names.next()) |requested_name| {
+    for (req.names.items) |requested_name| {
         if (m.export_index_by_name) |map| {
-            if (map.get(requested_name.*)) |eb_idx| {
+            if (map.get(requested_name)) |eb_idx| {
                 const eb = m.export_bindings[eb_idx];
                 if (eb.import_record_index) |eb_rec| {
                     if (eb_rec == rec_i) {
@@ -384,14 +375,14 @@ pub fn reExportRecordMatchesRequest(m: *const Module, rec_i: usize, req: *const 
                 if (eb.kind == .re_export_star) continue;
                 const eb_rec = eb.import_record_index orelse continue;
                 if (eb_rec != rec_i) continue;
-                if (!std.mem.eql(u8, eb.exported_name, requested_name.*)) continue;
+                if (!std.mem.eql(u8, eb.exported_name, requested_name)) continue;
                 switch (eb.kind) {
                     .re_export, .re_export_namespace => return true,
                     .local, .re_export_star => {},
                 }
             }
         }
-        if (has_star_for_rec and !nameHasDirectNonStarExport(m, requested_name.*)) return true;
+        if (has_star_for_rec and !nameHasDirectNonStarExport(m, requested_name)) return true;
     }
     return false;
 }

--- a/src/bundler/graph/state.zig
+++ b/src/bundler/graph/state.zig
@@ -19,10 +19,21 @@ pub const WorkerEntry = struct {
 
 pub const RequestedExports = struct {
     all: bool = false,
-    names: std.StringHashMapUnmanaged(void) = .{},
+    /// PR-Z2: flat array (≈10 평균 names) — HashMap 의 keyIterator bucket scan 보다 빠름.
+    /// M7 측정에서 caller copy 가 entry 의 91% (5.4ms). flat array iter 는 contiguous
+    /// memcpy + cache locality 로 ~50% 절감 가설.
+    names: std.ArrayListUnmanaged([]const u8) = .empty,
 
     pub fn deinit(self: *RequestedExports, allocator: std.mem.Allocator) void {
         self.names.deinit(allocator);
+    }
+
+    /// O(N) linear scan — N 평균 ~10. HashMap.contains 보다 cache locality 이득.
+    pub fn contains(self: *const RequestedExports, name: []const u8) bool {
+        for (self.names.items) |n| {
+            if (std.mem.eql(u8, n, name)) return true;
+        }
+        return false;
     }
 };
 


### PR DESCRIPTION
## Summary

graph_discover 잔여 epic 의 **PR-Z2**. #3598 M7 측정 결과 re_export entry 5.6 ms 의 91% (5.4 ms) 가 `req.names.keyIterator + stack/heap copy`. StringHashMap → ArrayList 로 교체.

## 변경

`RequestedExports.names: StringHashMapUnmanaged(void)` → `ArrayListUnmanaged([]const u8)`.

- `contains` method 추가 (O(N) linear scan, N≈10 unique 보장)
- `requestNamed`: contains O(1) → O(N) but N 작아 cache locality 이득
- `requestedExportsForReExportRecord`: keyIterator while → `@memcpy` contiguous copy
- `reExportRecordMatchesRequest`: keyIterator → for items

ECMAScript spec: import 마다 name unique → contains 후 append 로 duplicate 회피.

## 측정 결과

| 측정 | M0 | Z1 | **Z2** | 누적 절감 |
|---|---|---|---|---|
| **warm null** | **47.3 ms** | 26.1 ms | **22.3 ms** | **53%** |
| re_export | 18.3 ms | 10.0 ms | 6.0 ms | 67% |
| request_exports | 22.4 ms | 14.9 ms | 9.9 ms | 56% |

Z2 추가 절감 3.8 ms (warm 26.1 → 22.3). re_export 추가 4 ms (10 → 6).

## Test plan

- [x] `zig build test --summary all` — 5351/5356 통과 / 4 skipped (Z1 baseline 동일)
- [x] /simplify 3-agent review 통과 (fix 0건)
- [x] renumber.zig + lifecycle.zig 의 RequestedExports 의존성 변경 불요 확인

## 다음

누적 53% 절감 달성. 잔여 22 ms = mtime(1.5 ms) + replay(20 ms 분산) + finalize. ROI 30% 임계 영역 거의 소진.

🤖 Generated with [Claude Code](https://claude.com/claude-code)