### PR TITLE
fix(release): bun publish npm 인증 (.npmrc 리터럴 토큰)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,10 +264,16 @@ jobs:
           echo "dist-tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
           echo "Will publish with --tag ${DIST_TAG}"
 
+      # release.ts 는 `bun publish` 를 호출하는데, setup-node 가 만든 .npmrc 의
+      # `${NODE_AUTH_TOKEN}` env 치환(npm 전용)을 bun 은 처리하지 않아 인증 실패한다.
+      # $HOME/.npmrc 에 리터럴 토큰을 직접 써 bun publish 가 읽게 한다 (값은 redirect 라
+      # 로그 비노출 + GitHub secret 마스킹).
       - name: Publish via release.ts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun scripts/release.ts --publish --yes --tag "${{ steps.tag.outputs.dist-tag }}"
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > "$HOME/.npmrc"
+          bun scripts/release.ts --publish --yes --tag "${{ steps.tag.outputs.dist-tag }}"
 
   # ─── GitHub Release (CLI binary tarball) ───
   github-release:


### PR DESCRIPTION
## 배경

`v0.1.0` 배포 시 `publish-npm` job이 첫 패키지(`@zntc/core-linux-x64-gnu`)부터 실패:
```
error: missing authentication (run `bunx npm login`)
❌ @zntc/core-linux-x64-gnu publish 실패 — 중단
```

- **build-napi/build-cli 18개는 전부 통과** (앞선 cross-build fix 검증 완료)
- npm은 첫 패키지부터 막혀 **미배포** — 레지스트리 오염 0

## 원인

`release.ts`가 `bun publish`를 호출하는데, `actions/setup-node`가 생성한 `.npmrc`는 `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` 형태의 **env 치환(npm 전용)**입니다. `bun publish`는 이 치환을 처리하지 않아 토큰을 못 읽습니다.

## 수정

Publish step에서 `$HOME/.npmrc`에 **리터럴 토큰**을 직접 써 `bun publish`가 인증을 읽게 합니다. 토큰 값은 파일 redirect라 stdout에 노출되지 않고 GitHub secret 마스킹도 적용됩니다. (`release.ts`의 `bun publish`는 그대로 유지)

## 검증

publish 인증은 tag push 실배포에서만 동작하므로(PR CI에선 publish skip), 머지 후 `v0.1.0` 재태그로 실제 배포에서 확인합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)