### PR TITLE
docs(backlog): #25 unicode 범위 테이블 stale 항목 제거

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -30,7 +30,6 @@
 | 22 | peek() 캐싱 | 최적화 PR |
 | 23 | isAsciiIdentContinue → lookup table | ROI ≈ 0 확인 (2026-05-22) — 식별자 스캔 inner loop 는 이미 16B SIMD fast path, 이 함수는 16B 미만 tail 스칼라 fallback 에만 쓰임 |
 | 24 | line_offsets/template_depth_stack 초기 용량 | 최적화 PR |
-| 25 | unicode.zig 범위 테이블 불완전 (Georgian 등) | 별도 PR |
 | 31 | scratch ArrayList 미적용 일부 파싱 함수 | 최적화 PR |
 | 34 | parseForIn/parseForOf 통합 | 최적화 PR |
 


### PR DESCRIPTION
## 배경

BACKLOG #25 "unicode.zig 범위 테이블 불완전 (Georgian 등)" 이 실제로 미해결인지 검증했습니다.

## 검증 결과 — 이미 해결됨 (stale)

- `src/lexer/unicode.zig` 헤더 주석: **테이블은 Unicode 16.0.0 기준으로 생성** (Python unicodedata + 14.0/15.0/15.1/16.0 보충), 총 1065개 범위.
- **Georgian 완비**: `0x10A0–0x10C5`, `0x10C7`, `0x10CD`, `0x10D0–0x10FA` (2026-03-20 커밋 a93891837 에서 추가).
- **실측 통과** — 다음 식별자 transpile 전부 정상 (exit 0):

```ts
const ა = 1;           // Georgian
const 名前 = 2;        // CJK
const переменная = 3;  // Cyrillic
const ⲗⲟⲅⲟⲥ = 4;       // Coptic
const あ = 5;          // Hiragana
```

→ "불완전" 은 코드를 못 따라간 stale 항목이라 제거합니다. (이번 백로그 정리에서 #28 에 이어 두 번째 stale)

문서만 변경합니다.