### PR TITLE
chore(examples): add react-19-zntc to workspace + fix react-compiler version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ packages/react-native/dist/
 packages/rspack-loader/dist/
 packages/vite-plugin/dist/
 examples/web/dist/
+examples/react-19-zntc/dist/
 # 루트 cwd 에 떨어지는 임시 빌드 산출물 (NAPI 직접 호출 경로 / examples 빌드 leftover).
 /dist/
 

--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,23 @@
         "typescript": "^6.0.3",
       },
     },
+    "examples/react-19-zntc": {
+      "name": "@zntc/example-react-19-zntc",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "@babel/core": "^7.27.0",
+        "@types/babel__core": "^7.20.5",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@zntc/core": "workspace:*",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "typescript": "^6.0.3",
+      },
+    },
     "examples/react-native-bare": {
       "name": "zntc-example-react-native-bare",
       "version": "0.0.1",
@@ -2913,6 +2930,8 @@
     "@zntc/e2e": ["@zntc/e2e@workspace:tests/e2e"],
 
     "@zntc/example-module-federation": ["@zntc/example-module-federation@workspace:examples/module-federation"],
+
+    "@zntc/example-react-19-zntc": ["@zntc/example-react-19-zntc@workspace:examples/react-19-zntc"],
 
     "@zntc/example-web": ["@zntc/example-web@workspace:examples/web"],
 
@@ -6851,6 +6870,8 @@
     "@zntc/benchmark/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@zntc/example-module-federation/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "@zntc/example-react-19-zntc/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "@zntc/example-web/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 

--- a/examples/react-19-zntc/package.json
+++ b/examples/react-19-zntc/package.json
@@ -21,7 +21,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@zntc/core": "workspace:*",
-    "babel-plugin-react-compiler": "^19.0.0",
+    "babel-plugin-react-compiler": "^1.0.0",
     "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "./packages/rspack-loader",
     "./documents",
     "./examples/web",
+    "./examples/react-19-zntc",
     "./examples/module-federation",
     "./examples/react-native-bare",
     "./examples/react-native-large",


### PR DESCRIPTION
## Summary

`examples/react-19-zntc` (React 19 + React Compiler + zntc dev) 가 root workspaces 미등록 + deps 버전 오류로 `zntc dev` 가 안 떴다.

- **`babel-plugin-react-compiler` `^19.0.0` → `^1.0.0`** — `19.0.0` 태그는 npm 에 없어 `bun install` 이 `No version matching "^19.0.0"` 로 실패했다. React Compiler 정식 출시 버전은 `1.0.0` (`latest`). config 의 `{ target: "19" }` 옵션은 React 19 타겟으로 그대로 유지.
- **root `package.json` workspaces 에 `./examples/react-19-zntc` 편입** — `@zntc/core: workspace:*` 심링크가 생겨 config 로딩이 resolve 된다. 이전엔 `failed to load config — @zntc/core: module not found` 로 기동 실패.
- **`.gitignore`** 에 `examples/react-19-zntc/dist/` 추가 (web 예제와 동일).

## 검증

- [x] `bun install` 성공 — `@zntc/core` 심링크 + `babel-plugin-react-compiler@1.0.0` 설치
- [x] `zntc dev --host 0.0.0.0 --port 12308` 기동 → GET / 200, 로그 에러 없음
- [x] 번들 산출물 bare `require(` 0건 (React Compiler onTransform + JSX automatic 정상)

## 참고

react-19-vite 예제도 동일하게 workspace 미등록이지만 Vite 별도 의존이라 이 PR 범위 밖.