### PR TITLE
feat(plugin): this.getFileName(chunkRef) + emit chunk name (#1880 PR7-2c)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1857,6 +1857,7 @@ type NativeEmitFileFn = (file: {
   source?: string | Uint8Array;
   chunkId?: string;
   chunkName?: string;
+  chunkFileName?: string;
 }) => string | null;
 // #1880 PR6: native getFileName 콜백. reference id → 최종 출력 파일명(미등록이면 null).
 type NativeGetFileNameFn = (referenceId: string) => string | null;
@@ -3023,8 +3024,8 @@ function createRollupPluginContext(
         source?: unknown;
         id?: unknown;
       };
-      // type:'chunk' (#1880 PR7-2b): id(이미 graph 에 있는 모듈)를 별도 chunk 로 분리.
-      // 신규 모듈 emit 은 native 가 build 단계에서 진단으로 거부(B-ii 대기).
+      // type:'chunk' (#1880 PR7-2b/2c): id(graph 모듈/신규)를 별도 chunk 로 분리. name 은 [name]
+      // 패턴, fileName 은 명시 출력명. this.getFileName(refId) 로 최종 파일명 조회(PR7-2c).
       if (f.type === 'chunk') {
         if (typeof f.id !== 'string' || f.id.length === 0) {
           throw new Error(
@@ -3034,6 +3035,8 @@ function createRollupPluginContext(
         const chunkRef = fn({
           chunkId: f.id,
           chunkName: typeof f.name === 'string' && f.name.length > 0 ? f.name : undefined,
+          // 명시 fileName 의 "정확히 그대로(hash 없이)" 는 follow-up — 현재 name 기반 [name]-[hash]
+          // 출력 + getFileName 으로 최종명 조회. (chunkFileName 미노출)
         });
         if (typeof chunkRef !== 'string') {
           throw new Error(
@@ -3074,17 +3077,18 @@ function createRollupPluginContext(
       return referenceId;
     },
     getFileName(referenceId: string): string {
-      // native 가 hook 별로 __getFileName 슬롯에 주입 (#1880 PR6). reference id → 최종 출력 파일명.
+      // native 가 hook 별로 __getFileName 슬롯에 주입 (#1880 PR6/2c). reference id → 최종 출력 파일명.
+      // asset 은 resolveId/load/transform 에서 즉시; chunk 는 청킹 후라 generateBundle 에서 확정.
       const fn = (ctx as { __getFileName?: NativeGetFileNameFn }).__getFileName;
       if (typeof fn !== 'function') {
         throw new Error(
-          `@zntc/core [${pluginName}]: this.getFileName() 는 async build() 의 resolveId/load/transform hook 에서만 사용 가능합니다 (#1880 PR6).`,
+          `@zntc/core [${pluginName}]: this.getFileName() 는 resolveId/load/transform/generateBundle hook 에서만 사용 가능합니다 (#1880 PR6/2c).`,
         );
       }
       const name = fn(referenceId);
       if (typeof name !== 'string') {
         throw new Error(
-          `@zntc/core [${pluginName}]: this.getFileName(${JSON.stringify(referenceId)}) — 알 수 없는 reference id (this.emitFile 로 emit 되지 않았거나 아직 등록 전).`,
+          `@zntc/core [${pluginName}]: this.getFileName(${JSON.stringify(referenceId)}) — 알 수 없는 reference id (미emit, 또는 chunk 를 청킹 전 hook 에서 조회 — chunk 파일명은 generateBundle 에서 확정).`,
         );
       }
       return name;

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -391,13 +391,15 @@ pub const NapiPlugin = struct {
 
         const store: *EmitStore = @ptrCast(@alignCast(data orelse return js_null));
 
-        // chunk emit (#1880 PR7-2b): chunkId 가 있으면 source 없이 chunk 요청 수집.
-        // JS 가 type:'chunk' 일 때 { chunkId, chunkName? } 로 정규화해 넘긴다.
+        // chunk emit (#1880 PR7-2b/2c): chunkId 가 있으면 source 없이 chunk 요청 수집.
+        // JS 가 type:'chunk' 일 때 { chunkId, chunkName?, chunkFileName? } 로 정규화해 넘긴다.
         if (getObjectString(env, argv[0], "chunkId", native_alloc)) |chunk_id| {
             defer native_alloc.free(chunk_id);
             const chunk_name = getObjectString(env, argv[0], "chunkName", native_alloc);
             defer if (chunk_name) |n| native_alloc.free(n);
-            const cref = store.emitChunk(chunk_id, chunk_name) catch return js_null;
+            const chunk_file_name = getObjectString(env, argv[0], "chunkFileName", native_alloc);
+            defer if (chunk_file_name) |f| native_alloc.free(f);
+            const cref = store.emitChunk(chunk_id, chunk_name, chunk_file_name) catch return js_null;
             var js_cref: c.napi_value = undefined;
             if (c.napi_create_string_utf8(env, cref.ptr, cref.len, &js_cref) != c.napi_ok) return js_null;
             return js_cref;
@@ -745,9 +747,11 @@ fn NapiPluginAdapter(comptime Self: type) type {
             return callCodeHook(self, .renderChunk, code, chunk_name, alloc, hook_ctx);
         }
 
-        fn pluginGenerateBundle(ctx: ?*anyopaque, output_files: []const bundler_mod.emitter.OutputFile) void {
+        fn pluginGenerateBundle(ctx: ?*anyopaque, output_files: []const bundler_mod.emitter.OutputFile, hook_ctx: *plugin_mod.HookContext) void {
             const self: *Self = @ptrCast(@alignCast(ctx.?));
-            if (self.callHookFull(.generateBundle, "", null, output_files, null, null, null)) |resp| {
+            // PR7-2c: emit_store 를 전달해 generateBundle hook 의 this.getFileName(chunkRef) 활성화
+            // (back-fill 된 chunk 파일명 조회). discovery hook 과 달리 generateBundle 은 청킹 후라 확정.
+            if (self.callHookFull(.generateBundle, "", null, output_files, null, null, hook_ctx.emit_store)) |resp| {
                 NapiPlugin.freeResponseFields(resp);
             }
         }

--- a/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
+++ b/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
@@ -91,6 +91,46 @@ describe('@zntc/core build + plugins - this.emitFile chunk (PR7-2b-i)', () => {
     }
   });
 
+  test('chunk emit 후 generateBundle 의 this.getFileName 이 최종 파일명을 반환한다 (PR7-2c)', async () => {
+    let chunkRef = '';
+    let resolvedName: string | undefined;
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-getname-'));
+    const workerPath = join(dir, 'worker.ts');
+    const plugin: ZntcPlugin = {
+      name: 'chunk-getfilename',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          async function (this: RollupPluginContext, args: { path: string }) {
+            const r = await this.resolve('./worker.ts', args.path);
+            chunkRef = this.emitFile({ type: 'chunk', id: r!.id, name: 'myworker' }) as string;
+            return null;
+          },
+        );
+        // generateBundle 은 청킹 후 → getFileName 이 back-fill 된 최종 파일명 반환.
+        build.onGenerateBundle(function (this: RollupPluginContext) {
+          resolvedName = this.getFileName(chunkRef);
+        });
+      },
+    };
+    try {
+      writeFileSync(workerPath, 'export const w = 99;\nconsole.log("wk");\n');
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBe(0);
+      // name:'myworker' 가 [name] 으로 반영된 최종 chunk 파일명 + 실제 output 과 일치.
+      expect(resolvedName).toBeDefined();
+      expect(resolvedName).toContain('myworker');
+      expect(result.outputFiles.find((f) => f.path === resolvedName)).toBeDefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('resolve 불가능한 id 의 chunk emit 은 build 진단', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-ghost-'));
     const plugin: ZntcPlugin = {

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1820,6 +1820,27 @@ pub const Bundler = struct {
             null;
         metafile_scope.end();
 
+        // PR7-2c: emit chunk(this.emitFile type:'chunk')의 최종 출력 파일명을 emit_store 에
+        // back-fill → generateBundle hook 의 this.getFileName(chunkRef) 가 확정된 [name]-[hash]
+        // 파일명을 반환(명시 fileName 없는 auto chunk). emit chunk 모듈은 자기 chunk 의 entry 라
+        // 그 chunk OutputFile.module_ids 에 chk.id 가 포함된다. 명시 fileName chunk 는 skip.
+        if (emit_store.chunks.items.len > 0) {
+            if (outputs) |outs| {
+                for (emit_store.chunks.items) |chk| {
+                    for (outs) |out| {
+                        if (out.kind != .chunk) continue;
+                        const matched = for (out.module_ids) |mid| {
+                            if (std.mem.eql(u8, mid, chk.id)) break true;
+                        } else false;
+                        if (matched) {
+                            emit_store.setChunkFileName(chk.id, out.path) catch {};
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
         // 8. Plugin: generateBundle 훅 — 번들 완료 후 모든 플러그인에 알림
         if (self.options.plugins.len > 0) {
             const runner = plugin_mod.PluginRunner.init(self.options.plugins);
@@ -1827,7 +1848,11 @@ pub const Bundler = struct {
                 outs
             else
                 &.{.{ .path = "bundle.js", .contents = output }};
-            runner.runGenerateBundle(gen_outputs);
+            // PR7-2c: emit_store 를 hook_ctx 로 전달 → generateBundle 의 this.getFileName(chunkRef)
+            // 가 back-fill 된 chunk 파일명을 반환(청킹 후라 확정).
+            var gen_hook_ctx: plugin_mod.HookContext = .{ .emit_store = @ptrCast(&emit_store) };
+            defer gen_hook_ctx.deinit();
+            runner.runGenerateBundle(gen_outputs, &gen_hook_ctx);
         }
 
         // 5.6. CSS 번들 수집 (엔트리별 CSS 모듈 연결)

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -617,9 +617,23 @@ pub fn generateChunks(
         errdefer bits.deinit(allocator);
         bits.setBit(@intCast(bit_idx));
 
-        // 출력 파일명 = 모듈 파일명의 stem (확장자 제거)
+        // 출력 파일명 = 모듈 파일명의 stem (확장자 제거). plugin emit chunk(name 지정)면 그 name 우선
+        // (#1880 PR7-2c) — [name]-[hash] 의 [name] 으로 쓰여 plugin 이 chunk 이름을 제어한다.
         const entry_mod = graph.getModule(entry.module_idx) orelse return error.InvalidEntryModule;
-        const name = std.fs.path.stem(std.fs.path.basename(entry_mod.path));
+        const name = blk: {
+            if (entry_mod.is_emitted_chunk_entry) {
+                if (graph.emit_store) |sp| {
+                    const store: *const @import("emit_store.zig").EmitStore = @ptrCast(@alignCast(sp));
+                    for (store.chunks.items) |chk| {
+                        if (std.mem.eql(u8, chk.id, entry_mod.path)) {
+                            if (chk.name) |n| break :blk n;
+                            break;
+                        }
+                    }
+                }
+            }
+            break :blk std.fs.path.stem(std.fs.path.basename(entry_mod.path));
+        };
 
         var chunk = Chunk.init(.none, .{ .entry_point = .{
             .bit = @intCast(bit_idx),

--- a/src/bundler/emit_store.zig
+++ b/src/bundler/emit_store.zig
@@ -21,8 +21,11 @@ pub const EmittedChunk = struct {
     reference_id: []const u8,
     /// resolve 대상 모듈 specifier (entry 로 추가될 모듈).
     id: []const u8,
-    /// chunk 이름(옵션) — 파일명 패턴 `[name]` 치환용. null 이면 id 기반.
+    /// chunk 이름(옵션) — 파일명 패턴 `[name]` 치환용. null 이면 id stem 기반.
     name: ?[]const u8 = null,
+    /// 최종 출력 파일명 (#1880 PR7-2c). 명시 fileName 이면 emit 시 즉시 set(hash 없음);
+    /// name/auto 면 청킹+렌더 후 bundler 가 back-fill([name]-[hash] 확정). getFileName 이 read.
+    file_name: ?[]const u8 = null,
 };
 
 /// plugin `this.emitFile` 수집소 (#1880 PR5).
@@ -65,6 +68,7 @@ pub const EmitStore = struct {
             self.allocator.free(chk.reference_id);
             self.allocator.free(chk.id);
             if (chk.name) |n| self.allocator.free(n);
+            if (chk.file_name) |f| self.allocator.free(f);
         }
         self.chunks.deinit(self.allocator);
     }
@@ -104,32 +108,49 @@ pub const EmitStore = struct {
         return self.emitAsset(file_name, source);
     }
 
-    /// reference id 로 등록된 asset 의 출력 파일명을 조회한다(Rollup `this.getFileName`).
-    /// 메인 스레드 직렬이라 별도 동기화 없이 단순 스캔 — emit 된 asset 수는 작다.
+    /// reference id 로 등록된 asset/chunk 의 출력 파일명을 조회한다(Rollup `this.getFileName`).
+    /// 메인 스레드 직렬이라 별도 동기화 없이 단순 스캔 — emit 수는 작다. chunk 는 명시 fileName 이면
+    /// 즉시, name/auto 면 청킹 후 bundler 가 back-fill 한 file_name 을 반환(미확정이면 null → throw).
     pub fn getFileName(self: *const EmitStore, reference_id: []const u8) ?[]const u8 {
         for (self.assets.items) |a| {
             if (std.mem.eql(u8, a.reference_id, reference_id)) return a.file_name;
+        }
+        for (self.chunks.items) |c| {
+            if (std.mem.eql(u8, c.reference_id, reference_id)) return c.file_name;
         }
         return null;
     }
 
     /// chunk emit 요청을 등록하고 reference id ("chunk-N") 를 반환한다 (#1880 PR7-2).
-    /// id/name 은 dupe 로 소유. **PR7-2a 는 요청 수집만** — 이 요청을 새 entry 로 graph 에 주입해
-    /// 별도 chunk 로 출력하는 것은 PR7-2b, 파일명 lazy 확정은 PR7-2c 에서 처리한다.
-    pub fn emitChunk(self: *EmitStore, id: []const u8, name: ?[]const u8) ![]const u8 {
+    /// id/name/file_name 은 dupe 로 소유. file_name 명시(fileName) 면 getFileName 즉시 가능;
+    /// 미지정(name/auto)이면 bundler 가 청킹 후 `setChunkFileName` 으로 back-fill (PR7-2c).
+    pub fn emitChunk(self: *EmitStore, id: []const u8, name: ?[]const u8, file_name: ?[]const u8) ![]const u8 {
         const reference_id = try std.fmt.allocPrint(self.allocator, "chunk-{d}", .{self.counter});
         errdefer self.allocator.free(reference_id);
         const id_owned = try self.allocator.dupe(u8, id);
         errdefer self.allocator.free(id_owned);
         const name_owned: ?[]const u8 = if (name) |n| try self.allocator.dupe(u8, n) else null;
         errdefer if (name_owned) |n| self.allocator.free(n);
+        const fname_owned: ?[]const u8 = if (file_name) |f| try self.allocator.dupe(u8, f) else null;
+        errdefer if (fname_owned) |f| self.allocator.free(f);
         try self.chunks.append(self.allocator, .{
             .reference_id = reference_id,
             .id = id_owned,
             .name = name_owned,
+            .file_name = fname_owned,
         });
         self.counter += 1;
         return reference_id;
+    }
+
+    /// 청킹+렌더 후 bundler 가 emit chunk(id 매칭)의 최종 파일명을 back-fill 한다 (PR7-2c).
+    /// 이미 명시 fileName 으로 set 된 chunk 는 건드리지 않는다(plugin 지정 우선).
+    pub fn setChunkFileName(self: *EmitStore, id: []const u8, file_name: []const u8) !void {
+        for (self.chunks.items) |*c| {
+            if (c.file_name != null) continue; // 명시 fileName 우선
+            if (!std.mem.eql(u8, c.id, id)) continue;
+            c.file_name = try self.allocator.dupe(u8, file_name);
+        }
     }
 };
 
@@ -185,16 +206,36 @@ test "emitChunk 는 chunk-N reference id 를 발급하고 요청을 수집한다
     var store = EmitStore.init(testing.allocator, "[name]-[hash]");
     defer store.deinit();
 
-    const c0 = try store.emitChunk("./worker.ts", null);
-    const c1 = try store.emitChunk("./route.ts", "route");
+    const c0 = try store.emitChunk("./worker.ts", null, null);
+    const c1 = try store.emitChunk("./route.ts", "route", null);
     try testing.expectEqualStrings("chunk-0", c0);
     try testing.expectEqualStrings("chunk-1", c1);
     try testing.expectEqual(@as(usize, 2), store.chunks.items.len);
     try testing.expectEqualStrings("./worker.ts", store.chunks.items[0].id);
     try testing.expect(store.chunks.items[0].name == null);
     try testing.expectEqualStrings("route", store.chunks.items[1].name.?);
-    // chunk 는 아직 graph 미주입 → getFileName 으로는 조회 안 됨 (PR7-2c 에서 lazy 확정).
+    // file_name 미지정(auto) → 청킹 전엔 getFileName null. back-fill 후 확정(PR7-2c).
     try testing.expect(store.getFileName(c0) == null);
+}
+
+test "emitChunk file_name: 명시 fileName 은 즉시 getFileName, auto 는 setChunkFileName back-fill" {
+    const testing = std.testing;
+    var store = EmitStore.init(testing.allocator, "[name]-[hash]");
+    defer store.deinit();
+
+    // 명시 fileName → 즉시 조회 가능 (hash 없음).
+    const c_explicit = try store.emitChunk("/abs/lib.ts", null, "lib.js");
+    try testing.expectEqualStrings("lib.js", store.getFileName(c_explicit).?);
+
+    // auto(name) → 청킹 전 null, back-fill 후 확정.
+    const c_auto = try store.emitChunk("/abs/worker.ts", "worker", null);
+    try testing.expect(store.getFileName(c_auto) == null);
+    try store.setChunkFileName("/abs/worker.ts", "worker-abc12345.js");
+    try testing.expectEqualStrings("worker-abc12345.js", store.getFileName(c_auto).?);
+
+    // back-fill 은 명시 fileName chunk 를 덮어쓰지 않는다.
+    try store.setChunkFileName("/abs/lib.ts", "OTHER.js");
+    try testing.expectEqualStrings("lib.js", store.getFileName(c_explicit).?);
 }
 
 test "asset/chunk reference id 는 공유 카운터로 서로 유니크하다" {
@@ -203,7 +244,7 @@ test "asset/chunk reference id 는 공유 카운터로 서로 유니크하다" {
     defer store.deinit();
 
     const a0 = try store.emitAsset("a.css", "x");
-    const c1 = try store.emitChunk("./b.ts", null);
+    const c1 = try store.emitChunk("./b.ts", null, null);
     const a2 = try store.emitAsset("c.css", "y");
     try testing.expectEqualStrings("asset-0", a0);
     try testing.expectEqualStrings("chunk-1", c1);

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -222,7 +222,7 @@ pub const Plugin = struct {
     renderChunk: ?*const fn (ctx: ?*anyopaque, code: []const u8, chunk_name: []const u8, allocator: std.mem.Allocator, hook_ctx: *HookContext) PluginError!?[]const u8 = null,
 
     /// 번들 생성 완료 알림. 모든 플러그인에 호출됨.
-    generateBundle: ?*const fn (ctx: ?*anyopaque, output_files: []const OutputFile) void = null,
+    generateBundle: ?*const fn (ctx: ?*anyopaque, output_files: []const OutputFile, hook_ctx: *HookContext) void = null,
 
     /// bundle 시작 시 1회 호출. esbuild `onStart`, Rollup/Vite/rolldown `buildStart` 동일.
     /// 옵션 인자는 Zig 측에서 안 넘김 — JS 어댑터가 자체 context 로 forward.
@@ -462,10 +462,11 @@ pub const PluginRunner = struct {
     pub fn runGenerateBundle(
         self: *const PluginRunner,
         output_files: []const OutputFile,
+        hook_ctx: *HookContext,
     ) void {
         for (self.plugins) |p| {
             if (p.generateBundle) |hook| {
-                hook(p.context, output_files);
+                hook(p.context, output_files, hook_ctx);
             }
         }
     }

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -36,7 +36,7 @@ test "PluginRunner: empty plugins is no-op" {
     const render_result = try runner.runRenderChunk("code", "chunk", std.testing.allocator, &hook_ctx);
     try std.testing.expect(render_result == null);
 
-    runner.runGenerateBundle(&.{});
+    runner.runGenerateBundle(&.{}, &hook_ctx);
 }
 
 // --- resolveId 훅 테스트 ---
@@ -148,7 +148,7 @@ test "PluginRunner: renderChunk chaining" {
 
 var generate_bundle_called: bool = false;
 
-fn testGenerateBundleHook(_: ?*anyopaque, _: []const OutputFile) void {
+fn testGenerateBundleHook(_: ?*anyopaque, _: []const OutputFile, _: *plugin_mod.HookContext) void {
     generate_bundle_called = true;
 }
 
@@ -159,7 +159,8 @@ test "PluginRunner: generateBundle all executed" {
     };
     const runner = PluginRunner.init(&plugins);
 
-    runner.runGenerateBundle(&.{.{ .path = "out.js", .contents = "code" }});
+    var hook_ctx: plugin_mod.HookContext = .{};
+    runner.runGenerateBundle(&.{.{ .path = "out.js", .contents = "code" }}, &hook_ctx);
     try std.testing.expect(generate_bundle_called);
 }
 
@@ -423,7 +424,7 @@ test "Plugin integration: load output invalidates compiled cache (#2038)" {
 var integration_generate_called: bool = false;
 var integration_generate_output_len: usize = 0;
 
-fn integrationGenerateBundleHook(_: ?*anyopaque, outputs: []const OutputFile) void {
+fn integrationGenerateBundleHook(_: ?*anyopaque, outputs: []const OutputFile, _: *plugin_mod.HookContext) void {
     integration_generate_called = true;
     integration_generate_output_len = outputs.len;
 }


### PR DESCRIPTION
## 배경

#1880 epic **마지막 조각**. emit chunk(`this.emitFile({type:'chunk'})`)의 **최종 파일명 조회**(`this.getFileName`)와 **name 제어**를 추가합니다.

## 구현

- `EmittedChunk.file_name` + `emitChunk(id, name, file_name)` + `getFileName`이 chunks도 스캔 + `setChunkFileName`(back-fill).
- **chunk.zig**: emit chunk 모듈 `chunk.name = EmittedChunk.name`(있으면) → `[name]-[hash]`의 `[name]`으로 plugin 이 chunk 이름 제어.
- **bundler**: 청킹+렌더 후 emit chunk 모듈(`OutputFile.module_ids` 매칭)의 최종 `[name]-[hash]` 파일명을 emit_store 에 **back-fill** → generateBundle 의 `getFileName`이 확정값 반환.
- **generateBundle hook 에 hook_ctx(emit_store) 전달** — getFileName 활성화. `Plugin.generateBundle` 시그니처에 hook_ctx 추가(구현 1개=NapiPluginAdapter, 호출 1곳).

## 타이밍 (Rollup 호환)

- **asset** getFileName: 즉시(source hash) — resolveId/load/transform.
- **chunk** getFileName: 청킹 후라 **generateBundle 에서만 확정**(Rollup "renderStart 이후"와 동일). 청킹 전 hook 에서 조회하면 throw.
- 명시 `fileName`의 "정확히 그대로(hash 없이)"는 follow-up — 현재 name 기반 `[name]-[hash]`.

## `/code-review max` 발견 fix

- **plugin_test.zig 컴파일 에러** — generateBundle 시그니처 변경 후 mock hook(2-param)·`runGenerateBundle` 호출(1-arg) 미갱신. (`zig build`만 돌리고 `zig build test` 누락한 실수.) 새 시그니처로 수정.
- getFileName slot throw 메시지가 chunk 의 유효 hook(generateBundle) 누락 → 정정.

SAFE 확인(runtime 검증): back-fill 이 entry 강제 재배치로 정확한 chunk 매칭(공통 chunk 오배정 없음), name borrow lifetime(emit_store 가 chunk 수명 outlive), vite getFileName chain(`forwardEmitContext`+7th arg 주입), back-fill→generateBundle ordering.

## 검증

- `plugin-emit-chunk.ts` **6개**(B-i / B-ii / **getFileName generateBundle** / splitting:false / 신규 진단 / id 없음)
- `build-plugins` **50 pass** + `vite-plugin` **27 pass** / 회귀 0, `zig build test` 통과, `tsc` 통과, ReleaseFast napi

## #1880 epic 완료

PR5/6/7-1/7-2a/7-2b-i/7-2b-ii/**7-2c** — `this.emitFile`(asset+chunk) + `getFileName` + `getModuleInfo`/`resolve`/`warn`/`error` + ModuleInfo.meta + vitePlugin parity 전부 구현.

Refs #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)