### PR TITLE
fix(rn): preserve resolver options in hmr

### DIFF
--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -517,7 +517,6 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     // Issue #1223 Phase 2: 초기 빌드에도 PersistentModuleStore 전달.
     // 초기 빌드에서 store가 채워져야 첫 리빌드가 캐시 히트 경로로 진입한다.
     const module_store_mod = bundler_mod.module_store;
-    const ResolveCache = bundler_mod.ResolveCache;
     var persistent_store = module_store_mod.PersistentModuleStore.init(allocator);
     defer persistent_store.deinit();
 
@@ -596,19 +595,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         result.sourcemap_builder = null;
     }
 
-    var persistent_resolve_cache = ResolveCache.init(allocator, .{
-        .platform = bundle_opts.platform,
-        .external_patterns = bundle_opts.external,
-        .custom_conditions = bundle_opts.conditions,
-        .preserve_symlinks = bundle_opts.preserve_symlinks,
-        .resolve_symlink_siblings = bundle_opts.resolve_symlink_siblings,
-        .alias = bundle_opts.alias,
-        .fallback = bundle_opts.fallback,
-        .resolve_extensions = bundle_opts.resolve_extensions,
-        .main_fields = bundle_opts.main_fields,
-        .packages_external = bundle_opts.packages_external,
-        .node_paths = bundle_opts.node_paths,
-    });
+    var persistent_resolve_cache = Bundler.initResolveCacheFromOptions(allocator, bundle_opts);
     defer persistent_resolve_cache.deinit();
 
     // Issue #1223 Phase 1: 이벤트 기반 파일 워처 (kqueue/inotify, mtime 폴백).

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -641,6 +641,25 @@ pub const Bundler = struct {
         }
     }
 
+    pub fn initResolveCacheFromOptions(allocator: std.mem.Allocator, options: BundleOptions) ResolveCache {
+        return ResolveCache.init(allocator, .{
+            .platform = options.platform,
+            .external_patterns = options.external,
+            .custom_conditions = options.conditions,
+            .preserve_symlinks = options.preserve_symlinks,
+            .resolve_symlink_siblings = options.resolve_symlink_siblings,
+            .disable_hierarchical_lookup = options.disable_hierarchical_lookup,
+            .alias = options.alias,
+            .ts_paths = options.ts_paths,
+            .fallback = options.fallback,
+            .block_list = options.block_list,
+            .resolve_extensions = options.resolve_extensions,
+            .main_fields = options.main_fields,
+            .packages_external = options.packages_external,
+            .node_paths = options.node_paths,
+        });
+    }
+
     pub fn init(allocator: std.mem.Allocator, options: BundleOptions) Bundler {
         var opts = options;
         applyPlatformPreset(&opts);
@@ -648,22 +667,7 @@ pub const Bundler = struct {
         return .{
             .allocator = allocator,
             .options = opts,
-            .resolve_cache = ResolveCache.init(allocator, .{
-                .platform = opts.platform,
-                .external_patterns = options.external,
-                .custom_conditions = options.conditions,
-                .preserve_symlinks = options.preserve_symlinks,
-                .resolve_symlink_siblings = options.resolve_symlink_siblings,
-                .disable_hierarchical_lookup = options.disable_hierarchical_lookup,
-                .alias = options.alias,
-                .ts_paths = options.ts_paths,
-                .fallback = options.fallback,
-                .block_list = options.block_list,
-                .resolve_extensions = options.resolve_extensions,
-                .main_fields = options.main_fields,
-                .packages_external = options.packages_external,
-                .node_paths = options.node_paths,
-            }),
+            .resolve_cache = initResolveCacheFromOptions(allocator, opts),
         };
     }
 

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -3614,6 +3614,72 @@ test "react_native inlineRequires: defer top-level ESM value imports to use site
     try std.testing.expect(std.mem.indexOf(u8, result.output, ".fn();});\n,") == null);
 }
 
