### PR TITLE
fix(release): npm publish 인증 — setup-node registry-url 제거 + whoami

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,10 +191,12 @@ jobs:
         with:
           bun-version: latest
 
+      # registry-url 을 지정하면 setup-node 가 NPM_CONFIG_USERCONFIG 를 $RUNNER_TEMP/.npmrc
+      # 로 설정해, 아래 Publish step 이 $HOME/.npmrc 에 쓴 토큰을 npm 이 무시한다.
+      # registry-url 생략 → npm 이 기본 $HOME/.npmrc 를 읽게 함.
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
 
       - uses: ./.github/actions/bun-cache
 
@@ -264,15 +266,15 @@ jobs:
           echo "dist-tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
           echo "Will publish with --tag ${DIST_TAG}"
 
-      # release.ts 는 `bun publish` 를 호출하는데, setup-node 가 만든 .npmrc 의
-      # `${NODE_AUTH_TOKEN}` env 치환(npm 전용)을 bun 은 처리하지 않아 인증 실패한다.
-      # $HOME/.npmrc 에 리터럴 토큰을 직접 써 bun publish 가 읽게 한다 (값은 redirect 라
-      # 로그 비노출 + GitHub secret 마스킹).
+      # release.ts 의 npm publish 가 인증을 읽도록 $HOME/.npmrc 에 리터럴 토큰을 쓴다
+      # (값은 redirect 라 로그 비노출 + GitHub secret 마스킹). whoami 로 16개 publish
+      # 전에 인증을 사전 검증 — 실패 시 여기서 명확히 중단.
       - name: Publish via release.ts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > "$HOME/.npmrc"
+          npm whoami
           bun scripts/release.ts --publish --yes --tag "${{ steps.tag.outputs.dist-tag }}"
 
   # ─── GitHub Release (CLI binary tarball) ───


### PR DESCRIPTION
## 배경

`v0.1.0` 배포의 `publish-npm`이 세 번째 시도에서 `ENEEDAUTH`로 실패 (앞선 두 번은 `bun publish` missing auth → `npm publish` 전환했으나 여전히 인증 실패):
```
npm notice 📦 @zntc/core-linux-x64-gnu@0.1.0   (tarball/prepublishOnly 통과)
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```
npm 미배포 (레지스트리 오염 0).

## 원인

`actions/setup-node`에 `registry-url`을 지정하면 **`NPM_CONFIG_USERCONFIG=$RUNNER_TEMP/.npmrc`**가 설정됩니다. 그 결과 Publish step이 `$HOME/.npmrc`에 쓴 리터럴 토큰을 npm이 **무시**합니다(userconfig 경로 불일치). setup-node가 만든 `$RUNNER_TEMP/.npmrc`는 `${NODE_AUTH_TOKEN}` 치환 방식인데, release.ts가 spawn한 자식 npm에서 치환이 안 됐습니다.

## 수정

1. **setup-node에서 `registry-url` 제거** → `NPM_CONFIG_USERCONFIG` 미설정 → npm이 기본 `$HOME/.npmrc`(리터럴 토큰)를 읽습니다.
2. **`npm whoami` 추가** → 16개 publish 시도 전에 인증을 사전 검증해, 실패 시 즉시 명확히 중단합니다.

## 검증

publish 인증은 tag push 실배포에서만 동작(PR CI에선 publish-npm skip)하므로, 머지 후 `v0.1.0` 재태그로 확인합니다. 이번엔 `npm whoami`가 publish 전에 인증을 검증하므로 문제 시 조기에 드러납니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)