### PR TITLE
docs(documents): simplify zntc-cli skill (5 KB → 1.5 KB)

### DIFF
--- a/documents/public/zntc-cli.skill.md
+++ b/documents/public/zntc-cli.skill.md
@@ -1,191 +1,50 @@
 ---
 name: zntc-cli
-description: ZNTC (Zig Native Transpiler & Compiler) install + CLI/NAPI usage. Transpile JS/TS/JSX/Flow, bundle, tree-shake, minify. Drop-in alternative to esbuild/Bun/rolldown/rspack (transpile small -62% / bundle small 1st place)
+description: ZNTC (Zig Native Transpiler & Compiler) — transpile/bundle JS/TS/JSX/Flow. Drop-in alternative to esbuild/Bun/rolldown/rspack. Use when the user mentions zntc, transpile, bundle, or wants a fast Vite/Rollup-compatible toolchain.
 ---
 
-# ZNTC usage guide (Claude Code skill)
+# ZNTC
 
-A Claude Code skill that teaches LLMs how to install and use ZNTC. Place at `~/.claude/skills/zntc-cli/SKILL.md` (global) or `.claude/skills/zntc-cli/SKILL.md` (per-project).
+Zig-based JS/TS transpiler + bundler. CLI, NAPI (`.node`), or Vite/Rollup plugin.
 
-## What is ZNTC
-
-ZNTC is a JS/TS transpiler + bundler written in Zig:
-
-- **Transpile**: strip TypeScript types, JSX, Flow; downlevel ES2015+
-- **Bundle**: tree-shake + minify; on par with rolldown/esbuild in speed and sometimes smaller in output
-- **Invocation**: CLI binary, C NAPI (`.node`), WASM, or Vite/Rollup plugin adapter
-
-## Installation
-
-### Option A: CLI binary (simplest)
+## Install
 
 ```sh
-# One-line installer (downloads release binary)
-curl -fsSL https://raw.githubusercontent.com/ohah/zntc/main/install.sh | sh
-
-# Or via npm
-npm install -g @zntc/core
+npm install -g @zntc/core         # CLI
+npm install --save-dev @zntc/vite-plugin    # Vite (rollup alternative)
 ```
 
-### Option B: Individual packages
+## Use
 
 ```sh
-# Core bundler / CLI (rolldown alternative)
-npm install --save-dev @zntc/core
-
-# Vite plugin (rollup alternative)
-npm install --save-dev @zntc/vite-plugin
-
-# Rollup plugin
-npm install --save-dev @zntc/rollup-plugin
-```
-
-## Quick start
-
-### Transpile (TS → JS)
-
-```sh
+# Transpile
 zntc input.ts -o output.js
-zntc input.tsx -o output.js --jsx automatic
-zntc src/main.ts --target=es2020 -o dist/main.js
+zntc input.tsx -o output.js --jsx=automatic
+
+# Bundle
+zntc --bundle src/index.ts -o dist/bundle.js --target=es2020 --minify --tree-shake
+
+# Watch (HMR)
+zntc --bundle src/index.tsx --watch -o dist/bundle.js
 ```
-
-### Bundle
-
-```sh
-# Single-file bundle (esbuild-equivalent usage)
-zntc --bundle src/index.ts -o dist/bundle.js
-
-# Multi-format (rollup-style)
-zntc --bundle src/index.ts \
-  --format=esm --output=dist/esm/bundle.mjs \
-  --format=cjs --output=dist/cjs/bundle.cjs
-```
-
-### NAPI (Node.js / Bun in-process — ~50× faster than CLI spawn)
 
 ```ts
+// NAPI in-process (Node/Bun, ~50× faster than CLI spawn)
 import { transpile, bundle } from '@zntc/core';
-
-// Transpile
-const { code, map } = transpile(source, {
-  filename: 'input.tsx',
-  jsx: 'automatic',
-  target: 'es2022',
-});
-
-// Bundle
-const result = await bundle({
-  entryPoints: ['src/index.ts'],
-  outdir: 'dist',
-  format: 'esm',
-  minify: true,
-  treeShake: true,
-});
+const { code } = transpile(source, { filename: 'in.tsx', jsx: 'automatic', target: 'es2022' });
 ```
