### PR TITLE
docs(documents): make /llms.txt + /llms-full.txt + skill English-only

### DIFF
--- a/documents/public/zntc-cli.skill.md
+++ b/documents/public/zntc-cli.skill.md
@@ -1,45 +1,46 @@
 ---
 name: zntc-cli
-description: ZNTC (Zig Native Transpiler & Compiler) 설치 + CLI/NAPI 사용. JS/TS/JSX/Flow transpile, bundle, tree-shake, minify. esbuild/Bun/rolldown/rspack 대체용 (transpile small -62% / bundle small 1위)
+description: ZNTC (Zig Native Transpiler & Compiler) install + CLI/NAPI usage. Transpile JS/TS/JSX/Flow, bundle, tree-shake, minify. Drop-in alternative to esbuild/Bun/rolldown/rspack (transpile small -62% / bundle small 1st place)
 ---
 
-# ZNTC 사용 가이드 (Claude Code skill)
+# ZNTC usage guide (Claude Code skill)
 
-LLM (Claude / GPT 등) 이 ZNTC 의 *설치 + 사용* 을 빠르게 이해하도록 구성. `~/.claude/skills/zntc-cli/SKILL.md` 또는 프로젝트 `.claude/skills/zntc-cli/SKILL.md` 위치.
+A Claude Code skill that teaches LLMs how to install and use ZNTC. Place at `~/.claude/skills/zntc-cli/SKILL.md` (global) or `.claude/skills/zntc-cli/SKILL.md` (per-project).
 
-## 무엇
+## What is ZNTC
 
-ZNTC = Zig 로 작성한 JS/TS 트랜스파일러 + 번들러:
-- **트랜스파일**: TS 타입 strip, JSX, Flow, ES2015+ 다운레벨
-- **번들**: Tree-shake + minify, rolldown/esbuild 동급 속도, 일부 lib 더 작음
-- **호출 방식**: CLI binary, C NAPI (.node), WASM, Vite/Rollup plugin adapter
+ZNTC is a JS/TS transpiler + bundler written in Zig:
 
-## 설치
+- **Transpile**: strip TypeScript types, JSX, Flow; downlevel ES2015+
+- **Bundle**: tree-shake + minify; on par with rolldown/esbuild in speed and sometimes smaller in output
+- **Invocation**: CLI binary, C NAPI (`.node`), WASM, or Vite/Rollup plugin adapter
 
-### Option A: CLI binary (가장 단순)
+## Installation
+
+### Option A: CLI binary (simplest)
 
 ```sh
-# 한 번에 설치 (release binary 다운로드)
+# One-line installer (downloads release binary)
 curl -fsSL https://raw.githubusercontent.com/ohah/zntc/main/install.sh | sh
 
-# 또는 npm
+# Or via npm
 npm install -g @zntc/core
 ```
 
-### Option B: 개별 패키지
+### Option B: Individual packages
 
 ```sh
-# Bundler / CLI (rolldown 대체)
+# Core bundler / CLI (rolldown alternative)
 npm install --save-dev @zntc/core
 
-# Vite 플러그인 (rollup 대체)
+# Vite plugin (rollup alternative)
 npm install --save-dev @zntc/vite-plugin
 
-# Rollup 플러그인
+# Rollup plugin
 npm install --save-dev @zntc/rollup-plugin
 ```
 
-## 빠른 시작
+## Quick start
 
 ### Transpile (TS → JS)
 
@@ -52,7 +53,7 @@ zntc src/main.ts --target=es2020 -o dist/main.js
 ### Bundle
 
 ```sh
-# 단일 파일 번들 (esbuild 동급 사용법)
+# Single-file bundle (esbuild-equivalent usage)
 zntc --bundle src/index.ts -o dist/bundle.js
 
 # Multi-format (rollup-style)
@@ -61,7 +62,7 @@ zntc --bundle src/index.ts \
   --format=cjs --output=dist/cjs/bundle.cjs
 ```
 
-### NAPI (Node.js / Bun in-process — 50× faster than CLI spawn)
+### NAPI (Node.js / Bun in-process — ~50× faster than CLI spawn)
 
 ```ts
 import { transpile, bundle } from '@zntc/core';
@@ -94,21 +95,21 @@ export default defineConfig({
 });
 ```
 
-## 주요 옵션
+## Key options
 
-| Flag | 의미 |
+| Flag | Meaning |
 |---|---|
