### PR TITLE
docs(documents): LLM-friendly endpoints + Claude Code skill + 20-iter benchmark

### DIFF
--- a/documents/public/zntc-cli.skill.md
+++ b/documents/public/zntc-cli.skill.md
@@ -1,0 +1,189 @@
+---
+name: zntc-cli
+description: ZNTC (Zig Native Transpiler & Compiler) 설치 + CLI/NAPI 사용. JS/TS/JSX/Flow transpile, bundle, tree-shake, minify. esbuild/Bun/rolldown/rspack 대체용 (transpile small -62% / bundle small 1위)
+---
+
+# ZNTC 사용 가이드 (Claude Code skill)
+
+LLM (Claude / GPT 등) 이 ZNTC 의 *설치 + 사용* 을 빠르게 이해하도록 구성. `~/.claude/skills/zntc-cli/SKILL.md` 또는 프로젝트 `.claude/skills/zntc-cli/SKILL.md` 위치.
+
+## 무엇
+
+ZNTC = Zig 로 작성한 JS/TS 트랜스파일러 + 번들러:
+- **트랜스파일**: TS 타입 strip, JSX, Flow, ES2015+ 다운레벨
+- **번들**: Tree-shake + minify, rolldown/esbuild 동급 속도, 일부 lib 더 작음
+- **호출 방식**: CLI binary, C NAPI (.node), WASM, Vite/Rollup plugin adapter
+
+## 설치
+
+### Option A: CLI binary (가장 단순)
+
+```sh
+# 한 번에 설치 (release binary 다운로드)
+curl -fsSL https://raw.githubusercontent.com/ohah/zntc/main/install.sh | sh
+
+# 또는 npm
+npm install -g @zntc/core
+```
+
+### Option B: 개별 패키지
+
+```sh
+# Bundler / CLI (rolldown 대체)
+npm install --save-dev @zntc/core
+
+# Vite 플러그인 (rollup 대체)
+npm install --save-dev @zntc/vite-plugin
+
+# Rollup 플러그인
+npm install --save-dev @zntc/rollup-plugin
+```
+
+## 빠른 시작
+
+### Transpile (TS → JS)
+
+```sh
+zntc input.ts -o output.js
+zntc input.tsx -o output.js --jsx automatic
+zntc src/main.ts --target=es2020 -o dist/main.js
+```
+
+### Bundle
+
+```sh
+# 단일 파일 번들 (esbuild 동급 사용법)
+zntc --bundle src/index.ts -o dist/bundle.js
+
+# Multi-format (rollup-style)
+zntc --bundle src/index.ts \
+  --format=esm --output=dist/esm/bundle.mjs \
+  --format=cjs --output=dist/cjs/bundle.cjs
+```
+
+### NAPI (Node.js / Bun in-process — 50× faster than CLI spawn)
+
+```ts
+import { transpile, bundle } from '@zntc/core';
+
+// Transpile
+const { code, map } = transpile(source, {
+  filename: 'input.tsx',
+  jsx: 'automatic',
+  target: 'es2022',
+});
+
+// Bundle
+const result = await bundle({
+  entryPoints: ['src/index.ts'],
+  outdir: 'dist',
+  format: 'esm',
+  minify: true,
+  treeShake: true,
+});
+```
+
+### Vite plugin (vite.config.ts)
+
+```ts
+import { defineConfig } from 'vite';
+import zntc from '@zntc/vite-plugin';
+
+export default defineConfig({
+  plugins: [zntc()],
+});
+```
+
+## 주요 옵션
+
+| Flag | 의미 |
+|---|---|
+| `--bundle` | 번들 모드 (없으면 transpile only) |
+| `--format=esm/cjs/iife` | 출력 모듈 형식 |
+| `--target=es5/es2015/es2020/es2022` | ECMAScript 타깃 (다운레벨링) |
+| `--jsx=automatic/classic/preserve` | JSX 변환 모드 |
+| `--minify` / `--minify-identifiers` / `--minify-whitespace` | minify 모드 (esbuild 동등) |
+| `--tree-shake` | tree-shaking 활성 (`--bundle` 시 default on) |
+| `--watch` | watch mode (HMR — incremental rebuild ~22 ms / 641 module) |
+| `--profile=parse,transform,...` | 단계별 timing stdout (debug) |
+| `--target-platform=node/browser/react-native` | resolution 플랫폼 |
+
+## 성능 지표 (2026-05-21, darwin arm64, 20-run median)
+
+| Task | ZNTC | esbuild | Bun | rolldown | rspack |
+|---|---|---|---|---|---|
+| Transpile 100 lines | **1.79 ms** | 3.90 | 5.16 | — | — |
+| Transpile 1K lines | 3.02 ms | 4.79 | 5.59 | — | — |
+| Bundle 10 modules | **2.62 ms** | 10.8 | 8.05 | 52.3 | 62.4 |
+| Bundle 1K modules | **17.0 ms** | 26.8 | 23.3 | 70.2 | 83.8 |
+| Bundle 5K modules | 81.7 ms | 89.1 | **66.4** | 126 | 181 |
+
+## 실전 워크플로
+
+### React + TypeScript SPA
+
+```sh
+# Dev (watch)
+zntc --bundle src/index.tsx --watch --jsx=automatic -o dist/bundle.js
+
+# Production
+zntc --bundle src/index.tsx \
+  --jsx=automatic \
+  --target=es2020 \
+  --minify \
+  --tree-shake \
+  -o dist/bundle.js
+```
+
+### Library publish (Multi-format)
+
+```sh
+zntc --bundle src/index.ts \
+  --format=esm --output=dist/index.mjs \
+  --format=cjs --output=dist/index.cjs \
+  --target=es2018 \
+  --minify
+```
+
+### Existing Vite project (drop-in)
+
+```ts
+// vite.config.ts
+import zntc from '@zntc/vite-plugin';
+
+export default {
+  plugins: [zntc({ tsconfig: './tsconfig.json' })],
+};
+```
+
+## 한계 / 미지원
+
+- WASM build: `.wasm` 타깃 미릴리스 (계획 중)
+- Hermes regex named capture group 다운레벨: 미지원 (Hermes 한계, 기록만 strip)
+- Multi-format + dev_mode/splitting/MF 조합 거부 (error 명시)
+- 일부 minify case 에서 zod/effect 가 rolldown 보다 약간 큼 (mangler 격차, deferred)
+
+## 참고 자료
+
+- 공식 docs: https://ohah.github.io/zntc/
+- 영어 docs: https://ohah.github.io/zntc/en/
+- llms.txt (사이트맵): https://ohah.github.io/zntc/llms.txt
+- llms-full.txt (전체 docs plain text): https://ohah.github.io/zntc/llms-full.txt
+- GitHub: https://github.com/ohah/zntc
+- Playground: https://ohah.github.io/zntc/playground/
+
+## Claude Code 설치 방법
+
+이 파일을 다음 위치에 저장:
+```sh
+mkdir -p ~/.claude/skills/zntc-cli
+curl -fsSL https://ohah.github.io/zntc/zntc-cli.skill.md > ~/.claude/skills/zntc-cli/SKILL.md
+```
+
+또는 프로젝트 단위:
+```sh
+mkdir -p .claude/skills/zntc-cli
+curl -fsSL https://ohah.github.io/zntc/zntc-cli.skill.md > .claude/skills/zntc-cli/SKILL.md
+```
+
+설치 후 Claude Code 가 `zntc` 또는 `transpile` 관련 작업 시 이 skill 을 *자동 활용*.

