### PR TITLE
test(e2e): examples zntc-build browser smoke CI guard

### DIFF
--- a/tests/e2e/tests/examples-smoke-e2e.test.ts
+++ b/tests/e2e/tests/examples-smoke-e2e.test.ts
@@ -1,0 +1,63 @@
+// examples 의 `zntc build` 산출물이 실제 브라우저에서 크래시 없이 로드되는지
+// 회귀 가드. zntc build (app builder) 의 번들 회귀 — 타입체크/유닛이 못 잡는
+// 런타임 크래시 (예: emotion weak-memoize splitting DCE 누락, JSX classic +
+// React 미import) 를 잡는다. 둘 다 이 세션에서 발견된 실제 회귀.
+//
+// build → zntc preview 정적 서빙 → 헤드리스 Chromium 로드 → pageerror /
+// console.error 0 검증. (verify --browser 와 동일 로직을 E2E 잡에 편입.)
+
+import { test, expect } from '@playwright/test';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { resolve } from 'node:path';
+import { waitForServer } from '@zntc/test-helpers';
+import { PORTS } from './ports';
+
+const ZNTC = resolve(__dirname, '../../../packages/core/bin/zntc.mjs');
+const ROOT = resolve(__dirname, '../../..');
+
+// `zntc build` (app builder) 로 빌드 가능한 예제만 대상. react-19-zntc /
+// react-19-vite 는 config 에 JS 플러그인(react-compiler adapter)이 있어 app build
+// 가 미지원(`--bundle` 또는 Vite 경유), rspack 은 rspack 빌드라 별도 — 이들은
+// 각자 다른 빌드 경로라 zntc build app 회귀 가드 대상이 아니다.
+const EXAMPLES = [
+  { name: 'web (styled-components + emotion)', dir: 'examples/web', port: PORTS.EXAMPLE_WEB_SMOKE },
+];
+
+test.describe('examples — zntc build 산출물 브라우저 smoke', () => {
+  for (const ex of EXAMPLES) {
+    test(`${ex.name}: build → preview → 브라우저 크래시 없이 로드`, async ({ page }) => {
+      const dir = resolve(ROOT, ex.dir);
+
+      const build = spawnSync('node', [ZNTC, 'build'], { cwd: dir, encoding: 'utf8' });
+      expect(build.status, `build failed:\n${build.stderr}`).toBe(0);
+
+      const srv: ChildProcess = spawn(
+        'node',
+        [ZNTC, 'preview', 'dist', '--port', String(ex.port)],
+        {
+          cwd: dir,
+          stdio: 'pipe',
+        },
+      );
+      try {
+        await waitForServer(ex.port);
+
+        const errors: string[] = [];
+        page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`));
+        page.on('console', (m) => {
+          if (m.type() !== 'error') return;
+          const text = m.text();
+          // favicon 미존재 404 는 앱 무관 노이즈 — 제외.
+          if (/favicon/i.test(text)) return;
+          errors.push(`console.error: ${text}`);
+        });
+
+        await page.goto(`http://localhost:${ex.port}/`, { waitUntil: 'networkidle' });
+        expect(errors, errors.join('\n')).toEqual([]);
+      } finally {
+        srv.kill();
+        await new Promise((r) => srv.on('close', r));
+      }
+    });
+  }
+});

--- a/tests/e2e/tests/ports.ts
+++ b/tests/e2e/tests/ports.ts
@@ -26,4 +26,5 @@ export const PORTS = {
   DEV_JSX: 3984,
   BUILD_JSX: 3983,
   VERIFY_MCP: 3982,
+  EXAMPLE_WEB_SMOKE: 3981,
 } as const;


### PR DESCRIPTION
## Summary

`zntc build` (app builder) 산출물이 **실제 브라우저에서 크래시 없이 로드**되는지 회귀 가드. 이번 세션에서 발견된 두 크래시가 정확히 이 가드가 필요한 이유다:

- **emotion weak-memoize** splitting export DCE 누락 (#3623) → `weakMemoize is not defined`
- **app build JSX** classic 변환 + React 미import (#3626) → `React is not defined`

둘 다 **타입체크/유닛 테스트가 못 잡고 브라우저 런타임에서만** 터졌다. `examples/web` (styled-components + emotion) 을 `zntc build` → `zntc preview` → 헤드리스 Chromium 로드 → `pageerror` / `console.error` 0 으로 가드.

## CI 편입

`tests/e2e` 에 두므로 CI 의 **E2E Tests** 잡이 자동 실행 (별도 yml 변경 없음). `zntc-app-builder-e2e` 와 동일 환경(@zntc/web/server dist + playwright).

## 대상 범위

`zntc build` (app builder) 로 빌드 가능한 예제만:
- ✅ `examples/web` — compiler(styled/emotion) 는 플러그인이 아니라 app build OK
- ⏭ `react-19-zntc` / `react-19-vite` — config 에 JS 플러그인(react-compiler adapter) → app build 미지원 (`zntc build app mode does not support JS plugins`), Vite/`--bundle` 경유라 제외
- ⏭ `rspack` — rspack 빌드 (별도 경로)
- MF interop 은 `mf-interop-e2e` 가 별도 커버

## Test plan

- [x] `examples/web` build → preview → 브라우저 로드 pageerror/console.error 0 (favicon 404 노이즈 제외) — 1 pass
- [x] 검출력: fix 전(#3623/#3626 미적용) 빌드는 weakMemoize/React 크래시를 pageerror 로 포착 (이번 세션 재현으로 입증)
- [x] `oxfmt` 통과

## Follow-up

react-19-zntc 처럼 JS 플러그인 쓰는 app 의 build 미지원은 별개 한계 — app builder 가 plugin 을 지원하면 그 예제들도 이 가드에 편입 가능.