### PR TITLE
refactor(app-build): tighten jsx option type + alias jsx imports

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1449,7 +1449,7 @@ export interface AppBuildOptions {
   /** Enable code splitting for the application bundle. */
   splitting?: boolean;
   /** JSX runtime: "automatic" / "automatic-dev" / "classic" / "preserve". */
-  jsx?: string;
+  jsx?: 'classic' | 'automatic' | 'automatic-dev' | 'preserve';
   /** JSX import source for the automatic runtime (e.g. "react", "@emotion/react"). */
   jsxImportSource?: string;
   /** Classic-runtime JSX factory (e.g. "React.createElement", "h"). */

--- a/packages/core/src/napi/build_sync_entry.zig
+++ b/packages/core/src/napi/build_sync_entry.zig
@@ -3,6 +3,8 @@ const zntc_lib = @import("zntc_lib");
 const bundler_mod = zntc_lib.bundler;
 const Bundler = bundler_mod.Bundler;
 const transformer_mod = zntc_lib.transformer.transformer;
+const JsxRuntime = zntc_lib.codegen.codegen.JsxRuntime;
+const JsxConfig = zntc_lib.app.build.JsxConfig;
 const common = @import("common.zig");
 const options_mod = @import("options.zig");
 const result_napi_mod = @import("result.zig");
@@ -173,9 +175,9 @@ pub fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c
     // options.zig(buildSync)와 동일하게 strict throw — silent classic fallback 은
     // 사용자 typo 디버깅을 어렵게 한다. 미지정(null)은 JsxConfig default 그대로.
     const jsx_str = ownStr(env, opts_obj, "jsx", &owned_strings);
-    var jsx_cfg = zntc_lib.app.build.JsxConfig{};
+    var jsx_cfg = JsxConfig{};
     if (jsx_str) |s| {
-        jsx_cfg.runtime = zntc_lib.codegen.codegen.JsxRuntime.fromString(s) orelse
+        jsx_cfg.runtime = JsxRuntime.fromString(s) orelse
             return throwError(env, "invalid 'jsx' option (expected automatic / automatic-dev / classic / preserve)");
     }
     if (ownStr(env, opts_obj, "jsxImportSource", &owned_strings)) |s| jsx_cfg.import_source = s;


### PR DESCRIPTION
## 요약
app-build JSX 전달 fix(main `8c6e2ee8`) `/simplify` 후속 정리입니다.
- `AppBuildOptions.jsx` 를 non-app `BuildOptions` 와 동일한 union 으로 좁혀(`'classic' | 'automatic' | 'automatic-dev' | 'preserve'`) typo 를 컴파일 타임에 차단합니다.
- `build_sync_entry.zig` 에 `JsxRuntime`/`JsxConfig` alias 를 추가(`options.zig` 와 동일 컨벤션)하고 `.codegen.codegen` 중첩 경로를 제거합니다.

## 배경
원본 PR #3625 가 닫히고 fix 는 사용자가 `8c6e2ee8` 로 main 에 직접 반영했습니다. simplify 수정만 분리해 올립니다. (중복 fix 를 포함했던 #3628 은 닫음)

## 확인
- `zig build napi`
- `packages/core` `tsc -b --force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)