### PR TITLE
chore(examples): add react-19-vite + rspack to workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ packages/rspack-loader/dist/
 packages/vite-plugin/dist/
 examples/web/dist/
 examples/react-19-zntc/dist/
+examples/react-19-vite/dist/
+examples/rspack/dist/
 # 루트 cwd 에 떨어지는 임시 빌드 산출물 (NAPI 직접 호출 경로 / examples 빌드 leftover).
 /dist/
 

--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,25 @@
         "typescript": "^6.0.3",
       },
     },
+    "examples/react-19-vite": {
+      "name": "@zntc/example-react-19-vite",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "@babel/core": "^7.27.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^5.0.0",
+        "@zntc/core": "workspace:*",
+        "@zntc/vite-plugin": "workspace:*",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "typescript": "^6.0.3",
+        "vite": "^6.0.0",
+      },
+    },
     "examples/react-19-zntc": {
       "name": "@zntc/example-react-19-zntc",
       "version": "0.0.0",
@@ -394,6 +413,24 @@
         "babel-plugin-root-import": "^6.6.0",
         "react-native-svg-transformer": "^1.5.3",
         "typescript": "^5.8.3",
+      },
+    },
+    "examples/rspack": {
+      "name": "@zntc/example-rspack",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "@rspack/cli": "^2.0.1",
+        "@rspack/core": "^2.0.1",
+        "@rspack/dev-server": "^2.0.1",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@zntc/core": "workspace:*",
+        "@zntc/rspack-loader": "workspace:*",
+        "typescript": "^6.0.3",
       },
     },
     "examples/web": {
@@ -2233,6 +2270,10 @@
 
     "@rspack/core": ["@rspack/core@2.0.1", "", { "dependencies": { "@rspack/binding": "2.0.1" }, "peerDependencies": { "@module-federation/runtime-tools": "^0.24.1 || ^2.0.0", "@swc/helpers": ">=0.5.1" }, "optionalPeers": ["@module-federation/runtime-tools", "@swc/helpers"] }, "sha512-lgfZiExh8kDR/3obgi3RQKwKG5av1Xf5qDN1aVde777W9pbmx0Pqvrww1qtNvJ+gobEjbrrn5HEZWYGe0VLmcA=="],
 
+    "@rspack/dev-middleware": ["@rspack/dev-middleware@2.0.1", "", { "peerDependencies": { "@rspack/core": "^2.0.0-0" }, "optionalPeers": ["@rspack/core"] }, "sha512-cXSubf5/C+dvkWV2/+rGTtiZ93wSLd3OlTQhwMvsmsmGDdPlkYqIvQ+BTkOk9UCXxKIaF0DDYYmCpBeRRYJfJw=="],
+
+    "@rspack/dev-server": ["@rspack/dev-server@2.0.1", "", { "dependencies": { "@rspack/dev-middleware": "^2.0.1" }, "peerDependencies": { "@rspack/core": "^2.0.0-0", "selfsigned": "^5.0.0" }, "optionalPeers": ["selfsigned"] }, "sha512-N5sIdU9v6WhwPH6Ek8QCj4IMvGd8jA3ZW1NMAyHP1ezzKIr2/idcNV2zX5vbC6FJvOLRLww0rFjfKA+z4tshDA=="],
+
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
@@ -2931,7 +2972,11 @@
 
     "@zntc/example-module-federation": ["@zntc/example-module-federation@workspace:examples/module-federation"],
 
+    "@zntc/example-react-19-vite": ["@zntc/example-react-19-vite@workspace:examples/react-19-vite"],
+
     "@zntc/example-react-19-zntc": ["@zntc/example-react-19-zntc@workspace:examples/react-19-zntc"],
+
+    "@zntc/example-rspack": ["@zntc/example-rspack@workspace:examples/rspack"],
 
     "@zntc/example-web": ["@zntc/example-web@workspace:examples/web"],
 
@@ -6871,7 +6916,13 @@
 
     "@zntc/example-module-federation/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
+    "@zntc/example-react-19-vite/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "@zntc/example-react-19-vite/vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
+
     "@zntc/example-react-19-zntc/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "@zntc/example-rspack/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "@zntc/example-web/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 

--- a/examples/react-19-vite/package.json
+++ b/examples/react-19-vite/package.json
@@ -21,7 +21,7 @@
     "@vitejs/plugin-react": "^5.0.0",
     "@zntc/core": "workspace:*",
     "@zntc/vite-plugin": "workspace:*",
-    "babel-plugin-react-compiler": "^19.0.0",
+    "babel-plugin-react-compiler": "^1.0.0",
     "typescript": "^6.0.3",
     "vite": "^6.0.0"
   }

