### PR TITLE
feat(plugin): syntheticNamedExports (#3664 P2)

### DIFF
--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -60,6 +60,9 @@ pub const NapiPlugin = struct {
         /// onLoad/onResolveId callback 의 `meta` (Rollup `ModuleInfo.meta`). JS dispatcher 가
         /// object 를 JSON string 으로 정규화해 전달 (#1880 PR2). native_alloc 소유.
         meta: ?[]const u8 = null,
+        /// Rollup `syntheticNamedExports` (#3664 P2). true→"default", string→그대로 정규화한 fallback
+        /// 대상 export 이름. null = 미설정. native_alloc 소유.
+        synthetic_named_exports: ?[]const u8 = null,
         is_failure: bool = false,
         failure_plugin_name: ?[]const u8 = null,
         failure_hook_name: ?[]const u8 = null,
@@ -142,6 +145,17 @@ pub const NapiPlugin = struct {
         if (getObjectString(env, js_result, "meta", native_alloc)) |meta_json| {
             resp.meta = meta_json;
         }
+        // syntheticNamedExports (#3664 P2): string 이면 그 export 이름, boolean true 면 "default".
+        if (getObjectString(env, js_result, "syntheticNamedExports", native_alloc)) |target| {
+            resp.synthetic_named_exports = target;
+        } else if (getNamedProperty(env, js_result, "syntheticNamedExports")) |sne_val| {
+            var t: c.napi_valuetype = undefined;
+            if (c.napi_typeof(env, sne_val, &t) == c.napi_ok and t == c.napi_boolean) {
+                var b: bool = false;
+                _ = c.napi_get_value_bool(env, sne_val, &b);
+                if (b) resp.synthetic_named_exports = native_alloc.dupe(u8, "default") catch null;
+            }
+        }
         // AST plugin 응답 파싱
         if (getObjectString(env, js_result, "stripDirective", native_alloc)) |sd| {
             resp.strip_directive = sd;
@@ -187,6 +201,7 @@ pub const NapiPlugin = struct {
             native_alloc.free(maps);
         }
         if (resp.meta) |s| native_alloc.free(s);
+        if (resp.synthetic_named_exports) |s| native_alloc.free(s);
         if (resp.failure_plugin_name) |s| native_alloc.free(s);
         if (resp.failure_hook_name) |s| native_alloc.free(s);
         if (resp.failure_message) |s| native_alloc.free(s);
@@ -735,7 +750,9 @@ fn NapiPluginAdapter(comptime Self: type) type {
             try NapiPlugin.setResponseSourceMaps(resp, alloc, hook_ctx);
             // resp.meta 는 native_alloc 소유(freeResponseFields 가 해제) → caller(parse_arena) 로 dupe (#1880 PR2).
             const meta_dup: ?[]const u8 = if (resp.meta) |m| (alloc.dupe(u8, m) catch return error.OutOfMemory) else null;
-            return .{ .contents = contents, .loader = resp.loader_override, .module_type = resp.loader_module_type, .meta = meta_dup };
+            // syntheticNamedExports 도 동일하게 parse_arena 로 dupe (#3664 P2).
+            const synth_dup: ?[]const u8 = if (resp.synthetic_named_exports) |s| (alloc.dupe(u8, s) catch return error.OutOfMemory) else null;
+            return .{ .contents = contents, .loader = resp.loader_override, .module_type = resp.loader_module_type, .meta = meta_dup, .synthetic_named_exports = synth_dup };
         }
 
         fn pluginTransform(

--- a/packages/core/test/core/build-plugins.ts
+++ b/packages/core/test/core/build-plugins.ts
@@ -4,6 +4,7 @@ import './build-plugins/module-meta';
 import './build-plugins/plugin-resolve';
 import './build-plugins/plugin-emit-file';
 import './build-plugins/plugin-emit-chunk';
+import './build-plugins/plugin-synthetic-named-exports';
 import './build-plugins/transform-tree-shaking';
 import './build-plugins/resolve-context';
 import './build-plugins/build-sync';

--- a/packages/core/test/core/build-plugins/plugin-synthetic-named-exports.ts
+++ b/packages/core/test/core/build-plugins/plugin-synthetic-named-exports.ts
@@ -1,0 +1,71 @@
+import {
+  build,
+  describe,
+  expect,
+  join,
+  mkdtempSync,
+  rmSync,
+  test,
+  tmpdir,
+  writeFileSync,
+} from './helpers';
+import type { ZntcPlugin } from './helpers';
+
+// #3664 P2: Rollup syntheticNamedExports. plugin 이 load 결과에 syntheticNamedExports 를 달면,
+// 그 모듈에서 정적으로 export 안 된 named import 를 default(true) 또는 지정 export(string)의
+// member 로 fallback 한다. ZTS 의 CJS interop fallback(resolveOrCjsFallback)과 같은 메커니즘이되
+// 대상이 namespace 가 아니라 default/named export value.
+// scope (P2): 직접 named import(`import { foo } from './synth'`)만 지원. re-export forwarding
+// (`export { foo } from './synth'`)·nested synthetic indirection 은 미지원(synthExportFallback 이
+// resolveImports/seedExport 에만 배선) — Rollup 은 지원하나 수요 발생 시 follow-up.
+describe('@zntc/core - syntheticNamedExports (#3664 P2)', () => {
+  test('syntheticNamedExports:true → 정적 export 없는 named import 를 default export member 로 fallback', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-synth-true-'));
+    const plugin: ZntcPlugin = {
+      name: 'synth-true',
+      setup(build) {
+        build.onLoad({ filter: /synth\.ts$/ }, () => ({
+          // default 만 export — foo/bar 는 정적으로 export 되지 않는다.
+          contents: 'export default { foo: 42, bar: 7 };\n',
+          syntheticNamedExports: true,
+        }));
+      },
+    };
+    try {
+      writeFileSync(join(dir, 'synth.ts'), 'export default {};\n');
+      writeFileSync(
+        join(dir, 'main.ts'),
+        "import { foo, bar } from './synth';\nexport const r = foo + bar;\n",
+      );
+      const result = await build({ entryPoints: [join(dir, 'main.ts')], plugins: [plugin] });
+      // synthetic 없으면 foo/bar 가 missing_export 로 errors>0. synthetic 이면 default.foo 로 fallback.
+      expect(result.errors.length).toBe(0);
+      const out = result.outputFiles.map((f) => f.text).join('\n');
+      // foo/bar 가 default export 객체의 member 접근으로 codegen 되어야 한다(.foo / .bar).
+      expect(out).toContain('.foo');
+      expect(out).toContain('.bar');
+      // synthetic fallback 이 default export 를 참조 → synth 모듈(default 객체)이 tree-shaking 생존.
+      expect(out).toContain('42');
+      expect(out).toContain('7');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('synthetic 없는 모듈은 default-member fallback 을 하지 않는다(회귀 가드)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-synth-none-'));
+    try {
+      writeFileSync(join(dir, 'plain.ts'), 'export default {};\n');
+      writeFileSync(
+        join(dir, 'main.ts'),
+        "import { ghost } from './plain';\nexport const r = ghost;\n",
+      );
+      const result = await build({ entryPoints: [join(dir, 'main.ts')] });
+      // synthetic 아닌 모듈은 기존 동작 유지 — ghost 가 default member(.ghost)로 재작성되지 않는다.
+      const out = result.outputFiles.map((f) => f.text).join('\n');
+      expect(out).not.toContain('.ghost');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/bundler/graph/plugins.zig
+++ b/src/bundler/graph/plugins.zig
@@ -130,6 +130,9 @@ pub fn runLoadForModule(self: anytype, module: *Module, runner: ?plugin_mod.Plug
         // plugin 이 부여한 meta (JSON 문자열) 를 모듈에 귀속 (#1880 PR2).
         // plugin_result.meta 는 pluginLoad 가 parse_arena(tmp_arena) 로 dupe 했으므로 그대로 borrow.
         if (plugin_result.meta) |m| module.plugin_meta = m;
+        // syntheticNamedExports (#3664 P2) — linker 가 missing named import 를 이 export 의 member 로
+        // fallback. parse_arena 소유(meta 동일 패턴).
+        if (plugin_result.synthetic_named_exports) |s| module.synthetic_named_exports = s;
 
         if (plugin_result.loader) |loader_override| {
             module.loader = loader_override;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -127,6 +127,10 @@ pub const ResolvedBinding = struct {
     local_span: Span,
     /// 최종적으로 가리키는 export (re-export 체인 해결 후)
     canonical: SymbolRef,
+    /// Rollup `syntheticNamedExports` (#3664 P2). 정적으로 export 안 된 named import 가
+    /// synthetic 모듈의 fallback 대상(default/named) export 의 member 일 때 그 member 이름.
+    /// null = 일반 바인딩. 설정 시 codegen 은 `{canonical local name}.{synthetic_member}` 로 rename.
+    synthetic_member: ?[]const u8 = null,
 };
 
 pub const Linker = struct {
@@ -1456,12 +1460,30 @@ pub const Linker = struct {
 
                 if (source_record.resolved.isNone()) continue; // external 또는 미해석
 
+                const bk = BindingKey{
+                    .module_index = @intCast(i),
+                    .span_key = types.spanKey(ib.local_span),
+                };
+
                 // re-export 체인을 따라가서 canonical export 찾기
                 const canonical = self.resolveExportChain(
                     source_record.resolved,
                     ib.imported_name,
                     0,
                 ) orelse {
+                    // #3664 P2: synthetic_named_exports 모듈이면 정적으로 export 안 된 named import 를
+                    // fallback 대상(default/named) export 의 member 로 해석한다. canonical 은 그 대상
+                    // export 를 가리키고, synthetic_member 에 원래 import 이름을 담아 codegen 이
+                    // `{target}.{member}` 로 rename 하게 한다.
+                    if (self.synthExportFallback(source_record.resolved)) |target_ref| {
+                        try self.resolved_bindings.put(bk, .{
+                            .local_name = ib.local_name,
+                            .local_span = ib.local_span,
+                            .canonical = target_ref,
+                            .synthetic_member = ib.imported_name,
+                        });
+                        continue;
+                    }
                     // export를 찾을 수 없음
                     self.addDiag(
                         .missing_export,
@@ -1475,10 +1497,6 @@ pub const Linker = struct {
                     continue;
                 };
 
-                const bk = BindingKey{
-                    .module_index = @intCast(i),
-                    .span_key = types.spanKey(ib.local_span),
-                };
                 try self.resolved_bindings.put(bk, .{
                     .local_name = ib.local_name,
                     .local_span = ib.local_span,
@@ -1486,6 +1504,15 @@ pub const Linker = struct {
                 });
             }
         }
+    }
+
+    /// #3664 P2: synthetic_named_exports 모듈의 fallback 대상 export 를 resolve.
+    /// `synthetic_named_exports`("default" 또는 string target)를 resolveExportChain 으로 따라가
+    /// canonical SymbolRef 반환. 모듈이 synthetic 아니거나 target 자체도 missing 이면 null.
+    fn synthExportFallback(self: *const Linker, mod: ModuleIndex) ?SymbolRef {
+        const sm = self.graph.getModule(mod) orelse return null;
+        const target = sm.synthetic_named_exports orelse return null;
+        return self.resolveExportChain(mod, target, 0);
     }
 
     /// re-export 체인을 따라가서 canonical export를 찾는다.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -766,6 +766,11 @@ pub fn buildMetadataForAst(
                 }
                 if (self.tree_shaker_active and !value_init_mod.is_included) continue;
 
+                // #3664 P2: synthetic_named_exports 바인딩은 eager `{target}.{member}` 치환이라
+                // lazy(inline-requires) 대상이 아니다. lazy 로 두면 아래 appendEsmInitCall 이 스킵돼
+                // target(default) export 가 init_xxx() 호출 전에 참조됨 → 미초기화 ReferenceError
+                // (code-review max 적발: RN/Metro inline_requires + esm-wrapped sideEffects:false).
+                const is_synthetic_binding = if (resolved) |rb| rb.synthetic_member != null else false;
                 lazy_esm_import = self.inline_requires and
                     m.wrap_kind == .esm and
                     rec.kind == .static_import and
@@ -779,7 +784,8 @@ pub fn buildMetadataForAst(
                     !value_init_mod.uses_top_level_await and
                     !target_mod.isUserDeclaredSideEffectful() and
                     !value_init_mod.isUserDeclaredSideEffectful() and
-                    !exported_locals.contains(m.importBindingLocalName(ib));
+                    !exported_locals.contains(m.importBindingLocalName(ib)) and
+                    !is_synthetic_binding;
                 if (lazy_esm_import) {
                     lazy_esm_import_mod = value_init_mod;
                 }
@@ -935,11 +941,18 @@ pub fn buildMetadataForAst(
             // 채워졌으면 rename 스킵 (#2429).
             if (!isReservedName(target_name) and target_name.len > 0 and isValidIdentStartByte(target_name[0])) {
                 if (ib.local_symbol.semanticIndex()) |sym_idx| {
-                    const rename_value = if (lazy_esm_import)
+                    // #3664 P2: synthetic_named_exports → canonical(default/target) export 의 member
+                    // access 로 rename(`{target_name}.{member}`). 정적으로 export 안 된 named import 를
+                    // default export 객체의 member 참조로 치환. owned(allocPrint)라 lazy 와 같은
+                    // 소유권 경로(owned_nested_renames)로 등록.
+                    const synth_member: ?[]const u8 = if (resolved) |rb| rb.synthetic_member else null;
+                    const rename_value = if (synth_member) |member|
+                        try std.fmt.allocPrint(self.allocator, "{s}.{s}", .{ target_name, member })
+                    else if (lazy_esm_import)
                         try allocLazyEsmImportExpr(self, canonical_m_opt.?, lazy_esm_import_mod orelse canonical_m_opt.?, target_name)
                     else
                         target_name;
-                    if (lazy_esm_import) {
+                    if (synth_member != null or lazy_esm_import) {
                         var rename_owned_by_list = false;
                         errdefer if (!rename_owned_by_list) self.allocator.free(rename_value);
                         try owned_nested_renames.append(self.allocator, rename_value);
@@ -949,8 +962,9 @@ pub fn buildMetadataForAst(
                         try putOwnedRename(self, &renames, &owned_nested_renames, sym_idx, rename_value);
                     }
                     // __esm → __esm live binding: __export getter override 등록 +
-                    // 자체 rename 루프에서 덮어쓰기 방지
-                    if (m.wrap_kind == .esm and canonical_m_opt != null and
+                    // 자체 rename 루프에서 덮어쓰기 방지. synthetic member access(`_default.foo`)는
+                    // live binding 이 아니므로(default export 객체의 member) getter override 대상 제외.
+                    if (synth_member == null and m.wrap_kind == .esm and canonical_m_opt != null and
                         canonical_m_opt.?.wrap_kind == .esm)
                     {
                         try export_getter_overrides.put(self.allocator, m.importBindingLocalName(ib), rename_value);

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -156,6 +156,11 @@ pub const Module = struct {
     /// (resolveId/transform meta merge 는 follow-up — 현재 load hook 만.)
     /// null = plugin 이 meta 미설정. parse_arena 가 backing 을 소유 (#1880 PR2).
     plugin_meta: ?[]const u8 = null,
+    /// Rollup `syntheticNamedExports` (#3664 P2). null = 비활성. 그 외 = fallback 대상 export 이름
+    /// — `syntheticNamedExports:true` 는 `"default"`, `syntheticNamedExports:'name'` 은 `"name"`.
+    /// 정적으로 export 안 된 named import 를 이 export 의 member 로 해석(CJS fallback 과 동형이되
+    /// 대상이 namespace 가 아니라 default/named export value). parse_arena 가 backing 소유.
+    synthetic_named_exports: ?[]const u8 = null,
     /// 파싱된 AST. nodes/extra_data/string_table 의 backing 은 `parse_arena` 가 소유.
     ///
     /// ### Ownership 규약 (D1 디버그 인프라 — RFC #1672)

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -27,6 +27,9 @@ pub const LoadResult = struct {
     module_type: ?types.ModuleType = null,
     /// plugin 이 반환한 `{ meta }` (JSON 문자열). null = 미설정. caller(parse_arena) 소유 (#1880 PR2).
     meta: ?[]const u8 = null,
+    /// Rollup `syntheticNamedExports` (#3664 P2). null = 미설정. 그 외 = fallback 대상 export 이름
+    /// ("default" 또는 string target). caller(parse_arena) 소유.
+    synthetic_named_exports: ?[]const u8 = null,
 };
 
 /// 플러그인 훅에서 반환할 수 있는 에러 타입.

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -1386,7 +1386,17 @@ pub const TreeShaker = struct {
         const canonical = blk: {
             var resolve_scope = profile.begin(.shake_fixpoint_bfs_seed_export_resolve);
             defer resolve_scope.end();
-            break :blk self.linker.resolveExportChain(@enumFromInt(@as(u32, @intCast(target_mod))), imported_name, 0) orelse return;
+            const tm_idx = @as(u32, @intCast(target_mod));
+            if (self.linker.resolveExportChain(@enumFromInt(tm_idx), imported_name, 0)) |c| break :blk c;
+            // #3664 P2: synthetic_named_exports → 정적 export 없는 import 를 target(default) export 로
+            // seed 해 그 export(및 default 객체 모듈)가 tree-shaking 에서 생존하게 한다. codegen 의
+            // `_default.foo` 가 참조하는 default export 가 dead-code 제거되지 않도록.
+            if (self.graph.getModule(@enumFromInt(tm_idx))) |tm| {
+                if (tm.synthetic_named_exports) |st| {
+                    if (self.linker.resolveExportChain(@enumFromInt(tm_idx), st, 0)) |c| break :blk c;
+                }
+            }
+            return;
         };
         const canon_mod = canonical.module_index.toU32();
         const canon_m = self.graph.getModule(canonical.module_index) orelse return;

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -217,7 +217,7 @@ pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInf
         .is_included = m.is_included,
         .exports = if (m.is_external) &.{} else m.exported_names,
         // Phase B (plugin context API) 까지 placeholder 값.
-        .synthetic_named_exports = false,
+        .synthetic_named_exports = m.synthetic_named_exports != null,
         .implicitly_loaded_after_one_of = &.{},
         .implicitly_loaded_before = &.{},
         .meta = m.plugin_meta,


### PR DESCRIPTION
## 배경

#3664 잔여 **P2**. Rollup `syntheticNamedExports` — plugin 이 load 결과에 `syntheticNamedExports`(`true`|`string`)를 달면, **정적으로 export 안 된 named import** 를 default(`true`) 또는 지정 export(`string`)의 **member** 로 fallback 합니다. ZTS 의 CJS interop fallback 과 같은 메커니즘이되, 대상이 namespace 가 아니라 **default/named export value** 입니다(`@rollup/plugin-commonjs` 등이 사용).

## 구현

**배선**: `Module.synthetic_named_exports` / `PluginResponse` / `LoadResult` 필드(`plugin_meta` 와 동일 소유권 = parse_arena) · `parseJsResult` 정규화(`true`→`"default"`, string→그대로, 빈문자열/non-string/false→null) · `runLoadForModule` 저장 · `types.zig` ModuleInfo 노출.

**linker core (두 단계 — 분리하면 silent-broken)**:
- **codegen**: `resolveImports` missing 지점에서 `synthExportFallback` → `ResolvedBinding{canonical=target export, synthetic_member=원래 import 이름}`. `metadata` rename 이 `{target local}.{member}`(`_default.foo`)로 치환. live binding 아니라 `export_getter_overrides` 제외.
- **생존**: `tree_shaker.seedExport` 가 `resolveExportChain(name)` null 이면 synthetic target 으로 seed → default export(및 그 객체 모듈)가 tree-shaking 생존. 누락 시 codegen 의 `_default.foo` 가 dead `_default` 참조 → ReferenceError(실측 확인).

## `/code-review max` fix

- **lazy_esm_import 충돌**: synthetic 바인딩은 eager `{target}.{member}` 치환이라 lazy(inline-requires) 대상에서 제외. lazy 면 `appendEsmInitCall` 이 스킵돼 `init_xxx()` 호출 전 default export 참조(RN/Metro `inline_requires` + esm-wrapped `sideEffects:false` 경로 미초기화 ReferenceError).

review 가 확인한 안전: ownership(double-free/leak 없음, lazy 패턴 동일), recursion 없음, link→analyze 순서 일치, CJS no-op, tree_shaker default stmt seed.

## scope (P2)

직접 named import 만 지원. **re-export forwarding**(`export {foo} from './synth'`)·**nested synthetic indirection** 은 미지원(`synthExportFallback` 이 `resolveImports`/`seedExport` 에만 배선) — Rollup 은 지원하나 수요 발생 시 follow-up. CJS synthetic 은 no-op(namespace fallback 이 이미 커버).

## 검증

- `plugin-synthetic-named-exports.ts` — synthetic:true → `_default.foo`+`_default.bar` codegen + default 객체(`42`/`7`) tree-shaking 생존 / synthetic 없는 모듈 회귀 가드
- `zig build test` 통과, build-plugins **56** + vite-plugin **27** pass / 회귀 0, `tsc` 통과, ReleaseFast napi

Refs #3664

🤖 Generated with [Claude Code](https://claude.com/claude-code)