### PR TITLE
fix(bundler): polyfill transpile 결과 owned 필드 누수 + 실패 진단/개행 보강

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1382,17 +1382,33 @@ pub const Bundler = struct {
             const is_console = std.mem.eql(u8, basename, "console.js");
             const should_transpile = (self.options.flow or minify_ws) and (!is_console or minify_ws);
             const content = if (should_transpile) blk: {
-                const result = transpile_mod.transpile(self.allocator, raw, poly_path, .{
+                var result = transpile_mod.transpile(self.allocator, raw, poly_path, .{
                     .flow = self.options.flow,
                     .jsx_in_js = self.options.jsx_in_js,
                     // 폴리필도 verbatim 규칙을 따라야 함 — 그래야 번들 본체와 동일한 import 처리 정책.
                     .verbatim_module_syntax = self.options.verbatim_module_syntax,
                     .minify_whitespace = minify_ws,
-                }) catch {
-                    break :blk raw; // 트랜스파일 실패 시 원본 사용
+                }) catch |err| {
+                    // 트랜스파일 실패 시 원본 사용 — 단 진단 없이 조용히 넘어가면 minify 번들에
+                    // 원본 주석/들여쓰기가 다시 새는 것을 알아챌 수 없으므로 경고를 남긴다(#3649 후속).
+                    std.log.warn("zntc: polyfill '{s}' 트랜스파일 실패 ({s}), 원본 사용", .{ poly_path, @errorName(err) });
+                    // raw 는 codegen 종결자(`;`) 보장이 없다. trailing newline 이 없으면 emitter 의
+                    // minify IIFE wrap (`...content})();`) 에서 content 마지막 줄 주석/미종결 식이
+                    // `})()` 를 같은 줄로 삼켜 SyntaxError 가 날 수 있어 개행을 보장한다.
+                    if (raw.len > 0 and raw[raw.len - 1] != '\n') {
+                        const padded = std.mem.concat(self.allocator, u8, &.{ raw, "\n" }) catch break :blk raw;
+                        self.allocator.free(raw);
+                        break :blk padded;
+                    }
+                    break :blk raw;
                 };
                 self.allocator.free(raw);
-                break :blk result.code;
+                // result.code 를 content 로 인계. TranspileResult.deinit 은 code 까지 free 하므로
+                // code 를 복사해 content 로 쓰고 result 전체를 deinit 한다 — sourcemap/diagnostics/
+                // line_offsets 누수 방지(#3649 후속). 직접 필드 free 는 누락 위험이 있어 deinit 에 일임.
+                const code = self.allocator.dupe(u8, result.code) catch break :blk result.code;
+                result.deinit(self.allocator);
+                break :blk code;
             } else raw;
             try polyfill_entries.append(self.allocator, .{
                 .name = basename,

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -1331,6 +1331,36 @@ test "Bundler: minify_whitespace 가 polyfill content 도 minify (#3649 polyfill
     try std.testing.expect(std.mem.indexOf(u8, result.output, "    return") == null);
 }
 
+test "Bundler: polyfill transpile 의 semantic 진단 owned 필드 누수 없음 (#3649 후속, leak 가드)" {
+    // semantic 진단(let 재선언)을 내면서 code 도 정상 생성하는 polyfill — transpile 이
+    // diagnostics/line_offsets 를 self.allocator 로 할당한다. 수정 전엔 result.code 만 취하고
+    // 나머지를 free 안 해 누수했고, std.testing.allocator(GPA) 가 leak 으로 잡는다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('x');");
+    // `let x` 재선언 = analyzer 가 throw 없이 진단을 쌓고 codegen 은 진행(정상 code + 진단).
+    try writeFile(tmp.dir, "diag-poly.js", "let x = 1;\nlet x = 2;\nglobal.MyPolyfill = x;\n");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const polyfill = try absPath(&tmp, "diag-poly.js");
+    defer std.testing.allocator.free(polyfill);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .polyfills = &.{polyfill},
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // 핵심 가드: 테스트 종료 시 누수 없음(testing.allocator 가 자동 검출).
+    // polyfill 이 실제로 transpile 경로를 타고 번들에 포함됐는지도 확인.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MyPolyfill") != null);
+}
+
 test "Bundler: dev mode single file" {
     // Phase 2: dev mode에서 단일 파일이 프로덕션 파이프라인으로 scope-hoisted 출력
     var tmp = std.testing.tmpDir(.{});


### PR DESCRIPTION
## 배경
#3649(폴리필 minify, PR #3653) 후속으로 `/code-review max` 5-에이전트 fan-out 을 정식 실행해 발견한 보강입니다. **메모리 안전성 버그(double-free/UAF)는 0건**이었으나, leak 가드가 없던 영역에서 누수 1건과 방어 2건을 잡았습니다.

## 변경
- **누수 수정(C1)**: polyfill transpile 성공 시 `result.code` 만 취하고 `result.deinit()` 미호출 → 폴리필이 semantic 진단을 내면(`let` 재선언 등) `self.allocator` 로 할당된 `diagnostics`/`line_offsets` 가 누수. **`code` 만 dupe 해 content 로 인계하고 `result` 전체를 `deinit`** (직접 필드 free 는 owned 필드 추가 시 누락 위험이라 deinit 에 일임).
- **진단 가시화(C4)**: transpile 실패 시 조용한 raw fallback → `std.log.warn` 추가.
- **개행 보장(C4)**: raw fallback 의 trailing newline 보장 — minify IIFE wrap 에서 `})()` 가 마지막 줄 주석에 먹히는 SyntaxError 방지.

## 테스트 (red→green 실증)
`let` 재선언 폴리필 + `minify_whitespace` 누수 가드 추가. fix 제거 시 `line_offsets` dupe 가 `std.testing.allocator`(GPA) leak 으로 **검출(red)**, fix 적용 시 **green** 확인. 전체 회귀 통과.

> 이 누수는 직접 분석에선 "latent 라 테스트 어렵다"고 넘겼던 것을, 정식 5-에이전트가 `let` 재선언이라는 구체적 red 입력을 찾아 진짜 TDD 가 됐습니다.

#3649

🤖 Generated with [Claude Code](https://claude.com/claude-code)