### PR TITLE
feat(plugin): this.resolve plugin context (#1880 PR4)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1667,6 +1667,7 @@ type PluginDispatcher = ((
   arg1: unknown,
   arg2: string | null,
   getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
+  resolve?: NativeResolveFn,
 ) => Promise<unknown>) &
   PluginDispatcherLifecycle;
 type SyncPluginDispatcher = ((hookName: string, arg1: unknown, arg2: string | null) => unknown) &
@@ -1840,20 +1841,31 @@ function lifecycleHookSpec(
  * 기존 driveDispatch* 의 normalizePluginFailure 경로를 그대로 탄다. resolve/emitFile 는 아직
  * placeholder(throw), getModuleInfo 는 surface 미추가 — 후속 PR(#1880 PR3~5)에서 채운다.
  */
+type NativeResolveFn = (
+  source: string,
+  importer?: string | null,
+  options?: unknown,
+) => { id: string; external: boolean } | null;
+
 function getPluginContext(
   reg: PluginRegistry,
   pluginName: string,
   getModuleInfo?: ((id: string) => ManualChunksModuleInfo | null) | undefined,
+  resolve?: NativeResolveFn | undefined,
 ): RollupPluginContext {
   let ctx = reg.contexts.get(pluginName);
   if (!ctx) {
     ctx = createRollupPluginContext(pluginName, (d) => reg.pluginWarnings.push(d));
     reg.contexts.set(pluginName, ctx);
   }
-  // this.getModuleInfo (PR3): native 가 hook 별로 넘긴 graph-bound fn 을 매번 갱신(undefined 포함)
-  // — 캐시된 context 에 이전 hook 의 fn 이 stale 로 남지 않도록.
-  (ctx as { __getModuleInfo?: (id: string) => ManualChunksModuleInfo | null }).__getModuleInfo =
-    getModuleInfo;
+  // this.getModuleInfo (PR3) / this.resolve (PR4): native 가 hook 별로 넘긴 fn 을 매번 갱신
+  // (undefined 포함) — 캐시된 context 에 이전 hook 의 fn 이 stale 로 남지 않도록.
+  const slot = ctx as {
+    __getModuleInfo?: (id: string) => ManualChunksModuleInfo | null;
+    __resolve?: NativeResolveFn;
+  };
+  slot.__getModuleInfo = getModuleInfo;
+  slot.__resolve = resolve;
   return ctx;
 }
 
@@ -1868,6 +1880,7 @@ function* dispatchHook(
   arg1: unknown,
   arg2: string | null,
   getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
+  resolve?: NativeResolveFn,
 ): Generator<HookCall, unknown, DispatchedHookResult> {
   // astFunction: arg1 이 JSON 직렬화된 FunctionInfo. 첫 매칭 plugin 의 non-null 반환을 채택.
   if (hookName === 'astFunction') {
@@ -1881,7 +1894,8 @@ function* dispatchHook(
     for (const h of reg.astFunctionHooks) {
       if (!h.filter.test(info.sourcePath)) continue;
       const result = yield {
-        callback: () => h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo), info),
+        callback: () =>
+          h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo, resolve), info),
         pluginName: h.pluginName,
         hookName: 'astFunction',
         fallbackFile: info.sourcePath,
@@ -1912,7 +1926,8 @@ function* dispatchHook(
     for (const h of reg.hooks.resolveContext) {
       if (!h.filter.test(args.dir)) continue;
       const result = yield {
-        callback: () => h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo), args),
+        callback: () =>
+          h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo, resolve), args),
         pluginName: h.pluginName,
         hookName: 'resolveContext',
         fallbackFile: args.importer,
@@ -1933,7 +1948,8 @@ function* dispatchHook(
       let firstFailure: PluginFailureResult | null = null;
       for (const { pluginName, callback } of spec.callbacks) {
         const result = yield {
-          callback: () => callback.call(getPluginContext(reg, pluginName, getModuleInfo), spec.arg),
+          callback: () =>
+            callback.call(getPluginContext(reg, pluginName, getModuleInfo, resolve), spec.arg),
           pluginName,
           hookName,
         };
@@ -1961,7 +1977,8 @@ function* dispatchHook(
           ? { code: currentCode, path: arg2 }
           : { code: currentCode, chunk: arg2 };
       const result = yield {
-        callback: () => h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo), cbArgs),
+        callback: () =>
+          h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo, resolve), cbArgs),
         pluginName: h.pluginName,
         hookName,
         fallbackFile: arg2,
@@ -1996,7 +2013,8 @@ function* dispatchHook(
     if (!h.filter.test(filterTarget)) continue;
     const fallbackFile = hookName === 'resolveId' ? arg2 : filterTarget;
     const result = yield {
-      callback: () => h.callback.call(getPluginContext(reg, h.pluginName), cbArgs),
+      callback: () =>
+        h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo, resolve), cbArgs),
       pluginName: h.pluginName,
       hookName,
       fallbackFile,
@@ -2087,8 +2105,9 @@ function createPluginDispatcher(plugins: ZntcPlugin[]): PluginDispatcher {
     arg1: unknown,
     arg2: string | null,
     getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
+    resolve?: NativeResolveFn,
   ) {
-    return driveDispatchAsync(dispatchHook(reg, hookName, arg1, arg2, getModuleInfo));
+    return driveDispatchAsync(dispatchHook(reg, hookName, arg1, arg2, getModuleInfo, resolve));
   } as PluginDispatcher;
   dispatcher.takeLifecycleFailures = () => reg.lifecycleFailures.splice(0);
   dispatcher.takePluginWarnings = () => reg.pluginWarnings.splice(0);
@@ -2917,13 +2936,17 @@ function createRollupPluginContext(
       // SFC 의 `<style src="./x.css">` 같은 *외부* 파일 변경은 stale 캐시 가능 — 회귀 시 별도
       // surface 필요.
     },
-    resolve(_source, _importer, _options): Promise<never> {
-      // tsc 가 `Promise<never>` declared return 에서 sync `this.error(...)` (never) 만 있을 때
-      // reachable end point 검사를 통과시키지 못해 직접 throw 로 시그니처와 일치시킨다.
-      throw new Error(
-        `@zntc/core [${pluginName}]: this.resolve() is not supported by vitePlugin() adapter yet ` +
-          `(graph mutation surface missing). Use alias config or another plugin's resolveId hook.`,
-      );
+    resolve(source, importer, _options): Promise<{ id: string; external?: boolean } | null> {
+      // native resolver(순수 path resolution) 가 hook 별로 __resolve 슬롯에 주입됨 (#1880 PR4).
+      // sync native fn 을 Promise 로 감싸 Rollup async 시그니처에 맞춘다. skipSelf 는 native-only
+      // scope 에서 자명 충족(native resolver 는 plugin resolveId 를 타지 않음).
+      const fn = (ctx as { __resolve?: NativeResolveFn }).__resolve;
+      if (typeof fn !== 'function') {
+        throw new Error(
+          `@zntc/core [${pluginName}]: this.resolve() 는 async build() 의 resolveId/load/transform hook 에서만 사용 가능합니다 (#1880 PR4).`,
+        );
+      }
+      return Promise.resolve(fn(source, importer));
     },
     emitFile(_file): never {
       throw new Error(

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -2832,7 +2832,10 @@ export interface RollupPluginContext {
   warn(message: unknown): void;
   /** Register an additional file to watch in watch mode. Currently a no-op (graph mutation not supported). */
   addWatchFile(id: string): void;
-  /** Module resolve. Currently unsupported — throws an Error when called to notify the plugin author. */
+  /** Module resolve (Rollup `this.resolve` 호환, #1880 PR4). async build() 의 resolveId/load/transform
+   * hook 에서 native resolver(순수 path resolution)로 해석 → `{ id, external }` 또는 null(미해결).
+   * `options`(skipSelf 등)는 현재 no-op (native resolver 가 plugin 을 재진입하지 않아 skipSelf 자명 충족).
+   * 그 외 hook / buildSync / vitePlugin() 어댑터에서는 throw. */
   resolve(
     source: string,
     importer?: string | null,

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -320,6 +320,22 @@ pub const NapiPlugin = struct {
         const source_dir: []const u8 = if (importer) |imp| (std.fs.path.dirname(imp) orelse ".") else ".";
 
         const resolve_cache: *ResolveCache = @ptrCast(@alignCast(data orelse return js_null));
+
+        // external 패턴 매칭 specifier(node builtins / --packages=external / external 설정)는
+        // resolveThreadSafe 가 null 을 반환하므로, 먼저 판정해 `{ id: source, external: true }` 로
+        // 노출한다 (Rollup 호환 — plugin 이 external 여부로 분기). #1880 PR4.
+        if (resolve_cache.isExternal(source)) {
+            var js_ext_obj: c.napi_value = undefined;
+            _ = c.napi_create_object(env, &js_ext_obj);
+            var js_ext_id: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, source.ptr, source.len, &js_ext_id);
+            _ = c.napi_set_named_property(env, js_ext_obj, "id", js_ext_id);
+            var js_ext_true: c.napi_value = undefined;
+            _ = c.napi_get_boolean(env, true, &js_ext_true);
+            _ = c.napi_set_named_property(env, js_ext_obj, "external", js_ext_true);
+            return js_ext_obj;
+        }
+
         const resolved = (resolve_cache.resolveThreadSafe(source_dir, source, .static_import) catch return js_null) orelse return js_null;
         // resolveThreadSafe 는 path(+file.resolve_dir)를 self.allocator 로 dupe → caller free 책임.
         defer switch (resolved) {

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -23,6 +23,7 @@ const parseStringArray = common.parseStringArray;
 // 메인 스레드: JS 콜백 실행 → 결과 저장 → condvar 시그널
 
 const plugin_mod = bundler_mod.plugin;
+const ResolveCache = bundler_mod.ResolveCache;
 const graph_plugins_mod = bundler_mod.graph_plugins;
 const Plugin = plugin_mod.Plugin;
 const PluginError = plugin_mod.PluginError;
@@ -77,6 +78,9 @@ pub const NapiPlugin = struct {
         /// this.getModuleInfo (PR3 self-only) 용 현재 Module 포인터. non-null 이면 callJsCallback 이
         /// self-only getModuleInfo 함수를 dispatcher 4번째 인자로 전달 (graph 조회 없음 → race 없음).
         current_module: ?*const anyopaque = null,
+        /// this.resolve (PR4) 용 ResolveCache 포인터. non-null 이면 resolve 함수를 dispatcher
+        /// 5번째 인자로 전달 (순수 path resolution, plugin 재진입 없음 → race/deadlock 없음).
+        resolve_cache: ?*anyopaque = null,
         response: ?PluginResponse = null,
         response_ready: bool = false,
         mutex: std.Thread.Mutex = .{},
@@ -294,6 +298,63 @@ pub const NapiPlugin = struct {
         return js_obj;
     }
 
+    /// this.resolve (PR4) 구현. data = *ResolveCache. argv[0]=source, argv[1]=importer?, argv[2]=opts?.
+    /// native resolver(순수 path resolution, sharded-mutex thread-safe, plugin 재진입 없음)만 호출
+    /// → `{ id, external }` 또는 null(미해결). graph 미접근 + sync 실행이라 race/deadlock 없음.
+    fn resolveIdCallback(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+        var js_null: c.napi_value = undefined;
+        _ = c.napi_get_null(env, &js_null);
+
+        var argc: usize = 3;
+        var argv: [3]c.napi_value = undefined;
+        var data: ?*anyopaque = null;
+        if (c.napi_get_cb_info(env, info, &argc, &argv, null, &data) != c.napi_ok) return js_null;
+        if (argc < 1) return js_null;
+
+        const source = getStringArg(env, argv[0], native_alloc) orelse return js_null;
+        defer native_alloc.free(source);
+
+        // importer(argv[1], optional) → source_dir. Rollup importer 는 파일 경로 → dirname.
+        const importer: ?[]const u8 = if (argc >= 2) getStringArg(env, argv[1], native_alloc) else null;
+        defer if (importer) |imp| native_alloc.free(imp);
+        const source_dir: []const u8 = if (importer) |imp| (std.fs.path.dirname(imp) orelse ".") else ".";
+
+        const resolve_cache: *ResolveCache = @ptrCast(@alignCast(data orelse return js_null));
+        const resolved = (resolve_cache.resolveThreadSafe(source_dir, source, .static_import) catch return js_null) orelse return js_null;
+        // resolveThreadSafe 는 path(+file.resolve_dir)를 self.allocator 로 dupe → caller free 책임.
+        defer switch (resolved) {
+            .file => |f| {
+                resolve_cache.allocator.free(f.path);
+                if (f.resolve_dir) |rd| resolve_cache.allocator.free(rd);
+            },
+            .virtual => |v| resolve_cache.allocator.free(v.path),
+            .external => |e| resolve_cache.allocator.free(e.path),
+            .disabled => |d| resolve_cache.allocator.free(d.path),
+            .custom => |cm| resolve_cache.allocator.free(cm.path),
+            .dataurl => {},
+        };
+
+        const id_path: ?[]const u8 = switch (resolved) {
+            .file => |f| f.path,
+            .virtual => |v| v.path,
+            .external => |e| e.path,
+            .disabled => |d| d.path,
+            .custom => |cm| cm.path,
+            .dataurl => null, // data: URL 은 id 없음 → null
+        };
+        const path = id_path orelse return js_null;
+
+        var js_obj: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &js_obj);
+        var js_id: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, path.ptr, path.len, &js_id);
+        _ = c.napi_set_named_property(env, js_obj, "id", js_id);
+        var js_ext: c.napi_value = undefined;
+        _ = c.napi_get_boolean(env, resolved == .external, &js_ext);
+        _ = c.napi_set_named_property(env, js_obj, "external", js_ext);
+        return js_obj;
+    }
+
     /// threadsafe function의 call_js 콜백 (메인 스레드에서 실행)
     /// data = CallContext 포인터 (per-call, 워커 스레드가 스택에 소유하며 condvar 대기 중)
     pub fn callJsCallback(env: c.napi_env, js_callback: c.napi_value, _: ?*anyopaque, data: ?*anyopaque) callconv(.c) void {
@@ -335,14 +396,20 @@ pub const NapiPlugin = struct {
         // this.getModuleInfo (PR3 self-only): current_module 이 있으면 self-only getModuleInfo 를
         // dispatcher 4번째 인자로 전달. graph 조회 없음 → discovery 병렬 단계 race 없음.
         var js_get_mod_info: c.napi_value = js_undefined;
+        var js_resolve: c.napi_value = js_undefined;
         var argc: usize = 3;
         if (ctx.current_module) |m| {
             _ = c.napi_create_function(env, "getModuleInfo", "getModuleInfo".len, selfModuleInfoCallback, @constCast(m), &js_get_mod_info);
-            argc = 4;
+            if (argc < 4) argc = 4;
+        }
+        // this.resolve (PR4): resolve_cache 가 있으면 5번째 인자로 resolve 함수 전달.
+        if (ctx.resolve_cache) |rc| {
+            _ = c.napi_create_function(env, "resolve", "resolve".len, resolveIdCallback, rc, &js_resolve);
+            argc = 5;
         }
 
         var js_result: c.napi_value = undefined;
-        const args = [_]c.napi_value{ hook_str, js_arg1, js_arg2, js_get_mod_info };
+        const args = [_]c.napi_value{ hook_str, js_arg1, js_arg2, js_get_mod_info, js_resolve };
         if (c.napi_call_function(env, js_undefined, js_callback, argc, &args, &js_result) != c.napi_ok) {
             signalResponse(ctx, .{});
             return;
@@ -381,13 +448,14 @@ pub const NapiPlugin = struct {
 
     /// 워커 스레드에서 호출 — JS 콜백 실행 후 결과 대기.
     /// per-call CallContext를 스택에 생성하여 멀티스레드 안전.
-    fn callHookFull(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8, files: ?[]const bundler_mod.emitter.OutputFile, current_module: ?*const anyopaque) ?PluginResponse {
+    fn callHookFull(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8, files: ?[]const bundler_mod.emitter.OutputFile, current_module: ?*const anyopaque, resolve_cache: ?*anyopaque) ?PluginResponse {
         var ctx = CallContext{
             .hook = hook,
             .arg1 = arg1,
             .arg2 = arg2,
             .output_files = files,
             .current_module = current_module,
+            .resolve_cache = resolve_cache,
         };
 
         if (c.napi_call_threadsafe_function(self.tsfn, @ptrCast(&ctx), c.napi_tsfn_blocking) != c.napi_ok) {
@@ -406,7 +474,7 @@ pub const NapiPlugin = struct {
     }
 
     fn callHook(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8) ?PluginResponse {
-        return self.callHookFull(hook, arg1, arg2, null, null);
+        return self.callHookFull(hook, arg1, arg2, null, null, null);
     }
 
     /// JSON string field 인코딩 — `"` `\` 와 control char escape.
@@ -482,8 +550,8 @@ fn NapiPluginAdapter(comptime Self: type) type {
             alloc: std.mem.Allocator,
             hook_ctx: *plugin_mod.HookContext,
         ) PluginError!?[]const u8 {
-            // this.getModuleInfo (PR3 self-only): transform/renderChunk 에 hook_ctx.current_module 전달.
-            const resp = self.callHookFull(hook, arg1, arg2, null, hook_ctx.current_module) orelse return null;
+            // PR3 current_module(getModuleInfo) + PR4 resolve_cache(this.resolve) 를 transform/renderChunk 에 전달.
+            const resp = self.callHookFull(hook, arg1, arg2, null, hook_ctx.current_module, hook_ctx.resolve_cache) orelse return null;
             defer NapiPlugin.freeResponseFields(resp);
             if (resp.is_failure) return failWithResponse(self, resp, alloc, hook_ctx);
             if (resp.code) |result_code| {
@@ -502,7 +570,8 @@ fn NapiPluginAdapter(comptime Self: type) type {
             hook_ctx: *plugin_mod.HookContext,
         ) PluginError!?plugin_mod.ResolvedModule {
             const self: *Self = @ptrCast(@alignCast(ctx.?));
-            const resp = self.callHook(.resolveId, specifier, importer) orelse return null;
+            // this.resolve (PR4): resolveId hook 에 resolve_cache 전달.
+            const resp = self.callHookFull(.resolveId, specifier, importer, null, null, hook_ctx.resolve_cache) orelse return null;
             defer NapiPlugin.freeResponseFields(resp);
             if (resp.is_failure) return failWithResponse(self, resp, alloc, hook_ctx);
 
@@ -543,7 +612,8 @@ fn NapiPluginAdapter(comptime Self: type) type {
             hook_ctx: *plugin_mod.HookContext,
         ) PluginError!?plugin_mod.LoadResult {
             const self: *Self = @ptrCast(@alignCast(ctx.?));
-            const resp = self.callHook(.load, path, null) orelse return null;
+            // this.resolve (PR4): load hook 에 resolve_cache 전달.
+            const resp = self.callHookFull(.load, path, null, null, null, hook_ctx.resolve_cache) orelse return null;
             defer NapiPlugin.freeResponseFields(resp);
             if (resp.is_failure) return failWithResponse(self, resp, alloc, hook_ctx);
             const result_code = resp.code orelse return null;
@@ -578,7 +648,7 @@ fn NapiPluginAdapter(comptime Self: type) type {
 
         fn pluginGenerateBundle(ctx: ?*anyopaque, output_files: []const bundler_mod.emitter.OutputFile) void {
             const self: *Self = @ptrCast(@alignCast(ctx.?));
-            if (self.callHookFull(.generateBundle, "", null, output_files, null)) |resp| {
+            if (self.callHookFull(.generateBundle, "", null, output_files, null, null)) |resp| {
                 NapiPlugin.freeResponseFields(resp);
             }
         }
@@ -637,7 +707,7 @@ fn NapiPluginAdapter(comptime Self: type) type {
             NapiPlugin.appendJsonString(&json_buf, native_alloc, importer) catch return null;
             json_buf.append(native_alloc, '}') catch return null;
 
-            const resp = self.callHookFull(.resolveContext, json_buf.items, null, null, null) orelse return null;
+            const resp = self.callHookFull(.resolveContext, json_buf.items, null, null, null, null) orelse return null;
             defer NapiPlugin.freeResponseFields(resp);
             if (resp.is_failure) return failWithResponse(self, resp, alloc, hook_ctx);
 
@@ -746,9 +816,11 @@ pub const NapiSyncPlugin = struct {
         arg2: ?[]const u8,
         files: ?[]const bundler_mod.emitter.OutputFile,
         current_module: ?*const anyopaque,
+        resolve_cache: ?*anyopaque,
     ) ?NapiPlugin.PluginResponse {
-        // buildSync 는 this.getModuleInfo 미지원 (current_module 무시) — async build() 만 PR3 지원.
+        // buildSync 는 this.getModuleInfo/this.resolve 미지원 — async build() 만 PR3/PR4 지원.
         _ = current_module;
+        _ = resolve_cache;
         var js_callback: c.napi_value = undefined;
         if (c.napi_get_reference_value(self.env, self.callback_ref, &js_callback) != c.napi_ok) {
             return null;
@@ -805,7 +877,7 @@ pub const NapiSyncPlugin = struct {
     }
 
     fn callHook(self: *NapiSyncPlugin, hook: NapiPlugin.HookType, arg1: []const u8, arg2: ?[]const u8) ?NapiPlugin.PluginResponse {
-        return self.callHookFull(hook, arg1, arg2, null, null);
+        return self.callHookFull(hook, arg1, arg2, null, null, null);
     }
 
     pub fn toPlugin(self: *NapiSyncPlugin) Plugin {

--- a/packages/core/test/core/build-plugins.ts
+++ b/packages/core/test/core/build-plugins.ts
@@ -1,6 +1,7 @@
 import './build-plugins/basic-hooks';
 import './build-plugins/plugin-context';
 import './build-plugins/module-meta';
+import './build-plugins/plugin-resolve';
 import './build-plugins/transform-tree-shaking';
 import './build-plugins/resolve-context';
 import './build-plugins/build-sync';

--- a/packages/core/test/core/build-plugins/plugin-resolve.ts
+++ b/packages/core/test/core/build-plugins/plugin-resolve.ts
@@ -78,18 +78,21 @@ describe('@zntc/core build + plugins - this.resolve', () => {
 
   test('this.resolve 는 resolveId hook 에서도 동작한다 (skipSelf 재귀 없음)', async () => {
     let resolved: { id: string } | null = null;
+    let fired = false;
     const plugin: ZntcPlugin = {
       name: 'resolver-in-resolveid',
       setup(build) {
+        // 실제 import 되는 './dep.ts' 를 가로채는 resolveId hook — 반드시 발화한다.
         build.onResolve(
-          { filter: /^entry-virtual$/ },
+          { filter: /dep\.ts$/ },
           async function (
             this: RollupPluginContext,
             args: { path: string; importer: string | null },
           ) {
-            // 자기 hook 안에서 this.resolve 호출 — native resolver 만 타므로 재귀 없음.
-            resolved = await this.resolve('./dep.ts', args.importer, { skipSelf: true });
-            return null; // 실제 resolve 는 위임
+            fired = true;
+            // 자기 hook 안에서 this.resolve 호출 — native resolver 만 타므로 재귀 없음(skipSelf).
+            resolved = await this.resolve(args.path, args.importer, { skipSelf: true });
+            return null; // 실제 resolve 는 native 에 위임
           },
         );
       },
@@ -104,8 +107,41 @@ describe('@zntc/core build + plugins - this.resolve', () => {
         plugins: [plugin],
       });
       expect(result.errors.length).toBe(0);
-      // entry-virtual 은 import 안 되므로 hook 미발화일 수 있음 — resolved 가 set 됐다면 dep.ts
-      if (resolved) expect(resolved.id).toContain('dep.ts');
+      expect(fired).toBe(true); // hook 이 실제로 발화했는지 보장 (vacuous 방지)
+      expect(resolved).not.toBeNull();
+      expect(resolved!.id).toContain('dep.ts');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('this.resolve(external 패턴) 은 { external: true } 를 반환한다', async () => {
+    let resolved: { id: string; external?: boolean } | null = null;
+    const plugin: ZntcPlugin = {
+      name: 'resolver-external',
+      setup(build) {
+        build.onLoad(
+          { filter: /main\.ts$/ },
+          async function (this: RollupPluginContext, args: { path: string }) {
+            resolved = await this.resolve('some-external-pkg', args.path);
+            return null;
+          },
+        );
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-resolve-ext-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        external: ['some-external-pkg'],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(resolved).not.toBeNull();
+      expect(resolved!.id).toBe('some-external-pkg');
+      expect(resolved!.external).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/core/test/core/build-plugins/plugin-resolve.ts
+++ b/packages/core/test/core/build-plugins/plugin-resolve.ts
@@ -1,0 +1,113 @@
+import {
+  build,
+  describe,
+  expect,
+  join,
+  mkdtempSync,
+  rmSync,
+  test,
+  tmpdir,
+  writeFileSync,
+} from './helpers';
+import type { ZntcPlugin } from './helpers';
+import type { RollupPluginContext } from '../../../index';
+
+// #1880 PR4 — this.resolve(source, importer?, { skipSelf }). native resolver(순수 path
+// resolution, graph 미접근) 를 JS context 에서 sync 호출 → Promise 로 감싼다. race/deadlock 없음.
+describe('@zntc/core build + plugins - this.resolve', () => {
+  test('this.resolve(상대경로) 가 resolved id 를 반환한다', async () => {
+    let resolved: { id: string; external?: boolean } | null = null;
+    const plugin: ZntcPlugin = {
+      name: 'resolver-rel',
+      setup(build) {
+        build.onLoad(
+          { filter: /main\.ts$/ },
+          async function (this: RollupPluginContext, args: { path: string }) {
+            resolved = await this.resolve('./dep.ts', args.path, { skipSelf: true });
+            return null;
+          },
+        );
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-resolve-rel-'));
+    try {
+      writeFileSync(join(dir, 'dep.ts'), 'export const d = 1;\n');
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(resolved).not.toBeNull();
+      expect(resolved!.id).toContain('dep.ts');
+      expect(resolved!.external).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('this.resolve(존재하지 않는 모듈) 은 null', async () => {
+    let resolved: unknown = 'unset';
+    const plugin: ZntcPlugin = {
+      name: 'resolver-null',
+      setup(build) {
+        build.onLoad(
+          { filter: /main\.ts$/ },
+          async function (this: RollupPluginContext, args: { path: string }) {
+            resolved = await this.resolve('./does-not-exist-xyz.ts', args.path);
+            return null;
+          },
+        );
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-resolve-null-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(resolved).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('this.resolve 는 resolveId hook 에서도 동작한다 (skipSelf 재귀 없음)', async () => {
+    let resolved: { id: string } | null = null;
+    const plugin: ZntcPlugin = {
+      name: 'resolver-in-resolveid',
+      setup(build) {
+        build.onResolve(
+          { filter: /^entry-virtual$/ },
+          async function (
+            this: RollupPluginContext,
+            args: { path: string; importer: string | null },
+          ) {
+            // 자기 hook 안에서 this.resolve 호출 — native resolver 만 타므로 재귀 없음.
+            resolved = await this.resolve('./dep.ts', args.importer, { skipSelf: true });
+            return null; // 실제 resolve 는 위임
+          },
+        );
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-resolve-rid-'));
+    try {
+      writeFileSync(join(dir, 'dep.ts'), 'export const d = 1;\n');
+      writeFileSync(join(dir, 'main.ts'), "import './dep.ts';\nexport const x = 1;\n");
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      // entry-virtual 은 import 안 되므로 hook 미발화일 수 있음 — resolved 가 set 됐다면 dep.ts
+      if (resolved) expect(resolved.id).toContain('dep.ts');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/bundler/graph/discovery_scan.zig
+++ b/src/bundler/graph/discovery_scan.zig
@@ -133,7 +133,8 @@ pub fn scanModule(self: *ModuleGraph, idx: ModuleIndex) ScanResult {
 
             if (plugin_runner) |runner| {
                 if (self.shouldRunResolveId(record.specifier)) {
-                    var hook_ctx: plugin_mod.HookContext = .{};
+                    // this.resolve (PR4): resolveId hook 에 ResolveCache 전달.
+                    var hook_ctx: plugin_mod.HookContext = .{ .resolve_cache = @ptrCast(self.resolve_cache) };
                     const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator, &hook_ctx) catch |err| switch (err) {
                         error.PluginFailed => {
                             self.addPluginFailureDiag(hook_ctx.failure, module_path, record.span, .resolve);

--- a/src/bundler/graph/plugins.zig
+++ b/src/bundler/graph/plugins.zig
@@ -96,7 +96,8 @@ pub fn runLoadForModule(self: anytype, module: *Module, runner: ?plugin_mod.Plug
         module.state = .ready;
         return .done;
     };
-    var hook_ctx: plugin_mod.HookContext = .{};
+    // this.resolve (PR4): load hook 에 ResolveCache 전달 (순수 path resolution, race 없음).
+    var hook_ctx: plugin_mod.HookContext = .{ .resolve_cache = @ptrCast(self.resolve_cache) };
     const load_result = plugin_runner.runLoad(module.path, tmp_arena.allocator(), &hook_ctx) catch |err| switch (err) {
         error.PluginFailed => {
             graph_diagnostics.addPluginFailureDiag(self, hook_ctx.failure, module.path, Span.EMPTY, .resolve);
@@ -183,7 +184,7 @@ pub fn runTransformForModule(
     // this.getModuleInfo (PR3 self-only): graph 대신 현재 모듈 포인터만 전달.
     // graph 조회를 하지 않으므로 discovery 병렬 단계의 race 가 없다. self 모듈의 path/source/
     // plugin_meta 는 worker 가 load 단계에서 이미 확정해 안전하게 읽을 수 있다.
-    var hook_ctx: plugin_mod.HookContext = .{ .current_module = @ptrCast(module) };
+    var hook_ctx: plugin_mod.HookContext = .{ .current_module = @ptrCast(module), .resolve_cache = @ptrCast(self.resolve_cache) };
     const transform_result = plugin_runner.runTransform(module.source, module.path, arena_alloc, &hook_ctx) catch |err| switch (err) {
         error.PluginFailed => {
             graph_diagnostics.addPluginFailureDiag(self, hook_ctx.failure, module.path, Span.EMPTY, .transform);

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -448,7 +448,8 @@ pub fn resolveModuleImports(self: *ModuleGraph, idx: ModuleIndex) !void {
         // Plugin: resolveId 훅 — 기본 resolver 전에 플러그인에게 경로 해석 기회를 줌
         if (plugin_runner) |runner| {
             if (self.shouldRunResolveId(record.specifier)) {
-                var hook_ctx: plugin_mod.HookContext = .{};
+                // this.resolve (PR4): resolveId hook 에 ResolveCache 전달.
+                var hook_ctx: plugin_mod.HookContext = .{ .resolve_cache = @ptrCast(self.resolve_cache) };
                 const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator, &hook_ctx) catch |err| switch (err) {
                     error.PluginFailed => {
                         self.addPluginFailureDiag(hook_ctx.failure, module_path, record.span, .resolve);

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -121,6 +121,10 @@ pub const HookContext = struct {
     /// self 모듈은 worker 가 load 단계에서 확정(path/source/plugin_meta)했으므로 안전.
     /// transform hook 에서만 set. null = getModuleInfo 미지원 hook (#1880 PR3).
     current_module: ?*const anyopaque = null,
+    /// `this.resolve` (PR4) 용 ResolveCache 포인터. native resolver 는 순수 path resolution
+    /// (graph 미접근, sharded-mutex thread-safe)이라 worker/JS thread 에서 안전 + plugin 재진입
+    /// 없음. resolveId/load/transform hook 에서 set. null = this.resolve 미지원 (#1880 PR4).
+    resolve_cache: ?*anyopaque = null,
 
     /// 사용 안 하는 failure metadata 를 일괄 정리. 이미 consume 된 경우 no-op.
     /// swallow 경로 (lifecycle hook, fallback null path 등) 에서 `defer ctx.deinit()` 으로 사용.
@@ -402,8 +406,11 @@ pub const PluginRunner = struct {
                 // 각 plugin 별 fresh inner_ctx — source_maps 는 chain 에서 누적, failure 는
                 // 첫 실패 시 outer 로 옮긴다. plugin hook 이 failure 를 read 하는 contract 는
                 // 없으므로 hook_ctx.failure 시드 불필요.
-                // current_module 은 this.getModuleInfo (PR3 self-only) 용으로 전파.
-                var inner_ctx: HookContext = .{ .current_module = hook_ctx.current_module };
+                // current_module(PR3) / resolve_cache(PR4) 를 inner_ctx 로 전파.
+                var inner_ctx: HookContext = .{
+                    .current_module = hook_ctx.current_module,
+                    .resolve_cache = hook_ctx.resolve_cache,
+                };
                 const result = hook(p.context, input, id, allocator, &inner_ctx) catch |err| {
                     hook_ctx.failure = inner_ctx.failure;
                     return err;


### PR DESCRIPTION
## 배경

#1880 epic PR4. PR1(warn/error) → PR2+PR3(meta/getModuleInfo) 에 이은 plugin context API. 사전조사(#1900) 에서 **this.resolve 가 실용 plugin(node-resolve/commonjs) 호환의 단일 최대 레버**로 식별됨.

## 설계 — PR3 race 교훈 반영, race/deadlock 없음

PR3 에서 transform 에 graph 를 노출했다 race 로 self-only 재설계했다. this.resolve 는 그 함정이 **없다**:
- native resolver `resolveThreadSafe` 는 **순수 path resolution** (fs/package.json) — graph 미접근, sharded-mutex thread-safe, plugin resolveId 재진입 없음 (discovery_scan 에서 resolveId hook 과 native resolve 는 별개 순차 단계).
- 따라서 JS context 에서 **sync native fn 호출 + `Promise.resolve` 감싸기**(Option A)로 충분. TSFN 재진입(Option B)은 worker 가 block 중인데 main-thread 콜백에서 재진입 → deadlock 이라 **안 씀**.

흐름: `ResolveCache` 포인터 → `HookContext.resolve_cache` (resolveId/load/transform hook) → `callJsCallback` 이 `resolveIdCallback`(PR3 selfModuleInfo 와 동일 패턴, dispatcher 5번째 인자) 주입 → JS `context.resolve` 가 `Promise.resolve(nativeResolve(...))`.

`skipSelf`: native resolver 가 plugin resolveId 를 타지 않으므로 자명 충족.

## 동시성 검증

this.resolve 폭격 (80모듈 × 30회/load × 40 run = **97,200 resolve, crash 0, bad 0**). resolveThreadSafe 가 이미 worker 동시 호출되는 thread-safe API 라 추가 race 없음.

## 함께 수정

resolveId/load 콜백 사이트가 PR3 부터 `getModuleInfo` 미전달이던 것 수정 (transform 만 테스트해 누락) — 이제 getModuleInfo/resolve 모두 전달.

## 테스트 (TDD)

`plugin-resolve.ts` 3개: 상대경로 resolve → `{id, external:false}` / 미해결 → null / resolveId hook 내 this.resolve(재귀 없음). build-plugins 전체 **33 pass 회귀 0**, tsc 통과.

## 한계 (follow-up)

- buildSync 미지원 (async build 만 — PR3 와 동일)
- "다른 plugin 의 resolveId 재실행" 미지원 (native resolver 만) — 대부분 use case 충족, JS-side 재실행은 follow-up
- dataurl resolve 결과는 id 없어 null

남은 epic: PR5 this.emitFile, PR6 vitePlugin parity.

Refs #1880