### PR TITLE
feat(plugin): this.emitFile chunk B-ii — 신규 모듈 chunk emit (#1880 PR7-2b-ii)

### DIFF
--- a/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
+++ b/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
@@ -54,13 +54,50 @@ describe('@zntc/core build + plugins - this.emitFile chunk (PR7-2b-i)', () => {
     }
   });
 
-  test('graph 에 없는 신규 모듈 emit chunk 는 B-ii 대기 — build 진단', async () => {
+  test('코드에 import 없는 신규 모듈을 emit chunk 로 별도 chunk 분리한다 (B-ii)', async () => {
+    let refId: unknown = 'unset';
     const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-new-'));
+    const workerPath = join(dir, 'worker.ts');
     const plugin: ZntcPlugin = {
-      name: 'emit-chunk-new',
+      name: 'emit-chunk-new-module',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          async function (this: RollupPluginContext, args: { path: string }) {
+            // worker 는 main 이 정적/동적 import 안 함 → graph 에 없음(신규). this.resolve 로 abs id.
+            const r = await this.resolve('./worker.ts', args.path);
+            refId = this.emitFile({ type: 'chunk', id: r!.id });
+            return null;
+          },
+        );
+      },
+    };
+    try {
+      writeFileSync(workerPath, 'export const w = 99;\nconsole.log("worker-side-effect");\n');
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n'); // worker 미참조
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBe(0);
+      expect(typeof refId).toBe('string');
+      // worker 가 신규 entry 로 graph 에 추가되고 tree-shaking 생존 → 별도 chunk 로 출력.
+      const workerChunk = result.outputFiles.find((f) => f.path.includes('worker'));
+      expect(workerChunk).toBeDefined();
+      expect(workerChunk!.text).toContain('99');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('resolve 불가능한 id 의 chunk emit 은 build 진단', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-ghost-'));
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-ghost',
       setup(build) {
         build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
-          this.emitFile({ type: 'chunk', id: join(dir, 'ghost.ts') }); // graph 에 없음
+          this.emitFile({ type: 'chunk', id: join(dir, 'ghost.ts') }); // 파일 없음 → graph 추가 실패
           return null;
         });
       },

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -154,8 +154,8 @@ fn injectEmittedChunks(self: *ModuleGraph) !void {
     // chunk 분리가 없어 is_entry_point=true 가 단일파일 entry 오선택을 일으키므로 거부한다
     // (code-review: silent 오동작 방지).
     const splittable = self.code_splitting or self.preserve_modules;
-    for (store.chunks.items) |chk| {
-        if (!splittable) {
+    if (!splittable) {
+        for (store.chunks.items) |chk| {
             self.addDiag(
                 .plugin_error,
                 .@"error",
@@ -165,36 +165,73 @@ fn injectEmittedChunks(self: *ModuleGraph) !void {
                 "this.emitFile({ type: 'chunk' }) requires code splitting (splitting: true).",
                 "Enable code splitting, or emit type:'asset' instead.",
             );
-            continue;
         }
-        if (self.path_to_module.get(chk.id)) |idx| {
-            const ei = @intFromEnum(idx);
-            if (ei >= self.modules.count()) continue;
-            const m = self.modules.at(ei);
-            // external/disabled phantom 은 chunk 대상이 아님 — entry 오염 방지 (code-review).
-            if (m.is_external or m.is_disabled) {
-                self.addDiag(
-                    .plugin_error,
-                    .@"error",
-                    chk.id,
-                    .{ .start = 0, .end = 0 },
-                    .resolve,
-                    "this.emitFile({ type: 'chunk' }) id resolves to an external/disabled module — cannot be a chunk.",
-                    "Pass an id of a normal (bundled) module already in the graph.",
-                );
-                continue;
+        return;
+    }
+
+    // fixpoint (RFC §4.3): 신규 모듈(B-ii)을 addModule → discovery 하면 그 모듈의 transform 이
+    // 또 emit chunk 할 수 있어 store.chunks 가 늘 수 있다. processed 까지 처리 후, discovery 가
+    // 새 chunk 요청을 더했으면 while 이 재진입. addModule dedup 으로 bounded.
+    var processed: usize = 0;
+    while (processed < store.chunks.items.len) {
+        const cur_len = store.chunks.items.len;
+        const before_count = self.modules.count();
+        for (store.chunks.items[processed..cur_len]) |chk| {
+            if (self.path_to_module.get(chk.id)) |idx| {
+                // 이미 graph 에 있는 모듈 (B-i).
+                const ei = @intFromEnum(idx);
+                if (ei >= self.modules.count()) continue;
+                const m = self.modules.at(ei);
+                if (m.is_external or m.is_disabled) {
+                    self.addDiag(
+                        .plugin_error,
+                        .@"error",
+                        chk.id,
+                        .{ .start = 0, .end = 0 },
+                        .resolve,
+                        "this.emitFile({ type: 'chunk' }) id resolves to an external/disabled module — cannot be a chunk.",
+                        "Pass an id of a normal (bundled) module already in the graph.",
+                    );
+                    continue;
+                }
+                m.is_emitted_chunk_entry = true;
+            } else {
+                // 신규 모듈 (B-ii): graph 에 없는 id 를 새 entry 로 추가. id 는 plugin 이 this.resolve
+                // 로 얻은 abs path 여야 한다(아래 discovery 가 parse/resolve). addModule dedup.
+                const new_idx = self.addModule(chk.id) catch {
+                    self.addDiag(
+                        .plugin_error,
+                        .@"error",
+                        chk.id,
+                        .{ .start = 0, .end = 0 },
+                        .resolve,
+                        "this.emitFile({ type: 'chunk' }) id could not be added to the graph (resolve it via this.resolve first).",
+                        "Pass an absolute, resolvable module id (e.g. from this.resolve).",
+                    );
+                    continue;
+                };
+                _ = try graph_requested_exports.requestAll(self, new_idx);
+                const nei = @intFromEnum(new_idx);
+                if (nei < self.modules.count()) self.modules.at(nei).is_emitted_chunk_entry = true;
             }
-            m.is_emitted_chunk_entry = true;
-        } else {
-            self.addDiag(
-                .plugin_error,
-                .@"error",
-                chk.id,
-                .{ .start = 0, .end = 0 },
-                .resolve,
-                "this.emitFile({ type: 'chunk' }) id is not an already-graphed module — new-module chunk emit is not supported yet (PR7-2b-i).",
-                "Pass an id already in the module graph (e.g. resolved via this.resolve to a statically imported module).",
-            );
+        }
+        processed = cur_len;
+        // 새로 추가된 emit chunk 모듈을 parse/resolve. discovery 중 transform 이 또 emit chunk
+        // 하면 store.chunks 가 늘어 while 이 재진입(fixpoint).
+        if (self.modules.count() > before_count) {
+            try discoverPendingModulesSequential(self, before_count);
+            // discovery 가 신규 모듈을 external/disabled 로 판정했거나 read 실패(source 비어)면
+            // chunk 대상이 아니다 — 플래그를 clear 해 phantom 모듈이 entry/chunk 로 새는 것을
+            // 막는다. B-i 는 set 전에 가드하지만 B-ii 는 discovery 전에 set 하므로 사후 재검증
+            // (code-review: disabled/ghost 모듈 누수 방지). read 실패는 별도 진단으로 surfacing.
+            var ni = before_count;
+            while (ni < self.modules.count()) : (ni += 1) {
+                const nm = self.modules.at(ni);
+                if (!nm.is_emitted_chunk_entry) continue;
+                if (nm.is_external or nm.is_disabled or nm.source.len == 0) {
+                    nm.is_emitted_chunk_entry = false;
+                }
+            }
         }
     }
 }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -335,6 +335,11 @@ pub const TreeShaker = struct {
                         break;
                     }
                 }
+                // plugin this.emitFile({type:'chunk'}) 로 분리 요청된 모듈 (#1880 PR7-2b). 신규
+                // 모듈(코드에 import 없음)은 BFS 로 도달 불가 → entry_set 에 넣지 않으면 tree-shaking
+                // 으로 제거된다(RFC §4.5(1) 생존 핵심). 이미 import 된 B-i 모듈은 이미 set 됨.
+                if (self.entry_set.isSet(i)) continue;
+                if (m.is_emitted_chunk_entry) self.entry_set.set(i);
             }
         }
 


### PR DESCRIPTION
## 배경

#1880 epic **PR7-2b-ii** — PR7-2b-i(이미-graph 모듈) 위에 **신규 모듈**(코드에 정적/동적 import 없는 worker 파일 등) chunk emit 을 얹습니다. Rollup `this.emitFile` chunk 의 **주 use case** 완성.

## 구현 (RFC §4.2/4.3/4.5)

- **`injectEmittedChunks`**: `path_to_module` miss(신규 id)면 `addModule` + `requestAll` + 플래그 set 후 `discoverPendingModulesSequential` 로 parse/resolve. **fixpoint while**(신규 모듈 transform 이 또 emit chunk 하면 재진입; `addModule` dedup 으로 bounded). id 는 plugin 이 `this.resolve` 로 얻은 abs path.
- **`tree_shaker` entry_set 생존(§4.5(1) 핵심)**: `is_emitted_chunk_entry` 를 entry_set 에 추가. 신규 모듈은 BFS 미도달이라 여기 안 넣으면 tree-shaking 으로 제거됨.
- **결정성(#3564)**: 신규 모듈 + 그 deps 는 `renumber` 의 **orphan path-sort** 로 결정적(seed 불필요 — code-review runtime 검증).

## `/code-review max` 발견 fix

- **disabled/external/read-fail(ghost) 신규 모듈이 `is_emitted_chunk_entry` 유지** — 플래그를 discovery **전** set 해서 B-i 가드를 우회, phantom 모듈이 entry/chunk 로 샘. → discovery **후** 재스캔으로 external/disabled/`source` 비어있는 모듈 플래그 clear.

SAFE 확인(runtime 검증): 결정성(orphan path-sort), `addModule` path_arena dupe(emit_store dangling 없음), tree_shaker 생존 순서, chunk 분리(신규 모듈은 static importer 없어 깔끔), fixpoint bounded.

## 성능

chunk 미사용 빌드는 `injectEmittedChunks` early-return + 빈 while(0회) — PR7-2b-i 의 graph 단계 A/B(main 40.8 vs branch 41.4ms, 회귀 0)와 동일 경로. 신규 모듈 emit 시에만 그 서브그래프 discovery 비용(정상 작업).

## 한계 (follow-up)

- **watch/HMR**: 신규 emit chunk 모듈이 reparsed set 에 안 들어가 incremental rebuild 시 stale 가능(full build 무관). 
- chunkName/`fileName` 명명 + `getFileName(chunkRef)` = **PR7-2c**.

## 검증

- `plugin-emit-chunk.ts` 5개(B-i 분리 / **신규 모듈 분리** / 신규 진단 / splitting:false 진단 / id 없음 throw)
- `build-plugins` **49 pass** + `vite-plugin` **27 pass** / 회귀 0, `zig build test` 통과, `tsc` 통과, ReleaseFast napi

Refs #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)