### PR TITLE
fix(bundler): apply statement-level export DCE in splitting emit path

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -104,6 +104,45 @@ pub fn emitChunks(
         outputs.deinit(allocator);
     }
 
+    // 통합(non-split) 경로와 동일하게 statement-level export DCE 를 splitting 경로에도
+    // 적용한다. `generateChunks` 는 shaker 로 *모듈 단위* 포함 여부만 거르므로,
+    // 포함된 모듈 안의 미사용 export(예: 사용 안 한 `export function`) 와 그 종속
+    // top-level 선언은 emit 까지 살아남는다. 그 미사용 export 가 모듈 단위로 이미
+    // 제거된 cross-module import(예: default import)를 참조하면 `X is not defined`
+    // 런타임 크래시가 난다. shaker(=linker.tree_shaker)와 per-module used_export_names
+    // 를 emitModule 에 전달해 emitter.zig 의 statement_shaker 게이트를 활성화한다.
+    const shaker: ?*const TreeShaker = if (linker) |l| l.tree_shaker else null;
+    var used_names_by_modidx: []UsedNamesEntry = &.{};
+    defer if (used_names_by_modidx.len > 0) {
+        for (used_names_by_modidx) |un| allocator.free(un.names);
+        allocator.free(used_names_by_modidx);
+    };
+    if (shaker) |s| {
+        // module index → *const Module (희소 그래프 대비 별도 슬라이스로 dense 화).
+        var mod_ptrs: std.ArrayList(*const Module) = .empty;
+        defer mod_ptrs.deinit(allocator);
+        var idx_it = graph.modulesIterator();
+        while (idx_it.next()) |m| try mod_ptrs.append(allocator, m);
+        const computed = try computeAllUsedNames(allocator, mod_ptrs.items, graph, s);
+        defer allocator.free(computed); // names 슬라이스는 by_modidx 로 이동
+        used_names_by_modidx = try allocator.alloc(UsedNamesEntry, module_count);
+        for (used_names_by_modidx) |*e| e.* = .{ .names = &.{}, .all_used = true };
+        for (mod_ptrs.items, 0..) |m, i| {
+            const mi = m.index.toU32();
+            if (mi >= module_count) continue;
+            // `export * from "./this"` source 는 cross-chunk export 목록이 모든 export
+            // 이름을 over-approx 로 포함한다. emit DCE 로 그 export 선언을 지우면 codegen
+            // 의 `export { ... }` 절과 어긋나 Node `Export X is not defined` SyntaxError.
+            // 보수적으로 all_used (DCE 미적용) — over-include 는 correctness-safe.
+            if (s.isReExportStarTarget(mi)) {
+                allocator.free(computed[i].names);
+                used_names_by_modidx[mi] = .{ .names = &.{}, .all_used = true };
+            } else {
+                used_names_by_modidx[mi] = computed[i];
+            }
+        }
+    }
+
     // 청크를 exec_order 순으로 정렬하여 결정론적 출력 순서 보장.
     // 엔트리 청크가 먼저, 공통 청크가 나중에 오도록 정렬한다.
     const sorted_indices = try allocator.alloc(usize, chunk_graph.chunkCount());
