### PR TITLE
feat(plugin): this.emitFile asset 수집 (#1880 PR5)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1668,6 +1668,7 @@ type PluginDispatcher = ((
   arg2: string | null,
   getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
   resolve?: NativeResolveFn,
+  emitFile?: NativeEmitFileFn,
 ) => Promise<unknown>) &
   PluginDispatcherLifecycle;
 type SyncPluginDispatcher = ((hookName: string, arg1: unknown, arg2: string | null) => unknown) &
@@ -1847,25 +1848,32 @@ type NativeResolveFn = (
   options?: unknown,
 ) => { id: string; external: boolean } | null;
 
+// #1880 PR5: native emitFile 콜백. JS 가 검증한 `{ fileName, source }` 를 받아 EmitStore 에
+// 등록하고 reference id("asset-N") 를 sync 반환한다. type/fileName 검증은 JS emitFile 슬롯이 수행.
+type NativeEmitFileFn = (file: { fileName: string; source: string | Uint8Array }) => string;
+
 function getPluginContext(
   reg: PluginRegistry,
   pluginName: string,
   getModuleInfo?: ((id: string) => ManualChunksModuleInfo | null) | undefined,
   resolve?: NativeResolveFn | undefined,
+  emitFile?: NativeEmitFileFn | undefined,
 ): RollupPluginContext {
   let ctx = reg.contexts.get(pluginName);
   if (!ctx) {
     ctx = createRollupPluginContext(pluginName, (d) => reg.pluginWarnings.push(d));
     reg.contexts.set(pluginName, ctx);
   }
-  // this.getModuleInfo (PR3) / this.resolve (PR4): native 가 hook 별로 넘긴 fn 을 매번 갱신
-  // (undefined 포함) — 캐시된 context 에 이전 hook 의 fn 이 stale 로 남지 않도록.
+  // this.getModuleInfo (PR3) / this.resolve (PR4) / this.emitFile (PR5): native 가 hook 별로 넘긴
+  // fn 을 매번 갱신(undefined 포함) — 캐시된 context 에 이전 hook 의 fn 이 stale 로 남지 않도록.
   const slot = ctx as {
     __getModuleInfo?: (id: string) => ManualChunksModuleInfo | null;
     __resolve?: NativeResolveFn;
+    __emitFile?: NativeEmitFileFn;
   };
   slot.__getModuleInfo = getModuleInfo;
   slot.__resolve = resolve;
+  slot.__emitFile = emitFile;
   return ctx;
 }
 
@@ -1881,6 +1889,7 @@ function* dispatchHook(
   arg2: string | null,
   getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
   resolve?: NativeResolveFn,
+  emitFile?: NativeEmitFileFn,
 ): Generator<HookCall, unknown, DispatchedHookResult> {
   // astFunction: arg1 이 JSON 직렬화된 FunctionInfo. 첫 매칭 plugin 의 non-null 반환을 채택.
   if (hookName === 'astFunction') {
@@ -1895,7 +1904,10 @@ function* dispatchHook(
       if (!h.filter.test(info.sourcePath)) continue;
       const result = yield {
         callback: () =>
-          h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo, resolve), info),
+          h.callback.call(
+            getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile),
+            info,
+          ),
         pluginName: h.pluginName,
         hookName: 'astFunction',
         fallbackFile: info.sourcePath,
@@ -1927,7 +1939,10 @@ function* dispatchHook(
       if (!h.filter.test(args.dir)) continue;
       const result = yield {
         callback: () =>
-          h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo, resolve), args),
+          h.callback.call(
+            getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile),
+            args,
+          ),
         pluginName: h.pluginName,
         hookName: 'resolveContext',
         fallbackFile: args.importer,
