### PR TITLE
docs(backlog): stale 항목 정리 라운드2 (TS 타입 섹션 전체 + #17/#74)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -22,7 +22,6 @@
 | 10 | line_offsets Small Buffer Optimization | 최적화 PR |
 | 14 | scanHexDigits/scanOctalDigits/scanBinaryDigits 통합 | 최적화 PR |
 | 15 | scanHexLiteral/scanOctalLiteral/scanBinaryLiteral 통합 | 최적화 PR |
-| 17 | skipUnicodeEscape 헬퍼 추출 | 최적화 PR |
 | 18 | isAsciiIdentStart/Continue를 unicode.zig로 이동 | 최적화 PR |
 | 19 | pragma dead guard 제거 | 최적화 PR |
 | 20 | checkPureComment 최적화 (단일 패스) | 최적화 PR |
@@ -59,22 +58,5 @@ CSS Modules + Sass 도입 (PR #2225) 후 식별된 후속 작업.
 | ~~70~~ | ~~dev rebuild full re-prep (cpSync) 비용~~ | ✅ 해결: `prepare(dirtyPaths)` 가 incremental — 변경 파일만 cpSync, sass/css-modules transform 도 dirty 입력만 재처리, postcss prep 호출 자체도 CSS 관련 dirty 가 없으면 skip. JS-only 변경은 cpSync (dirty 만) + rewriter (dirty 만) 만 수행 — 풀 prep 의 비용 거의 전부 회피. |
 | ~~71~~ | ~~`.scss` 단일 파일 fast-path~~ | ✅ 해결: 단일 non-module `.scss/.sass` 변경은 `isCssOnlyChange=true` 로 분류되어 `rebuildScssIncremental` 진입 — 그 파일만 sass.compile + tempRoot/outdir 갱신 + `CssUpdate` broadcast. import dep 추적 없으므로 다른 sass 파일이 이 파일을 import 하면 갱신 누락 (별 issue 로 sass loadPaths dep tracking) |
 | ~~72~~ | ~~E2E `setTimeout(2000-2500)` → readiness poll~~ | ✅ 해결 (PR #3532): `tests/e2e/tests/wait-for-server.ts` 폴링 helper 도입, `zntc-app-builder-e2e.test.ts` 의 서버 기동 `setTimeout` 12곳 일괄 대체 + 로컬 중복 helper 제거. 200 한정이 아니라 **임의 HTTP 응답 = bind 완료** (error-overlay fixture 가 500/에러 HTML 을 주므로). |
-| 74 | 크로스-스위트 `waitForServer` 통합 | server-readiness 폴링이 3곳에 중복: `packages/core/test/cli/helpers.ts` (positional args), `tests/integration/tests/devserver-sse-mcp.test.ts` 인라인 루프, `tests/e2e/tests/wait-for-server.ts`. 워크스페이스 분리 + `bun:test`↔Playwright 런너 결합으로 직접 import 불가 — runner-agnostic 공유 모듈로 추출해야 단일화 가능. (#3533 /simplify 에서 식별, 범위 초과로 보류) |
+| ~~74~~ | ~~크로스-스위트 `waitForServer` 통합~~ | ✅ 해결: `tests/test-helpers/wait-for-server.ts` 정본을 `@zntc/test-helpers` 워크스페이스로 추출, `packages/core/test/cli/helpers.ts`(호환 wrapper)·`tests/integration/tests/devserver-sse-mcp.test.ts`(직접 사용)가 공유 모듈 import. 실질 중복 제거 완료. |
 | ~~73~~ | ~~Dev mode 에서 bundler 가 CSS chunk 를 emit 하지 않음~~ | ✅ 해결: bundler 측은 그대로 두고, JS 파이프라인이 sass / css-modules 컴파일 산출물을 tempRoot → outdir 로 mirror 하고 HTML 에 `<link>` 를 주입. inline `<style>` 우회 (`buildDevStyleInjector`) 제거. |
-
----
-
-## TS 타입 전용 (d.ts 생성 시 필요)
-
-ZNTC는 타입 체크를 하지 않으므로 (스트리핑만) 당장 필요하지 않음.
-AST Tag는 정의되어 있으나 파싱 미구현 — isolatedDeclarations 구현 시 추가.
-
-| # | 항목 | 비고 |
-|---|------|------|
-| 49 | conditional type `T extends U ? X : Y` | Tag 정의됨, 파싱 미구현 |
-| 50 | mapped type `{ [K in keyof T]: V }` | Tag 정의됨, 파싱 미구현 |
-| 51 | infer type `infer T` | Tag 정의됨, 파싱 미구현 |
-| 52 | template literal type `` `hello ${string}` `` | Tag 정의됨, 파싱 미구현 |
-| 53 | declare 문 wrapper 노드 (ambient 구분) | .d.ts용 |
-| 55 | declare global 미지원 | .d.ts용 |
-| 56 | module "string" (문자열 모듈 이름) 미지원 | .d.ts용 |


### PR DESCRIPTION
## 배경

남은 백로그 항목들이 실제로 미해결인지 코드로 전수 확인했습니다. stale 패턴(#28/#25에 이어)이 또 다수 발견됐습니다.

## TS 타입 전용 섹션(#49~56) 전체 — stale, 섹션 삭제

BACKLOG는 "Tag 정의됨, 파싱 미구현"이라 적었으나 **전부 파싱 구현 + 테스트 존재**:

| # | 항목 | 구현 위치 |
|---|---|---|
| 49 | conditional type | `ts.zig:718` + parser_test |
| 50 | mapped type | `ts.zig:1612` + parser_test |
| 51 | infer type | `ts.zig:832` + parser_test |
| 52 | template literal type | `ts.zig:1706` |
| 53 | declare wrapper (ambient) | `ts.zig:295` |
| 55 | declare global | `ts.zig:302` + parser_test |
| 56 | module "string" | `ts.zig:207` |

**실측 검증** — 다음 strip 전부 통과(타입 제거, `const x=1`만 남음, exit 0):

```ts
type Cond<T> = T extends string ? number : boolean;
type Mapped<T> = { [K in keyof T]: T[K] };
type Infer<T> = T extends Array<infer U> ? U : never;
type Tmpl = `hello ${string}`;
declare global { interface Window { __x: number } }
declare module "*.css";
```

## 그 외 stale

- **#17 skipUnicodeEscape 헬퍼 추출** → `scanIdentifierEscape`(`scanner.zig:2018`)로 이미 구현됨 → 제거
- **#74 waitForServer 통합** → `tests/test-helpers/wait-for-server.ts` 정본을 `@zntc/test-helpers` 워크스페이스로 추출 완료, 3곳이 공유 모듈 사용 → ✅ 해결 표시

## 유지한 항목 (진짜 미구현)

#5/#9/#10/#14/#15/#18/#20/#22/#24/#34 등 lexer/parser 마이크로 최적화는 미구현 상태로 유지 (단 scan SIMD 바운드라 ROI 낮을 것으로 예상 — measure-first 필요). #63 dead-store 부분 구현 상태도 정확하므로 유지.

문서만 변경합니다.