--- a/documents/src/content/docs/en/index.mdx
+++ b/documents/src/content/docs/en/index.mdx
@@ -43,12 +43,12 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <StatsStrip
   stats={[
-    { value: "2.3", unit: "ms", label: "Transpile", caption: "1K LOC · TypeScript" },
+    { value: "3.0", unit: "ms", label: "Transpile", caption: "1K LOC · TypeScript" },
     { value: "2.6", unit: "ms", label: "Bundle", caption: "10 modules" },
-    { value: "19", unit: "×", label: "faster", caption: "vs rolldown (small)" },
+    { value: "20", unit: "×", label: "faster", caption: "vs rolldown (small)" },
     { value: "340", unit: "+", label: "Doc pages", caption: "ko · en" },
   ]}
-  note="As of 2026-05-06 · darwin arm64 · 5-run median"
+  note="As of 2026-05-21 · darwin arm64 · 20-run median"
 />
 
 <Section padding="py-16">
@@ -60,29 +60,29 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     <div class="mt-6 grid gap-4 text-sm sm:grid-cols-3">
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">small (10 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">3.00 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">2.62 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 6.68 · esbuild 8.84 · rolldown 50.5 · rspack 58.8 ms
+          vs Bun 8.05 · esbuild 10.8 · rolldown 52.3 · rspack 62.4 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">medium (1000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">17.5 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">17.0 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 20.2 · esbuild 23.9 · rolldown 67.8 · rspack 84.2 ms
+          vs Bun 23.3 · esbuild 26.8 · rolldown 70.2 · rspack 83.8 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">large (5000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">80.7 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2nd)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">81.7 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2nd)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 67.6 · esbuild 86.1 · rolldown 145 · rspack 211 ms
+          vs Bun 66.4 · esbuild 89.1 · rolldown 126 · rspack 181 ms
         </div>
       </div>
     </div>
 
     <p class="mt-6 text-center text-xs text-[color:var(--sl-color-gray-3)]">
