### PR TITLE
feat(plugin): vitePlugin() emitFile / getFileName parity (#1880 PR7)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -2884,7 +2884,8 @@ export interface RollupPluginContext {
    * resolveId/load/transform hook 에서 `{ type: 'asset', fileName | name, source }` 를 emit →
    * reference id 반환, 해당 asset 은 `result.outputFiles` 에 나타난다. `fileName` 은 그대로,
    * `name` 은 source hash 로 파일명 자동 생성(file/copy loader 와 동일 `assetNames` 패턴).
-   * `type: 'chunk'` 는 follow-up 으로 throw. 그 외 hook / buildSync / vitePlugin() 에서도 throw.
+   * vitePlugin() 어댑터의 resolveId/load/transform hook 에서도 동작(#1880 PR7). `type: 'chunk'` 는
+   * follow-up 으로 throw. 그 외 hook / buildSync 에서도 throw.
    * **반드시 hook 본문에서 동기적으로 호출**해야 한다 — `await` 이후나 detached promise 에서
    * 호출하면 EmitStore 수명을 벗어나 asset 이 누락되거나 정의되지 않은 동작이 된다 (follow-up). */
   emitFile(file: unknown): string;
@@ -3086,6 +3087,20 @@ function createDropWarner(context: RollupPluginContext): (reason: string) => voi
   };
 }
 
