### PR TITLE
docs(backlog): measure-first 결과로 성능 백로그 정리

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2969,6 +2969,24 @@
 
     "@zntc/core": ["@zntc/core@workspace:packages/core"],
 
+    "@zntc/core-darwin-arm64": ["@zntc/core-darwin-arm64@0.1.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZhCUcErEm101VpfoIRQdAiNrhmEpP7FjlXVjBsJIwB6sDjInv4tt9ZLZwwU4HPDheKgHiNZp2wqWazdLzQN7Lw=="],
+
+    "@zntc/core-darwin-x64": ["@zntc/core-darwin-x64@0.1.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-go2WSnwSsFMiCy4roFrr0mc+rqDcmri9EBAqVw4TPcBYSrABY+z4vHHGikyzQGJY5tfzDBZpz4FecXooAfb6Bw=="],
+
+    "@zntc/core-linux-arm64-gnu": ["@zntc/core-linux-arm64-gnu@0.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-vFF08GrUvjvsuOKIgRmOjSwohhiRekNr4boozX/qV+xKfjBUTq27QkEDjL29W7lyB/TwlyJASTLZVydZwlBo7A=="],
+
+    "@zntc/core-linux-arm64-musl": ["@zntc/core-linux-arm64-musl@0.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-FgMrITlMp8vQRaZWyMCgmPeN/A04q28RBcsIeZNiZbU/t7Wm++dIrAyVcTeymCCBLo6YTGdRPBrx5wvlZdSUAA=="],
+
+    "@zntc/core-linux-x64-gnu": ["@zntc/core-linux-x64-gnu@0.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-akoA4ElGT9one9xalBzKDVY1SYHRyw6dwzW69ALf7UDRCPB/f+Awi6DOrrl2G8JYmo5Eh+eLdg/ba1gNIOa8QQ=="],
+
+    "@zntc/core-linux-x64-musl": ["@zntc/core-linux-x64-musl@0.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-73g3NqRufvvdeGvZedlpsym78rTYX2Uer3nw0CS1N24mBufMQwpr5wulPSwQFyEUoFDCkkurhi+5LrS1bJ4lyg=="],
+
+    "@zntc/core-win32-arm64-msvc": ["@zntc/core-win32-arm64-msvc@0.1.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-zeXry9pjoe2+eTJBEm6koklC8oZnmERWMlsYqxEoGB/kboiDMN2JsBof4VlyGsKQDy2hAlJ0aUwxkH0h60K6PA=="],
+
+    "@zntc/core-win32-ia32-msvc": ["@zntc/core-win32-ia32-msvc@0.1.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-4P5iw0vZdIFCvNetNY/63bS6CcTgv57ZdMqWebESZrKRuzxb2b8/bdy6BF39/VeStOLkSHef38U7qp7W1aRamg=="],
+
+    "@zntc/core-win32-x64-msvc": ["@zntc/core-win32-x64-msvc@0.1.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mLo2EectkhT49E3EKlvOuz0aFphSfkpxwiLveGbQOf2ej4+YuzmFs4Ili8hEerH0NhJLzwSXGDM18Ga69EXz6Q=="],
+
     "@zntc/e2e": ["@zntc/e2e@workspace:tests/e2e"],
 
     "@zntc/example-module-federation": ["@zntc/example-module-federation@workspace:examples/module-federation"],

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,14 +6,18 @@
 
 ## 성능 최적화 (SIMD/프로파일링 후)
 