-      2026-05-11 · darwin arm64 · 5-run median · fan-out tree fixture (see <a href="/zntc/en/reference/benchmarks/" class="text-zig-400 hover:underline">full benchmarks →</a>)
+      2026-05-21 · darwin arm64 · 20-run median · fan-out tree fixture (see <a href="/zntc/en/reference/benchmarks/" class="text-zig-400 hover:underline">full benchmarks →</a>)
     </p>
   </div>
 </Section>

--- a/documents/src/content/docs/en/reference/benchmarks.mdx
+++ b/documents/src/content/docs/en/reference/benchmarks.mdx
@@ -10,9 +10,9 @@ ZNTC compares transpile and bundle performance — and final bundle size (tree-s
 ## Environment
 
 - **Platform**: `darwin arm64`
-- **Baseline date**: 2026-05-06
-- **CLI**: `bench.ts`, 5-run median, direct CLI binary execution without npx overhead
-- **NAPI / WASM / CLI**: `napi-bench.ts`, 3 warmups + 10-run median
+- **Baseline date**: 2026-05-21
+- **CLI**: `bench.ts`, 20-run median, direct CLI binary execution without npx overhead
+- **NAPI / WASM / CLI**: `napi-bench.ts`, 5 warmups + 20-run median
 - **Bundle perf**: `bundle-perf.ts`, 5 warmups + 20-run median, CI-style same-run ZNTC/Rolldown/Rspack comparison
 - **Pipeline**: `pipeline.ts`, 5-run median, profile total
 - **Bundle size**: `smoke.ts --minify-all`, 2026-05-17, 9 real npm libraries bundled + minified, raw output bytes

--- a/documents/src/content/docs/index.mdx
+++ b/documents/src/content/docs/index.mdx
@@ -43,12 +43,12 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <StatsStrip
   stats={[
-    { value: "2.3", unit: "ms", label: "트랜스파일", caption: "1K LOC · TypeScript" },
+    { value: "3.0", unit: "ms", label: "트랜스파일", caption: "1K LOC · TypeScript" },
     { value: "2.6", unit: "ms", label: "번들링", caption: "10 modules" },
-    { value: "19", unit: "×", label: "faster", caption: "vs rolldown (small)" },
+    { value: "20", unit: "×", label: "faster", caption: "vs rolldown (small)" },
     { value: "340", unit: "+", label: "문서 페이지", caption: "ko · en 지원" },
   ]}
-  note="2026-05-06 기준 · darwin arm64 · 5회 median"
+  note="2026-05-21 기준 · darwin arm64 · 20회 median"
 />
 
 <Section padding="py-16">
@@ -60,29 +60,29 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     <div class="mt-6 grid gap-4 text-sm sm:grid-cols-3">
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">small (10 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">3.00 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">2.62 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 6.68 · esbuild 8.84 · rolldown 50.5 · rspack 58.8 ms
+          vs Bun 8.05 · esbuild 10.8 · rolldown 52.3 · rspack 62.4 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">medium (1000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">17.5 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">17.0 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 20.2 · esbuild 23.9 · rolldown 67.8 · rspack 84.2 ms
+          vs Bun 23.3 · esbuild 26.8 · rolldown 70.2 · rspack 83.8 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">large (5000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">80.7 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2위)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">81.7 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 67.6 · esbuild 86.1 · rolldown 145 · rspack 211 ms
+          vs Bun 66.4 · esbuild 89.1 · rolldown 126 · rspack 181 ms
         </div>
       </div>
     </div>
 
     <p class="mt-6 text-center text-xs text-[color:var(--sl-color-gray-3)]">
