### PR TITLE
feat(dev-server): verify_in_chrome MCP tool — agent-driven browser verify

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -794,7 +794,8 @@ pub const DevServer = struct {
             try w.writeAll(
                 \\"result":{"tools":[
                 \\{"name":"reset_cache","description":"Clear the build cache. Next build will be a full rebuild.","inputSchema":{"type":"object","properties":{},"additionalProperties":false}},
-                \\{"name":"get_build_events","description":"Subscribe to bundler events for a duration and return collected events.","inputSchema":{"type":"object","properties":{"duration":{"type":"number","minimum":1000,"maximum":60000,"default":10000,"description":"milliseconds to listen"}},"additionalProperties":false}}
+                \\{"name":"get_build_events","description":"Subscribe to bundler events for a duration and return collected events.","inputSchema":{"type":"object","properties":{"duration":{"type":"number","minimum":1000,"maximum":60000,"default":10000,"description":"milliseconds to listen"}},"additionalProperties":false}},
+                \\{"name":"verify_in_chrome","description":"Run `zntc verify` (headless Chromium) against the dev server (or a custom target) and return the JSON report. Requires Playwright in the Node CLI environment; set ZNTC_CLI env to the path of bin/zntc.mjs (npm-install environments find `zntc` on PATH automatically).","inputSchema":{"type":"object","properties":{"target":{"type":"string","description":"Path or URL to verify. Defaults to the dev server root URL."},"timeout":{"type":"number","minimum":1000,"maximum":60000,"description":"Page load timeout in ms (default: 10000)"},"ignore":{"type":"array","items":{"type":"string"},"description":"Regex patterns; matching console/url events are skipped."},"allowConsoleError":{"type":"boolean","description":"If true, console.error events do not affect exit code."}},"additionalProperties":false}}
                 \\]}
             );
         } else if (std.mem.eql(u8, method, "tools/call")) {
@@ -884,7 +885,114 @@ pub const DevServer = struct {
             return;
         }
 
+        if (std.mem.eql(u8, tool_name, "verify_in_chrome")) {
+            try self.handleVerifyInChrome(w, args);
+            return;
+        }
+
         try w.writeAll("\"error\":{\"code\":-32602,\"message\":\"Unknown tool\"}");
+    }
+
+    /// `verify_in_chrome` MCP 도구. Node CLI (`zntc verify --verify-json ...`) 를
+    /// 자식 프로세스로 spawn 해 JSON 리포트를 받아온다. CLI 경로는 `ZNTC_CLI` env →
+    /// PATH 의 `zntc` 순. Playwright optionalDependency 가 Node 측 책임.
+    fn handleVerifyInChrome(self: *DevServer, w: anytype, args: std.json.Value) !void {
+        const allocator = self.allocator;
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        const arena_alloc = arena.allocator();
+
+        // 1. target — 기본값 = 서버 root URL.
+        var target: []const u8 = "";
+        var timeout_ms: ?i64 = null;
+        var allow_console_error = false;
+        var ignore_patterns: []const std.json.Value = &.{};
+        switch (args) {
+            .object => |o| {
+                switch (o.get("target") orelse .null) {
+                    .string => |s| target = s,
+                    else => {},
+                }
+                switch (o.get("timeout") orelse .null) {
+                    .integer => |n| timeout_ms = n,
+                    .float => |f| timeout_ms = @intFromFloat(f),
+                    else => {},
+                }
+                switch (o.get("allowConsoleError") orelse .null) {
+                    .bool => |b| allow_console_error = b,
+                    else => {},
+                }
+                switch (o.get("ignore") orelse .null) {
+                    .array => |arr| ignore_patterns = arr.items,
+                    else => {},
+                }
+            },
+            else => {},
+        }
+        if (target.len == 0) {
+            target = try std.fmt.allocPrint(arena_alloc, "http://{s}:{d}/", .{ self.host, self.port });
+        }
+
+        // 2. CLI 경로 — ZNTC_CLI 우선 (모노레포 dev / 비표준 install 환경), 없으면 PATH 의 `zntc`.
+        const cli_path = std.process.getEnvVarOwned(arena_alloc, "ZNTC_CLI") catch
+            try arena_alloc.dupe(u8, "zntc");
+
+        // 3. argv 구성 — ZNTC_CLI 가 `.mjs/.js` 면 직접 exec 불가 (Node 는 스크립트
+        // 파일을 ELF/Mach-O 처럼 실행 못함, `node script.mjs` 형태 필요).
+        const needs_node = std.mem.endsWith(u8, cli_path, ".mjs") or
+            std.mem.endsWith(u8, cli_path, ".js");
+        var argv: std.ArrayList([]const u8) = .empty;
+        if (needs_node) try argv.append(arena_alloc, "node");
+        try argv.append(arena_alloc, cli_path);
+        try argv.append(arena_alloc, "verify");
+        try argv.append(arena_alloc, target);
+        try argv.append(arena_alloc, "--verify-json");
+        if (timeout_ms) |t| {
+            try argv.append(arena_alloc, "--verify-timeout");
+            try argv.append(arena_alloc, try std.fmt.allocPrint(arena_alloc, "{d}", .{t}));
+        }
+        if (allow_console_error) {
+            try argv.append(arena_alloc, "--verify-allow-console-error");
+        }
+        for (ignore_patterns) |p| switch (p) {
+            .string => |s| {
+                try argv.append(arena_alloc, "--verify-ignore");
+                try argv.append(arena_alloc, s);
+            },
+            else => {},
+        };
+
+        // 4. spawn (1MB stdout / stderr 상한 — verify 리포트는 보통 1-10KB).
+        const result = std.process.Child.run(.{
+            .allocator = arena_alloc,
+            .argv = argv.items,
+            .max_output_bytes = 1024 * 1024,
+        }) catch |err| {
+            try w.writeAll("\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"");
+            const msg = try std.fmt.allocPrint(
+                arena_alloc,
+                "zntc verify spawn 실패: {}. ZNTC_CLI env (또는 PATH 의 `zntc` Node CLI) 가 설치/실행 가능한지 확인.",
+                .{err},
+            );
+            try writeJsonEscaped(w, msg);
+            try w.writeAll("\"}],\"isError\":true}");
+            return;
+        };
+
+        // 5. 응답 구성 — stdout (JSON 1줄) 이 verify 리포트. 비어있으면 stderr 노출.
+        const is_error = switch (result.term) {
+            .Exited => |code| code != 0,
+            else => true,
+        };
+        const stdout_trim = std.mem.trim(u8, result.stdout, " \t\r\n");
+        const stderr_trim = std.mem.trim(u8, result.stderr, " \t\r\n");
+        const payload = if (stdout_trim.len > 0) stdout_trim else stderr_trim;
+
+        try w.writeAll("\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"");
+        try writeJsonEscaped(w, payload);
+        try w.writeAll("\"}]");
+        if (is_error) try w.writeAll(",\"isError\":true");
+        try w.writeAll("}");
     }
 
     /// 이벤트를 SSE 구독자 전원에 브로드캐스트.

--- a/tests/e2e/tests/ports.ts
+++ b/tests/e2e/tests/ports.ts
@@ -25,4 +25,5 @@ export const PORTS = {
   NESTED: 3996,
   DEV_JSX: 3984,
   BUILD_JSX: 3983,
+  VERIFY_MCP: 3982,
 } as const;

--- a/tests/e2e/tests/verify-in-chrome-mcp-e2e.test.ts
+++ b/tests/e2e/tests/verify-in-chrome-mcp-e2e.test.ts
@@ -1,0 +1,124 @@
+// Zig dev server 의 MCP `verify_in_chrome` 도구 회귀 가드.
+// dev server 가 자식 프로세스로 `zntc verify --verify-json` 을 spawn 해
+// MCP 응답 wrap 까지 한 루프가 정상 동작하는지 사용자 시점에서 검증한다.
+//
+// 의존성: #3609 의 `zntc verify` CLI 가 머지되어 있어야 한다. spawn 시
+// ZNTC_CLI env 로 zntc.mjs 절대 경로 명시 — 모노레포 dev 환경에서는
+// PATH 의 `zntc` binstub 가 없으므로 필수.
+
+import { test, expect } from '@playwright/test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { PORTS } from './ports';
+
+const ZNTC_BIN = resolve(__dirname, '../../../zig-out/bin/zntc');
+const ZNTC_CLI_MJS = resolve(__dirname, '../../../packages/core/bin/zntc.mjs');
+const PORT = PORTS.VERIFY_MCP;
+
+let server: ChildProcess | null = null;
+let fixtureDir: string;
+
+async function callMcp(method: string, params: unknown, id = 1): Promise<unknown> {
+  const res = await fetch(`http://localhost:${PORT}/mcp`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', method, id, params }),
+  });
+  return res.json();
+}
+
+function parseToolResult(rpc: any): { report: any; isError: boolean } {
+  const result = rpc.result;
+  const text = result.content[0].text;
+  return { report: JSON.parse(text), isError: result.isError === true };
+}
+
+test.beforeAll(async () => {
+  fixtureDir = await mkdtemp(join(tmpdir(), 'zntc-verify-mcp-'));
+  await mkdir(fixtureDir, { recursive: true });
+  await writeFile(join(fixtureDir, 'main.ts'), 'console.log("ok");');
+  await writeFile(join(fixtureDir, 'ok.html'), '<!doctype html><h1>ok</h1>');
+  await writeFile(
+    join(fixtureDir, 'pageerror.html'),
+    '<!doctype html><script>throw new Error("verify-mcp boom");</script>',
+  );
+
+  server = spawn(
+    ZNTC_BIN,
+    ['--serve', '--bundle', join(fixtureDir, 'main.ts'), '--port', String(PORT)],
+    {
+      stdio: 'pipe',
+      env: { ...process.env, ZNTC_CLI: ZNTC_CLI_MJS },
+    },
+  );
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+});
+
+test.afterAll(async () => {
+  if (server) {
+    server.kill();
+    await new Promise((r) => server!.on('close', r));
+  }
+  await rm(fixtureDir, { recursive: true, force: true });
+});
+
+test.describe('MCP verify_in_chrome', () => {
+  test('tools/list 가 verify_in_chrome 을 노출한다', async () => {
+    const rpc: any = await callMcp('tools/list', undefined);
+    const names = rpc.result.tools.map((t: { name: string }) => t.name);
+    expect(names).toContain('verify_in_chrome');
+  });
+
+  test('정상 페이지는 pass + isError 없음', async () => {
+    const rpc = await callMcp('tools/call', {
+      name: 'verify_in_chrome',
+      arguments: { target: `http://localhost:${PORT}/ok.html` },
+    });
+    const { report, isError } = parseToolResult(rpc);
+    expect(isError).toBe(false);
+    expect(report.status).toBe('pass');
+    expect(report.events).toEqual([]);
+  });
+
+  test('pageerror 가 있으면 isError:true + events 에 pageerror', async () => {
+    const rpc = await callMcp('tools/call', {
+      name: 'verify_in_chrome',
+      arguments: { target: `http://localhost:${PORT}/pageerror.html` },
+    });
+    const { report, isError } = parseToolResult(rpc);
+    expect(isError).toBe(true);
+    expect(report.status).toBe('fail');
+    expect(
+      report.events.some(
+        (e: { type: string; message?: string }) =>
+          e.type === 'pageerror' && /verify-mcp boom/.test(e.message ?? ''),
+      ),
+    ).toBe(true);
+  });
+
+  test('allowConsoleError 인자가 console.error 만 발생 시 isError 를 막는다', async () => {
+    await writeFile(
+      join(fixtureDir, 'console-error.html'),
+      '<!doctype html><script>console.error("expected");</script>',
+    );
+    const fail = await callMcp('tools/call', {
+      name: 'verify_in_chrome',
+      arguments: { target: `http://localhost:${PORT}/console-error.html` },
+    });
+    const failResult = parseToolResult(fail);
+    expect(failResult.isError).toBe(true);
+
+    const ok = await callMcp('tools/call', {
+      name: 'verify_in_chrome',
+      arguments: {
+        target: `http://localhost:${PORT}/console-error.html`,
+        allowConsoleError: true,
+      },
+    });
+    const okResult = parseToolResult(ok);
+    expect(okResult.isError).toBe(false);
+    expect(okResult.report.status).toBe('pass');
+  });
+});


### PR DESCRIPTION
## Summary

dev server 의 MCP (`/mcp` JSON-RPC) 에 `verify_in_chrome` 도구 추가. tool call 이 들어오면 Zig dev server 가 Node 자식 프로세스로 `zntc verify --verify-json ...` (#3609) 를 spawn → JSON 리포트 수집 → MCP `content[].text` + `isError` 로 wrap. 에이전트가 **"빌드 → 브라우저 런타임 검증"** 한 루프로 (CD-2).

## 사용 예시

```jsonrpc
// tools/list
{"name":"verify_in_chrome","description":"...","inputSchema":{...}}

// tools/call
{
  "name": "verify_in_chrome",
  "arguments": {
    "target": "http://localhost:12300/",   // 생략 시 서버 root URL 자동
    "timeout": 15000,
    "ignore": ["third-party"],
    "allowConsoleError": false
  }
}

// 응답
{
  "result": {
    "content": [{"type":"text","text":"{\"target\":\"...\",\"status\":\"pass\",\"events\":[]}"}],
    "isError": false
  }
}
```

## 변경

- **`src/server/dev_server.zig`**:
  - `tools/list` 에 verify_in_chrome schema (`target` / `timeout` / `ignore` / `allowConsoleError`)
  - `handleVerifyInChrome` 함수 — ArenaAllocator, JSON arg 파싱, argv 구성, `std.process.Child.run` (1MB 출력 상한)
  - CLI 경로: `ZNTC_CLI` env 우선 (모노레포 dev / 비표준 install), fallback PATH 의 `zntc`
  - `.mjs/.js` 면 `node` prefix 자동 (Node 가 스크립트 파일을 ELF/Mach-O 처럼 직접 exec 못함)
- **`tests/e2e/tests/verify-in-chrome-mcp-e2e.test.ts`** (NEW) — 4 케이스
  - tools/list 가 verify_in_chrome 노출
  - 정상 페이지 → isError:false
  - pageerror → isError:true + events 에 pageerror
  - allowConsoleError 토글로 console.error 무시
- **`tests/e2e/tests/ports.ts`** — PORTS.VERIFY_MCP=3982 예약

## 왜 Zig dev server MCP 에 추가했나

- 기존 `reset_cache` / `get_build_events` 와 같은 MCP 도구 풀에 합류 → 에이전트가 한 endpoint 로 검증 + 캐시 reset + 이벤트 구독 일관
- JS dev server (zntc.mjs runAppDev) 는 MCP 미보유 — 신설 비용 없이 기존 인프라 재사용
- 메모리상 epic #2538 4-6 에서 Zig 단일 dev server 로 수렴 예정 — 미래 지향적 위치

## /simplify 적용

3-agent review 후:
- ✅ argv mutation 재배열 (`needs_node` 선분기 → `argv.items[0]=` 제거)
- ✅ 주석 정확도 (`Node 는 .mjs 를 ELF/Mach-O 처럼 직접 실행 못함, node script.mjs 필요`)
- ⏭ MCP envelope 헬퍼 추출 (2회 반복, 별도 follow-up 적합)
- ⏭ JSON arg / argv 헬퍼 (idiomatic 패턴, 추출 가치 없음)

## Test plan

- [x] `zig build` 통과
- [x] e2e 19/19 통과 (Dev Server 9 + verify CLI 6 + MCP verify 4)
- [x] 실제 MCP 호출 수동 smoke: tools/list 응답에 verify_in_chrome 등록, tools/call 응답에 verify JSON + isError 정상
- [x] `oxfmt` 통과 (pre-push hook)

## 후속 (이 PR 범위 외)

- **PR 2 CI 통합**: `zntc verify` / `verify_in_chrome` 을 어느 CI 잡에 끼울지 측정 후 결정
- **MCP envelope 헬퍼 추출**: 4번 반복 시점 (reset_cache / get_build_events / verify_in_chrome × 2 응답경로) 에 정리

Closes part of ROADMAP "CD-2 (verify_in_chrome MCP 도구)".