### PR TITLE
fix(rn): preserve re-export source side effects

### DIFF
--- a/packages/react-native/src/plugins/metro-resolve-request.test.ts
+++ b/packages/react-native/src/plugins/metro-resolve-request.test.ts
@@ -70,6 +70,15 @@ describe('createMetroResolveRequestPlugin', () => {
     expect(handler({ path: 'react', importer: '/abs/x' })).toBeNull();
   });
 
+  test('default resolver 위임 중 absolute specifier 로 교체하면 해당 path 반환', () => {
+    const resolver: CustomResolver = (ctx, _name, platform) =>
+      ctx.resolveRequest(ctx, '/abs/redux-saga-effects.cjs.js', platform);
+    const handler = captureHandler({ resolveRequest: resolver, platform: 'ios' });
+    expect(handler({ path: 'redux-saga/effects', importer: '/abs/origin.ts' })).toEqual({
+      path: '/abs/redux-saga-effects.cjs.js',
+    });
+  });
+
   test('custom resolver 의 일반 throw 는 propagate', () => {
     const resolver: CustomResolver = () => {
       throw new Error('custom-error');

--- a/packages/react-native/src/plugins/metro-resolve-request.ts
+++ b/packages/react-native/src/plugins/metro-resolve-request.ts
@@ -2,16 +2,29 @@
 // `(context, moduleName, platform)` 그대로 호출. 위임 시 sentinel throw 로 ZNTC
 // 기본 해석기 fallthrough (Metro 의 `context.resolveRequest()` 호출과 동등).
 
+import { createRequire } from 'node:module';
+import { dirname, isAbsolute, resolve } from 'node:path';
+
 import type { ZntcPlugin } from '@zntc/core';
 
 import type { CustomResolver, MetroPlatform } from '../metro-resolver-types.ts';
 
 /** ZNTC 기본 해석기로 위임 위해 사용자 resolver 가 던지는 sentinel error message. */
 const DELEGATE_TO_DEFAULT_SENTINEL = '__ZNTC_RN_DELEGATE_TO_DEFAULT__';
+const nodeRequire = createRequire(import.meta.url);
 
 export interface MetroResolveRequestOptions {
   resolveRequest: CustomResolver;
   platform: MetroPlatform;
+}
+
+function resolveFallbackRequest(moduleName: string, originModulePath: string): string {
+  if (isAbsolute(moduleName)) return moduleName;
+
+  const baseDir = originModulePath ? dirname(originModulePath) : process.cwd();
+  if (moduleName.startsWith('.')) return resolve(baseDir, moduleName);
+
+  return nodeRequire.resolve(moduleName, { paths: [baseDir] });
 }
 
 export function createMetroResolveRequestPlugin(opts: MetroResolveRequestOptions): ZntcPlugin {
@@ -23,9 +36,16 @@ export function createMetroResolveRequestPlugin(opts: MetroResolveRequestOptions
     name: 'zntc:react-native:metro-resolve-request',
     setup(build) {
       build.onResolve({ filter: /.*/ }, (args) => {
-        // Default resolver 위임 함수 — Metro 의 `context.resolveRequest()` 동등.
-        // throw 시 ZNTC 가 catch 후 기본 해석 진행 (return null 과 동일 효과).
-        const fallbackResolver = (): never => {
+        // Default resolver 위임 함수 — 원래 요청 그대로면 ZNTC 기본 해석기로
+        // fallthrough, 사용자가 specifier 를 바꾸면 그 바뀐 값으로 해석한다.
+        const fallbackResolver: CustomResolver = (_context, moduleName) => {
+          if (moduleName !== args.path) {
+            return {
+              type: 'sourceFile',
+              filePath: resolveFallbackRequest(moduleName, args.importer ?? ''),
+            };
+          }
+
           throw new Error(DELEGATE_TO_DEFAULT_SENTINEL);
         };
         try {
@@ -33,7 +53,7 @@ export function createMetroResolveRequestPlugin(opts: MetroResolveRequestOptions
             {
               originModulePath: args.importer ?? '',
               platform: metroPlatform,
-              resolveRequest: fallbackResolver as never,
+              resolveRequest: fallbackResolver,
             },
             args.path,
             metroPlatform,

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -3789,6 +3789,73 @@ test "react_native inlineRequires: named re-export preserves package entry side 
     try std.testing.expect(std.mem.indexOf(u8, result.output, chained_lazy_init) != null);
 }
 
+test "react_native inlineRequires: export-star source side effects stay eager" {
+    // RNFirebase analytics 축소 재현:
+    // package entry가 export-star로 modular API와 namespaced 등록 모듈을 re-export한다.
+    // named getter만 lazy init하면 getAnalytics 함수는 있어도 getApp().analytics 등록이 없다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("analytics");
+    try writeFile(tmp.dir, "entry.js",
+        \\import { getAnalytics } from './analytics';
+        \\globalThis.__zntcAnalyticsResult = getAnalytics().dataCollectionEnabled;
+    );
+    try writeFile(tmp.dir, "app.js",
+        \\export function getApp() {
+        \\  return globalThis.__zntcFirebaseApp;
+        \\}
+    );
+    try writeFile(tmp.dir, "analytics/index.js",
+        \\export * from './modular';
+        \\export * from './namespaced';
+        \\export { default } from './namespaced';
+    );
+    try writeFile(tmp.dir, "analytics/modular.js",
+        \\import { getApp } from '../app';
+        \\export function getAnalytics() {
+        \\  return getApp().analytics();
+        \\}
+    );
+    try writeFile(tmp.dir, "analytics/namespaced.js",
+        \\globalThis.__zntcFirebaseApp = {
+        \\  analytics() {
+        \\    return { dataCollectionEnabled: 'analytics-ready' };
+        \\  },
+        \\};
+        \\export const firebase = {};
+        \\export default {};
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const namespaced = try absPath(&tmp, "analytics/namespaced.js");
+    defer std.testing.allocator.free(namespaced);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = true,
+        .dev_mode = true,
+        .entry_error_guard = true,
+        .strict_execution_order = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const eager_namespaced_init = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "__zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn();}});",
+        .{namespaced},
+    );
+    defer std.testing.allocator.free(eager_namespaced_init);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, eager_namespaced_init) != null);
+}
+
 test "react_native inlineRequires: namespace member rewrite initializes source modules" {
     // Sentry.init / modalSelectors.getFoo 축소 재현:
     // `import * as ns` 뒤의 `ns.member` 직접 치환도 namespace object getter와 동일하게
@@ -3950,6 +4017,57 @@ test "react_native inlineRequires: namespace import from export-star barrel init
     defer std.testing.allocator.free(getter_with_source_init);
     try std.testing.expect(std.mem.indexOf(u8, result.output, getter_with_source_init) != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "get fadeIn() { return fadeIn; }") == null);
+}
+
+test "react_native inlineRequires: named import of namespace re-export stays eager" {
+    // 축소 재현: `api` barrel 이 `import * as serverStatusApi` 후 named export 하고,
+    // consumer 가 `serverStatusApi.fetchServerHealthFlag` 멤버만 쓰면 namespace rewrite 가
+    // direct binding 으로 바뀐다. 이때 barrel init 을 lazy 로 미루면 source export 변수가
+    // 아직 undefined 로 남아 action creator 생성 중 터진다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { action } from './actions.js';
+        \\globalThis.__zntcAction = action;
+    );
+    try writeFile(tmp.dir, "api.js",
+        \\import * as serverStatusApi from './server-status.js';
+        \\export { serverStatusApi };
+    );
+    try writeFile(tmp.dir, "server-status.js",
+        \\export function fetchServerHealthFlag() {
+        \\  return 1;
+        \\}
+    );
+    try writeFile(tmp.dir, "actions.js",
+        \\import { serverStatusApi } from './api.js';
+        \\export const action = serverStatusApi.fetchServerHealthFlag;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = true,
+        .dev_mode = false,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const actions_init = std.mem.indexOf(u8, result.output, "\"actions.js\"()") orelse unreachable;
+    const actions_end = std.mem.indexOf(u8, result.output[actions_init..], "\n\t}\n});") orelse
+        std.mem.indexOf(u8, result.output[actions_init..], "}});") orelse unreachable;
+    const actions_body = result.output[actions_init .. actions_init + actions_end];
+    try std.testing.expect(std.mem.indexOf(u8, actions_body, "init_api") != null);
+    try std.testing.expect(std.mem.indexOf(u8, actions_body, "fetchServerHealthFlag") != null);
 }
 
 test "react_native inlineRequires: keeps default ESM imports eager for provider side effects" {

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -54,7 +54,7 @@ pub fn promoteExportsKinds(self: *ModuleGraph) void {
         var it = self.modules.iterator(0);
         while (it.next()) |m| {
             for (m.import_records) |rec| {
-                if (rec.kind != .static_import and rec.kind != .side_effect and rec.kind != .re_export) continue;
+                if (!rec.kind.isEagerEvalDependency()) continue;
                 if (rec.resolved.isNone()) continue;
                 const target_idx = @intFromEnum(rec.resolved);
                 if (target_idx >= self.modules.count()) continue;
@@ -347,7 +347,7 @@ pub fn propagateTopLevelAwait(self: *ModuleGraph) void {
         while (it.next()) |m| : (src_idx += 1) {
             for (m.import_records) |rec| {
                 if (rec.resolved.isNone()) continue;
-                if (rec.kind != .static_import and rec.kind != .side_effect and rec.kind != .re_export) continue;
+                if (!rec.kind.isEagerEvalDependency()) continue;
                 const target_idx = @intFromEnum(rec.resolved);
                 if (target_idx >= count) continue;
                 reverse_deps[target_idx].append(self.allocator, @intCast(src_idx)) catch return;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -462,11 +462,11 @@ pub fn buildMetadataForAst(
         }
 
         if (self.strict_execution_order and m.wrap_kind == .esm) {
-            // 정적 import의 평가 효과는 모든 importer 본문보다 먼저, 그리고 소스에
-            // 나타난 순서대로 발생해야 한다. 단, RN inlineRequires 가 값 사용 지점으로
-            // 내리는 named import 는 Metro 와 같이 여기서 선행 실행하지 않는다.
+            // 정적 import/export-from의 평가 효과는 모든 importer 본문보다 먼저, 그리고
+            // 소스에 나타난 순서대로 발생해야 한다. 단, RN inlineRequires 가 값 사용
+            // 지점으로 내리는 named import 는 Metro 와 같이 여기서 선행 실행하지 않는다.
             for (m.import_records, 0..) |rec, rec_index| {
-                if (rec.kind != .static_import and rec.kind != .side_effect) continue;
+                if (rec.kind != .static_import and rec.kind != .side_effect and rec.kind != .re_export) continue;
                 if (rec.resolved.isNone()) continue;
                 const target_mod = self.graph.getModule(rec.resolved) orelse continue;
                 if (self.tree_shaker_active and !target_mod.is_included) continue;
@@ -746,6 +746,7 @@ pub fn buildMetadataForAst(
                 // lazy 화로 누락되어 Metro 와 다른 초기화 순서가 되는 것을 차단.
                 var value_init_mod = target_mod;
                 var value_init_mod_idx = canonical_mod;
+                var import_is_namespace_export = false;
                 if (resolved) |rb| {
                     const rb_idx = @intFromEnum(rb.canonical.module_index);
                     if (rb_idx != canonical_mod) {
@@ -753,6 +754,15 @@ pub fn buildMetadataForAst(
                             if (rb_mod.wrap_kind == .esm) {
                                 value_init_mod = rb_mod;
                                 value_init_mod_idx = @intCast(rb_idx);
+                            }
+                        }
+                    }
+                    const export_local = self.getExportLocalName(@intCast(@intFromEnum(rb.canonical.module_index)), rb.canonical.export_name) orelse rb.canonical.export_name;
+                    if (self.graph.getModule(rb.canonical.module_index)) |rb_mod| {
+                        for (rb_mod.import_bindings) |cib| {
+                            if (cib.kind == .namespace and std.mem.eql(u8, cib.local_name, export_local)) {
+                                import_is_namespace_export = true;
+                                break;
                             }
                         }
                     }
@@ -767,6 +777,7 @@ pub fn buildMetadataForAst(
                     !is_helper_binding and
                     ib.kind == .named and
                     !ib.importsDefault() and
+                    !import_is_namespace_export and
                     !target_mod.uses_top_level_await and
                     !value_init_mod.uses_top_level_await and
                     !exported_locals.contains(m.importBindingLocalName(ib));
@@ -807,6 +818,7 @@ pub fn buildMetadataForAst(
                     &owned_nested_renames,
                     &ns_target_to_var,
                     force_inline,
+                    false,
                     module_index,
                     ns_sym_id,
                     @intCast(canonical_mod),
@@ -870,6 +882,7 @@ pub fn buildMetadataForAst(
                                                 &owned_nested_renames,
                                                 &ns_target_to_var,
                                                 nsForceInline(self, ast, override_symbol_ids orelse sem.symbol_ids, @intCast(import_sym_id), module_index, ib.local_name),
+                                                false,
                                                 module_index,
                                                 @intCast(import_sym_id),
                                                 @intFromEnum(src),
@@ -900,6 +913,7 @@ pub fn buildMetadataForAst(
                                     &owned_nested_renames,
                                     &ns_target_to_var,
                                     nsForceInline(self, ast, override_symbol_ids orelse sem.symbol_ids, @intCast(imp_sym), module_index, ib.local_name),
+                                    true,
                                     module_index,
                                     @intCast(imp_sym),
                                     @intCast(ns_target_mod),

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -466,7 +466,7 @@ pub fn buildMetadataForAst(
             // 소스에 나타난 순서대로 발생해야 한다. 단, RN inlineRequires 가 값 사용
             // 지점으로 내리는 named import 는 Metro 와 같이 여기서 선행 실행하지 않는다.
             for (m.import_records, 0..) |rec, rec_index| {
-                if (rec.kind != .static_import and rec.kind != .side_effect and rec.kind != .re_export) continue;
+                if (!rec.kind.isEagerEvalDependency()) continue;
                 if (rec.resolved.isNone()) continue;
                 const target_mod = self.graph.getModule(rec.resolved) orelse continue;
                 if (self.tree_shaker_active and !target_mod.is_included) continue;
@@ -516,7 +516,7 @@ pub fn buildMetadataForAst(
             // resolve 미완료: external 또는 resolve 실패.
             if (rec.resolved.isNone()) {
                 if (rec.is_lazy_resolved) continue;
-                if (rec.kind == .static_import or rec.kind == .side_effect or rec.kind == .re_export) {
+                if (rec.kind.isEagerEvalDependency()) {
                     if (!ib.is_helper and !ib.local_symbol.isValid()) continue;
                     const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
                     // helper binding (JSX runtime 등) + ESM-wrapped 모듈 조합에서는 top-level
@@ -749,16 +749,12 @@ pub fn buildMetadataForAst(
                 var import_is_namespace_export = false;
                 if (resolved) |rb| {
                     const rb_idx = @intFromEnum(rb.canonical.module_index);
-                    if (rb_idx != canonical_mod) {
-                        if (self.graph.getModule(rb.canonical.module_index)) |rb_mod| {
-                            if (rb_mod.wrap_kind == .esm) {
-                                value_init_mod = rb_mod;
-                                value_init_mod_idx = @intCast(rb_idx);
-                            }
-                        }
-                    }
-                    const export_local = self.getExportLocalName(@intCast(@intFromEnum(rb.canonical.module_index)), rb.canonical.export_name) orelse rb.canonical.export_name;
                     if (self.graph.getModule(rb.canonical.module_index)) |rb_mod| {
+                        if (rb_idx != canonical_mod and rb_mod.wrap_kind == .esm) {
+                            value_init_mod = rb_mod;
+                            value_init_mod_idx = @intCast(rb_idx);
+                        }
+                        const export_local = self.getExportLocalName(@intCast(rb_idx), rb.canonical.export_name) orelse rb.canonical.export_name;
                         for (rb_mod.import_bindings) |cib| {
                             if (cib.kind == .namespace and std.mem.eql(u8, cib.local_name, export_local)) {
                                 import_is_namespace_export = true;

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -40,6 +40,8 @@ pub fn nsRewriteDisabled() bool {
 ///
 /// `force_inline`: caller 가 isNamespaceUsedAsValue / exported_locals 등으로 결정한
 /// 강제 inline 신호. shadow 충돌은 함수 안에서 자체 감지하여 ns_inline_list 를 활성화.
+/// `force_target_init`: caller preamble 이 target namespace 모듈 init 을 보장하지 못하는
+/// named-import-of-namespace-export 경로에서 member rewrite 값에 target init 을 붙인다.
 pub fn registerNamespaceRewrites(
     self: *const Linker,
     ns_rewrite_list: *std.ArrayList(LinkingMetadata.NsMemberRewrites.Entry),
@@ -49,6 +51,7 @@ pub fn registerNamespaceRewrites(
     /// 를 공유하도록 caller 가 owned. `cjs_var_cache` 와 같은 패턴 (`metadata.zig`).
     ns_target_to_var: *std.AutoHashMap(u32, []const u8),
     force_inline: bool,
+    force_target_init: bool,
     importer_mod_idx: u32,
     symbol_id: u32,
     target_mod_idx: u32,
@@ -119,7 +122,7 @@ pub fn registerNamespaceRewrites(
     // dev lazy runtime 에서는 access site 가 package entry 도 깨워야 하므로 target init 을
     // 포함한다. release 는 module preamble 이 target init 을 이미 보장하므로 source init 만
     // rewrite value 에 붙인다.
-    const target_init: ?[]const u8 = if (self.dev_mode)
+    const target_init: ?[]const u8 = if (self.dev_mode or force_target_init)
         try allocEsmInitExprForModuleIndex(self, target_mod_idx)
     else
         null;

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -272,6 +272,13 @@ pub const ImportKind = enum {
     glob,
     /// require.context("./pages", true, /\.tsx$/, "sync") — webpack/Metro 호환 (#1579)
     require_context,
+
+    /// importer 본문보다 먼저 평가 효과가 발생해야 하는 정적 ESM 의존성 종류.
+    /// `export { x } from`/`export * from`(re_export)도 source 모듈의 side effect 를
+    /// eager 초기화해야 하므로 포함한다.
+    pub fn isEagerEvalDependency(self: ImportKind) bool {
+        return self == .static_import or self == .side_effect or self == .re_export;
+    }
 };
 
 /// require.context mode. Metro/webpack 명세상 4가지.


### PR DESCRIPTION
## 변경 사항
- RN 번들 strict execution order에서 `export * from`/`export { ... } from` 대상 모듈도 ESM 평가 의존성으로 초기화합니다.
- namespace re-export getter lazy init과 export-star side effect 누락 재현 테스트를 추가했습니다.
- Metro resolver fallback 경로 처리와 namespace re-export eager init 보강 변경도 함께 포함했습니다.

## 검증
- `zig build test -- --test-filter "react_native inlineRequires: export-star source side effects stay eager"`
- `zig build test -- --test-filter "react_native inlineRequires: named import of namespace re-export stays eager"`
- `zig build napi`
- 테스트앱 Android productionRelease APK를 `zntc.config.ts` + zntc CLI로 빌드/설치 후 로그인 화면 진입 확인
