### PR TITLE
feat(plugin): this.getFileName + name-only asset emit (#1880 PR6)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1669,6 +1669,7 @@ type PluginDispatcher = ((
   getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
   resolve?: NativeResolveFn,
   emitFile?: NativeEmitFileFn,
+  getFileName?: NativeGetFileNameFn,
 ) => Promise<unknown>) &
   PluginDispatcherLifecycle;
 type SyncPluginDispatcher = ((hookName: string, arg1: unknown, arg2: string | null) => unknown) &
@@ -1848,9 +1849,15 @@ type NativeResolveFn = (
   options?: unknown,
 ) => { id: string; external: boolean } | null;
 
-// #1880 PR5: native emitFile 콜백. JS 가 검증한 `{ fileName, source }` 를 받아 EmitStore 에
-// 등록하고 reference id("asset-N") 를 sync 반환한다. type/fileName 검증은 JS emitFile 슬롯이 수행.
-type NativeEmitFileFn = (file: { fileName: string; source: string | Uint8Array }) => string;
+// #1880 PR5/6: native emitFile 콜백. JS 가 검증한 `{ fileName?, name?, source }` 를 받아 EmitStore
+// 에 등록하고 reference id("asset-N") 를 sync 반환한다(실패 시 null). 검증은 JS emitFile 슬롯이 수행.
+type NativeEmitFileFn = (file: {
+  fileName?: string;
+  name?: string;
+  source: string | Uint8Array;
+}) => string | null;
+// #1880 PR6: native getFileName 콜백. reference id → 최종 출력 파일명(미등록이면 null).
+type NativeGetFileNameFn = (referenceId: string) => string | null;
 
 function getPluginContext(
   reg: PluginRegistry,
@@ -1858,22 +1865,25 @@ function getPluginContext(
   getModuleInfo?: ((id: string) => ManualChunksModuleInfo | null) | undefined,
   resolve?: NativeResolveFn | undefined,
   emitFile?: NativeEmitFileFn | undefined,
+  getFileName?: NativeGetFileNameFn | undefined,
 ): RollupPluginContext {
   let ctx = reg.contexts.get(pluginName);
   if (!ctx) {
     ctx = createRollupPluginContext(pluginName, (d) => reg.pluginWarnings.push(d));
     reg.contexts.set(pluginName, ctx);
   }
-  // this.getModuleInfo (PR3) / this.resolve (PR4) / this.emitFile (PR5): native 가 hook 별로 넘긴
-  // fn 을 매번 갱신(undefined 포함) — 캐시된 context 에 이전 hook 의 fn 이 stale 로 남지 않도록.
+  // this.getModuleInfo (PR3) / this.resolve (PR4) / this.emitFile (PR5) / this.getFileName (PR6):
+  // native 가 hook 별로 넘긴 fn 을 매번 갱신(undefined 포함) — stale 슬롯 방지.
   const slot = ctx as {
     __getModuleInfo?: (id: string) => ManualChunksModuleInfo | null;
     __resolve?: NativeResolveFn;
     __emitFile?: NativeEmitFileFn;
+    __getFileName?: NativeGetFileNameFn;
   };
   slot.__getModuleInfo = getModuleInfo;
   slot.__resolve = resolve;
   slot.__emitFile = emitFile;
+  slot.__getFileName = getFileName;
   return ctx;
 }
 
@@ -1890,6 +1900,7 @@ function* dispatchHook(
   getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
   resolve?: NativeResolveFn,
   emitFile?: NativeEmitFileFn,
+  getFileName?: NativeGetFileNameFn,
 ): Generator<HookCall, unknown, DispatchedHookResult> {
   // astFunction: arg1 이 JSON 직렬화된 FunctionInfo. 첫 매칭 plugin 의 non-null 반환을 채택.
   if (hookName === 'astFunction') {
@@ -1905,7 +1916,7 @@ function* dispatchHook(
       const result = yield {
         callback: () =>
           h.callback.call(
-            getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile),
+            getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile, getFileName),
             info,
           ),
         pluginName: h.pluginName,
@@ -1940,7 +1951,7 @@ function* dispatchHook(
       const result = yield {
         callback: () =>
           h.callback.call(
-            getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile),
+            getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile, getFileName),
             args,
           ),
         pluginName: h.pluginName,
@@ -1965,7 +1976,7 @@ function* dispatchHook(
         const result = yield {
           callback: () =>
             callback.call(
-              getPluginContext(reg, pluginName, getModuleInfo, resolve, emitFile),
+              getPluginContext(reg, pluginName, getModuleInfo, resolve, emitFile, getFileName),
               spec.arg,
             ),
           pluginName,
@@ -1997,7 +2008,7 @@ function* dispatchHook(
       const result = yield {
         callback: () =>
           h.callback.call(
-            getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile),
+            getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile, getFileName),
             cbArgs,
           ),
         pluginName: h.pluginName,
@@ -2036,7 +2047,7 @@ function* dispatchHook(
     const result = yield {
       callback: () =>
         h.callback.call(
-          getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile),
+          getPluginContext(reg, h.pluginName, getModuleInfo, resolve, emitFile, getFileName),
           cbArgs,
         ),
       pluginName: h.pluginName,
@@ -2131,9 +2142,10 @@ function createPluginDispatcher(plugins: ZntcPlugin[]): PluginDispatcher {
     getModuleInfo?: (id: string) => ManualChunksModuleInfo | null,
     resolve?: NativeResolveFn,
     emitFile?: NativeEmitFileFn,
+    getFileName?: NativeGetFileNameFn,
   ) {
     return driveDispatchAsync(
-      dispatchHook(reg, hookName, arg1, arg2, getModuleInfo, resolve, emitFile),
+      dispatchHook(reg, hookName, arg1, arg2, getModuleInfo, resolve, emitFile, getFileName),
     );
   } as PluginDispatcher;
   dispatcher.takeLifecycleFailures = () => reg.lifecycleFailures.splice(0);
@@ -2868,14 +2880,18 @@ export interface RollupPluginContext {
     importer?: string | null,
     options?: unknown,
   ): Promise<{ id: string; external?: boolean } | null>;
-  /** Emit an additional asset (Rollup `this.emitFile` 호환, #1880 PR5). async build() 의
-   * resolveId/load/transform hook 에서 `{ type: 'asset', fileName, source }` 를 emit → reference id
-   * 반환, 해당 asset 은 `result.outputFiles` 에 나타난다. MVP 는 명시 fileName 의 asset 만 —
-   * `type: 'chunk'` 및 name-only(hash 파일명)+`getFileName` 은 follow-up 으로 throw.
-   * 그 외 hook / buildSync / vitePlugin() 어댑터에서도 throw.
+  /** Emit an additional asset (Rollup `this.emitFile` 호환, #1880 PR5/6). async build() 의
+   * resolveId/load/transform hook 에서 `{ type: 'asset', fileName | name, source }` 를 emit →
+   * reference id 반환, 해당 asset 은 `result.outputFiles` 에 나타난다. `fileName` 은 그대로,
+   * `name` 은 source hash 로 파일명 자동 생성(file/copy loader 와 동일 `assetNames` 패턴).
+   * `type: 'chunk'` 는 follow-up 으로 throw. 그 외 hook / buildSync / vitePlugin() 에서도 throw.
    * **반드시 hook 본문에서 동기적으로 호출**해야 한다 — `await` 이후나 detached promise 에서
    * 호출하면 EmitStore 수명을 벗어나 asset 이 누락되거나 정의되지 않은 동작이 된다 (follow-up). */
   emitFile(file: unknown): string;
+  /** Resolve an emitted file's final output name (Rollup `this.getFileName` 호환, #1880 PR6).
+   * `this.emitFile` 이 돌려준 reference id → 최종 출력 파일명. asset hash 는 source 기반이라 emit
+   * 시점에 확정되므로 같은(또는 먼저 완료된) hook 에서 즉시 조회 가능. 미등록 id 는 throw. */
+  getFileName(referenceId: string): string;
   /** 모듈 그래프 정보(+plugin meta) 조회 (Rollup `this.getModuleInfo` 호환).
    * async build() 의 transform hook 에서만 사용 가능 (#1880 PR3). 그 외 hook/buildSync 에선 throw. */
   getModuleInfo(id: string): ManualChunksModuleInfo | null;
@@ -2985,8 +3001,8 @@ function createRollupPluginContext(
       return Promise.resolve(fn(source, importer));
     },
     emitFile(file: unknown): string {
-      // native 가 hook 별로 __emitFile 슬롯에 주입 (#1880 PR5). asset(명시 fileName)만 MVP —
-      // type/fileName/source 검증은 여기서 수행하고 native 는 단순 store append 만 한다.
+      // native 가 hook 별로 __emitFile 슬롯에 주입 (#1880 PR5/6). type:'asset' 만 — 명시 fileName
+      // 또는 name(source hash 파일명 자동 생성) 중 하나 필요. 검증은 여기서, native 는 store append.
       const fn = (ctx as { __emitFile?: NativeEmitFileFn }).__emitFile;
       if (typeof fn !== 'function') {
         throw new Error(
@@ -2996,17 +3012,18 @@ function createRollupPluginContext(
       if (typeof file !== 'object' || file === null) {
         throw new Error(`@zntc/core [${pluginName}]: this.emitFile() 는 객체 인자가 필요합니다.`);
       }
-      const f = file as { type?: unknown; fileName?: unknown; source?: unknown };
+      const f = file as { type?: unknown; fileName?: unknown; name?: unknown; source?: unknown };
       if (f.type !== 'asset') {
         throw new Error(
-          `@zntc/core [${pluginName}]: this.emitFile({ type: '${String(f.type)}' }) 는 아직 미지원입니다 — 현재 type:'asset' 만 지원 (chunk 는 follow-up, #1880 PR5).`,
+          `@zntc/core [${pluginName}]: this.emitFile({ type: '${String(f.type)}' }) 는 아직 미지원입니다 — 현재 type:'asset' 만 지원 (chunk 는 follow-up, #1880 PR6).`,
         );
       }
-      if (typeof f.fileName !== 'string' || f.fileName.length === 0) {
-        // 빈 fileName 은 native getStringArg 가 len==0 을 missing 으로 취급해 silent null 을
-        // 반환하므로 JS 단에서 거부 — Rollup 도 빈/누락 fileName 을 허용하지 않는다.
+      // 빈 문자열은 native getStringArg 가 missing(silent null)으로 취급하므로 비어있지 않은 값만 허용.
+      const hasFileName = typeof f.fileName === 'string' && f.fileName.length > 0;
+      const hasName = typeof f.name === 'string' && (f.name as string).length > 0;
+      if (!hasFileName && !hasName) {
         throw new Error(
-          `@zntc/core [${pluginName}]: this.emitFile() asset 은 비어있지 않은 명시 fileName 이 필요합니다 (name-only hash 파일명 + getFileName 은 follow-up, #1880 PR5).`,
+          `@zntc/core [${pluginName}]: this.emitFile() asset 은 비어있지 않은 fileName 또는 name 이 필요합니다 (#1880 PR6).`,
         );
       }
       if (typeof f.source !== 'string' && !(f.source instanceof Uint8Array)) {
@@ -3014,15 +3031,34 @@ function createRollupPluginContext(
           `@zntc/core [${pluginName}]: this.emitFile() asset 은 source(string | Uint8Array) 가 필요합니다.`,
         );
       }
-      const referenceId = fn({ fileName: f.fileName, source: f.source });
+      // fileName 우선, 없으면 name 으로 hash 파일명 자동 생성(native emitAssetByName).
+      const referenceId = hasFileName
+        ? fn({ fileName: f.fileName as string, source: f.source })
+        : fn({ name: f.name as string, source: f.source });
       // native 는 OOM/내부 실패 시 null 을 반환 — Rollup 의 `=> string` 계약을 지키도록 throw
       // (silent null 이 reference id 자리에 새어 나가 downstream 에서 모호한 에러를 내는 것 방지).
       if (typeof referenceId !== 'string') {
         throw new Error(
-          `@zntc/core [${pluginName}]: this.emitFile({ fileName: ${JSON.stringify(f.fileName)} }) 가 reference id 를 반환하지 못했습니다 (asset emit 실패).`,
+          `@zntc/core [${pluginName}]: this.emitFile(${JSON.stringify(hasFileName ? f.fileName : f.name)}) 가 reference id 를 반환하지 못했습니다 (asset emit 실패).`,
         );
       }
       return referenceId;
+    },
+    getFileName(referenceId: string): string {
+      // native 가 hook 별로 __getFileName 슬롯에 주입 (#1880 PR6). reference id → 최종 출력 파일명.
+      const fn = (ctx as { __getFileName?: NativeGetFileNameFn }).__getFileName;
+      if (typeof fn !== 'function') {
+        throw new Error(
+          `@zntc/core [${pluginName}]: this.getFileName() 는 async build() 의 resolveId/load/transform hook 에서만 사용 가능합니다 (#1880 PR6).`,
+        );
+      }
+      const name = fn(referenceId);
+      if (typeof name !== 'string') {
+        throw new Error(
+          `@zntc/core [${pluginName}]: this.getFileName(${JSON.stringify(referenceId)}) — 알 수 없는 reference id (this.emitFile 로 emit 되지 않았거나 아직 등록 전).`,
+        );
+      }
+      return name;
     },
     getModuleInfo(id: string): ManualChunksModuleInfo | null {
       // native 가 transform hook 에 한해 graph-bound fn 을 __getModuleInfo 슬롯에 주입 (#1880 PR3).

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -375,10 +375,10 @@ pub const NapiPlugin = struct {
         return js_obj;
     }
 
-    /// this.emitFile (PR5) 구현. data = *EmitStore. argv[0] = JS 가 검증한 `{ fileName, source }`
-    /// (type='asset' + 명시 fileName 만 — chunk/name-only 검증은 JS 측에서 throw). store.emitAsset
-    /// 으로 등록 후 reference id("asset-N") 를 string 으로 반환. 메인 스레드 직렬 호출이라 store
-    /// write 동기화 불필요(emit_store.zig doc 참조).
+    /// this.emitFile (PR5/6) 구현. data = *EmitStore. argv[0] = JS 가 검증한
+    /// `{ fileName?, name?, source }` (type='asset' 만 — chunk 검증은 JS 측에서 throw).
+    /// 명시 fileName 이면 그대로, 없고 name 이면 source hash 로 파일명 자동 생성(emitAssetByName).
+    /// reference id("asset-N") 를 string 으로 반환. 메인 스레드 직렬 호출이라 동기화 불필요.
     fn emitFileCallback(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
         var js_null: c.napi_value = undefined;
         _ = c.napi_get_null(env, &js_null);
@@ -391,16 +391,46 @@ pub const NapiPlugin = struct {
 
         const store: *EmitStore = @ptrCast(@alignCast(data orelse return js_null));
 
-        const file_name = getObjectString(env, argv[0], "fileName", native_alloc) orelse return js_null;
-        defer native_alloc.free(file_name);
         // source 는 string / Uint8Array / Buffer 모두 수용 (binary-safe asset). 빈 source 도 허용.
         const source = getObjectBytes(env, argv[0], "source", native_alloc) orelse return js_null;
         defer native_alloc.free(source);
 
-        const ref_id = store.emitAsset(file_name, source) catch return js_null;
+        // 명시 fileName 우선; 없으면 name-only(hash 파일명 자동 생성). JS 가 둘 중 하나는 보장.
+        const ref_id = blk: {
+            if (getObjectString(env, argv[0], "fileName", native_alloc)) |file_name| {
+                defer native_alloc.free(file_name);
+                break :blk store.emitAsset(file_name, source) catch return js_null;
+            }
+            const name = getObjectString(env, argv[0], "name", native_alloc) orelse return js_null;
+            defer native_alloc.free(name);
+            break :blk store.emitAssetByName(name, source) catch return js_null;
+        };
         var js_ref: c.napi_value = undefined;
         if (c.napi_create_string_utf8(env, ref_id.ptr, ref_id.len, &js_ref) != c.napi_ok) return js_null;
         return js_ref;
+    }
+
+    /// this.getFileName (PR6) 구현. data = *EmitStore. argv[0] = reference id. emit 된 asset 의
+    /// 최종 파일명을 반환(미등록이면 null). asset hash 는 source 기반이라 emit 시점에 확정되므로
+    /// lazy 없이 단순 lookup. 메인 스레드 직렬.
+    fn getFileNameCallback(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+        var js_null: c.napi_value = undefined;
+        _ = c.napi_get_null(env, &js_null);
+
+        var argc: usize = 1;
+        var argv: [1]c.napi_value = undefined;
+        var data: ?*anyopaque = null;
+        if (c.napi_get_cb_info(env, info, &argc, &argv, null, &data) != c.napi_ok) return js_null;
+        if (argc < 1) return js_null;
+
+        const store: *EmitStore = @ptrCast(@alignCast(data orelse return js_null));
+        const ref_id = getStringArg(env, argv[0], native_alloc) orelse return js_null;
+        defer native_alloc.free(ref_id);
+
+        const file_name = store.getFileName(ref_id) orelse return js_null;
+        var js_name: c.napi_value = undefined;
+        if (c.napi_create_string_utf8(env, file_name.ptr, file_name.len, &js_name) != c.napi_ok) return js_null;
+        return js_name;
     }
 
     /// threadsafe function의 call_js 콜백 (메인 스레드에서 실행)
@@ -446,6 +476,7 @@ pub const NapiPlugin = struct {
         var js_get_mod_info: c.napi_value = js_undefined;
         var js_resolve: c.napi_value = js_undefined;
         var js_emit_file: c.napi_value = js_undefined;
+        var js_get_file_name: c.napi_value = js_undefined;
         var argc: usize = 3;
         if (ctx.current_module) |m| {
             _ = c.napi_create_function(env, "getModuleInfo", "getModuleInfo".len, selfModuleInfoCallback, @constCast(m), &js_get_mod_info);
@@ -456,14 +487,15 @@ pub const NapiPlugin = struct {
             _ = c.napi_create_function(env, "resolve", "resolve".len, resolveIdCallback, rc, &js_resolve);
             if (argc < 5) argc = 5;
         }
-        // this.emitFile (PR5): emit_store 가 있으면 6번째 인자로 emitFile 함수 전달.
+        // this.emitFile (PR5) 6번째 + this.getFileName (PR6) 7번째: emit_store 로 둘 다 전달.
         if (ctx.emit_store) |es| {
             _ = c.napi_create_function(env, "emitFile", "emitFile".len, emitFileCallback, es, &js_emit_file);
-            argc = 6;
+            _ = c.napi_create_function(env, "getFileName", "getFileName".len, getFileNameCallback, es, &js_get_file_name);
+            argc = 7;
         }
 
         var js_result: c.napi_value = undefined;
-        const args = [_]c.napi_value{ hook_str, js_arg1, js_arg2, js_get_mod_info, js_resolve, js_emit_file };
+        const args = [_]c.napi_value{ hook_str, js_arg1, js_arg2, js_get_mod_info, js_resolve, js_emit_file, js_get_file_name };
         if (c.napi_call_function(env, js_undefined, js_callback, argc, &args, &js_result) != c.napi_ok) {
             signalResponse(ctx, .{});
             return;

--- a/packages/core/test/core/build-plugins/plugin-emit-file.ts
+++ b/packages/core/test/core/build-plugins/plugin-emit-file.ts
@@ -12,9 +12,10 @@ import {
 import type { ZntcPlugin } from './helpers';
 import type { RollupPluginContext } from '../../../index';
 
-// #1880 PR5 — this.emitFile({ type: 'asset', fileName, source }) → referenceId. emit 된 asset 은
-// build 의 메인 스레드(TSFN callJsCallback)에서 단일 EmitStore 에 직렬 수집 → result.outputFiles 로
-// 노출(asset_outputs 경유). MVP 는 명시 fileName 의 asset 만 — chunk / name-only(getFileName) 은 throw.
+// #1880 PR5/6 — this.emitFile({ type: 'asset', fileName | name, source }) → referenceId +
+// this.getFileName(referenceId). emit 된 asset 은 build 의 메인 스레드(TSFN callJsCallback)에서 단일
+// EmitStore 에 직렬 수집 → result.outputFiles 로 노출(asset_outputs 경유). name-only 는 source hash
+// 파일명 자동 생성(file-loader 와 동일 패턴). type:'chunk' 는 아직 throw(follow-up).
 describe('@zntc/core build + plugins - this.emitFile', () => {
   test('transform 에서 emit 한 asset 이 outputFiles 에 나타난다', async () => {
     let refId: unknown = 'unset';
@@ -160,18 +161,76 @@ describe('@zntc/core build + plugins - this.emitFile', () => {
     }
   });
 
-  test('fileName 없는 asset(name-only hash 파일명) 은 아직 미지원 — plugin failure', async () => {
+  test('name-only asset 은 source hash 파일명으로 emit 되고 stem/ext 를 보존한다', async () => {
+    let fileName: string | undefined;
     const plugin: ZntcPlugin = {
-      name: 'emit-name-only-unsupported',
+      name: 'emit-name-only',
       setup(build) {
         build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
-          this.emitFile({ type: 'asset', name: 'logo.png', source: 'PNGDATA' });
+          const ref = this.emitFile({ type: 'asset', name: 'logo.png', source: 'PNGDATA' });
+          fileName = this.getFileName(ref);
           return null;
         });
       },
     };
 
     const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-nameonly-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      // 기본 assetNames "[name]-[hash]" → "logo-XXXXXXXX.png"
+      expect(fileName).toMatch(/^logo-[0-9a-f]{8}\.png$/);
+      const asset = result.outputFiles.find((f) => f.path === fileName);
+      expect(asset).toBeDefined();
+      expect(asset!.text).toBe('PNGDATA');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('this.getFileName 은 명시 fileName asset 의 파일명을 그대로 반환한다', async () => {
+    let resolved: string | undefined;
+    const plugin: ZntcPlugin = {
+      name: 'emit-getfilename',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          const ref = this.emitFile({ type: 'asset', fileName: 'styles/app.css', source: 'a{}' });
+          resolved = this.getFileName(ref);
+          return null;
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-getname-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(resolved).toBe('styles/app.css');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('this.getFileName(미등록 id) 은 plugin failure', async () => {
+    const plugin: ZntcPlugin = {
+      name: 'emit-getfilename-unknown',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          this.getFileName('asset-does-not-exist');
+          return null;
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-getname-unknown-'));
     try {
       writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
       const result = await build({

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1051,7 +1051,7 @@ pub const Bundler = struct {
         // this.emitFile (PR5): plugin 이 emit 한 asset 수집소. graph build 가 plugin hook 을
         // 호출하기 *전* 에 연결해야 한다. emit 된 asset 은 아래에서 OutputFile(kind=.asset)로
         // 복사되어 final_asset_outputs 에 합쳐지고, store 는 scratch 라 bundle() 종료 시 해제.
-        var emit_store = EmitStore.init(self.allocator);
+        var emit_store = EmitStore.init(self.allocator, self.options.asset_names);
         defer emit_store.deinit();
         graph.emit_store = @ptrCast(&emit_store);
         graph.dev_mode = self.options.dev_mode;

--- a/src/bundler/emit_store.zig
+++ b/src/bundler/emit_store.zig
@@ -1,11 +1,12 @@
 const std = @import("std");
+const assets_mod = @import("graph/assets.zig");
 
-/// plugin `this.emitFile({ type: 'asset', fileName, source })` 로 emit 된 단일 asset.
+/// plugin `this.emitFile({ type: 'asset', fileName | name, source })` 로 emit 된 단일 asset.
 /// 세 필드 모두 `EmitStore.allocator` 소유 — `EmitStore.deinit` 이 일괄 해제한다.
 pub const EmittedAsset = struct {
     /// `this.emitFile` 이 plugin 에 돌려준 reference id ("asset-N").
     reference_id: []const u8,
-    /// 출력 파일명 (MVP 는 명시 fileName 만 — name-only hash 파일명은 follow-up).
+    /// 출력 파일명. 명시 fileName 또는 name-only 시 source hash 로 자동 생성된 이름.
     file_name: []const u8,
     /// asset 내용 (binary-safe).
     source: []const u8,
@@ -19,14 +20,22 @@ pub const EmittedAsset = struct {
 /// 호출되는 일이 없다. rolldown 이 `DashMap`/`AtomicUsize` 를 쓰는 건 plugin 이 native 코드라
 /// worker thread 에서 직접 FileEmitter 를 치기 때문이고, ZNTC=JS plugin 은 Rollup 의 단일-스레드
 /// 모델과 동형이라 일반 ArrayList + 카운터로 충분하다.
+///
+/// MVP 한계(follow-up): ① 동일 source 중복 emit 의 dedup 없음(Rollup 은 combine) — 같은 asset 을
+/// 두 번 emit 하면 동일 path OutputFile 2개. ② getFileName 은 *이미 등록된* reference id 만 조회
+/// 가능 — 다른 모듈 transform 이 아직 emit 하지 않은 id 를 병렬로 조회하면 null(throw). 같은
+/// hook 안에서 emit→getFileName 하는 일반 패턴은 메인 스레드 직렬이라 안전.
 pub const EmitStore = struct {
     allocator: std.mem.Allocator,
     assets: std.ArrayList(EmittedAsset),
     /// reference id 생성용 단조 증가 카운터. 메인 스레드 직렬이라 atomic 불필요.
     counter: usize = 0,
+    /// name-only emit 의 hash 파일명 생성 패턴 (graph.asset_names, 예 "[name]-[hash]").
+    /// file/copy loader 와 동일 규칙을 쓰도록 bundler 가 옵션에서 주입한다.
+    asset_names: []const u8 = "[name]-[hash]",
 
-    pub fn init(allocator: std.mem.Allocator) EmitStore {
-        return .{ .allocator = allocator, .assets = .empty };
+    pub fn init(allocator: std.mem.Allocator, asset_names: []const u8) EmitStore {
+        return .{ .allocator = allocator, .assets = .empty, .asset_names = asset_names };
     }
 
     pub fn deinit(self: *EmitStore) void {
@@ -55,11 +64,37 @@ pub const EmitStore = struct {
         self.counter += 1;
         return reference_id;
     }
+
+    /// name-only asset: 명시 fileName 없이 `name`(예 "logo.png") + source hash 로 파일명을 자동
+    /// 생성한다(file/copy loader 와 동일한 `applyAssetNamingPattern`). hash 는 source 만으로 결정
+    /// 되므로 emit 시점에 즉시 확정 가능 → getFileName 도 lazy 불필요(Rollup 은 chunk 때문에 lazy).
+    pub fn emitAssetByName(self: *EmitStore, name: []const u8, source: []const u8) ![]const u8 {
+        const hash = assets_mod.contentHash(source);
+        // file/copy loader(graph/loaders.zig)와 동일하게 분리: [name]=basename(확장자 제거),
+        // [dir]=디렉토리. dir 을 "" 로 넘기면 패턴에 [dir] 토큰이 있을 때 leading-slash 등
+        // 깨진 경로가 나오므로 name 의 dirname 을 그대로 전달한다.
+        const basename = std.fs.path.basename(name);
+        const ext = std.fs.path.extension(basename); // ".png" 또는 ""
+        const stem = if (ext.len > 0 and basename.len > ext.len) basename[0 .. basename.len - ext.len] else basename;
+        const dir = std.fs.path.dirname(name) orelse "";
+        const file_name = try assets_mod.applyAssetNamingPattern(self.allocator, self.asset_names, stem, &hash, ext, dir);
+        defer self.allocator.free(file_name);
+        return self.emitAsset(file_name, source);
+    }
+
+    /// reference id 로 등록된 asset 의 출력 파일명을 조회한다(Rollup `this.getFileName`).
+    /// 메인 스레드 직렬이라 별도 동기화 없이 단순 스캔 — emit 된 asset 수는 작다.
+    pub fn getFileName(self: *const EmitStore, reference_id: []const u8) ?[]const u8 {
+        for (self.assets.items) |a| {
+            if (std.mem.eql(u8, a.reference_id, reference_id)) return a.file_name;
+        }
+        return null;
+    }
 };
 
 test "emitAsset 은 고유 reference id 를 발급하고 내용을 소유한다" {
     const testing = std.testing;
-    var store = EmitStore.init(testing.allocator);
+    var store = EmitStore.init(testing.allocator, "[name]-[hash]");
     defer store.deinit();
 
     const id0 = try store.emitAsset("a.css", "body{}");
@@ -71,4 +106,35 @@ test "emitAsset 은 고유 reference id 를 발급하고 내용을 소유한다"
     try testing.expectEqualStrings("a.css", store.assets.items[0].file_name);
     try testing.expectEqualStrings("body{}", store.assets.items[0].source);
     try testing.expectEqualStrings("b.json", store.assets.items[1].file_name);
+}
+
+test "emitAssetByName 은 source hash 로 파일명을 생성하고 getFileName 으로 조회된다" {
+    const testing = std.testing;
+    var store = EmitStore.init(testing.allocator, "[name]-[hash]");
+    defer store.deinit();
+
+    const id = try store.emitAssetByName("logo.png", "PNGDATA");
+    // [name]-[hash].png 형태 — stem=logo, ext=.png 보존, hash 8 hex.
+    const fname = store.getFileName(id).?;
+    try testing.expect(std.mem.startsWith(u8, fname, "logo-"));
+    try testing.expect(std.mem.endsWith(u8, fname, ".png"));
+    try testing.expectEqual(@as(usize, "logo-".len + 8 + ".png".len), fname.len);
+    // 동일 source 는 동일 hash 파일명 (결정적).
+    const id2 = try store.emitAssetByName("logo.png", "PNGDATA");
+    try testing.expectEqualStrings(fname, store.getFileName(id2).?);
+    // 미등록 reference id → null.
+    try testing.expect(store.getFileName("asset-999") == null);
+}
+
+test "emitAssetByName 은 [dir] 패턴에서 name 의 디렉토리를 [dir] 로 넣는다 (loader parity)" {
+    const testing = std.testing;
+    var store = EmitStore.init(testing.allocator, "[dir]/[name]-[hash]");
+    defer store.deinit();
+
+    // name="icons/logo.png" → stem=logo, dir=icons → "icons/logo-HASH.png" (leading-slash 없음).
+    const id = try store.emitAssetByName("icons/logo.png", "DATA");
+    const fname = store.getFileName(id).?;
+    try testing.expect(std.mem.startsWith(u8, fname, "icons/logo-"));
+    try testing.expect(std.mem.endsWith(u8, fname, ".png"));
+    try testing.expect(!std.mem.startsWith(u8, fname, "/")); // dir="" 였다면 "/logo-..." 가 됐을 것
 }


### PR DESCRIPTION
## 배경

#1880 epic **PR6**. PR5(emitFile asset, 명시 fileName 만)의 자연스러운 완성입니다. CSS/이미지 plugin 의 핵심 패턴 — **emit 하고 그 최종 URL 을 코드에 박기** — 를 가능하게 합니다.

- `this.emitFile({ type: 'asset', name, source })` — 명시 fileName 없이 `name` 만 주면 **source hash 로 파일명 자동 생성**
- `this.getFileName(referenceId)` — emit 된 asset 의 최종 출력 파일명 조회

## 설계 — asset hash 는 source 기반이라 lazy 불필요

Rollup 은 `getFileName` 을 lazy(output 생성 후)로 처리하지만, 그건 **chunk** 파일명이 청킹 후에야 정해지기 때문입니다. **asset hash 는 source 만으로 결정**되므로 ZNTC 의 EmitStore 모델에선 **emit 시점에 즉시 파일명을 확정** → `getFileName` 은 단순 lookup 이면 됩니다.

- `EmitStore.emitAssetByName`: `graph/assets.zig` 의 `contentHash` + `applyAssetNamingPattern` 재사용. `basename→[name]`, `dirname→[dir]` 로 분리해 **file/copy loader(`graph/loaders.zig`)와 동일한 명명 규칙**.
- `EmitStore.getFileName`: `reference_id → file_name` 스캔(메인 스레드 직렬, PR5 와 동일 동시성 모델).
- 배선: `emitFileCallback` 이 `fileName | name` 분기 + 새 `getFileNameCallback`(dispatcher 7번째 인자). `index.ts` `emitFile` 검증 완화(fileName 또는 name) + `this.getFileName` 슬롯/인터페이스.

## `/code-review max` 반영

5개 앵글 리뷰 → 메모리 안전성·lifetime·double-free·import 사이클·디스패처 일관성 **전부 안전 확인**. 조치:

- **`[dir]` parity 버그 수정**: `emitAssetByName` 가 `applyAssetNamingPattern` 에 `dir=""` 를 넘겨, 커스텀 `assetNames` 에 `[dir]` 토큰이 있으면 `/logo-HASH.png` 처럼 **leading-slash 깨진 경로**를 만들던 것 → `name` 의 dirname 을 전달(file-loader parity). 유닛 테스트로 가드.
- **문서화한 한계(follow-up)**: ① 동일 source 중복 emit 의 dedup 없음(Rollup 은 combine) ② cross-module `getFileName` 순서 의존(다른 worker 가 아직 emit 안 한 id 조회 시 throw). 둘 다 **같은 hook 안 동기 emit→getFileName 은 메인 스레드 직렬이라 안전**.

## 테스트

`plugin-emit-file.ts` +3 (name-only hash 파일명 + stem/ext 보존, `getFileName` 명시 fileName 반환, 미등록 id throw) + `EmitStore` 유닛 +2 (name-only 생성/getFileName, `[dir]` 패턴 parity).

- `build-plugins` 전체 **42 pass / 회귀 0**
- `zig build test` 통과, `tsc` 통과, **ReleaseFast** 재현
- `css-bundle`/`css-code-splitting`/`manual-chunks` 통합 **82 pass** (dispatcher 7번째 인자·bundler 무회귀)

## 남은 epic

PR7 this.emitFile `type:'chunk'` + vitePlugin emitFile parity.

Refs #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)