### PR TITLE
feat(plugin): this.emitFile chunk B-ii — 신규 모듈 resolution + 생존 (#1880 PR7-2b-ii)

### DIFF
--- a/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
+++ b/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
@@ -12,9 +12,10 @@ import {
 import type { ZntcPlugin } from './helpers';
 import type { RollupPluginContext } from '../../../index';
 
-// #1880 PR7-2b-i — this.emitFile({ type: 'chunk', id }). B-i 는 id 가 *이미 graph 에 있는*
-// 모듈일 때만 별도 chunk 로 분리(federation/dynamic entry 청킹 재사용). 신규 모듈(graph 미존재)은
-// resolution/discovery 가 필요해 B-ii 대기 → build 진단으로 surfacing. id 누락은 plugin failure.
+// #1880 PR7-2b — this.emitFile({ type: 'chunk', id }). B-i 는 id 가 *이미 graph 에 있는*
+// 모듈일 때만 별도 chunk 로 분리(federation/dynamic entry 청킹 재사용). B-ii 는 graph 에 없는
+// 신규 모듈을 resolution + fixpoint 재-discovery 로 주입 + tree_shaker 생존(정적 import 없어도
+// 살아남아 별도 chunk 로 출력). id 누락은 plugin failure.
 describe('@zntc/core build + plugins - this.emitFile chunk (PR7-2b-i)', () => {
   test('이미 import 된 모듈을 emit chunk 로 별도 chunk 분리한다', async () => {
     let refId: unknown = 'unset';
@@ -54,13 +55,81 @@ describe('@zntc/core build + plugins - this.emitFile chunk (PR7-2b-i)', () => {
     }
   });
 
-  test('graph 에 없는 신규 모듈 emit chunk 는 B-ii 대기 — build 진단', async () => {
+  // === PR7-2b-ii: 신규 모듈(graph 미존재) emit chunk ===
+
+  test('정적 import 없는 신규 모듈을 emit chunk 로 주입 — tree-shaking 생존 + 별도 chunk', async () => {
+    // 핵심 end-to-end 증명(RFC §6 invariant 1): worker.ts 는 어디서도 정적/동적 import 되지
+    // 않는다. plugin 이 emitFile chunk 로만 추가 → resolution + 재-discovery + tree_shaker
+    // entry_set 생존이 모두 맞물려야 별도 output chunk 로 살아남는다(하나라도 빠지면 사라짐).
+    let refId: unknown = 'unset';
     const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-new-'));
     const plugin: ZntcPlugin = {
       name: 'emit-chunk-new',
       setup(build) {
         build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
-          this.emitFile({ type: 'chunk', id: join(dir, 'ghost.ts') }); // graph 에 없음
+          // abs path 로 emit (graph 에 없음 → B-ii resolution 경로).
+          refId = this.emitFile({ type: 'chunk', id: join(dir, 'worker.ts') });
+          return null;
+        });
+      },
+    };
+    try {
+      // worker 는 main 과 무관 — 정적 import 엣지가 없다.
+      writeFileSync(join(dir, 'worker.ts'), 'export const w = 99;\nconsole.log(w);\n');
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBe(0);
+      expect(typeof refId).toBe('string');
+      // worker 가 별도 chunk 로 출력 + 내용(99) 생존 → tree-shaking 살아남음을 실증.
+      const workerChunk = result.outputFiles.find((f) => f.path.includes('worker'));
+      expect(workerChunk).toBeDefined();
+      expect(workerChunk!.text).toContain('99');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('상대 specifier 신규 모듈 emit chunk 도 project_root 기준 resolve 된다', async () => {
+    // id 가 미해석 상대 경로('./worker.ts') — resolveThreadSafe(project_root, ...) 검증.
+    let refId: unknown = 'unset';
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-rel-'));
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-rel',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          refId = this.emitFile({ type: 'chunk', id: './worker.ts' });
+          return null;
+        });
+      },
+    };
+    try {
+      writeFileSync(join(dir, 'worker.ts'), 'export const w = 7;\nconsole.log(w);\n');
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBe(0);
+      expect(typeof refId).toBe('string');
+      const workerChunk = result.outputFiles.find((f) => f.path.includes('worker'));
+      expect(workerChunk).toBeDefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('해석 불가한 신규 모듈 id 는 진단(에러) — silent drop 아님', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-unresolved-'));
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-unresolved',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'chunk', id: './does-not-exist.ts' });
           return null;
         });
       },
@@ -73,6 +142,39 @@ describe('@zntc/core build + plugins - this.emitFile chunk (PR7-2b-i)', () => {
         splitting: true,
       });
       expect(result.errors.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('emit-within-emit: 신규 모듈의 transform 이 또 emit chunk 하면 fixpoint 로 둘 다 분리', async () => {
+    // a.ts 는 plugin 이 emit, a.ts 의 transform 이 b.ts 를 또 emit → 재-discovery fixpoint 검증.
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-nested-'));
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-nested',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'chunk', id: join(dir, 'a.ts') });
+          return null;
+        });
+        build.onTransform({ filter: /a\.ts$/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'chunk', id: join(dir, 'b.ts') });
+          return null;
+        });
+      },
+    };
+    try {
+      writeFileSync(join(dir, 'a.ts'), 'export const a = 11;\nconsole.log(a);\n');
+      writeFileSync(join(dir, 'b.ts'), 'export const b = 22;\nconsole.log(b);\n');
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBe(0);
+      expect(result.outputFiles.find((f) => f.path.includes('a'))).toBeDefined();
+      expect(result.outputFiles.find((f) => f.path.includes('b'))).toBeDefined();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -137,15 +137,19 @@ pub fn build(self: *ModuleGraph, entry_points: []const []const u8) !void {
     try finalizeGraph(self, entry_points);
 }
 
-/// PR7-2b-i (#1880): plugin `this.emitFile({ type: 'chunk', id })` 로 별도 chunk 요청된 모듈을
-/// 표시한다. discovery 패스가 모두 끝난 뒤(build thread, 모든 hook drain) emit_store.chunks 를
-/// read 하므로 Node main 의 write 와 패스 경계로 분리돼 mutex 불필요(RFC §3 옵션 B).
+/// PR7-2b (#1880): plugin `this.emitFile({ type: 'chunk', id })` 로 별도 chunk 요청된 모듈을
+/// graph 에 주입/표시한다. discovery 패스가 모두 끝난 뒤(build thread, 모든 hook drain) emit_store
+/// .chunks 를 read 하므로 Node main 의 write 와 패스 경계로 분리돼 mutex 불필요(RFC §3 옵션 B).
 ///
-/// **B-i 범위**: id 가 *이미 graph 에 있는* 모듈일 때만 `is_emitted_chunk_entry` 플래그를 set
-/// (finalizeGraph 가 DFS 루트로, chunk.zig 가 dynamic entry 로 분리). 신규 모듈(graph 미존재)은
-/// resolution+discovery 가 필요해 B-ii 대기 → 진단으로 surfacing(silent-broken 방지).
-/// 플래그는 renumber 가 Module 을 옮겨도 따라가므로 finalizeGraph/chunk.zig 가 renumber 후
-/// 안전하게 읽는다(index 배열 전달 불필요).
+/// **B-i**: id 가 *이미 graph 에 있는* 모듈이면 `is_emitted_chunk_entry` 플래그만 set.
+/// **B-ii**: graph 에 없는 신규 모듈이면 `resolve_cache` 로 resolve → `addModuleWithResolveDir`
+/// (dedup) → 플래그 + `requestAll` → `discoverPendingModulesSequential` 로 서브그래프 디스커버리.
+/// emit-within-emit(신규 모듈 transform 이 또 emit) 은 `store.chunks` 가 더 자라므로 fixpoint
+/// 루프로 재드레인 — addModule dedup 으로 bounded(RFC §4.3, §6 invariant 4).
+///
+/// 생존은 tree_shaker entry_set(§4.5(1)), 청킹은 finalizeGraph 의 DFS 루트 + chunk.zig 의
+/// dynamic entry 가 담당. 플래그는 renumber 가 Module 을 옮겨도 따라가므로(shallow copy) 이후
+/// 단계가 renumber 후 안전하게 읽는다(index 배열 전달 불필요).
 fn injectEmittedChunks(self: *ModuleGraph) !void {
     const store_ptr = self.emit_store orelse return; // chunk 미사용 빌드: hot path 0
     const store: *@import("../emit_store.zig").EmitStore = @ptrCast(@alignCast(store_ptr));
@@ -154,49 +158,150 @@ fn injectEmittedChunks(self: *ModuleGraph) !void {
     // chunk 분리가 없어 is_entry_point=true 가 단일파일 entry 오선택을 일으키므로 거부한다
     // (code-review: silent 오동작 방지).
     const splittable = self.code_splitting or self.preserve_modules;
-    for (store.chunks.items) |chk| {
-        if (!splittable) {
+    // 신규 모듈 resolve 기준 디렉토리: importer 가 없으므로 project_root(없으면 entry_dir).
+    // Rollup 도 importer 미지정 emit 은 cwd 기준 — 여기선 project_root MVP (RFC §4.2).
+    const source_dir = if (self.project_root.len > 0) self.project_root else self.entry_dir;
+
+    var prev: usize = 0;
+    // 방어 캡: 신뢰 못 할 plugin 이 discovery 패스마다 *새로운 distinct id* 를 emit 하면
+    // store.chunks 가 끝없이 자라 수렴하지 않는다(무한 import 그래프와 동형). 정상 빌드는
+    // emit-chain 깊이만큼만 도므로 절대 도달하지 않는 큰 상수로 hang 대신 진단을 낸다.
+    var pass: usize = 0;
+    const max_passes: usize = 1 << 16;
+    while (true) {
+        const cur = store.chunks.items.len;
+        if (cur <= prev) break; // fixpoint: 신규 emit 없음
+        pass += 1;
+        if (pass > max_passes) {
             self.addDiag(
                 .plugin_error,
                 .@"error",
-                chk.id,
+                store.chunks.items[prev].id,
                 .{ .start = 0, .end = 0 },
                 .resolve,
-                "this.emitFile({ type: 'chunk' }) requires code splitting (splitting: true).",
-                "Enable code splitting, or emit type:'asset' instead.",
+                "this.emitFile({ type: 'chunk' }) did not converge — a plugin keeps emitting new chunk ids during discovery.",
+                "Emit a finite, stable set of chunk ids; avoid emitting a fresh id on every transform.",
             );
-            continue;
+            break;
         }
-        if (self.path_to_module.get(chk.id)) |idx| {
-            const ei = @intFromEnum(idx);
-            if (ei >= self.modules.count()) continue;
-            const m = self.modules.at(ei);
-            // external/disabled phantom 은 chunk 대상이 아님 — entry 오염 방지 (code-review).
-            if (m.is_external or m.is_disabled) {
+        const discover_from = self.modules.count();
+        for (store.chunks.items[prev..cur]) |chk| {
+            if (!splittable) {
                 self.addDiag(
                     .plugin_error,
                     .@"error",
                     chk.id,
                     .{ .start = 0, .end = 0 },
                     .resolve,
-                    "this.emitFile({ type: 'chunk' }) id resolves to an external/disabled module — cannot be a chunk.",
-                    "Pass an id of a normal (bundled) module already in the graph.",
+                    "this.emitFile({ type: 'chunk' }) requires code splitting (splitting: true).",
+                    "Enable code splitting, or emit type:'asset' instead.",
                 );
                 continue;
             }
-            m.is_emitted_chunk_entry = true;
-        } else {
-            self.addDiag(
-                .plugin_error,
-                .@"error",
-                chk.id,
-                .{ .start = 0, .end = 0 },
-                .resolve,
-                "this.emitFile({ type: 'chunk' }) id is not an already-graphed module — new-module chunk emit is not supported yet (PR7-2b-i).",
-                "Pass an id already in the module graph (e.g. resolved via this.resolve to a statically imported module).",
-            );
+            // 1. 이미 graph 에 있는 모듈(B-i / 이전 fixpoint 패스가 추가한 모듈): 플래그만.
+            //    이미 discovery 됐으므로 requestAll/재-discover 불필요(생존은 tree_shaker entry_set).
+            if (self.path_to_module.get(chk.id)) |idx| {
+                _ = flagEmittedChunkEntry(self, idx, chk.id);
+                continue;
+            }
+            // 2. 신규 모듈(B-ii): resolve → addModule → 플래그 + requestAll.
+            const resolved = self.resolve_cache.resolveThreadSafe(source_dir, chk.id, .static_import) catch |err| switch (err) {
+                error.ModuleNotFound => {
+                    self.addDiag(
+                        .plugin_error,
+                        .@"error",
+                        chk.id,
+                        .{ .start = 0, .end = 0 },
+                        .resolve,
+                        "this.emitFile({ type: 'chunk' }) id could not be resolved.",
+                        "Pass a resolvable specifier (relative to project root) or an id already in the graph.",
+                    );
+                    continue;
+                },
+                else => |e| return e,
+            };
+            // null = external(isExternal). external 은 chunk 가 될 수 없다.
+            const m_union = resolved orelse {
+                self.addDiag(
+                    .plugin_error,
+                    .@"error",
+                    chk.id,
+                    .{ .start = 0, .end = 0 },
+                    .resolve,
+                    "this.emitFile({ type: 'chunk' }) id resolves to an external module — cannot be a chunk.",
+                    "Pass an id of a normal (bundled) module.",
+                );
+                continue;
+            };
+            switch (m_union) {
+                .file => |f| {
+                    // f.path/f.resolve_dir 는 graph allocator 소유 → addModuleWithResolveDir 가
+                    // dupe(path→arena, resolve_dir→allocator) 한 뒤 caller 가 free (resolve_imports.zig 동형).
+                    defer {
+                        self.allocator.free(f.path);
+                        if (f.resolve_dir) |dir| self.allocator.free(dir);
+                    }
+                    const idx = try self.addModuleWithResolveDir(f.path, f.resolve_dir);
+                    // 신규로 플래그된 경우에만 requestAll(중복 emit dedup 시 재요청 방지).
+                    if (flagEmittedChunkEntry(self, idx, chk.id)) {
+                        _ = try graph_requested_exports.requestAll(self, idx);
+                    }
+                },
+                .disabled => |d| {
+                    self.allocator.free(d.path);
+                    self.addDiag(
+                        .plugin_error,
+                        .@"error",
+                        chk.id,
+                        .{ .start = 0, .end = 0 },
+                        .resolve,
+                        "this.emitFile({ type: 'chunk' }) id resolves to a disabled module — cannot be a chunk.",
+                        "Pass an id of a normal (bundled) module.",
+                    );
+                },
+                // Phase-1 cache 는 virtual/dataurl/external/custom 을 반환하지 않는다
+                // (resolve_imports.zig 와 동일 불변식). 방어적 진단 — crash 대신 surfacing.
+                .virtual, .dataurl, .external, .custom => {
+                    self.addDiag(
+                        .plugin_error,
+                        .@"error",
+                        chk.id,
+                        .{ .start = 0, .end = 0 },
+                        .resolve,
+                        "this.emitFile({ type: 'chunk' }) id resolves to a non-file module — unsupported as a chunk.",
+                        "Pass an id of a normal (bundled) file module.",
+                    );
+                },
+            }
         }
+        prev = cur;
+        // 이번 패스에서 추가된 신규 모듈만 순차 디스커버리(pool 은 이미 닫힘 — RFC §4.3).
+        try discoverPendingModulesSequential(self, discover_from);
     }
+}
+
+/// emit chunk 대상 모듈에 `is_emitted_chunk_entry` 를 set. external/disabled phantom 이면
+/// 진단하고 false. 이미 플래그됐으면(중복 emit) false 를 돌려 caller 의 requestAll 재실행을 막는다.
+/// 신규로 플래그 set 한 경우에만 true.
+fn flagEmittedChunkEntry(self: *ModuleGraph, idx: ModuleIndex, diag_id: []const u8) bool {
+    const ei = @intFromEnum(idx);
+    if (ei >= self.modules.count()) return false;
+    const m = self.modules.at(ei);
+    if (m.is_external or m.is_disabled) {
+        self.addDiag(
+            .plugin_error,
+            .@"error",
+            diag_id,
+            .{ .start = 0, .end = 0 },
+            .resolve,
+            "this.emitFile({ type: 'chunk' }) id resolves to an external/disabled module — cannot be a chunk.",
+            "Pass an id of a normal (bundled) module already in the graph.",
+        );
+        return false;
+    }
+    if (m.is_emitted_chunk_entry) return false; // 이미 처리됨 (dedup)
+    m.is_emitted_chunk_entry = true;
+    return true;
 }
 
 fn applyRuntimePolyfills(self: *ModuleGraph, runtime_indices: *std.ArrayList(ModuleIndex)) !void {
@@ -599,8 +704,11 @@ pub fn buildIncremental(
     try applyRuntimePolyfills(self, &runtime_indices);
     if (self.modules.count() > before_runtime_count) graph_changed = true;
     // watch/incremental 에서도 emit chunk 플래그를 이번 emit_store.chunks 기준으로 set
-    // (cache-hit restore 에서 stale 은 이미 reset). build() 와 동일 처리 (#1880 PR7-2b-i).
+    // (cache-hit restore 에서 stale 은 이미 reset). build() 와 동일 처리 (#1880 PR7-2b).
+    // B-ii: 신규 모듈 emit 은 graph 를 늘리므로 graph_changed 반영(downstream 재계산 트리거).
+    const before_emit_count = self.modules.count();
     try injectEmittedChunks(self);
+    if (self.modules.count() > before_emit_count) graph_changed = true;
     try linkExecutionRoots(self, entry_points, inject_indices.items, runtime_indices.items, run_before_main_indices.items);
 
     discover_scope.end();

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -335,6 +335,13 @@ pub const TreeShaker = struct {
                         break;
                     }
                 }
+                // plugin `this.emitFile({ type: 'chunk' })` 로 emit 된 모듈은 importer 가
+                // 없어 BFS 도달 불가 → 여기서 entry_set 에 넣지 않으면 tree-shaking 으로
+                // 제거된다. emit chunk 는 새 entry 이므로 BFS seed + 전체 export 보존
+                // (#1880 PR7-2b-ii, RFC §4.5(1)). finalizeGraph 는 이 모듈을 별도 chunk
+                // 루트로 만들지만, tree-shaking 이 먼저라 여기서 살아남아야 청킹에 도달한다.
+                if (self.entry_set.isSet(i)) continue;
+                if (m.is_emitted_chunk_entry) self.entry_set.set(i);
             }
         }
 


### PR DESCRIPTION
## 무엇을

plugin `this.emitFile({ type: 'chunk', id })` 에서 **graph 에 없는 신규 모듈**을 별도 chunk 로 주입합니다. 정적/동적 import 가 전혀 없는 worker 파일을 plugin 이 번들에 추가하는 주 use case 를 완성합니다 (B-i 의 "이미 graph 에 있는 모듈" 제약 해제).

## 왜

B-i 는 이미 import 된 모듈을 별도 chunk 로 승격하는 것까지였습니다. 실용적 핵심(코드에 import 가 없는 동적 진입점/worker emit)은 resolution + 재-discovery + tree-shaking 생존이 모두 맞물려야 하는 B-ii 입니다. RFC `docs/RFC_PLUGIN_EMIT_CHUNK.md` §8 의 단계 계획대로 B-i → B-ii 순으로 진행했습니다.

## 구현 (RFC §4.2 / §4.3 / §4.5(1))

- **`injectEmittedChunks`** (`build_flow.zig`): id 가 graph 에 없으면
  `resolve_cache.resolveThreadSafe`(project_root 기준) → `addModuleWithResolveDir`(dedup) → `is_emitted_chunk_entry` + `requestAll` → `discoverPendingModulesSequential`(신규 모듈만; pool 은 discovery 블록에서 이미 닫힘). emit-within-emit 은 `store.chunks` 가 자라므로 **fixpoint 루프**로 재드레인.
  - ownership: `f.path`/`f.resolve_dir` 는 `addModuleWithResolveDir` 가 dupe 후 caller 가 free (`resolve_imports.zig` 동형 패턴).
  - external / disabled / non-file 결과는 **진단**(silent drop 금지).
- **`tree_shaker.zig`**: `is_emitted_chunk_entry → entry_set.set`. emit chunk 는 importer 가 없어 BFS 미도달 → 여기서 안 넣으면 tree-shaking 으로 제거된다. `entry_set` = BFS seed + 전체 export 보존 → "새 entry" 의미 정확. **tree-shaking 이 청킹보다 먼저라 진짜 생존 지점**.
- **`buildIncremental`**: emit 이 신규 모듈을 추가하면 `graph_changed=true`.

생존/청킹의 나머지(finalizeGraph DFS 루트 + `chunk.zig` `addDynamicEntry`)는 B-i 가 플래그 순회로 처리하므로 신규 모듈도 자동 적용. renumber orphan path-sort 가 결정성을 보장하므로 seed 불필요(RFC §4.6).

## code-review max 반영

- **fixpoint 무한 루프 방어**: plugin 이 discovery 패스마다 *새로운 distinct id* 를 emit 하면 `store.chunks` 가 끝없이 자라 미수렴(무한 import 그래프와 동형). 정상 빌드는 절대 도달하지 않는 큰 상수(`1<<16`) 캡 + 진단으로 hang 대신 error 를 낸다.
- 메모리 ownership / slice realloc / discover_from dedup / source_dir fallback 은 검증 결과 안전(또는 문서화된 MVP)으로 확인.

## 한계 (follow-up)

- emit 기준 디렉토리는 **project_root MVP** — emitting 모듈 dir 기준으로 resolve 하는 Rollup parity 는 B-ii 범위 밖 (RFC §4.2 / §9 미해결 질문).
- watch 에서 emit 하는 transform 이 cache-hit 으로 skip 되면 그 chunk 가 main 으로 합쳐짐 — B-i + incremental 설계 속성(asset emit 도 동일). 별도 추적.

## 검증

- `plugin-emit-chunk.ts` **7개** (신규모듈 생존+별도 chunk / 상대 specifier resolve / 미해결 진단 / emit-within-emit fixpoint + 기존 4). 핵심 테스트는 import 없는 worker.ts 가 별도 output chunk 로 나오고 내용(99)이 살아있음을 실증.
- build-plugins **51 pass** 회귀 0, `zig build test` 전체 통과, napi ReleaseFast 빌드.
- 결정성: orphan path-sort 로 보장. `Build Determinism` CI 가 emit-chunk 사용 빌드 재현성 확인.

Refs #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)