### PR TITLE
feat(plugin): this.emitFile chunk B-i — 이미-graph 모듈 별도 chunk (#1880 PR7-2b-i)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1854,7 +1854,9 @@ type NativeResolveFn = (
 type NativeEmitFileFn = (file: {
   fileName?: string;
   name?: string;
-  source: string | Uint8Array;
+  source?: string | Uint8Array;
+  chunkId?: string;
+  chunkName?: string;
 }) => string | null;
 // #1880 PR6: native getFileName 콜백. reference id → 최종 출력 파일명(미등록이면 null).
 type NativeGetFileNameFn = (referenceId: string) => string | null;
@@ -2884,8 +2886,9 @@ export interface RollupPluginContext {
    * resolveId/load/transform hook 에서 `{ type: 'asset', fileName | name, source }` 를 emit →
    * reference id 반환, 해당 asset 은 `result.outputFiles` 에 나타난다. `fileName` 은 그대로,
    * `name` 은 source hash 로 파일명 자동 생성(file/copy loader 와 동일 `assetNames` 패턴).
-   * vitePlugin() 어댑터의 resolveId/load/transform hook 에서도 동작(#1880 PR7). `type: 'chunk'` 는
-   * follow-up 으로 throw. 그 외 hook / buildSync 에서도 throw.
+   * vitePlugin() 어댑터의 resolveId/load/transform hook 에서도 동작(#1880 PR7).
+   * `{ type: 'chunk', id }` 는 id(이미 graph 에 있는 모듈)를 별도 chunk 로 분리(#1880 PR7-2b-i,
+   * splitting:true). 신규 모듈 chunk emit 은 미지원(build 진단). 그 외 hook / buildSync 는 throw.
    * **반드시 hook 본문에서 동기적으로 호출**해야 한다 — `await` 이후나 detached promise 에서
    * 호출하면 EmitStore 수명을 벗어나 asset 이 누락되거나 정의되지 않은 동작이 된다 (follow-up). */
   emitFile(file: unknown): string;
@@ -3013,10 +3016,35 @@ function createRollupPluginContext(
       if (typeof file !== 'object' || file === null) {
         throw new Error(`@zntc/core [${pluginName}]: this.emitFile() 는 객체 인자가 필요합니다.`);
       }
-      const f = file as { type?: unknown; fileName?: unknown; name?: unknown; source?: unknown };
+      const f = file as {
+        type?: unknown;
+        fileName?: unknown;
+        name?: unknown;
+        source?: unknown;
+        id?: unknown;
+      };
+      // type:'chunk' (#1880 PR7-2b): id(이미 graph 에 있는 모듈)를 별도 chunk 로 분리.
+      // 신규 모듈 emit 은 native 가 build 단계에서 진단으로 거부(B-ii 대기).
+      if (f.type === 'chunk') {
+        if (typeof f.id !== 'string' || f.id.length === 0) {
+          throw new Error(
+            `@zntc/core [${pluginName}]: this.emitFile({ type: 'chunk' }) 는 비어있지 않은 id(모듈 specifier)가 필요합니다 (#1880 PR7-2b).`,
+          );
+        }
+        const chunkRef = fn({
+          chunkId: f.id,
+          chunkName: typeof f.name === 'string' && f.name.length > 0 ? f.name : undefined,
+        });
+        if (typeof chunkRef !== 'string') {
+          throw new Error(
+            `@zntc/core [${pluginName}]: this.emitFile({ type: 'chunk', id: ${JSON.stringify(f.id)} }) 가 reference id 를 반환하지 못했습니다.`,
+          );
+        }
+        return chunkRef;
+      }
       if (f.type !== 'asset') {
         throw new Error(
-          `@zntc/core [${pluginName}]: this.emitFile({ type: '${String(f.type)}' }) 는 아직 미지원입니다 — 현재 type:'asset' 만 지원 (chunk 는 follow-up, #1880 PR6).`,
+          `@zntc/core [${pluginName}]: this.emitFile({ type: '${String(f.type)}' }) 는 아직 미지원입니다 — 현재 type:'asset'/'chunk' 만 지원 (#1880 PR7-2b).`,
         );
       }
       // 빈 문자열은 native getStringArg 가 missing(silent null)으로 취급하므로 비어있지 않은 값만 허용.

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -391,6 +391,18 @@ pub const NapiPlugin = struct {
 
         const store: *EmitStore = @ptrCast(@alignCast(data orelse return js_null));
 
+        // chunk emit (#1880 PR7-2b): chunkId 가 있으면 source 없이 chunk 요청 수집.
+        // JS 가 type:'chunk' 일 때 { chunkId, chunkName? } 로 정규화해 넘긴다.
+        if (getObjectString(env, argv[0], "chunkId", native_alloc)) |chunk_id| {
+            defer native_alloc.free(chunk_id);
+            const chunk_name = getObjectString(env, argv[0], "chunkName", native_alloc);
+            defer if (chunk_name) |n| native_alloc.free(n);
+            const cref = store.emitChunk(chunk_id, chunk_name) catch return js_null;
+            var js_cref: c.napi_value = undefined;
+            if (c.napi_create_string_utf8(env, cref.ptr, cref.len, &js_cref) != c.napi_ok) return js_null;
+            return js_cref;
+        }
+
         // source 는 string / Uint8Array / Buffer 모두 수용 (binary-safe asset). 빈 source 도 허용.
         const source = getObjectBytes(env, argv[0], "source", native_alloc) orelse return js_null;
         defer native_alloc.free(source);

--- a/packages/core/test/core/build-plugins.ts
+++ b/packages/core/test/core/build-plugins.ts
@@ -3,6 +3,7 @@ import './build-plugins/plugin-context';
 import './build-plugins/module-meta';
 import './build-plugins/plugin-resolve';
 import './build-plugins/plugin-emit-file';
+import './build-plugins/plugin-emit-chunk';
 import './build-plugins/transform-tree-shaking';
 import './build-plugins/resolve-context';
 import './build-plugins/build-sync';

--- a/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
+++ b/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
@@ -1,0 +1,134 @@
+import {
+  build,
+  describe,
+  expect,
+  join,
+  mkdtempSync,
+  rmSync,
+  test,
+  tmpdir,
+  writeFileSync,
+} from './helpers';
+import type { ZntcPlugin } from './helpers';
+import type { RollupPluginContext } from '../../../index';
+
+// #1880 PR7-2b-i — this.emitFile({ type: 'chunk', id }). B-i 는 id 가 *이미 graph 에 있는*
+// 모듈일 때만 별도 chunk 로 분리(federation/dynamic entry 청킹 재사용). 신규 모듈(graph 미존재)은
+// resolution/discovery 가 필요해 B-ii 대기 → build 진단으로 surfacing. id 누락은 plugin failure.
+describe('@zntc/core build + plugins - this.emitFile chunk (PR7-2b-i)', () => {
+  test('이미 import 된 모듈을 emit chunk 로 별도 chunk 분리한다', async () => {
+    let refId: unknown = 'unset';
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-'));
+    const depPath = join(dir, 'dep.ts');
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-existing',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          async function (this: RollupPluginContext, args: { path: string }) {
+            // dep 는 main 이 정적 import → 이미 graph 에 있음. graph 와 동일한 abs id 를 얻으려고
+            // this.resolve 로 해석(B-i 는 emitFile 안에서 resolve 안 하므로 plugin 이 resolved id 전달).
+            const r = await this.resolve('./dep.ts', args.path);
+            refId = this.emitFile({ type: 'chunk', id: r!.id });
+            return null;
+          },
+        );
+      },
+    };
+    try {
+      writeFileSync(depPath, 'export const d = 42;\n');
+      writeFileSync(join(dir, 'main.ts'), 'import { d } from "./dep.ts";\nexport const x = d;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBe(0);
+      expect(typeof refId).toBe('string');
+      // dep 가 별도 chunk 로 분리 → outputFiles 에 dep chunk 파일 존재.
+      const depChunk = result.outputFiles.find((f) => f.path.includes('dep'));
+      expect(depChunk).toBeDefined();
+      expect(depChunk!.text).toContain('42');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('graph 에 없는 신규 모듈 emit chunk 는 B-ii 대기 — build 진단', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-new-'));
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-new',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'chunk', id: join(dir, 'ghost.ts') }); // graph 에 없음
+          return null;
+        });
+      },
+    };
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('splitting 없이 chunk emit 은 거부된다 (code splitting 필요)', async () => {
+    // emit chunk 는 별도 chunk 분리가 가능한 splitting 모드에서만 의미. 단일파일 모드면 진단.
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-nosplit-'));
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-nosplit',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          async function (this: RollupPluginContext, args: { path: string }) {
+            const r = await this.resolve('./dep.ts', args.path);
+            this.emitFile({ type: 'chunk', id: r!.id });
+            return null;
+          },
+        );
+      },
+    };
+    try {
+      writeFileSync(join(dir, 'dep.ts'), 'export const d = 1;\n');
+      writeFileSync(join(dir, 'main.ts'), 'import { d } from "./dep.ts";\nexport const x = d;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        // splitting 생략 = false (단일파일)
+      });
+      expect(result.errors.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('id 없는 chunk emit 은 plugin failure', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-noid-'));
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-noid',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'chunk' }); // id 누락
+          return null;
+        });
+      },
+    };
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -524,6 +524,18 @@ pub fn generateChunks(
         }
     }
 