@@ -1949,7 +1964,10 @@ function* dispatchHook(
       for (const { pluginName, callback } of spec.callbacks) {
         const result = yield {
           callback: () =>
-            callback.call(getPluginContext(reg, pluginName, getModuleInfo, resolve), spec.arg),
+            callback.call(
+              getPluginContext(reg, pluginName, getModuleInfo, resolve, emitFile),
+              spec.arg,
+            ),
           pluginName,
           hookName,
         };
@@ -1978,7 +1996,10 @@ function* dispatchHook(
           : { code: currentCode, chunk: arg2 };
       const result = yield {
         callback: () =>
-          h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo, resolve), cbArgs),
+          h.callback.call(
+            getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile),
+            cbArgs,
+          ),
         pluginName: h.pluginName,
         hookName,
         fallbackFile: arg2,
@@ -2014,7 +2035,10 @@ function* dispatchHook(
     const fallbackFile = hookName === 'resolveId' ? arg2 : filterTarget;
     const result = yield {
       callback: () =>
-        h.callback.call(getPluginContext(reg, h.pluginName, getModuleInfo, resolve), cbArgs),
+        h.callback.call(
+          getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile),
+          cbArgs,
+        ),
       pluginName: h.pluginName,
       hookName,
       fallbackFile,
@@ -2106,8 +2130,11 @@ function createPluginDispatcher(plugins: ZntcPlugin[]): PluginDispatcher {
     arg2: string | null,
     getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
     resolve?: NativeResolveFn,
+    emitFile?: NativeEmitFileFn,
   ) {
-    return driveDispatchAsync(dispatchHook(reg, hookName, arg1, arg2, getModuleInfo, resolve));
+    return driveDispatchAsync(
+      dispatchHook(reg, hookName, arg1, arg2, getModuleInfo, resolve, emitFile),
+    );
   } as PluginDispatcher;
   dispatcher.takeLifecycleFailures = () => reg.lifecycleFailures.splice(0);
   dispatcher.takePluginWarnings = () => reg.pluginWarnings.splice(0);
@@ -2841,7 +2868,13 @@ export interface RollupPluginContext {
     importer?: string | null,
     options?: unknown,
   ): Promise<{ id: string; external?: boolean } | null>;
-  /** Emit an additional asset/chunk. Currently unsupported — throws an Error when called. */
+  /** Emit an additional asset (Rollup `this.emitFile` 호환, #1880 PR5). async build() 의
+   * resolveId/load/transform hook 에서 `{ type: 'asset', fileName, source }` 를 emit → reference id
+   * 반환, 해당 asset 은 `result.outputFiles` 에 나타난다. MVP 는 명시 fileName 의 asset 만 —
+   * `type: 'chunk'` 및 name-only(hash 파일명)+`getFileName` 은 follow-up 으로 throw.
+   * 그 외 hook / buildSync / vitePlugin() 어댑터에서도 throw.
+   * **반드시 hook 본문에서 동기적으로 호출**해야 한다 — `await` 이후나 detached promise 에서
+   * 호출하면 EmitStore 수명을 벗어나 asset 이 누락되거나 정의되지 않은 동작이 된다 (follow-up). */
   emitFile(file: unknown): string;
   /** 모듈 그래프 정보(+plugin meta) 조회 (Rollup `this.getModuleInfo` 호환).
    * async build() 의 transform hook 에서만 사용 가능 (#1880 PR3). 그 외 hook/buildSync 에선 throw. */
@@ -2951,10 +2984,45 @@ function createRollupPluginContext(
       }
       return Promise.resolve(fn(source, importer));
     },
-    emitFile(_file): never {
-      throw new Error(
-        `@zntc/core [${pluginName}]: this.emitFile() is not supported by vitePlugin() adapter yet.`,
-      );
+    emitFile(file: unknown): string {
+      // native 가 hook 별로 __emitFile 슬롯에 주입 (#1880 PR5). asset(명시 fileName)만 MVP —
+      // type/fileName/source 검증은 여기서 수행하고 native 는 단순 store append 만 한다.
+      const fn = (ctx as { __emitFile?: NativeEmitFileFn }).__emitFile;
+      if (typeof fn !== 'function') {
+        throw new Error(
+          `@zntc/core [${pluginName}]: this.emitFile() 는 async build() 의 resolveId/load/transform hook 에서만 사용 가능합니다 (#1880 PR5).`,
+        );
+      }
+      if (typeof file !== 'object' || file === null) {
+        throw new Error(`@zntc/core [${pluginName}]: this.emitFile() 는 객체 인자가 필요합니다.`);
+      }
+      const f = file as { type?: unknown; fileName?: unknown; source?: unknown };
+      if (f.type !== 'asset') {
+        throw new Error(
+          `@zntc/core [${pluginName}]: this.emitFile({ type: '${String(f.type)}' }) 는 아직 미지원입니다 — 현재 type:'asset' 만 지원 (chunk 는 follow-up, #1880 PR5).`,
+        );
+      }
+      if (typeof f.fileName !== 'string' || f.fileName.length === 0) {
+        // 빈 fileName 은 native getStringArg 가 len==0 을 missing 으로 취급해 silent null 을
+        // 반환하므로 JS 단에서 거부 — Rollup 도 빈/누락 fileName 을 허용하지 않는다.
+        throw new Error(
+          `@zntc/core [${pluginName}]: this.emitFile() asset 은 비어있지 않은 명시 fileName 이 필요합니다 (name-only hash 파일명 + getFileName 은 follow-up, #1880 PR5).`,
+        );
+      }
+      if (typeof f.source !== 'string' && !(f.source instanceof Uint8Array)) {
+        throw new Error(
+          `@zntc/core [${pluginName}]: this.emitFile() asset 은 source(string | Uint8Array) 가 필요합니다.`,
+        );
+      }
+      const referenceId = fn({ fileName: f.fileName, source: f.source });
+      // native 는 OOM/내부 실패 시 null 을 반환 — Rollup 의 `=> string` 계약을 지키도록 throw
+      // (silent null 이 reference id 자리에 새어 나가 downstream 에서 모호한 에러를 내는 것 방지).
+      if (typeof referenceId !== 'string') {
+        throw new Error(
+          `@zntc/core [${pluginName}]: this.emitFile({ fileName: ${JSON.stringify(f.fileName)} }) 가 reference id 를 반환하지 못했습니다 (asset emit 실패).`,
+        );
+      }
+      return referenceId;
     },
     getModuleInfo(id: string): ManualChunksModuleInfo | null {
       // native 가 transform hook 에 한해 graph-bound fn 을 __getModuleInfo 슬롯에 주입 (#1880 PR3).

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -24,6 +24,7 @@ const parseStringArray = common.parseStringArray;
 
 const plugin_mod = bundler_mod.plugin;
 const ResolveCache = bundler_mod.ResolveCache;
+const EmitStore = bundler_mod.EmitStore;
 const graph_plugins_mod = bundler_mod.graph_plugins;
 const Plugin = plugin_mod.Plugin;
 const PluginError = plugin_mod.PluginError;
@@ -81,6 +82,9 @@ pub const NapiPlugin = struct {
         /// this.resolve (PR4) 용 ResolveCache 포인터. non-null 이면 resolve 함수를 dispatcher
         /// 5번째 인자로 전달 (순수 path resolution, plugin 재진입 없음 → race/deadlock 없음).
         resolve_cache: ?*anyopaque = null,
+        /// this.emitFile (PR5) 용 EmitStore 포인터. non-null 이면 emitFile 함수를 dispatcher
+        /// 6번째 인자로 전달. callJsCallback 은 메인 스레드 직렬이라 store write 동기화 불필요.
+        emit_store: ?*anyopaque = null,
         response: ?PluginResponse = null,
         response_ready: bool = false,
         mutex: std.Thread.Mutex = .{},
@@ -371,6 +375,34 @@ pub const NapiPlugin = struct {
         return js_obj;
     }
 
+    /// this.emitFile (PR5) 구현. data = *EmitStore. argv[0] = JS 가 검증한 `{ fileName, source }`
+    /// (type='asset' + 명시 fileName 만 — chunk/name-only 검증은 JS 측에서 throw). store.emitAsset
+    /// 으로 등록 후 reference id("asset-N") 를 string 으로 반환. 메인 스레드 직렬 호출이라 store
+    /// write 동기화 불필요(emit_store.zig doc 참조).
+    fn emitFileCallback(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+        var js_null: c.napi_value = undefined;
+        _ = c.napi_get_null(env, &js_null);
+
+        var argc: usize = 1;
+        var argv: [1]c.napi_value = undefined;
+        var data: ?*anyopaque = null;
+        if (c.napi_get_cb_info(env, info, &argc, &argv, null, &data) != c.napi_ok) return js_null;
+        if (argc < 1) return js_null;
+
+        const store: *EmitStore = @ptrCast(@alignCast(data orelse return js_null));
+
+        const file_name = getObjectString(env, argv[0], "fileName", native_alloc) orelse return js_null;
+        defer native_alloc.free(file_name);
+        // source 는 string / Uint8Array / Buffer 모두 수용 (binary-safe asset). 빈 source 도 허용.
+        const source = getObjectBytes(env, argv[0], "source", native_alloc) orelse return js_null;
+        defer native_alloc.free(source);
+
+        const ref_id = store.emitAsset(file_name, source) catch return js_null;
+        var js_ref: c.napi_value = undefined;
+        if (c.napi_create_string_utf8(env, ref_id.ptr, ref_id.len, &js_ref) != c.napi_ok) return js_null;
+        return js_ref;
+    }
+
     /// threadsafe function의 call_js 콜백 (메인 스레드에서 실행)
     /// data = CallContext 포인터 (per-call, 워커 스레드가 스택에 소유하며 condvar 대기 중)
     pub fn callJsCallback(env: c.napi_env, js_callback: c.napi_value, _: ?*anyopaque, data: ?*anyopaque) callconv(.c) void {
@@ -413,6 +445,7 @@ pub const NapiPlugin = struct {
         // dispatcher 4번째 인자로 전달. graph 조회 없음 → discovery 병렬 단계 race 없음.
         var js_get_mod_info: c.napi_value = js_undefined;
         var js_resolve: c.napi_value = js_undefined;
+        var js_emit_file: c.napi_value = js_undefined;
         var argc: usize = 3;
         if (ctx.current_module) |m| {
             _ = c.napi_create_function(env, "getModuleInfo", "getModuleInfo".len, selfModuleInfoCallback, @constCast(m), &js_get_mod_info);
@@ -421,11 +454,16 @@ pub const NapiPlugin = struct {
         // this.resolve (PR4): resolve_cache 가 있으면 5번째 인자로 resolve 함수 전달.
         if (ctx.resolve_cache) |rc| {
             _ = c.napi_create_function(env, "resolve", "resolve".len, resolveIdCallback, rc, &js_resolve);
-            argc = 5;
+            if (argc < 5) argc = 5;
+        }
+        // this.emitFile (PR5): emit_store 가 있으면 6번째 인자로 emitFile 함수 전달.
+        if (ctx.emit_store) |es| {
+            _ = c.napi_create_function(env, "emitFile", "emitFile".len, emitFileCallback, es, &js_emit_file);
+            argc = 6;
         }
 
         var js_result: c.napi_value = undefined;
-        const args = [_]c.napi_value{ hook_str, js_arg1, js_arg2, js_get_mod_info, js_resolve };
+        const args = [_]c.napi_value{ hook_str, js_arg1, js_arg2, js_get_mod_info, js_resolve, js_emit_file };
         if (c.napi_call_function(env, js_undefined, js_callback, argc, &args, &js_result) != c.napi_ok) {
             signalResponse(ctx, .{});
             return;
@@ -464,7 +502,7 @@ pub const NapiPlugin = struct {
 
     /// 워커 스레드에서 호출 — JS 콜백 실행 후 결과 대기.
     /// per-call CallContext를 스택에 생성하여 멀티스레드 안전.
-    fn callHookFull(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8, files: ?[]const bundler_mod.emitter.OutputFile, current_module: ?*const anyopaque, resolve_cache: ?*anyopaque) ?PluginResponse {
+    fn callHookFull(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8, files: ?[]const bundler_mod.emitter.OutputFile, current_module: ?*const anyopaque, resolve_cache: ?*anyopaque, emit_store: ?*anyopaque) ?PluginResponse {
         var ctx = CallContext{
             .hook = hook,
             .arg1 = arg1,
@@ -472,6 +510,7 @@ pub const NapiPlugin = struct {
             .output_files = files,
             .current_module = current_module,
             .resolve_cache = resolve_cache,
+            .emit_store = emit_store,
         };
 
         if (c.napi_call_threadsafe_function(self.tsfn, @ptrCast(&ctx), c.napi_tsfn_blocking) != c.napi_ok) {
@@ -490,7 +529,7 @@ pub const NapiPlugin = struct {
     }
 
     fn callHook(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8) ?PluginResponse {
-        return self.callHookFull(hook, arg1, arg2, null, null, null);
+        return self.callHookFull(hook, arg1, arg2, null, null, null, null);
     }
 
     /// JSON string field 인코딩 — `"` `\` 와 control char escape.
@@ -566,8 +605,8 @@ fn NapiPluginAdapter(comptime Self: type) type {
             alloc: std.mem.Allocator,
             hook_ctx: *plugin_mod.HookContext,
         ) PluginError!?[]const u8 {
-            // PR3 current_module(getModuleInfo) + PR4 resolve_cache(this.resolve) 를 transform/renderChunk 에 전달.
-            const resp = self.callHookFull(hook, arg1, arg2, null, hook_ctx.current_module, hook_ctx.resolve_cache) orelse return null;
+            // PR3 current_module(getModuleInfo) + PR4 resolve_cache(this.resolve) + PR5 emit_store(this.emitFile) 를 transform/renderChunk 에 전달.
+            const resp = self.callHookFull(hook, arg1, arg2, null, hook_ctx.current_module, hook_ctx.resolve_cache, hook_ctx.emit_store) orelse return null;
             defer NapiPlugin.freeResponseFields(resp);
             if (resp.is_failure) return failWithResponse(self, resp, alloc, hook_ctx);
             if (resp.code) |result_code| {
@@ -586,8 +625,8 @@ fn NapiPluginAdapter(comptime Self: type) type {
             hook_ctx: *plugin_mod.HookContext,
         ) PluginError!?plugin_mod.ResolvedModule {
             const self: *Self = @ptrCast(@alignCast(ctx.?));
-            // this.resolve (PR4): resolveId hook 에 resolve_cache 전달.
-            const resp = self.callHookFull(.resolveId, specifier, importer, null, null, hook_ctx.resolve_cache) orelse return null;
+            // this.resolve (PR4): resolveId hook 에 resolve_cache 전달. this.emitFile (PR5): emit_store 전달.
+            const resp = self.callHookFull(.resolveId, specifier, importer, null, null, hook_ctx.resolve_cache, hook_ctx.emit_store) orelse return null;
             defer NapiPlugin.freeResponseFields(resp);
             if (resp.is_failure) return failWithResponse(self, resp, alloc, hook_ctx);
 
@@ -628,8 +667,8 @@ fn NapiPluginAdapter(comptime Self: type) type {
             hook_ctx: *plugin_mod.HookContext,
         ) PluginError!?plugin_mod.LoadResult {
             const self: *Self = @ptrCast(@alignCast(ctx.?));
-            // this.resolve (PR4): load hook 에 resolve_cache 전달.
-            const resp = self.callHookFull(.load, path, null, null, null, hook_ctx.resolve_cache) orelse return null;
+            // this.resolve (PR4): load hook 에 resolve_cache 전달. this.emitFile (PR5): emit_store 전달.
+            const resp = self.callHookFull(.load, path, null, null, null, hook_ctx.resolve_cache, hook_ctx.emit_store) orelse return null;
             defer NapiPlugin.freeResponseFields(resp);
             if (resp.is_failure) return failWithResponse(self, resp, alloc, hook_ctx);
             const result_code = resp.code orelse return null;
@@ -664,7 +703,7 @@ fn NapiPluginAdapter(comptime Self: type) type {
 
         fn pluginGenerateBundle(ctx: ?*anyopaque, output_files: []const bundler_mod.emitter.OutputFile) void {
             const self: *Self = @ptrCast(@alignCast(ctx.?));
-            if (self.callHookFull(.generateBundle, "", null, output_files, null, null)) |resp| {
+            if (self.callHookFull(.generateBundle, "", null, output_files, null, null, null)) |resp| {
                 NapiPlugin.freeResponseFields(resp);
             }
         }
@@ -723,7 +762,7 @@ fn NapiPluginAdapter(comptime Self: type) type {
             NapiPlugin.appendJsonString(&json_buf, native_alloc, importer) catch return null;
             json_buf.append(native_alloc, '}') catch return null;
 
-            const resp = self.callHookFull(.resolveContext, json_buf.items, null, null, null, null) orelse return null;
+            const resp = self.callHookFull(.resolveContext, json_buf.items, null, null, null, null, null) orelse return null;
             defer NapiPlugin.freeResponseFields(resp);
             if (resp.is_failure) return failWithResponse(self, resp, alloc, hook_ctx);
 
@@ -833,10 +872,12 @@ pub const NapiSyncPlugin = struct {
         files: ?[]const bundler_mod.emitter.OutputFile,
         current_module: ?*const anyopaque,
         resolve_cache: ?*anyopaque,
+        emit_store: ?*anyopaque,
     ) ?NapiPlugin.PluginResponse {
-        // buildSync 는 this.getModuleInfo/this.resolve 미지원 — async build() 만 PR3/PR4 지원.
+        // buildSync 는 this.getModuleInfo/this.resolve/this.emitFile 미지원 — async build() 만 PR3/4/5 지원.
         _ = current_module;
         _ = resolve_cache;
+        _ = emit_store;
         var js_callback: c.napi_value = undefined;
         if (c.napi_get_reference_value(self.env, self.callback_ref, &js_callback) != c.napi_ok) {
             return null;
@@ -893,7 +934,7 @@ pub const NapiSyncPlugin = struct {
     }
 
     fn callHook(self: *NapiSyncPlugin, hook: NapiPlugin.HookType, arg1: []const u8, arg2: ?[]const u8) ?NapiPlugin.PluginResponse {
-        return self.callHookFull(hook, arg1, arg2, null, null, null);
+        return self.callHookFull(hook, arg1, arg2, null, null, null, null);
     }
 
     pub fn toPlugin(self: *NapiSyncPlugin) Plugin {

--- a/packages/core/test/core/build-plugins.ts
+++ b/packages/core/test/core/build-plugins.ts
@@ -2,6 +2,7 @@ import './build-plugins/basic-hooks';
 import './build-plugins/plugin-context';
 import './build-plugins/module-meta';
 import './build-plugins/plugin-resolve';
+import './build-plugins/plugin-emit-file';
 import './build-plugins/transform-tree-shaking';
 import './build-plugins/resolve-context';
 import './build-plugins/build-sync';

--- a/packages/core/test/core/build-plugins/plugin-emit-file.ts
+++ b/packages/core/test/core/build-plugins/plugin-emit-file.ts
@@ -1,0 +1,186 @@
+import {
+  build,
+  describe,
+  expect,
+  join,
+  mkdtempSync,
+  rmSync,
+  test,
+  tmpdir,
+  writeFileSync,
+} from './helpers';
+import type { ZntcPlugin } from './helpers';
+import type { RollupPluginContext } from '../../../index';
+
+// #1880 PR5 — this.emitFile({ type: 'asset', fileName, source }) → referenceId. emit 된 asset 은
+// build 의 메인 스레드(TSFN callJsCallback)에서 단일 EmitStore 에 직렬 수집 → result.outputFiles 로
+// 노출(asset_outputs 경유). MVP 는 명시 fileName 의 asset 만 — chunk / name-only(getFileName) 은 throw.
+describe('@zntc/core build + plugins - this.emitFile', () => {
+  test('transform 에서 emit 한 asset 이 outputFiles 에 나타난다', async () => {
+    let refId: unknown = 'unset';
+    const plugin: ZntcPlugin = {
+      name: 'emit-asset-transform',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          function (this: RollupPluginContext, args: { code: string }) {
+            refId = this.emitFile({
+              type: 'asset',
+              fileName: 'extracted.css',
+              source: 'body{margin:0}',
+            });
+            return null;
+          },
+        );
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-transform-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(typeof refId).toBe('string');
+      const asset = result.outputFiles.find((f) => f.path === 'extracted.css');
+      expect(asset).toBeDefined();
+      expect(asset!.text).toBe('body{margin:0}');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('load hook 에서도 emit 한 asset 이 노출된다', async () => {
+    const plugin: ZntcPlugin = {
+      name: 'emit-asset-load',
+      setup(build) {
+        build.onLoad(
+          { filter: /main\.ts$/ },
+          function (this: RollupPluginContext, _args: { path: string }) {
+            this.emitFile({ type: 'asset', fileName: 'data.json', source: '{"a":1}' });
+            return null;
+          },
+        );
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-load-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      const asset = result.outputFiles.find((f) => f.path === 'data.json');
+      expect(asset).toBeDefined();
+      expect(asset!.text).toBe('{"a":1}');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('emit 한 referenceId 는 매번 고유하다', async () => {
+    const ids: string[] = [];
+    const plugin: ZntcPlugin = {
+      name: 'emit-asset-multi',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          ids.push(this.emitFile({ type: 'asset', fileName: 'a.txt', source: 'A' }) as string);
+          ids.push(this.emitFile({ type: 'asset', fileName: 'b.txt', source: 'B' }) as string);
+          return null;
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-multi-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(ids.length).toBe(2);
+      expect(ids[0]).not.toBe(ids[1]);
+      expect(result.outputFiles.find((f) => f.path === 'a.txt')?.text).toBe('A');
+      expect(result.outputFiles.find((f) => f.path === 'b.txt')?.text).toBe('B');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('type:chunk 는 아직 미지원 — plugin failure 로 정규화', async () => {
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-unsupported',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'chunk', id: './other.ts' });
+          return null;
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('빈 fileName 은 silent null 대신 plugin failure 로 거부된다', async () => {
+    const plugin: ZntcPlugin = {
+      name: 'emit-empty-filename',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'asset', fileName: '', source: 'x' });
+          return null;
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-empty-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('fileName 없는 asset(name-only hash 파일명) 은 아직 미지원 — plugin failure', async () => {
+    const plugin: ZntcPlugin = {
+      name: 'emit-name-only-unsupported',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'asset', name: 'logo.png', source: 'PNGDATA' });
+          return null;
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-nameonly-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -18,6 +18,7 @@ const fs = @import("fs.zig");
 const BundlerDiagnostic = types.BundlerDiagnostic;
 const ModuleIndex = types.ModuleIndex;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
+const EmitStore = @import("emit_store.zig").EmitStore;
 const ResolveCache = @import("resolve_cache.zig").ResolveCache;
 const Platform = @import("resolve_cache.zig").Platform;
 const emitter = @import("emitter.zig");
@@ -1047,6 +1048,12 @@ pub const Bundler = struct {
         // 1. 모듈 그래프 구축
         var graph_scope = profile.begin(.graph);
         var graph = ModuleGraph.init(self.allocator, self.getResolveCache());
+        // this.emitFile (PR5): plugin 이 emit 한 asset 수집소. graph build 가 plugin hook 을
+        // 호출하기 *전* 에 연결해야 한다. emit 된 asset 은 아래에서 OutputFile(kind=.asset)로
+        // 복사되어 final_asset_outputs 에 합쳐지고, store 는 scratch 라 bundle() 종료 시 해제.
+        var emit_store = EmitStore.init(self.allocator);
+        defer emit_store.deinit();
+        graph.emit_store = @ptrCast(&emit_store);
         graph.dev_mode = self.options.dev_mode;
         graph.incremental_mode = self.options.module_store != null or
             self.options.changed_files != null or
@@ -1827,14 +1834,35 @@ pub const Bundler = struct {
             }
         }
 
-        // Worker + CSS + mf-manifest 출력 파일을 asset_outputs에 합침
-        const final_asset_outputs: ?[]OutputFile = if (worker_output_files.items.len > 0 or asset_outputs != null or css_output_files.items.len > 0 or mf_manifest != null) blk: {
+        // this.emitFile (PR5): plugin 이 emit 한 asset 을 OutputFile(kind=.asset)로 변환.
+        // path/contents 를 새로 dupe — emit_store 는 scratch 로 deinit 되므로 OutputFile 이
+        // 자기 복사본을 소유해야 한다(OutputFile.deinit 이 path+contents 해제).
+        var emit_asset_files: std.ArrayList(OutputFile) = .empty;
+        defer emit_asset_files.deinit(self.allocator);
+        for (emit_store.assets.items) |a| {
+            const path = try self.allocator.dupe(u8, a.file_name);
+            errdefer self.allocator.free(path);
+            const contents = try self.allocator.dupe(u8, a.source);
+            errdefer self.allocator.free(contents);
+            try emit_asset_files.append(self.allocator, .{ .path = path, .contents = contents, .kind = .asset });
+        }
+        // 결정성(#3564): emit 순서는 worker 스케줄링(병렬 transform) 의존이라 path 로 정렬해
+        // outputFiles 의 asset 순서를 run 간 안정화한다. (MVP 는 fileName 중복 검출 안 함 —
+        // 같은 fileName 을 두 번 emit 하면 동일 path OutputFile 2개. Rollup 은 throw, follow-up.)
+        std.mem.sort(OutputFile, emit_asset_files.items, {}, struct {
+            fn lessThan(_: void, a: OutputFile, b: OutputFile) bool {
+                return std.mem.lessThan(u8, a.path, b.path);
+            }
+        }.lessThan);
+
+        // Worker + CSS + emit asset + mf-manifest 출력 파일을 asset_outputs에 합침
+        const final_asset_outputs: ?[]OutputFile = if (worker_output_files.items.len > 0 or asset_outputs != null or css_output_files.items.len > 0 or emit_asset_files.items.len > 0 or mf_manifest != null) blk: {
             const existing = if (asset_outputs) |a| a.len else 0;
             const mf_n: usize = if (mf_manifest != null) 1 else 0;
             // P2-2 (#3422): manifest 산출 시 SHA-256 무결성 sidecar 도 1개.
             // P2-3 (#3423): + 키 지정 시 Ed25519 `.sig` 1개 (opt-in).
             const sig_n: usize = if (mf_n == 1 and self.options.mf_sign_key_path != null) 1 else 0;
-            const total = existing + worker_output_files.items.len + css_output_files.items.len + mf_n * 2 + sig_n;
+            const total = existing + worker_output_files.items.len + css_output_files.items.len + emit_asset_files.items.len + mf_n * 2 + sig_n;
             const merged = try self.allocator.alloc(OutputFile, total);
             if (asset_outputs) |a| {
                 @memcpy(merged[0..a.len], a);
@@ -1847,8 +1875,12 @@ pub const Bundler = struct {
             for (css_output_files.items, 0..) |cf, i| {
                 merged[css_start + i] = cf;
             }
+            const emit_start = css_start + css_output_files.items.len;
+            for (emit_asset_files.items, 0..) |ef, i| {
+                merged[emit_start + i] = ef;
+            }
             if (mf_manifest) |m| {
-                const slot = css_start + css_output_files.items.len;
+                const slot = emit_start + emit_asset_files.items.len;
                 // P2-2: manifest + 모든 JS 출력 청크의 SHA-256 SRI sidecar.
                 // m(아직 살아있음) + outputs(최종 바이트, placeholder 치환
                 // 완료) 입력. sidecar 자신·서명은 미포함(P2-3 서명 자기참조

--- a/src/bundler/emit_store.zig
+++ b/src/bundler/emit_store.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+
+/// plugin `this.emitFile({ type: 'asset', fileName, source })` 로 emit 된 단일 asset.
+/// 세 필드 모두 `EmitStore.allocator` 소유 — `EmitStore.deinit` 이 일괄 해제한다.
+pub const EmittedAsset = struct {
+    /// `this.emitFile` 이 plugin 에 돌려준 reference id ("asset-N").
+    reference_id: []const u8,
+    /// 출력 파일명 (MVP 는 명시 fileName 만 — name-only hash 파일명은 follow-up).
+    file_name: []const u8,
+    /// asset 내용 (binary-safe).
+    source: []const u8,
+};
+
+/// plugin `this.emitFile` 수집소 (#1880 PR5).
+///
+/// **메인 스레드에서만 write 되므로 동기화(mutex/atomic)가 불필요하다.** ZNTC 의 JS plugin hook
+/// 본문은 worker 가 `callHookFull` 에서 condvar 로 block 한 채 main thread 의 `callJsCallback`
+/// 이 직렬 실행한다(JS single-thread). 따라서 `emitFile` native 콜백이 두 worker 에서 동시에
+/// 호출되는 일이 없다. rolldown 이 `DashMap`/`AtomicUsize` 를 쓰는 건 plugin 이 native 코드라
+/// worker thread 에서 직접 FileEmitter 를 치기 때문이고, ZNTC=JS plugin 은 Rollup 의 단일-스레드
+/// 모델과 동형이라 일반 ArrayList + 카운터로 충분하다.
+pub const EmitStore = struct {
+    allocator: std.mem.Allocator,
+    assets: std.ArrayList(EmittedAsset),
+    /// reference id 생성용 단조 증가 카운터. 메인 스레드 직렬이라 atomic 불필요.
+    counter: usize = 0,
+
+    pub fn init(allocator: std.mem.Allocator) EmitStore {
+        return .{ .allocator = allocator, .assets = .empty };
+    }
+
+    pub fn deinit(self: *EmitStore) void {
+        for (self.assets.items) |a| {
+            self.allocator.free(a.reference_id);
+            self.allocator.free(a.file_name);
+            self.allocator.free(a.source);
+        }
+        self.assets.deinit(self.allocator);
+    }
+
+    /// asset 을 등록하고 reference id ("asset-N") 를 반환한다. file_name/source 는 dupe 로 소유.
+    /// 반환 slice 는 store 소유 — caller(NAPI)는 napi string 으로 복사해 JS 에 돌려준다.
+    pub fn emitAsset(self: *EmitStore, file_name: []const u8, source: []const u8) ![]const u8 {
+        const reference_id = try std.fmt.allocPrint(self.allocator, "asset-{d}", .{self.counter});
+        errdefer self.allocator.free(reference_id);
+        const fname = try self.allocator.dupe(u8, file_name);
+        errdefer self.allocator.free(fname);
+        const src = try self.allocator.dupe(u8, source);
+        errdefer self.allocator.free(src);
+        try self.assets.append(self.allocator, .{
+            .reference_id = reference_id,
+            .file_name = fname,
+            .source = src,
+        });
+        self.counter += 1;
+        return reference_id;
+    }
+};
+
+test "emitAsset 은 고유 reference id 를 발급하고 내용을 소유한다" {
+    const testing = std.testing;
+    var store = EmitStore.init(testing.allocator);
+    defer store.deinit();
+
+    const id0 = try store.emitAsset("a.css", "body{}");
+    const id1 = try store.emitAsset("b.json", "{}");
+
+    try testing.expectEqualStrings("asset-0", id0);
+    try testing.expectEqualStrings("asset-1", id1);
+    try testing.expectEqual(@as(usize, 2), store.assets.items.len);
+    try testing.expectEqualStrings("a.css", store.assets.items[0].file_name);
+    try testing.expectEqualStrings("body{}", store.assets.items[0].source);
+    try testing.expectEqualStrings("b.json", store.assets.items[1].file_name);
+}

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -88,6 +88,10 @@ pub const ModuleGraph = struct {
     diagnostics: std.ArrayList(BundlerDiagnostic),
     owned_diagnostic_strings: std.ArrayList([]const u8) = .empty,
     resolve_cache: *ResolveCache,
+    /// `this.emitFile` (PR5) 수집소 포인터(`emit_store.EmitStore`). bundler 가 bundle() 에서
+    /// 단일 store 를 만들어 세팅하며, plugin hook 사이트가 hook_ctx 로 전파한다. null = emitFile
+    /// 미연결(예: worker sub-bundle). 메인 스레드 직렬 write 라 동기화 불필요 (#1880 PR5).
+    emit_store: ?*anyopaque = null,
     source_read_cache: fs.ReadFileCache = .{},
     /// 병렬 워커에서 diagnostics 접근 보호용 mutex
     diag_mutex: std.Thread.Mutex = .{},

--- a/src/bundler/graph/discovery_scan.zig
+++ b/src/bundler/graph/discovery_scan.zig
@@ -134,7 +134,8 @@ pub fn scanModule(self: *ModuleGraph, idx: ModuleIndex) ScanResult {
             if (plugin_runner) |runner| {
                 if (self.shouldRunResolveId(record.specifier)) {
                     // this.resolve (PR4): resolveId hook 에 ResolveCache 전달.
-                    var hook_ctx: plugin_mod.HookContext = .{ .resolve_cache = @ptrCast(self.resolve_cache) };
+                    // this.emitFile (PR5): resolveId hook 에 EmitStore 전달.
+                    var hook_ctx: plugin_mod.HookContext = .{ .resolve_cache = @ptrCast(self.resolve_cache), .emit_store = self.emit_store };
                     const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator, &hook_ctx) catch |err| switch (err) {
                         error.PluginFailed => {
                             self.addPluginFailureDiag(hook_ctx.failure, module_path, record.span, .resolve);

--- a/src/bundler/graph/plugins.zig
+++ b/src/bundler/graph/plugins.zig
@@ -97,7 +97,8 @@ pub fn runLoadForModule(self: anytype, module: *Module, runner: ?plugin_mod.Plug
         return .done;
     };
     // this.resolve (PR4): load hook 에 ResolveCache 전달 (순수 path resolution, race 없음).
-    var hook_ctx: plugin_mod.HookContext = .{ .resolve_cache = @ptrCast(self.resolve_cache) };
+    // this.emitFile (PR5): load hook 에 EmitStore 전달.
+    var hook_ctx: plugin_mod.HookContext = .{ .resolve_cache = @ptrCast(self.resolve_cache), .emit_store = self.emit_store };
     const load_result = plugin_runner.runLoad(module.path, tmp_arena.allocator(), &hook_ctx) catch |err| switch (err) {
         error.PluginFailed => {
             graph_diagnostics.addPluginFailureDiag(self, hook_ctx.failure, module.path, Span.EMPTY, .resolve);
@@ -184,7 +185,7 @@ pub fn runTransformForModule(
     // this.getModuleInfo (PR3 self-only): graph 대신 현재 모듈 포인터만 전달.
     // graph 조회를 하지 않으므로 discovery 병렬 단계의 race 가 없다. self 모듈의 path/source/
     // plugin_meta 는 worker 가 load 단계에서 이미 확정해 안전하게 읽을 수 있다.
-    var hook_ctx: plugin_mod.HookContext = .{ .current_module = @ptrCast(module), .resolve_cache = @ptrCast(self.resolve_cache) };
+    var hook_ctx: plugin_mod.HookContext = .{ .current_module = @ptrCast(module), .resolve_cache = @ptrCast(self.resolve_cache), .emit_store = self.emit_store };
     const transform_result = plugin_runner.runTransform(module.source, module.path, arena_alloc, &hook_ctx) catch |err| switch (err) {
         error.PluginFailed => {
             graph_diagnostics.addPluginFailureDiag(self, hook_ctx.failure, module.path, Span.EMPTY, .transform);

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -449,7 +449,8 @@ pub fn resolveModuleImports(self: *ModuleGraph, idx: ModuleIndex) !void {
         if (plugin_runner) |runner| {
             if (self.shouldRunResolveId(record.specifier)) {
                 // this.resolve (PR4): resolveId hook 에 ResolveCache 전달.
-                var hook_ctx: plugin_mod.HookContext = .{ .resolve_cache = @ptrCast(self.resolve_cache) };
+                // this.emitFile (PR5): resolveId hook 에 EmitStore 전달.
+                var hook_ctx: plugin_mod.HookContext = .{ .resolve_cache = @ptrCast(self.resolve_cache), .emit_store = self.emit_store };
                 const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator, &hook_ctx) catch |err| switch (err) {
                     error.PluginFailed => {
                         self.addPluginFailureDiag(hook_ctx.failure, module_path, record.span, .resolve);

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -56,6 +56,7 @@ pub const Resolver = resolver.Resolver;
 pub const ResolveResult = resolver.ResolveResult;
 pub const ResolveCache = resolve_cache.ResolveCache;
 pub const Platform = resolve_cache.Platform;
+pub const EmitStore = @import("emit_store.zig").EmitStore;
 pub const Module = module.Module;
 pub const ModuleGraph = graph.ModuleGraph;
 pub const Linker = linker.Linker;

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -125,6 +125,10 @@ pub const HookContext = struct {
     /// (graph 미접근, sharded-mutex thread-safe)이라 worker/JS thread 에서 안전 + plugin 재진입
     /// 없음. resolveId/load/transform hook 에서 set. null = this.resolve 미지원 (#1880 PR4).
     resolve_cache: ?*anyopaque = null,
+    /// `this.emitFile` (PR5) 용 EmitStore 포인터. emit 된 asset 은 메인 스레드(TSFN callJsCallback)
+    /// 에서만 단일 store 에 직렬 수집되므로 동기화 불필요(emit_store.zig doc 참조). resolveId/load/
+    /// transform hook 에서 set. null = this.emitFile 미지원 hook (#1880 PR5).
+    emit_store: ?*anyopaque = null,
 
     /// 사용 안 하는 failure metadata 를 일괄 정리. 이미 consume 된 경우 no-op.
     /// swallow 경로 (lifecycle hook, fallback null path 등) 에서 `defer ctx.deinit()` 으로 사용.
@@ -406,10 +410,11 @@ pub const PluginRunner = struct {
                 // 각 plugin 별 fresh inner_ctx — source_maps 는 chain 에서 누적, failure 는
                 // 첫 실패 시 outer 로 옮긴다. plugin hook 이 failure 를 read 하는 contract 는
                 // 없으므로 hook_ctx.failure 시드 불필요.
-                // current_module(PR3) / resolve_cache(PR4) 를 inner_ctx 로 전파.
+                // current_module(PR3) / resolve_cache(PR4) / emit_store(PR5) 를 inner_ctx 로 전파.
                 var inner_ctx: HookContext = .{
                     .current_module = hook_ctx.current_module,
                     .resolve_cache = hook_ctx.resolve_cache,
+                    .emit_store = hook_ctx.emit_store,
                 };
                 const result = hook(p.context, input, id, allocator, &inner_ctx) catch |err| {
                     hook_ctx.failure = inner_ctx.failure;


### PR DESCRIPTION
## 배경

#1880 epic **PR5**. PR1(warn/error) → PR2+3(meta/getModuleInfo) → PR4(this.resolve) 에 이은 plugin context API. Rollup `this.emitFile` 호환으로, plugin 이 추가 asset 을 emit 하면 `result.outputFiles` 에 나타납니다.

## 설계 — Rollup 단일-스레드 모델과 동형 (4-tool 비교 근거)

emit 수집을 **단일 EmitStore + 카운터** 로 구현했습니다. 동기화(mutex/atomic) 없습니다. 근거:

- ZNTC 의 **JS plugin hook 본문은 worker 가 condvar block 중 main thread(TSFN `callJsCallback`)에서 직렬 실행** → `emitFileCallback` 도 main thread 직렬. 두 worker 의 emit 이 물리적으로 interleave 되지 않습니다.
- rolldown 이 `DashMap`/`AtomicUsize` 를 쓰는 건 plugin 이 **native 코드라 worker thread 에서 직접** FileEmitter 를 치기 때문이고, ZNTC=JS plugin 은 그 동시성이 origin 부터 없어 **Rollup 의 단일-스레드 모델과 동형**입니다 (rollup `Map`+counter, rspack 직렬 단계 merge, esbuild emit-API 부재와 대비).
- "느려지지 않나" → 직렬화는 emitFile 이 아니라 *기존* "JS hook=main thread" 성질에서 오며, emit append 는 ns 단위. per-worker 수집은 동시 emit 이 없어 이득 0 + merge 비용만 추가.

## 흐름

`EmitStore`(src/bundler/emit_store.zig) → graph build **전** 연결 → output 생성 후 `OutputFile{kind=.asset}`로 복사해 `final_asset_outputs` 에 합침(기존 `asset_outputs` 경유 → `outputFiles`). store 는 scratch, `bundle()` 종료 시 해제. 배선은 PR4 `resolve_cache` 패턴 그대로: `HookContext`/`ModuleGraph.emit_store` → graph hook 사이트 → `plugin_bridge` `emitFileCallback`(dispatcher 6번째 인자).

## MVP 범위

- ✅ `{ type: 'asset', fileName, source }` (명시 fileName) — string / Uint8Array / Buffer source (binary-safe)
- ❌ `type: 'chunk'` — throw (청킹 통합 필요, follow-up)
- ❌ name-only(hash 파일명) + `this.getFileName` — throw (follow-up)
- ❌ buildSync / vitePlugin() 어댑터 / worker sub-bundle — throw (PR3/PR4 와 동일)

## `/code-review --effort high` 반영

5개 앵글 리뷰 → 메모리 소유권/머지 산술/디스패처 일관성/double-free/vitePlugin·buildSync throw 는 **안전 확인**. 조치:

- **silent null 차단**: 빈 fileName 이 JS `typeof==='string'` 검증을 통과한 뒤 native `getStringArg(len==0)` 가 null 을 반환해 plugin 이 `string` 자리에 `null` 을 조용히 받던 문제 → JS 에서 빈 fileName 거부 + native 반환이 string 아니면 throw (`=> string` 계약 보존, OOM 도 surface).
- **결정성(#3564)**: emit 순서가 worker 스케줄링 의존이라 `outputFiles` asset 순서가 run 간 흔들림 → path 정렬로 안정화.
- **문서화한 한계**: 동기 호출 제약(await 이후/detached promise emit 미지원), duplicate fileName 미검출(Rollup 은 throw).

## 테스트 (TDD)

`plugin-emit-file.ts` 6개: transform/load asset → outputFiles 노출, 고유 referenceId, chunk/name-only/**빈 fileName** 거부. 빈 fileName 테스트는 수정 전이면 silent null(errors 0)로 fail → genuine guard.

- `build-plugins` 전체 **40 pass / 회귀 0**
- `zig build test` 통과 (EmitStore 유닛 테스트 포함), `tsc` 통과
- **ReleaseFast** 재현 (`feedback_release_only_bugs`)
- `css-bundle`/`css-code-splitting`/`manual-chunks` 통합 **82 pass** (asset_outputs 머지 오프셋·디스패처 무회귀 확인)

## 남은 epic

PR6 this.emitFile chunk + getFileName / vitePlugin parity.

Refs #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)