### PR TITLE
feat(core): zntc verify --browser CLI — headless Chromium runtime gate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -419,6 +419,7 @@
         "core-js": "^3.49.0",
         "core-js-compat": "^3.49.0",
         "lightningcss": "^1.28.0",
+        "playwright": "^1.50.0",
       },
     },
     "packages/init": {

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -59,6 +59,42 @@ imported CSS 산출물에 자동 적용한다. Tailwind v4는 `postcss.config.mj
 source map을 적용해 가능한 경우 원본 `main.ts:line:column` 위치로 보여준다.
 세부 동작: [HMR.md § 에러 오버레이](./HMR.md#에러-오버레이).
 
+### 브라우저 런타임 검증 (`zntc verify`)
+
+```bash
+zntc verify dist/index.html          # 정적 빌드 결과 검증
+zntc verify dist/                    # 디렉토리 → index.html 자동
+zntc verify http://localhost:3000/   # 실행 중인 서버 검증
+```
+
+빌드 산출물이 실제 브라우저에서 깨지는지 한 줄로 가드 — headless Chromium 으로 페이지를
+띄우고 `pageerror` (uncaught + unhandledrejection) / `console.error` / 4xx 응답 /
+request 실패를 수집한다. 이벤트 발견 시 **exit 1** 로 CI 가 fail 처리.
+
+```bash
+zntc verify dist/ --verify-json --verify-report=verify-report.json
+zntc verify dist/ --verify-ignore "third-party warning" --verify-allow-console-error
+```
+
+- `--verify-timeout <ms>` — 페이지 로드 타임아웃 (기본 10000)
+- `--verify-ignore <pattern>` — 매칭되는 console/url 이벤트는 무시 (정규식, 반복 가능)
+- `--verify-allow-console-error` — `console.error` 는 exit 코드에 영향 없음 (pageerror 만 fail)
+- `--verify-json` — 사람이 읽는 요약 대신 JSON 보고서를 stdout 에
+- `--verify-report <path>` — JSON 보고서를 파일로 저장
+
+다른 모드의 flag 와 격리하기 위해 모두 `--verify-` prefix.
+
+**의존성**: Playwright peer/optional. 미설치 시 친화 에러 + exit 64.
+
+```bash
+npm install --save-dev playwright
+npx playwright install chromium
+```
+
+타입체크와 유닛 테스트가 못 잡는 런타임 회귀 (ESM circular dep, TDZ, scope-hoist
+오재작성, 누락된 리소스) 를 잡는 게 목적. 사용자가 `npx playwright` 로 한 번 설치하면
+`zntc build && zntc verify dist/` 한 줄로 CI 검증 추가.
+
 ## 설정 파일 (`zntc.config.json` / `zntc.config.{ts,js,mjs,cjs,mts,cts}`)
 
 ### `zntc.config.json` — TranspileOptions defaults

--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -266,6 +266,13 @@ export const FLAG_REGISTRY = [
   { kind: 'string-bool', flag: '--emit-disk-sourcemap', target: 'emitDiskSourcemap' },
   { kind: 'string-bool', flag: '--use-define-for-class-fields', target: 'useDefineForClassFields' },
   { kind: 'string-bool', flag: '--tokenize', target: 'tokenize' },
+
+  // ─── `zntc verify` 전용. 다른 모드와 silent 충돌 방지를 위해 prefix 강제 ───
+  { kind: 'int', flag: '--verify-timeout', target: 'verifyTimeout' },
+  { kind: 'array', flag: '--verify-ignore', target: 'verifyIgnore' },
+  { kind: 'bool', flag: '--verify-allow-console-error', target: 'verifyAllowConsoleError' },
+  { kind: 'bool', flag: '--verify-json', target: 'verifyJson' },
+  { kind: 'string', flag: '--verify-report', target: 'verifyReport' },
 ];
 
 /**

--- a/packages/core/bin/verify.mjs
+++ b/packages/core/bin/verify.mjs
@@ -1,0 +1,190 @@
+// `zntc verify <path-or-url>` 진입점. 정적 결과물 (`dist/`) 또는 URL 을 헤드리스
+// Chromium 에 띄우고 pageerror / console.error / 4xx 응답 / request 실패를
+// 수집해 JSON 리포트로 리턴. CI 한 줄로 "번들이 브라우저에서 깨지는지" 검증.
+//
+// playwright 는 optionalDependency — 미설치 시 친절한 안내 후 exit 64.
+
+import { statSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { isAbsolute, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// Exit code contract — runVerify 의 public API. CI 가 의존하므로 변경 시 docs/USAGE.md 동기.
+const EXIT_OK = 0;
+const EXIT_EVENTS_FOUND = 1;
+const EXIT_LOAD_FAILED = 2;
+const EXIT_BAD_USAGE = 64;
+
+const PLAYWRIGHT_INSTALL_HINT = [
+  'zntc verify requires Playwright to be installed.',
+  '',
+  '  npm install --save-dev playwright',
+  '  npx playwright install chromium',
+  '',
+].join('\n');
+
+// cwd 의 node_modules 와 verify.mjs 위치 양쪽에서 playwright / @playwright/test 를
+// 순차 탐색. 사용자가 자기 프로젝트에 playwright 를 설치한 경우 그쪽 우선.
+// require() 가 dynamic import 보다 우선 — @playwright/test 는 CJS/ESM dual 인데
+// CJS entry 를 ESM 으로 평가하면 default export 만 노출되고 chromium 같은 named
+// export 는 사라진다. require() 는 CJS entry 의 module.exports 전체를 그대로 반환.
+async function loadChromium() {
+  const requireFromCwd = createRequire(resolve(process.cwd(), 'package.json'));
+  for (const name of ['playwright', '@playwright/test']) {
+    try {
+      const mod = requireFromCwd(name);
+      if (mod?.chromium) return mod.chromium;
+    } catch {}
+    try {
+      const mod = await import(name);
+      if (mod?.chromium) return mod.chromium;
+    } catch {}
+  }
+  return null;
+}
+
+export async function runVerify(opts) {
+  const target = normalizeTarget(opts.verifyTarget);
+  if (!target) {
+    process.stderr.write(
+      'zntc verify: missing or invalid target. Usage: zntc verify <path-or-url> [options]\n',
+    );
+    return { exitCode: EXIT_BAD_USAGE };
+  }
+
+  const chromium = await loadChromium();
+  if (!chromium) {
+    process.stderr.write(PLAYWRIGHT_INSTALL_HINT);
+    return { exitCode: EXIT_BAD_USAGE };
+  }
+
+  const ignorePatterns = (opts.verifyIgnore || []).map((p) => new RegExp(p));
+  const timeout = opts.verifyTimeout ?? 10000;
+  const allowConsoleError = opts.verifyAllowConsoleError ?? false;
+  const events = [];
+
+  const start = Date.now();
+  let browser;
+  let loadOk = false;
+  let loadFailure = null;
+
+  try {
+    browser = await chromium.launch({ headless: true });
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    page.on('pageerror', (err) => {
+      events.push({
+        type: 'pageerror',
+        message: err.message,
+        stack: err.stack ?? '',
+      });
+    });
+    page.on('console', (msg) => {
+      if (msg.type() !== 'error') return;
+      const text = msg.text();
+      if (ignorePatterns.some((re) => re.test(text))) return;
+      const loc = msg.location();
+      events.push({
+        type: 'console_error',
+        text,
+        location: loc?.url ? `${loc.url}:${loc.lineNumber + 1}:${loc.columnNumber + 1}` : '',
+      });
+    });
+    page.on('requestfailed', (req) => {
+      const url = req.url();
+      if (ignorePatterns.some((re) => re.test(url))) return;
+      events.push({
+        type: 'request_failed',
+        url,
+        method: req.method(),
+        failure: req.failure()?.errorText ?? '',
+      });
+    });
+    page.on('response', (res) => {
+      const status = res.status();
+      if (status < 400) return;
+      const url = res.url();
+      if (ignorePatterns.some((re) => re.test(url))) return;
+      events.push({ type: 'response', url, status });
+    });
+
+    await page.goto(target.url, { timeout, waitUntil: 'networkidle' });
+    loadOk = true;
+  } catch (err) {
+    loadFailure = err instanceof Error ? err.message : String(err);
+  } finally {
+    if (browser) await browser.close().catch(() => {});
+  }
+
+  const duration_ms = Date.now() - start;
+  if (loadFailure) {
+    events.push({ type: 'load_failed', message: loadFailure });
+  }
+  const fatalEvents = events.filter((e) => {
+    if (e.type === 'console_error') return !allowConsoleError;
+    return true;
+  });
+  let exitCode = EXIT_OK;
+  if (!loadOk) exitCode = EXIT_LOAD_FAILED;
+  else if (fatalEvents.length > 0) exitCode = EXIT_EVENTS_FOUND;
+
+  const report = {
+    target: target.url,
+    status: exitCode === 0 ? 'pass' : 'fail',
+    duration_ms,
+    events,
+  };
+
+  if (opts.verifyReport) {
+    writeFileSync(opts.verifyReport, `${JSON.stringify(report, null, 2)}\n`);
+  }
+
+  if (opts.verifyJson) {
+    process.stdout.write(`${JSON.stringify(report)}\n`);
+  } else {
+    formatHuman(report, allowConsoleError);
+  }
+
+  return { exitCode };
+}
+
+function normalizeTarget(raw) {
+  if (!raw) return null;
+  if (/^https?:\/\//.test(raw) || raw.startsWith('file://')) {
+    return { url: raw };
+  }
+  const abs = isAbsolute(raw) ? raw : resolve(process.cwd(), raw);
+  try {
+    const stat = statSync(abs);
+    const filePath = stat.isDirectory() ? join(abs, 'index.html') : abs;
+    statSync(filePath);
+    return { url: pathToFileURL(filePath).href };
+  } catch {
+    return null;
+  }
+}
+
+function formatHuman(report, allowConsoleError) {
+  const stream = report.status === 'pass' ? process.stdout : process.stderr;
+  stream.write(`zntc verify: ${report.status.toUpperCase()} (${report.duration_ms} ms)\n`);
+  stream.write(`  target: ${report.target}\n`);
+  if (report.events.length === 0) return;
+  stream.write(`  ${report.events.length} event(s):\n`);
+  for (const e of report.events) {
+    if (e.type === 'pageerror') {
+      stream.write(`    [pageerror] ${e.message}\n`);
+    } else if (e.type === 'console_error') {
+      stream.write(`    [console.error] ${e.text}${e.location ? ` @ ${e.location}` : ''}\n`);
+    } else if (e.type === 'response') {
+      stream.write(`    [HTTP ${e.status}] ${e.url}\n`);
+    } else if (e.type === 'request_failed') {
+      stream.write(`    [request_failed] ${e.url} (${e.failure})\n`);
+    } else if (e.type === 'load_failed') {
+      stream.write(`    [load_failed] ${e.message}\n`);
+    }
+  }
+  if (allowConsoleError && report.events.some((e) => e.type === 'console_error')) {
+    stream.write('  (--verify-allow-console-error: console errors do not affect exit code)\n');
+  }
+}

--- a/packages/core/bin/zntc-cli-schema-sync.test.ts
+++ b/packages/core/bin/zntc-cli-schema-sync.test.ts
@@ -397,6 +397,15 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
     '--global-identifier=', // → globalIdentifiers
     '--polyfill=', // → polyfills
     '--watch-folder=', // → watchFolders (RN-CLI `--watchFolders` csv 와 별개)
+    // `zntc verify` 전용 — BuildOptions/TranspileOptions 매핑 없음 (Playwright runner option).
+    '--verify-timeout',
+    '--verify-timeout=',
+    '--verify-ignore',
+    '--verify-ignore=',
+    '--verify-allow-console-error',
+    '--verify-json',
+    '--verify-report',
+    '--verify-report=',
   ]);
 
   // BuildOptions/TranspileOptions 에 있고 CLI 에 없는 키 (의도적). 함수형/고급 옵션.

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -147,6 +147,27 @@ function usageLines(command) {
       '  --help, -h                 Show this help message',
     ];
   }
+  if (command === 'verify') {
+    return [
+      'Usage: zntc verify <path-or-url> [options]',
+      '',
+      'Loads the target in a headless Chromium and reports pageerror,',
+      'console.error, 4xx responses, and request failures. Exits non-zero',
+      'on any captured event so CI can gate on real browser runtime errors.',
+      '',
+      'Options:',
+      '  --verify-timeout <ms>          Page load timeout (default: 10000)',
+      '  --verify-ignore <pattern>      Regex to skip matching console/url events (repeatable)',
+      '  --verify-allow-console-error   console.error events do not affect exit code',
+      '  --verify-json                  Emit machine-readable report on stdout',
+      '  --verify-report <path>         Write JSON report to file',
+      '  --help, -h                     Show this help message',
+      '',
+      'Requires Playwright (peer/optional):',
+      '  npm install --save-dev playwright',
+      '  npx playwright install chromium',
+    ];
+  }
   return [
     'Usage: zntc [options] <file.ts>',
     '       zntc --bundle <entry.ts> -o out.js',
@@ -202,7 +223,7 @@ function printUsage(command, stream = console.log) {
 
 function parseArgs(argv) {
   const args = argv.slice(2);
-  const appCommands = new Set(['dev', 'build', 'preview']);
+  const appCommands = new Set(['dev', 'build', 'preview', 'verify']);
   const appCommand = appCommands.has(args[0]) ? args.shift() : undefined;
   const opts = {
     appCommand,
@@ -359,6 +380,14 @@ function parseArgs(argv) {
     tokenize: false,
     tokenizeFormat: 'text',
     test262: undefined,
+    // verify 모드 (`zntc verify <path-or-url>`) 전용 — FLAG_REGISTRY 가 다른 모드에서
+    // 매칭해도 핸들러가 무시. verifyTarget 만 positional 로 채워진다.
+    verifyTarget: undefined,
+    verifyJson: false,
+    verifyReport: undefined,
+    verifyTimeout: undefined,
+    verifyIgnore: [],
+    verifyAllowConsoleError: false,
   };
 
   if (appCommand === 'dev') {
@@ -386,6 +415,8 @@ function parseArgs(argv) {
         opts.appRoot = opts.appRoot ?? arg;
       } else if (opts.appCommand === 'preview') {
         opts.previewDir = opts.previewDir ?? arg;
+      } else if (opts.appCommand === 'verify') {
+        opts.verifyTarget = opts.verifyTarget ?? arg;
       } else {
         opts.entryPoints.push(arg);
       }
@@ -2177,6 +2208,18 @@ async function main() {
       process.exit(1);
     }
     return;
+  }
+
+  // verify 는 Playwright 만 호출 — config / NAPI dlopen 불필요. test262 와 동일한 early dispatch.
+  if (opts.appCommand === 'verify') {
+    try {
+      const { runVerify } = await import('./verify.mjs');
+      const r = await runVerify(opts);
+      process.exit(r.exitCode);
+    } catch (err) {
+      console.error(`error: ${err.message}`);
+      process.exit(1);
+    }
   }
 
   // RN dev/build 의 positional arg 는 entry point (파일) — web 처럼 appRoot (디렉토리)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,7 @@
     "bin/cli-flags.mjs",
     "bin/rn-asset-copy.mjs",
     "bin/rn-dev-input.mjs",
+    "bin/verify.mjs",
     "bin/zntc.mjs"
   ],
   "type": "module",
@@ -86,7 +87,8 @@
     "browserslist": "^4.24.0",
     "core-js": "^3.49.0",
     "core-js-compat": "^3.49.0",
-    "lightningcss": "^1.28.0"
+    "lightningcss": "^1.28.0",
+    "playwright": "^1.50.0"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/tests/e2e/tests/verify-cli-e2e.test.ts
+++ b/tests/e2e/tests/verify-cli-e2e.test.ts
@@ -1,0 +1,115 @@
+// `zntc verify <path-or-url>` CLI 의 회귀 가드.
+// CLI 진입점 + Playwright loader + exit-code 규약을 사용자 시점에서 검증한다.
+// 실제 Playwright import 는 verify.mjs 의 loadChromium 이 tests/e2e/node_modules
+// (`@playwright/test` fallback) 에서 chromium 을 찾는다 — cwd=tests/e2e 로 spawn.
+
+import { test, expect } from '@playwright/test';
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const ZNTC_MJS = resolve(__dirname, '../../../packages/core/bin/zntc.mjs');
+const E2E_CWD = resolve(__dirname, '..');
+
+interface VerifyResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runVerify(args: string[]): Promise<VerifyResult> {
+  return new Promise((resolve) => {
+    const child = spawn('node', [ZNTC_MJS, 'verify', ...args], {
+      stdio: 'pipe',
+      cwd: E2E_CWD,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
+    child.on('close', (code) => {
+      resolve({ exitCode: code, stdout, stderr });
+    });
+  });
+}
+
+let fixtureDir: string;
+
+test.beforeAll(async () => {
+  fixtureDir = await mkdtemp(join(tmpdir(), 'zntc-verify-cli-'));
+});
+
+test.afterAll(async () => {
+  await rm(fixtureDir, { recursive: true, force: true });
+});
+
+test.describe('zntc verify CLI', () => {
+  test('정상 페이지는 exit 0 + pass 리포트', async () => {
+    const file = join(fixtureDir, 'ok.html');
+    await writeFile(file, '<!doctype html><h1>ok</h1>');
+    const r = await runVerify([file, '--verify-json']);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout.trim());
+    expect(report.status).toBe('pass');
+    expect(report.events).toEqual([]);
+  });
+
+  test('pageerror 는 exit 1 + JSON 에 pageerror 이벤트', async () => {
+    const file = join(fixtureDir, 'pageerror.html');
+    await writeFile(file, '<!doctype html><script>throw new Error("zntc verify boom");</script>');
+    const r = await runVerify([file, '--verify-json']);
+    expect(r.exitCode).toBe(1);
+    const report = JSON.parse(r.stdout.trim());
+    expect(report.status).toBe('fail');
+    expect(
+      report.events.some(
+        (e: { type: string; message?: string }) =>
+          e.type === 'pageerror' && /zntc verify boom/.test(e.message ?? ''),
+      ),
+    ).toBe(true);
+  });
+
+  test('console.error 는 기본 exit 1, --verify-allow-console-error 면 exit 0', async () => {
+    const file = join(fixtureDir, 'console-error.html');
+    await writeFile(
+      file,
+      '<!doctype html><script>console.error("expected console error");</script>',
+    );
+    const fail = await runVerify([file, '--verify-json']);
+    expect(fail.exitCode).toBe(1);
+    const ok = await runVerify([file, '--verify-json', '--verify-allow-console-error']);
+    expect(ok.exitCode).toBe(0);
+  });
+
+  test('존재하지 않는 경로는 exit 64', async () => {
+    const r = await runVerify(['/path/does/not/exist.html']);
+    expect(r.exitCode).toBe(64);
+  });
+
+  test('--verify-report 가 지정되면 JSON 파일로 저장', async () => {
+    const file = join(fixtureDir, 'ok-report.html');
+    const reportPath = join(fixtureDir, 'report.json');
+    await writeFile(file, '<!doctype html><h1>ok</h1>');
+    const r = await runVerify([file, '--verify-report', reportPath]);
+    expect(r.exitCode).toBe(0);
+    const saved = JSON.parse(await readFile(reportPath, 'utf8'));
+    expect(saved.status).toBe('pass');
+  });
+
+  test('--verify-ignore <pattern> 으로 매칭되는 console.error 는 무시', async () => {
+    const file = join(fixtureDir, 'console-ignored.html');
+    await writeFile(
+      file,
+      '<!doctype html><script>console.error("noisy third-party warning");</script>',
+    );
+    const r = await runVerify([file, '--verify-json', '--verify-ignore', 'noisy third-party']);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(r.stdout.trim());
+    expect(report.events).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

빌드 산출물 / dev server URL 을 헤드리스 Chromium 에 로드하고 `pageerror` (uncaught + unhandledrejection) / `console.error` / 4xx 응답 / request 실패를 수집해 JSON 리포트 + non-zero exit 로 보고하는 `zntc verify` CLI 신설. 타입체크 / 유닛테스트가 못 잡는 런타임 회귀 (ESM circular dep, TDZ, scope-hoist rewrite, 누락 리소스) 를 CI 한 줄로 가드.

```bash
zntc verify dist/index.html             # 정적 빌드 검증
zntc verify dist/                       # 디렉토리 → index.html 자동
zntc verify http://localhost:3000/      # 실행 중인 서버
zntc verify dist/ --verify-json --verify-report=report.json
zntc verify dist/ --verify-ignore "third-party" --verify-allow-console-error
```

## 변경

- **`packages/core/bin/verify.mjs`** (NEW) — runner + Playwright loader. `loadChromium` 이 cwd-rooted `createRequire` 우선 + dynamic `import` fallback, `playwright` 와 `@playwright/test` 둘 다 시도 (CJS/ESM dual 패키지에서 named export 정상 노출 보장)
- **`packages/core/bin/zntc.mjs`** — `verify` 서브커맨드 라우팅 + `usageLines('verify')` + early dispatch (config / NAPI dlopen 스킵, `--test262` 패턴)
- **`packages/core/bin/cli-flags.mjs`** — 5 옵션 `--verify-*` prefix. 다른 모드 (`--timeout` 등) 와 silent 충돌 방지
- **`packages/core/package.json`** — `playwright` 를 `optionalDependencies` 로
- **`packages/core/bin/zntc-cli-schema-sync.test.ts`** — verify flag 5개 CLI-only allowlist 등록
- **`tests/e2e/tests/verify-cli-e2e.test.ts`** (NEW) — 6 케이스 회귀 가드 (pass / pageerror / console.error / 64 / report / ignore)
- **`docs/USAGE.md`** — 사용법 + 의존성 + 적용 시나리오

## Exit code contract

| 코드 | 의미 |
|---|---|
| 0 | 깨끗 |
| 1 | pageerror / console.error / 4xx / request failure 발견 |
| 2 | 페이지 로드 실패 (타임아웃 / 네트워크) |
| 64 | 잘못된 사용 (타깃 없음, Playwright 미설치) |

## 의존성

`playwright` 가 optionalDependency. 미설치 시 친화 메시지 + exit 64.

```bash
npm install --save-dev playwright
npx playwright install chromium
```

## /simplify 적용 내역

3-agent review (reuse / quality / efficiency) 후:
- ✅ exit code 상수화 (`EXIT_OK`/`EXIT_EVENTS_FOUND`/`EXIT_LOAD_FAILED`/`EXIT_BAD_USAGE`)
- ✅ generic flag 이름 → `--verify-*` prefix (사용자 결정, 다른 모드와 silent 충돌 차단)
- ✅ CJS/ESM dual entry 주석 보강
- ✅ TOCTOU `existsSync`+`statSync` → `try { statSync }` 로 단순화
- ⏭ Early-dispatch 헬퍼 추출 (2개 사례, premature abstraction)
- ⏭ `waitUntil: 'networkidle'` 변경 (measure-first 원칙)
- ⏭ Event type 상수화 (작은 파일, producer/consumer 인접)

## Test plan

- [x] e2e `Dev Server` + `zntc verify` 15/15 통과
- [x] `bin/cli-flags.test.ts` + `bin/zntc-cli-schema-sync.test.ts` 회귀 없음 (pre-existing main breakage 1건 — `output` 키 — 본 PR 무관)
- [x] core build 통과 (`bun run build`)
- [x] `oxfmt` 통과 (pre-push hook)
- [x] verify CLI 자체 fixture 6 시나리오 — pageerror / console.error / --verify-allow-console-error / 잘못된 경로 / --verify-report / --verify-ignore

## 후속 (이 PR 범위 외)

- **PR 2 (CD-1 CI 통합)** — 어느 잡에 `zntc verify` 를 끼울지 측정 후 결정. smoke 136 케이스 전체 vs 대표 lib 선별 vs e2e.yml 묶음
- **CD-2 (`verify_in_chrome` MCP 도구)** — dev-server MCP 에 노출, 에이전트가 "빌드 → 브라우저 검증" 한 루프로

ROADMAP.md "CD-1 (CDP 번들 검증 CLI)" 항목.