+/** vitePlugin 어댑터는 자체 `context` 를 만들어 핸들러를 `.call(context, ...)` 로 호출하므로,
+ *  native 디스패처가 hook 별로 주입하는 emit 슬롯(`this.__emitFile`/`__getFileName`)이 어댑터
+ *  context 에 닿지 않는다(#1880 PR7). 핸들러를 일반 함수로 두고 native `this` 의 슬롯을 어댑터
+ *  context 로 전달해 vite plugin 에서도 this.emitFile/getFileName 이 동작하게 한다. native this 가
+ *  슬롯을 안 가진 hook(renderChunk 등)·buildSync 에선 undefined 가 전달돼 그대로 throw — 지원 매트릭스 유지. */
+function forwardEmitContext(nativeThis: unknown, viteCtx: RollupPluginContext): void {
+  const from = nativeThis as
+    | { __emitFile?: NativeEmitFileFn; __getFileName?: NativeGetFileNameFn }
+    | undefined;
+  const to = viteCtx as { __emitFile?: NativeEmitFileFn; __getFileName?: NativeGetFileNameFn };
+  to.__emitFile = from?.__emitFile;
+  to.__getFileName = from?.__getFileName;
+}
+
 export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
   return {
     name: rollupPlugin.name,
@@ -3094,7 +3109,8 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
       const onDropSourceMap = createDropWarner(context);
       const resolveId = extractHandler(rollupPlugin.resolveId);
       if (resolveId) {
-        build.onResolve({ filter: /.*/ }, (args) => {
+        build.onResolve({ filter: /.*/ }, function (this: RollupPluginContext, args) {
+          forwardEmitContext(this, context);
           const result = resolveId.call(context, args.path, args.importer);
           return mapMaybePromise(result, (result) => {
             if (result == null) return null;
@@ -3109,7 +3125,8 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
 
       const load = extractHandler(rollupPlugin.load);
       if (load) {
-        build.onLoad({ filter: /.*/ }, (args) => {
+        build.onLoad({ filter: /.*/ }, function (this: RollupPluginContext, args) {
+          forwardEmitContext(this, context);
           const result = load.call(context, args.path);
           return mapMaybePromise(result, (result) => {
             if (result == null) return null;
@@ -3127,7 +3144,8 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
 
       const transform = extractHandler(rollupPlugin.transform);
       if (transform) {
-        build.onTransform({ filter: /.*/ }, (args) => {
+        build.onTransform({ filter: /.*/ }, function (this: RollupPluginContext, args) {
+          forwardEmitContext(this, context);
           const result = transform.call(context, args.code, args.path);
           return mapMaybePromise(result, (result) => {
             if (result == null) return null;
@@ -3145,7 +3163,10 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
 
       const renderChunk = extractHandler(rollupPlugin.renderChunk);
       if (renderChunk) {
-        build.onRenderChunk({ filter: /.*/ }, (args) => {
+        build.onRenderChunk({ filter: /.*/ }, function (this: RollupPluginContext, args) {
+          // emit 미지원 hook — forward 로 어댑터 context 의 stale 슬롯을 clear(native this 슬롯 없음)
+          // 해야 transform 등에서 남은 슬롯으로 emitFile 이 잘못 동작하는 것을 막는다(#1880 PR7).
+          forwardEmitContext(this, context);
           const result = renderChunk.call(context, args.code, args.chunk);
           return mapMaybePromise(result, (result) => {
             if (result == null) return null;
@@ -3160,22 +3181,34 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
 
       const generateBundle = extractHandler(rollupPlugin.generateBundle);
       if (generateBundle) {
-        build.onGenerateBundle((outputs) => generateBundle.call(context, outputs));
+        build.onGenerateBundle(function (this: RollupPluginContext, outputs) {
+          forwardEmitContext(this, context); // stale 슬롯 clear (위 동일)
+          return generateBundle.call(context, outputs);
+        });
       }
 
       const buildStart = extractHandler(rollupPlugin.buildStart);
       if (buildStart) {
-        build.onBuildStart(() => buildStart.call(context));
+        build.onBuildStart(function (this: RollupPluginContext) {
+          forwardEmitContext(this, context);
+          return buildStart.call(context);
+        });
       }
 
       const buildEnd = extractHandler(rollupPlugin.buildEnd);
       if (buildEnd) {
-        build.onBuildEnd((err) => buildEnd.call(context, err));
+        build.onBuildEnd(function (this: RollupPluginContext, err) {
+          forwardEmitContext(this, context);
+          return buildEnd.call(context, err);
+        });
       }
 
       const closeBundle = extractHandler(rollupPlugin.closeBundle);
       if (closeBundle) {
-        build.onCloseBundle(() => closeBundle.call(context));
+        build.onCloseBundle(function (this: RollupPluginContext) {
+          forwardEmitContext(this, context);
+          return closeBundle.call(context);
+        });
       }
     },
   };

--- a/packages/core/test/core/build-plugins/plugin-emit-file.ts
+++ b/packages/core/test/core/build-plugins/plugin-emit-file.ts
@@ -53,6 +53,62 @@ describe('@zntc/core build + plugins - this.emitFile', () => {
     }
   });
 
+  test('binary source(Uint8Array) 가 손실 없이 emit 된다', async () => {
+    // 0x00 포함 — string 경유 시 깨지는 바이트로 binary-safe 검증.
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0x01]);
+    const plugin: ZntcPlugin = {
+      name: 'emit-binary',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'asset', fileName: 'logo.png', source: bytes });
+          return null;
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-binary-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      const asset = result.outputFiles.find((f) => f.path === 'logo.png');
+      expect(asset).toBeDefined();
+      expect(Array.from(asset!.contents)).toEqual(Array.from(bytes));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('resolveId hook 에서도 emit 한 asset 이 노출된다', async () => {
+    // onResolve 필터는 *specifier* 에 매칭 — import 를 둬야 hook 이 발동한다.
+    const plugin: ZntcPlugin = {
+      name: 'emit-resolveid',
+      setup(build) {
+        build.onResolve({ filter: /dep/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'asset', fileName: 'from-resolve.txt', source: 'R' });
+          return null; // 해석은 기본 resolver 에 위임
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-resolveid-'));
+    try {
+      writeFileSync(join(dir, 'dep.ts'), 'export const d = 1;\n');
+      writeFileSync(join(dir, 'main.ts'), 'import { d } from "./dep.ts";\nexport const x = d;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(result.outputFiles.find((f) => f.path === 'from-resolve.txt')?.text).toBe('R');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('load hook 에서도 emit 한 asset 이 노출된다', async () => {
     const plugin: ZntcPlugin = {
       name: 'emit-asset-load',

--- a/packages/core/test/core/vite-plugin.ts
+++ b/packages/core/test/core/vite-plugin.ts
@@ -2,5 +2,6 @@ import './vite-plugin/hook-return-values';
 import './vite-plugin/real-world-loaders';
 import './vite-plugin/transform-chaining';
 import './vite-plugin/resolve-importer';
+import './vite-plugin/emit-file';
 import './vite-plugin/diagnostics';
 import './vite-plugin/sourcemap';

--- a/packages/core/test/core/vite-plugin/emit-file.ts
+++ b/packages/core/test/core/vite-plugin/emit-file.ts
@@ -1,0 +1,106 @@
+import {
+  build,
+  describe,
+  expect,
+  join,
+  mkdtempSync,
+  rmSync,
+  test,
+  tmpdir,
+  vitePlugin,
+  writeFileSync,
+} from './helpers';
+import type { RollupPlugin } from './helpers';
+
+// #1880 PR7 — vitePlugin() 어댑터에서도 this.emitFile / this.getFileName 동작. 어댑터는 자체
+// context 를 쓰지만, native 디스패처가 transform/load/resolveId hook 에 주입한 emit 슬롯을
+// 핸들러(this)에서 어댑터 context 로 전달한다(forwardEmitContext).
+describe('vitePlugin 어댑터 - this.emitFile / getFileName', () => {
+  test('transform 에서 emit 한 asset 이 outputFiles 에 나타나고 getFileName 으로 조회된다', async () => {
+    let resolved: string | undefined;
+    const plugin: RollupPlugin = {
+      name: 'vite-emit-transform',
+      transform(code) {
+        const ref = this.emitFile({ type: 'asset', fileName: 'vite-extracted.css', source: 'a{}' });
+        resolved = this.getFileName(ref);
+        return null;
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-vite-emit-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [vitePlugin(plugin)],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(resolved).toBe('vite-extracted.css');
+      const asset = result.outputFiles.find((f) => f.path === 'vite-extracted.css');
+      expect(asset).toBeDefined();
+      expect(asset!.text).toBe('a{}');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('transform emit 후 renderChunk 의 emitFile 은 stale 슬롯으로 새지 않고 throw 한다', async () => {
+    // 회귀 가드(PR7 code-review): 어댑터 context 슬롯이 transform 에서 set 된 채 renderChunk 로
+    // 남아 emitFile 이 잘못 동작하던 버그. renderChunk 는 emit 미지원이므로 throw 해야 한다.
+    const plugin: RollupPlugin = {
+      name: 'vite-emit-renderchunk-stale',
+      transform() {
+        this.emitFile({ type: 'asset', fileName: 'ok-from-transform.txt', source: 'T' });
+        return null;
+      },
+      renderChunk(code) {
+        this.emitFile({ type: 'asset', fileName: 'leaked-from-renderchunk.txt', source: 'X' });
+        return null;
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-vite-emit-stale-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [vitePlugin(plugin)],
+      });
+      // renderChunk 의 emitFile 은 stale 슬롯이 clear 돼 throw(renderChunk 실패는 swallow 되어
+      // result.errors 로는 안 올라오지만) → 핵심은 그 asset 이 output 에 새지 않는 것.
+      expect(
+        result.outputFiles.find((f) => f.path === 'leaked-from-renderchunk.txt'),
+      ).toBeUndefined();
+      // transform 의 정상 emit 은 그대로 노출.
+      expect(result.outputFiles.find((f) => f.path === 'ok-from-transform.txt')?.text).toBe('T');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('name-only asset 도 vitePlugin 에서 source hash 파일명으로 emit 된다', async () => {
+    let fileName: string | undefined;
+    const plugin: RollupPlugin = {
+      name: 'vite-emit-name-only',
+      load() {
+        const ref = this.emitFile({ type: 'asset', name: 'icon.svg', source: '<svg/>' });
+        fileName = this.getFileName(ref);
+        return null;
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-vite-emit-name-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [vitePlugin(plugin)],
+      });
+      expect(result.errors.length).toBe(0);
+      expect(fileName).toMatch(/^icon-[0-9a-f]{8}\.svg$/);
+      expect(result.outputFiles.find((f) => f.path === fileName)?.text).toBe('<svg/>');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 배경

#1880 epic **PR7** (1/2). PR5/6 에서 native plugin 의 `this.emitFile`/`this.getFileName` 을 구현했으나, **vitePlugin() 어댑터**에서는 동작하지 않았습니다(throw). 어댑터는 자체 `context` 를 만들어 핸들러를 `.call(context, ...)` 로 호출하므로, native 디스패처가 hook 별로 주입하는 emit 슬롯(`this.__emitFile`/`__getFileName`)이 어댑터 context 에 닿지 않았기 때문입니다.

## 구현

- **`forwardEmitContext(nativeThis, viteCtx)`**: native `this` 의 emit 슬롯을 어댑터 context 로 전달. 핸들러를 화살표 → **일반 함수**로 바꿔 native `this`(디스패처가 `.call` 로 넘기는 context)에 접근.
- **모든 hook 핸들러가 forward 호출**: native `getPluginContext` 가 매 디스패치마다 슬롯을 갱신하듯, 어댑터 context 슬롯도 항상 **현재 hook 의 native 슬롯을 미러**. emit 미지원 hook(renderChunk/lifecycle)·buildSync 는 native 슬롯이 없어 `undefined` 가 전달돼 throw 가 복원됩니다(지원 매트릭스 유지).

## `/code-review max` — 재현된 버그 fix

리뷰가 **stale 슬롯 누수**를 잡았고 재현됐습니다: `forwardEmitContext` 가 공유 어댑터 context(build당 1회 생성)에 슬롯을 쓰고 **clear 하지 않아서**, transform 에서 emit 한 뒤 **renderChunk 의 `emitFile` 이 stale 슬롯으로 잘못 동작**(아직 살아있는 EmitStore 에 asset 누수)했습니다. native plugin 은 throw 하는데 어댑터만 새던 divergence.

→ **모든 핸들러가 forward 하게 만들어 clear**(emit 미지원 hook 의 native `this` 는 슬롯이 없으니 `undefined` 로 덮어 throw 복원). 회귀 가드 테스트 추가(renderChunk emitFile 의 asset 이 output 에 안 새는지).

## 테스트 보강 (테스트 충분성 점검)

PR5/6 의 미검증 경로를 함께 보강:
- **`vite-plugin/emit-file.ts`**: vitePlugin transform/load emit + getFileName, name-only hash, renderChunk stale 누수 차단 회귀 가드.
- **`plugin-emit-file.ts`**: **binary source**(Uint8Array, `0x00` 포함) roundtrip — "binary-safe" 주장 검증, **resolveId hook emit** — wiring 됐으나 미검증이던 경로.

## 검증

- `build-plugins` **44 pass** + `vite-plugin` **27 pass** / 회귀 0
- `tsc` 통과. **JS-only PR**(Zig 무변경 → addon 재빌드 불필요, native 경로 영향 없음)
- lifecycle 핸들러 arrow→regular 변경도 lifecycle 테스트 통과로 무회귀 확인

## 남은 epic

PR7 (2/2) = `this.emitFile({ type: 'chunk' })` (청킹/linker 통합, 큰 작업).

Refs #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)