### PR TITLE
feat(plugin): EmitStore chunk 요청 수집 토대 (#1880 PR7-2a)

### DIFF
--- a/src/bundler/emit_store.zig
+++ b/src/bundler/emit_store.zig
@@ -12,6 +12,19 @@ pub const EmittedAsset = struct {
     source: []const u8,
 };
 
+/// plugin `this.emitFile({ type: 'chunk', id, name? })` 로 emit 된 chunk 요청 (#1880 PR7-2).
+/// asset 과 달리 `id`(모듈 specifier)를 resolve→load→parse 해 새 entry chunk 로 graph 에 주입해야
+/// 한다. **PR7-2a 는 요청 수집 자료구조만** — 실제 graph 주입/청킹은 PR7-2b, 파일명 lazy 확정은
+/// PR7-2c. 두 필드 모두 `EmitStore.allocator` 소유.
+pub const EmittedChunk = struct {
+    /// `this.emitFile` 이 plugin 에 돌려준 reference id ("chunk-N").
+    reference_id: []const u8,
+    /// resolve 대상 모듈 specifier (entry 로 추가될 모듈).
+    id: []const u8,
+    /// chunk 이름(옵션) — 파일명 패턴 `[name]` 치환용. null 이면 id 기반.
+    name: ?[]const u8 = null,
+};
+
 /// plugin `this.emitFile` 수집소 (#1880 PR5).
 ///
 /// **메인 스레드에서만 write 되므로 동기화(mutex/atomic)가 불필요하다.** ZNTC 의 JS plugin hook
@@ -28,14 +41,17 @@ pub const EmittedAsset = struct {
 pub const EmitStore = struct {
     allocator: std.mem.Allocator,
     assets: std.ArrayList(EmittedAsset),
-    /// reference id 생성용 단조 증가 카운터. 메인 스레드 직렬이라 atomic 불필요.
+    /// chunk emit 요청 (#1880 PR7-2). PR7-2a 는 수집만 — graph 주입은 PR7-2b.
+    chunks: std.ArrayList(EmittedChunk),
+    /// reference id 생성용 단조 증가 카운터(asset/chunk 공유 → "asset-N"/"chunk-N" 모두 유니크).
+    /// 메인 스레드 직렬이라 atomic 불필요.
     counter: usize = 0,
     /// name-only emit 의 hash 파일명 생성 패턴 (graph.asset_names, 예 "[name]-[hash]").
     /// file/copy loader 와 동일 규칙을 쓰도록 bundler 가 옵션에서 주입한다.
     asset_names: []const u8 = "[name]-[hash]",
 
     pub fn init(allocator: std.mem.Allocator, asset_names: []const u8) EmitStore {
-        return .{ .allocator = allocator, .assets = .empty, .asset_names = asset_names };
+        return .{ .allocator = allocator, .assets = .empty, .chunks = .empty, .asset_names = asset_names };
     }
 
     pub fn deinit(self: *EmitStore) void {
@@ -45,6 +61,12 @@ pub const EmitStore = struct {
             self.allocator.free(a.source);
         }
         self.assets.deinit(self.allocator);
+        for (self.chunks.items) |chk| {
+            self.allocator.free(chk.reference_id);
+            self.allocator.free(chk.id);
+            if (chk.name) |n| self.allocator.free(n);
+        }
+        self.chunks.deinit(self.allocator);
     }
 
     /// asset 을 등록하고 reference id ("asset-N") 를 반환한다. file_name/source 는 dupe 로 소유.
@@ -89,6 +111,25 @@ pub const EmitStore = struct {
             if (std.mem.eql(u8, a.reference_id, reference_id)) return a.file_name;
         }
         return null;
+    }
+
+    /// chunk emit 요청을 등록하고 reference id ("chunk-N") 를 반환한다 (#1880 PR7-2).
+    /// id/name 은 dupe 로 소유. **PR7-2a 는 요청 수집만** — 이 요청을 새 entry 로 graph 에 주입해
+    /// 별도 chunk 로 출력하는 것은 PR7-2b, 파일명 lazy 확정은 PR7-2c 에서 처리한다.
+    pub fn emitChunk(self: *EmitStore, id: []const u8, name: ?[]const u8) ![]const u8 {
+        const reference_id = try std.fmt.allocPrint(self.allocator, "chunk-{d}", .{self.counter});
+        errdefer self.allocator.free(reference_id);
+        const id_owned = try self.allocator.dupe(u8, id);
+        errdefer self.allocator.free(id_owned);
+        const name_owned: ?[]const u8 = if (name) |n| try self.allocator.dupe(u8, n) else null;
+        errdefer if (name_owned) |n| self.allocator.free(n);
+        try self.chunks.append(self.allocator, .{
+            .reference_id = reference_id,
+            .id = id_owned,
+            .name = name_owned,
+        });
+        self.counter += 1;
+        return reference_id;
     }
 };
 
@@ -137,4 +178,34 @@ test "emitAssetByName 은 [dir] 패턴에서 name 의 디렉토리를 [dir] 로 
     try testing.expect(std.mem.startsWith(u8, fname, "icons/logo-"));
     try testing.expect(std.mem.endsWith(u8, fname, ".png"));
     try testing.expect(!std.mem.startsWith(u8, fname, "/")); // dir="" 였다면 "/logo-..." 가 됐을 것
+}
+
+test "emitChunk 는 chunk-N reference id 를 발급하고 요청을 수집한다 (PR7-2a, graph 미주입)" {
+    const testing = std.testing;
+    var store = EmitStore.init(testing.allocator, "[name]-[hash]");
+    defer store.deinit();
+
+    const c0 = try store.emitChunk("./worker.ts", null);
+    const c1 = try store.emitChunk("./route.ts", "route");
+    try testing.expectEqualStrings("chunk-0", c0);
+    try testing.expectEqualStrings("chunk-1", c1);
+    try testing.expectEqual(@as(usize, 2), store.chunks.items.len);
+    try testing.expectEqualStrings("./worker.ts", store.chunks.items[0].id);
+    try testing.expect(store.chunks.items[0].name == null);
+    try testing.expectEqualStrings("route", store.chunks.items[1].name.?);
+    // chunk 는 아직 graph 미주입 → getFileName 으로는 조회 안 됨 (PR7-2c 에서 lazy 확정).
+    try testing.expect(store.getFileName(c0) == null);
+}
+
+test "asset/chunk reference id 는 공유 카운터로 서로 유니크하다" {
+    const testing = std.testing;
+    var store = EmitStore.init(testing.allocator, "[name]-[hash]");
+    defer store.deinit();
+
+    const a0 = try store.emitAsset("a.css", "x");
+    const c1 = try store.emitChunk("./b.ts", null);
+    const a2 = try store.emitAsset("c.css", "y");
+    try testing.expectEqualStrings("asset-0", a0);
+    try testing.expectEqualStrings("chunk-1", c1);
+    try testing.expectEqualStrings("asset-2", a2);
 }


