### PR TITLE
fix(release): bun publish 대신 npm publish 로 인증 해결

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -187,7 +187,10 @@ async function main() {
     console.log(`\n--- publishing ${t.name}@${t.version} ---`);
     const publishArgs = ['publish', '--access', 'public'];
     if (tag) publishArgs.push('--tag', tag);
-    const res = spawnSync('bun', publishArgs, {
+    // npm publish 사용 — `bun publish` 는 setup-node/.npmrc 의 토큰 인증을 못 읽어
+    // CI 에서 "missing authentication" 으로 실패한다. npm 은 .npmrc(_authToken)를
+    // 표준대로 읽어 인증. prepublishOnly hook(bun run build)은 npm 도 그대로 실행.
+    const res = spawnSync('npm', publishArgs, {
       cwd: resolve(repoRoot, t.dir),
       stdio: 'inherit',
     });


### PR DESCRIPTION
## 배경

`v0.1.0` 배포의 `publish-npm`이 **두 번 연속 첫 패키지부터 실패**:
```
error: missing authentication (run `bunx npm login`)
❌ @zntc/core-linux-x64-gnu publish 실패 — 중단
```

- PR #3633에서 `$HOME/.npmrc`에 리터럴 토큰을 써봤지만 **여전히 실패** → `bun publish`의 .npmrc 토큰 인증 처리가 CI에서 동작하지 않음
- 에러가 `403 forbidden`이 아닌 `missing authentication` → 토큰 자체는 유효, **전달이 안 됨**
- 첫 패키지부터 막혀 npm **미배포** (레지스트리 오염 0)

## 수정

`release.ts`의 publish 명령을 `bun publish` → **`npm publish`**로 전환. npm은 `.npmrc`의 `_authToken`을 표준대로 읽어 인증하며, `setup-node` + `NODE_AUTH_TOKEN`은 GitHub Actions npm publish의 검증된 표준 조합입니다.

- `prepublishOnly` hook(`bun run build && bunx publint`)은 npm publish도 그대로 실행 → 빌드/검증 동작 무변경
- `pre-release-check`는 여전히 `bun run` 사용(publish와 무관)

## 검증

publish 인증은 tag push 실배포에서만 동작하므로, 머지 후 `v0.1.0` 재태그로 실제 배포에서 확인합니다. (build 18개는 이미 통과 검증됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)