### PR TITLE
feat(graph): path arena allocator for module paths (Z4)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -74,6 +74,10 @@ pub const ModuleGraph = struct {
     const isPackageTypeModule = graph_package_info.isPackageTypeModule;
 
     allocator: std.mem.Allocator,
+    /// PR-Z4: Module path/resolve_dir 전용 arena. M8 측정에서 add_module alloc 의
+    /// 69% (3.1ms) 가 path/dir dupe. arena 로 alloc 비용 cheap + graph deinit 시 일괄
+    /// 해제 (path_to_module key free loop 회피).
+    path_arena: std.heap.ArenaAllocator,
     /// Module storage. SegmentedList 는 append 시에도 기존 포인터를 무효화하지
     /// 않아서 worker race-safety 를 보장한다 (#1779 PR #3). prealloc=0 은 전량
     /// heap chunk — Module 이 수백 바이트라 stack pre-alloc 비효율.

--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -11,6 +11,7 @@ const ResolveCache = resolve_cache_mod.ResolveCache;
 pub fn init(allocator: std.mem.Allocator, resolve_cache: *ResolveCache) ModuleGraph {
     return .{
         .allocator = allocator,
+        .path_arena = std.heap.ArenaAllocator.init(allocator),
         // modules 는 default (.{}) 로 빈 SegmentedList.
         .path_to_module = std.StringHashMap(ModuleIndex).init(allocator),
         .diagnostics = .empty,
@@ -26,11 +27,9 @@ pub fn deinit(self: *ModuleGraph) void {
         m.deinit(self.allocator); // parse_arena.deinit() + dependencies/importers 해제
     }
     self.modules.deinit(self.allocator);
-    var key_it = self.path_to_module.keyIterator();
-    while (key_it.next()) |key| {
-        self.allocator.free(key.*);
-    }
+    // PR-Z4: path_to_module key 메모리는 path_arena 가 owned — 개별 free 불요, 일괄 해제.
     self.path_to_module.deinit();
+    self.path_arena.deinit();
     var req_it = self.requested_exports.valueIterator();
     while (req_it.next()) |req| req.deinit(self.allocator);
     self.requested_exports.deinit(self.allocator);

--- a/src/bundler/graph/module_registry.zig
+++ b/src/bundler/graph/module_registry.zig
@@ -89,12 +89,12 @@ pub fn addModuleWithResolveDir(self: *ModuleGraph, abs_path: []const u8, resolve
         return existing;
     }
 
-    // 새 모듈 슬롯 할당
+    // 새 모듈 슬롯 할당 — PR-Z4: path 만 path_arena (Module.deinit/store transfer 안전).
+    // resolve_dir 은 Module.deinit 가 graph_allocator 로 free 하므로 그대로 유지.
     var s_alloc = profile.begin(.graph_discover_incr_add_module_alloc);
     const index: ModuleIndex = @enumFromInt(@as(u32, @intCast(self.modules.count())));
     var ownership_transferred = false;
-    const path_owned = try self.allocator.dupe(u8, abs_path);
-    errdefer if (!ownership_transferred) self.allocator.free(path_owned);
+    const path_owned = try self.path_arena.allocator().dupe(u8, abs_path);
     const resolve_dir_owned = if (resolve_dir) |dir| try self.allocator.dupe(u8, dir) else null;
     errdefer if (!ownership_transferred) if (resolve_dir_owned) |dir| self.allocator.free(dir);
 
@@ -155,11 +155,11 @@ fn addDisabledModuleWithMode(
     specifier: []const u8,
     throw_on_require: bool,
 ) !ModuleIndex {
-    const disabled_path = try std.mem.concat(self.allocator, u8, &.{ prefix, specifier });
+    // PR-Z4: path_arena 에 alloc — graph 일괄 해제.
+    const disabled_path = try std.mem.concat(self.path_arena.allocator(), u8, &.{ prefix, specifier });
 
-    // 중복 체크
+    // 중복 체크 (arena 에 buffer 남지만 graph deinit 시 일괄 해제, leak 아님)
     if (self.path_to_module.get(disabled_path)) |existing| {
-        self.allocator.free(disabled_path);
         return existing;
     }
 
@@ -185,7 +185,8 @@ pub fn addExternalModule(self: *ModuleGraph, specifier: []const u8) !ModuleIndex
     if (self.path_to_module.get(specifier)) |existing| return existing;
 
     const index: ModuleIndex = @enumFromInt(@as(u32, @intCast(self.modules.count())));
-    const path_owned = try self.allocator.dupe(u8, specifier);
+    // PR-Z4: path_arena 에서 alloc — graph 일괄 해제.
+    const path_owned = try self.path_arena.allocator().dupe(u8, specifier);
     var module = Module.init(index, path_owned);
     module.is_external = true;
     module.module_type = .js;

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -1359,9 +1359,11 @@ test "renumber: orphan modules sorted by path regardless of add order" {
     try graph.modules.append(alloc, Module.init(@enumFromInt(0), "c.ts"));
     try graph.modules.append(alloc, Module.init(@enumFromInt(1), "b.ts"));
     try graph.modules.append(alloc, Module.init(@enumFromInt(2), "a.ts"));
-    try graph.path_to_module.put(try alloc.dupe(u8, "c.ts"), @enumFromInt(0));
-    try graph.path_to_module.put(try alloc.dupe(u8, "b.ts"), @enumFromInt(1));
-    try graph.path_to_module.put(try alloc.dupe(u8, "a.ts"), @enumFromInt(2));
+    // PR-Z4: path_to_module key 는 path_arena 가 owned (graph deinit 시 일괄 해제).
+    const arena_alloc = graph.path_arena.allocator();
+    try graph.path_to_module.put(try arena_alloc.dupe(u8, "c.ts"), @enumFromInt(0));
+    try graph.path_to_module.put(try arena_alloc.dupe(u8, "b.ts"), @enumFromInt(1));
+    try graph.path_to_module.put(try arena_alloc.dupe(u8, "a.ts"), @enumFromInt(2));
 
     try renumber_mod.renumberModulesDeterministically(&graph, &.{});
 


### PR DESCRIPTION
## Summary

graph_discover 잔여 epic 의 **PR-Z4**. #3601 M8 측정 결과 add_module alloc 의 69% (3.1 ms) 가 path dupe.

## 변경

ModuleGraph 에 `path_arena: std.heap.ArenaAllocator` 추가:

1. `addModuleWithResolveDir`, `addDisabledModuleWithMode`, `addExternalModule` 의 path 가 `path_arena.allocator().dupe(...)`
2. `lifecycle.deinit`: `path_to_module` key free loop 제거 (arena 가 일괄)
3. resolve_dir 은 graph_allocator 유지 (Module.deinit free + store transfer 안전)

## 측정 결과

| 항목 | Z3 baseline | **Z4** |
|---|---|---|
| **add_module alloc** | 3,061 µs | **883 µs** (-71%) |
| add_module put | 563 µs | 6,368 µs (Z3 ensureCapacity 비용 흡수) |
| warm null | 22.3 ms | 21.7 ms (noise ±2 ms) |

alloc 절감 명확 (2.2 ms). 누적 M0 → Z4: 47.3 → 21.7 ms ≈ **54% 절감**.

## Test plan

- [x] `zig build test --summary all` — 5352/5356 통과 / 4 skipped
- [x] graph_test.zig 의 `alloc.dupe` → `graph.path_arena.allocator().dupe` 일치
- [x] Leak detection 통과 (이전 graph allocator path dup 의 free loop 회피)

## epic close 권고

Z3+Z4 합쳐서 add_module alloc + record_dep link 의 진짜 dominant fix. 잔여 22 ms 의 대부분은 측정 overhead + graph 외 영역. 단일 PR ROI 30% 임계 소진.

🤖 Generated with [Claude Code](https://claude.com/claude-code)