### PR TITLE
feat(plugin): this.warn / this.error plugin context (#1880 PR1)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1829,8 +1829,8 @@ function lifecycleHookSpec(
 /**
  * plugin hook 콜백의 `this` 로 바인딩할 context 를 plugin 이름별로 캐시해 반환.
  * `this.warn(...)` 은 `reg.pluginWarnings` 로 수집되고, `this.error(...)` 는 throw 되어
- * 기존 driveDispatch* 의 normalizePluginFailure 경로를 그대로 탄다. resolve/emitFile/getModuleInfo
- * 는 아직 placeholder(throw) — 후속 PR(#1880 PR3~5)에서 채운다.
+ * 기존 driveDispatch* 의 normalizePluginFailure 경로를 그대로 탄다. resolve/emitFile 는 아직
+ * placeholder(throw), getModuleInfo 는 surface 미추가 — 후속 PR(#1880 PR3~5)에서 채운다.
  */
 function getPluginContext(reg: PluginRegistry, pluginName: string): RollupPluginContext {
   let ctx = reg.contexts.get(pluginName);
@@ -1979,7 +1979,7 @@ function* dispatchHook(
     if (!h.filter.test(filterTarget)) continue;
     const fallbackFile = hookName === 'resolveId' ? arg2 : filterTarget;
     const result = yield {
-      callback: () => h.callback(cbArgs),
+      callback: () => h.callback.call(getPluginContext(reg, h.pluginName), cbArgs),
       pluginName: h.pluginName,
       hookName,
       fallbackFile,
@@ -3016,7 +3016,14 @@ export function watch(options: BuildOptions): WatchHandle {
     // swallow — 그렇지 않으면 user callback throw 와 closeBundle dispatch 실패가
     // unhandledRejection 으로 샌다. build() 는 await 가능해 이 래핑이 필요 없다.
     const dispatchCloseBundle = () => {
-      void dispatcher('closeBundle', undefined, null).catch(() => {});
+      void dispatcher('closeBundle', undefined, null)
+        .catch(() => {})
+        .finally(() => {
+          // watch 는 BuildResult 가 없어 plugin 의 this.warn 을 result.warnings 로 옮길 곳이 없다.
+          // drain 하지 않으면 reg.pluginWarnings 가 rebuild 마다 무한 누적(누수)되고, onWarn sink
+          // 때문에 console 에도 안 뜬다. rebuild 마다 비우면서 console 로 surfacing 한다.
+          for (const w of dispatcher.takePluginWarnings()) console.warn(w.text);
+        });
     };
     const wrapWatchCallback =
       <T>(callback?: (event: T) => void | Promise<void>) =>

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1652,6 +1652,8 @@ function mapMaybePromise<T, U>(value: T | PromiseLike<T>, mapper: (value: T) => 
 type HookEntry = { pluginName: string; filter: RegExp; callback: (...args: any[]) => any };
 type PluginDispatcherLifecycle = {
   takeLifecycleFailures(): PluginFailureResult[];
+  /** plugin hook 의 `this.warn(...)` 으로 수집된 경고를 꺼내 result.warnings 로 surfacing. */
+  takePluginWarnings(): Diagnostic[];
 };
 type PluginDispatcher = ((
   hookName: string,
@@ -1676,6 +1678,10 @@ type PluginRegistry = {
   closeBundleCallbacks: Array<{ pluginName: string; callback: () => void | Promise<void> }>;
   astFunctionHooks: HookEntry[];
   lifecycleFailures: PluginFailureResult[];
+  /** plugin 의 `this.warn(...)` 누적 — build/buildSync 가 result.warnings 로 옮긴다. */
+  pluginWarnings: Diagnostic[];
+  /** plugin 이름별 context(`this` 바인딩) 캐시 — 한 빌드 동안 동일 plugin 은 같은 context 를 본다. */
+  contexts: Map<string, RollupPluginContext>;
 };
 
 function collectPluginRegistry(plugins: ZntcPlugin[]): PluginRegistry {
@@ -1693,6 +1699,8 @@ function collectPluginRegistry(plugins: ZntcPlugin[]): PluginRegistry {
     closeBundleCallbacks: [],
     astFunctionHooks: [],
     lifecycleFailures: [],
+    pluginWarnings: [],
+    contexts: new Map(),
   };
 
   for (const plugin of plugins) {
@@ -1819,6 +1827,21 @@ function lifecycleHookSpec(
 }
 
 /**
+ * plugin hook 콜백의 `this` 로 바인딩할 context 를 plugin 이름별로 캐시해 반환.
+ * `this.warn(...)` 은 `reg.pluginWarnings` 로 수집되고, `this.error(...)` 는 throw 되어
+ * 기존 driveDispatch* 의 normalizePluginFailure 경로를 그대로 탄다. resolve/emitFile/getModuleInfo
+ * 는 아직 placeholder(throw) — 후속 PR(#1880 PR3~5)에서 채운다.
+ */
+function getPluginContext(reg: PluginRegistry, pluginName: string): RollupPluginContext {
+  let ctx = reg.contexts.get(pluginName);
+  if (!ctx) {
+    ctx = createRollupPluginContext(pluginName, (d) => reg.pluginWarnings.push(d));
+    reg.contexts.set(pluginName, ctx);
+  }
+  return ctx;
+}
+
+/**
  * Dispatcher 본체를 generator 로 작성해서 async/sync runner 가 동일 body 를 driving 한다.
  * 분기별 (astFunction / resolveContext / lifecycle / transform-chain / first-match) 결정은
  * 여기서 한 번만 정의되고 callback 실행 / Promise 처리만 runner 로 위임된다.
@@ -1841,7 +1864,7 @@ function* dispatchHook(
     for (const h of reg.astFunctionHooks) {
       if (!h.filter.test(info.sourcePath)) continue;
       const result = yield {
-        callback: () => h.callback(info),
+        callback: () => h.callback.call(getPluginContext(reg, h.pluginName), info),
         pluginName: h.pluginName,
         hookName: 'astFunction',
         fallbackFile: info.sourcePath,
@@ -1872,7 +1895,7 @@ function* dispatchHook(
     for (const h of reg.hooks.resolveContext) {
       if (!h.filter.test(args.dir)) continue;
       const result = yield {
-        callback: () => h.callback(args),
+        callback: () => h.callback.call(getPluginContext(reg, h.pluginName), args),
         pluginName: h.pluginName,
         hookName: 'resolveContext',
         fallbackFile: args.importer,
@@ -1893,7 +1916,7 @@ function* dispatchHook(
       let firstFailure: PluginFailureResult | null = null;
       for (const { pluginName, callback } of spec.callbacks) {
         const result = yield {
-          callback: () => callback(spec.arg),
+          callback: () => callback.call(getPluginContext(reg, pluginName), spec.arg),
           pluginName,
           hookName,
         };
@@ -1921,7 +1944,7 @@ function* dispatchHook(
           ? { code: currentCode, path: arg2 }
           : { code: currentCode, chunk: arg2 };
       const result = yield {
-        callback: () => h.callback(cbArgs),
+        callback: () => h.callback.call(getPluginContext(reg, h.pluginName), cbArgs),
         pluginName: h.pluginName,
         hookName,
         fallbackFile: arg2,
@@ -2026,6 +2049,7 @@ function createPluginDispatcher(plugins: ZntcPlugin[]): PluginDispatcher {
     return driveDispatchAsync(dispatchHook(reg, hookName, arg1, arg2));
   } as PluginDispatcher;
   dispatcher.takeLifecycleFailures = () => reg.lifecycleFailures.splice(0);
+  dispatcher.takePluginWarnings = () => reg.pluginWarnings.splice(0);
   return dispatcher;
 }
 
@@ -2039,6 +2063,7 @@ function createSyncPluginDispatcher(plugins: ZntcPlugin[]): SyncPluginDispatcher
     return driveDispatchSync(dispatchHook(reg, hookName, arg1, arg2));
   } as SyncPluginDispatcher;
   dispatcher.takeLifecycleFailures = () => reg.lifecycleFailures.splice(0);
+  dispatcher.takePluginWarnings = () => reg.pluginWarnings.splice(0);
   return dispatcher;
 }
 
@@ -2380,6 +2405,9 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
       for (const failure of dispatcher.takeLifecycleFailures()) {
         result.errors.push(pluginFailureToDiagnostic(failure));
       }
+      for (const warning of dispatcher.takePluginWarnings()) {
+        result.warnings.push(warning);
+      }
     }
 
     postProcessCssOutputs(result, options);
@@ -2389,6 +2417,9 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
       await dispatcher('closeBundle', undefined, null);
       for (const failure of dispatcher.takeLifecycleFailures()) {
         result.errors.push(pluginFailureToDiagnostic(failure));
+      }
+      for (const warning of dispatcher.takePluginWarnings()) {
+        result.warnings.push(warning);
       }
     }
     return result;
@@ -2416,6 +2447,9 @@ export function buildSync(options: BuildOptions): BuildResult {
       for (const failure of dispatcher.takeLifecycleFailures()) {
         result.errors.push(pluginFailureToDiagnostic(failure));
       }
+      for (const warning of dispatcher.takePluginWarnings()) {
+        result.warnings.push(warning);
+      }
     }
     postProcessCssOutputs(result, options);
     writeOutputFiles(result, options);
@@ -2423,6 +2457,9 @@ export function buildSync(options: BuildOptions): BuildResult {
       dispatcher('closeBundle', undefined, null);
       for (const failure of dispatcher.takeLifecycleFailures()) {
         result.errors.push(pluginFailureToDiagnostic(failure));
+      }
+      for (const warning of dispatcher.takePluginWarnings()) {
+        result.warnings.push(warning);
       }
     }
     return result;
@@ -2812,15 +2849,22 @@ function normalizeVitePluginSourceMap(
   }
 }
 
-function createRollupPluginContext(pluginName: string): RollupPluginContext {
+/**
+ * @param onWarn `this.warn(...)` 을 받을 sink. native plugin dispatcher 는 이를 전달해
+ *   경고를 `result.warnings` 로 surfacing 한다. 미전달 시(예: vitePlugin 어댑터) console.warn fallback.
+ */
+function createRollupPluginContext(
+  pluginName: string,
+  onWarn?: (diagnostic: Diagnostic) => void,
+): RollupPluginContext {
   return {
     error(error: unknown): never {
       throw error;
     },
     warn(message: unknown): void {
-      console.warn(
-        `@zntc/core [${pluginName}]: ${typeof message === 'string' ? message : String(message)}`,
-      );
+      const text = `@zntc/core [${pluginName}]: ${typeof message === 'string' ? message : String(message)}`;
+      if (onWarn) onWarn({ text });
+      else console.warn(text);
     },
     addWatchFile(_id: string): void {
       // no-op: ZNTC 는 plugin 이 알려준 추가 watch 파일을 native watcher 에 전파하는 surface 가

--- a/packages/core/test/core/build-plugins.ts
+++ b/packages/core/test/core/build-plugins.ts
@@ -1,4 +1,5 @@
 import './build-plugins/basic-hooks';
+import './build-plugins/plugin-context';
 import './build-plugins/transform-tree-shaking';
 import './build-plugins/resolve-context';
 import './build-plugins/build-sync';

--- a/packages/core/test/core/build-plugins/plugin-context.ts
+++ b/packages/core/test/core/build-plugins/plugin-context.ts
@@ -42,6 +42,33 @@ describe('@zntc/core build + plugins - plugin context (this.warn / this.error)',
     }
   });
 
+  test('this.warn 은 load hook(resolveId/load dispatch 사이트)에서도 동작한다', async () => {
+    // 회귀 가드: dispatchHook 의 resolveId/load 콜백 사이트도 context 를 this 로 바인딩해야 한다.
+    // (transform 사이트만 바인딩되고 이 사이트가 누락되면 load hook 의 this.warn 이 TypeError)
+    const loadWarner: ZntcPlugin = {
+      name: 'load-warner',
+      setup(build) {
+        build.onLoad({ filter: /\.ts$/ }, function (this: RollupPluginContext, _args) {
+          this.warn('warn from load');
+          return null; // contents 미반환 → native 가 실제 파일을 읽는다.
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-ctx-load-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'console.log(1);');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [loadWarner],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(result.warnings.some((w) => w.text.includes('warn from load'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('this.error 는 plugin failure 로 result.errors 에 들어간다', async () => {
     const errPlugin: ZntcPlugin = {
       name: 'boomer',

--- a/packages/core/test/core/build-plugins/plugin-context.ts
+++ b/packages/core/test/core/build-plugins/plugin-context.ts
@@ -1,0 +1,117 @@
+import {
+  build,
+  buildSync,
+  describe,
+  expect,
+  join,
+  mkdtempSync,
+  rmSync,
+  test,
+  tmpdir,
+  writeFileSync,
+} from './helpers';
+import type { ZntcPlugin } from './helpers';
+import type { RollupPluginContext } from '../../../index';
+
+// #1880 PR1 — plugin hook 의 `this` context: this.warn / this.error.
+describe('@zntc/core build + plugins - plugin context (this.warn / this.error)', () => {
+  test('this.warn 은 result.warnings 로 surfacing (transform hook)', async () => {
+    const warnPlugin: ZntcPlugin = {
+      name: 'warner',
+      setup(build) {
+        build.onTransform({ filter: /\.ts$/ }, function (this: RollupPluginContext, _args) {
+          this.warn('heads up from transform');
+          return null;
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-ctx-warn-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'console.log(1);');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [warnPlugin],
+      });
+      expect(result.errors.length).toBe(0);
+      // warn 메시지 + plugin 이름 prefix 가 result.warnings 에 들어와야 한다.
+      expect(result.warnings.some((w) => w.text.includes('heads up from transform'))).toBe(true);
+      expect(result.warnings.some((w) => w.text.includes('warner'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('this.error 는 plugin failure 로 result.errors 에 들어간다', async () => {
+    const errPlugin: ZntcPlugin = {
+      name: 'boomer',
+      setup(build) {
+        build.onTransform({ filter: /\.ts$/ }, function (this: RollupPluginContext, _args) {
+          this.error('explode from transform');
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-ctx-err-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'console.log(1);');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [errPlugin],
+      });
+      expect(result.errors.some((e) => e.text.includes('explode from transform'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('buildSync 에서도 this.warn 이 surfacing 된다', () => {
+    const warnPlugin: ZntcPlugin = {
+      name: 'sync-warner',
+      setup(build) {
+        build.onTransform({ filter: /\.ts$/ }, function (this: RollupPluginContext, _args) {
+          this.warn('sync heads up');
+          return null;
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-ctx-sync-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'console.log(1);');
+      const result = buildSync({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [warnPlugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(result.warnings.some((w) => w.text.includes('sync heads up'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('this 를 쓰지 않는 plugin 은 영향 없이 동작한다', async () => {
+    const plainPlugin: ZntcPlugin = {
+      name: 'plain',
+      setup(build) {
+        build.onTransform({ filter: /\.ts$/ }, (args) => ({
+          code: args.code.replace('console.log', 'console.warn'),
+        }));
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-ctx-plain-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'console.log("hello");');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plainPlugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(result.warnings.length).toBe(0);
+      expect(result.outputFiles[0].text).toContain('console.warn');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 배경

#1880 (plugin context API) epic 의 **PR1**. 사전조사(#1898/#1900)에서 ZTS plugin 의 1차 hook 8개는 이미 구현됐고, 호환 병목은 plugin context API(`this.resolve`/`this.emitFile`) 임을 확인했습니다. 그 토대인 **context 주입 인프라**와 가장 단순한 `this.warn`/`this.error` 부터 시작합니다.

## 변경

- **context 주입 인프라**: `dispatchHook` 의 모든 콜백 호출을 `.call(ctx, args)` 로 변경. `getPluginContext(reg, pluginName)` 가 plugin 이름별로 `RollupPluginContext` 를 캐시. **현재 bare call 이라 `this.*` 자체가 불가능했던 것을 해소** — 후속 PR(this.resolve/emitFile/getModuleInfo)이 전부 이 위에 얹힘.
- **`this.warn`**: `reg.pluginWarnings` 로 수집 → `build`/`buildSync` 가 `result.warnings` 로 surfacing. 기존 `lifecycleFailures → result.errors` 채널을 그대로 미러링.
- **`this.error`**: throw → 기존 `normalizePluginFailure` 경로로 `result.errors`. 추가 배선 0.
- `createRollupPluginContext` 에 `onWarn` sink 옵션 추가. 미전달 시 `console.warn` fallback — **vitePlugin 어댑터 기존 동작 유지**.

## vitePlugin 어댑터 충돌 없음

vitePlugin 의 native 콜백은 화살표 함수(`(args) => handler.call(viteCtx, ...)`)라 `dispatchHook` 의 `.call(nativeCtx)` 를 무시하고 내부에서 자기 context 를 바인딩합니다. native plugin 콜백만 새 context 의 `this` 를 받습니다.

## 테스트 (TDD)

`test/core/build-plugins/plugin-context.ts` 4개:
- transform hook 의 `this.warn` → `result.warnings`
- `this.error` → `result.errors` (plugin failure)
- `buildSync` 에서도 `this.warn` surfacing
- `this` 미사용 plugin 무영향 (화살표 콜백)

**red→green 검증**: warn sink 주입을 제거하면 warn 테스트 2개가 정확히 fail, 복원 시 4 pass. `build-plugins` 전체 **23 pass / 회귀 0** (vitePlugin 어댑터 포함).

## 다음 (epic #1880)

PR2 ModuleInfo.meta → PR3 this.getModuleInfo → PR4 this.resolve(+skipSelf) → PR5 this.emitFile → PR6 vitePlugin parity. 단일 최대 호환 레버는 PR4 `this.resolve`.

Refs #1880