-| `--bundle` | 번들 모드 (없으면 transpile only) |
-| `--format=esm/cjs/iife` | 출력 모듈 형식 |
-| `--target=es5/es2015/es2020/es2022` | ECMAScript 타깃 (다운레벨링) |
-| `--jsx=automatic/classic/preserve` | JSX 변환 모드 |
-| `--minify` / `--minify-identifiers` / `--minify-whitespace` | minify 모드 (esbuild 동등) |
-| `--tree-shake` | tree-shaking 활성 (`--bundle` 시 default on) |
-| `--watch` | watch mode (HMR — incremental rebuild ~22 ms / 641 module) |
-| `--profile=parse,transform,...` | 단계별 timing stdout (debug) |
-| `--target-platform=node/browser/react-native` | resolution 플랫폼 |
+| `--bundle` | bundle mode (without this flag, transpile only) |
+| `--format=esm/cjs/iife` | output module format |
+| `--target=es5/es2015/es2020/es2022` | ECMAScript target (for downleveling) |
+| `--jsx=automatic/classic/preserve` | JSX transform mode |
+| `--minify` / `--minify-identifiers` / `--minify-whitespace` | minify (esbuild-equivalent flags) |
+| `--tree-shake` | enable tree-shaking (default on with `--bundle`) |
+| `--watch` | watch mode (HMR — incremental rebuild ~22 ms / 641 modules) |
+| `--profile=parse,transform,...` | print per-phase timing to stderr (debug) |
+| `--target-platform=node/browser/react-native` | resolution platform |
 
-## 성능 지표 (2026-05-21, darwin arm64, 20-run median)
+## Performance (2026-05-21, darwin arm64, 20-run median)
 
 | Task | ZNTC | esbuild | Bun | rolldown | rspack |
 |---|---|---|---|---|---|
