### PR TITLE
perf(react-native): remove duplicate Metro scale fallback in asset plugin

### DIFF
--- a/packages/react-native/src/plugins/asset.test.ts
+++ b/packages/react-native/src/plugins/asset.test.ts
@@ -11,10 +11,6 @@ interface OnLoadHandler {
   (args: { path: string }): Promise<{ contents?: string } | null> | { contents?: string } | null;
 }
 
-interface OnResolveHandler {
-  (args: { path: string; importer?: string }): { path?: string } | null;
-}
-
 interface CapturedHandler {
   filter: RegExp;
   handler: OnLoadHandler;
@@ -28,23 +24,6 @@ function captureHandlers(config: PluginConfig): CapturedHandler[] {
       captured.push({ filter: filter.filter, handler });
     },
     onResolve() {},
-    onResolveContext() {},
-    onTransform() {},
-  };
-  plugin.setup(fakeBuild as never);
-  return captured;
-}
-
-function captureResolveHandlers(
-  config: PluginConfig,
-): Array<{ filter: RegExp; handler: OnResolveHandler }> {
-  const plugin = createAssetPlugin(config);
-  const captured: Array<{ filter: RegExp; handler: OnResolveHandler }> = [];
-  const fakeBuild = {
-    onLoad() {},
-    onResolve(filter: { filter: RegExp }, handler: OnResolveHandler) {
-      captured.push({ filter: filter.filter, handler });
-    },
     onResolveContext() {},
     onTransform() {},
   };
@@ -78,30 +57,6 @@ describe('createAssetPlugin', () => {
     const result = handlers[0]!.handler({ path: '/abs/Libraries/Utilities/HMRClient.js' });
     expect(result?.contents).toBe(ZNTC_HMR_CLIENT_CODE);
     expect(result?.contents).not.toContain('__ZNTC_FORWARD_CLIENT_LOGS__');
-  });
-
-  test('Metro asset resolution — base 파일 없이 @3x 파일만 있어도 logical asset import 해결', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'zntc-rn-scale-asset-'));
-    try {
-      mkdirSync(join(dir, 'src'), { recursive: true });
-      const asset3x = join(dir, 'src', 'poster@3x.webp');
-      writeFileSync(asset3x, 'webp');
-
-      const handlers = captureResolveHandlers({
-        ...baseConfig,
-        projectRoot: dir,
-        assetExts: ['webp'],
-      });
-
-      expect(handlers.length).toBe(1);
-      const resolved = handlers[0]!.handler({
-        path: './poster.webp',
-        importer: join(dir, 'src', 'index.ts'),
-      });
-      expect(resolved).toEqual({ path: asset3x });
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
   });
 
   test('babelTransformerPath 미지정 — HMRClient.js handler 만 등록 (custom transformer 없음)', () => {

--- a/packages/react-native/src/plugins/asset.ts
+++ b/packages/react-native/src/plugins/asset.ts
@@ -1,10 +1,10 @@
 // React Native runtime injection plugin — Metro 의 HMRClient.js 를 ZNTC HMR
 // runtime (`runtime/zntc-hmr-client.js`) 으로 교체 + RN source asset transformer
 // 통합. Asset registry / scale variant 처리는 ZNTC 코어가 직접 (preset 의
-// assetRegistry/loader/alias 옵션) 처리한다.
+// assetRegistry/loader/alias 옵션, resolver 의 RN scale fallback) 처리한다.
 
-import { existsSync, readFileSync } from 'node:fs';
-import { basename, dirname, extname, isAbsolute, join, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { basename, extname } from 'node:path';
 
 import type { ZntcPlugin } from '@zntc/core';
 
@@ -12,8 +12,6 @@ import { HMR_CLIENT_SUFFIX, ZNTC_HMR_CLIENT_CODE } from '../runtime-loader.ts';
 import { escapeRegex } from './escape-regex.ts';
 import { getErrorMessage, normalizeExt, requireFromCli } from './internal.ts';
 import type { PluginConfig } from './types.ts';
-
-const METRO_ASSET_RESOLUTIONS = ['1', '1.5', '2', '3', '4'];
 
 interface MetroTransformerResult {
   code?: string;
@@ -42,52 +40,6 @@ function svgComponentName(filePath: string): string {
     .map((part) => part[0]!.toUpperCase() + part.slice(1))
     .join('');
   return pascal ? `Svg${pascal}` : 'SvgComponent';
-}
-
-function isRelativeSpecifier(path: string): boolean {
-  return path.startsWith('./') || path.startsWith('../');
-}
-
-function isScaledAssetName(name: string): boolean {
-  return /@\d+(?:\.\d+)?x$/.test(name);
-}
-
-function createAssetResolvePattern(assetExts: readonly string[]): RegExp | null {
-  const extensions = assetExts.map((e) => escapeRegex(normalizeExt(e).slice(1))).filter(Boolean);
-  if (extensions.length === 0) return null;
-  return new RegExp(`\\.(${extensions.join('|')})$`, 'i');
-}
-
-function resolveMetroAssetFile(
-  specifier: string,
-  importer: string | null | undefined,
-): string | null {
-  if (!importer) return null;
-  if (!isRelativeSpecifier(specifier) && !isAbsolute(specifier)) return null;
-
-  const ext = extname(specifier);
-  const baseName = basename(specifier, ext);
-  if (!ext || isScaledAssetName(baseName)) return null;
-
-  const specifierDir = dirname(specifier);
-  const originDir = isAbsolute(specifier)
-    ? dirname(specifier)
-    : resolve(dirname(importer), specifierDir);
-  const logicalBase = isAbsolute(specifier)
-    ? join(originDir, baseName)
-    : resolve(dirname(importer), specifierDir, baseName);
-
-  // Metro DependencyGraph.resolveAsset 와 같은 후보군. base 파일이 없어도 @3x 같은
-  // scale variant 만 있으면 assetFiles 로 취급하고, ModuleResolution 은 그중
-  // lexicographically lowest path 하나를 graph module 로 사용한다.
-  const candidates = [
-    `${logicalBase}${ext}`,
-    ...METRO_ASSET_RESOLUTIONS.map((resolution) => `${logicalBase}@${resolution}x${ext}`),
-  ].filter((path) => existsSync(path));
-
-  if (candidates.length === 0) return null;
-  candidates.sort();
-  return candidates[0]!;
 }
 
 export function createSvgComponentModule(svg: string, filePath: string): string {
@@ -120,14 +72,6 @@ export function createAssetPlugin(config: PluginConfig): ZntcPlugin {
   return {
     name: 'zntc:react-native:runtime',
     setup(build) {
-      const assetResolvePattern = createAssetResolvePattern(config.assetExts);
-      if (assetResolvePattern) {
-        build.onResolve({ filter: assetResolvePattern }, (args) => {
-          const resolved = resolveMetroAssetFile(args.path, args.importer);
-          return resolved ? { path: resolved } : null;
-        });
-      }
-
       // HMRClient.js path 매칭 — onLoad 응답으로 ZNTC_HMR_CLIENT_CODE 그대로.
       const hmrClientPattern = new RegExp(`${escapeRegex(HMR_CLIENT_SUFFIX)}$`);
       build.onLoad({ filter: hmrClientPattern }, () => ({


### PR DESCRIPTION
## 요약

`asset.ts` 의 `createAssetResolvePattern` + `resolveMetroAssetFile` onResolve hook 이 Zig resolver 의 `tryReactNativeScaleAssetFallback` (resolver.zig:585-612) 과 같은 일 — base 없는 logical asset import 를 `@Nx` variant 로 해소 — 을 중복으로 처리하고 있었습니다.

plugin onResolve 가 asset 확장자 모든 import 를 가로채서 6 개 candidate (`base + @1x + @1.5x + @2x + @3x + @4x`) 를 **매번 `existsSync` 로 stat** — base 있는 정상 케이스에서도 5 개 불필요 IO 발생.

`/simplify` 효율성 리뷰에서 식별된 항목입니다.

## Zig resolver 가 이미 같은 일을 합니다

- `tryResolvePathLike(abs_path)` 가 base 파일 시도 (`fileExists` — DirEntryCache 활용)
- 실패 시 `tryReactNativeScaleAssetFallback` 호출 → `@1x` … `@4x` 순회, 첫 hit 반환
- `platform == .react_native` 일 때만 활성 (`resolve_cache.zig:248`)

## 회귀 보장

`src/bundler/bundler_test/cjs_esm.zig` 의 통합 테스트가 동일 케이스를 검증합니다:

- `RN asset registry: scale-only asset keeps Metro base name and scale` (line 1986)
- `RN asset registry: base asset import resolves scale-only sibling` (line 2025) — \"`import './poster.webp'` 하면 `poster@3x.webp` 만 있어도 resolve 됨\" 케이스

asset.ts 의 onResolve hook 을 제거해도 동일 시나리오가 Zig 측에서 그대로 처리됩니다.

## 동작 차이

- **정수 scale 만 지원**: `@1.5x` 제거. PR #3542 시나리오가 정수 케이스이고 RN 0.85 시점 1.5x 는 사실상 deprecated.
- 그 외 base / @1x..@4x resolve 는 동일.

## 정리된 dead code

- `METRO_ASSET_RESOLUTIONS` 상수
- `isRelativeSpecifier`, `isScaledAssetName` 헬퍼
- `createAssetResolvePattern`, `resolveMetroAssetFile` 함수
- asset plugin `setup` 의 onResolve 등록 블록
- `captureResolveHandlers` test helper + 관련 테스트 1 개 (Zig 통합 테스트로 대체됨)

## 검증

- `bun x tsc -b --force` 통과
- `bun test packages/react-native/src/plugins/asset.test.ts packages/react-native/src/preset.test.ts packages/react-native/src/plugins/styled-components-native.test.ts` — 87 pass / 1 skip / 0 fail
- `zig build install` 성공
- `zig build test` 전체 5372/5376 (4 skipped — 변경 전과 동일)

## 영향 범위

`packages/react-native/src/plugins/asset.ts` (+3/-62), `asset.test.ts` (-45). 총 -104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)