### PR TITLE
refactor(bundler): plug used-names leak in splitting export DCE

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -121,6 +121,7 @@ pub fn emitChunks(
         // module index → *const Module (희소 그래프 대비 별도 슬라이스로 dense 화).
         var mod_ptrs: std.ArrayList(*const Module) = .empty;
         defer mod_ptrs.deinit(allocator);
+        try mod_ptrs.ensureTotalCapacity(allocator, module_count);
         var idx_it = graph.modulesIterator();
         while (idx_it.next()) |m| try mod_ptrs.append(allocator, m);
         const computed = try computeAllUsedNames(allocator, mod_ptrs.items, graph, s);
@@ -129,7 +130,10 @@ pub fn emitChunks(
         for (used_names_by_modidx) |*e| e.* = .{ .names = &.{}, .all_used = true };
         for (mod_ptrs.items, 0..) |m, i| {
             const mi = m.index.toU32();
-            if (mi >= module_count) continue;
+            if (mi >= module_count) {
+                allocator.free(computed[i].names);
+                continue;
+            }
             // `export * from "./this"` source 는 cross-chunk export 목록이 모든 export
             // 이름을 over-approx 로 포함한다. emit DCE 로 그 export 선언을 지우면 codegen
             // 의 `export { ... }` 절과 어긋나 Node `Export X is not defined` SyntaxError.


### PR DESCRIPTION
## 요약
- #3623(splitting emit 경로 statement-level export DCE) `/simplify` 후속 정리입니다.
- `emitChunks`에서 module index 범위 밖(`mi >= module_count`) `continue` 경로가 `computed[i].names`를 by_modidx로 옮기지도, 해제하지도 않아 누수되던 것을 명시 해제했습니다.
- `mod_ptrs`를 `module_count`로 사전 예약해 dense화 시 realloc churn을 제거했습니다.

## 배경
#3623이 rebase 머지되는 사이 simplify 수정 커밋이 원본(rebase 전) 커밋 위에 올라가 분기되어, 최신 main 기준 별도 PR로 분리했습니다.

## 확인
- `zig build install`
- `zig build test -Dtest-filter='splitting'`
- `tests/integration` `bun test tests/manual-chunks-smoke.test.ts` (32 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)