+> **2026-05-22 measure-first 결과 (typescript.js 9MB / ReleaseFast / `zntc bench`)**
+> lexer scan 의 식별자·공백·문자열 스캔은 이미 16바이트 SIMD 적용 완료. 키워드 조회·lookup table 계열(#4/#8/#23)은 실측상 noise floor 아래로 **ROI ≈ 0** 확인.
+> `parse.expression.assignment` 가 profile self 45% 로 최대처럼 보이나, scope 제거 A/B 시 parse −100ms — 대부분 `profile.begin/end` timer 계측 오버헤드(count 큰 scope 의 self 절대값은 신뢰 불가). 새 lexer/parser 최적화 아이디어는 scope 제거 A/B 로 실측 후 진행할 것.
+
 | # | 항목 | 비고 |
 |---|------|------|
-| 1 | `Span`에 `source_id` 추가 (multi-file) | 번들러에서 필요 |
-| 4 | `StaticStringMap` → perfect hash 최적화 | 프로파일링 후 |
+| 1 | `Span`에 `source_id` 추가 (multi-file) | **비표준 설계 — 보류 (2026-05-22 references 4종 실측).** 어느 메이저 번들러도 AST 노드에 source_id 안 박음: esbuild=`Loc{Start int32}` 오프셋만(SourceIndex u32 는 심볼 Ref 전용), rolldown=oxc 동일, rspack=소스맵 합성. 출처는 "번들 줄 위치 + 모듈별 루프(module_id 명시)" 로 추적(현 zts 방식=esbuild 와 동일·정석). 함수 본문 인라인(노드 통째 이동)은 rspack 만 하며, 그조차 인라인 코드를 정의처로 **소스맵 합성(compose)** 으로 매핑 — 노드 확장 아님. Node 24B(`ast.zig:67`) 깨면 캐시 효율 하락(2.6→2.0/line). 진짜 트리거=함수 인라인 도입 시이고 그때도 정석은 소스맵 합성. 굳이 노드에 넣어야 하면 노는 pad 2B(u16=65536 모듈)로 크기 무증가 가능 |
+| 4 | `StaticStringMap` → perfect hash 최적화 | ROI ≈ 0 확인 (2026-05-22) — 키워드 조회 우회 A/B 시 scan 변화 noise floor 아래 |
 | 5 | scan* 함수 테이블 기반 통합 | 구조 리팩토링 |
 | 6 | skipWhitespace/scanIdentifierTail → local pos 패턴 | SIMD PR |
 | 7 | handleNewline 특수화 (handleLF/handleCR) | SIMD PR |
-| 8 | keyword lookup 길이 체크 early-exit | 최적화 PR |
+| 8 | keyword lookup 길이 체크 early-exit | ROI ≈ 0 확인 (2026-05-22) — #4 와 동일 측정. 키워드 조회 자체가 noise floor 아래 |
 | 9 | getLineColumn hint 캐싱 | 최적화 PR |
 | 10 | line_offsets Small Buffer Optimization | 최적화 PR |
 | 14 | scanHexDigits/scanOctalDigits/scanBinaryDigits 통합 | 최적화 PR |
@@ -24,10 +28,9 @@
 | 20 | checkPureComment 최적화 (단일 패스) | 최적화 PR |
 | 21 | checkJSXPragma early-exit | 최적화 PR |
 | 22 | peek() 캐싱 | 최적화 PR |
-| 23 | isAsciiIdentContinue → lookup table | SIMD PR |
+| 23 | isAsciiIdentContinue → lookup table | ROI ≈ 0 확인 (2026-05-22) — 식별자 스캔 inner loop 는 이미 16B SIMD fast path, 이 함수는 16B 미만 tail 스칼라 fallback 에만 쓰임 |
 | 24 | line_offsets/template_depth_stack 초기 용량 | 최적화 PR |
 | 25 | unicode.zig 범위 테이블 불완전 (Georgian 등) | 별도 PR |
-| 28 | runner.zig failed_list 메모리 누수 | Arena 도입 시 해결 |
 | 31 | scratch ArrayList 미적용 일부 파싱 함수 | 최적화 PR |
 | 34 | parseForIn/parseForOf 통합 | 최적화 PR |
 


### PR DESCRIPTION
## 배경

성능 최적화 백로그 항목을 무작정 다 시도하기 전에, `feedback_measure_before_optimize` 원칙대로 **먼저 실측**했습니다. 측정 도구: `zntc bench --phase=scan,parse` + `--profile` (typescript.js 9MB / ReleaseFast).

## 측정 결과

| Phase | self time | 비중 |
|---|---|---|
| `parse.expression.assignment` | 98ms | 45% |
| `scan` | 79.8ms | 37% |
| `parse.statement` | 37.8ms | 17.5% |

핵심 발견 (전부 A/B 측정으로 검증):

1. **scan 은 이미 SIMD 적용 완료** — 식별자·공백·문자열 스캔 모두 16바이트 벡터. lookup table(#23) 은 16B 미만 tail fallback 에만 쓰여 효과 없음.
2. **키워드 조회(#4 perfect hash / #8 early-exit) ROI ≈ 0** — 조회를 완전 우회해도 scan median 변화가 noise floor 아래.
3. **`parse.expression.assignment` self 45% 는 계측 artifact** — 그 scope 의 `profile.begin/end` 두 줄만 제거해도 parse median 이 228ms→~125ms (≈100ms 가 `std.time.Timer` 오버헤드). count 가 큰 scope 의 self 절대값은 신뢰 불가.

## 변경 내용

- 성능 최적화 섹션에 measure-first 노트 추가 (scope 제거 A/B 측정법 안내)
- **#4 / #8 / #23**: "ROI ≈ 0 확인 (2026-05-22)" 메모
- **#28 (runner.zig 누수)**: `runDirectory` 가 이미 `free`+`deinit` 으로 해제 중 → **이미 해결된 stale 항목이라 제거**
- **#1 (Span source_id)**: references 4종(esbuild/rolldown/rspack) 실측으로 문구 교정

### #1 source_id — references 4종 실측

| | 상수 전파 | 함수 본문 인라인 |
|---|---|---|
| esbuild | ✅(minify) | ❌ 호출 유지 |
| rolldown | ✅ | ❌ 호출 유지 |
| rspack | ✅ | ✅ `84` (concat+minifier) |

**어느 메이저 번들러도 AST 노드에 source_id 를 박지 않습니다.** esbuild 의 `Loc` 은 파일 오프셋만 가지고(`SourceIndex u32` 는 심볼 `Ref` 전용), 함수 인라인을 실제로 하는 rspack 조차 인라인된 코드를 정의처로 **소스맵 합성(compose)** 으로 매핑합니다(인라인된 `84` → `consts.js:2:35` 확인). zts 의 현재 방식(노드는 오프셋, 출처는 "번들 줄 위치 + 모듈별 루프")은 esbuild 와 동일한 정석입니다.

→ #1 "Span 에 source_id 추가" 는 **비표준 설계이며 현재 불필요**. 진짜 트리거는 함수 본문 인라인 도입 시점이고, 그때도 정석은 노드 확장이 아니라 소스맵 합성입니다.

## 참고 (Zig 초보자용)

- `@sizeOf(Node) == 24` 는 `ast.zig:67` 의 컴파일타임 assert 로 강제됩니다. AST 노드는 캐시라인(64B)에 2.6개 들어가도록 24B 고정인데, source_id 를 박아 28/32B 가 되면 라인당 2.0개로 줄어 parse/codegen(메모리 바운드)이 느려집니다.
- `profile.begin` 은 활성 시 `std.time.Timer.start()`(clock 읽기)를 호출하므로, 호출 횟수가 많은 scope 일수록 self time 이 부풀려집니다.

코드 변경 없이 문서만 수정합니다.

---

## 추가: CI lockfile fix (커밋 2)

`bun install --frozen-lockfile` 이 `lockfile had changes` 로 실패하던 문제 수정. v0.1.1 release 시 `@zntc/core` 의 플랫폼별 prebuilt optionalDependencies 9개(`@zntc/core-{darwin,linux,win32}-*`)가 0.1.1 로 bump 됐으나 `bun.lock` 갱신이 누락된 것이 원인 (main 전체 영향, 문서 변경과 무관). package.json 의 0.1.1 optionalDeps 를 lockfile 에 반영 → 로컬 `--frozen-lockfile` 통과 확인.
