### PR TITLE
fix(lexer): keep scoped package path in @jsxImportSource pragma

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -1163,10 +1163,12 @@ pub const Scanner = struct {
         }
         if (start >= after.len) return null;
 
-        // 값 끝 찾기 (공백, *, / 에서 멈춤)
+        // 값 끝 찾기 (공백, 개행, 블록 주석 종료에서 멈춤). scoped 패키지의 `/`
+        // (`@emotion/react`) 는 값의 일부이므로 `/` 단독은 종료가 아니다 — `*` 가
+        // 블록 종료 `*/` 와 jsdoc ` * ` 라인 마커를 잡는다 (#3615 emotion-cases 회귀).
         var end = start;
         while (end < after.len and after[end] != ' ' and after[end] != '\t' and
-            after[end] != '*' and after[end] != '/' and after[end] != '\n' and after[end] != '\r')
+            after[end] != '*' and after[end] != '\n' and after[end] != '\r')
         {
             end += 1;
         }

--- a/src/lexer/scanner_test.zig
+++ b/src/lexer/scanner_test.zig
@@ -1194,6 +1194,16 @@ test "Scanner: @jsxImportSource pragma" {
     try std.testing.expectEqualStrings("preact", scanner.jsx_import_source_pragma.?);
 }
 
+test "Scanner: @jsxImportSource pragma — scoped package keeps full path" {
+    // `@emotion/react` 의 `/` 가 값 종료로 오인되어 `@emotion` 으로 잘리던 회귀 (#3615).
+    const source = "/** @jsxImportSource @emotion/react */";
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+
+    try scanner.next();
+    try std.testing.expectEqualStrings("@emotion/react", scanner.jsx_import_source_pragma.?);
+}
+
 test "Scanner: multiple pragmas in one file" {
     const source = "/** @jsx h */\n// @jsxFrag Fragment\nconst x = 1;";
     var scanner = try Scanner.init(std.testing.allocator, source);

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -2621,6 +2621,22 @@ test "D026 per-file JSX pragma override" {
         try std.testing.expect(std.mem.indexOf(u8, result.code, "\"preact/jsx-runtime\"") != null);
         try std.testing.expect(std.mem.indexOf(u8, result.code, "from \"react/jsx-runtime\"") == null);
     }
+    // `@jsxImportSource @emotion/react` → scoped 패키지 전체 경로 보존 (#3615).
+    // 이전엔 `/` 가 pragma 값 종료로 오인되어 `@emotion` 으로 잘려 `@emotion/jsx-runtime`
+    // (존재하지 않는 패키지) import 가 생성, 번들 시 `require()` fallback → 브라우저 크래시.
+    {
+        var result = try transpile_mod.transpile(
+            std.testing.allocator,
+            \\/** @jsxImportSource @emotion/react */
+            \\export const App = () => <p>x</p>;
+        ,
+            "input.jsx",
+            .{ .jsx_runtime = .automatic },
+        );
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "\"@emotion/react/jsx-runtime\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "\"@emotion/jsx-runtime\"") == null);
+    }
     // `@jsxRuntime classic` → automatic 기본 프로젝트를 classic 으로 전환.
     {
         var result = try transpile_mod.transpile(


### PR DESCRIPTION
## 증상

`@jsxImportSource @emotion/react` pragma 를 쓴 파일을 번들하면 브라우저에서:

```
bundle.js:NNNN ReferenceError: require is not defined
    at bundle.js:NNNN
```

`examples/web` 의 `src/emotion-cases.tsx` (emotion automatic JSX runtime) 에서 재현. dev 로그엔 `Cannot resolve module (@emotion/jsx-runtime)` 가 함께 떴다.

## 근본 원인

`src/lexer/scanner.zig` 의 `extractPragmaValue` 가 pragma 값 끝을 찾을 때 `/` 를 종료 문자로 포함했다:

```zig
while (... and after[end] != '*' and after[end] != '/' and ...) { end += 1; }
```

`@jsxImportSource @emotion/react` 에서 `@emotion/react` 의 `/` 가 값 종료로 오인 → `@emotion` 으로 잘림 → `@emotion` + `/jsx-runtime` = **`@emotion/jsx-runtime`** (존재하지 않는 패키지) import 생성. resolver 가 못 찾아 `require()` fallback 을 emit, ESM 번들에서 `require` 가 정의 안 돼 런타임 크래시.

esbuild/Babel 규약은 `jsxImportSource + "/jsx-runtime"` 단순 연결 — `@emotion/react` → `@emotion/react/jsx-runtime` 이어야 정상.

## 수정

`/` 를 종료 문자에서 제거. scoped 패키지의 `/` 는 값의 일부다. 블록 주석 종료 `*/` 와 jsdoc ` * ` 라인 마커는 `*` 가 잡으므로 안전 (서브에이전트 edge-case 검토 8/8 통과: line/block 주석, `*/` 직전 무공백, `React.createElement`, EOF 등).

## TDD

1. **Red** — `scanner_test.zig` 에 `@jsxImportSource @emotion/react` → `@emotion/react` 단언 추가 → fail (`found @emotion`)
2. **Green** — `/` 종료 조건 제거
3. **End-to-end 가드** — `transformer_test.zig` 에 `@emotion/react/jsx-runtime` 생성 + `@emotion/jsx-runtime` 미생성 단언

## Test plan

- [x] `zig build test` 0 fail (5378 tests)
- [x] 신규 unit (scanner) + end-to-end (transformer) 테스트 통과
- [x] 실제 검증: NAPI 재빌드 → `examples/web` dev server 재시작 → 번들에서 `require("@emotion...")` 소멸, `@emotion/react/jsx-runtime` 정상 import, `Cannot resolve` 로그 사라짐
- [x] `/simplify` 통과 (reuse/quality/edge-case 3-agent, actionable 0)

## 영향 범위

scoped npm 패키지를 `@jsxImportSource` pragma 로 쓰는 모든 케이스 (`@emotion/react`, `@builder.io/qwik` 등). 기존 비-scoped (`preact`, `react`) 는 무영향 — 회귀 가드 테스트로 확인.