### PR TITLE
fix(server): 32-bit & macOS Intel CLI release 빌드 회귀 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   push:
     tags:
       - 'v*'
+  # 빌드 설정(release.yml/build.zig)을 바꾸는 PR 은 9-플랫폼 NAPI/CLI 빌드만 돌려
+  # cross-build 회귀를 tag push 전에 잡는다. publish/release 는 push 이벤트 전용이라 skip.
+  pull_request:
+    paths:
+      - '.github/workflows/release.yml'
+      - 'build.zig'
+      - 'build.zig.zon'
+  # default branch 에 이 트리거가 있어야 수동 실행 가능 (머지 후 임의 검증용).
+  workflow_dispatch:
 
 # permissions:
 #   contents: write   — github-release job (CLI binary tarball 업로드)
@@ -138,6 +147,13 @@ jobs:
           version: 0.15.2
           cache-key: cli-${{ matrix.target }}
 
+      # mimalloc(prim.c)이 macOS 에서 <CommonCrypto/CommonCryptoError.h> 를 include 하는데,
+      # -Dtarget 명시 시 zig 가 cross 모드가 되어 시스템 SDK 헤더 경로를 자동 포함하지 않는다.
+      # SDKROOT 를 주면 native runner 의 SDK 헤더를 찾아 해결.
+      - name: Setup macOS SDK
+        if: runner.os == 'macOS'
+        run: echo "SDKROOT=$(xcrun --show-sdk-path)" >> "$GITHUB_ENV"
+
       - name: Build CLI (ReleaseFast)
         run: zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }}
 
@@ -152,6 +168,8 @@ jobs:
   publish-npm:
     name: Publish to npm
     needs: build-napi
+    # tag push 일 때만 실제 publish. workflow_dispatch(수동) 는 빌드 검증 전용.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
       # `runs-on` 과 매칭 — 변경 시 함께 갱신. 사용처: "Place zntc.node in main package".
@@ -255,6 +273,8 @@ jobs:
   github-release:
     name: Create GitHub Release
     needs: [build-cli, publish-npm]
+    # tag push 전용 — workflow_dispatch 검증 실행에서는 publish-npm 이 skip 되므로 함께 skip.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:

--- a/build.zig
+++ b/build.zig
@@ -78,6 +78,16 @@ pub fn build(b: *std.Build) void {
     });
     exe.addIncludePath(b.path("vendor/mimalloc/include"));
 
+    // macOS 를 -Dtarget 으로 cross 빌드하면 zig 가 SDK 의 usr/include 를 자동 포함하지
+    // 않아 mimalloc(prim.c)의 <CommonCrypto/CommonCryptoError.h> 를 못 찾는다.
+    // SDKROOT(CI: xcrun --show-sdk-path) 의 usr/include 를 보강. native 빌드(SDKROOT 미설정)
+    // 는 zig 가 SDK 를 자동 탐지하므로 이 분기를 타지 않는다.
+    if (target.result.os.tag == .macos) {
+        if (b.graph.env_map.get("SDKROOT")) |sdk| {
+            exe.addSystemIncludePath(.{ .cwd_relative = b.fmt("{s}/usr/include", .{sdk}) });
+        }
+    }
+
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default
     // step when running `zig build`).

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const http = std.http;
 const mime = @import("mime.zig");
 const FileWatcher = @import("file_watcher.zig").FileWatcher;
