### PR TITLE
chore(profile): record_dep + add_module internal decomposition (M8)

### DIFF
--- a/src/bundler/bundler_test/incremental_bench_v4.zig
+++ b/src/bundler/bundler_test/incremental_bench_v4.zig
@@ -58,6 +58,12 @@ const WarmResult = struct {
     incr_re_export_entry_copy_ns: u64,
     incr_re_export_entry_star_scan_ns: u64,
     incr_re_export_outer_ns: u64,
+    incr_record_dep_rec_write_ns: u64,
+    incr_record_dep_link_ns: u64,
+    incr_add_module_dedup_ns: u64,
+    incr_add_module_alloc_ns: u64,
+    incr_add_module_put_ns: u64,
+    incr_add_module_preopen_ns: u64,
     incr_miss_resolve_ns: u64,
 };
 
@@ -114,6 +120,12 @@ fn measureWarm(allocator: std.mem.Allocator, store: *PersistentModuleStore, entr
         .incr_re_export_entry_copy_ns = profile.totalNs(.graph_discover_incr_re_export_entry_copy),
         .incr_re_export_entry_star_scan_ns = profile.totalNs(.graph_discover_incr_re_export_entry_star_scan),
         .incr_re_export_outer_ns = profile.totalNs(.graph_discover_incr_re_export_outer),
+        .incr_record_dep_rec_write_ns = profile.totalNs(.graph_discover_incr_record_dep_rec_write),
+        .incr_record_dep_link_ns = profile.totalNs(.graph_discover_incr_record_dep_link),
+        .incr_add_module_dedup_ns = profile.totalNs(.graph_discover_incr_add_module_dedup),
+        .incr_add_module_alloc_ns = profile.totalNs(.graph_discover_incr_add_module_alloc),
+        .incr_add_module_put_ns = profile.totalNs(.graph_discover_incr_add_module_put),
+        .incr_add_module_preopen_ns = profile.totalNs(.graph_discover_incr_add_module_preopen),
         .incr_miss_resolve_ns = profile.totalNs(.graph_discover_incr_miss_resolve),
     };
 }
@@ -202,6 +214,32 @@ fn printSubPhase(label: []const u8, r: WarmResult) void {
         r.incr_re_export_outer_ns / 1000,
         if (r.incr_req_re_export_ns == 0) @as(u64, 0) else r.incr_re_export_outer_ns * 100 / r.incr_req_re_export_ns,
     });
+    const rec_dep = r.incr_record_dep_rec_write_ns + r.incr_record_dep_link_ns;
+    const add_mod = r.incr_add_module_dedup_ns + r.incr_add_module_alloc_ns + r.incr_add_module_put_ns + r.incr_add_module_preopen_ns;
+    std.debug.print(
+        \\    record_dep breakdown (us, % of record_dep):
+        \\      rec_write     = {d:>7}us ({d:>3}%)
+        \\      link          = {d:>7}us ({d:>3}%)
+        \\    add_module breakdown (us, % of add_module):
+        \\      dedup         = {d:>7}us ({d:>3}%)
+        \\      alloc         = {d:>7}us ({d:>3}%)
+        \\      put           = {d:>7}us ({d:>3}%)
+        \\      preopen       = {d:>7}us ({d:>3}%)
+        \\
+    , .{
+        r.incr_record_dep_rec_write_ns / 1000,
+        if (rec_dep == 0) @as(u64, 0) else r.incr_record_dep_rec_write_ns * 100 / rec_dep,
+        r.incr_record_dep_link_ns / 1000,
+        if (rec_dep == 0) @as(u64, 0) else r.incr_record_dep_link_ns * 100 / rec_dep,
+        r.incr_add_module_dedup_ns / 1000,
+        if (add_mod == 0) @as(u64, 0) else r.incr_add_module_dedup_ns * 100 / add_mod,
+        r.incr_add_module_alloc_ns / 1000,
+        if (add_mod == 0) @as(u64, 0) else r.incr_add_module_alloc_ns * 100 / add_mod,
+        r.incr_add_module_put_ns / 1000,
+        if (add_mod == 0) @as(u64, 0) else r.incr_add_module_put_ns * 100 / add_mod,
+        r.incr_add_module_preopen_ns / 1000,
+        if (add_mod == 0) @as(u64, 0) else r.incr_add_module_preopen_ns * 100 / add_mod,
+    });
 }
 
 test "incremental bench v4: changed_files null/empty/single comparison" {
@@ -232,6 +270,12 @@ test "incremental bench v4: changed_files null/empty/single comparison" {
         "graph_discover_incr_re_export_entry_copy",
         "graph_discover_incr_re_export_entry_star_scan",
         "graph_discover_incr_re_export_outer",
+        "graph_discover_incr_record_dep_rec_write",
+        "graph_discover_incr_record_dep_link",
+        "graph_discover_incr_add_module_dedup",
+        "graph_discover_incr_add_module_alloc",
+        "graph_discover_incr_add_module_put",
+        "graph_discover_incr_add_module_preopen",
         "graph_discover_incr_miss_resolve",
     });
 

