### PR TITLE
fix(rn): stabilize release worklet bundling

### DIFF
--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -427,6 +427,12 @@ describe('buildRnBundleOptions — dev mode 분기 (jsx / devMode / reactRefresh
     expect(opts.minifyIdentifiers).toBeUndefined();
   });
 
+  test('dev=false + minify 미지정 — tri-state: minify!==true 라 syntax pruning 기본 활성', () => {
+    const opts = buildRnBundleOptions(baseInput({ dev: false }));
+    expect(opts.minify).toBe(false);
+    expect(opts.minifySyntax).toBe(true);
+  });
+
   test('dev=false + override.minifySyntax=false — 사용자 override 가 마지막에 적용', () => {
     const opts = buildRnBundleOptions(
       baseInput({

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -418,6 +418,27 @@ describe('buildRnBundleOptions — dev mode 분기 (jsx / devMode / reactRefresh
     expect(opts.reactRefresh).toBeUndefined();
     expect(opts.collectModuleCodes).toBeUndefined();
   });
+
+  test('dev=false + minify=false — 공백/식별자 축약 없이 release dead branch pruning 활성', () => {
+    const opts = buildRnBundleOptions(baseInput({ dev: false, minify: false }));
+    expect(opts.minify).toBe(false);
+    expect(opts.minifySyntax).toBe(true);
+    expect(opts.minifyWhitespace).toBeUndefined();
+    expect(opts.minifyIdentifiers).toBeUndefined();
+  });
+
+  test('dev=false + override.minifySyntax=false — 사용자 override 가 마지막에 적용', () => {
+    const opts = buildRnBundleOptions(
+      baseInput({
+        dev: false,
+        minify: false,
+        override: {
+          minifySyntax: false,
+        },
+      }),
+    );
+    expect(opts.minifySyntax).toBe(false);
+  });
 });
 
 describe('buildRnBundleOptions — plugins (asset/optional-babel/require-context/[+metro-resolve])', () => {

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -538,6 +538,11 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     preset.devMode = true;
     preset.reactRefresh = true;
     preset.collectModuleCodes = true;
+  } else if (minify !== true) {
+    // Metro release 와 같이 __DEV__ false 분기는 full minify 없이도 제거한다.
+    // 공백 압축/식별자 축약은 유지하고 syntax pass 만 켜서 dev-only worklet 이
+    // 릴리즈 번들에 남지 않게 한다.
+    preset.minifySyntax = true;
   }
 
   if (extra?.watchFolders && extra.watchFolders.length > 0) {

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -147,13 +147,20 @@ const JS_GLOBALS = std.StaticStringMap(void).initComptime(.{
     .{ "eval", {} },              .{ "arguments", {} },             .{ "this", {} },
 });
 
+/// Babel react-native-worklets/plugin이 글로벌로 취급하는 에러 바인딩.
+/// import binding이어도 worklet closure에 넣지 않아야 UI runtime에서 동일한 글로벌을 참조한다.
+const WORKLET_GLOBAL_BINDINGS = std.StaticStringMap(void).initComptime(.{
+    .{ "ReanimatedError", {} },
+    .{ "WorkletsError", {} },
+});
+
 /// 함수 body와 파라미터로부터 closure 변수(외부 참조)를 추출한다.
 ///
 /// 알고리즘:
 ///   1. 함수 이름 + 파라미터 이름 → locals 집합에 추가
 ///   2. body 내 지역 선언(var/let/const/function) 이름 → locals 집합에 추가
 ///   3. body 내 identifier_reference 이름 → refs 집합에 추가
-///   4. refs - locals - JS_GLOBALS = closure 변수
+///   4. refs - locals - globals = closure 변수
 pub fn collectClosureVars(
     self: *Transformer,
     body_idx: NodeIndex,
@@ -198,7 +205,7 @@ pub fn collectClosureVars(
     while (iter.next()) |entry| {
         const name = entry.key_ptr.*;
         if (locals.contains(name)) continue;
-        if (isGlobal(name)) continue;
+        if (isClosureExcludedGlobal(name)) continue;
         // 사용자 설정 globals (옵션)도 closure에서 제외
         if (string_list.contains(self.options.worklet_globals, name)) continue;
         const duped = self.allocator.dupe(u8, name) catch return error.OutOfMemory;
@@ -210,7 +217,7 @@ pub fn collectClosureVars(
     while (nc_iter.next()) |entry| {
         const base_name = entry.key_ptr.*;
         if (locals.contains(base_name)) continue;
-        if (isGlobal(base_name)) continue;
+        if (isClosureExcludedGlobal(base_name)) continue;
         if (string_list.contains(self.options.worklet_globals, base_name)) continue;
         const base_duped = self.allocator.dupe(u8, base_name) catch return error.OutOfMemory;
         // factory key: "<BaseClass>__classFactory"
@@ -519,6 +526,11 @@ fn walkBodyForClosureAnalysis(
 /// JS 글로벌 식별자인지 확인 (O(1) comptime HashMap 조회).
 fn isGlobal(name: []const u8) bool {
     return JS_GLOBALS.has(name);
+}
+
+/// worklet closure에서 제외해야 하는 글로벌 식별자인지 확인.
+fn isClosureExcludedGlobal(name: []const u8) bool {
+    return isGlobal(name) or WORKLET_GLOBAL_BINDINGS.has(name);
 }
 
 // ================================================================

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -160,7 +160,7 @@ const WORKLET_GLOBAL_BINDINGS = std.StaticStringMap(void).initComptime(.{
 ///   1. 함수 이름 + 파라미터 이름 → locals 집합에 추가
 ///   2. body 내 지역 선언(var/let/const/function) 이름 → locals 집합에 추가
 ///   3. body 내 identifier_reference 이름 → refs 집합에 추가
-///   4. refs - locals - globals = closure 변수
+///   4. refs - locals - (JS_GLOBALS ∪ WORKLET_GLOBAL_BINDINGS) - worklet_globals 옵션 = closure 변수
 pub fn collectClosureVars(
     self: *Transformer,
     body_idx: NodeIndex,

--- a/src/transformer/worklet_test.zig
+++ b/src/transformer/worklet_test.zig
@@ -177,6 +177,27 @@ test "Worklet: react-native-worklets default globals are excluded from closure v
     try std.testing.expect(std.mem.indexOf(u8, code, "performance: performance") == null);
 }
 
+test "Worklet: worklets error bindings are excluded from closure vars" {
+    var r = try transformWorklet(std.testing.allocator,
+        \\const ReanimatedError = Error;
+        \\const WorkletsError = Error;
+        \\function anim() {
+        \\  "worklet";
+        \\  if (Math.random()) throw new ReanimatedError("bad");
+        \\  throw new WorkletsError("bad");
+        \\}
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // Babel plugin은 이 에러 바인딩을 글로벌로 취급하므로 closure/classFactory에 넣지 않는다.
+    try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "ReanimatedError: ReanimatedError") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "ReanimatedError__classFactory") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "WorkletsError: WorkletsError") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "WorkletsError__classFactory") == null);
+}
+
 test "Worklet: worklet transform disabled when no plugins" {
     // plugins 없이 변환하면 worklet 처리 안 됨
     var r = try parseAndTransformWithOptions(


### PR DESCRIPTION
## 요약
- worklet 에러 전역 바인딩이 closure/class factory 로 수집되지 않도록 제외했습니다.
- RN release 번들에서 `minify:false`여도 `minifySyntax`만 켜서 `__DEV__` dead branch 를 제거하도록 했습니다.
- 공백 압축과 식별자 축약은 그대로 비활성 상태를 유지합니다.

## 원인
- release 에서 `__DEV__`는 false 로 정의되지만, 기존 RN preset 은 `minify:false`일 때 syntax pruning 도 꺼두고 있었습니다.
- 그 결과 실행되지 않아야 할 dev-only worklet 코드가 테스트앱 release 번들에 남았고, Hermes/worklet runtime 경로에서 크래시가 발생했습니다.
- full minify 에서는 `minifySyntax`가 함께 켜져 해당 dead branch 가 제거되어 문제가 보이지 않았습니다.

## 검증
- `zig fmt src/transformer/transformer/worklet.zig src/transformer/worklet_test.zig`
- `zig build test -Dtest-filter="worklets error bindings"`
- `zig build test -Dtest-filter="Worklet"`
- `zig build test`
- `zig build napi`
- `bun test packages/react-native/src/preset.test.ts`
- `bunx oxfmt format --check packages/react-native/src/preset.ts packages/react-native/src/preset.test.ts`
- 테스트앱 release no-min 번들 생성 및 Hermes bytecode 컴파일
- 시뮬레이터에서 테스트앱 release no-min HBC 실행 후 프로세스 유지 확인