### PR TITLE
refactor(module-store): reuse freeCachedModule in putModule error paths

### DIFF
--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -122,31 +122,13 @@ pub const PersistentModuleStore = struct {
                 .module = cached_module,
                 .import_specifiers = specs,
             }) catch {
-                if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
-                if (cached_module.resolve_dir) |dir| self.allocator.free(dir);
-                if (cached_module.alias_table) |*t| t.deinit();
-                if (cached_module.export_index_by_name) |*m| m.deinit(self.allocator);
-                for (cached_module.resolved_deps.items) |dep| {
-                    self.allocator.free(dep.path);
-                    if (dep.resolve_dir) |dir| self.allocator.free(dir);
-                }
-                cached_module.resolved_deps.deinit(self.allocator);
-                for (specs) |s| self.allocator.free(s);
-                self.allocator.free(specs);
+                var orphan: CachedModule = .{ .mtime = mtime, .module = cached_module, .import_specifiers = specs };
+                self.freeCachedModule(&orphan);
             };
         } else {
             const key = self.allocator.dupe(u8, path) catch {
-                if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
-                if (cached_module.resolve_dir) |dir| self.allocator.free(dir);
-                if (cached_module.alias_table) |*t| t.deinit();
-                if (cached_module.export_index_by_name) |*m| m.deinit(self.allocator);
-                for (cached_module.resolved_deps.items) |dep| {
-                    self.allocator.free(dep.path);
-                    if (dep.resolve_dir) |dir| self.allocator.free(dir);
-                }
-                cached_module.resolved_deps.deinit(self.allocator);
-                for (specs) |s| self.allocator.free(s);
-                self.allocator.free(specs);
+                var orphan: CachedModule = .{ .mtime = mtime, .module = cached_module, .import_specifiers = specs };
+                self.freeCachedModule(&orphan);
                 return;
             };
 
@@ -156,17 +138,8 @@ pub const PersistentModuleStore = struct {
                 .import_specifiers = specs,
             }) catch {
                 self.allocator.free(key);
-                if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
-                if (cached_module.resolve_dir) |dir| self.allocator.free(dir);
-                if (cached_module.alias_table) |*t| t.deinit();
-                if (cached_module.export_index_by_name) |*m| m.deinit(self.allocator);
-                for (cached_module.resolved_deps.items) |dep| {
-                    self.allocator.free(dep.path);
-                    if (dep.resolve_dir) |dir| self.allocator.free(dir);
-                }
-                cached_module.resolved_deps.deinit(self.allocator);
-                for (specs) |s| self.allocator.free(s);
-                self.allocator.free(specs);
+                var orphan: CachedModule = .{ .mtime = mtime, .module = cached_module, .import_specifiers = specs };
+                self.freeCachedModule(&orphan);
             };
         }
     }


### PR DESCRIPTION
## 요약

`putModule` 의 세 error path (modules.put 실패 ×2, allocator.dupe 실패 ×1) 가 `freeCachedModule` 과 거의 동일한 cleanup 시퀀스를 손으로 반복하고 있었습니다. 각 error path 에서 임시 `CachedModule` 을 만들어 `freeCachedModule` 을 호출하도록 통합했습니다.

## 동기

`/simplify` 리뷰 중 발견된 항목입니다. cleanup 시퀀스가 4 곳 (정상 freer 1 + error path 3) 에 거의 같은 코드로 흩어져 있어, 향후 `CachedModule` 에 새 owned 리소스가 추가될 때 한 곳만 갱신하면 다른 세 곳이 누락되는 drift 위험이 있었습니다. 단일 freer (`freeCachedModule`) 로 통합해 "어떤 리소스가 풀려야 하는지" 의 진실의 원천을 한 곳에 둡니다.

## 변경 안전성

Error path 시점 `cached_module` 의 상태:

- `import_records = &.{}` (line 115) → `freeCachedModule` 의 `require_context` loop no-op
- `dependencies/importers/dynamic_imports/dynamic_importers = .empty` (line 97-100) → 빈 ArrayList deinit no-op
- `resolved_deps = .empty` (line 116) → loop/deinit no-op

따라서 `freeCachedModule` 이 실제로 free 하는 것은 `parse_arena`, `alias_table`, `export_index_by_name`, `resolve_dir`, `import_specifiers` 뿐 — 기존 hand-rolled 시퀀스와 동일.

## 검증

- `zig build install` 성공
- `zig build test` 전체 5372/5376 (4 skipped — 기존과 동일)
- 회귀 테스트:
  - `PersistentModuleStore: alias_table ownership 왕복 (rebuild 2회)` 통과
  - `PersistentModuleStore: parse_arena ownership 왕복 후 alloc 정상 (#2694)` 통과

## 영향 범위

`src/bundler/module_store.zig` 한 파일, +6/-33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)