--- a/src/bundler/graph/module_registry.zig
+++ b/src/bundler/graph/module_registry.zig
@@ -11,6 +11,7 @@ const Module = module_mod.Module;
 const plugin_mod = @import("../plugin.zig");
 const graph_parse_helpers = @import("parse_helpers.zig");
 const moduleTypeForLoader = graph_parse_helpers.moduleTypeForLoader;
+const profile = @import("../../profile.zig");
 
 /// 확장자에 대한 로더를 결정한다.
 /// --loader 오버라이드가 있으면 우선 사용, 없으면 확장자 기본값.
@@ -75,7 +76,10 @@ pub fn addModule(self: *ModuleGraph, abs_path: []const u8) !ModuleIndex {
 
 pub fn addModuleWithResolveDir(self: *ModuleGraph, abs_path: []const u8, resolve_dir: ?[]const u8) !ModuleIndex {
     // 중복 체크
-    if (self.path_to_module.get(abs_path)) |existing| {
+    var s_dedup = profile.begin(.graph_discover_incr_add_module_dedup);
+    const existing_opt = self.path_to_module.get(abs_path);
+    s_dedup.end();
+    if (existing_opt) |existing| {
         if (resolve_dir) |dir| {
             const existing_module = self.modules.at(@intFromEnum(existing));
             if (existing_module.resolve_dir == null) {
@@ -86,6 +90,7 @@ pub fn addModuleWithResolveDir(self: *ModuleGraph, abs_path: []const u8, resolve
     }
 
     // 새 모듈 슬롯 할당
+    var s_alloc = profile.begin(.graph_discover_incr_add_module_alloc);
     const index: ModuleIndex = @enumFromInt(@as(u32, @intCast(self.modules.count())));
     var ownership_transferred = false;
     const path_owned = try self.allocator.dupe(u8, abs_path);
@@ -101,14 +106,20 @@ pub fn addModuleWithResolveDir(self: *ModuleGraph, abs_path: []const u8, resolve
     const parsed_loader = resolveLoader(self, ext_for_loader);
     module.loader = parsed_loader.loader;
     module.module_type = parsed_loader.module_type orelse moduleTypeForLoader(module.module_type, module.loader);
+    s_alloc.end();
+
+    var s_put = profile.begin(.graph_discover_incr_add_module_put);
     try self.modules.append(self.allocator, module);
     ownership_transferred = true;
     try self.path_to_module.put(path_owned, index);
+    s_put.end();
 
     // 신규 모듈 path 의 dir 를 source_read_cache 에 pre-warm — readModuleSource 단계의
     // dir-fd cache MISS (avg 70μs) 를 graph BFS 시점에 미리 처리. virtual path
     // (disabled / optional missing 등) 는 disabled_path 전용 함수에서 처리되므로
     // 여기 들어오는 abs_path 는 fs file path. openDir 실패는 preopenDir 가 swallow.
+    var s_pre = profile.begin(.graph_discover_incr_add_module_preopen);
+    defer s_pre.end();
     if (std.fs.path.dirname(abs_path)) |dir_path| {
         self.source_read_cache.preopenDir(self.allocator, dir_path);
     }

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -203,9 +203,13 @@ fn recordResolvedDep(
     dep_idx: ModuleIndex,
     kind: types.ImportKind,
 ) !void {
+    var s_rw = profile.begin(.graph_discover_incr_record_dep_rec_write);
     const src_mod = self.modules.at(mod_idx);
     src_mod.import_records[rec_i].resolved = dep_idx;
     src_mod.import_records[rec_i].is_lazy_resolved = false;
+    s_rw.end();
+    var s_lk = profile.begin(.graph_discover_incr_record_dep_link);
+    defer s_lk.end();
     if (kind == .dynamic_import) {
         try self.linkDynamicImport(mod_index, dep_idx);
     } else {

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -180,6 +180,15 @@ pub const Category = enum {
     graph_discover_incr_re_export_entry_copy, // names.keyIterator + stack/heap append (Z1 buffer)
     graph_discover_incr_re_export_entry_star_scan, // has_star_for_rec scan (export_bindings 순회)
     graph_discover_incr_re_export_outer, // outer loop body (per-name index lookup + branch)
+    // record_dep + add_module 내부 분해 (PR-M8). Z2 후 잔여 22ms 의 다음 후보:
+    // record_dep 5.7ms (linkDep 양방향 append + import_records write)
+    // add_module 4.3ms (path_to_module.get + alloc + dup + put + preopenDir)
+    graph_discover_incr_record_dep_rec_write, // import_records[rec_i].resolved = dep_idx (single store)
+    graph_discover_incr_record_dep_link, // linkDependency/linkDynamicImport (양방향 ArrayList append)
+    graph_discover_incr_add_module_dedup, // path_to_module.get(abs_path) — dedup 분기
+    graph_discover_incr_add_module_alloc, // Module.init + path/dir dupe + slot alloc
+    graph_discover_incr_add_module_put, // path_to_module.put + modules.append
+    graph_discover_incr_add_module_preopen, // source_read_cache.preopenDir
     graph_discover_incr_miss_resolve, // 미스 분기: resolveModuleImports (대칭 측정용)
     graph_finalize,
     graph_renumber,


### PR DESCRIPTION
## Summary

graph_discover 잔여 epic 의 **PR-M8**. Z2 후 잔여 22 ms 의 `record_dep` (5.7 ms) + `add_module` (4.3 ms) 의 진짜 dominant 식별.

## 측정 결과

### record_dep 5.9 ms

| Sub-step | µs | % |
|---|---|---|
| **link** | **5,548** | **98%** ← 4 ArrayList append × 1923 dep |
| rec_write | 86 | 1% |

### add_module 4.5 ms

| Sub-step | µs | % |
|---|---|---|
| **alloc** | **3,061** | **69%** ← path/dir dupe × 2 + Module.init |
| put | 563 | 12% |
| dedup | 493 | 11% |
| preopen | 277 | 6% |

## 결론 + 가능한 PR

진짜 dominant 2개:
1. **`record_dep link` 5.5 ms** — `from.dependencies` + `to.importers` ArrayList grow
2. **`add_module alloc` 3.1 ms** — `allocator.dupe(path)` × 2

- **Z3 link ensureCapacity(8)** in Module.init → grow 회수 1/N, ROI ~1-2 ms
- **Z4 path arena** in graph allocator → dupe 비용 cheap, ROI ~1-2 ms

## Test plan

- [x] `zig build test --summary all` — 5352/5356 통과 / 4 skipped (Z2 baseline 동일)
- [x] warm null 22.3 ms baseline 동일 (M8 측정 overhead 무시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)