### PR TITLE
fix(app-build): forward jsx options to buildApp (React is not defined)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -696,6 +696,10 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
       minify: opts.minify || opts.minifyWhitespace || opts.minifyIdentifiers || opts.minifySyntax,
       sourcemap: opts.sourcemap,
       splitting: opts.splitting || undefined,
+      jsx: opts.jsx,
+      jsxImportSource: opts.jsxImportSource,
+      jsxFactory: opts.jsxFactory,
+      jsxFragment: opts.jsxFragment,
       compiler: config?.compiler,
     });
     const htmlEnv = loadEnv(

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1449,7 +1449,7 @@ export interface AppBuildOptions {
   /** Enable code splitting for the application bundle. */
   splitting?: boolean;
   /** JSX runtime: "automatic" / "automatic-dev" / "classic" / "preserve". */
-  jsx?: string;
+  jsx?: 'classic' | 'automatic' | 'automatic-dev' | 'preserve';
   /** JSX import source for the automatic runtime (e.g. "react", "@emotion/react"). */
   jsxImportSource?: string;
   /** Classic-runtime JSX factory (e.g. "React.createElement", "h"). */

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1448,6 +1448,14 @@ export interface AppBuildOptions {
   sourcemap?: boolean;
   /** Enable code splitting for the application bundle. */
   splitting?: boolean;
+  /** JSX runtime: "automatic" / "automatic-dev" / "classic" / "preserve". */
+  jsx?: string;
+  /** JSX import source for the automatic runtime (e.g. "react", "@emotion/react"). */
+  jsxImportSource?: string;
+  /** Classic-runtime JSX factory (e.g. "React.createElement", "h"). */
+  jsxFactory?: string;
+  /** Classic-runtime JSX fragment (e.g. "React.Fragment"). */
+  jsxFragment?: string;
   /**
    * Per-library 1st-party transform (`@next/swc` `compiler`-compatible
    * surface). Same meaning as in BuildOptions — both bundle / app builds use

--- a/packages/core/src/napi/build_sync_entry.zig
+++ b/packages/core/src/napi/build_sync_entry.zig
@@ -166,6 +166,22 @@ pub fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c
         owned_arrays.append(native_alloc, arr) catch return throwError(env, "OutOfMemory");
     }
 
+    // JSX 옵션 — buildApp(=app build) 도 일반 build 처럼 jsx runtime/import-source 를
+    // 전달해야 한다. 누락 시 JsxConfig default(.classic, React.createElement)로 떨어져
+    // pragma 없는 파일이 `React.createElement` 로 변환되는데 automatic 모드 사용자는
+    // React 를 import 하지 않아 런타임 `React is not defined`. invalid vocab 은
+    // options.zig(buildSync)와 동일하게 strict throw — silent classic fallback 은
+    // 사용자 typo 디버깅을 어렵게 한다. 미지정(null)은 JsxConfig default 그대로.
+    const jsx_str = ownStr(env, opts_obj, "jsx", &owned_strings);
+    var jsx_cfg = zntc_lib.app.build.JsxConfig{};
+    if (jsx_str) |s| {
+        jsx_cfg.runtime = zntc_lib.codegen.codegen.JsxRuntime.fromString(s) orelse
+            return throwError(env, "invalid 'jsx' option (expected automatic / automatic-dev / classic / preserve)");
+    }
+    if (ownStr(env, opts_obj, "jsxImportSource", &owned_strings)) |s| jsx_cfg.import_source = s;
+    if (ownStr(env, opts_obj, "jsxFactory", &owned_strings)) |s| jsx_cfg.factory = s;
+    if (ownStr(env, opts_obj, "jsxFragment", &owned_strings)) |s| jsx_cfg.fragment = s;
+
     const output_count = zntc_lib.app.build.buildApp(native_alloc, .{
         .root = root,
         .outdir = outdir,
@@ -194,6 +210,7 @@ pub fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c
         .emotion_label_format = ownStr(env, opts_obj, "emotionLabelFormat", &owned_strings) orelse "",
         .emotion_extra_css_sources = emotion_extra_css orelse &.{},
         .emotion_extra_styled_sources = emotion_extra_styled orelse &.{},
+        .jsx = jsx_cfg,
     }) catch |err| {
         return throwError(env, @errorName(err));
     };

--- a/packages/core/src/napi/build_sync_entry.zig
+++ b/packages/core/src/napi/build_sync_entry.zig
@@ -3,6 +3,8 @@ const zntc_lib = @import("zntc_lib");
 const bundler_mod = zntc_lib.bundler;
 const Bundler = bundler_mod.Bundler;
 const transformer_mod = zntc_lib.transformer.transformer;
+const JsxRuntime = zntc_lib.codegen.codegen.JsxRuntime;
+const JsxConfig = zntc_lib.app.build.JsxConfig;
 const common = @import("common.zig");
 const options_mod = @import("options.zig");
 const result_napi_mod = @import("result.zig");
@@ -173,9 +175,9 @@ pub fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c
     // options.zig(buildSync)와 동일하게 strict throw — silent classic fallback 은
     // 사용자 typo 디버깅을 어렵게 한다. 미지정(null)은 JsxConfig default 그대로.
     const jsx_str = ownStr(env, opts_obj, "jsx", &owned_strings);
-    var jsx_cfg = zntc_lib.app.build.JsxConfig{};
+    var jsx_cfg = JsxConfig{};
     if (jsx_str) |s| {
-        jsx_cfg.runtime = zntc_lib.codegen.codegen.JsxRuntime.fromString(s) orelse
+        jsx_cfg.runtime = JsxRuntime.fromString(s) orelse
             return throwError(env, "invalid 'jsx' option (expected automatic / automatic-dev / classic / preserve)");
     }
     if (ownStr(env, opts_obj, "jsxImportSource", &owned_strings)) |s| jsx_cfg.import_source = s;

--- a/tests/integration/tests/app-build-jsx.test.ts
+++ b/tests/integration/tests/app-build-jsx.test.ts
@@ -1,0 +1,59 @@
+// app build (`zntc build` → buildAppSync) 의 JSX runtime 옵션 전달 회귀 가드.
+//
+// buildAppSync 가 jsx/jsxImportSource/jsxFactory/jsxFragment 를 buildApp 에 안
+// 넘겨 항상 JsxConfig default(.classic)로 떨어지던 버그. pragma 없는 파일이
+// `React.createElement` 로 변환되는데 automatic 모드 사용자는 React 를 import
+// 하지 않아 런타임 `React is not defined`. (`zntc --bundle` 은 jsx 전달돼 정상,
+// app build 만 누락했다.)
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { buildAppSync, init } from '@zntc/core';
+import { createFixture } from './helpers';
+import { join } from 'node:path';
+import { readFileSync, readdirSync } from 'node:fs';
+
+init();
+
+describe('app build — JSX runtime 옵션 전달 (#React-not-defined 회귀)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = undefined;
+  });
+
+  const REACT_STUB = {
+    'node_modules/react/package.json': JSON.stringify({
+      name: 'react',
+      version: '19.0.0',
+      exports: { './jsx-runtime': './jsx-runtime.js' },
+    }),
+    'node_modules/react/jsx-runtime.js':
+      'export function jsx(t,p){return{t,p};}\nexport function jsxs(t,p){return{t,p};}\nexport const Fragment="F";\n',
+  };
+
+  async function buildApp(jsx: string): Promise<string> {
+    const fx = await createFixture({
+      'index.html':
+        '<!doctype html><html><body><div id="root"></div><script type="module" src="/main.tsx"></script></body></html>',
+      'main.tsx': 'export const App = () => <div>hi</div>;\nglobalThis.__App = App;\n',
+      ...REACT_STUB,
+    });
+    cleanup = fx.cleanup;
+    const out = join(fx.dir, 'dist');
+    buildAppSync({ root: fx.dir, outdir: out, entryHtml: 'index.html', publicDir: false, jsx });
+    const jsName = readdirSync(out).find((f) => f.endsWith('.js'))!;
+    return readFileSync(join(out, jsName), 'utf8');
+  }
+
+  test('jsx: automatic → react/jsx-runtime 사용, React.createElement 미생성', async () => {
+    const code = await buildApp('automatic');
+    expect(code).not.toMatch(/React\.createElement/);
+    expect(code).toMatch(/jsx-runtime/);
+  });
+
+  test('jsx: classic → React.createElement 사용 (옵션 그대로 반영)', async () => {
+    const code = await buildApp('classic');
+    expect(code).toMatch(/React\.createElement/);
+    expect(code).not.toMatch(/jsx-runtime/);
+  });
+});


### PR DESCRIPTION
## 요약
- `zntc build`(app build) 경로가 `jsx`/`jsxImportSource`/`jsxFactory`/`jsxFragment` 를 `buildApp` 에 전달하지 않아 항상 `JsxConfig` default(`.classic`, `React.createElement`)로 떨어지던 버그를 고칩니다.
- pragma 없는 파일이 `React.createElement` 로 변환되는데 automatic 모드 사용자는 React 를 import 하지 않아 런타임 `React is not defined` 가 발생했습니다. (`zntc --bundle` 은 정상, app build 만 누락)
- 회귀 가드 통합 테스트 추가 (`automatic` → `react/jsx-runtime`, `classic` → `React.createElement`).

## 배경
원래 PR #3625 가 머지 없이 닫혀(충돌 상태) `/simplify` 검토를 위해 최신 main 기준으로 rebase 후 새 브랜치로 분리했습니다. simplify 후속으로 `AppBuildOptions.jsx` 타입을 non-app 과 동일한 union 으로 좁히고, `build_sync_entry.zig` 에 `JsxRuntime`/`JsxConfig` alias 를 추가했습니다.

## 확인
- `zig build napi`
- `packages/core` `tsc -b --force`
- `tests/integration` `bun test tests/app-build-jsx.test.ts` (2 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)