--- a/examples/rspack/README.md
+++ b/examples/rspack/README.md
@@ -1,0 +1,36 @@
+# @zntc/example-rspack
+
+`@zntc/rspack-loader` 를 rspack 의 `.tsx` loader 로 써서 React 19 앱을 빌드·서빙하는 예제.
+swc-loader / babel-loader / esbuild-loader 자리에 ZNTC 를 끼우는 구성.
+
+## 동작 원리
+
+```
+파일 변경
+   ↓
+@zntc/rspack-loader — ZNTC 가 TS strip + JSX automatic runtime 변환 (+ 소스맵 생성)
+   ↓
+rspack — 모듈 그래프 · 번들 · HMR · dev server
+   ↓
+브라우저
+```
+
+`rspack.config.mjs` 의 핵심:
+
+- `transpileOptions.sourcemap: true` + `devtool: "source-map"` — 둘 다 켜야 DevTools
+  Sources 에서 변환 결과(`_jsx(...)`)가 아닌 **원본 `.tsx`** 가 보인다. 끄면 loader 가
+  rspack 에 map 을 넘기지 못해 디버깅 시 변환 코드가 그대로 노출된다.
+- `@rspack/dev-server` 는 `@rspack/core` 와 메이저 버전이 일치해야 한다 (`^2.0.1`).
+
+## 실행
+
+```bash
+bun run dev      # rspack serve — http://localhost:8080/ (기본 포트)
+bun run build    # NODE_ENV=production rspack build → dist/
+```
+
+호스트/포트를 바꾸려면 CLI flag 로:
+
+```bash
+bun run dev -- --host 0.0.0.0 --port 12308
+```

--- a/examples/rspack/index.html
+++ b/examples/rspack/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZNTC + Rspack (React 19)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/rspack/package.json
+++ b/examples/rspack/package.json
@@ -7,7 +7,7 @@
     "predev": "bun run --cwd ../../packages/core build:js && bun run --cwd ../../packages/rspack-loader build",
     "dev": "rspack serve",
     "prebuild": "bun run --cwd ../../packages/core build:js && bun run --cwd ../../packages/rspack-loader build",
-    "build": "rspack build"
+    "build": "NODE_ENV=production rspack build"
   },
   "dependencies": {
     "react": "^19.0.0",

--- a/examples/rspack/package.json
+++ b/examples/rspack/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@zntc/example-rspack",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "predev": "bun run --cwd ../../packages/core build:js && bun run --cwd ../../packages/rspack-loader build",
+    "dev": "rspack serve",
+    "prebuild": "bun run --cwd ../../packages/core build:js && bun run --cwd ../../packages/rspack-loader build",
+    "build": "rspack build"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@rspack/cli": "^2.0.1",
+    "@rspack/core": "^2.0.1",
+    "@rspack/dev-server": "^2.0.1",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@zntc/core": "workspace:*",
+    "@zntc/rspack-loader": "workspace:*",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/rspack/rspack.config.mjs
+++ b/examples/rspack/rspack.config.mjs
@@ -1,0 +1,40 @@
+import { createRequire } from "node:module";
+import { rspack } from "@rspack/core";
+
+// @zntc/rspack-loader 를 rspack 의 .tsx/.ts loader 로 사용한다. zntc 가 TS strip +
+// JSX automatic runtime 변환을 담당하고, rspack 이 모듈 그래프·번들·HMR·dev server 를
+// 맡는다 (swc/babel loader 자리에 zntc 를 끼우는 구성).
+const require = createRequire(import.meta.url);
+const zntcLoader = require.resolve("@zntc/rspack-loader");
+
+export default {
+  mode: "development",
+  // zntc-loader 의 소스맵(원본 .tsx → 변환 JS)을 rspack 이 이어붙이게 한다.
+  // 미지정 시 DevTools 가 변환 결과(_jsx(...))를 원본으로 보여준다.
+  devtool: "source-map",
+  entry: "./src/main.tsx",
+  resolve: {
+    extensions: [".tsx", ".ts", ".jsx", ".js"],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.[jt]sx?$/,
+        loader: zntcLoader,
+        options: {
+          transpileOptions: {
+            target: "es2022",
+            jsx: "automatic",
+            // loader 가 result.map 을 rspack 에 넘기려면 zntc 가 map 을 생성해야 한다.
+            sourcemap: true,
+          },
+        },
+      },
+    ],
+  },
+  plugins: [new rspack.HtmlRspackPlugin({ template: "./index.html" })],
+  devServer: {
+    host: "0.0.0.0",
+    port: 12308,
+  },
+};

--- a/examples/rspack/rspack.config.mjs
+++ b/examples/rspack/rspack.config.mjs
@@ -7,8 +7,10 @@ import { rspack } from "@rspack/core";
 const require = createRequire(import.meta.url);
 const zntcLoader = require.resolve("@zntc/rspack-loader");
 