-
-### Vite plugin (vite.config.ts)
-
-```ts
-import { defineConfig } from 'vite';
-import zntc from '@zntc/vite-plugin';
-
-export default defineConfig({
-  plugins: [zntc()],
-});
-```
-
-## Key options
-
-| Flag | Meaning |
-|---|---|
-| `--bundle` | bundle mode (without this flag, transpile only) |
-| `--format=esm/cjs/iife` | output module format |
-| `--target=es5/es2015/es2020/es2022` | ECMAScript target (for downleveling) |
-| `--jsx=automatic/classic/preserve` | JSX transform mode |
-| `--minify` / `--minify-identifiers` / `--minify-whitespace` | minify (esbuild-equivalent flags) |
-| `--tree-shake` | enable tree-shaking (default on with `--bundle`) |
-| `--watch` | watch mode (HMR — incremental rebuild ~22 ms / 641 modules) |
-| `--profile=parse,transform,...` | print per-phase timing to stderr (debug) |
-| `--target-platform=node/browser/react-native` | resolution platform |
-
-## Performance (2026-05-21, darwin arm64, 20-run median)
-
-| Task | ZNTC | esbuild | Bun | rolldown | rspack |
-|---|---|---|---|---|---|
-| Transpile 100 lines | **1.79 ms** | 3.90 | 5.16 | — | — |
-| Transpile 1K lines | 3.02 ms | 4.79 | 5.59 | — | — |
-| Bundle 10 modules | **2.62 ms** | 10.8 | 8.05 | 52.3 | 62.4 |
-| Bundle 1K modules | **17.0 ms** | 26.8 | 23.3 | 70.2 | 83.8 |
-| Bundle 5K modules | 81.7 ms | 89.1 | **66.4** | 126 | 181 |
-
-## Practical workflows
-
-### React + TypeScript SPA
-
-```sh
-# Dev (watch)
-zntc --bundle src/index.tsx --watch --jsx=automatic -o dist/bundle.js
-
-# Production
-zntc --bundle src/index.tsx \
-  --jsx=automatic \
-  --target=es2020 \
-  --minify \
-  --tree-shake \
-  -o dist/bundle.js
-```
-
-### Library publish (Multi-format)
-
-```sh
-zntc --bundle src/index.ts \
-  --format=esm --output=dist/index.mjs \
-  --format=cjs --output=dist/index.cjs \
-  --target=es2018 \
-  --minify
-```
-
-### Drop-in to an existing Vite project
 
 ```ts
 // vite.config.ts
 import zntc from '@zntc/vite-plugin';
-
-export default {
-  plugins: [zntc({ tsconfig: './tsconfig.json' })],
-};
+export default { plugins: [zntc()] };
 ```
 
-## Limitations / not supported
+## More details (fetch when needed)
 
-- WASM build: `.wasm` target not released yet (planned)
-- Hermes regex named capture group downleveling: not supported (Hermes limitation — only kept in original form)
-- Multi-format + dev_mode/splitting/MF combination is rejected (explicit error)
-- Some minify cases: zod/effect output is slightly larger than rolldown's (mangler gap, deferred work)
+- Sitemap of all docs: <https://ohah.github.io/zntc/llms.txt>
+- Full documentation in one plain-text file (for LLM context): <https://ohah.github.io/zntc/llms-full.txt>
+- Docs site: <https://ohah.github.io/zntc/en/>
+- GitHub: <https://github.com/ohah/zntc>
 
-## References
-
-- Official docs: https://ohah.github.io/zntc/
-- English docs: https://ohah.github.io/zntc/en/
-- llms.txt (sitemap): https://ohah.github.io/zntc/llms.txt
-- llms-full.txt (entire docs as plain text): https://ohah.github.io/zntc/llms-full.txt
-- GitHub: https://github.com/ohah/zntc
-- Playground: https://ohah.github.io/zntc/en/playground/
-
-## How to install this skill (Claude Code)
-
-```sh
-# Global (works in every project)
-mkdir -p ~/.claude/skills/zntc-cli
-curl -fsSL https://ohah.github.io/zntc/zntc-cli.skill.md > ~/.claude/skills/zntc-cli/SKILL.md
-```
-
-Or per-project:
-
-```sh
-mkdir -p .claude/skills/zntc-cli
-curl -fsSL https://ohah.github.io/zntc/zntc-cli.skill.md > .claude/skills/zntc-cli/SKILL.md
-```
-
-After installing, Claude Code automatically invokes this skill when it detects `zntc`, `transpile`, or `bundle`-related tasks.
+Fetch `llms-full.txt` (~400 KB) when you need full CLI flag reference, NAPI API, plugin internals, performance benchmarks, or migration guides.


### PR DESCRIPTION
## Summary

이전 5 KB skill 이 *전체 옵션 표 + 성능 표 + 워크플로 + 한계* 등 자세한 내용을 전부 안에 담았음 → Claude context 부담 + 정보 갱신 부담.

**간소화 (1.5 KB, -70%)**:

- 빠른 설치 (CLI + Vite plugin)
- 핵심 사용 4가지 (transpile / bundle / watch / NAPI / vite.config)
- "필요 시 `llms-full.txt` fetch" hint — LLM 이 자세한 내용 필요 시 직접 fetch

## 효과

- skill 본문 짧음 → Claude context 절약
- 자세한 내용 (CLI flag 전체 / NAPI API / 한계) = `llms-full.txt` 한 번 fetch
- skill 본문 갱신 부담 작음 — docs 만 갱신하면 llms-full.txt 자동 따라옴

## Test plan

- [x] `bun run build` 통과 (531 page)
- [x] 1.5 KB size 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)