### PR TITLE
fix(release): bun publish 인증을 NPM_CONFIG_TOKEN 환경변수로 해결

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,13 +266,14 @@ jobs:
           echo "dist-tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
           echo "Will publish with --tag ${DIST_TAG}"
 
-      # release.ts 의 bun publish 가 인증을 읽도록 $HOME/.npmrc 에 리터럴 토큰을 쓴다
-      # (값은 redirect 라 로그 비노출 + GitHub secret 마스킹). registry-url 을 빼서
-      # NPM_CONFIG_USERCONFIG 가 이 파일을 가리지 않게 했고, whoami 로 16개 publish 전에
-      # 인증을 사전 검증한다 — 실패 시 여기서 명확히 중단.
+      # 인증: bun publish 는 각 패키지 cwd(packages/core-*)에서 실행되어 $HOME/.npmrc 를
+      # 못 찾고 "missing authentication" 으로 실패한다. NPM_CONFIG_TOKEN 환경변수는 cwd 무관
+      # 하게 인식되므로 이걸로 bun publish 를 인증한다(로컬 `bun pm whoami` 로 검증).
+      # $HOME/.npmrc + npm whoami 는 16개 publish 전 인증 사전 검증용.
       - name: Publish via release.ts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > "$HOME/.npmrc"
           npm whoami


### PR DESCRIPTION
## 배경

`v0.1.1` 배포에서 `bun publish`가 다시 인증 실패:
```
npm whoami → ohah                       ← npm 은 $HOME/.npmrc 로 인증 성공
bun publish → "missing authentication"  ← bun 은 같은 .npmrc 를 못 읽음
```

`release.ts`는 각 패키지 cwd(`packages/core-*`)에서 `bun publish`를 실행하는데, bun이 그 cwd 기준으로 `.npmrc`를 찾아 `$HOME/.npmrc`를 놓치는 것으로 보입니다.

## 수정

**`NPM_CONFIG_TOKEN` 환경변수**로 bun publish를 인증합니다 — 환경변수는 cwd와 무관하게 인식됩니다. 이로써 `bun publish`의 **`workspace:*` 자동 변환**(0.1.0 어댑터 4종이 깨졌던 원인)을 그대로 활용하면서 인증도 해결합니다.

## 로컬 검증

`bun pm whoami`가 세 방식 모두 `ohah` 반환 → bun이 `NPM_CONFIG_TOKEN`을 인식함:
```
1. 리터럴 ~/.npmrc          → ohah
2. NPM_CONFIG_TOKEN env      → ohah  ← 이 방식 채택 (cwd 무관)
3. ${ENV} 플레이스홀더 + env  → ohah
```
또한 `bun pm pack`이 `@zntc/web` deps `workspace:* → 0.1.1` 변환 확인.

## 검증
publish 인증/변환은 tag push 실배포에서만 동작 → 머지 후 `v0.1.1` 재태그로 확인, 어댑터 4종 실제 설치 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)