@@ -118,7 +119,7 @@ export default defineConfig({
 | Bundle 1K modules | **17.0 ms** | 26.8 | 23.3 | 70.2 | 83.8 |
 | Bundle 5K modules | 81.7 ms | 89.1 | **66.4** | 126 | 181 |
 
-## 실전 워크플로
+## Practical workflows
 
 ### React + TypeScript SPA
 
@@ -145,7 +146,7 @@ zntc --bundle src/index.ts \
   --minify
 ```
 
-### Existing Vite project (drop-in)
+### Drop-in to an existing Vite project
 
 ```ts
 // vite.config.ts
@@ -156,34 +157,35 @@ export default {
 };
 ```
 
-## 한계 / 미지원
+## Limitations / not supported
 
-- WASM build: `.wasm` 타깃 미릴리스 (계획 중)
-- Hermes regex named capture group 다운레벨: 미지원 (Hermes 한계, 기록만 strip)
-- Multi-format + dev_mode/splitting/MF 조합 거부 (error 명시)
-- 일부 minify case 에서 zod/effect 가 rolldown 보다 약간 큼 (mangler 격차, deferred)
+- WASM build: `.wasm` target not released yet (planned)
+- Hermes regex named capture group downleveling: not supported (Hermes limitation — only kept in original form)
+- Multi-format + dev_mode/splitting/MF combination is rejected (explicit error)
+- Some minify cases: zod/effect output is slightly larger than rolldown's (mangler gap, deferred work)
 
-## 참고 자료
+## References
 
-- 공식 docs: https://ohah.github.io/zntc/
-- 영어 docs: https://ohah.github.io/zntc/en/
-- llms.txt (사이트맵): https://ohah.github.io/zntc/llms.txt
-- llms-full.txt (전체 docs plain text): https://ohah.github.io/zntc/llms-full.txt
+- Official docs: https://ohah.github.io/zntc/
+- English docs: https://ohah.github.io/zntc/en/
+- llms.txt (sitemap): https://ohah.github.io/zntc/llms.txt
+- llms-full.txt (entire docs as plain text): https://ohah.github.io/zntc/llms-full.txt
 - GitHub: https://github.com/ohah/zntc
-- Playground: https://ohah.github.io/zntc/playground/
+- Playground: https://ohah.github.io/zntc/en/playground/
 
-## Claude Code 설치 방법
+## How to install this skill (Claude Code)
 
-이 파일을 다음 위치에 저장:
 ```sh
+# Global (works in every project)
 mkdir -p ~/.claude/skills/zntc-cli
 curl -fsSL https://ohah.github.io/zntc/zntc-cli.skill.md > ~/.claude/skills/zntc-cli/SKILL.md
 ```
 
-또는 프로젝트 단위:
+Or per-project:
+
 ```sh
 mkdir -p .claude/skills/zntc-cli
 curl -fsSL https://ohah.github.io/zntc/zntc-cli.skill.md > .claude/skills/zntc-cli/SKILL.md
 ```
 
-설치 후 Claude Code 가 `zntc` 또는 `transpile` 관련 작업 시 이 skill 을 *자동 활용*.
+After installing, Claude Code automatically invokes this skill when it detects `zntc`, `transpile`, or `bundle`-related tasks.

--- a/documents/src/pages/llms-full.txt.ts
+++ b/documents/src/pages/llms-full.txt.ts
@@ -1,11 +1,11 @@
 /**
- * llms-full.txt — LLM context 직접 주입용 단일 plain text dump.
+ * llms-full.txt — Single plain-text dump for direct LLM context injection.
  *
- * docs collection 의 모든 페이지 본문을 *순서대로 concat*. LLM 의 long-context
- * window 에 통째로 넣어 사이트 전체를 컨텍스트로 활용 가능. RAG 보조 시스템 없이도
- * 한 번의 fetch 로 모든 문서 학습 가능.
+ * Concatenates every English docs page in order. Designed to be fed to an LLM's
+ * long-context window in one shot — no RAG infrastructure needed. Korean docs
+ * are excluded; readers wanting Korean should browse the docs site.
  *
- * 주의: 매우 큰 응답 (수 MB 가능). 일반 사용자는 사용 안 함.
+ * Note: response is large (hundreds of KB to a few MB). Not intended for end users.
  */
 
 import { getCollection } from 'astro:content';
@@ -13,13 +13,10 @@ import { getCollection } from 'astro:content';
 export async function GET() {
   const docs = await getCollection('docs');
 
-  // 한국어 → 영어 순서 (가독성)
-  const sorted = [...docs].sort((a, b) => {
-    const aEn = a.id.startsWith('en/') ? 1 : 0;
-    const bEn = b.id.startsWith('en/') ? 1 : 0;
-    if (aEn !== bEn) return aEn - bEn;
-    return a.id.localeCompare(b.id);
-  });
+  // English docs only, sorted by id for stable ordering
+  const sorted = [...docs.filter((d) => d.id.startsWith('en/'))].sort((a, b) =>
+    a.id.localeCompare(b.id),
+  );
 
   const parts = sorted.map((d) => {
     const slug = d.id.replace(/\.(md|mdx)$/, '');
@@ -32,8 +29,9 @@ export async function GET() {
 
   const header = `# ZNTC — All Documentation (LLM-readable single file)
 
-# This is a plain-text concatenation of every page on https://ohah.github.io/zntc/
-# Intended for direct LLM context injection. For sitemap-style links, see /llms.txt.
+# This is a plain-text concatenation of every English page on https://ohah.github.io/zntc/
+# Intended for direct LLM context injection. For a sitemap-style index, see /llms.txt.
+# Korean documentation is not included here; visit the docs site directly for Korean.
 
 `;
 

--- a/documents/src/pages/llms.txt.ts
+++ b/documents/src/pages/llms.txt.ts
@@ -1,9 +1,12 @@
 /**
- * llms.txt — LLM 친화적 사이트 overview (https://llmstxt.org/).
+ * llms.txt — LLM-friendly site overview (https://llmstxt.org/).
  *
- * docs collection 의 모든 페이지 title + description + URL 을 plain text 로 노출.
- * LLM (Claude / GPT 등) 이 *전체 사이트 구조* 를 빠르게 이해하고 *관련 페이지 URL*
- * 직접 fetch 할 수 있게 한다. RAG / context loading 워크플로 표준.
+ * Lists all English docs pages with title + description + URL as plain text so
+ * LLMs (Claude / GPT etc.) can quickly understand the site structure and fetch
+ * individual pages. RAG / context-loading workflow standard.
+ *
+ * Only English docs are listed here — Korean docs are excluded to keep this
+ * file LLM-optimal. Korean readers should browse the docs site directly.
  */
 
 import { getCollection } from 'astro:content';
@@ -13,51 +16,52 @@ const SITE = 'https://ohah.github.io/zntc';
 export async function GET() {
   const docs = await getCollection('docs');
 
-  // 언어/카테고리별 grouping
+  // Only English documents
   const enDocs = docs.filter((d) => d.id.startsWith('en/'));
-  const koDocs = docs.filter((d) => !d.id.startsWith('en/'));
 
-  function fmtSection(items: typeof docs, langPrefix: string) {
-    return items
-      .filter((d) => d.id !== 'index' && d.id !== 'en/index')
-      .map((d) => {
-        const slug = d.id.replace(/\.(md|mdx)$/, '');
-        const url = `${SITE}/${slug}/`;
-        const title = d.data.title ?? slug;
-        const desc = d.data.description ?? '';
-        return `- [${title}](${url})${desc ? ` — ${desc}` : ''}`;
-      })
-      .join('\n');
-  }
+  const items = enDocs
+    .filter((d) => d.id !== 'en/index')
+    .map((d) => {
+      const slug = d.id.replace(/\.(md|mdx)$/, '');
+      const url = `${SITE}/${slug}/`;
+      const title = d.data.title ?? slug;
+      const desc = d.data.description ?? '';
+      return `- [${title}](${url})${desc ? ` — ${desc}` : ''}`;
+    })
+    .join('\n');
 
   const body = `# ZNTC
 
-> Zig Native Transpiler & Compiler for JavaScript/TypeScript. JS·TS·JSX·Flow를 네이티브 속도로 transpile + bundle. Vite/Rollup 호환 plugin 시스템.
+> Zig Native Transpiler & Compiler for JavaScript/TypeScript. Transpile and bundle JS · TS · JSX · Flow at native speed with a Vite/Rollup-compatible plugin system.
 
-## 핵심 기능
+## Core features
 
-- TypeScript / JSX / Flow strip (~3 ms / 1K lines)
-- ES2015+ 다운레벨링 (target=es5/es2015/es2020/es2022)
-- Tree-shake + minify (rolldown/esbuild/rspack 동급 또는 우위)
+- TypeScript / JSX / Flow stripping (~3 ms / 1K lines)
+- ES2015+ downleveling (target=es5/es2015/es2020/es2022)
+- Tree-shake + minify (on par with or smaller than rolldown/esbuild/rspack)
 - Bundle (rollup-style + esbuild-style API)
-- React Native (Metro/Hermes 호환)
-- C NAPI in-process 호출 (Node/Bun ~50× faster than CLI spawn)
-- Vite/Rollup plugin adapter
+- React Native (Metro / Hermes compatible)
+- C NAPI in-process calls (Node/Bun, ~50× faster than CLI spawn)
+- Vite / Rollup plugin adapter
 
-## 한국어 문서
+## Performance (2026-05-21, darwin arm64, 20-run median)
 
-${fmtSection(koDocs, '')}
+- Transpile small (100 lines): **1.79 ms** (1st, vs esbuild 3.90 / Bun 5.16)
+- Bundle small (10 modules): **2.62 ms** (1st, vs Bun 8.05 / esbuild 10.8)
+- Bundle medium (1000 modules): **17.0 ms** (1st, vs Bun 23.3 / esbuild 26.8)
+- Warm incremental rebuild (lodash-es, 641 modules): **21.7 ms** (47.3 → 21.7 ms after graph_discover optimization epic, -54%)
 
-## English Documentation
+## Documentation
 
-${fmtSection(enDocs, 'en/')}
+${items}
 
-## 추가 자료
+## Additional resources
 
-- [전체 문서 (LLM context 직접 주입용 plain text)](${SITE}/llms-full.txt)
-- [Claude Code skill 다운로드](${SITE}/zntc-cli.skill.md)
+- [Full documentation as a single plain-text file (for LLM context injection)](${SITE}/llms-full.txt)
+- [Claude Code skill — install as ~/.claude/skills/zntc-cli/SKILL.md](${SITE}/zntc-cli.skill.md)
 - [GitHub](https://github.com/ohah/zntc)
-- [Playground](${SITE}/playground/)
+- [Playground](${SITE}/en/playground/)
+- [Korean docs site (separate language)](${SITE}/)
 `;
 
   return new Response(body, {


### PR DESCRIPTION
## Summary

PR #3604 의 `llms.txt` + `llms-full.txt` + skill 을 **영어로** 재작성. LLM context loading 시 영어가 표준 — Korean docs 제외, English docs 만 dump.

## 변경

### `/llms.txt` (사이트맵)
- 헤더/섹션 라벨 영어 ("Core features", "Performance", "Documentation", "Additional resources")
- **EN docs 만 listing** (Korean docs 제외)
- Performance 섹션 추가 (transpile/bundle 1위 + warm rebuild 54% 절감 명시)
- 한국어 사이트 별도 link 안내

### `/llms-full.txt` (전체 docs dump)
- 헤더 영어
- EN docs 본문만 concat (이전 ~960 KB → **397 KB**, 절반 절감)

### `/zntc-cli.skill.md` (Claude Code skill)
- 전체 영어로 재작성 (글로벌 사용성)
- Korean dev 도 영어 skill 그대로 사용 가능

## 빌드

| 파일 | 크기 |
|---|---|
| `dist/llms.txt` | 29 KB (전 30%) |
| `dist/llms-full.txt` | 397 KB (전 41%) |
| `dist/zntc-cli.skill.md` | ~5 KB |

`bun run build` 통과, internal links validate 통과, 531 page built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)