+test "react_native inlineRequires: package sideEffects pattern keeps static ESM init eager" {
+    // 패키지가 sideEffects 배열로 선언한 파일은 top-level 초기화 순서가 의미 있다.
+    // Metro도 이 신호를 보고 inlineRequires lazy 대상으로 보지 않으므로, ZNTC도
+    // named import 값 사용 지점으로 미루지 않는다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { result } from './node_modules/worklets/specs';
+        \\globalThis.__zntcWorkletsResult = result;
+    );
+    try writeFile(tmp.dir, "node_modules/worklets/package.json",
+        \\{"name":"worklets","main":"./index.js","sideEffects":["./**/runtimeKind.{js,ts}"]}
+    );
+    try writeFile(tmp.dir, "node_modules/worklets/specs.js",
+        \\import { RuntimeKind } from './runtimeKind';
+        \\import NativeModule from './native-module';
+        \\export const result = globalThis.__RUNTIME_KIND === RuntimeKind.ReactNative ? NativeModule : null;
+    );
+    try writeFile(tmp.dir, "node_modules/worklets/runtimeKind.ts",
+        \\export const RuntimeKind = { ReactNative: 1 };
+        \\if (globalThis.__RUNTIME_KIND === undefined) {
+        \\  globalThis.__RUNTIME_KIND = RuntimeKind.ReactNative;
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/worklets/native-module.js",
+        \\export default 'native-module';
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const runtime_kind = try absPath(&tmp, "node_modules/worklets/runtimeKind.ts");
+    defer std.testing.allocator.free(runtime_kind);
+    const specs = try absPath(&tmp, "node_modules/worklets/specs.js");
+    defer std.testing.allocator.free(specs);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const eager_runtime_init = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "__zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn();}});",
+        .{runtime_kind},
+    );
+    defer std.testing.allocator.free(eager_runtime_init);
+
+    const specs_pos = std.mem.indexOf(u8, result.output, specs) orelse return error.SpecsModuleMissing;
+    const specs_tail = result.output[specs_pos..];
+    const eager_pos = std.mem.indexOf(u8, specs_tail, eager_runtime_init) orelse return error.EagerRuntimeInitMissing;
+    const compare_pos = std.mem.indexOf(u8, specs_tail, "globalThis.__RUNTIME_KIND ===") orelse return error.RuntimeKindCompareMissing;
+
+    try std.testing.expect(eager_pos < compare_pos);
+    try std.testing.expect(std.mem.indexOf(u8, specs_tail, "globalThis.__RUNTIME_KIND === (__zntc_guarded") == null);
+}
+
 test "react_native inlineRequires: strict order still defers named CJS imports" {
     // Metro inlineRequires 는 CJS named import 도 값 사용 지점에서 require 한다.
     // strictExecutionOrder 가 켜져도 이 named import 를 선행 실행하면 RN app 초기

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -2121,6 +2121,81 @@ test "Bundler: dev mode alias named import does not emit raw require" {
     try std.testing.expect(saw_layout);
 }
 
+test "Bundler: dev mode HMR mixed alias imports do not emit raw require" {
+    // 테스트앱 재현: HMR payload는 eval 스코프에서 실행되므로 alias import가
+    // `require("~/...")`로 남으면 RN/Hermes에 global require가 없어 실패한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "src/core/settings/index.ts",
+        \\export * from './optionStore';
+    );
+    try writeFile(tmp.dir, "src/core/settings/optionStore.ts",
+        \\export const defaultOptions = { mode: 'dev' };
+    );
+    try writeFile(tmp.dir, "src/widgets/loading/index.js",
+        \\import LoadingRing from './LoadingRing';
+        \\export { LoadingRing };
+    );
+    try writeFile(tmp.dir, "src/widgets/loading/LoadingRing.js",
+        \\export default function LoadingRing() {
+        \\  return null;
+        \\}
+    );
+    try writeFile(tmp.dir, "src/App.tsx",
+        \\import { defaultOptions as appDefaults } from '~/core/settings';
+        \\import { LoadingRing } from '~/widgets/loading';
+        \\export default function App() {
+        \\  return [appDefaults.mode, LoadingRing];
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "src/App.tsx");
+    defer std.testing.allocator.free(entry);
+    const root = try absPath(&tmp, ".");
+    defer std.testing.allocator.free(root);
+    const src_prefix = try std.fmt.allocPrint(std.testing.allocator, "{s}/src/", .{root});
+    defer std.testing.allocator.free(src_prefix);
+
+    const ts_path_targets = [_]@import("../../config.zig").TsConfig.PathEntry.Target{
+        .{ .prefix = src_prefix, .suffix = "" },
+    };
+    const ts_paths = [_]@import("../../config.zig").TsConfig.PathEntry{
+        .{
+            .key_prefix = "~/",
+            .key_suffix = "",
+            .has_wildcard = true,
+            .targets = &ts_path_targets,
+        },
+    };
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .dev_mode = true,
+        .collect_module_codes = true,
+        .ts_paths = &ts_paths,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"~/") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require('~/") == null);
+
+    const codes = result.module_dev_codes orelse return error.TestUnexpectedResult;
+    var saw_app = false;
+    for (codes) |c| {
+        if (std.mem.indexOf(u8, c.id, "src/App.tsx") == null) continue;
+        saw_app = true;
+        try std.testing.expect(std.mem.indexOf(u8, c.code, "require(\"~/") == null);
+        try std.testing.expect(std.mem.indexOf(u8, c.code, "require('~/") == null);
+        try std.testing.expect(std.mem.indexOf(u8, c.code, "__zntc_modules[") != null);
+    }
+    try std.testing.expect(saw_app);
+}
+
 test "Bundler: dev mode ts paths re-exported CJS named import does not emit raw require" {
     // Expo Router _layout + tsconfig paths 재현:
     // app/_layout.tsx -> @/hooks/use-color-scheme -> react-native(CJS) re-export.

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -776,6 +776,25 @@ test "matchSideEffectsPatterns: exact path match" {
     ));
 }
 