+    // PR7-2b (#1880): plugin this.emitFile({type:'chunk'}) 로 별도 chunk 요청된 모듈 →
+    // federation expose 와 동형으로 dynamic entry(lazy 청크) 로 분리. dedup/append 동일 규칙.
+    {
+        var mi: usize = 0;
+        while (mi < module_count) : (mi += 1) {
+            const eidx = ModuleIndex.fromUsize(mi);
+            const em = graph.getModule(eidx) orelse continue;
+            if (!em.is_emitted_chunk_entry) continue;
+            try addDynamicEntry(allocator, &entries, &dynamic_seen, graph, eidx);
+        }
+    }
+
     const entry_count = entries.items.len;
     if (entry_count == 0) {
         return ChunkGraph.init(allocator, module_count);

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -130,10 +130,73 @@ pub fn build(self: *ModuleGraph, entry_points: []const []const u8) !void {
     var runtime_indices: std.ArrayList(types.ModuleIndex) = .empty;
     defer runtime_indices.deinit(self.allocator);
     try applyRuntimePolyfills(self, &runtime_indices);
+    try injectEmittedChunks(self);
     try linkExecutionRoots(self, entry_points, inject_indices.items, runtime_indices.items, run_before_main_indices.items);
     discover_scope.end();
 
     try finalizeGraph(self, entry_points);
+}
+
+/// PR7-2b-i (#1880): plugin `this.emitFile({ type: 'chunk', id })` 로 별도 chunk 요청된 모듈을
+/// 표시한다. discovery 패스가 모두 끝난 뒤(build thread, 모든 hook drain) emit_store.chunks 를
+/// read 하므로 Node main 의 write 와 패스 경계로 분리돼 mutex 불필요(RFC §3 옵션 B).
+///
+/// **B-i 범위**: id 가 *이미 graph 에 있는* 모듈일 때만 `is_emitted_chunk_entry` 플래그를 set
+/// (finalizeGraph 가 DFS 루트로, chunk.zig 가 dynamic entry 로 분리). 신규 모듈(graph 미존재)은
+/// resolution+discovery 가 필요해 B-ii 대기 → 진단으로 surfacing(silent-broken 방지).
+/// 플래그는 renumber 가 Module 을 옮겨도 따라가므로 finalizeGraph/chunk.zig 가 renumber 후
+/// 안전하게 읽는다(index 배열 전달 불필요).
+fn injectEmittedChunks(self: *ModuleGraph) !void {
+    const store_ptr = self.emit_store orelse return; // chunk 미사용 빌드: hot path 0
+    const store: *@import("../emit_store.zig").EmitStore = @ptrCast(@alignCast(store_ptr));
+    if (store.chunks.items.len == 0) return;
+    // emit chunk 는 별도 chunk 분리가 가능한 모드에서만 의미. 단일파일 모드(splitting:false)면
+    // chunk 분리가 없어 is_entry_point=true 가 단일파일 entry 오선택을 일으키므로 거부한다
+    // (code-review: silent 오동작 방지).
+    const splittable = self.code_splitting or self.preserve_modules;
+    for (store.chunks.items) |chk| {
+        if (!splittable) {
+            self.addDiag(
+                .plugin_error,
+                .@"error",
+                chk.id,
+                .{ .start = 0, .end = 0 },
+                .resolve,
+                "this.emitFile({ type: 'chunk' }) requires code splitting (splitting: true).",
+                "Enable code splitting, or emit type:'asset' instead.",
+            );
+            continue;
+        }
+        if (self.path_to_module.get(chk.id)) |idx| {
+            const ei = @intFromEnum(idx);
+            if (ei >= self.modules.count()) continue;
+            const m = self.modules.at(ei);
+            // external/disabled phantom 은 chunk 대상이 아님 — entry 오염 방지 (code-review).
+            if (m.is_external or m.is_disabled) {
+                self.addDiag(
+                    .plugin_error,
+                    .@"error",
+                    chk.id,
+                    .{ .start = 0, .end = 0 },
+                    .resolve,
+                    "this.emitFile({ type: 'chunk' }) id resolves to an external/disabled module — cannot be a chunk.",
+                    "Pass an id of a normal (bundled) module already in the graph.",
+                );
+                continue;
+            }
+            m.is_emitted_chunk_entry = true;
+        } else {
+            self.addDiag(
+                .plugin_error,
+                .@"error",
+                chk.id,
+                .{ .start = 0, .end = 0 },
+                .resolve,
+                "this.emitFile({ type: 'chunk' }) id is not an already-graphed module — new-module chunk emit is not supported yet (PR7-2b-i).",
+                "Pass an id already in the module graph (e.g. resolved via this.resolve to a statically imported module).",
+            );
+        }
+    }
 }
 
 fn applyRuntimePolyfills(self: *ModuleGraph, runtime_indices: *std.ArrayList(ModuleIndex)) !void {
@@ -291,6 +354,21 @@ fn finalizeGraph(self: *ModuleGraph, entry_points: []const []const u8) !void {
         }
     }
 
+    // PR7-2b-i (#1880): emit chunk 모듈도 DFS 루트 — exec_index 부여 + is_entry_point(export 보존).
+    // renumber 후라 플래그를 순회해 현재 index 로 처리(plugin emit 은 entry_points 경로에 없음).
+    // 이미 import 된 모듈(B-i)이면 dfs 가 visited 로 빠르게 리턴, is_entry_point/markViaDynamic 만 의미.
+    {
+        var mi: usize = 0;
+        while (mi < self.modules.count()) : (mi += 1) {
+            const m = self.modules.at(mi);
+            if (!m.is_emitted_chunk_entry) continue;
+            m.is_entry_point = true;
+            const idx: ModuleIndex = @enumFromInt(@as(u32, @intCast(mi)));
+            try graph_cycles.dfs(self, idx, &visited, &in_stack);
+            try entry_indices.append(self.allocator, idx);
+        }
+    }
+
     // dfs 는 dependencies 만 따라가서 exec_index/TLA 분석 정확. dynamic edge 통한
     // static cycle 멤버 marking 은 별도 pass (#2211).
     try graph_cycles.markViaDynamic(self, entry_indices.items);
@@ -443,6 +521,11 @@ pub fn buildIncremental(
                 mod.dynamic_imports = saved_dynamic;
                 mod.dynamic_importers = saved_dynamic_importers;
                 mod.mtime = mtime;
+                // is_emitted_chunk_entry 는 빌드별 derived state(plugin this.emitFile chunk).
+                // store round-trip 으로 복원하면 이전 빌드의 emit 이 영구 split 으로 굳으므로
+                // 매 rebuild reset → injectEmittedChunks 가 이번 emit_store.chunks 기준 재set
+                // (code-review: watch stale 플래그 방지, #1880 PR7-2b-i).
+                mod.is_emitted_chunk_entry = false;
                 // PR-Z3: 정상 경로에선 `addModuleWithResolveDir` 에서 이미 capacity 8 을
                 // 확보하므로 여기서는 no-op (saved_deps 는 그 capacity 를 그대로 캐리).
                 // 다만 disabled/external 같은 by-pass 경로가 미래에 cache-hit 분기로
@@ -515,6 +598,9 @@ pub fn buildIncremental(
     const before_runtime_count = self.modules.count();
     try applyRuntimePolyfills(self, &runtime_indices);
     if (self.modules.count() > before_runtime_count) graph_changed = true;
+    // watch/incremental 에서도 emit chunk 플래그를 이번 emit_store.chunks 기준으로 set
+    // (cache-hit restore 에서 stale 은 이미 reset). build() 와 동일 처리 (#1880 PR7-2b-i).
+    try injectEmittedChunks(self);
     try linkExecutionRoots(self, entry_points, inject_indices.items, runtime_indices.items, run_before_main_indices.items);
 
     discover_scope.end();

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -334,6 +334,10 @@ pub const Module = struct {
     /// container.get 이 `__zntc_load_chunk().then(()=>__zntc_require(id))`
     /// (동적 wrapper) 재사용. boundary ⊇ expose (shared 는 expose 아님).
     is_federation_expose: bool = false,
+    /// plugin `this.emitFile({ type: 'chunk' })` 로 별도 chunk 로 분리 요청된 모듈 (#1880 PR7-2b).
+    /// build_flow 가 emit_store.chunks 의 id 를 graph 에서 찾아 set → chunk.zig 가 federation
+    /// expose 와 동형으로 dynamic entry 로 분리. is_federation_expose 와 같은 lazy-chunk 경로.
+    is_emitted_chunk_entry: bool = false,
     /// DFS 후위 순서 = ESM 실행 순서 (D058, D076).
     /// maxInt = 미방문 (DFS에서 할당되지 않음).
     exec_index: u32,


### PR DESCRIPTION
## 배경

#1880 epic **PR7-2b-i** — `this.emitFile({ type: 'chunk', id })` 의 첫 동작 단계. RFC([docs/RFC_PLUGIN_EMIT_CHUNK.md](./docs/RFC_PLUGIN_EMIT_CHUNK.md)) 분할대로 위험을 격리: **id 가 이미 graph 에 있는 모듈**일 때만 별도 chunk 로 분리하고, 신규 모듈(resolution/discovery 필요)은 B-ii 대기.

## 구현

- `Module.is_emitted_chunk_entry` 플래그.
- `build_flow.injectEmittedChunks`: discovery 패스 종료 후(build thread, 모든 hook drain — RFC §3 옵션 B) `emit_store.chunks` read → `path_to_module` 매칭 모듈에 플래그 set. **build thread ≠ Node main 이라 패스 경계 분리로 mutex 불필요.** plugin 은 `this.resolve` 로 얻은 abs id 전달.
- `finalizeGraph`: emit chunk 모듈 DFS 루트(exec_index + is_entry_point). renumber 후 플래그 순회 → index 전달 불필요(플래그가 Module 따라감).
- `chunk.zig`: `is_emitted_chunk_entry → addDynamicEntry` (federation expose 동형 → BitSet 도달성으로 별도 chunk).
- native/JS: `emitFileCallback` chunk 분기(`chunkId`) + `emitFile({type:'chunk'})` 허용.

## `/code-review max` 발견 3건 fix

엄격 리뷰가 제 테스트(splitting:true만 커버)가 놓친 실제 버그를 잡았습니다:

1. **`splitting:false`(기본) entry 오선택** — emit chunk 에 `is_entry_point=true` 를 무조건 set → 단일파일 모드에서 dep(exec_index 작음)를 entry 로 오선택, 출력 오염(silent). → `code_splitting/preserve_modules` 가드(없으면 진단). **회귀 테스트 추가.**
2. **watch/incremental stale 플래그** — `injectEmittedChunks` 가 build()만 + module_store 가 플래그를 whole-struct 영속 → 이전 빌드 emit 이 영구 split. → buildIncremental 에도 추가 + cache-hit restore 에서 `is_emitted_chunk_entry` reset(매 rebuild emit_store 기준 재계산).
3. **external/disabled phantom** 을 chunk 로 set → 가드(진단).

SAFE 확인(리뷰 runtime 검증): DFS double-visit(early-return), **chunk split 실제 동작·중복 0**, free/counter/renumber 플래그.

## 성능 (게이트)

chunk 미사용 빌드는 `injectEmittedChunks` 빈 순회(early-return). `graph` 단계 A/B 실측(lodash-es 641 module, `--profile=all --profile-format=json`):

| | median graph_ms | min–max |
|---|---|---|
| main | 40.8 | 17.9–83.5 |
| branch | 41.4 | 16.2–68.1 |

차이 **0.67ms** 가 변동범위(16–83ms)에 묻힘 = **회귀 0 실측 확인**.

## 한계 (follow-up)

- 신규 모듈 chunk emit = **PR7-2b-ii** (resolution + fixpoint + tree_shaker entry_set).
- chunkName/`fileName` 명명 + `getFileName(chunkRef)` = **PR7-2c**.
- path 매칭은 `this.resolve` 결과 권장(symlink 정규화 차이 시 진단).

## 검증

- `plugin-emit-chunk.ts` 4개(이미-import 분리 / 신규 진단 / splitting:false 진단 / id 없음 throw)
- `build-plugins` **48 pass** + `vite-plugin` **27 pass** / 회귀 0, `zig build test` 통과, `tsc` 통과, ReleaseFast napi

Refs #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)