### PR TITLE
test(bundler): mangle/polyfill 엣지 케이스 회귀 가드 추가

### DIFF
--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -37,6 +37,8 @@ comptime {
     _ = @import("bundler_test/lowering_rename_leak.zig");
     _ = @import("bundler_test/manual_chunks.zig");
     _ = @import("bundler_test/runtime_helper_shadow.zig");
+    _ = @import("bundler_test/mangle_edge_cases.zig");
+    _ = @import("bundler_test/polyfill_edge_cases.zig");
     _ = @import("bundler_test/multi_format.zig");
     _ = @import("bundler_test/incremental_bench.zig");
     _ = @import("bundler_test/incremental_bench_v2.zig");

--- a/src/bundler/bundler_test/mangle_edge_cases.zig
+++ b/src/bundler/bundler_test/mangle_edge_cases.zig
@@ -1,0 +1,541 @@
+//! Top-level/nested 식별자 mangle + shadow 회피 엣지 케이스 회귀 가드.
+//!
+//! `Bundler.computeMangling` (linker.zig) → `unified_mangler.mangleAll` 의
+//! top-level + nested 통합 mangle (RFC #1760) 의 현재 동작을 고정한다.
+//!
+//! 핵심 불변식 (linker.zig:797~ collectUnifiedInput):
+//!   - mangle 은 minify_identifiers 또는 minify_whitespace 시 동작.
+//!   - candidate 제외(mangle 안 함): entry export 이름 + external import binding.
+//!   - reserved set: unresolved global + 모든 scope 의 1-char 식별자(#2965/#2966)
+//!     + entry export/import local.
+//!   - dead 모듈 / helper virtual module 은 candidate skip.
+//!
+//! 이 파일의 assert 는 추측이 아니라 실제 번들 출력을 보고 고정한 것이다.
+
+const std = @import("std");
+const Bundler = @import("../bundler.zig").Bundler;
+const test_helpers = @import("../test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+const absPath = test_helpers.absPath;
+
+// ============================================================
+// 1. entry export 이름은 mangle 되지 않는다 (public API 계약).
+// ============================================================
+
+test "Mangle: entry 의 export const 이름은 minify 후에도 보존된다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // 비-entry 모듈을 하나 끼워 mangle 경로가 실제로 활성되도록 한다.
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { internalLongHelperName } from './lib';
+        \\export const fooBarBaz = internalLongHelperName() + 1;
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export function internalLongHelperName() { return 41; }
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // entry 의 export 이름은 mangle 안 됨.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "fooBarBaz") != null);
+    // 비-entry 모듈의 긴 이름은 mangle 되어 사라진다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "internalLongHelperName") == null);
+}
+
+// ============================================================
+// 2. 비-entry 모듈의 top-level binding 은 짧은 이름으로 mangle 된다.
+// ============================================================
+
+test "Mangle: non-entry 모듈 top-level const/function 은 짧은 이름으로 바뀐다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { computeSomethingVeryLong, AVeryLongConstantName } from './lib';
+        \\console.log(computeSomethingVeryLong(AVeryLongConstantName));
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export const AVeryLongConstantName = 7;
+        \\export function computeSomethingVeryLong(x) { return x * 2; }
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 원본 긴 이름은 모두 사라진다 (import binding 까지 mangle 통일).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "computeSomethingVeryLong") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "AVeryLongConstantName") == null);
+    // 동작 보존: `* 2` 표현식은 살아있어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "* 2") != null or
+        std.mem.indexOf(u8, result.output, "*2") != null);
+}
+
+// ============================================================
+// 3. shadow 회피 (#2965/#2966): nested 1-char 변수를 top-level mangle 이
+//    shadow 하지 않는다.
+// ============================================================
+
+test "Mangle: nested 1-char 변수를 top-level mangled 이름이 shadow 하지 않는다 (#2965)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // lib 모듈은 nested scope 에 `i`, `j` 같은 1-char 변수를 사용한다.
+    // entry 가 가리키는 export 이름이 mangle 될 때 그 1-char 를 재사용하면
+    // for-loop 내부에서 shadow 가 발생한다.
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { sumRange, productRange } from './lib';
+        \\console.log(sumRange(5), productRange(4));
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export function sumRange(n) {
+        \\  let total = 0;
+        \\  for (let i = 0; i < n; i++) { total += i; }
+        \\  return total;
+        \\}
+        \\export function productRange(n) {
+        \\  let total = 1;
+        \\  for (let j = 1; j <= n; j++) { total *= j; }
+        \\  return total;
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const out = result.output;
+
+    // for-loop 의 1-char init 변수 `i`/`j` 는 1-char 라 mangle skip → 원형 유지.
+    try std.testing.expect(std.mem.indexOf(u8, out, "i++") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "j++") != null or
+        std.mem.indexOf(u8, out, "j <=") != null or
+        std.mem.indexOf(u8, out, "j<=") != null);
+
+    // 현재 동작 고정: top-level mangle 은 1-char 이름을 새로 부여하지 않는다
+    // (모든 scope 의 1-char 가 reserved). top-level declaration 으로
+    // `function i(` / `var i=` / `let i=` 같은 1-char top-level binding 이
+    // 생기면 회귀.
+    for ([_][]const u8{ "function i(", "function j(", "var i=", "var j=" }) |needle| {
+        if (std.mem.indexOf(u8, out, needle)) |pos| {
+            std.debug.print(
+                "Regression: 1-char top-level binding `{s}` at byte {d} shadows nested loop var.\nOutput:\n{s}\n",
+                .{ needle, pos, out },
+            );
+            return error.OneCharTopLevelBindingShadowsNested;
+        }
+    }
+}
+
+// ============================================================
+// 4. cross-module top-level 이름 충돌 deconflict (#2971 류).
+// ============================================================
+
+test "Mangle: 두 모듈이 같은 top-level 이름을 갖고 cross-import 시 deconflict (#2971)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // 두 모듈 모두 `sharedName` 이라는 top-level 을 갖고 entry 가 둘 다 import.
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { sharedName as a } from './a';
+        \\import { sharedName as b } from './b';
+        \\console.log(a(), b());
+    );
+    try writeFile(tmp.dir, "a.ts",
+        \\export function sharedName() { return "from-a-module"; }
+    );
+    try writeFile(tmp.dir, "b.ts",
+        \\export function sharedName() { return "from-b-module"; }
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 두 모듈의 동작이 모두 보존되어야 한다 (deconflict 성공 → 둘 다 살아있음).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from-a-module") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "from-b-module") != null);
+
+    // 핵심 검증: 두 함수가 서로 다른 이름으로 deconflict 되어야 한다.
+    // 같은 mangled 이름으로 병합되면 entry 호출이 `x(), x()` 가 되어 한 모듈이
+    // 가려진다 — 이때도 두 함수 본문(문자열 리터럴 포함)은 모두 출력에 남으므로
+    // 위의 리터럴 생존 체크만으로는 병합 회귀를 잡지 못한다. entry 호출부
+    // `console.log(A(), B())` 의 두 callee 이름이 실제로 다른지 본다.
+    const out = result.output;
+    const log_marker = "console.log(";
+    const log_at = std.mem.indexOf(u8, out, log_marker) orelse return error.MissingEntryCall;
+    const a_start = log_at + log_marker.len;
+    const a_paren = std.mem.indexOfScalarPos(u8, out, a_start, '(') orelse return error.MalformedEntryCall;
+    const a_name = out[a_start..a_paren];
+    const comma = std.mem.indexOfPos(u8, out, a_paren, ", ") orelse return error.MalformedEntryCall;
+    const b_start = comma + 2;
+    const b_paren = std.mem.indexOfScalarPos(u8, out, b_start, '(') orelse return error.MalformedEntryCall;
+    const b_name = out[b_start..b_paren];
+    if (std.mem.eql(u8, a_name, b_name)) {
+        std.debug.print(
+            "Regression: cross-module deconflict failed — both callees named `{s}` in `{s}...`.\nOutput:\n{s}\n",
+            .{ a_name, log_marker, out },
+        );
+        return error.CrossModuleDeconflictMerged;
+    }
+}
+
+test "Mangle: 1-char top-level binding `z` 가 entry import alias 와 충돌 회피 (#2971 zod)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // zod 의 `class z` ↔ entry import alias `z` 충돌 root cause 의 축소판.
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { z } from './schema';
+        \\console.log(z.parse(1));
+    );
+    try writeFile(tmp.dir, "schema.ts",
+        \\function makeLongInternalName() { return { parse: (v) => v }; }
+        \\export const z = makeLongInternalName();
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // entry 가 참조하는 `z` 는 1-char 라 reserved → mangle 안 됨, 동작 보존.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "z.parse") != null or
+        std.mem.indexOf(u8, result.output, "z.parse(1)") != null);
+    // 긴 internal 이름은 mangle 되어 사라진다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "makeLongInternalName") == null);
+}
+
+// ============================================================
+// 5. external import binding 은 mangle 되지 않는다.
+// ============================================================
+
+test "Mangle: external import binding 은 mangle 되지 않는다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import reactDefaultExport from 'react';
+        \\import { internalThing } from './lib';
+        \\console.log(reactDefaultExport, internalThing());
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export function internalThing() { return 1; }
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .external = &.{"react"},
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // external import 의 local binding 은 contract → mangle 안 됨.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "reactDefaultExport") != null);
+    // import 문 자체가 'react' 로 보존되어야 한다 (external).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"react\"") != null or
+        std.mem.indexOf(u8, result.output, "'react'") != null);
+}
+
+// ============================================================
+// 6. unresolved global (Promise/Set 등) 이름을 top-level mangle 이
+//    재사용하지 않는다.
+// ============================================================
+
+test "Mangle: 모듈이 참조하는 unresolved global(Promise/Set)을 top-level mangle 이 재사용하지 않는다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // lib 가 Promise / Set 을 참조 → reserved_globals 에 등록.
+    // 많은 top-level binding 을 만들어 mangler 가 짧은 이름 풀을 소진하도록 유도.
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { runAll } from './lib';
+        \\runAll();
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\const longNameOne = 1;
+        \\const longNameTwo = 2;
+        \\const longNameThree = 3;
+        \\const longNameFour = 4;
+        \\export function runAll() {
+        \\  const p = Promise.resolve(longNameOne + longNameTwo);
+        \\  const s = new Set([longNameThree, longNameFour]);
+        \\  return p.then(() => s.size);
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const out = result.output;
+    // Promise / Set 참조가 보존되어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, out, "Promise.resolve") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "new Set(") != null);
+    // 회귀 가드: top-level declaration 이 `Promise` / `Set` 이름을 재사용하면
+    // hoist 되어 global 을 shadow 한다.
+    for ([_][]const u8{ "var Promise=", "var Promise =", "function Promise(", "var Set=", "var Set =", "function Set(" }) |needle| {
+        if (std.mem.indexOf(u8, out, needle)) |pos| {
+            std.debug.print(
+                "Regression: top-level binding reuses global name `{s}` at byte {d}.\nOutput:\n{s}\n",
+                .{ needle, pos, out },
+            );
+            return error.TopLevelMangleShadowsGlobal;
+        }
+    }
+}
+
+// ============================================================
+// 7. helper virtual module 식별자는 추가 rename 되지 않는다.
+//    ES5 lowering 은 `__async` / `__generator` 런타임 helper 를 주입한다
+//    (실제 출력 기준 — `$`-prefix 가 아니라 `__`-prefix). mangler 가 이 이름을
+//    rename/분열시키면 정의(def)와 호출(call) site 가 어긋나 ReferenceError.
+// ============================================================
+
+test "Mangle: 런타임 helper(`__`-prefix) 식별자는 추가 rename 되지 않는다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // async/await → ES5 lower → runtime helper (`$aS` 등) 주입.
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { fetchValue } from './lib';
+        \\fetchValue().then((v) => console.log(v));
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export async function fetchValue() {
+        \\  const a = await Promise.resolve(1);
+        \\  const bbbbbbbb = await Promise.resolve(2);
+        \\  return a + bbbbbbbb;
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const compat_mod = @import("../../transformer/compat.zig");
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .unsupported = compat_mod.fromESTarget(.es5),
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const out = result.output;
+
+    // 전제 확인: ES5 lowering 으로 helper 가 실제 주입되었는지. 이게 깨지면
+    // 아래 일관성 검사가 vacuous 해지므로 명시적으로 fail 시킨다.
+    try std.testing.expect(std.mem.indexOf(u8, out, "__async") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "__generator") != null);
+
+    // 각 helper 이름은 정의(`var __async =` / `function ...`)와 호출(`__async(`)
+    // 양쪽에 동일하게 등장해야 한다 → 최소 2회. mangler 가 def 만(또는 call 만)
+    // rename 하면 한쪽이 사라져 count 가 줄거나 dangling 참조가 된다.
+    for ([_][]const u8{ "__async", "__generator" }) |helper| {
+        var count: usize = 0;
+        var idx: usize = 0;
+        while (std.mem.indexOfPos(u8, out, idx, helper)) |pos| {
+            count += 1;
+            idx = pos + helper.len;
+        }
+        if (count < 2) {
+            std.debug.print(
+                "Helper rename leak: `{s}` appears {d}x (def+call 이면 >=2 여야 함).\nOutput:\n{s}\n",
+                .{ helper, count, out },
+            );
+            return error.HelperIdentifierRenameLeak;
+        }
+        // deconflict suffix 로 분열되면 회귀: `__async$1` / `__async2` 같은 변형.
+        var sfx_buf: [32]u8 = undefined;
+        const dollar_sfx = std.fmt.bufPrint(&sfx_buf, "{s}$", .{helper}) catch unreachable;
+        try std.testing.expect(std.mem.indexOf(u8, out, dollar_sfx) == null);
+    }
+}
+
+// ============================================================
+// 8. tree-shaken dead 모듈의 binding 은 짧은 이름 풀을 잠식하지 않는다.
+// ============================================================
+
+test "Mangle: dead 모듈 binding 은 included 모듈의 짧은 이름 풀을 잠식하지 않는다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { liveFunctionAlpha } from './live';
+        \\console.log(liveFunctionAlpha());
+    );
+    try writeFile(tmp.dir, "live.ts",
+        \\export function liveFunctionAlpha() { return 1; }
+    );
+    // dead 모듈: 아무도 import 하지 않음.
+    try writeFile(tmp.dir, "dead.ts",
+        \\export function deadFunctionBeta() { return 2; }
+        \\export const deadConstGamma = 3;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const out = result.output;
+    // dead 모듈은 번들에서 제외 → 그 이름이 아예 안 나온다.
+    try std.testing.expect(std.mem.indexOf(u8, out, "deadFunctionBeta") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "deadConstGamma") == null);
+    // live 모듈은 mangle 되어 짧은 이름을 받는다 (긴 이름 사라짐).
+    try std.testing.expect(std.mem.indexOf(u8, out, "liveFunctionAlpha") == null);
+}
+
+// ============================================================
+// 9. 대조: minify off 면 mangle 안 됨 (원본 이름 유지).
+// ============================================================
+
+test "Mangle: minify off 시 비-entry 모듈 top-level 이름이 보존된다 (대조 케이스)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { keepThisLongName } from './lib';
+        \\console.log(keepThisLongName());
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export function keepThisLongName() { return 42; }
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        // minify 옵션 모두 off.
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // mangle 비활성 → 원본 이름 그대로 유지.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "keepThisLongName") != null);
+}
+
+// ============================================================
+// 9b. Bundler API 레벨에서 mangle 게이트는 minify_identifiers 단독이다.
+//     (minify_whitespace 만으로는 식별자 mangle 이 일어나지 않는다 — 실증.
+//      "minify_whitespace 가 mangle 을 함의" 는 CLI 레벨 매핑이지 Bundler
+//      옵션의 동작이 아니다.)
+// ============================================================
+
+test "Mangle: minify_whitespace=true 단독으로는 식별자 mangle 이 일어나지 않는다 (게이트는 minify_identifiers)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { whitespaceModeLongName } from './lib';
+        \\console.log(whitespaceModeLongName());
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export function whitespaceModeLongName() { return 99; }
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // minify_whitespace 만으로는 mangle 안 됨 → 긴 이름 보존.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "whitespaceModeLongName") != null);
+    // 값 보존.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "99") != null);
+}
+
+test "Mangle: minify_whitespace + minify_identifiers 함께면 비-entry top-level 이 mangle 된다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { bothFlagsLongName } from './lib';
+        \\console.log(bothFlagsLongName());
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export function bothFlagsLongName() { return 99; }
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 두 플래그 함께면 mangle → 긴 이름 사라짐.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "bothFlagsLongName") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "99") != null);
+}