-      2026-05-11 · darwin arm64 · 5회 median · fan-out tree fixture (자세히는 <a href="/zntc/reference/benchmarks/" class="text-zig-400 hover:underline">전체 벤치마크 →</a>)
+      2026-05-21 · darwin arm64 · 20회 median · fan-out tree fixture (자세히는 <a href="/zntc/reference/benchmarks/" class="text-zig-400 hover:underline">전체 벤치마크 →</a>)
     </p>
   </div>
 </Section>

--- a/documents/src/content/docs/reference/benchmarks.mdx
+++ b/documents/src/content/docs/reference/benchmarks.mdx
@@ -10,9 +10,9 @@ ZNTC의 트랜스파일/번들 성능과 최종 번들 크기(tree-shaking + min
 ## 측정 환경
 
 - **Platform**: `darwin arm64`
-- **기준 일시**: 2026-05-06
-- **CLI**: `bench.ts` median 5회, 직접 CLI 바이너리 실행 (npx 오버헤드 제거)
-- **NAPI / WASM / CLI**: `napi-bench.ts` warmup 3회 + median 10회
+- **기준 일시**: 2026-05-21
+- **CLI**: `bench.ts` median 20회, 직접 CLI 바이너리 실행 (npx 오버헤드 제거)
+- **NAPI / WASM / CLI**: `napi-bench.ts` warmup 5회 + median 20회
 - **Bundle perf**: `bundle-perf.ts` warmup 5회 + median 20회, CI와 같은 ZNTC/Rolldown/Rspack same-run 비교
 - **Pipeline**: `pipeline.ts` median 5회, profile total 기준
 - **번들 크기**: `smoke.ts --minify-all`, 2026-05-17, 실제 npm 라이브러리 9종을 번들 + minify 한 raw 출력 바이트

--- a/documents/src/data/benchmark-data.json
+++ b/documents/src/data/benchmark-data.json
@@ -2,8 +2,8 @@
   "date": "2026-05-21",
   "platform": "darwin arm64",
   "runs": {
-    "cli": { "iterations": 5 },
-    "napi": { "warmup": 3, "iterations": 10 },
+    "cli": { "iterations": 20 },
+    "napi": { "warmup": 5, "iterations": 20 },
     "bundlePerf": { "warmup": 5, "iterations": 20 },
     "pipeline": { "iterations": 5 }
   },

--- a/documents/src/pages/llms-full.txt.ts
+++ b/documents/src/pages/llms-full.txt.ts
@@ -1,0 +1,43 @@
+/**
+ * llms-full.txt — LLM context 직접 주입용 단일 plain text dump.
+ *
+ * docs collection 의 모든 페이지 본문을 *순서대로 concat*. LLM 의 long-context
+ * window 에 통째로 넣어 사이트 전체를 컨텍스트로 활용 가능. RAG 보조 시스템 없이도
+ * 한 번의 fetch 로 모든 문서 학습 가능.
+ *
+ * 주의: 매우 큰 응답 (수 MB 가능). 일반 사용자는 사용 안 함.
+ */
+
+import { getCollection } from 'astro:content';
+
+export async function GET() {
+  const docs = await getCollection('docs');
+
+  // 한국어 → 영어 순서 (가독성)
+  const sorted = [...docs].sort((a, b) => {
+    const aEn = a.id.startsWith('en/') ? 1 : 0;
+    const bEn = b.id.startsWith('en/') ? 1 : 0;
+    if (aEn !== bEn) return aEn - bEn;
+    return a.id.localeCompare(b.id);
+  });
+
+  const parts = sorted.map((d) => {
+    const slug = d.id.replace(/\.(md|mdx)$/, '');
+    const url = `https://ohah.github.io/zntc/${slug}/`;
+    const title = d.data.title ?? slug;
+    const desc = d.data.description ?? '';
+    const body = d.body ?? '';
+    return `# ${title}\n\nURL: ${url}\n${desc ? `Description: ${desc}\n` : ''}\n${body}\n\n---\n`;
+  });
+
+  const header = `# ZNTC — All Documentation (LLM-readable single file)
+
+# This is a plain-text concatenation of every page on https://ohah.github.io/zntc/
+# Intended for direct LLM context injection. For sitemap-style links, see /llms.txt.
+
+`;
+
+  return new Response(header + parts.join('\n'), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/documents/src/pages/llms.txt.ts
+++ b/documents/src/pages/llms.txt.ts
@@ -1,0 +1,66 @@
+/**
+ * llms.txt — LLM 친화적 사이트 overview (https://llmstxt.org/).
+ *
+ * docs collection 의 모든 페이지 title + description + URL 을 plain text 로 노출.
+ * LLM (Claude / GPT 등) 이 *전체 사이트 구조* 를 빠르게 이해하고 *관련 페이지 URL*
+ * 직접 fetch 할 수 있게 한다. RAG / context loading 워크플로 표준.
+ */
+
+import { getCollection } from 'astro:content';
+
+const SITE = 'https://ohah.github.io/zntc';
+
+export async function GET() {
+  const docs = await getCollection('docs');
+
+  // 언어/카테고리별 grouping
+  const enDocs = docs.filter((d) => d.id.startsWith('en/'));
+  const koDocs = docs.filter((d) => !d.id.startsWith('en/'));
+
+  function fmtSection(items: typeof docs, langPrefix: string) {
+    return items
+      .filter((d) => d.id !== 'index' && d.id !== 'en/index')
+      .map((d) => {
+        const slug = d.id.replace(/\.(md|mdx)$/, '');
+        const url = `${SITE}/${slug}/`;
+        const title = d.data.title ?? slug;
+        const desc = d.data.description ?? '';
+        return `- [${title}](${url})${desc ? ` — ${desc}` : ''}`;
+      })
+      .join('\n');
+  }
+
+  const body = `# ZNTC
+
+> Zig Native Transpiler & Compiler for JavaScript/TypeScript. JS·TS·JSX·Flow를 네이티브 속도로 transpile + bundle. Vite/Rollup 호환 plugin 시스템.
+
+## 핵심 기능
+
+- TypeScript / JSX / Flow strip (~3 ms / 1K lines)
+- ES2015+ 다운레벨링 (target=es5/es2015/es2020/es2022)
+- Tree-shake + minify (rolldown/esbuild/rspack 동급 또는 우위)
+- Bundle (rollup-style + esbuild-style API)
+- React Native (Metro/Hermes 호환)
+- C NAPI in-process 호출 (Node/Bun ~50× faster than CLI spawn)
+- Vite/Rollup plugin adapter
+
+## 한국어 문서
+
+${fmtSection(koDocs, '')}
+
+## English Documentation
+
+${fmtSection(enDocs, 'en/')}
+
+## 추가 자료
+
+- [전체 문서 (LLM context 직접 주입용 plain text)](${SITE}/llms-full.txt)
+- [Claude Code skill 다운로드](${SITE}/zntc-cli.skill.md)
+- [GitHub](https://github.com/ohah/zntc)
+- [Playground](${SITE}/playground/)
+`;
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}


### PR DESCRIPTION
## Summary

3가지 추가:

### 1. LLM-friendly endpoints ([llmstxt.org](https://llmstxt.org) 표준)

- **`/llms.txt`** — 사이트맵 (KO + EN docs 페이지 링크 + description)
- **`/llms-full.txt`** — 전체 docs 본문 단일 plain text dump (~960 KB)

LLM (Claude / GPT) 의 RAG / context loading 워크플로 표준. 한 번의 fetch 로 사이트 전체 학습 가능:
- `/llms.txt` → 사이트맵 + 추가 자료 링크
- `/llms-full.txt` → context window 직접 주입용

```
curl https://ohah.github.io/zntc/llms.txt          # 사이트맵
curl https://ohah.github.io/zntc/llms-full.txt     # 전체 docs (960 KB)
```

### 2. Claude Code skill 파일 (다운로드 가능)

**`/zntc-cli.skill.md`** — `agent-browser` skill 처럼 다운로드 후 즉시 사용:

```sh
# 글로벌 (전체 프로젝트에서 사용)
mkdir -p ~/.claude/skills/zntc-cli
curl -fsSL https://ohah.github.io/zntc/zntc-cli.skill.md > ~/.claude/skills/zntc-cli/SKILL.md

# 프로젝트 단위
mkdir -p .claude/skills/zntc-cli
curl -fsSL https://ohah.github.io/zntc/zntc-cli.skill.md > .claude/skills/zntc-cli/SKILL.md
```

설치 후 Claude Code 가 *zntc / transpile / bundle 관련 작업* 시 이 skill 을 **자동 활용**. 내용:

- 설치 방법 (CLI / npm / vite-plugin)
- CLI 옵션 표 (`--bundle`, `--format`, `--target`, `--jsx`, `--minify`, `--watch` 등)
- NAPI direct 호출 (`@zntc/core`)
- 성능 지표 (2026-05-21 20-run median)
- 실전 워크플로 (React SPA, library publish, Vite drop-in)
- 한계 / 미지원 명시

### 3. 20-iter benchmark 데이터 반영 (PR #3603 의 amend 누락 분 재반영)

PR #3603 force-push 의 race 로 첫 commit (5 iter) 만 머지됨. 누락된 20 iter + hardcoded docs text 함께 재반영:

- `benchmark-data.json` runs: cli 5→20, napi warmup 3→5, iter 10→20
- `index.mdx` (KO/EN) stats 박스 + Bundle 비교 카드 + footnote
- `reference/benchmarks.mdx` (KO/EN) 측정 환경

## 빌드 검증

```
documents/dist/llms.txt           (사이트맵, ~6 KB)
documents/dist/llms-full.txt      (전체 docs, ~960 KB)
documents/dist/zntc-cli.skill.md  (Claude Code skill, ~5 KB)
```

- `bun run build` 통과
- internal links validate 통과
- 531 page built (10.42 s)

## Test plan

- [x] `bun run build` 성공
- [x] dist 에 3 파일 (llms.txt / llms-full.txt / zntc-cli.skill.md) 생성 확인
- [x] internal link validator 통과
- [x] 4 페이지 hardcoded benchmark text 갱신 (KO/EN × index/reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)