### PR TITLE
fix(bundler): minify_whitespace 시 RN polyfill content 도 minify

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1368,18 +1368,26 @@ pub const Bundler = struct {
                 continue;
             };
             const basename = std.fs.path.basename(poly_path);
-            // Flow 모드일 때 트랜스파일하여 타입 구문 제거 (RN 폴리필은 Flow로 작성됨)
+            // 폴리필은 모듈 그래프를 우회해 여기서 직접 읽어 prepend 된다. Flow strip 과
+            // (minify 빌드 시) whitespace minify 를 transpile 1회로 처리한다. 그렇지 않으면
+            // 폴리필 원본 주석/들여쓰기/줄바꿈이 minify 번들에 그대로 남는다 (#3649).
             //
             // RN console.js 는 @noflow 이며 DevTools console callsite 의 기준 파일이다.
-            // 이를 변환하면 하단 originalConsole bridge 의 generated line 이 원본 line 과
-            // 어긋나 `console.js:<generated>` 로 노출된다. 원본이 JS 문법으로 parse 가능하므로
-            // 그대로 두고 identity sourcemap 을 유지한다.
-            const content = if (self.options.flow and !std.mem.eql(u8, basename, "console.js")) blk: {
+            // 변환하면 originalConsole bridge 의 generated line 이 원본 line 과 어긋나
+            // `console.js:<generated>` 로 노출되므로, dev(비-minify) 에선 raw 로 둔다.
+            // minify 빌드에선 sourcemap 자체가 단일 line 으로 minify 되어 callsite 보존
+            // 의미가 없으므로 console.js 도 transpile 을 허용한다.
+            // identifiers/syntax minify 는 폴리필 global 등록 안전성 때문에 제외 — whitespace 만.
+            const minify_ws = self.options.minify_whitespace;
+            const is_console = std.mem.eql(u8, basename, "console.js");
+            const should_transpile = (self.options.flow or minify_ws) and (!is_console or minify_ws);
+            const content = if (should_transpile) blk: {
                 const result = transpile_mod.transpile(self.allocator, raw, poly_path, .{
-                    .flow = true,
+                    .flow = self.options.flow,
                     .jsx_in_js = self.options.jsx_in_js,
                     // 폴리필도 verbatim 규칙을 따라야 함 — 그래야 번들 본체와 동일한 import 처리 정책.
                     .verbatim_module_syntax = self.options.verbatim_module_syntax,
+                    .minify_whitespace = minify_ws,
                 }) catch {
                     break :blk raw; // 트랜스파일 실패 시 원본 사용
                 };

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -1299,6 +1299,38 @@ test "Bundler: dev mode includes polyfills and banner" {
     try std.testing.expect(polyfill_pos < code_pos);
 }
 
+test "Bundler: minify_whitespace 가 polyfill content 도 minify (#3649 polyfill root cause)" {
+    // RN polyfill 은 모듈 그래프를 우회해 bundler 가 직접 읽어 prepend 한다.
+    // minify_whitespace 시 polyfill content 도 주석/공백/들여쓰기가 제거돼야 한다
+    // (이전엔 flow strip 만 하고 minify 미전달 → 원본 그대로 남던 회귀).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+    try writeFile(tmp.dir, "my-polyfill.js", "// license banner comment\nfunction polyHelper(argName) {\n    return argName + 1;\n}\nglobal.MyPolyfill = { run: polyHelper };\n");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const polyfill = try absPath(&tmp, "my-polyfill.js");
+    defer std.testing.allocator.free(polyfill);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .polyfills = &.{polyfill},
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // polyfill content 는 여전히 포함
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MyPolyfill") != null);
+    // minify: 주석 제거 + 4-space 들여쓰기 제거
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "license banner comment") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "    return") == null);
+}
+
 test "Bundler: dev mode single file" {
     // Phase 2: dev mode에서 단일 파일이 프로덕션 파이프라인으로 scope-hoisted 출력
     var tmp = std.testing.tmpDir(.{});


### PR DESCRIPTION
## 루트커즈
RN polyfill(`@react-native/js-polyfills`: `console.js`·`error-guard.js`·`Object.es*.js` 등, `@polyfill` pragma)은 **모듈 그래프를 우회**해 `bundler` 가 파일을 직접 읽어 prepend 합니다. 그런데 content 생성 시:
- transpile 이 **Flow strip 만** 하고 `minify_whitespace`/`minify_identifiers`/`minify_syntax` 를 안 넘김
- **`console.js` 는 transpile 자체를 스킵**(DevTools console callsite sourcemap 보존)

→ minify 번들에도 polyfill 원본 **주석(license)·들여쓰기·줄바꿈**이 그대로 남았습니다. (bare 기준 들여쓴 줄 599, `joyent/node util.js` 주석 블록 등 — minify 번들이 SWC 대비 컸던 한 원인)

## 수정
`minify_whitespace` 빌드 시 polyfill transpile 에도 `minify_whitespace=true` 를 전달합니다.
- `console.js` 는 dev(비-minify)에선 raw 유지(sourcemap callsite 보존), **minify 빌드에선 transpile 허용**(sourcemap 이 단일 line 으로 minify 되어 callsite 보존 의미 없음)
- `identifiers/syntax` minify 는 polyfill 의 global 등록 안전성 때문에 제외 — **whitespace 만**

## 효과 (react-native-bare, iOS production)
| | before | after |
|---|---|---|
| lines | 6,954 | 6,148 |
| raw | 2,133,059 | 2,122,106 (**−11KB**) |
| **gzip** | 472,999 | 469,386 (**−3.6KB**) |
| 들여쓴 줄 | 599 | 8 |
| license 주석 | 33 | 0 |

개행 separator(별건, gzip≈0)와 달리 **주석·공백 제거라 gzip 에도 실효**가 있습니다.

## 검증
- bundler 통합 테스트 추가(polyfill 주석/들여쓰기 제거) — red→green
- `zig build test` 전체 통과 (console.js sourcemap 테스트 무영향)
- e2e: bare 번들 크기·줄 수 감소 + 번들 유효성 확인

> 참고: #3649 의 "개행 separator" 부분(모듈 경계 `\n`)은 gzip≈0 이라 별도/보류이며, 본 PR 은 실효가 있는 polyfill content minify(루트커즈)를 다룹니다.

Closes #3649

🤖 Generated with [Claude Code](https://claude.com/claude-code)