### PR TITLE
test(integration): bundle-level regression guard for scoped @jsxImportSource

### DIFF
--- a/tests/integration/tests/jsx-scoped-import-source.test.ts
+++ b/tests/integration/tests/jsx-scoped-import-source.test.ts
@@ -1,0 +1,74 @@
+// scoped `@jsxImportSource` 번들 회귀 가드 (#3617).
+//
+// lexer 의 pragma 값 파서가 `@emotion/react` 의 `/` 를 값 종료로 오인해 `@emotion`
+// 으로 잘랐고, 그 결과 `@emotion/jsx-runtime` (존재하지 않는 패키지) import 가 생성,
+// 번들 시 resolve 실패 → `require()` fallback → 브라우저 `require is not defined` 크래시.
+//
+// scanner/transformer 유닛 테스트(#3617)는 lexer·transform 레벨만 잡는다. 이 테스트는
+// 번들 파이프라인 (transform → resolve → emit) 산출물에 잘린 specifier·bare require 가
+// 남지 않는지 end-to-end 로 가드 — "사전 발견" 못 했던 회귀 표면.
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { createFixture, runZntcInDir } from './helpers';
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+
+describe('JSX automatic — scoped @jsxImportSource (#3617 회귀)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = undefined;
+  });
+
+  test('scoped 패키지 importSource → 전체 경로 jsx-runtime import (require fallback 없음)', async () => {
+    const fx = await createFixture({
+      'app.tsx': '/** @jsxImportSource @emotion/react */\nexport const App = () => <p>hi</p>;\n',
+    });
+    cleanup = fx.cleanup;
+    const out = join(fx.dir, 'out.js');
+
+    const r = await runZntcInDir(fx.dir, [
+      '--bundle',
+      'app.tsx',
+      '-o',
+      out,
+      '--platform=browser',
+      '--format=esm',
+      '--packages=external',
+      '--jsx=automatic',
+    ]);
+    expect(r.exitCode).toBe(0);
+
+    const code = await readFile(out, 'utf8');
+    // scoped 전체 경로 보존 (`@emotion/react` + `/jsx-runtime`).
+    expect(code).toContain('"@emotion/react/jsx-runtime"');
+    // 잘린 잘못된 specifier 미존재.
+    expect(code).not.toContain('"@emotion/jsx-runtime"');
+    // ESM 번들에 bare `require("@emotion...")` 미존재 — 잘린 specifier resolve 실패 시
+    // 나오던 크래시 패턴.
+    expect(code).not.toMatch(/\brequire\("@emotion/);
+  });
+
+  test('non-scoped importSource (preact) 회귀 없음', async () => {
+    const fx = await createFixture({
+      'app.tsx': '/** @jsxImportSource preact */\nexport const App = () => <p>hi</p>;\n',
+    });
+    cleanup = fx.cleanup;
+    const out = join(fx.dir, 'out.js');
+
+    const r = await runZntcInDir(fx.dir, [
+      '--bundle',
+      'app.tsx',
+      '-o',
+      out,
+      '--platform=browser',
+      '--format=esm',
+      '--packages=external',
+      '--jsx=automatic',
+    ]);
+    expect(r.exitCode).toBe(0);
+
+    const code = await readFile(out, 'utf8');
+    expect(code).toContain('"preact/jsx-runtime"');
+  });
+});


### PR DESCRIPTION
## Summary

#3617 (scoped `@jsxImportSource` 가 `@emotion` 으로 잘려 브라우저 `require is not defined` 크래시) 의 **번들 파이프라인 레벨 회귀 가드**.

#3617 의 scanner/transformer 유닛 테스트는 lexer·transform 레벨만 검증했다. 실제 회귀는 **번들 산출물** 에 잘린 `@emotion/jsx-runtime` specifier + bare `require()` 가 남아 발생했고, 이걸 잡는 end-to-end 테스트가 없어 "사전 발견" 못 했다. 이 PR 이 transform → resolve → emit 전체 경로를 가드한다.

## 테스트

`tests/integration/tests/jsx-scoped-import-source.test.ts` — Zig CLI (`zntc --bundle`) 로 실제 번들 후 산출물 검증:

1. **scoped** `@jsxImportSource @emotion/react`:
   - `"@emotion/react/jsx-runtime"` 전체 경로 import 존재
   - 잘린 `"@emotion/jsx-runtime"` 미존재
   - bare `require("@emotion...)` 미존재 (크래시 패턴)
2. **non-scoped** `preact` 회귀 가드 (`"preact/jsx-runtime"`)

`--packages=external` 이므로 emotion 실설치 불필요 — specifier 정확성만 검증.

## CI 편입

별도 yml 변경 없음. CI 의 `Integration Tests (ubuntu/macos)` 잡이 `bun run test:integration` (= `tests/integration` 디렉토리 전체) 을 돌리므로 새 파일이 자동 포함된다.

## Test plan

- [x] `bun test tests/jsx-scoped-import-source.test.ts` 2/2 통과
- [x] #3617 fix 없는 바이너리로 돌리면 scoped 케이스 fail 확인 (회귀 검출력 검증 — fix 전 bin 에서 `@emotion/jsx-runtime` 잘림 재현됨)
- [x] `oxfmt` 통과

Refs #3617.