### PR TITLE
feat(plugin): emit chunk 상대/bare specifier resolution (#1880 PR7-2b-ii follow-up)

### DIFF
--- a/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
+++ b/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
@@ -131,6 +131,79 @@ describe('@zntc/core build + plugins - this.emitFile chunk (PR7-2b-i)', () => {
     }
   });
 
+  test('상대 specifier 신규 모듈 emit chunk — this.resolve 없이 project_root 기준 resolve (RFC §4.2)', async () => {
+    // abs path(this.resolve 결과)뿐 아니라 RFC §4.2 는 resolveThreadSafe 로 상대/bare specifier 도
+    // 받도록 명세한다. plugin 이 this.resolve 를 선호출하지 않고 './worker.ts' 를 그대로 emit 해도
+    // source_dir(project_root) 기준으로 resolve 되어 별도 chunk 로 나와야 한다(Rollup 동형).
+    let refId: unknown = 'unset';
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-rel-'));
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-relative',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          // 미해석 상대 경로 — resolve 는 ZNTC 내부가 담당.
+          refId = this.emitFile({ type: 'chunk', id: './worker.ts' });
+          return null;
+        });
+      },
+    };
+    try {
+      // package.json 으로 project_root 를 dir 에 고정 → 상대 './worker.ts' 가 dir 기준 resolve.
+      // (project_root 자동탐지가 tmpdir 조상의 package.json 으로 새지 않도록 — 환경 독립 보장.)
+      writeFileSync(join(dir, 'package.json'), '{}\n');
+      writeFileSync(join(dir, 'worker.ts'), 'export const w = 7;\nconsole.log("rel-worker");\n');
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBe(0);
+      expect(typeof refId).toBe('string');
+      const workerChunk = result.outputFiles.find((f) => f.path.includes('worker'));
+      expect(workerChunk).toBeDefined();
+      expect(workerChunk!.text).toContain('7');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('emit-within-emit: 신규 모듈의 transform 이 또 emit chunk 하면 fixpoint 로 둘 다 분리', async () => {
+    // a.ts 는 plugin 이 emit(신규), 그 a.ts 의 transform 이 b.ts 를 또 emit → 재-discovery
+    // fixpoint 가 b.ts 까지 별도 chunk 로 분리해야 한다(RFC §4.3).
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-nested-'));
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-nested',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'chunk', id: './a.ts' });
+          return null;
+        });
+        build.onTransform({ filter: /a\.ts$/ }, function (this: RollupPluginContext) {
+          this.emitFile({ type: 'chunk', id: './b.ts' });
+          return null;
+        });
+      },
+    };
+    try {
+      // project_root 를 dir 에 고정(상대 './a.ts'/'./b.ts' resolve 기준 — 환경 독립).
+      writeFileSync(join(dir, 'package.json'), '{}\n');
+      writeFileSync(join(dir, 'a.ts'), 'export const a = 11;\nconsole.log("a-side");\n');
+      writeFileSync(join(dir, 'b.ts'), 'export const b = 22;\nconsole.log("b-side");\n');
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBe(0);
+      expect(result.outputFiles.find((f) => f.path.includes('a'))).toBeDefined();
+      expect(result.outputFiles.find((f) => f.path.includes('b'))).toBeDefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('resolve 불가능한 id 의 chunk emit 은 build 진단', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-ghost-'));
     const plugin: ZntcPlugin = {

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -137,15 +137,17 @@ pub fn build(self: *ModuleGraph, entry_points: []const []const u8) !void {
     try finalizeGraph(self, entry_points);
 }
 
-/// PR7-2b-i (#1880): plugin `this.emitFile({ type: 'chunk', id })` 로 별도 chunk 요청된 모듈을
-/// 표시한다. discovery 패스가 모두 끝난 뒤(build thread, 모든 hook drain) emit_store.chunks 를
-/// read 하므로 Node main 의 write 와 패스 경계로 분리돼 mutex 불필요(RFC §3 옵션 B).
+/// PR7-2b (#1880): plugin `this.emitFile({ type: 'chunk', id })` 로 별도 chunk 요청된 모듈을
+/// graph 에 주입/표시한다. discovery 패스가 모두 끝난 뒤(build thread, 모든 hook drain) emit_store
+/// .chunks 를 read 하므로 Node main 의 write 와 패스 경계로 분리돼 mutex 불필요(RFC §3 옵션 B).
 ///
-/// **B-i 범위**: id 가 *이미 graph 에 있는* 모듈일 때만 `is_emitted_chunk_entry` 플래그를 set
-/// (finalizeGraph 가 DFS 루트로, chunk.zig 가 dynamic entry 로 분리). 신규 모듈(graph 미존재)은
-/// resolution+discovery 가 필요해 B-ii 대기 → 진단으로 surfacing(silent-broken 방지).
-/// 플래그는 renumber 가 Module 을 옮겨도 따라가므로 finalizeGraph/chunk.zig 가 renumber 후
-/// 안전하게 읽는다(index 배열 전달 불필요).
+/// **B-i**: id 가 *이미 graph 에 있는* 모듈이면 `is_emitted_chunk_entry` 플래그만 set.
+/// **B-ii**: graph 에 없는 신규 모듈이면 `resolve_cache` 로 resolve(상대/bare specifier 도
+/// project_root 기준 — RFC §4.2) → `addModuleWithResolveDir`(dedup) → 플래그 + `requestAll` →
+/// `discoverPendingModulesSequential`. emit-within-emit 은 fixpoint 루프로 재드레인.
+/// finalizeGraph 가 DFS 루트로, chunk.zig 가 dynamic entry 로 분리, tree_shaker 가 entry_set 으로
+/// 생존시킨다. 플래그는 renumber 가 Module 을 옮겨도 따라가므로(shallow copy) 이후 단계가 renumber
+/// 후 안전하게 읽는다(index 배열 전달 불필요).
 fn injectEmittedChunks(self: *ModuleGraph) !void {
     const store_ptr = self.emit_store orelse return; // chunk 미사용 빌드: hot path 0
     const store: *@import("../emit_store.zig").EmitStore = @ptrCast(@alignCast(store_ptr));
@@ -169,11 +171,33 @@ fn injectEmittedChunks(self: *ModuleGraph) !void {
         return;
     }
 
+    // 신규 모듈 resolve 기준 디렉토리: importer 가 없으므로 project_root(없으면 entry_dir).
+    // 상대/bare specifier 도 이 기준으로 resolve (RFC §4.2). Rollup 의 importer 미지정 emit 과 동형.
+    const source_dir = if (self.project_root.len > 0) self.project_root else self.entry_dir;
+
     // fixpoint (RFC §4.3): 신규 모듈(B-ii)을 addModule → discovery 하면 그 모듈의 transform 이
     // 또 emit chunk 할 수 있어 store.chunks 가 늘 수 있다. processed 까지 처리 후, discovery 가
     // 새 chunk 요청을 더했으면 while 이 재진입. addModule dedup 으로 bounded.
+    // 방어 캡: 신뢰 못 할 plugin 이 패스마다 *새로운 distinct id* 를 emit 하면 store.chunks 가
+    // 끝없이 자라 미수렴(무한 import 그래프 동형). 정상 빌드는 절대 도달하지 않는 큰 상수로 hang
+    // 대신 진단을 낸다.
     var processed: usize = 0;
+    var pass: usize = 0;
+    const max_passes: usize = 1 << 16;
     while (processed < store.chunks.items.len) {
+        pass += 1;
+        if (pass > max_passes) {
+            self.addDiag(
+                .plugin_error,
+                .@"error",
+                store.chunks.items[processed].id,
+                .{ .start = 0, .end = 0 },
+                .resolve,
+                "this.emitFile({ type: 'chunk' }) did not converge — a plugin keeps emitting new chunk ids during discovery.",
+                "Emit a finite, stable set of chunk ids; avoid emitting a fresh id on every transform.",
+            );
+            break;
+        }
         const cur_len = store.chunks.items.len;
         const before_count = self.modules.count();
         for (store.chunks.items[processed..cur_len]) |chk| {
@@ -195,9 +219,10 @@ fn injectEmittedChunks(self: *ModuleGraph) !void {
                     continue;
                 }
                 m.is_emitted_chunk_entry = true;
-            } else {
-                // 신규 모듈 (B-ii): graph 에 없는 id 를 새 entry 로 추가. id 는 plugin 이 this.resolve
-                // 로 얻은 abs path 여야 한다(아래 discovery 가 parse/resolve). addModule dedup.
+            } else if (std.fs.path.isAbsolute(chk.id)) {
+                // 절대경로면 resolve 불필요 — 그대로 등록한다. 플랫폼 무관(Windows `C:\` 포함)이며
+                // resolver 가 abs 를 bare specifier 로 오인하는 경로를 피한다. 존재/disabled/read
+                // 실패는 discovery 후 phantom 재스캔이 정리(B-ii 머지본 동작 유지).
                 const new_idx = self.addModule(chk.id) catch {
                     self.addDiag(
                         .plugin_error,
@@ -205,14 +230,101 @@ fn injectEmittedChunks(self: *ModuleGraph) !void {
                         chk.id,
                         .{ .start = 0, .end = 0 },
                         .resolve,
-                        "this.emitFile({ type: 'chunk' }) id could not be added to the graph (resolve it via this.resolve first).",
-                        "Pass an absolute, resolvable module id (e.g. from this.resolve).",
+                        "this.emitFile({ type: 'chunk' }) id could not be added to the graph.",
+                        "Pass an absolute, readable file path or a resolvable specifier.",
                     );
                     continue;
                 };
                 _ = try graph_requested_exports.requestAll(self, new_idx);
                 const nei = @intFromEnum(new_idx);
                 if (nei < self.modules.count()) self.modules.at(nei).is_emitted_chunk_entry = true;
+            } else {
+                // 상대/bare specifier (B-ii): source_dir(project_root) 기준 resolve (RFC §4.2).
+                // plugin 이 this.resolve 를 선호출하지 않아도 된다(Rollup 동형).
+                const resolved = self.resolve_cache.resolveThreadSafe(source_dir, chk.id, .static_import) catch |err| switch (err) {
+                    error.ModuleNotFound => {
+                        self.addDiag(
+                            .plugin_error,
+                            .@"error",
+                            chk.id,
+                            .{ .start = 0, .end = 0 },
+                            .resolve,
+                            "this.emitFile({ type: 'chunk' }) id could not be resolved.",
+                            "Pass a resolvable specifier (relative to project root) or an id already in the graph.",
+                        );
+                        continue;
+                    },
+                    else => |e| return e,
+                };
+                // null = external(isExternal). external 은 chunk 가 될 수 없다.
+                const m_union = resolved orelse {
+                    self.addDiag(
+                        .plugin_error,
+                        .@"error",
+                        chk.id,
+                        .{ .start = 0, .end = 0 },
+                        .resolve,
+                        "this.emitFile({ type: 'chunk' }) id resolves to an external module — cannot be a chunk.",
+                        "Pass an id of a normal (bundled) module.",
+                    );
+                    continue;
+                };
+                switch (m_union) {
+                    .file => |f| {
+                        // f.path/f.resolve_dir 는 graph allocator 소유 → addModuleWithResolveDir 가
+                        // dupe(path→arena, resolve_dir→allocator) 한 뒤 caller 가 free (resolve_imports.zig 동형).
+                        defer {
+                            self.allocator.free(f.path);
+                            if (f.resolve_dir) |dir| self.allocator.free(dir);
+                        }
+                        const new_idx = try self.addModuleWithResolveDir(f.path, f.resolve_dir);
+                        const nei = @intFromEnum(new_idx);
+                        if (nei >= self.modules.count()) continue;
+                        const nm = self.modules.at(nei);
+                        // 기존 external/disabled 모듈로 dedup 되면 chunk 대상이 아니다. 신규 모듈은
+                        // discovery 후 phantom 재스캔이 정리하지만, dedup(count 불변)은 재스캔이
+                        // skip 되므로 여기서 가드한다 (B-i 와 대칭, code-review).
+                        if (nm.is_external or nm.is_disabled) {
+                            self.addDiag(
+                                .plugin_error,
+                                .@"error",
+                                chk.id,
+                                .{ .start = 0, .end = 0 },
+                                .resolve,
+                                "this.emitFile({ type: 'chunk' }) id resolves to an external/disabled module — cannot be a chunk.",
+                                "Pass an id of a normal (bundled) module.",
+                            );
+                            continue;
+                        }
+                        _ = try graph_requested_exports.requestAll(self, new_idx);
+                        nm.is_emitted_chunk_entry = true;
+                    },
+                    .disabled => |d| {
+                        self.allocator.free(d.path);
+                        self.addDiag(
+                            .plugin_error,
+                            .@"error",
+                            chk.id,
+                            .{ .start = 0, .end = 0 },
+                            .resolve,
+                            "this.emitFile({ type: 'chunk' }) id resolves to a disabled module — cannot be a chunk.",
+                            "Pass an id of a normal (bundled) module.",
+                        );
+                    },
+                    // Phase-1 cache 는 virtual/dataurl/external/custom 을 반환하지 않는다
+                    // (resolve_imports.zig 와 동일 불변식). 방어적 진단 — crash 대신 surfacing.
+                    .virtual, .dataurl, .external, .custom => {
+                        self.addDiag(
+                            .plugin_error,
+                            .@"error",
+                            chk.id,
+                            .{ .start = 0, .end = 0 },
+                            .resolve,
+                            "this.emitFile({ type: 'chunk' }) id resolves to a non-file module — unsupported as a chunk.",
+                            "Pass an id of a normal (bundled) file module.",
+                        );
+                    },
+                }
             }
         }
         processed = cur_len;


### PR DESCRIPTION
## 무엇을

`this.emitFile({ type: 'chunk', id })` 의 **신규 모듈 id 에 상대/bare specifier 지원**을 추가합니다. 머지된 B-ii(`bb683d40`)는 plugin 이 `this.resolve` 로 미리 해석한 **절대경로**만 받았는데, RFC §4.2 가 명세한 `resolveThreadSafe` 를 써서 plugin 이 `'./worker.ts'` 같은 미해석 specifier 를 그대로 emit 해도 동작하게 합니다 (Rollup 의 importer 미지정 emit 과 동형).

## 왜

B-ii 머지본은 `addModule(chk.id)` 로 절대경로를 직접 등록해, plugin 이 반드시 `this.resolve` 를 선호출해야 했습니다. 이는 RFC §4.2(`resolve_cache.resolveThreadSafe` 사용)와 어긋나고 Rollup 호환성도 떨어집니다. 이 PR 이 그 공백을 메웁니다.

## 변경

`injectEmittedChunks` 신규 모듈 분기:
- **절대경로 id**: `addModule` 직접 — 플랫폼 무관(Windows `C:\` 도 resolver 의 bare-specifier 오인 없이 등록, 머지본 동작 보존). 존재/disabled/read-fail 은 discovery 후 phantom 재스캔이 정리.
- **상대/bare id**: `resolveThreadSafe(source_dir=project_root, ...)` → `addModuleWithResolveDir`. ownership 은 `f.path`/`f.resolve_dir` 를 caller 가 free (`resolve_imports.zig` 동형). external/disabled/non-file 결과는 진단(silent drop 금지).
- **무한루프 방어 캡**: plugin 이 discovery 패스마다 새 distinct id 를 emit 하면 `store.chunks` 가 미수렴(무한 import 그래프 동형) → 큰 상수(`1<<16`) 캡 + 진단으로 hang 대신 error.

## code-review max 반영

- **테스트 환경 결합 제거**: 신규 상대-specifier 테스트가 `project_root` 자동탐지에 의존 → tmpdir 조상에 package.json 이 있으면(CI/TMPDIR) 엉뚱한 dir 로 resolve 돼 flaky. tmpdir 에 `package.json` 작성해 project_root 를 고정(환경 독립).
- **guard 비대칭 보강**: 상대 id 가 기존 external/disabled 모듈로 dedup 될 때 가드 부재(phantom 재스캔은 count 불변이면 skip) → `.file` arm 에 `is_external`/`is_disabled` 가드 추가(B-i 와 대칭).
- 메모리 ownership / dead-arm / cap index / 에러 전파는 검증 결과 안전(`ResolveError = {ModuleNotFound, OutOfMemory}`).

## 검증

- `plugin-emit-chunk.ts` **+2** (상대 './worker.ts' resolve / emit-within-emit fixpoint). 전체 7개.
- build-plugins **51 pass** 회귀 0, `zig build test` 전체 통과, napi ReleaseFast.

## 한계 (follow-up)

- emit 기준 디렉토리는 **project_root MVP** — emitting 모듈 dir 기준 Rollup parity 는 별도(RFC §9).
- watch 에서 emit 하는 transform 이 cache-hit 으로 skip 되면 그 chunk 가 main 으로 합쳐짐(B-i + incremental 설계 속성, asset emit 도 동일).

Refs #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)