### PR DESCRIPTION
## 배경

#1880 epic **PR7-2a** — `this.emitFile({ type: 'chunk' })` 구현의 첫 조각. chunk emit 은 asset 과 근본이 다릅니다:

| | asset (PR5/6) | **chunk (PR7-2)** |
|---|---|---|
| 입력 | source 바이트 | **모듈 id** (resolve 대상) |
| 처리 | list append | **resolve→load→parse→graph 주입→청킹** |
| graph mutation | ❌ | ✅ 필수 (새 entry) |
| 파일명 | emit 즉시 (source hash) | **청킹 후 lazy** |

이 PR 은 그 토대 — **EmitStore 에 chunk 요청 수집 자료구조만** 추가합니다. 외부 동작은 불변(emitFileCallback/JS 의 chunk 분기는 여전히 throw).

## 변경

- `EmittedChunk { reference_id, id, name? }` + `EmitStore.chunks: ArrayList`
- `emitChunk(id, name?)` → `"chunk-N"` reference id (asset 과 **공유 카운터**로 유니크: asset-0/chunk-1/asset-2)
- `init`/`deinit` 갱신 — errdefer 체인·null 가드는 검증된 `emitAsset` 패턴과 동형

## 왜 토대만 분리했나 (silent-broken 방지)

graph 주입(PR7-2b) 없이 emitFileCallback 이 chunk refId 를 반환하면 "emit 했는데 chunk 가 안 나오는" **silent-broken** 이 됩니다. 그래서 emitFileCallback 은 graph 주입 + getFileName lazy 가 붙기 전까지 chunk 를 throw 로 유지하고, 이 PR 은 내부 자료구조 토대만 깝니다.

## 설계 요약 (다음 PR)

- **PR7-2b**: emit 요청을 **메인스레드 직렬 수집**(asset 동형) → build thread 가 디스커버리 패스 경계에서 안전하게 read → 새 entry 로 graph 주입(**fixpoint 재-discovery**, dynamic-import 청킹 재사용). build thread ≠ Node main thread 라 패스 경계 분리로 mutex 없이 race-free.
- **PR7-2c**: `getFileName(chunkRefId)` lazy resolution (청킹 후 파일명 back-fill).

## 성능

미사용 빌드는 **자료구조 1개 추가뿐, 런타임 경로 불변**. 주입(PR7-2b) 시 `graph_discover` bench 회귀 0 을 머지 게이트로 둡니다.

## 검증

- `EmitStore` 유닛 +2 (chunk-N 발급/요청 수집, asset·chunk 공유 카운터 유니크)
- `zig build test` 통과, `build-plugins` **44 pass** + `vite-plugin` **27 pass** / 회귀 0 (addon 재빌드 후 — 구조체 레이아웃 변경 무영향 확인)
- `/code-review max` **발견 0** (errdefer 체인·deinit·cross-file init/deinit 전부 안전 확인)

Refs #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)