### PR TITLE
feat(plugin): ModuleInfo.meta resolveId/transform hook merge (#3664 P1)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1638,6 +1638,42 @@ function isPluginFailureResult(value: unknown): value is PluginFailureResult {
 }
 
 /**
+ * plugin meta object 를 deep merge (#1880 #3664 P1). nested object 는 재귀 merge, 그 외(scalar/
+ * array/타입불일치)는 `source`(나중 plugin) 우선 — Rollup 의 hook 순서 의미와 일치. Zig 쪽
+ * `mergeMetaJson`(graph/plugins.zig)과 동일 규칙(object recurse / later wins / array 덮어쓰기).
+ * transform chain 의 여러 plugin meta 를 단일 결과로 합칠 때 사용.
+ */
+function deepMergeMeta(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...target };
+  for (const key of Object.keys(source)) {
+    const sv = source[key];
+    const tv = out[key];
+    const merged =
+      sv != null &&
+      typeof sv === 'object' &&
+      !Array.isArray(sv) &&
+      tv != null &&
+      typeof tv === 'object' &&
+      !Array.isArray(tv)
+        ? deepMergeMeta(tv as Record<string, unknown>, sv as Record<string, unknown>)
+        : sv;
+    // `out[key] =` 의 [[Set]] 은 `__proto__`/`constructor` 키에서 setter 를 타 데이터가 손실되고
+    // Zig mergeMetaJson(plain string 키 보존)과 발산한다. defineProperty 로 own data 를 할당해
+    // setter 를 우회 → JS↔Zig 동일 결과 + prototype 오염 차단 (code-review).
+    Object.defineProperty(out, key, {
+      value: merged,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+  return out;
+}
+
+/**
  * `serializePluginSourceMap` 의 throw (invalid map JSON) 를 결과 객체로 wrap.
  * generator 본체는 runner 의 try/catch 밖에서 실행되므로 직접 normalize 가 필요하다.
  */
@@ -2002,6 +2038,9 @@ function* dispatchHook(
     let currentCode = arg1 as string;
     let changed = false;
     const sourceMaps: string[] = [];
+    // #1880 #3664 P1: transform chain 의 여러 plugin meta 를 deep merge(나중 plugin 우선, nested
+    // 보존). 단일 결과로 native 에 전달 → Zig 가 load meta 와 다시 deep merge. transform 만 해당.
+    let mergedMeta: Record<string, unknown> | undefined;
     for (const h of hookList) {
       if (!h.filter.test(arg2 ?? '')) continue;
       const cbArgs =
@@ -2020,7 +2059,7 @@ function* dispatchHook(
       };
       if (isPluginFailureResult(result)) return result;
       if (result != null) {
-        const obj = result as { code?: unknown; map?: unknown };
+        const obj = result as { code?: unknown; map?: unknown; meta?: unknown };
         const newCode = typeof result === 'string' ? result : obj.code;
         if (typeof newCode === 'string') {
           currentCode = newCode;
@@ -2031,10 +2070,33 @@ function* dispatchHook(
           if (!r.ok) return normalizePluginFailure(h.pluginName, hookName, r.err, arg2);
           if (r.map != null) sourceMaps.push(r.map);
         }
+        if (hookName === 'transform' && typeof result === 'object' && obj.meta != null) {
+          if (typeof obj.meta !== 'object') {
+            // Rollup 은 object meta 만 — primitive 는 무시(load/resolveId 경로와 동일 정책).
+          } else {
+            mergedMeta =
+              mergedMeta === undefined
+                ? { ...(obj.meta as Record<string, unknown>) }
+                : deepMergeMeta(mergedMeta, obj.meta as Record<string, unknown>);
+          }
+        }
       }
     }
-    return changed
-      ? { code: currentCode, ...(sourceMaps.length > 0 ? { maps: sourceMaps } : {}) }
+    let metaJson: string | undefined;
+    if (mergedMeta !== undefined) {
+      try {
+        metaJson = JSON.stringify(mergedMeta);
+      } catch (err) {
+        return normalizePluginFailure('transform-chain', hookName, err, arg2);
+      }
+    }
+    // code 변경 없이 meta 만 있어도 native 로 전달해야 한다(meta-only transform).
+    return changed || metaJson !== undefined
+      ? {
+          ...(changed ? { code: currentCode } : {}),
+          ...(sourceMaps.length > 0 ? { maps: sourceMaps } : {}),
+          ...(metaJson !== undefined ? { meta: metaJson } : {}),
+        }
       : null;
   }
 

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -135,9 +135,10 @@ pub const NapiPlugin = struct {
         } else if (getNamedProperty(env, js_result, "maps")) |maps_val| {
             resp.source_maps = parseStringArray(env, maps_val, native_alloc);
         }
-        // ModuleInfo.meta (#1880 PR2): JS dispatcher 가 object 를 JSON string 으로 정규화해 전달.
-        // 현재 load hook 결과만 module.plugin_meta 로 저장(runLoadForModule). 다른 hook 결과의 meta 는
-        // 추출돼도 소비처가 없어 freeResponseFields 로 해제됨 — resolveId/transform merge 는 follow-up.
+        // ModuleInfo.meta (#1880 PR2 / #3664 P1): JS dispatcher 가 object 를 JSON string 으로 정규화.
+        // load 결과는 runLoadForModule, transform 결과는 callCodeHook→setResponseMeta→
+        // runTransformForModule 이 module.plugin_meta 에 deep merge. resolveId meta(cross-module
+        // 귀속)는 별도 항목(#3664).
         if (getObjectString(env, js_result, "meta", native_alloc)) |meta_json| {
             resp.meta = meta_json;
         }
@@ -202,6 +203,15 @@ pub const NapiPlugin = struct {
             copied[i] = alloc.dupe(u8, map_json) catch return error.OutOfMemory;
         }
         hook_ctx.source_maps = copied;
+    }
+
+    /// transform hook 의 `{ meta }`(JSON 문자열)를 hook_ctx.meta 로 전달 (#1880 #3664 P1).
+    /// resp.meta 는 native_alloc 소유(freeResponseFields 가 해제)라 caller(parse_arena)로 dupe —
+    /// runTransformForModule 이 module.plugin_meta 에 merge 할 때 module 수명만큼 살아야 한다.
+    fn setResponseMeta(resp: PluginResponse, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!void {
+        const m = resp.meta orelse return;
+        if (m.len == 0) return;
+        hook_ctx.meta = alloc.dupe(u8, m) catch return error.OutOfMemory;
     }
 
     /// CallContext에 응답을 기록하고 워커 스레드에 시그널을 보낸다.
@@ -655,6 +665,9 @@ fn NapiPluginAdapter(comptime Self: type) type {
             const resp = self.callHookFull(hook, arg1, arg2, null, hook_ctx.current_module, hook_ctx.resolve_cache, hook_ctx.emit_store) orelse return null;
             defer NapiPlugin.freeResponseFields(resp);
             if (resp.is_failure) return failWithResponse(self, resp, alloc, hook_ctx);
+            // meta 는 code 유무와 무관하게 전달 — Rollup transform 은 code 없이 { meta } 만 반환 가능
+            // (#1880 #3664 P1). runTransformForModule 이 hook_ctx.meta 를 module.plugin_meta 에 merge.
+            try NapiPlugin.setResponseMeta(resp, alloc, hook_ctx);
             if (resp.code) |result_code| {
                 const result = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
                 try NapiPlugin.setResponseSourceMaps(resp, alloc, hook_ctx);

--- a/packages/core/test/core/build-plugins/module-meta.ts
+++ b/packages/core/test/core/build-plugins/module-meta.ts
@@ -209,4 +209,78 @@ describe('@zntc/core build + plugins - ModuleInfo.meta / this.getModuleInfo (sel
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // #3664 P1: transform hook 의 meta 가 load meta 와 deep merge 된다(나중 hook=transform 우선,
+  // nested 보존). transform meta 는 chain 종료 후 module 에 반영되므로 frozen graph(manualChunks
+  // getModuleInfo)에서 검증. transform 은 code 없이 meta 만 반환(meta-only).
+  test('transform meta 가 load meta 와 deep merge 되어 manualChunks getModuleInfo 로 노출 (P1)', async () => {
+    let merged: Record<string, unknown> | undefined;
+    const plugin: ZntcPlugin = {
+      name: 'meta-merge',
+      setup(build) {
+        build.onLoad({ filter: /main\.ts$/ }, () => ({
+          contents: 'export const x = 1;\n',
+          meta: { a: 1, nested: { p: 1, q: 1 } },
+        }));
+        build.onTransform({ filter: /main\.ts$/ }, () => ({
+          // code 없이 meta 만 — meta-only transform.
+          meta: { b: 2, nested: { q: 99, r: 2 } },
+        }));
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-meta-merge-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+        manualChunks: (id, meta) => {
+          if (id.includes('main.ts')) {
+            merged = meta.getModuleInfo(id)?.meta as Record<string, unknown>;
+          }
+          return null;
+        },
+      });
+      expect(result.errors.length).toBe(0);
+      // load {a, nested:{p,q}} + transform {b, nested:{q→99, r}} → deep merge, transform 우선.
+      expect(merged).toEqual({ a: 1, b: 2, nested: { p: 1, q: 99, r: 2 } });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // #3664 P1: 같은 plugin 의 여러 transform 결과(chain)도 nested 보존 deep merge.
+  test('transform chain 의 여러 meta 가 deep merge 된다 (P1)', async () => {
+    let merged: Record<string, unknown> | undefined;
+    const plugin: ZntcPlugin = {
+      name: 'meta-chain',
+      setup(build) {
+        build.onTransform({ filter: /main\.ts$/ }, () => ({ meta: { nested: { a: 1 } } }));
+        build.onTransform({ filter: /main\.ts$/ }, () => ({ meta: { nested: { b: 2 } } }));
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-meta-chain-'));
+    try {
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+        manualChunks: (id, meta) => {
+          if (id.includes('main.ts')) {
+            merged = meta.getModuleInfo(id)?.meta as Record<string, unknown>;
+          }
+          return null;
+        },
+      });
+      expect(result.errors.length).toBe(0);
+      // 두 transform 의 nested 가 키 손실 없이 합쳐진다(shallow 면 {b:2}만 남음).
+      expect(merged).toEqual({ nested: { a: 1, b: 2 } });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/bundler/graph/plugins.zig
+++ b/src/bundler/graph/plugins.zig
@@ -197,6 +197,13 @@ pub fn runTransformForModule(
             return .done;
         },
     };
+    // transform hook 의 { meta } 를 module.plugin_meta 에 deep merge (#1880 #3664 P1).
+    // Rollup transform 은 code 없이 meta 만 반환할 수 있으므로 transform_result 유무와 무관하게
+    // 처리한다. 결과/입력 meta 모두 parse_arena(arena_alloc) 소유 = module 수명과 동일(load meta
+    // 동일 패턴). worker 가 결과로 반환 → main 이 module 에 저장하는 경로라 graph race 없음.
+    if (hook_ctx.meta) |tm| {
+        module.plugin_meta = plugin_mod.mergeMetaJson(arena_alloc, module.plugin_meta, tm) catch module.plugin_meta;
+    }
     if (transform_result) |result| {
         if (hook_ctx.source_maps) |maps| {
             if (!graph_diagnostics.validatePluginSourceMaps(self, maps, module.path, Span.EMPTY, .transform, "transform")) {

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -115,6 +115,10 @@ pub const HookContext = struct {
     /// `load` / `transform` 이 반환한 source map JSON chain.
     /// 다른 hook 은 사용 안 함. caller 가 free 책임.
     source_maps: ?[]const []const u8 = null,
+    /// `transform` hook 결과의 `{ meta }` (JSON 문자열) out-param (#1880 #3664 P1). source_maps 와
+    /// 동일 패턴 — pluginTransform 이 set, runTransformForModule 이 module.plugin_meta 에 deep merge.
+    /// load/resolveId meta 는 각 hook 결과로 직접 처리. caller(parse_arena) 소유.
+    meta: ?[]const u8 = null,
     /// `this.getModuleInfo` (PR3, self-only) 용 현재 transform 중인 Module 포인터.
     /// graph 를 조회하지 않고 이 모듈 자신의 정보(id/code/meta)만 노출한다 — discovery 병렬
     /// 단계에서 graph 는 main thread 가 mutate 중이므로 worker 가 graph 를 읽으면 race.
@@ -139,6 +143,36 @@ pub const HookContext = struct {
         }
     }
 };
+
+/// 두 plugin meta JSON object 를 deep merge 한다 (#1880 #3664 P1: hook 간 meta 누적).
+/// nested object 는 재귀 merge, scalar/array/타입불일치는 `add`(나중 hook/plugin) 우선 — Rollup 의
+/// hook 순서 의미(later wins)와 일치. shallow merge 는 nested 손실이라 쓰지 않는다. 중간/결과 Value
+/// 는 `arena` 소유. 한쪽이 비-object 이거나 parse 실패면 안전하게 add/base 로 fallback. runTransform
+/// (chain 누적)·runTransformForModule(load+transform) 양쪽이 공유하도록 plugin.zig 에 둔다.
+pub fn mergeMetaJson(arena: std.mem.Allocator, base: ?[]const u8, add: []const u8) ![]const u8 {
+    const base_json = base orelse return arena.dupe(u8, add);
+    var base_v = std.json.parseFromSliceLeaky(std.json.Value, arena, base_json, .{}) catch
+        return arena.dupe(u8, add);
+    const add_v = std.json.parseFromSliceLeaky(std.json.Value, arena, add, .{}) catch
+        return arena.dupe(u8, base_json);
+    if (base_v != .object or add_v != .object) return arena.dupe(u8, add);
+    try deepMergeMetaValue(&base_v, add_v);
+    return std.fmt.allocPrint(arena, "{f}", .{std.json.fmt(base_v, .{})});
+}
+
+fn deepMergeMetaValue(base: *std.json.Value, add: std.json.Value) std.mem.Allocator.Error!void {
+    var it = add.object.iterator();
+    while (it.next()) |e| {
+        if (base.object.getPtr(e.key_ptr.*)) |existing| {
+            if (existing.* == .object and e.value_ptr.* == .object) {
+                try deepMergeMetaValue(existing, e.value_ptr.*);
+                continue;
+            }
+        }
+        // 신규 키, 또는 둘 중 하나가 비-object → add(나중) 값으로 덮어쓴다.
+        try base.object.put(e.key_ptr.*, e.value_ptr.*);
+    }
+}
 
 /// Plugin resolveId 응답의 통합 모델 (#1885).
 ///
@@ -420,6 +454,17 @@ pub const PluginRunner = struct {
                     hook_ctx.failure = inner_ctx.failure;
                     return err;
                 };
+                // meta 는 code(result) 유무와 무관하게 누적 — Rollup transform 은 meta 만 반환 가능.
+                // chain 의 각 plugin meta 를 outer hook_ctx.meta 에 deep merge(later plugin 우선).
+                // source_maps 와 동일하게 inner_ctx → outer 로 모은다(#1880 #3664 P1). NAPI 경유 JS
+                // plugin 은 단일 dispatcher 가 JS chain 을 이미 merge 하므로 existing 분기는 native↔
+                // native(여러 native plugin 이 meta 반환) 전용 가드 — 현재는 거의 안 타지만 안전망.
+                if (inner_ctx.meta) |m| {
+                    hook_ctx.meta = if (hook_ctx.meta) |existing|
+                        (mergeMetaJson(allocator, existing, m) catch m)
+                    else
+                        m;
+                }
                 if (result) |r| {
                     if (inner_ctx.source_maps) |maps| {
                         try source_maps.appendSlice(allocator, maps);

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -864,3 +864,33 @@ test "Plugin integration: buildStart 실패 시 build 실패 + errdefer 경로�
     try std.testing.expectEqual(@as(u32, 1), LifecycleLog.close_bundle_count);
     try std.testing.expect(LifecycleLog.build_end_error_was_null); // catastrophic path: build_error=null
 }
+
+// --- mergeMetaJson deep merge (#1880 #3664 P1) ---
+test "mergeMetaJson: nested deep merge + later wins + 비-object fallback" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // nested object 는 키 손실 없이 recurse, 충돌 키는 add(나중) 우선.
+    const merged = try plugin_mod.mergeMetaJson(
+        a,
+        "{\"a\":1,\"n\":{\"p\":1,\"q\":1}}",
+        "{\"b\":2,\"n\":{\"q\":9,\"r\":2}}",
+    );
+    const parsed = try std.json.parseFromSliceLeaky(std.json.Value, a, merged, .{});
+    const o = parsed.object;
+    try std.testing.expectEqual(@as(i64, 1), o.get("a").?.integer);
+    try std.testing.expectEqual(@as(i64, 2), o.get("b").?.integer);
+    const n = o.get("n").?.object;
+    try std.testing.expectEqual(@as(i64, 1), n.get("p").?.integer); // base 보존
+    try std.testing.expectEqual(@as(i64, 9), n.get("q").?.integer); // add 우선
+    try std.testing.expectEqual(@as(i64, 2), n.get("r").?.integer); // add 신규
+
+    // base 가 null 이면 add 를 그대로 채택.
+    const r2 = try plugin_mod.mergeMetaJson(a, null, "{\"x\":1}");
+    try std.testing.expectEqualStrings("{\"x\":1}", r2);
+
+    // 한쪽이 비-object(array)면 deep merge 불가 → add(나중) 우선.
+    const r3 = try plugin_mod.mergeMetaJson(a, "{\"a\":1}", "[1,2]");
+    try std.testing.expectEqualStrings("[1,2]", r3);
+}


### PR DESCRIPTION
## 배경

#1880 epic 후 #3664 잔여 **P1**. 현재 **load hook 결과만** `module.plugin_meta` 로 저장돼, **transform 에서 설정한 meta 가 silent drop** 되던 갭을 닫습니다(transform 에서 meta 다는 vite/rollup plugin 호환 — 유일하게 "현재 동작 plugin 의 갭"이라 P1).

## 구조 (임시방편 없이)

- **merge 책임 단일화**: meta merge 를 `module.plugin_meta` 한 곳에서 **deep merge**(nested 보존, 나중 hook/plugin 우선 = Rollup later-wins). shallow 는 nested 손실이라 금지.
- `mergeMetaJson`(plugin.zig, `std.json` deep merge)를 `runTransform`(chain 누적)·`runTransformForModule`(load+transform) **양쪽이 공유**. `HookContext.meta` out-param (source_maps 와 동일 패턴).
- **race-safe**: transform meta 는 worker 가 결과로 반환 → main 이 module 에 저장(load 와 동일 경로, graph mutation 아님). 소유권 `parse_arena`(module 수명).
- JS dispatcher transform chain 도 `deepMergeMeta`(동일 규칙)로 단일 결과 합쳐 native 전달.

## 근본 원인 (계측 확정)

`runTransform` 이 `inner_ctx` 의 **source_maps 만** outer 로 누적하고 **meta 는 버리던 것**. source_maps 와 동일하게 meta 도 누적하도록 수정. (3-layer stderr 계측으로 *JS metaJson 생성 OK ↔ native hook_ctx.meta=null* 격리 → `runTransform` inner_ctx.meta 미누적으로 확정. 추측 아닌 계측.)

## `/code-review max` 발견 fix

- `deepMergeMeta` 의 `out[key]=` [[Set]] 이 `__proto__`/`constructor` 키에서 **setter 를 타 데이터 손실** + Zig `mergeMetaJson`(plain string 키 보존)과 **발산** → `Object.defineProperty` 로 own data 할당해 setter 우회(JS↔Zig 일관 + prototype 오염 차단). node 로 mechanism 검증.

한 finder 는 deep merge aliasing/rehash·결정성(#3564, StringArrayHashMap insertion-order)·arena 소유권을 **empirical(Debug/ReleaseSafe pointer_stability) 검증해 버그 0**. 더블 merge 없음(single dispatcher), meta-only transform 안전.

## 범위 (#3664 잔여 유지)

- 다중 plugin meta 를 `meta[pluginName]` 로 분리(Rollup)·resolveId meta(cross-module 귀속)는 **별개 구조** → #3664 잔여. 같은 plugin 의 hook 간 merge 가 P1.

## 검증

- `module-meta.ts` **+2**(load+transform deep merge / chain nested 보존) + `plugin_test.zig` `mergeMetaJson` 유닛(nested / later-wins / 비-object fallback)
- module-meta **8** + build-plugins **52** + vite-plugin **27** pass / 회귀 0, `zig build test` 통과, `tsc` 통과, ReleaseFast napi

Refs #3664

🤖 Generated with [Claude Code](https://claude.com/claude-code)