@@ -538,14 +577,18 @@ pub fn emitChunks(
             // IIFE splitting: emitModule 에 wrapped `return{}` 억제 플래그 전달
             // (factory 가 함수 스코프 제공, export 는 emitCjsEntryExports/
             // xchunk_exports 가 담당). iife_emit_opts 는 빌드당 1회 복사.
+            const mod_used_names: ?[]const []const u8 = if (mi < used_names_by_modidx.len and !used_names_by_modidx[mi].all_used)
+                used_names_by_modidx[mi].names
+            else
+                null;
             const raw_code = try emitModule(
                 allocator,
                 m,
                 if (reg_split) &iife_emit_opts else options,
                 linker,
                 is_entry,
-                null,
-                null,
+                mod_used_names,
+                shaker,
                 null,
                 if (chunk_sm != null) &module_mappings else null,
                 if (chunk_sm != null) &module_names else null,

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -781,6 +781,17 @@ pub const TreeShaker = struct {
         return self.used_exports.contains(key);
     }
 
+    /// 이 모듈이 어떤 모듈의 `export * from "./this"` source 인가.
+    /// 그렇다면 splitting/preserve-modules 의 cross-chunk export 목록이 이 모듈의
+    /// *모든* export 이름을 (star 재노출 chain 으로 over-approx) 포함하므로,
+    /// emit 단계 statement-level export DCE 로 export 선언을 제거하면 codegen 이
+    /// 낸 `export { ... }` 절과 불일치 → Node `SyntaxError: Export X is not defined`.
+    pub fn isReExportStarTarget(self: *const TreeShaker, module_index: u32) bool {
+        const mask = self.re_export_star_targets orelse return false;
+        if (module_index >= mask.capacity()) return false;
+        return mask.isSet(module_index);
+    }
+
     /// lazy require 의 source span 이 module 의 cjs_export_fact (lazy getter property) 의
     /// method body 안인지 매핑 + 그 fact 의 export_name 이 consumer 에서 used 인지 확인.
     /// matched fact 없으면 보수적으로 true (retain) — non-RN-core 패턴의 lazy callback 등.

--- a/tests/integration/tests/manual-chunks-smoke.test.ts
+++ b/tests/integration/tests/manual-chunks-smoke.test.ts
@@ -77,10 +77,12 @@ describe('manualChunks smoke (실제 번들 실행)', () => {
         expect.stringMatching(/vendor\/string-utils\.ts$/),
       ]),
     );
-    // 보조: vendor 청크에 수학/string-utils 구현 전부 (transitive dep 포함 정책)
+    // 보조: vendor 청크에 실제로 import 된 export 구현은 포함.
     expect(vendor!.text).toMatch(/function\s+add\s*\(/);
     expect(vendor!.text).toMatch(/function\s+toUpper\s*\(/);
-    expect(vendor!.text).toMatch(/function\s+multiply\s*\(/);
+    // 미사용 export(`multiply`)는 splitting 청크에서도 statement-level DCE 로 제거된다
+    // (esbuild/rolldown 동일). 청크 단위 module 포함 ≠ export 단위 보존.
+    expect(vendor!.text).not.toMatch(/function\s+multiply\s*\(/);
 
     // moduleIds 는 entry / vendor 가 서로 겹치지 않아야 함
     expect(entry!.moduleIds).toEqual(expect.arrayContaining([expect.stringMatching(/entry\.ts$/)]));


### PR DESCRIPTION
## 증상

`zntc build` (app builder — splitting 기본 ON) 로 `@emotion/react` 사용 앱을 빌드하면 브라우저에서:

```
Uncaught ReferenceError: weakMemoize is not defined
    at emotion-element-*.browser.esm.js
```

emotion-element 의 미사용 export `ThemeProvider` 가 보존되며 `var createCacheWithTheme = /* @__PURE__ */ weakMemoize(...)` 호출이 남는데, `@emotion/weak-memoize` 모듈은 모듈 단위 DCE 로 이미 제거돼 정의가 없다.

## Root cause

splitting 경로 `emitChunks` (`src/bundler/emitter/chunks.zig`) 가 `emitModule` 에 `used_export_names`/`shaker` 를 **`null`** 로 넘겨 **statement-level export DCE 를 비활성화**했다.

- `generateChunks` 의 shaker 는 *모듈 단위* 포함 여부만 거른다 → 포함된 모듈 안의 미사용 export 와 종속 top-level 선언은 emit 까지 생존
- 그 미사용 export 가 *모듈 단위* DCE 로 제거된 cross-module import(default import 등)를 참조 → `X is not defined`
- **single-bundle 경로(`emitWithTreeShaking`)는 전 모듈을 emit 하므로 안 터져 가려졌다** — 그래서 `zntc --bundle` 은 정상, `zntc build`(splitting) 만 크래시

> 진단 함정: `zig build` 만으론 `zig-out/lib/zntc.node` 가 안 바뀐다 (`zig build napi` 필요). stale addon 때문에 초기에 "splitting 무관"으로 오진했다가, addon 재빌드 후 `--bundle --splitting` 도 동일 재현됨을 확인.

## Fix

`emitChunks` 가 non-split 경로와 **동일하게** `computeAllUsedNames` + shaker 를 `emitModule` 에 전달해 emit 단계 DCE 게이트 활성화:

- module-level DCE(청크 포함) ↔ statement-level export DCE 일관화
- `export * from "./this"` source 모듈은 cross-chunk export 목록이 모든 export 이름을 over-approx 로 포함 → DCE 시 codegen `export {}` 절과 어긋나 `SyntaxError`. 그 모듈만 보수적 `all_used` (DCE 스킵). `TreeShaker.isReExportStarTarget` accessor 추가.

esbuild/rolldown 도 splitting 에서 미사용 export 를 제거한다 (reference parity).

## Minimal repro (emotion 무관)

```
main.ts:    import { Foo } from "./element"; globalThis.x = Foo();
element.ts: import dflt from "./dflt";
            var cache = /* @__PURE__ */ dflt(fn);   // 미사용 top-level
            export function Unused() { return cache(...); }  // 미사용 export
            export function Foo() { return 1; }              // 사용
dflt.ts:    export default function dflt(){ var c = new WeakMap(); ... }
```
`buildAppSync` (splitting): `Unused`/`cache` 보존 + `dflt` 정의 누락 → 크래시. `zntc --bundle`: 정상 (DCE 로 전부 제거).

## Test plan

- [x] minimal repro: buildAppSync 정상 (Unused/cache DCE, 실행 OK)
- [x] 실제 `examples/web` (emotion): `zntc build` → `weakMemoize` refs 0, 크래시 없음
- [x] `zig build test` 0 fail
- [x] code-splitting integration 112 pass 0 fail (cross-chunk-reexport / cjs / css / iife / umd-amd / manual-chunks / inline-dynamic / dynamic-import)
- [x] manual-chunks-smoke: 미사용 export `multiply` 가 청크에 남아야 한다던 단언이 버그를 고착 → DCE 됨을 단언하도록 정정
- [x] RN fixture 오염 없음
- [x] `zig fmt` / `oxfmt` 통과

## corpus 안전성

144-lib smoke 는 `--bundle ... -o <outfile>` (splitting 미사용) → `emitWithTreeShaking` 경로라 이 변경 무영향.