### PR TITLE
refactor(cli): drop inlineDynamicImportsExplicit sentinel + restore schema drift guard

### DIFF
--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -91,12 +91,7 @@ export const FLAG_REGISTRY = [
   { kind: 'bool', flag: '--shim-missing-exports', target: 'shimMissingExports' },
   { kind: 'bool', flag: '--ascii-only', target: 'asciiOnly' },
   { kind: 'bool', flag: '--preserve-modules', target: 'preserveModules' },
-  {
-    kind: 'bool',
-    flag: '--inline-dynamic-imports',
-    target: 'inlineDynamicImports',
-    extra: { inlineDynamicImportsExplicit: true },
-  },
+  { kind: 'bool', flag: '--inline-dynamic-imports', target: 'inlineDynamicImports' },
   { kind: 'bool', flag: '--preserve-symlinks', target: 'preserveSymlinks' },
   { kind: 'bool', flag: '--resolve-symlink-siblings', target: 'resolveSymlinkSiblings' },
   { kind: 'bool', flag: '--disable-hierarchical-lookup', target: 'disableHierarchicalLookup' },

--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -115,10 +115,7 @@ function assignRnBuildOptionOverrides(out, config, opts = {}) {
   }
   if (opts.inlineDynamicImports === true || cfg.inlineDynamicImports === true) {
     out.inlineDynamicImports = true;
-  } else if (
-    (opts.inlineDynamicImportsExplicit === true && opts.inlineDynamicImports === false) ||
-    cfg.inlineDynamicImports === false
-  ) {
+  } else if (opts.inlineDynamicImports === false || cfg.inlineDynamicImports === false) {
     out.inlineDynamicImports = false;
   }
 }

--- a/packages/core/bin/zntc-cli-schema-sync.test.ts
+++ b/packages/core/bin/zntc-cli-schema-sync.test.ts
@@ -426,6 +426,7 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
     // 함수형 / 중첩 객체 (CLI 표현 불가)
     'compiler', // compiler.styledComponents / compiler.emotion — 중첩 객체, CLI 미노출
     'mf', // Module Federation (#3318) — nested 객체, config/build() 전용 (CLI flag 없음)
+    'output', // esbuild-style build({output:[]}) sugar — config/build() 전용, CLI 는 --outfile/--outdir 로 cover
     'manualChunks',
     'plugins',
     'moduleSpecifierMap',

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -326,8 +326,7 @@ function parseArgs(argv) {
     allowOverwrite: false,
     preserveModules: false,
     preserveModulesRoot: undefined,
-    inlineDynamicImports: false,
-    inlineDynamicImportsExplicit: false,
+    inlineDynamicImports: undefined,
     loader: {},
     legalComments: undefined,
     resolveExtensions: [],
@@ -1232,11 +1231,13 @@ function mergeConfigIntoOpts(opts, config) {
     }
   }
 
-  // false 도 의미가 있는 옵션이라 일반 BOOL_KEYS 루프로는 명시 여부가 사라진다.
-  // single-file bundle 보정에서 Zig CLI 와 같은 에러를 내기 위해 별도로 추적한다.
-  if (config.inlineDynamicImports !== undefined) {
-    opts.inlineDynamicImports = config.inlineDynamicImports;
-    opts.inlineDynamicImportsExplicit = true;
+  // tristate bool: false 가 명시적 의미를 가져서 default 를 undefined 로 두는 키.
+  // CLI 가 미지정(undefined)일 때만 config 값(true/false)을 채택한다 (CLI flag 우선).
+  // inlineDynamicImports=false 의 single-file 보정은 applySingleFileDynamicImportDefault.
+  for (const key of ['inlineDynamicImports']) {
+    if (opts[key] === undefined && config[key] !== undefined) {
+      opts[key] = config[key];
+    }
   }
 
   const ARRAY_KEYS = [
@@ -1468,7 +1469,7 @@ async function runBundle(opts, config) {
 
 function applySingleFileDynamicImportDefault(opts) {
   if (opts.splitting || opts.preserveModules) return;
-  if (opts.inlineDynamicImportsExplicit && opts.inlineDynamicImports === false) {
+  if (opts.inlineDynamicImports === false) {
     throw new Error(
       'inlineDynamicImports=false requires splitting or preserveModules in bundle mode',
     );


### PR DESCRIPTION
## 요약

`inlineDynamicImports` 의 명시 여부를 추적하려고 CLI parsing / config merge / RN dev input 3 곳에 흘리던 sentinel flag `inlineDynamicImportsExplicit` 를 제거했습니다. `/simplify` 리뷰에서 식별된 항목 (B1) 입니다.

부수적으로, 같은 schema-sync 테스트 파일에서 기존부터 빨강이던 가드 2 개를 함께 복구했습니다.

## 1. sentinel 제거 (tristate default)

`inlineDynamicImports` 는 `false` 가 명시적 의미(chunk-capable 출력 강제)를 가져서 "미지정" 과 "명시적 false" 를 구분해야 했고, 그래서 `inlineDynamicImportsExplicit` sentinel 을 별도로 추적했습니다.

default 를 `false` → `undefined` 로 바꾸면 `=== false` 자체가 "명시적 false" 가 되어 sentinel 이 불필요합니다.

- `cli-flags.mjs`: `extra: { inlineDynamicImportsExplicit: true }` 제거 → 평범한 bool flag
- `zntc.mjs`: opts default `false` → `undefined`, `inlineDynamicImportsExplicit` 필드 삭제
- `zntc.mjs` merge: 개별 if 분기 → 리스트 기반 tristate 머지 (CLI flag 우선)
- `zntc.mjs` `applySingleFileDynamicImportDefault`: `explicit && === false` → `=== false`
- `rn-dev-input.mjs`: explicit 분기 제거

### 우선순위 변경

기존 특수 분기는 **config 가 CLI 를 덮어쓰는** 비일관 동작이었습니다 (다른 옵션은 모두 CLI flag 우선). tristate 머지는 `opts === undefined` 일 때만 config 값을 채택해 CLI 우선으로 정렬했습니다. CLI+config 동시 지정 케이스의 기존 테스트는 없어 회귀 없음.

## 2. schema drift 가드 복구 (기존 빨강)

`zntc-cli-schema-sync.test.ts` 가 main 에서 2 fail 이었습니다:

- **inlineDynamicImports**: silent-무시 가드가 머지를 *리스트 기반* 으로 추적하는데, 기존 개별 if 분기는 quoted key 가 없어 가드가 놓치고 있었음. 위 리스트화로 자동 회복.
- **output**: esbuild-style `build({output:[]})` sugar (commit 4fdd62e0) 가 추가한 키인데 CLI 노출도 allowlist 등록도 안 됨. config/build() 전용이고 CLI 는 `--outfile/--outdir` 로 cover 하므로 `buildOptionsOnlyKeys` 에 사유와 함께 등록.

## 검증

- `bun test packages/core/bin/zntc-cli-schema-sync.test.ts` — 13 pass / 0 fail (기존 2 fail → 0)
- `cd packages/core && bun test bin/zntc.test.ts` — 293 pass / 2 skip / 0 fail (dynamic-imports 동작 포함)
- `bun test ./packages/core/test/cli/react-native-dev-input/bundle-options/*.ts` — 17 pass / 0 fail

## 영향 범위

`cli-flags.mjs`, `zntc.mjs`, `rn-dev-input.mjs`, `zntc-cli-schema-sync.test.ts`. 4 파일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)