--- a/src/bundler/bundler_test/polyfill_edge_cases.zig
+++ b/src/bundler/bundler_test/polyfill_edge_cases.zig
@@ -1,0 +1,309 @@
+// polyfill_edge_cases.zig — RN polyfill transpile/minify 처리 엣지 케이스.
+//
+// 배경: RN polyfill 은 모듈 그래프를 우회해 bundler 가 파일을 직접 읽어 prepend 한다
+// (src/bundler/bundler.zig 의 polyfill loop ~1365-1420). transpile/minify 동작:
+//   - should_transpile = (flow or minify_ws) and (!is_console or minify_ws)
+//   - transpile 실패 시 raw fallback(경고만 남기고 크래시 없음), trailing newline 보장
+//   - emitter 는 polyfill 을 `(function(){` + content + `})();` 로 wrap
+//     (minify 시 separator 없음, src/bundler/emitter.zig ~478-513).
+//
+// splitting_dev.zig 의 기존 polyfill 테스트 3개(dev 포함, #3649 minify, 누수 가드)와
+// 중복하지 않는, 빠진 엣지만 다룬다. assert 는 모두 실제 번들 출력 기준(추측 금지).
+//
+// transpile-실패 입력 검증: `function f() {`(닫히지 않은 brace), `const = ;` 모두
+// ZNTC transpile() 이 안정적으로 error.ParseError 를 낸다(probe 로 확인). raw fallback
+// 경로(bundler.zig ~1394-1404)가 타게 된다.
+
+const std = @import("std");
+const Bundler = @import("../bundler.zig").Bundler;
+const test_helpers = @import("../test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+const absPath = test_helpers.absPath;
+
+// 1. transpile 실패 → raw fallback (크래시 없음).
+//    명백한 parse error polyfill + minify 빌드 → 번들이 죽지 않고 생성되며 raw 가 포함.
+test "Polyfill: transpile 실패 시 raw fallback — 크래시 없이 번들 생성 + raw 포함" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+    // 닫히지 않은 brace — transpile() 이 error.ParseError 를 낸다(probe 확인).
+    // 식별 가능한 토큰 POLY_RAW_MARKER 를 raw 에 둬 fallback 포함 여부를 검증.
+    try writeFile(tmp.dir, "bad-polyfill.js", "var POLY_RAW_MARKER = 1;\nfunction f() {\n");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const polyfill = try absPath(&tmp, "bad-polyfill.js");
+    defer std.testing.allocator.free(polyfill);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .polyfills = &.{polyfill},
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+
+    // transpile 실패는 경고만 — 번들 자체는 성공.
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // raw 가 그대로 포함 (transpile 됐다면 minify 로 형태가 바뀌었겠지만 raw 보존).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "POLY_RAW_MARKER") != null);
+    // entry 코드도 정상 포함.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log") != null);
+}
+
+// 2. raw fallback + trailing newline 없는 입력.
+//    transpile 실패 polyfill 을 trailing `\n` 없이 작성 → 출력에서 polyfill content 와
+//    `})()` 사이에 개행이 보장돼 `})()` 가 content 마지막 줄에 안 붙는지.
+//    (붙으면 minify IIFE wrap `(function(){<content>})();` 에서 SyntaxError 위험.)
+test "Polyfill: raw fallback + trailing newline 없음 — })() 가 content 마지막 줄에 안 붙음" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+    // ParseError 나는 입력 + trailing newline 없음. 마지막 줄이 `function f() {`.
+    try writeFile(tmp.dir, "no-nl-polyfill.js", "var POLY_NO_NL = 1;\nfunction f() {");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const polyfill = try absPath(&tmp, "no-nl-polyfill.js");
+    defer std.testing.allocator.free(polyfill);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .polyfills = &.{polyfill},
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "POLY_NO_NL") != null);
+    // 핵심: raw 의 마지막 토큰 `{` 바로 뒤에 `})()` 가 붙지 않아야 함.
+    // bundler 가 trailing newline 을 보장하므로 `{\n})()` 형태여야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "{})()") == null);
+    // 개행으로 분리된 형태가 실제로 존재.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "{\n})()") != null);
+}
+
+// 3a. console.js dev(비-minify) — raw 보존 (주석/들여쓰기 남음).
+//     should_transpile = (flow or minify_ws) and (!is_console or minify_ws).
+//     console.js + minify_ws=false → false → transpile 안 함 → raw 그대로.
+test "Polyfill: console.js 비-minify — raw 보존(주석/들여쓰기 남음)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+    try writeFile(tmp.dir, "console.js", "// console polyfill banner\nfunction setupConsole(argName) {\n    return argName;\n}\nglobal.ConsolePoly = setupConsole;\n");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const polyfill = try absPath(&tmp, "console.js");
+    defer std.testing.allocator.free(polyfill);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .polyfills = &.{polyfill},
+        .minify_whitespace = false,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ConsolePoly") != null);
+    // raw 보존: 주석과 4-space 들여쓰기가 남아 있어야 함.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "console polyfill banner") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "    return argName") != null);
+}
+
+// 3b. console.js minify — transpile 되어 주석/들여쓰기 제거.
+//     console.js + minify_ws=true → (false or true) and (false or true) = true → transpile.
+test "Polyfill: console.js minify — transpile 되어 주석/들여쓰기 제거" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+    try writeFile(tmp.dir, "console.js", "// console polyfill banner\nfunction setupConsole(argName) {\n    return argName;\n}\nglobal.ConsolePoly = setupConsole;\n");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const polyfill = try absPath(&tmp, "console.js");
+    defer std.testing.allocator.free(polyfill);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .polyfills = &.{polyfill},
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // content 는 여전히 포함.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ConsolePoly") != null);
+    // minify: 주석 제거 + 4-space 들여쓰기 제거.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "console polyfill banner") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "    return argName") == null);
+}
+
+// 4. flow polyfill (@flow pragma) — flow=true 빌드에서 Flow 타입 strip.
+test "Polyfill: flow pragma polyfill — flow=true 빌드에서 Flow 타입 strip" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+    try writeFile(tmp.dir, "flow-polyfill.js", "/* @flow */\nconst flowVal: number = 1;\nglobal.FlowPoly = flowVal;\n");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const polyfill = try absPath(&tmp, "flow-polyfill.js");
+    defer std.testing.allocator.free(polyfill);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .polyfills = &.{polyfill},
+        .flow = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "FlowPoly") != null);
+    // Flow 타입 어노테이션이 strip 되어야 함 — `: number` 사라짐.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ": number") == null);
+    // 선언 자체는 보존 (값 1).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "flowVal") != null);
+}
+
+// 4b. flow polyfill + minify 조합 — Flow strip 과 whitespace minify 동시.
+test "Polyfill: flow pragma polyfill + minify — Flow strip + 주석/들여쓰기 제거" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+    try writeFile(tmp.dir, "flow-polyfill.js", "/* @flow */\n// flow helper banner\nfunction flowHelper(argName: number): number {\n    return argName;\n}\nglobal.FlowPoly = flowHelper;\n");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const polyfill = try absPath(&tmp, "flow-polyfill.js");
+    defer std.testing.allocator.free(polyfill);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .polyfills = &.{polyfill},
+        .flow = true,
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "FlowPoly") != null);
+    // Flow 타입 strip.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ": number") == null);
+    // minify: 주석 + 4-space 들여쓰기 제거.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "flow helper banner") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "    return") == null);
+}
+
+// 5. 정상 JS polyfill minify on/off 대조.
+//    동일 polyfill 을 두 빌드로 → minify on 은 공백/주석 제거, off 는 원본 유지.
+test "Polyfill: 정상 JS polyfill — minify on/off 대조" {
+    const src = "// poly contrast banner\nfunction contrastHelper(argName) {\n    return argName + 1;\n}\nglobal.ContrastPoly = contrastHelper;\n";
+
+    // (a) minify off — 원본(주석/들여쓰기) 유지.
+    {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+        try writeFile(tmp.dir, "contrast-polyfill.js", src);
+
+        const entry = try absPath(&tmp, "index.ts");
+        defer std.testing.allocator.free(entry);
+        const polyfill = try absPath(&tmp, "contrast-polyfill.js");
+        defer std.testing.allocator.free(polyfill);
+
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .polyfills = &.{polyfill},
+            .minify_whitespace = false,
+        });
+        defer b.deinit();
+
+        const result = try b.bundle();
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expect(!result.hasErrors());
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "ContrastPoly") != null);
+        // off: 주석 + 4-space 들여쓰기 보존.
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "poly contrast banner") != null);
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "    return argName") != null);
+    }
+
+    // (b) minify on — 공백/주석 제거.
+    {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+        try writeFile(tmp.dir, "contrast-polyfill.js", src);
+
+        const entry = try absPath(&tmp, "index.ts");
+        defer std.testing.allocator.free(entry);
+        const polyfill = try absPath(&tmp, "contrast-polyfill.js");
+        defer std.testing.allocator.free(polyfill);
+
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .polyfills = &.{polyfill},
+            .minify_whitespace = true,
+        });
+        defer b.deinit();
+
+        const result = try b.bundle();
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expect(!result.hasErrors());
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "ContrastPoly") != null);
+        // on: 주석 + 4-space 들여쓰기 제거.
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "poly contrast banner") == null);
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "    return argName") == null);
+    }
+}
+
+// 6. 빈 polyfill 파일 — 0-byte → 크래시 없이 번들 생성(raw.len==0 가드).
+test "Polyfill: 빈 polyfill 파일(0-byte) — 크래시 없이 번들 생성" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+    try writeFile(tmp.dir, "empty-polyfill.js", "");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const polyfill = try absPath(&tmp, "empty-polyfill.js");
+    defer std.testing.allocator.free(polyfill);
+
+    // minify on/off 둘 다 — minify 경로(transpile)도 0-byte 에서 안전한지 확인.
+    inline for (.{ true, false }) |minify| {
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .polyfills = &.{polyfill},
+            .minify_whitespace = minify,
+        });
+        defer b.deinit();
+
+        const result = try b.bundle();
+        defer result.deinit(std.testing.allocator);
+
+        // 빈 polyfill 이어도 번들은 정상 생성, entry 코드 포함.
+        try std.testing.expect(!result.hasErrors());
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log") != null);
+        // 빈 IIFE wrap 이 생성됨.
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "(function(){") != null);
+    }
+}


