### PR TITLE
fix(release): bun publish 복귀로 workspace protocol 자동 변환 + v0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,9 +266,10 @@ jobs:
           echo "dist-tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
           echo "Will publish with --tag ${DIST_TAG}"
 
-      # release.ts 의 npm publish 가 인증을 읽도록 $HOME/.npmrc 에 리터럴 토큰을 쓴다
-      # (값은 redirect 라 로그 비노출 + GitHub secret 마스킹). whoami 로 16개 publish
-      # 전에 인증을 사전 검증 — 실패 시 여기서 명확히 중단.
+      # release.ts 의 bun publish 가 인증을 읽도록 $HOME/.npmrc 에 리터럴 토큰을 쓴다
+      # (값은 redirect 라 로그 비노출 + GitHub secret 마스킹). registry-url 을 빼서
+      # NPM_CONFIG_USERCONFIG 가 이 파일을 가리지 않게 했고, whoami 로 16개 publish 전에
+      # 인증을 사전 검증한다 — 실패 시 여기서 명확히 중단.
       - name: Publish via release.ts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/bun.lock
+++ b/bun.lock
@@ -453,7 +453,7 @@
     },
     "packages/core": {
       "name": "@zntc/core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "zntc": "./bin/zntc.mjs",
       },
@@ -462,15 +462,15 @@
         "@zntc/test-helpers": "workspace:*",
       },
       "optionalDependencies": {
-        "@zntc/core-darwin-arm64": "0.1.0",
-        "@zntc/core-darwin-x64": "0.1.0",
-        "@zntc/core-linux-arm64-gnu": "0.1.0",
-        "@zntc/core-linux-arm64-musl": "0.1.0",
-        "@zntc/core-linux-x64-gnu": "0.1.0",
-        "@zntc/core-linux-x64-musl": "0.1.0",
-        "@zntc/core-win32-arm64-msvc": "0.1.0",
-        "@zntc/core-win32-ia32-msvc": "0.1.0",
-        "@zntc/core-win32-x64-msvc": "0.1.0",
+        "@zntc/core-darwin-arm64": "0.1.1",
+        "@zntc/core-darwin-x64": "0.1.1",
+        "@zntc/core-linux-arm64-gnu": "0.1.1",
+        "@zntc/core-linux-arm64-musl": "0.1.1",
+        "@zntc/core-linux-x64-gnu": "0.1.1",
+        "@zntc/core-linux-x64-musl": "0.1.1",
+        "@zntc/core-win32-arm64-msvc": "0.1.1",
+        "@zntc/core-win32-ia32-msvc": "0.1.1",
+        "@zntc/core-win32-x64-msvc": "0.1.1",
         "browserslist": "^4.24.0",
         "core-js": "^3.49.0",
         "core-js-compat": "^3.49.0",
@@ -480,7 +480,7 @@
     },
     "packages/init": {
       "name": "@zntc/init",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "zntc-init": "./bin/zntc-init.mjs",
       },
@@ -490,7 +490,7 @@
     },
     "packages/react-native": {
       "name": "@zntc/react-native",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@react-native-community/cli-server-api": "^15.0.0",
         "@zntc/core": "workspace:*",
@@ -512,7 +512,7 @@
     },
     "packages/rspack-loader": {
       "name": "@zntc/rspack-loader",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@zntc/core": "workspace:*",
       },
@@ -532,7 +532,7 @@
     },
     "packages/server": {
       "name": "@zntc/server",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@zntc/core": "workspace:*",
       },
@@ -542,7 +542,7 @@
     },
     "packages/vite-plugin": {
       "name": "@zntc/vite-plugin",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@zntc/core": "workspace:*",
       },