+const isProd = process.env.NODE_ENV === "production";
+
 export default {
-  mode: "development",
+  mode: isProd ? "production" : "development",
   // zntc-loader 의 소스맵(원본 .tsx → 변환 JS)을 rspack 이 이어붙이게 한다.
   // 미지정 시 DevTools 가 변환 결과(_jsx(...))를 원본으로 보여준다.
   devtool: "source-map",
@@ -20,6 +22,7 @@ export default {
     rules: [
       {
         test: /\.[jt]sx?$/,
+        exclude: /node_modules/,
         loader: zntcLoader,
         options: {
           transpileOptions: {
@@ -33,8 +36,4 @@ export default {
     ],
   },
   plugins: [new rspack.HtmlRspackPlugin({ template: "./index.html" })],
-  devServer: {
-    host: "0.0.0.0",
-    port: 12308,
-  },
 };

--- a/examples/rspack/src/App.tsx
+++ b/examples/rspack/src/App.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+
+export function App() {
+  const [count, setCount] = useState(0);
+  const [filter, setFilter] = useState("");
+
+  const items = Array.from({ length: 20 }, (_, i) => i + count);
+  const filtered = items.filter((n) => String(n).includes(filter));
+
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 24, maxWidth: 720, margin: "0 auto" }}>
+      <h1>ZNTC + Rspack (React 19)</h1>
+      <p>@zntc/rspack-loader 가 rspack 의 .tsx loader 로 TS/JSX 변환 · rspack 이 번들·HMR·dev server.</p>
+
+      <section>
+        <label>
+          counter: <strong>{count}</strong>{" "}
+          <button onClick={() => setCount((c) => c + 1)}>+1</button>
+        </label>
+      </section>
+
+      <section style={{ marginTop: 24 }}>
+        <label>
+          filter:{" "}
+          <input value={filter} onChange={(e) => setFilter(e.target.value)} placeholder="e.g. 1" />
+        </label>
+        <ul>
+          {filtered.map((n) => (
+            <li key={n}>{n}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/examples/rspack/src/main.tsx
+++ b/examples/rspack/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("#root not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/rspack/tsconfig.json
+++ b/examples/rspack/tsconfig.json
@@ -2,13 +2,16 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
+    "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "types": ["react", "react-dom"]
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
   },
-  "include": ["src"]
+  "include": ["src/**/*", "rspack.config.mjs"]
 }

--- a/examples/rspack/tsconfig.json
+++ b/examples/rspack/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["react", "react-dom"]
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "./documents",
     "./examples/web",
     "./examples/react-19-zntc",
+    "./examples/react-19-vite",
+    "./examples/rspack",
     "./examples/module-federation",
     "./examples/react-native-bare",
     "./examples/react-native-large",


### PR DESCRIPTION
## Summary

#3618 (react-19-zntc) 에 이어 나머지 번들러 비교 예제를 workspace 에 편입.

### react-19-vite
- `babel-plugin-react-compiler` `^19.0.0` → `^1.0.0` (npm 에 `19.0.0` 태그 없음 — `bun install` 실패 원인). config 의 `{ target: "19" }` 유지.
- root workspaces 편입. Vite + `@vitejs/plugin-react` + `@zntc/vite-plugin` 구성.

### rspack (신규 예제)
- `@zntc/rspack-loader` 를 rspack 의 `.tsx` loader 로 쓰는 dev server 예제 (swc/babel-loader 자리에 zntc).
- `@rspack/dev-server` 는 `@rspack/core@2.0.1` 과 페어인 **`^2.0.1`** — `^1.x` 는 `hotEmitter` default export mismatch (`ESModulesLinkingError`) 로 HMR client 가 깨진다.
- `rspack.config.mjs` 에 **`transpileOptions.sourcemap: true` + `devtool: "source-map"`**. 미설정 시 zntc 가 map 을 생성하지 않아 (loader 의 map 전달 경로는 정상) DevTools Sources 가 변환 결과(`_jsx(...)`)를 원본으로 보여줘 디버깅 불가. 설정 후 `.map` 의 `sourcesContent` 에 원본 JSX 보존 확인.

## 검증

- [x] react-19-vite: `vite --host 0.0.0.0 --port 12308` → GET / 200 (Vite v6.4.2)
- [x] rspack: `rspack serve` → `Rspack compiled successfully`, GET / 200, 앱 타입 잔존 0, `.map` 의 `sourcesContent` 에 원본 `main.tsx` JSX 보존
- [x] `bun install` 성공 (workspace 심링크 + deps)

## Follow-up 후보

`@zntc/rspack-loader` README 예제가 `sourcemap` 을 안 켜고 있어 소스맵 디버깅 함정이 그대로 — README 에 `sourcemap: true` 안내 추가 권장 (별도 PR).