### PR TITLE
chore: .gitignore 에 NAPI/pack 빌드 산출물 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,10 @@ check_inferred
 *.wasm
 references/
 .claude/
+
+# NAPI 네이티브 애드온 + 플랫폼 바이너리 (zig build / napi 산출물이 플랫폼 패키지에 떨어짐)
+*.node
+packages/core-*/zntc
+
+# npm pack 산출물 (pre-release-check 의 `bun pm pack` → <name>-<version>.tgz)
+*.tgz


### PR DESCRIPTION
## 무엇을

빌드 산출물이 `git status` 에 untracked 로 떠 실수로 commit 되지 않도록 `.gitignore` 무시 패턴을 추가합니다.

```
*.node                  # NAPI 네이티브 애드온
packages/core-*/zntc    # 플랫폼 바이너리
*.tgz                   # bun pm pack tarball (pre-release-check)
```

## 왜

`packages/core-darwin-arm64/zntc`, `*.node`, `*-0.1.0.tgz` 등이 zig build / napi 빌드와 pre-release-check(`bun pm pack`) 과정에서 생성되는데 무시되지 않아 매 작업마다 untracked 로 노출됐습니다. 실수 commit 위험이 있어 차단합니다.

## 검증

- `git check-ignore` 로 대상 5개 산출물이 모두 무시됨을 확인
- 현재 추적 중인 `.node`/`.tgz`/플랫폼 바이너리는 없음 (`git ls-files` 확인) → 기존 추적 파일에 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)