### PR TITLE
feat(plugin): ModuleInfo.meta + this.getModuleInfo self-only (#1880 PR2+PR3)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -562,6 +562,9 @@ export interface ManualChunksModuleInfo {
   /** Modules that this module dynamically imports (`import()`). Includes
    * external modules. */
   dynamicallyImportedIds: string[];
+  /** Plugin이 load hook의 `{ meta }`로 부여한 메타데이터 (Rollup `info.meta` 호환).
+   * plugin이 meta를 설정하지 않은 모듈은 빈 객체 `{}` (#1880 PR2). */
+  meta: Record<string, unknown>;
 }
 
 /** The second argument of the `manualChunks` callback — module graph topology lookup. */
@@ -1318,9 +1321,13 @@ export interface PluginBuild {
   ): void;
   onLoad(
     options: { filter: RegExp },
-    callback: (args: {
-      path: string;
-    }) => HookResult<{ contents: string | Uint8Array; loader?: string; map?: unknown }>,
+    callback: (args: { path: string }) => HookResult<{
+      contents: string | Uint8Array;
+      loader?: string;
+      map?: unknown;
+      /** Rollup `ModuleInfo.meta` 호환 — getModuleInfo(id).meta 로 노출 (#1880 PR2). */
+      meta?: Record<string, unknown>;
+    }>,
   ): void;
   onTransform(
     options: { filter: RegExp },
@@ -1659,6 +1666,7 @@ type PluginDispatcher = ((
   hookName: string,
   arg1: unknown,
   arg2: string | null,
+  getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
 ) => Promise<unknown>) &
   PluginDispatcherLifecycle;
 type SyncPluginDispatcher = ((hookName: string, arg1: unknown, arg2: string | null) => unknown) &
@@ -1832,12 +1840,20 @@ function lifecycleHookSpec(
  * 기존 driveDispatch* 의 normalizePluginFailure 경로를 그대로 탄다. resolve/emitFile 는 아직
  * placeholder(throw), getModuleInfo 는 surface 미추가 — 후속 PR(#1880 PR3~5)에서 채운다.
  */
-function getPluginContext(reg: PluginRegistry, pluginName: string): RollupPluginContext {
+function getPluginContext(
+  reg: PluginRegistry,
+  pluginName: string,
+  getModuleInfo?: ((id: string) => ManualChunksModuleInfo | null) | undefined,
+): RollupPluginContext {
   let ctx = reg.contexts.get(pluginName);
   if (!ctx) {
     ctx = createRollupPluginContext(pluginName, (d) => reg.pluginWarnings.push(d));
     reg.contexts.set(pluginName, ctx);
   }
+  // this.getModuleInfo (PR3): native 가 hook 별로 넘긴 graph-bound fn 을 매번 갱신(undefined 포함)
+  // — 캐시된 context 에 이전 hook 의 fn 이 stale 로 남지 않도록.
+  (ctx as { __getModuleInfo?: (id: string) => ManualChunksModuleInfo | null }).__getModuleInfo =
+    getModuleInfo;
   return ctx;
 }
 
@@ -1851,6 +1867,7 @@ function* dispatchHook(
   hookName: string,
   arg1: unknown,
   arg2: string | null,
+  getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
 ): Generator<HookCall, unknown, DispatchedHookResult> {
   // astFunction: arg1 이 JSON 직렬화된 FunctionInfo. 첫 매칭 plugin 의 non-null 반환을 채택.
   if (hookName === 'astFunction') {
@@ -1864,7 +1881,7 @@ function* dispatchHook(
     for (const h of reg.astFunctionHooks) {
       if (!h.filter.test(info.sourcePath)) continue;
       const result = yield {
-        callback: () => h.callback.call(getPluginContext(reg, h.pluginName), info),
+        callback: () => h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo), info),
         pluginName: h.pluginName,
         hookName: 'astFunction',
         fallbackFile: info.sourcePath,
@@ -1895,7 +1912,7 @@ function* dispatchHook(
     for (const h of reg.hooks.resolveContext) {
       if (!h.filter.test(args.dir)) continue;
       const result = yield {
-        callback: () => h.callback.call(getPluginContext(reg, h.pluginName), args),
+        callback: () => h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo), args),
         pluginName: h.pluginName,
         hookName: 'resolveContext',
         fallbackFile: args.importer,
@@ -1916,7 +1933,7 @@ function* dispatchHook(
       let firstFailure: PluginFailureResult | null = null;
       for (const { pluginName, callback } of spec.callbacks) {
         const result = yield {
-          callback: () => callback.call(getPluginContext(reg, pluginName), spec.arg),
+          callback: () => callback.call(getPluginContext(reg, pluginName, getModuleInfo), spec.arg),
           pluginName,
           hookName,
         };
@@ -1944,7 +1961,7 @@ function* dispatchHook(
           ? { code: currentCode, path: arg2 }
           : { code: currentCode, chunk: arg2 };
       const result = yield {
-        callback: () => h.callback.call(getPluginContext(reg, h.pluginName), cbArgs),
+        callback: () => h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo), cbArgs),
         pluginName: h.pluginName,
         hookName,
         fallbackFile: arg2,
@@ -1986,12 +2003,32 @@ function* dispatchHook(
     };
     if (isPluginFailureResult(result)) return result;
     if (result != null) {
-      if (hookName === 'load' && typeof result === 'object' && 'map' in (result as object)) {
-        const r = safeSerializeSourceMap((result as { map?: unknown }).map);
-        if (!r.ok) return normalizePluginFailure(h.pluginName, hookName, r.err, fallbackFile);
-        return { ...(result as object), ...(r.map != null ? { map: r.map } : { map: undefined }) };
+      // #1880 PR2: meta object → JSON string. native parseJsResult 가 string 으로 수신.
+      // meta 는 object 일 때만 직렬화(Rollup 호환 — primitive meta 무시) + circular/BigInt 등
+      // JSON.stringify throw 는 plugin failure 로 정규화 (safeSerializeSourceMap 과 동일 정책).
+      let withMeta: unknown = result;
+      const rawMeta =
+        typeof result === 'object' && result !== null
+          ? (result as { meta?: unknown }).meta
+          : undefined;
+      if (rawMeta != null && typeof rawMeta === 'object') {
+        let metaJson: string;
+        try {
+          metaJson = JSON.stringify(rawMeta);
+        } catch (err) {
+          return normalizePluginFailure(h.pluginName, hookName, err, fallbackFile);
+        }
+        withMeta = { ...(result as object), meta: metaJson };
       }
-      return result;
+      if (hookName === 'load' && typeof withMeta === 'object' && 'map' in (withMeta as object)) {
+        const r = safeSerializeSourceMap((withMeta as { map?: unknown }).map);
+        if (!r.ok) return normalizePluginFailure(h.pluginName, hookName, r.err, fallbackFile);
+        return {
+          ...(withMeta as object),
+          ...(r.map != null ? { map: r.map } : { map: undefined }),
+        };
+      }
+      return withMeta;
     }
   }
   return null;
@@ -2045,8 +2082,13 @@ function createPluginDispatcher(plugins: ZntcPlugin[]): PluginDispatcher {
   const reg = collectPluginRegistry(plugins);
   // 외부 async wrap 제거 — driveDispatchAsync 가 이미 Promise 반환. async 한 겹 더 씌우면
   // 매 호출마다 Promise 가 한 번 더 할당된다.
-  const dispatcher = function dispatcher(hookName: string, arg1: unknown, arg2: string | null) {
-    return driveDispatchAsync(dispatchHook(reg, hookName, arg1, arg2));
+  const dispatcher = function dispatcher(
+    hookName: string,
+    arg1: unknown,
+    arg2: string | null,
+    getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
+  ) {
+    return driveDispatchAsync(dispatchHook(reg, hookName, arg1, arg2, getModuleInfo));
   } as PluginDispatcher;
   dispatcher.takeLifecycleFailures = () => reg.lifecycleFailures.splice(0);
   dispatcher.takePluginWarnings = () => reg.pluginWarnings.splice(0);
@@ -2779,6 +2821,9 @@ export interface RollupPluginContext {
   ): Promise<{ id: string; external?: boolean } | null>;
   /** Emit an additional asset/chunk. Currently unsupported — throws an Error when called. */
   emitFile(file: unknown): string;
+  /** 모듈 그래프 정보(+plugin meta) 조회 (Rollup `this.getModuleInfo` 호환).
+   * async build() 의 transform hook 에서만 사용 가능 (#1880 PR3). 그 외 hook/buildSync 에선 throw. */
+  getModuleInfo(id: string): ManualChunksModuleInfo | null;
 }
 
 type ResolveIdResult = string | null | undefined | void | { id: string; external?: boolean };
@@ -2857,7 +2902,7 @@ function createRollupPluginContext(
   pluginName: string,
   onWarn?: (diagnostic: Diagnostic) => void,
 ): RollupPluginContext {
-  return {
+  const ctx: RollupPluginContext = {
     error(error: unknown): never {
       throw error;
     },
@@ -2885,7 +2930,19 @@ function createRollupPluginContext(
         `@zntc/core [${pluginName}]: this.emitFile() is not supported by vitePlugin() adapter yet.`,
       );
     },
+    getModuleInfo(id: string): ManualChunksModuleInfo | null {
+      // native 가 transform hook 에 한해 graph-bound fn 을 __getModuleInfo 슬롯에 주입 (#1880 PR3).
+      const fn = (ctx as { __getModuleInfo?: (id: string) => ManualChunksModuleInfo | null })
+        .__getModuleInfo;
+      if (typeof fn !== 'function') {
+        throw new Error(
+          `@zntc/core [${pluginName}]: this.getModuleInfo() 는 async build() 의 transform hook 에서만 사용 가능합니다 (#1880 PR3).`,
+        );
+      }
+      return fn(id);
+    },
   };
+  return ctx;
 }
 
 /** 동일 plugin 의 동일 sourcemap drop reason 은 한 번만 warn — vue/svelte SFC 처럼 모듈 N 개에서

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -55,6 +55,9 @@ pub const NapiPlugin = struct {
         /// onLoad/onTransform callback 의 source map JSON chain. JS dispatcher 가 object map 을
         /// JSON string 으로 정규화해서 전달한다 (#1902).
         source_maps: ?[]const []const u8 = null,
+        /// onLoad/onResolveId callback 의 `meta` (Rollup `ModuleInfo.meta`). JS dispatcher 가
+        /// object 를 JSON string 으로 정규화해 전달 (#1880 PR2). native_alloc 소유.
+        meta: ?[]const u8 = null,
         is_failure: bool = false,
         failure_plugin_name: ?[]const u8 = null,
         failure_hook_name: ?[]const u8 = null,
@@ -71,6 +74,9 @@ pub const NapiPlugin = struct {
         arg2: ?[]const u8,
         /// generateBundle 전용: OutputFile 배열 (callJsCallback에서 JS 배열로 변환)
         output_files: ?[]const bundler_mod.emitter.OutputFile = null,
+        /// this.getModuleInfo (PR3 self-only) 용 현재 Module 포인터. non-null 이면 callJsCallback 이
+        /// self-only getModuleInfo 함수를 dispatcher 4번째 인자로 전달 (graph 조회 없음 → race 없음).
+        current_module: ?*const anyopaque = null,
         response: ?PluginResponse = null,
         response_ready: bool = false,
         mutex: std.Thread.Mutex = .{},
@@ -121,6 +127,12 @@ pub const NapiPlugin = struct {
         } else if (getNamedProperty(env, js_result, "maps")) |maps_val| {
             resp.source_maps = parseStringArray(env, maps_val, native_alloc);
         }
+        // ModuleInfo.meta (#1880 PR2): JS dispatcher 가 object 를 JSON string 으로 정규화해 전달.
+        // 현재 load hook 결과만 module.plugin_meta 로 저장(runLoadForModule). 다른 hook 결과의 meta 는
+        // 추출돼도 소비처가 없어 freeResponseFields 로 해제됨 — resolveId/transform merge 는 follow-up.
+        if (getObjectString(env, js_result, "meta", native_alloc)) |meta_json| {
+            resp.meta = meta_json;
+        }
         // AST plugin 응답 파싱
         if (getObjectString(env, js_result, "stripDirective", native_alloc)) |sd| {
             resp.strip_directive = sd;
@@ -165,6 +177,7 @@ pub const NapiPlugin = struct {
             for (maps) |m| native_alloc.free(m);
             native_alloc.free(maps);
         }
+        if (resp.meta) |s| native_alloc.free(s);
         if (resp.failure_plugin_name) |s| native_alloc.free(s);
         if (resp.failure_hook_name) |s| native_alloc.free(s);
         if (resp.failure_message) |s| native_alloc.free(s);
@@ -218,6 +231,69 @@ pub const NapiPlugin = struct {
         return undef;
     }
 
+    /// this.getModuleInfo (PR3 self-only) 구현. data = 현재 transform 중인 Module 포인터.
+    /// id 가 self 모듈 path 와 일치할 때만 그 모듈의 id/code/meta 를 반환(아니면 null) — graph 를
+    /// 조회하지 않고 worker 가 load 단계에서 확정한 path/source/plugin_meta 만 읽으므로 race 없음.
+    /// importers/exports 등 graph/linker 의존 필드는 transform 시점 미완성이라 빈 값(self-only 한계).
+    fn selfModuleInfoCallback(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+        var js_null: c.napi_value = undefined;
+        _ = c.napi_get_null(env, &js_null);
+
+        var argc: usize = 1;
+        var argv: [1]c.napi_value = undefined;
+        var data: ?*anyopaque = null;
+        if (c.napi_get_cb_info(env, info, &argc, &argv, null, &data) != c.napi_ok) return js_null;
+        if (argc < 1) return js_null;
+
+        const id = getStringArg(env, argv[0], native_alloc) orelse return js_null;
+        defer native_alloc.free(id);
+
+        const module: *const bundler_mod.Module = @ptrCast(@alignCast(data orelse return js_null));
+        // self-only: 현재 transform 중인 모듈이 아니면 null.
+        if (!std.mem.eql(u8, id, module.path)) return js_null;
+
+        var js_obj: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &js_obj);
+
+        var js_id: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, module.path.ptr, module.path.len, &js_id);
+        _ = c.napi_set_named_property(env, js_obj, "id", js_id);
+
+        var js_code: c.napi_value = undefined;
+        if (module.source.len == 0 or
+            c.napi_create_string_utf8(env, module.source.ptr, module.source.len, &js_code) != c.napi_ok)
+        {
+            _ = c.napi_get_null(env, &js_code);
+        }
+        _ = c.napi_set_named_property(env, js_obj, "code", js_code);
+
+        var js_meta: c.napi_value = undefined;
+        if (module.plugin_meta) |meta_json| {
+            js_meta = NapiManualChunksResolver.parseJsonToObject(env, meta_json);
+        } else {
+            _ = c.napi_create_object(env, &js_meta);
+        }
+        _ = c.napi_set_named_property(env, js_obj, "meta", js_meta);
+
+        // graph/linker 의존 필드는 transform 시점 미완성 → 안전한 기본값.
+        var js_false: c.napi_value = undefined;
+        _ = c.napi_get_boolean(env, false, &js_false);
+        var js_true: c.napi_value = undefined;
+        _ = c.napi_get_boolean(env, true, &js_true);
+        _ = c.napi_set_named_property(env, js_obj, "isEntry", js_false);
+        _ = c.napi_set_named_property(env, js_obj, "isExternal", js_false);
+        _ = c.napi_set_named_property(env, js_obj, "hasModuleSideEffects", js_true);
+        _ = c.napi_set_named_property(env, js_obj, "isIncluded", js_false);
+        _ = c.napi_set_named_property(env, js_obj, "syntheticNamedExports", js_false);
+        inline for (.{ "exports", "importers", "dynamicImporters", "importedIds", "dynamicallyImportedIds", "implicitlyLoadedAfterOneOf", "implicitlyLoadedBefore" }) |field| {
+            var arr: c.napi_value = undefined;
+            _ = c.napi_create_array(env, &arr);
+            _ = c.napi_set_named_property(env, js_obj, field, arr);
+        }
+
+        return js_obj;
+    }
+
     /// threadsafe function의 call_js 콜백 (메인 스레드에서 실행)
     /// data = CallContext 포인터 (per-call, 워커 스레드가 스택에 소유하며 condvar 대기 중)
     pub fn callJsCallback(env: c.napi_env, js_callback: c.napi_value, _: ?*anyopaque, data: ?*anyopaque) callconv(.c) void {
@@ -253,11 +329,21 @@ pub const NapiPlugin = struct {
             _ = c.napi_get_null(env, &js_arg2);
         }
 
-        var js_result: c.napi_value = undefined;
-        const args = [_]c.napi_value{ hook_str, js_arg1, js_arg2 };
         var js_undefined: c.napi_value = undefined;
         _ = c.napi_get_undefined(env, &js_undefined);
-        if (c.napi_call_function(env, js_undefined, js_callback, 3, &args, &js_result) != c.napi_ok) {
+
+        // this.getModuleInfo (PR3 self-only): current_module 이 있으면 self-only getModuleInfo 를
+        // dispatcher 4번째 인자로 전달. graph 조회 없음 → discovery 병렬 단계 race 없음.
+        var js_get_mod_info: c.napi_value = js_undefined;
+        var argc: usize = 3;
+        if (ctx.current_module) |m| {
+            _ = c.napi_create_function(env, "getModuleInfo", "getModuleInfo".len, selfModuleInfoCallback, @constCast(m), &js_get_mod_info);
+            argc = 4;
+        }
+
+        var js_result: c.napi_value = undefined;
+        const args = [_]c.napi_value{ hook_str, js_arg1, js_arg2, js_get_mod_info };
+        if (c.napi_call_function(env, js_undefined, js_callback, argc, &args, &js_result) != c.napi_ok) {
             signalResponse(ctx, .{});
             return;
         }
@@ -295,12 +381,13 @@ pub const NapiPlugin = struct {
 
     /// 워커 스레드에서 호출 — JS 콜백 실행 후 결과 대기.
     /// per-call CallContext를 스택에 생성하여 멀티스레드 안전.
-    fn callHookFull(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8, files: ?[]const bundler_mod.emitter.OutputFile) ?PluginResponse {
+    fn callHookFull(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8, files: ?[]const bundler_mod.emitter.OutputFile, current_module: ?*const anyopaque) ?PluginResponse {
         var ctx = CallContext{
             .hook = hook,
             .arg1 = arg1,
             .arg2 = arg2,
             .output_files = files,
+            .current_module = current_module,
         };
 
         if (c.napi_call_threadsafe_function(self.tsfn, @ptrCast(&ctx), c.napi_tsfn_blocking) != c.napi_ok) {
@@ -319,7 +406,7 @@ pub const NapiPlugin = struct {
     }
 
     fn callHook(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8) ?PluginResponse {
-        return self.callHookFull(hook, arg1, arg2, null);
+        return self.callHookFull(hook, arg1, arg2, null, null);
     }
 
     /// JSON string field 인코딩 — `"` `\` 와 control char escape.
@@ -395,7 +482,8 @@ fn NapiPluginAdapter(comptime Self: type) type {
             alloc: std.mem.Allocator,
             hook_ctx: *plugin_mod.HookContext,
         ) PluginError!?[]const u8 {
-            const resp = self.callHook(hook, arg1, arg2) orelse return null;
+            // this.getModuleInfo (PR3 self-only): transform/renderChunk 에 hook_ctx.current_module 전달.
+            const resp = self.callHookFull(hook, arg1, arg2, null, hook_ctx.current_module) orelse return null;
             defer NapiPlugin.freeResponseFields(resp);
             if (resp.is_failure) return failWithResponse(self, resp, alloc, hook_ctx);
             if (resp.code) |result_code| {
@@ -461,7 +549,9 @@ fn NapiPluginAdapter(comptime Self: type) type {
             const result_code = resp.code orelse return null;
             const contents = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
             try NapiPlugin.setResponseSourceMaps(resp, alloc, hook_ctx);
-            return .{ .contents = contents, .loader = resp.loader_override, .module_type = resp.loader_module_type };
+            // resp.meta 는 native_alloc 소유(freeResponseFields 가 해제) → caller(parse_arena) 로 dupe (#1880 PR2).
+            const meta_dup: ?[]const u8 = if (resp.meta) |m| (alloc.dupe(u8, m) catch return error.OutOfMemory) else null;
+            return .{ .contents = contents, .loader = resp.loader_override, .module_type = resp.loader_module_type, .meta = meta_dup };
         }
 
         fn pluginTransform(
@@ -488,7 +578,7 @@ fn NapiPluginAdapter(comptime Self: type) type {
 
         fn pluginGenerateBundle(ctx: ?*anyopaque, output_files: []const bundler_mod.emitter.OutputFile) void {
             const self: *Self = @ptrCast(@alignCast(ctx.?));
-            if (self.callHookFull(.generateBundle, "", null, output_files)) |resp| {
+            if (self.callHookFull(.generateBundle, "", null, output_files, null)) |resp| {
                 NapiPlugin.freeResponseFields(resp);
             }
         }
@@ -547,7 +637,7 @@ fn NapiPluginAdapter(comptime Self: type) type {
             NapiPlugin.appendJsonString(&json_buf, native_alloc, importer) catch return null;
             json_buf.append(native_alloc, '}') catch return null;
 
-            const resp = self.callHookFull(.resolveContext, json_buf.items, null, null) orelse return null;
+            const resp = self.callHookFull(.resolveContext, json_buf.items, null, null, null) orelse return null;
             defer NapiPlugin.freeResponseFields(resp);
             if (resp.is_failure) return failWithResponse(self, resp, alloc, hook_ctx);
 
@@ -655,7 +745,10 @@ pub const NapiSyncPlugin = struct {
         arg1: []const u8,
         arg2: ?[]const u8,
         files: ?[]const bundler_mod.emitter.OutputFile,
+        current_module: ?*const anyopaque,
     ) ?NapiPlugin.PluginResponse {
+        // buildSync 는 this.getModuleInfo 미지원 (current_module 무시) — async build() 만 PR3 지원.
+        _ = current_module;
         var js_callback: c.napi_value = undefined;
         if (c.napi_get_reference_value(self.env, self.callback_ref, &js_callback) != c.napi_ok) {
             return null;
@@ -712,7 +805,7 @@ pub const NapiSyncPlugin = struct {
     }
 
     fn callHook(self: *NapiSyncPlugin, hook: NapiPlugin.HookType, arg1: []const u8, arg2: ?[]const u8) ?NapiPlugin.PluginResponse {
-        return self.callHookFull(hook, arg1, arg2, null);
+        return self.callHookFull(hook, arg1, arg2, null, null);
     }
 
     pub fn toPlugin(self: *NapiSyncPlugin) Plugin {
@@ -760,6 +853,31 @@ pub const NapiManualChunksResolver = struct {
             write_idx += 1;
         }
         return js_arr;
+    }
+
+    /// JSON 문자열 → JS object (global `JSON.parse`). 실패/예외 시 빈 객체 `{}` 반환.
+    /// plugin meta(JSON string)를 ModuleInfo.meta JS object 로 복원할 때 사용 (#1880 PR2).
+    fn parseJsonToObject(env: c.napi_env, json: []const u8) c.napi_value {
+        var empty_obj: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &empty_obj);
+        var global: c.napi_value = undefined;
+        if (c.napi_get_global(env, &global) != c.napi_ok) return empty_obj;
+        const json_ns = getNamedProperty(env, global, "JSON") orelse return empty_obj;
+        const parse_fn = getNamedProperty(env, json_ns, "parse") orelse return empty_obj;
+        var js_str: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, json.ptr, json.len, &js_str);
+        var result: c.napi_value = undefined;
+        const args = [_]c.napi_value{js_str};
+        if (c.napi_call_function(env, json_ns, parse_fn, 1, &args, &result) != c.napi_ok) {
+            var pending: bool = false;
+            _ = c.napi_is_exception_pending(env, &pending);
+            if (pending) {
+                var e: c.napi_value = undefined;
+                _ = c.napi_get_and_clear_last_exception(env, &e);
+            }
+            return empty_obj;
+        }
+        return result;
     }
 
     /// JS `meta.getModuleInfo(id)` 구현. napi function 의 data 슬롯에 graph 포인터를
@@ -834,6 +952,15 @@ pub const NapiManualChunksResolver = struct {
         _ = c.napi_set_named_property(env, js_obj, "dynamicImporters", pathArrayFromIndices(env, graph, mod_info.dynamic_importers));
         _ = c.napi_set_named_property(env, js_obj, "importedIds", pathArrayFromIndices(env, graph, mod_info.imported_ids));
         _ = c.napi_set_named_property(env, js_obj, "dynamicallyImportedIds", pathArrayFromIndices(env, graph, mod_info.dynamically_imported_ids));
+
+        // ModuleInfo.meta (#1880 PR2): plugin 이 부여한 JSON 을 object 로 복원. 미설정 시 빈 객체 {}.
+        var js_meta: c.napi_value = undefined;
+        if (mod_info.meta) |meta_json| {
+            js_meta = parseJsonToObject(env, meta_json);
+        } else {
+            _ = c.napi_create_object(env, &js_meta);
+        }
+        _ = c.napi_set_named_property(env, js_obj, "meta", js_meta);
 
         return js_obj;
     }

--- a/packages/core/test/core/build-plugins.ts
+++ b/packages/core/test/core/build-plugins.ts
@@ -1,5 +1,6 @@
 import './build-plugins/basic-hooks';
 import './build-plugins/plugin-context';
+import './build-plugins/module-meta';
 import './build-plugins/transform-tree-shaking';
 import './build-plugins/resolve-context';
 import './build-plugins/build-sync';

--- a/packages/core/test/core/build-plugins/module-meta.ts
+++ b/packages/core/test/core/build-plugins/module-meta.ts
@@ -1,0 +1,212 @@
+import {
+  build,
+  describe,
+  expect,
+  join,
+  mkdtempSync,
+  rmSync,
+  test,
+  tmpdir,
+  writeFileSync,
+} from './helpers';
+import type { ZntcPlugin } from './helpers';
+import type { RollupPluginContext } from '../../../index';
+
+// #1880 PR2+PR3 — ModuleInfo.meta store(PR2) + this.getModuleInfo(PR3, self-only).
+// PR3 는 self-module(현재 transform 중인 모듈)만 노출한다. graph 조회를 하지 않으므로
+// discovery 병렬 단계의 race 가 원천 제거된다. cross-module 조회는 null
+// (transform 시점 다른 모듈은 graph 미완성이라 어차피 무의미). 완전한 graph 조회는
+// manualChunks(splitting, frozen) getModuleInfo 영역.
+describe('@zntc/core build + plugins - ModuleInfo.meta / this.getModuleInfo (self-only)', () => {
+  // PR2 write + PR3 read: load 가 set 한 meta 를 transform 의 this.getModuleInfo(self).meta 로 본다.
+  test('load hook 의 meta 가 transform 의 this.getModuleInfo(self).meta 로 노출된다', async () => {
+    let metaInTransform: Record<string, unknown> | null = null;
+    const plugin: ZntcPlugin = {
+      name: 'meta-roundtrip',
+      setup(build) {
+        build.onLoad({ filter: /main\.ts$/ }, () => ({
+          contents: 'export const x = 1;\n',
+          meta: { framework: 'vue', score: 7 },
+        }));
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          function (this: RollupPluginContext, args: { code: string; path: string }) {
+            const info = this.getModuleInfo(args.path);
+            if (info && info.meta) metaInTransform = info.meta as Record<string, unknown>;
+            return null;
+          },
+        );
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-meta-gmi-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(metaInTransform).toEqual({ framework: 'vue', score: 7 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // PR3: meta 미설정 모듈의 this.getModuleInfo(self).meta 는 빈 객체 (Rollup 호환).
+  test('meta 미설정 모듈의 this.getModuleInfo(self).meta 는 빈 객체', async () => {
+    let metaSeen: unknown = 'unset';
+    const plugin: ZntcPlugin = {
+      name: 'meta-empty',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          function (this: RollupPluginContext, args: { code: string; path: string }) {
+            const info = this.getModuleInfo(args.path);
+            if (info) metaSeen = info.meta;
+            return null;
+          },
+        );
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-meta-empty-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(metaSeen).toEqual({});
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // PR3 self-only: 현재 모듈(self)은 id/code 를 노출한다.
+  test('this.getModuleInfo(self) 가 id/code 를 노출한다', async () => {
+    let info: { id?: string; code?: string | null } | null = null;
+    const plugin: ZntcPlugin = {
+      name: 'self-info',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          function (this: RollupPluginContext, args: { code: string; path: string }) {
+            info = this.getModuleInfo(args.path) as { id: string; code: string | null };
+            return null;
+          },
+        );
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-meta-self-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(info).not.toBeNull();
+      expect(info!.id).toContain('main.ts');
+      expect(typeof info!.code).toBe('string');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // #2 가드: circular/직렬화 불가 meta 는 plugin failure 로 정규화 (dispatch 크래시 방지).
+  test('circular meta 는 plugin failure 로 정규화된다', async () => {
+    const plugin: ZntcPlugin = {
+      name: 'circ-meta',
+      setup(build) {
+        build.onLoad({ filter: /main\.ts$/ }, () => {
+          const m: Record<string, unknown> = {};
+          m.self = m; // 순환 참조 → JSON.stringify throw
+          return { contents: 'export const x = 1;\n', meta: m };
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-meta-circ-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      // 크래시 없이 plugin failure 로 result.errors 에 담겨야 한다.
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // nested object / array / null 값 meta 의 round-trip.
+  test('nested/array/null 값 meta 가 round-trip 된다', async () => {
+    let seen: Record<string, unknown> | null = null;
+    const nested = { a: { b: [1, 2, 3] }, n: null, s: 'x' };
+    const plugin: ZntcPlugin = {
+      name: 'nested-meta',
+      setup(build) {
+        build.onLoad({ filter: /main\.ts$/ }, () => ({
+          contents: 'export const x = 1;\n',
+          meta: nested,
+        }));
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          function (this: RollupPluginContext, args: { code: string; path: string }) {
+            const info = this.getModuleInfo(args.path);
+            if (info && info.meta) seen = info.meta as Record<string, unknown>;
+            return null;
+          },
+        );
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-meta-nested-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(seen).toEqual(nested);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // PR3 self-only: cross-module(다른 모듈 id) 조회는 null — graph 조회를 하지 않으므로 race 없음.
+  test('this.getModuleInfo(다른 모듈 id) 는 null (self-only)', async () => {
+    let crossResult: unknown = 'unset';
+    const plugin: ZntcPlugin = {
+      name: 'cross-null',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          function (this: RollupPluginContext, args: { code: string; path: string }) {
+            // 자기 자신이 아닌 임의 id → self-only 이므로 null
+            crossResult = this.getModuleInfo(args.path + '.other-nonexistent');
+            return null;
+          },
+        );
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-meta-cross-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(crossResult).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/bundler/graph/plugins.zig
+++ b/src/bundler/graph/plugins.zig
@@ -125,6 +125,10 @@ pub fn runLoadForModule(self: anytype, module: *Module, runner: ?plugin_mod.Plug
             module.plugin_source_maps = load_source_maps;
         }
 
+        // plugin 이 부여한 meta (JSON 문자열) 를 모듈에 귀속 (#1880 PR2).
+        // plugin_result.meta 는 pluginLoad 가 parse_arena(tmp_arena) 로 dupe 했으므로 그대로 borrow.
+        if (plugin_result.meta) |m| module.plugin_meta = m;
+
         if (plugin_result.loader) |loader_override| {
             module.loader = loader_override;
             module.module_type = plugin_result.module_type orelse
@@ -176,7 +180,10 @@ pub fn runTransformForModule(
     const plugin_runner = runner orelse return .skipped;
     if (!self.has_transform_plugins) return .skipped;
 
-    var hook_ctx: plugin_mod.HookContext = .{};
+    // this.getModuleInfo (PR3 self-only): graph 대신 현재 모듈 포인터만 전달.
+    // graph 조회를 하지 않으므로 discovery 병렬 단계의 race 가 없다. self 모듈의 path/source/
+    // plugin_meta 는 worker 가 load 단계에서 이미 확정해 안전하게 읽을 수 있다.
+    var hook_ctx: plugin_mod.HookContext = .{ .current_module = @ptrCast(module) };
     const transform_result = plugin_runner.runTransform(module.source, module.path, arena_alloc, &hook_ctx) catch |err| switch (err) {
         error.PluginFailed => {
             graph_diagnostics.addPluginFailureDiag(self, hook_ctx.failure, module.path, Span.EMPTY, .transform);

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -151,6 +151,11 @@ pub const Module = struct {
     /// JS plugin load/transform 이 반환한 Source Map V3 JSON chain.
     /// 순서는 transform 실행 순서이며 parse_arena 가 backing 을 소유한다.
     plugin_source_maps: []const []const u8 = &.{},
+    /// JS plugin 이 load hook 의 `{ meta }` 로 부여한 모듈 메타데이터 (JSON 문자열).
+    /// Rollup `ModuleInfo.meta` 호환. `getModuleInfo`(manualChunks / this.getModuleInfo)로 노출.
+    /// (resolveId/transform meta merge 는 follow-up — 현재 load hook 만.)
+    /// null = plugin 이 meta 미설정. parse_arena 가 backing 을 소유 (#1880 PR2).
+    plugin_meta: ?[]const u8 = null,
     /// 파싱된 AST. nodes/extra_data/string_table 의 backing 은 `parse_arena` 가 소유.
     ///
     /// ### Ownership 규약 (D1 디버그 인프라 — RFC #1672)

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -25,6 +25,8 @@ pub const LoadResult = struct {
     contents: []const u8,
     loader: ?types.Loader = null,
     module_type: ?types.ModuleType = null,
+    /// plugin 이 반환한 `{ meta }` (JSON 문자열). null = 미설정. caller(parse_arena) 소유 (#1880 PR2).
+    meta: ?[]const u8 = null,
 };
 
 /// 플러그인 훅에서 반환할 수 있는 에러 타입.
@@ -113,6 +115,12 @@ pub const HookContext = struct {
     /// `load` / `transform` 이 반환한 source map JSON chain.
     /// 다른 hook 은 사용 안 함. caller 가 free 책임.
     source_maps: ?[]const []const u8 = null,
+    /// `this.getModuleInfo` (PR3, self-only) 용 현재 transform 중인 Module 포인터.
+    /// graph 를 조회하지 않고 이 모듈 자신의 정보(id/code/meta)만 노출한다 — discovery 병렬
+    /// 단계에서 graph 는 main thread 가 mutate 중이므로 worker 가 graph 를 읽으면 race.
+    /// self 모듈은 worker 가 load 단계에서 확정(path/source/plugin_meta)했으므로 안전.
+    /// transform hook 에서만 set. null = getModuleInfo 미지원 hook (#1880 PR3).
+    current_module: ?*const anyopaque = null,
 
     /// 사용 안 하는 failure metadata 를 일괄 정리. 이미 consume 된 경우 no-op.
     /// swallow 경로 (lifecycle hook, fallback null path 등) 에서 `defer ctx.deinit()` 으로 사용.
@@ -394,7 +402,8 @@ pub const PluginRunner = struct {
                 // 각 plugin 별 fresh inner_ctx — source_maps 는 chain 에서 누적, failure 는
                 // 첫 실패 시 outer 로 옮긴다. plugin hook 이 failure 를 read 하는 contract 는
                 // 없으므로 hook_ctx.failure 시드 불필요.
-                var inner_ctx: HookContext = .{};
+                // current_module 은 this.getModuleInfo (PR3 self-only) 용으로 전파.
+                var inner_ctx: HookContext = .{ .current_module = hook_ctx.current_module };
                 const result = hook(p.context, input, id, allocator, &inner_ctx) catch |err| {
                     hook_ctx.failure = inner_ctx.failure;
                     return err;

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -193,6 +193,9 @@ pub const ModuleInfo = struct {
     implicitly_loaded_after_one_of: []const ModuleIndex,
     /// 위와 반대 방향 — 이 모듈을 implicitly 로드 후에 로드돼야 하는 모듈들.
     implicitly_loaded_before: []const ModuleIndex,
+    /// plugin 이 load hook 에서 부여한 meta (JSON 문자열, Rollup `meta` 호환).
+    /// null = 미설정 → JS 측에서 빈 객체 `{}` 로 노출 (#1880 PR2).
+    meta: ?[]const u8,
 };
 
 /// `id` 로 모듈 메타를 조회. 없으면 null. Zero allocation — 모든 slice 가 graph borrow.
@@ -217,6 +220,7 @@ pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInf
         .synthetic_named_exports = false,
         .implicitly_loaded_after_one_of = &.{},
         .implicitly_loaded_before = &.{},
+        .meta = m.plugin_meta,
     };
 }
 


### PR DESCRIPTION
## 배경

#1880 epic PR2(ModuleInfo.meta store) + PR3(this.getModuleInfo). PR1(this.warn/error)에 이어 plugin context API 확장.

## PR2 — meta store/read

plugin 이 `load` hook 에서 `{ meta }` 반환 → JS dispatcher 가 JSON string 으로 정규화 → NAPI → `Module.plugin_meta`(parse_arena) 저장 → `getModuleInfo` 가 `JSON.parse` 로 복원(미설정 시 `{}`).

- write: `module.zig`(plugin_meta) / `plugin.zig`(LoadResult.meta) / `graph/plugins.zig`
- read: `types.zig`(ModuleInfo.meta) / `plugin_bridge.zig` getModuleInfoCallback(manualChunks) + `index.ts` ManualChunksModuleInfo.meta

## PR3 — this.getModuleInfo (self-only)

transform hook 에서 현재 모듈 정보 조회. **max-effort code-review 가 graph race 를 발견** — transform 은 discovery 병렬 단계라 worker 가 graph 를 read 하면 main 의 `addModule`(HashMap/ArrayList mutation)과 충돌(torn read/UAF). 

→ **self-only 재설계로 race 원천 제거**:
- graph pointer 대신 **현재 Module pointer** 만 transform hook 에 전달
- `selfModuleInfoCallback` 이 self 모듈의 `id`/`code`/`meta`(worker 가 load 에서 확정한 path/source/plugin_meta)만 직접 read — **graph 미조회** → ZTS 의 "worker 는 graph 안 건드림" 불변식 유지
- cross-module(다른 id) 조회는 `null` (transform 시점 graph 미완성이라 어차피 무의미)
- 완전한 graph 조회는 frozen 단계인 manualChunks getModuleInfo 영역

검증: self-module getModuleInfo 폭격(120모듈 × 200회 × 50run = **1.2M read, crash 0**), cross-module 폭격 전부 null.

## code-review fix 동봉

- `JSON.stringify(meta)` circular/BigInt throw → plugin failure 정규화 (기존 `safeSerializeSourceMap` 과 동일 정책 — dispatch 크래시 방지)
- meta 는 object 일 때만 직렬화 (primitive meta 무시, Rollup 호환)
- resolveId/transform meta 는 현재 미저장 → 주석 정정 (load only, merge 는 follow-up)

## 테스트 (TDD)

`module-meta.ts` 6개: self meta roundtrip / 빈 객체 / self id·code / cross null / **circular 가드** / **nested·null roundtrip**. build-plugins 전체 **30 pass 회귀 0**, tsc 통과.

## 한계 (follow-up)

- buildSync 는 this.getModuleInfo 미지원 (async build 만)
- transform 시점 self info 의 graph 의존 필드(isEntry/exports/importers 등)는 미완성이라 빈 값 (Rollup 도 transform 시점 graph 는 incomplete)
- resolveId/transform meta merge

Refs #1880