@@ -556,14 +556,14 @@
     },
     "packages/wasm": {
       "name": "@zntc/wasm",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/node": "^25.5.2",
       },
     },
     "packages/web": {
       "name": "@zntc/web",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@zntc/core": "workspace:*",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zntc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "packageManager": "bun@1.3.11",
   "workspaces": [

--- a/packages/core-darwin-arm64/package.json
+++ b/packages/core-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/core-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "macOS arm64 (Apple Silicon) native binary for @zntc/core",
   "keywords": [
     "compiler",

--- a/packages/core-darwin-x64/package.json
+++ b/packages/core-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/core-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "macOS x64 native binary for @zntc/core",
   "keywords": [
     "compiler",

--- a/packages/core-linux-arm64-gnu/package.json
+++ b/packages/core-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/core-linux-arm64-gnu",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Linux arm64 (glibc) native binary for @zntc/core",
   "keywords": [
     "compiler",

--- a/packages/core-linux-arm64-musl/package.json
+++ b/packages/core-linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/core-linux-arm64-musl",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Linux arm64 (musl) native binary for @zntc/core",
   "keywords": [
     "compiler",

--- a/packages/core-linux-x64-gnu/package.json
+++ b/packages/core-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/core-linux-x64-gnu",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Linux x64 (glibc) native binary for @zntc/core",
   "keywords": [
     "compiler",

--- a/packages/core-linux-x64-musl/package.json
+++ b/packages/core-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/core-linux-x64-musl",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Linux x64 (musl) native binary for @zntc/core",
   "keywords": [
     "compiler",

--- a/packages/core-win32-arm64-msvc/package.json
+++ b/packages/core-win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/core-win32-arm64-msvc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Windows arm64 (MSVC) native binary for @zntc/core",
   "keywords": [
     "compiler",

--- a/packages/core-win32-ia32-msvc/package.json
+++ b/packages/core-win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/core-win32-ia32-msvc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Windows ia32 (32-bit, MSVC) native binary for @zntc/core",
   "keywords": [
     "compiler",

--- a/packages/core-win32-x64-msvc/package.json
+++ b/packages/core-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/core-win32-x64-msvc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Windows x64 (MSVC) native binary for @zntc/core",
   "keywords": [
     "compiler",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ZNTC native transpiler & compiler binding",
   "keywords": [
     "bundler",
@@ -76,15 +76,15 @@
     "@zntc/test-helpers": "workspace:*"
   },
   "optionalDependencies": {
-    "@zntc/core-darwin-arm64": "0.1.0",
-    "@zntc/core-darwin-x64": "0.1.0",
-    "@zntc/core-linux-arm64-gnu": "0.1.0",
-    "@zntc/core-linux-arm64-musl": "0.1.0",
-    "@zntc/core-linux-x64-gnu": "0.1.0",
-    "@zntc/core-linux-x64-musl": "0.1.0",
-    "@zntc/core-win32-arm64-msvc": "0.1.0",
-    "@zntc/core-win32-ia32-msvc": "0.1.0",
-    "@zntc/core-win32-x64-msvc": "0.1.0",
+    "@zntc/core-darwin-arm64": "0.1.1",
+    "@zntc/core-darwin-x64": "0.1.1",
+    "@zntc/core-linux-arm64-gnu": "0.1.1",
+    "@zntc/core-linux-arm64-musl": "0.1.1",
+    "@zntc/core-linux-x64-gnu": "0.1.1",
+    "@zntc/core-linux-x64-musl": "0.1.1",
+    "@zntc/core-win32-arm64-msvc": "0.1.1",
+    "@zntc/core-win32-ia32-msvc": "0.1.1",
+    "@zntc/core-win32-x64-msvc": "0.1.1",
     "browserslist": "^4.24.0",
     "core-js": "^3.49.0",
     "core-js-compat": "^3.49.0",

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/init",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ZNTC project initializer and React Native CLI overlay",
   "keywords": [
     "create",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/react-native",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ZNTC React Native platform — Metro HMR adapter + RN preset (buildRnBundleOptions) + plugin factories + RN runtime",
   "keywords": [
     "bundler",

--- a/packages/rspack-loader/package.json
+++ b/packages/rspack-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/rspack-loader",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Use ZNTC as the TypeScript/JSX/Flow transformer in Rspack and Webpack (drop-in alternative to swc-loader / esbuild-loader / babel-loader)",
   "keywords": [
     "babel-loader",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "ZNTC internal server layer — HMR protocol, WS frame, watcher, TLS",
   "license": "MIT",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/vite-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Use ZNTC as the TypeScript/JSX transformer in Vite (replaces esbuild)",
   "keywords": [
     "esbuild",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/wasm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ZNTC native transpiler & compiler — WASM build",
   "keywords": [
     "browser",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zntc/web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ZNTC web platform — dev server + HMR overlay + postcss/sass pipeline + dev controller",
   "keywords": [
     "bundler",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -187,10 +187,10 @@ async function main() {
     console.log(`\n--- publishing ${t.name}@${t.version} ---`);
     const publishArgs = ['publish', '--access', 'public'];
     if (tag) publishArgs.push('--tag', tag);
-    // npm publish 사용 — `bun publish` 는 setup-node/.npmrc 의 토큰 인증을 못 읽어
-    // CI 에서 "missing authentication" 으로 실패한다. npm 은 .npmrc(_authToken)를
-    // 표준대로 읽어 인증. prepublishOnly hook(bun run build)은 npm 도 그대로 실행.
-    const res = spawnSync('npm', publishArgs, {
+    // bun publish — `workspace:*` 를 실제 버전으로 자동 변환한다(npm 은 미지원). 인증은
+    // release.yml 이 $HOME/.npmrc 에 리터럴 토큰을 쓰고 setup-node registry-url 을 빼서
+    // (NPM_CONFIG_USERCONFIG 미설정) bun 이 기본 .npmrc 를 읽도록 해 해결.
+    const res = spawnSync('bun', publishArgs, {
       cwd: resolve(repoRoot, t.dir),
       stdio: 'inherit',
     });


### PR DESCRIPTION
## 배경

`v0.1.0` 배포 후 실제 설치 검증에서 발견: 어댑터 4종(`@zntc/web`, `react-native`, `vite-plugin`, `rspack-loader`)이 `dependencies`의 `@zntc/core: "workspace:*"`를 변환하지 못한 채 publish되어 **설치 불가**.

```
[npm] @zntc/web@0.1.0  → EUNSUPPORTEDPROTOCOL "workspace:*"
[bun] @zntc/web@0.1.0  → "@zntc/core@workspace:* failed to resolve"
```

(npm·bun 모두 외부 consumer는 `workspace:*` 배포본을 설치 불가. `@zntc/core`·`wasm`·`init`·platform 9종은 workspace 의존이 없어 정상.)

## 원인

publish 인증 문제로 `bun publish` → `npm publish`로 전환했는데, **npm publish는 `workspace:*`를 변환하지 않습니다**(bun/pnpm/yarn 전용). 인증 fix의 부작용.

## 수정

- **release.ts: `npm publish` → `bun publish` 복귀** — bun이 `workspace:*`를 실제 버전으로 자동 변환. 로컬 `bun pm pack`으로 `@zntc/core: workspace:* → 0.1.1` 변환 확인.
- 이전 bun publish 인증 실패 원인은 이미 해소: ① 토큰 무효 → 유효 토큰 ② `setup-node` `registry-url`이 `NPM_CONFIG_USERCONFIG`로 `$HOME/.npmrc`를 가림 → registry-url 제거 완료. whoami가 publish 전 인증 사전 검증.
- 수동 변환 로직(`resolveWorkspaceDeps`) 제거 — bun이 처리.
- **전체 0.1.0 → 0.1.1 lockstep bump** (16 publishable + server + root + core의 optionalDependencies platform 9종).

## 검증

- 로컬 `bun pm pack`: `@zntc/web` deps `workspace:* → 0.1.1` 변환 확인 ✅
- publish 인증/변환은 tag push 실배포에서만 동작 → 머지 후 `v0.1.1` 태그로 확인, 4개 어댑터 실제 설치 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)