### PR DESCRIPTION
## 무엇을

식별자 mangle(RFC #1760)과 RN polyfill transpile/minify 처리의 **현재 동작을 실제 번들 출력 기준으로 고정**하는 회귀 테스트 2개 파일을 추가합니다. 소스 동작 변경은 없습니다 — 순수 테스트 추가입니다.

## 왜

mangle 의 reserved/deconflict 규칙(1-char shadow 회피 #2965/#2966, cross-module 충돌 #2971)과 polyfill 의 raw fallback·trailing-newline 보장 같은 미묘한 불변식이 회귀 가드 없이 남아 있었습니다. 리팩터링 시 조용히 깨질 수 있어 출력 기준으로 못박았습니다.

## 추가된 케이스

### `mangle_edge_cases.zig` (10)
- entry export 이름 보존 / 비-entry top-level mangle
- nested 1-char 변수 shadow 회피 (#2965/#2966)
- cross-module 이름 충돌 deconflict (#2971) — entry 호출부 두 callee 이름이 **실제로 다른지** 검증 (본문 생존만 보면 병합 회귀를 못 잡음)
- external import binding / unresolved global(Promise·Set) 미잠식
- 런타임 helper(`__async`/`__generator`) 의 def↔call 이름 일관성
- dead 모듈 미잠식 / minify 게이트는 `minify_identifiers` 단독임을 대조

### `polyfill_edge_cases.zig` (8)
- transpile 실패 시 raw fallback — 크래시 없이 번들 생성 + raw 포함
- trailing newline 없는 입력에서 `})()` 가 content 마지막 줄에 안 붙음
- `console.js` dev(raw 보존)/minify(strip) 분기
- `@flow` pragma strip / strip+minify 조합
- 정상 JS polyfill minify on·off 대조
- 빈 polyfill(0-byte) 안전

## 검증

- `zig build test` 전체 통과
- assert 는 모두 실제 번들 출력을 보고 고정 (추측 없음). 인용한 소스 사실(`linker.zig` reserved/exclusion, `bundler.zig` polyfill `should_transpile`/fallback, `emitter.zig` IIFE wrap)은 코드와 대조 확인
- `/code-review max` 결과 반영: vacuous 했던 helper 테스트(`$`-prefix 가정이 사실과 달라 스캐너가 한 번도 실행 안 됨 → `__`-prefix 실측으로 교체)와 약했던 deconflict 테스트(callee distinct 검증 추가)를 강화

🤖 Generated with [Claude Code](https://claude.com/claude-code)