### PR TITLE
feat(plugin): emit chunk 명시 fileName verbatim 출력 (#3664, #1880 PR7-2d)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -3097,8 +3097,10 @@ function createRollupPluginContext(
         const chunkRef = fn({
           chunkId: f.id,
           chunkName: typeof f.name === 'string' && f.name.length > 0 ? f.name : undefined,
-          // 명시 fileName 의 "정확히 그대로(hash 없이)" 는 follow-up — 현재 name 기반 [name]-[hash]
-          // 출력 + getFileName 으로 최종명 조회. (chunkFileName 미노출)
+          // 명시 fileName 은 "정확히 그대로(hash/[name] 패턴 우회)" 출력 — Rollup emitFile chunk fileName.
+          // 미지정이면 name 기반 [name]-[hash]. getFileName(refId) 가 둘 다 최종명 반환 (#1880 PR7-2c/2d).
+          chunkFileName:
+            typeof f.fileName === 'string' && f.fileName.length > 0 ? f.fileName : undefined,
         });
         if (typeof chunkRef !== 'string') {
           throw new Error(

--- a/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
+++ b/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
@@ -131,6 +131,56 @@ describe('@zntc/core build + plugins - this.emitFile chunk (PR7-2b-i)', () => {
     }
   });
 
+  test('명시 fileName 의 chunk emit 은 hash/[name] 패턴 없이 그대로 출력된다 (PR7-2d)', async () => {
+    // name(→[name]-[hash]) 대조: fileName 은 verbatim. Rollup emitFile chunk fileName 동형.
+    let chunkRef = '';
+    let resolvedName: string | undefined;
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-fname-'));
+    const plugin: ZntcPlugin = {
+      name: 'chunk-explicit-filename',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          async function (this: RollupPluginContext, args: { path: string }) {
+            const r = await this.resolve('./worker.ts', args.path);
+            // 서브디렉토리 + 확장자 포함 명시 fileName.
+            chunkRef = this.emitFile({
+              type: 'chunk',
+              id: r!.id,
+              fileName: 'workers/sw.js',
+            }) as string;
+            return null;
+          },
+        );
+        build.onGenerateBundle(function (this: RollupPluginContext) {
+          resolvedName = this.getFileName(chunkRef);
+        });
+      },
+    };
+    try {
+      writeFileSync(join(dir, 'worker.ts'), 'export const w = 99;\nconsole.log("wk");\n');
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBe(0);
+      // 출력 파일명이 정확히 'workers/sw.js' (hash 없음).
+      const swChunk = result.outputFiles.find((f) => f.path === 'workers/sw.js');
+      expect(swChunk).toBeDefined();
+      expect(swChunk!.text).toContain('99');
+      // hash 가 붙은 변형이 없어야 한다.
+      expect(result.outputFiles.some((f) => /workers\/sw-[0-9a-f]{8}\.js$/.test(f.path))).toBe(
+        false,
+      );
+      // getFileName 도 동일 verbatim 반환(출력과 일치).
+      expect(resolvedName).toBe('workers/sw.js');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('상대 specifier 신규 모듈 emit chunk — this.resolve 없이 project_root 기준 resolve (RFC §4.2)', async () => {
     // abs path(this.resolve 결과)뿐 아니라 RFC §4.2 는 resolveThreadSafe 로 상대/bare specifier 도
     // 받도록 명세한다. plugin 이 this.resolve 를 선호출하지 않고 './worker.ts' 를 그대로 emit 해도

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -196,6 +196,10 @@ pub const Chunk = struct {
     name: ?[]const u8,
     /// 최종 출력 경로 (예: "dist/index-abc123.js"). 빌림 — deinit에서 해제하지 않음.
     filename: ?[]const u8,
+    /// plugin `emitFile({ type:'chunk', fileName })` 의 verbatim 출력 경로 (#1880 PR7-2d).
+    /// non-null 이면 naming pattern([name]-[hash]) / content-hash placeholder / 확장자 append 를
+    /// 모두 우회해 이 문자열을 그대로 출력 파일명·import 경로로 쓴다. emit_store 소유 — 빌림(미해제).
+    explicit_file_name: ?[]const u8 = null,
     /// 실행 순서 (exec_index 기준 정렬에 사용)
     exec_order: u32,
     /// preserve-modules: 원본 모듈의 절대 경로 (출력 디렉토리 구조 결정용).
@@ -619,13 +623,16 @@ pub fn generateChunks(
 
         // 출력 파일명 = 모듈 파일명의 stem (확장자 제거). plugin emit chunk(name 지정)면 그 name 우선
         // (#1880 PR7-2c) — [name]-[hash] 의 [name] 으로 쓰여 plugin 이 chunk 이름을 제어한다.
+        // 명시 fileName(#1880 PR7-2d)이면 verbatim 출력 — explicit_file_name 으로 캐리해 패턴/hash 우회.
         const entry_mod = graph.getModule(entry.module_idx) orelse return error.InvalidEntryModule;
+        var explicit_file_name: ?[]const u8 = null;
         const name = blk: {
             if (entry_mod.is_emitted_chunk_entry) {
                 if (graph.emit_store) |sp| {
                     const store: *const @import("emit_store.zig").EmitStore = @ptrCast(@alignCast(sp));
                     for (store.chunks.items) |chk| {
                         if (std.mem.eql(u8, chk.id, entry_mod.path)) {
+                            explicit_file_name = chk.file_name; // 명시 fileName 이면 verbatim (없으면 null)
                             if (chk.name) |n| break :blk n;
                             break;
                         }
@@ -641,6 +648,7 @@ pub fn generateChunks(
             .is_dynamic = entry.is_dynamic,
         } }, bits);
         chunk.name = name;
+        chunk.explicit_file_name = explicit_file_name;
 
         const ci = try chunk_graph.addChunk(chunk);
         try bits_to_chunk.put(allocator, bits, ci);

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -414,8 +414,13 @@ pub fn emitChunks(
             const dep_id = if (reg_split) reg_ids[@intFromEnum(dep_chunk_idx)] else "";
 
             // import 경로 결정: preserve-modules면 상대 경로, 아니면 "./{stem}{ext}"
+            // PR7-2d: 명시 fileName 은 preserve-modules 보다 우선 — 출력 파일명(verbatim)과 import
+            // 경로가 일치해야 한다(filename 생성부도 explicit 을 먼저 검사). emit chunk 는 rel_dir
+            // 이 null 이라 preserve 분기가 verbatim 을 떨어뜨리면 ref 가 실제 출력과 어긋난다.
             const resolved_path = if (reg_split)
                 try allocator.dupe(u8, "")
+            else if (dep_chunk.explicit_file_name) |efn|
+                try std.fmt.allocPrint(allocator, "./{s}", .{efn})
             else if (options.preserve_modules) blk: {
                 const src_path = chunk.rel_dir orelse "./";
                 const dep_path = dep_chunk.rel_dir orelse "./";
@@ -908,7 +913,12 @@ pub fn emitChunks(
         }
 
         // 출력 파일명 생성
-        const filename = if (options.preserve_modules and chunk.rel_dir != null)
+        const filename = if (chunk.explicit_file_name) |efn|
+            // plugin emitFile fileName (#1880 PR7-2d): verbatim — 패턴/hash placeholder/ext 우회.
+            // efn 은 확장자를 포함한 최종 경로(Rollup 동형). content-hash 치환 대상 placeholder 가
+            // 없으므로 resolveContentHashes 의 path 치환은 no-op.
+            try allocator.dupe(u8, efn)
+        else if (options.preserve_modules and chunk.rel_dir != null)
             // preserve-modules: 원본 경로에서 root를 제거한 상대 경로 사용
             try computePreserveModulesPath(allocator, chunk.rel_dir.?, ext, options.preserve_modules_root)
         else blk: {
@@ -1058,7 +1068,11 @@ fn emitRunBeforeMainCrossImports(
             const src_path = current_chunk.rel_dir orelse "./";
             const dep_path = dep_chunk.rel_dir orelse "./";
             break :blk try computeRelativeImportPath(allocator, src_path, dep_path, ext, options.preserve_modules_root);
-        } else try std.fmt.allocPrint(allocator, "./{s}{s}", .{ dep_stem, ext });
+        } else if (dep_chunk.explicit_file_name) |efn|
+            // PR7-2d: 명시 fileName chunk 는 verbatim 참조.
+            try std.fmt.allocPrint(allocator, "./{s}", .{efn})
+        else
+            try std.fmt.allocPrint(allocator, "./{s}{s}", .{ dep_stem, ext });
         defer allocator.free(resolved_path);
 
         if (!options.minify_whitespace) {
@@ -1392,9 +1406,15 @@ fn rewriteDynamicImports(
         const target_chunk = chunk_graph.getChunk(target_chunk_idx);
 
         // 청크 파일명 생성: public_path가 있으면 "{public_path}{stem}{ext}", 없으면 "./{stem}{ext}"
+        // PR7-2d: 명시 fileName chunk 는 verbatim(패턴/hash 우회) — public_path 만 prefix.
         var stem_buf: [128]u8 = undefined;
         const stem = chunkPlaceholderStem(target_chunk, &stem_buf, emit_options);
-        const replacement = if (public_path.len > 0)
+        const replacement = if (target_chunk.explicit_file_name) |efn|
+            (if (public_path.len > 0)
+                try std.fmt.allocPrint(allocator, "{s}{s}", .{ public_path, efn })
+            else
+                try std.fmt.allocPrint(allocator, "./{s}", .{efn}))
+        else if (public_path.len > 0)
             try std.fmt.allocPrint(allocator, "{s}{s}{s}", .{ public_path, stem, out_ext })
         else
             try std.fmt.allocPrint(allocator, "./{s}{s}", .{ stem, out_ext });


### PR DESCRIPTION
## 무엇을

plugin `this.emitFile({ type:'chunk', id, fileName })` 의 명시 **`fileName` 을 `[name]-[hash]` 패턴/content-hash 없이 그대로(verbatim) 출력**합니다 (Rollup `emitFile` chunk `fileName` 동형). 기존 `name` 은 `[name]-[hash]` 패턴을 유지 — 둘은 대조 관계입니다.

#3664 의 minor follow-up 항목("emit chunk 명시 fileName 정확히 그대로")을 구현합니다.

## 왜

PR7-2c 는 `name` → `[name]-[hash]` + `getFileName` 까지였고, 명시 `fileName` 그대로 출력은 follow-up 으로 남겨져 있었습니다(`index.ts` 주석). Rollup 호환 plugin(worker/service-worker 등 고정 경로가 필요한 산출물)에 필요합니다.

## 변경

- **`index.ts`**: `f.fileName` → native `chunkFileName` 전달. (native `emitChunk(id, name, file_name)` / `setChunkFileName` 우선순위는 PR7-2c 에 이미 존재.)
- **`chunk.zig`**: `Chunk.explicit_file_name` 필드(빌림, emit_store 소유). `generateChunks` Phase 1c 에서 `chk.file_name` 캐리 — back-fill 전이라 **명시 fileName 만** 잡힘.
- **`emitter/chunks.zig`**: 출력 파일명 생성에서 `explicit_file_name` 이면 verbatim(패턴/hash placeholder/확장자 우회). cross-chunk import ref 3곳(static / run-before-main / dynamic import)도 verbatim 참조 — placeholder hash 없는 이름이라 importer 가 그대로 가리켜야 일치. content-hash 치환은 placeholder 부재로 path 에서 no-op.

## code-review max 반영

- **preserve-modules 우선순위**: static cross-chunk import ref 에서 `explicit_file_name` 을 preserve-modules 분기보다 **먼저** 검사하도록 순서 조정. 출력 파일명(verbatim)은 explicit 을 먼저 보는데 import ref 가 preserve 분기를 먼저 타면 경로가 어긋나므로 일치시킴.
- 검증으로 기각: 메모리 ownership(dupe+errdefer 대칭), Phase 1c 순서(explicit 캐리 후 break), name+fileName 시 fileName 우선, sourcemap(`basename(efn)` + `.map` 형제로 일관), 출력 path 구분자 `/`(Windows 비결합), reg_split 무관.

## 한계 (follow-up)

- **subdir importer 상대경로**: 명시 fileName 이 subdir(`workers/sw.js`)이고 *importer chunk 도* subdir 일 때 `./` 고정이라 깊이 미보정 — non-explicit code-split 경로도 동일한 flat-`./` 가정(기존 한계). 주 use case(root importer)는 정상.
- **중복 fileName**: 동일 id 를 서로 다른 fileName 으로 중복 emit 시 first-match 우선(진단 없음; Rollup 은 throw). `preserve_modules` + emit chunk 조합은 비표준.

## 검증

- `plugin-emit-chunk.ts` **+1** (`fileName:'workers/sw.js'` → 정확 출력 + hash 없음 + `getFileName` 일치). 전체 emit-chunk 9개.
- build-plugins **55 pass** 회귀 0, `zig build test` 통과, `tsc` 통과, ReleaseFast napi.

Refs #3664, #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)