+test "matchSideEffectsPatterns: react-native-worklets style brace pattern" {
+    const patterns = &[_][]const u8{"./**/runtimeKind.{js,ts}"};
+    try std.testing.expect(ModuleGraph.matchSideEffectsPatterns(
+        "/app/node_modules/react-native-worklets/src/runtimeKind.ts",
+        "/app/node_modules/react-native-worklets",
+        patterns,
+    ));
+    try std.testing.expect(ModuleGraph.matchSideEffectsPatterns(
+        "/app/node_modules/react-native-worklets/lib/module/runtimeKind.js",
+        "/app/node_modules/react-native-worklets",
+        patterns,
+    ));
+    try std.testing.expect(!ModuleGraph.matchSideEffectsPatterns(
+        "/app/node_modules/react-native-worklets/src/runtimeKind.jsx",
+        "/app/node_modules/react-native-worklets",
+        patterns,
+    ));
+}
+
 test "matchSideEffectsPatterns: no patterns = no side effects" {
     const patterns = &[_][]const u8{};
     try std.testing.expect(!ModuleGraph.matchSideEffectsPatterns(

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -142,19 +142,7 @@ pub const IncrementalBundler = struct {
     fn doBuild(self: *IncrementalBundler, is_first: bool) !RebuildResult {
         // resolve_cache 초기화 (첫 빌드 시) 또는 재사용
         if (self.resolve_cache == null) {
-            self.resolve_cache = ResolveCache.init(self.allocator, .{
-                .platform = self.options.platform,
-                .external_patterns = self.options.external,
-                .custom_conditions = self.options.conditions,
-                .preserve_symlinks = self.options.preserve_symlinks,
-                .resolve_symlink_siblings = self.options.resolve_symlink_siblings,
-                .disable_hierarchical_lookup = self.options.disable_hierarchical_lookup,
-                .alias = self.options.alias,
-                .fallback = self.options.fallback,
-                .block_list = self.options.block_list,
-                .resolve_extensions = self.options.resolve_extensions,
-                .main_fields = self.options.main_fields,
-            });
+            self.resolve_cache = Bundler.initResolveCacheFromOptions(self.allocator, self.options);
         }
 
         // 증분 빌드: 첫 빌드가 아니면 module_store 를 전달하여 파싱 캐시 활용.

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
+const Bundler = @import("bundler.zig").Bundler;
 const IncrementalBundler = @import("incremental.zig").IncrementalBundler;
 const BundleResult = @import("bundler.zig").BundleResult;
+const CompiledOutputCache = @import("compiled_cache.zig").CompiledOutputCache;
+const module_store = @import("module_store.zig");
 const test_helpers = @import("test_helpers.zig");
 const writeFile = test_helpers.writeFile;
 const absPath = test_helpers.absPath;
@@ -185,6 +188,220 @@ test "IncrementalBundler: changed module code keeps bundle require rewrites" {
         .build_error => return error.TestUnexpectedResult,
         .fatal => return error.TestUnexpectedResult,
     }
+}
+
+test "IncrementalBundler: changed HMR module rewrites mixed alias imports" {
+    // 테스트앱 재현: 증분 HMR payload에서 alias import가 raw `require("~/...")`
+    // 로 돌아오면 RN eval 스코프에서 global require가 없어 실패한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "src/core/settings/index.ts",
+        \\export * from './optionStore';
+    );
+    try writeFile(tmp.dir, "src/core/settings/optionStore.ts",
+        \\export const defaultOptions = { mode: 'dev' };
+    );
+    try writeFile(tmp.dir, "src/widgets/loading/index.js",
+        \\import LoadingRing from './LoadingRing';
+        \\export { LoadingRing };
+    );
+    try writeFile(tmp.dir, "src/widgets/loading/LoadingRing.js",
+        \\export default function LoadingRing() {
+        \\  return null;
+        \\}
+    );
+    try writeFile(tmp.dir, "src/App.tsx",
+        \\import { defaultOptions as appDefaults } from '~/core/settings';
+        \\import { LoadingRing } from '~/widgets/loading';
+        \\export default function App() {
+        \\  return [appDefaults.mode, LoadingRing, 1];
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "src/App.tsx");
+    defer std.testing.allocator.free(entry);
+    const root = try absPath(&tmp, ".");
+    defer std.testing.allocator.free(root);
+    const src_prefix = try std.fmt.allocPrint(std.testing.allocator, "{s}/src/", .{root});
+    defer std.testing.allocator.free(src_prefix);
+
+    const ts_path_targets = [_]@import("../config.zig").TsConfig.PathEntry.Target{
+        .{ .prefix = src_prefix, .suffix = "" },
+    };
+    const ts_paths = [_]@import("../config.zig").TsConfig.PathEntry{
+        .{
+            .key_prefix = "~/",
+            .key_suffix = "",
+            .has_wildcard = true,
+            .targets = &ts_path_targets,
+        },
+    };
+
+    var ib = IncrementalBundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .dev_mode = true,
+        .collect_module_codes = true,
+        .ts_paths = &ts_paths,
+    });
+    defer ib.deinit();
+
+    {
+        const r = try ib.rebuild();
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            .build_error => |e| {
+                std.testing.allocator.free(e);
+                return error.TestUnexpectedResult;
+            },
+            .fatal => return error.TestUnexpectedResult,
+        }
+    }
+
+    std.Thread.sleep(50 * std.time.ns_per_ms);
+    try writeFile(tmp.dir, "src/App.tsx",
+        \\import { defaultOptions as appDefaults } from '~/core/settings';
+        \\import { LoadingRing } from '~/widgets/loading';
+        \\export default function App() {
+        \\  return [appDefaults.mode, LoadingRing, 2];
+        \\}
+    );
+
+    const result = try ib.rebuild();
+    switch (result) {
+        .success => |r| {
+            defer freeChanged(r.changed_modules);
+            try std.testing.expect(r.changed_modules.len > 0);
+
+            var saw_app = false;
+            for (r.changed_modules) |m| {
+                if (std.mem.indexOf(u8, m.id, "src/App.tsx") == null) continue;
+                saw_app = true;
+                try std.testing.expect(std.mem.indexOf(u8, m.code, "require(\"~/") == null);
+                try std.testing.expect(std.mem.indexOf(u8, m.code, "require('~/") == null);
+                try std.testing.expect(std.mem.indexOf(u8, m.code, "__zntc_modules[") != null);
+            }
+            try std.testing.expect(saw_app);
+        },
+        .build_error => return error.TestUnexpectedResult,
+        .fatal => return error.TestUnexpectedResult,
+    }
+}
+
+test "Bundler watch path: changed HMR module rewrites mixed alias imports" {
+    // 테스트앱 재현: NAPI watch 경로는 첫 빌드부터 module_store/compiled_cache를
+    // 유지하고, 리빌드 때 changed_files와 skip_bundle_output을 함께 사용한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "src/core/settings/index.ts",
+        \\export * from './optionStore';
+    );
+    try writeFile(tmp.dir, "src/core/settings/optionStore.ts",
+        \\export const defaultOptions = { mode: 'dev' };
+    );
+    try writeFile(tmp.dir, "src/widgets/loading/index.js",
+        \\import LoadingRing from './LoadingRing';
+        \\export { LoadingRing };
+    );
+    try writeFile(tmp.dir, "src/widgets/loading/LoadingRing.js",
+        \\export default function LoadingRing() {
+        \\  return null;
+        \\}
+    );
+    try writeFile(tmp.dir, "src/widgets/header/index.js",
+        \\export { HeaderSlot } from './HeaderSlot';
+    );
+    try writeFile(tmp.dir, "src/widgets/header/HeaderSlot.js",
+        \\export function HeaderSlot() {
+        \\  return null;
+        \\}
+    );
+    try writeFile(tmp.dir, "src/App.tsx",
+        \\import { defaultOptions as appDefaults } from '~/core/settings';
+        \\import { LoadingRing } from '~/widgets/loading';
+        \\import { HeaderSlot } from '~/widgets/header';
+        \\export default function App() {
+        \\  return [appDefaults.mode, LoadingRing, HeaderSlot, 1];
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "src/App.tsx");
+    defer std.testing.allocator.free(entry);
+    const root = try absPath(&tmp, ".");
+    defer std.testing.allocator.free(root);
+    const src_prefix = try std.fmt.allocPrint(std.testing.allocator, "{s}/src/", .{root});
+    defer std.testing.allocator.free(src_prefix);
+
+    const ts_path_targets = [_]@import("../config.zig").TsConfig.PathEntry.Target{
+        .{ .prefix = src_prefix, .suffix = "" },
+    };
+    const ts_paths = [_]@import("../config.zig").TsConfig.PathEntry{
+        .{
+            .key_prefix = "~/",
+            .key_suffix = "",
+            .has_wildcard = true,
+            .targets = &ts_path_targets,
+        },
+    };
+
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var compiled_cache = CompiledOutputCache.init(std.testing.allocator);
+    defer compiled_cache.deinit();
+
+    const initial_opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .dev_mode = true,
+        .collect_module_codes = true,
+        .module_store = &store,
+        .compiled_cache = &compiled_cache,
+        .ts_paths = &ts_paths,
+        .sourcemap = .{ .enable = true, .lazy = true },
+    });
+    var resolve_cache = Bundler.initResolveCacheFromOptions(std.testing.allocator, initial_opts);
+    defer resolve_cache.deinit();
+
+    var initial = Bundler.init(std.testing.allocator, initial_opts);
+    var initial_result = try initial.bundle();
+    defer initial_result.deinit(std.testing.allocator);
+    defer initial.deinit();
+    try std.testing.expect(!initial_result.hasErrors());
+
+    std.Thread.sleep(50 * std.time.ns_per_ms);
+    try writeFile(tmp.dir, "src/App.tsx",
+        \\import { defaultOptions as appDefaults } from '~/core/settings';
+        \\import { LoadingRing } from '~/widgets/loading';
+        \\import { HeaderSlot } from '~/widgets/header';
+        \\export default function App() {
+        \\  return [appDefaults.mode, LoadingRing, HeaderSlot, 2];
+        \\}
+    );
+
+    var touched = std.StringHashMap(void).init(std.testing.allocator);
+    defer touched.deinit();
+    try touched.put(entry, {});
+
+    var rebuild_opts = initial_opts;
+    rebuild_opts.changed_files = &touched;
+    rebuild_opts.skip_bundle_output = true;
+
+    var rebuild = Bundler.initWithResolveCache(std.testing.allocator, rebuild_opts, &resolve_cache);
+    var rebuild_result = try rebuild.bundle();
+    defer rebuild_result.deinit(std.testing.allocator);
+    defer rebuild.deinit();
+    try std.testing.expect(!rebuild_result.hasErrors());
+
+    const codes = rebuild_result.module_dev_codes orelse return error.TestUnexpectedResult;
+    var saw_app = false;
+    for (codes) |m| {
+        if (std.mem.indexOf(u8, m.id, "src/App.tsx") == null) continue;
+        saw_app = true;
+        try std.testing.expect(std.mem.indexOf(u8, m.code, "require(\"~/") == null);
+        try std.testing.expect(std.mem.indexOf(u8, m.code, "require('~/") == null);
+        try std.testing.expect(std.mem.indexOf(u8, m.code, "__zntc_modules[") != null);
+    }
+    try std.testing.expect(saw_app);
 }
 
 test "IncrementalBundler: detects graph change (new import)" {
@@ -637,7 +854,6 @@ test "BundleResult.reparsed_paths: cache-hit 모듈은 제외, cache-miss 만 �
     // BundleResult 를 직접 생성해 reparsed_paths 검사. IncrementalBundler 는
     // 내부적으로 Bundler.bundle() 을 호출하지만 결과를 노출하지 않으므로,
     // 같은 store 를 공유한 별도 Bundler 로 검증.
-    const Bundler = @import("bundler.zig").Bundler;
     var bundler = Bundler.init(std.testing.allocator, .{
         .entry_points = &.{entry},
         .dev_mode = true,

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -47,7 +47,7 @@ fn canDeferStaticImportForInlineRequires(
     exported_locals: *const std.StringHashMap(void),
 ) bool {
     if (target_mod.uses_top_level_await) return false;
-    if (target_mod.side_effects and target_mod.side_effects_user_defined) return false;
+    if (target_mod.isUserDeclaredSideEffectful()) return false;
 
     var saw_binding = false;
     for (m.import_bindings) |ib| {
@@ -777,8 +777,8 @@ pub fn buildMetadataForAst(
                     !import_is_namespace_export and
                     !target_mod.uses_top_level_await and
                     !value_init_mod.uses_top_level_await and
-                    !(target_mod.side_effects and target_mod.side_effects_user_defined) and
-                    !(value_init_mod.side_effects and value_init_mod.side_effects_user_defined) and
+                    !target_mod.isUserDeclaredSideEffectful() and
+                    !value_init_mod.isUserDeclaredSideEffectful() and
                     !exported_locals.contains(m.importBindingLocalName(ib));
                 if (lazy_esm_import) {
                     lazy_esm_import_mod = value_init_mod;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -47,6 +47,7 @@ fn canDeferStaticImportForInlineRequires(
     exported_locals: *const std.StringHashMap(void),
 ) bool {
     if (target_mod.uses_top_level_await) return false;
+    if (target_mod.side_effects and target_mod.side_effects_user_defined) return false;
 
     var saw_binding = false;
     for (m.import_bindings) |ib| {
@@ -776,6 +777,8 @@ pub fn buildMetadataForAst(
                     !import_is_namespace_export and
                     !target_mod.uses_top_level_await and
                     !value_init_mod.uses_top_level_await and
+                    !(target_mod.side_effects and target_mod.side_effects_user_defined) and
+                    !(value_init_mod.side_effects and value_init_mod.side_effects_user_defined) and
                     !exported_locals.contains(m.importBindingLocalName(ib));
                 if (lazy_esm_import) {
                     lazy_esm_import_mod = value_init_mod;

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -421,6 +421,13 @@ pub const Module = struct {
         return self.side_effects_user_defined and !self.side_effects;
     }
 
+    /// 모듈이 *user-declared side-effectful* — package.json `sideEffects` 배열에
+    /// 명시돼 top-level 실행 순서가 의미 있는 경우. inlineRequires lazy 대상에서
+    /// 제외하는 게이트가 공유.
+    pub inline fn isUserDeclaredSideEffectful(self: *const Module) bool {
+        return self.side_effects and self.side_effects_user_defined;
+    }
+
     /// member-augment 귀속 게이트: user-declared pure 모듈이고 크기 최적화
     /// (minify_syntax) 일 때만 top-level `X.member = pureRHS` 를 X 의
     /// augmentation 으로 귀속한다 (dev/non-minify 회귀 방지).

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -857,19 +857,69 @@ pub fn matchPackageSubPath(pattern: []const u8, specifier: []const u8) bool {
 }
 
 pub fn matchGlob(pattern: []const u8, text: []const u8) bool {
-    if (std.mem.indexOf(u8, pattern, "*")) |star_pos| {
-        const prefix = pattern[0..star_pos];
-        const suffix = pattern[star_pos + 1 ..];
-
-        if (!std.mem.startsWith(u8, text, prefix)) return false;
-        if (text.len < prefix.len + suffix.len) return false;
-        if (!std.mem.endsWith(u8, text, suffix)) return false;
-
-        // * 가 매칭한 부분에 / 가 있으면 불매칭
-        const matched = text[prefix.len .. text.len - suffix.len];
-        return std.mem.indexOf(u8, matched, "/") == null;
+    if (std.mem.indexOfScalar(u8, pattern, '{')) |open| {
+        if (std.mem.indexOfScalarPos(u8, pattern, open + 1, '}')) |close| {
+            const prefix = pattern[0..open];
+            const body = pattern[open + 1 .. close];
+            const suffix = pattern[close + 1 ..];
+            var rest = body;
+            while (true) {
+                const comma = std.mem.indexOfScalar(u8, rest, ',');
+                const alt = if (comma) |idx| rest[0..idx] else rest;
+                var expanded_buf: [4096]u8 = undefined;
+                if (prefix.len + alt.len + suffix.len <= expanded_buf.len) {
+                    @memcpy(expanded_buf[0..prefix.len], prefix);
+                    @memcpy(expanded_buf[prefix.len .. prefix.len + alt.len], alt);
+                    @memcpy(expanded_buf[prefix.len + alt.len .. prefix.len + alt.len + suffix.len], suffix);
+                    if (matchGlob(expanded_buf[0 .. prefix.len + alt.len + suffix.len], text)) return true;
+                }
+                if (comma) |idx| {
+                    rest = rest[idx + 1 ..];
+                } else break;
+            }
+            return false;
+        }
     }
 
-    // 글롭 없으면 exact match
-    return std.mem.eql(u8, pattern, text);
+    return matchGlobNoBrace(pattern, text);
+}
+
+fn matchGlobNoBrace(pattern: []const u8, text: []const u8) bool {
+    if (pattern.len == 0) return text.len == 0;
+
+    if (std.mem.startsWith(u8, pattern, "**")) {
+        var rest = pattern[2..];
+        if (std.mem.startsWith(u8, rest, "/")) {
+            rest = rest[1..];
+            if (matchGlobNoBrace(rest, text)) return true;
+            for (text, 0..) |ch, i| {
+                if (ch == '/' and matchGlobNoBrace(rest, text[i + 1 ..])) return true;
+            }
+            return false;
+        }
+
+        var i: usize = 0;
+        while (i <= text.len) : (i += 1) {
+            if (matchGlobNoBrace(rest, text[i..])) return true;
+        }
+        return false;
+    }
+
+    if (pattern[0] == '*') {
+        const rest = pattern[1..];
+        var i: usize = 0;
+        while (i <= text.len) : (i += 1) {
+            if (matchGlobNoBrace(rest, text[i..])) return true;
+            if (i == text.len or text[i] == '/') break;
+        }
+        return false;
+    }
+
+    if (pattern[0] == '?') {
+        if (text.len == 0 or text[0] == '/') return false;
+        return matchGlobNoBrace(pattern[1..], text[1..]);
+    }
+
+    if (text.len == 0 or pattern[0] != text[0]) return false;
+    return matchGlobNoBrace(pattern[1..], text[1..]);
 }

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -23,6 +23,13 @@ test "matchGlob: wildcard" {
     try std.testing.expect(!matchGlob("@mui/*", "@mui/icons/filled"));
 }
 
+test "matchGlob: doublestar and brace alternates" {
+    try std.testing.expect(matchGlob("**/runtimeKind.{js,ts}", "src/runtimeKind.ts"));
+    try std.testing.expect(matchGlob("**/runtimeKind.{js,ts}", "lib/module/runtimeKind.js"));
+    try std.testing.expect(matchGlob("**/runtimeKind.{js,ts}", "runtimeKind.ts"));
+    try std.testing.expect(!matchGlob("**/runtimeKind.{js,ts}", "src/runtimeKind.jsx"));
+}
+
 test "matchGlob: node: prefix" {
     try std.testing.expect(matchGlob("node:*", "node:fs"));
     try std.testing.expect(matchGlob("node:*", "node:path"));

--- a/src/main.zig
+++ b/src/main.zig
@@ -826,7 +826,6 @@ pub fn main() !void {
         if (opts.watch) {
             // 증분 빌드용 파싱 캐시 + resolve 캐시 (watch 전체 수명동안 보존)
             const module_store_mod = @import("zntc_lib").bundler.module_store;
-            const ResolveCache = @import("zntc_lib").bundler.ResolveCache;
             var persistent_store = module_store_mod.PersistentModuleStore.init(allocator);
             defer persistent_store.deinit();
 
@@ -855,20 +854,7 @@ pub fn main() !void {
                     };
                 }
             }
-            var persistent_resolve_cache = ResolveCache.init(allocator, .{
-                .platform = bundle_opts.platform,
-                .external_patterns = bundle_opts.external,
-                .custom_conditions = bundle_opts.conditions,
-                .preserve_symlinks = bundle_opts.preserve_symlinks,
-                .resolve_symlink_siblings = bundle_opts.resolve_symlink_siblings,
-                .disable_hierarchical_lookup = bundle_opts.disable_hierarchical_lookup,
-                .alias = bundle_opts.alias,
-                .fallback = bundle_opts.fallback,
-                .resolve_extensions = bundle_opts.resolve_extensions,
-                .main_fields = bundle_opts.main_fields,
-                .packages_external = bundle_opts.packages_external,
-                .node_paths = bundle_opts.node_paths,
-            });
+            var persistent_resolve_cache = Bundler.initResolveCacheFromOptions(allocator, bundle_opts);
             defer persistent_resolve_cache.deinit();
 
             // 첫 빌드 결과의 모듈을 store에 저장 (bundler가 이미 deinit된 후이므로 직접 수집)


### PR DESCRIPTION
## 요약
- React Native dev/HMR 경로에서도 일반 번들 경로와 같은 resolver 옵션을 사용하도록 공통 초기화 함수를 추가했습니다.
- NAPI watch/IncrementalBundler의 persistent ResolveCache가 ts paths, block list, hierarchical lookup 설정을 놓치지 않게 했습니다.
- alias import가 HMR payload에서 raw `require("~/...")`로 남지 않는 회귀 테스트를 추가했습니다.

## 확인
- `zig build test -Dtest-filter='mixed alias imports'`
- `zig build napi`
- 테스트앱 HMR payload에서 raw `require("~/...")` 미발생 확인

## 참고
- 루트에 생성된 이미지 파일들은 이번 PR 대상이 아니어서 포함하지 않았습니다.