@@ -38,6 +39,9 @@ pub const DevServer = struct {
     sse_clients: SseClients = .{},
     /// 모노토닉 이벤트 시퀀스 (SSE payload의 id 필드).
     event_seq: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    /// event_seq fallback 보호용 — 32-bit 타깃은 64-bit atomic 미지원이라
+    /// `loadSeq`/`nextSeq`가 atomic 대신 이 mutex로 직렬화한다 (아래 헬퍼 참조).
+    seq_mutex: std.Thread.Mutex = .{},
     error_state: ErrorState = .{},
     /// Control API `/reset-cache`가 설정; watchLoop가 다음 iteration에서 소비.
     cache_reset_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
@@ -538,7 +542,7 @@ pub const DevServer = struct {
             if (has_css and !has_non_css) continue;
 
             // bundle_build_started 이벤트
-            const build_id = self.event_seq.load(.monotonic);
+            const build_id = self.loadSeq();
             {
                 var buf: [128]u8 = undefined;
                 if (std.fmt.bufPrint(&buf, "{{\"type\":\"bundle_build_started\",\"id\":\"{d}\"}}", .{build_id})) |json| {
@@ -849,7 +853,7 @@ pub const DevServer = struct {
                 },
                 else => {},
             }
-            const start_seq = self.event_seq.load(.monotonic);
+            const start_seq = self.loadSeq();
             std.Thread.sleep(duration_ms * std.time.ns_per_ms);
             const records = self.event_ring.snapshotSince(self.allocator, start_seq) catch {
                 try w.writeAll("\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"[]\"}]}");
@@ -996,9 +1000,34 @@ pub const DevServer = struct {
     }
 
     /// 이벤트를 SSE 구독자 전원에 브로드캐스트.
+    /// event_seq 는 u64 라 32-bit 네이티브 타깃에서는 lock-free atomic 이 불가능하다
+    /// ("expected 32-bit integer type or smaller"). 64-bit & 멀티스레드일 때만 atomic 을
+    /// 쓰고, 그 외(32-bit 멀티스레드)는 mutex, single-thread 면 plain 접근으로 fallback —
+    /// profile.zig 의 useAtomicCounter 와 동일한 전략이다.
+    inline fn seqUsesAtomic() bool {
+        return !builtin.single_threaded and
+            !builtin.cpu.arch.isWasm() and
+            @bitSizeOf(u64) <= @bitSizeOf(usize);
+    }
+
+    fn loadSeq(self: *DevServer) u64 {
+        if (comptime seqUsesAtomic()) return self.event_seq.load(.monotonic);
+        if (comptime !builtin.single_threaded) self.seq_mutex.lock();
+        defer if (comptime !builtin.single_threaded) self.seq_mutex.unlock();
+        return self.event_seq.raw;
+    }
+
+    fn nextSeq(self: *DevServer) u64 {
+        if (comptime seqUsesAtomic()) return self.event_seq.fetchAdd(1, .monotonic) + 1;
+        if (comptime !builtin.single_threaded) self.seq_mutex.lock();
+        defer if (comptime !builtin.single_threaded) self.seq_mutex.unlock();
+        self.event_seq.raw += 1;
+        return self.event_seq.raw;
+    }
+
     /// `data_json`은 유효한 JSON 오브젝트 문자열이어야 한다 (이스케이프 호출부 책임).
     pub fn publishEvent(self: *DevServer, event_type: []const u8, data_json: []const u8) void {
-        const seq = self.event_seq.fetchAdd(1, .monotonic) + 1;
+        const seq = self.nextSeq();
         self.event_ring.push(seq, event_type, data_json);
         self.sse_clients.broadcast(event_type, data_json);
     }

--- a/src/server/events.zig
+++ b/src/server/events.zig
@@ -184,7 +184,7 @@ pub const EventRing = struct {
     pub fn deinit(self: *EventRing) void {
         self.mutex.lock();
         defer self.mutex.unlock();
-        const count = @min(self.head, capacity);
+        const count: usize = @intCast(@min(self.head, capacity));
         for (self.items[0..count]) |*r| {
             self.allocator.free(r.event_type);
             self.allocator.free(r.data_json);
@@ -194,7 +194,9 @@ pub const EventRing = struct {
     pub fn push(self: *EventRing, seq: u64, event_type: []const u8, data_json: []const u8) void {
         self.mutex.lock();
         defer self.mutex.unlock();
-        const idx = self.head % capacity;
+        // head 는 u64 라 32-bit 타깃에서 배열 인덱스(usize)로 직접 못 쓴다.
+        // `% capacity`(256) 결과는 항상 usize 범위 → @intCast 안전.
+        const idx: usize = @intCast(self.head % capacity);
         if (self.head >= capacity) {
             self.allocator.free(self.items[idx].event_type);
             self.allocator.free(self.items[idx].data_json);
@@ -224,7 +226,7 @@ pub const EventRing = struct {
         }
         var i: u64 = start;
         while (i < total) : (i += 1) {
-            const src = self.items[i % capacity];
+            const src = self.items[@as(usize, @intCast(i % capacity))];
             if (src.seq <= since_seq) continue;
             try out.append(alloc, .{
                 .seq = src.seq,


### PR DESCRIPTION
## 배경

`v0.1.0` 첫 배포 시 `release.yml`의 9-플랫폼 CLI 빌드 매트릭스 중 **2개 타겟이 ReleaseFast 빌드 실패**해서 `github-release`(CLI 바이너리 첨부)가 막혔습니다. (npm publish 전에 워크플로우를 취소했고 태그도 삭제해 레지스트리 오염은 없습니다.)

## 원인과 수정

### 1. `x86-windows-msvc` (32bit) — 64비트 atomic 미지원
```
std/atomic.zig:14: error: expected 32-bit integer type or smaller; found 64-bit integer type
```
- `DevServer.event_seq`가 `std.atomic.Value(u64)`인데 32-bit native 타겟은 8바이트 atomic을 지원하지 않습니다.
- `src/profile.zig`의 `useAtomicCounter` 전략대로 `loadSeq`/`nextSeq` 헬퍼를 추가해, **64-bit & 멀티스레드일 때만 lock-free atomic**, 그 외(32-bit 멀티스레드)는 `seq_mutex`, single-thread면 plain 접근으로 fallback합니다. (`isWasm` 가드 포함 — profile.zig와 동형)
- 더불어 `EventRing`에서 `u64` head/seq를 배열 인덱스(`usize`)로 쓰던 3곳에 `@intCast`를 추가했습니다. 64-bit에선 `usize==u64`라 가려져 있던 잠재 버그로, atomic 수정 후 32bit 빌드에서 드러났습니다.

### 2. `x86_64-macos` (macos-15-intel) — mimalloc CommonCrypto 헤더
```
vendor/mimalloc/.../prim.c:869: error: 'CommonCrypto/CommonCryptoError.h' file not found
```
- mimalloc `prim.c`가 macOS에서 CommonCrypto 헤더를 include하는데, `-Dtarget` 명시로 zig가 cross 모드가 되어 시스템 SDK 헤더 경로를 자동 포함하지 않습니다. (NAPI 빌드는 mimalloc을 안 써서 성공했음)
- build-cli step에 `SDKROOT=$(xcrun --show-sdk-path)`를 주입해 native runner의 SDK 헤더를 찾게 했습니다. mimalloc 소스/매크로는 건드리지 않습니다.

### 3. build-전용 검증 트리거
- `release.yml`에 `workflow_dispatch` 트리거를 추가하고 `publish-npm`/`github-release`를 `if: github.event_name == 'push'`로 게이팅했습니다. **tag push 전에 9-플랫폼 빌드만 검증**(npm publish 없이)할 수 있습니다.

## 검증

- 로컬에서 `-Dtarget=x86-linux-gnu`(zig가 libc 제공하는 32bit 경로)로 재현·수정 확인 → **ELF 32-bit Intel 80386 바이너리 빌드 성공** (atomic + EventRing 수정 모두 통과)
- native arm64 ReleaseFast 빌드로 64bit 경로 회귀 없음 확인
- 32bit Windows / macOS Intel은 로컬 재현 불가(MSVC libc 부재 / arm 호스트)라, **머지 전 `workflow_dispatch`로 9-플랫폼 빌드 매트릭스 통과를 최종 확인**합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)