### PR TITLE
feat(examples): module-federation browser demo (host renders zntc remote)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ examples/web/dist/
 examples/react-19-zntc/dist/
 examples/react-19-vite/dist/
 examples/rspack/dist/
+examples/module-federation/dist/
 # 루트 cwd 에 떨어지는 임시 빌드 산출물 (NAPI 직접 호출 경로 / examples 빌드 leftover).
 /dist/
 

--- a/bun.lock
+++ b/bun.lock
@@ -74,6 +74,7 @@
       "dependencies": {
         "@module-federation/runtime": "2.4.0",
         "react": "^19.0.0",
+        "react-dom": "^19.0.0",
       },
       "devDependencies": {
         "@zntc/core": "workspace:*",

--- a/examples/module-federation/index.html
+++ b/examples/module-federation/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZNTC Module Federation — host ↔ zntc remote</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/dist/host-web.js"></script>
+  </body>
+</html>

--- a/examples/module-federation/package.json
+++ b/examples/module-federation/package.json
@@ -7,11 +7,14 @@
     "prebuild": "bun run --cwd ../../packages/core build:js",
     "build": "cd remote && zntc --bundle src/index.ts --outdir dist --format=iife --public-path=file://$PWD/dist/",
     "start": "node host.mjs",
-    "demo": "bun run build && bun run start"
+    "demo": "bun run build && bun run start",
+    "predev:web": "bun run --cwd ../../packages/core build:js",
+    "dev:web": "node serve-web.mjs"
   },
   "dependencies": {
     "@module-federation/runtime": "2.4.0",
-    "react": "^19.0.0"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@zntc/core": "workspace:*",

--- a/examples/module-federation/serve-web.mjs
+++ b/examples/module-federation/serve-web.mjs
@@ -1,0 +1,43 @@
+// MF 브라우저 데모 정적 서버 — host (index.html + dist/host-web.js) 와
+// remote(remote/dist/*) 를 한 origin 에서 서빙한다. host 의 loadRemote 가
+// `/remote/dist/index.js` 를 같은 origin 에서 가져온다 (CORS 불필요).
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { join, dirname, extname, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+};
+
+const port = Number(process.env.PORT) || 12308;
+const host = process.env.HOST || "0.0.0.0";
+
+const server = createServer(async (req, res) => {
+  const urlPath = (req.url || "/").split("?")[0];
+  const rel = urlPath === "/" ? "/index.html" : urlPath;
+  const file = join(here, rel);
+  // 0.0.0.0 바인드라 LAN 노출 — `/../` 디렉토리 탈출 차단 (here 밖 파일 거부).
+  if (file !== here && !file.startsWith(here + sep)) {
+    res.writeHead(403).end("403");
+    return;
+  }
+  try {
+    const data = await readFile(file);
+    res.writeHead(200, { "content-type": MIME[extname(rel)] || "application/octet-stream" });
+    res.end(data);
+  } catch {
+    res.writeHead(404).end("404");
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(`\n  zntc module-federation (browser)\n`);
+  console.log(`  Local:   http://localhost:${port}/`);
+  console.log(`  Network: http://${host}:${port}/\n`);
+});

--- a/examples/module-federation/src/host-web.tsx
+++ b/examples/module-federation/src/host-web.tsx
@@ -1,0 +1,63 @@
+// 브라우저 host — zntc 로 IIFE 빌드한 remote 의 컴포넌트를 표준
+// @module-federation/runtime 으로 loadRemote 해서 react-dom 으로 렌더한다.
+// host 가 react 를 shared singleton 으로 제공 → remote 의 useState 가 host 의
+// 단일 react 인스턴스를 공유 (hooks 동작 조건). host.mjs(Node 검증)의 브라우저판.
+
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { init, loadRemote } from "@module-federation/runtime";
+
+init({
+  name: "host_web",
+  remotes: [{ name: "remote_app", entry: "/remote/dist/index.js" }],
+  shared: {
+    react: {
+      version: "19.0.0",
+      lib: () => React,
+      shareConfig: { singleton: true, requiredVersion: "^19" },
+    },
+  },
+});
+
+const { createElement: h, useState } = React;
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return h(
+    "div",
+    { style: { fontFamily: "system-ui, sans-serif", padding: 24, maxWidth: 720, margin: "0 auto" } },
+    h("h1", null, "ZNTC Module Federation"),
+    h(
+      "p",
+      null,
+      "host 가 zntc-IIFE remote(",
+      h("code", null, "remote_app"),
+      ")의 ",
+      h("code", null, "Button"),
+      " 을 표준 @module-federation/runtime 으로 loadRemote → react-dom 렌더. react 는 host 가 shared singleton 으로 제공.",
+    ),
+    children,
+  );
+}
+
+function HostCounter() {
+  const [n, setN] = useState(0);
+  return h(
+    "p",
+    null,
+    h("button", { onClick: () => setN(n + 1) }, `host 자체 카운터: ${n}`),
+    " (remote 와 동일 react 인스턴스 — 양쪽 hooks 정상)",
+  );
+}
+
+async function main() {
+  const root = createRoot(document.getElementById("root")!);
+  try {
+    const mod = (await loadRemote("remote_app/Button")) as { default?: React.ComponentType } | React.ComponentType;
+    const RemoteButton = ((mod as { default?: React.ComponentType }).default ?? mod) as React.ComponentType;
+    root.render(h(Shell, null, h(HostCounter), h(RemoteButton)));
+  } catch (err) {
+    root.render(h(Shell, null, h("pre", { style: { color: "crimson" } }, String(err))));
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

기존 `examples/module-federation` 은 `host.mjs` 가 Node 에서 `loadRemote` 후 콘솔 검증하고 종료하는 interop 데모였다 (브라우저 페이지 없음). 다른 예제처럼 **브라우저에서 보는** host 웹앱을 추가.

- **`src/host-web.tsx`**: `@module-federation/runtime` `init` + `loadRemote("remote_app/Button")` → react-dom 렌더. host 가 react 를 **shared singleton** 으로 제공 → remote 의 `useState` 가 host 와 동일 react 인스턴스 (hooks 동작 조건).
- **`serve-web.mjs`**: host(index.html + dist/host-web.js) + remote(remote/dist/*) 를 **단일 origin** 정적 서빙 — `loadRemote` 가 same-origin `/remote/dist/index.js` fetch.
- **`index.html`** + `package.json`: react-dom 의존 + `dev:web` 스크립트.
- 기존 `host.mjs` (Node 검증 데모) 는 그대로 유지.

remote 는 `--public-path=/remote/dist/` (http) 로 빌드.

## 브라우저에서 보이는 것

1. "ZNTC Module Federation" 제목
2. "host 자체 카운터" 버튼 (host react)
3. **"remote Button — count: 0"** — zntc-IIFE remote 컴포넌트 (loadRemote 동적 로드). 클릭 시 카운트 증가 = host/remote 단일 react 공유.

## 검증

- [x] `bun run dev:web` → `zntc verify http://localhost:12308/` → **status pass / events []** (실 Chromium, console error/pageerror/4xx 없음)
- [x] remote entry MF container 규약 (`get`/`init`/`remote_app`) 확인

## CI 보호 관계

MF **기능** (manifest-driven loadRemote / shared singleton / 양방향 interop) 회귀는 이미 `tests/e2e/mf-interop-e2e.test.ts` 가 실 Chromium 으로 CI E2E 검증한다. 이 PR 은 그 검증된 기능의 **사용자 직접 확인용 예제**. (예제 빌드 회귀를 잡는 `examples smoke` CI 잡은 별도 PR 로 추가 예정.)