### PR TITLE
feat(plugin): syntheticNamedExports re-export forwarding (#3664 P2 follow-up)

### DIFF
--- a/packages/core/test/core/build-plugins/plugin-synthetic-named-exports.ts
+++ b/packages/core/test/core/build-plugins/plugin-synthetic-named-exports.ts
@@ -15,9 +15,9 @@ import type { ZntcPlugin } from './helpers';
 // 그 모듈에서 정적으로 export 안 된 named import 를 default(true) 또는 지정 export(string)의
 // member 로 fallback 한다. ZTS 의 CJS interop fallback(resolveOrCjsFallback)과 같은 메커니즘이되
 // 대상이 namespace 가 아니라 default/named export value.
-// scope (P2): 직접 named import(`import { foo } from './synth'`)만 지원. re-export forwarding
-// (`export { foo } from './synth'`)·nested synthetic indirection 은 미지원(synthExportFallback 이
-// resolveImports/seedExport 에만 배선) — Rollup 은 지원하나 수요 발생 시 follow-up.
+// 직접 named import 와 barrel re-export forwarding(`export {foo} from './synth'`) 모두 지원.
+// resolveExportChain 한 곳에서 synthetic 을 canonical.synthetic_member 로 해석하므로 codegen·
+// tree_shaker 가 통합 경로로 따라온다.
 describe('@zntc/core - syntheticNamedExports (#3664 P2)', () => {
   test('syntheticNamedExports:true → 정적 export 없는 named import 를 default export member 로 fallback', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'zntc-synth-true-'));
@@ -47,6 +47,65 @@ describe('@zntc/core - syntheticNamedExports (#3664 P2)', () => {
       // synthetic fallback 이 default export 를 참조 → synth 모듈(default 객체)이 tree-shaking 생존.
       expect(out).toContain('42');
       expect(out).toContain('7');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('re-export forwarding: export {foo} from synthetic → barrel 거쳐 import 도 default member', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-synth-reexport-'));
+    const plugin: ZntcPlugin = {
+      name: 'synth-reexport',
+      setup(build) {
+        build.onLoad({ filter: /synth\.ts$/ }, () => ({
+          contents: 'export default { foo: 42, bar: 7 };\n',
+          syntheticNamedExports: true,
+        }));
+      },
+    };
+    try {
+      writeFileSync(join(dir, 'synth.ts'), 'export default {};\n');
+      // barrel 이 synthetic 모듈의 이름을 forwarding.
+      writeFileSync(join(dir, 're.ts'), "export { foo, bar } from './synth';\n");
+      writeFileSync(
+        join(dir, 'main.ts'),
+        "import { foo, bar } from './re';\nexport const r = foo + bar;\n",
+      );
+      const result = await build({ entryPoints: [join(dir, 'main.ts')], plugins: [plugin] });
+      expect(result.errors.length).toBe(0);
+      const out = result.outputFiles.map((f) => f.text).join('\n');
+      expect(out).toContain('.foo');
+      expect(out).toContain('.bar');
+      expect(out).toContain('42');
+      expect(out).toContain('7');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('export * 는 synthetic 을 전파하지 않는다 — 임의 이름이 default member 로 새지 않음(회귀 가드)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-synth-star-'));
+    const plugin: ZntcPlugin = {
+      name: 'synth-star',
+      setup(build) {
+        build.onLoad({ filter: /synth\.ts$/ }, () => ({
+          contents: 'export default { foo: 42 };\n',
+          syntheticNamedExports: true,
+        }));
+      },
+    };
+    try {
+      writeFileSync(join(dir, 'synth.ts'), 'export default {};\n');
+      // star re-export 는 synthetic 이름을 forwarding 하지 않는다(Rollup: non-enumerable).
+      writeFileSync(join(dir, 'star.ts'), "export * from './synth';\n");
+      writeFileSync(
+        join(dir, 'main.ts'),
+        "import { neverExists } from './star';\nexport const r = neverExists;\n",
+      );
+      const result = await build({ entryPoints: [join(dir, 'main.ts')], plugins: [plugin] });
+      const out = result.outputFiles.map((f) => f.text).join('\n');
+      // neverExists 가 synth default 의 member(.neverExists)로 잘못 resolve 되면 안 된다.
+      expect(out).not.toContain('.neverExists');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -117,6 +117,12 @@ pub const SymbolRef = struct {
     module_index: ModuleIndex,
     /// 해당 모듈의 export 이름 (e.g. "x", "default")
     export_name: []const u8,
+    /// Rollup `syntheticNamedExports` (#3664 P2). 정적으로 export 안 된 named import/re-export 가
+    /// synthetic 모듈의 fallback 대상(default/named) export 의 member 일 때 그 member 이름.
+    /// null = 일반 ref. 설정 시 codegen 은 `{module export local name}.{synthetic_member}` 로 rename.
+    /// resolveExportChain 이 re-export 체인 끝에서 synthetic 을 만나면 채워 전달(직접 import·barrel
+    /// forwarding 통합). HashMap 키/eql 에 안 쓰이므로 필드 추가 안전.
+    synthetic_member: ?[]const u8 = null,
 };
 
 /// 해석된 import 바인딩. linker가 codegen에 전달.
@@ -125,12 +131,8 @@ pub const ResolvedBinding = struct {
     local_name: []const u8,
     /// 로컬 바인딩의 소스 위치 (rename 키)
     local_span: Span,
-    /// 최종적으로 가리키는 export (re-export 체인 해결 후)
+    /// 최종적으로 가리키는 export (re-export 체인 해결 후). synthetic 은 canonical.synthetic_member.
     canonical: SymbolRef,
-    /// Rollup `syntheticNamedExports` (#3664 P2). 정적으로 export 안 된 named import 가
-    /// synthetic 모듈의 fallback 대상(default/named) export 의 member 일 때 그 member 이름.
-    /// null = 일반 바인딩. 설정 시 codegen 은 `{canonical local name}.{synthetic_member}` 로 rename.
-    synthetic_member: ?[]const u8 = null,
 };
 
 pub const Linker = struct {
@@ -1460,30 +1462,14 @@ pub const Linker = struct {
 
                 if (source_record.resolved.isNone()) continue; // external 또는 미해석
 
-                const bk = BindingKey{
-                    .module_index = @intCast(i),
-                    .span_key = types.spanKey(ib.local_span),
-                };
-
-                // re-export 체인을 따라가서 canonical export 찾기
+                // re-export 체인을 따라가서 canonical export 찾기. synthetic_named_exports(직접 import
+                // 또는 barrel re-export forwarding)는 resolveExportChain 이 canonical.synthetic_member 로
+                // 전달한다(한 곳 통합).
                 const canonical = self.resolveExportChain(
                     source_record.resolved,
                     ib.imported_name,
                     0,
                 ) orelse {
-                    // #3664 P2: synthetic_named_exports 모듈이면 정적으로 export 안 된 named import 를
-                    // fallback 대상(default/named) export 의 member 로 해석한다. canonical 은 그 대상
-                    // export 를 가리키고, synthetic_member 에 원래 import 이름을 담아 codegen 이
-                    // `{target}.{member}` 로 rename 하게 한다.
-                    if (self.synthExportFallback(source_record.resolved)) |target_ref| {
-                        try self.resolved_bindings.put(bk, .{
-                            .local_name = ib.local_name,
-                            .local_span = ib.local_span,
-                            .canonical = target_ref,
-                            .synthetic_member = ib.imported_name,
-                        });
-                        continue;
-                    }
                     // export를 찾을 수 없음
                     self.addDiag(
                         .missing_export,
@@ -1497,6 +1483,10 @@ pub const Linker = struct {
                     continue;
                 };
 
+                const bk = BindingKey{
+                    .module_index = @intCast(i),
+                    .span_key = types.spanKey(ib.local_span),
+                };
                 try self.resolved_bindings.put(bk, .{
                     .local_name = ib.local_name,
                     .local_span = ib.local_span,
@@ -1504,15 +1494,6 @@ pub const Linker = struct {
                 });
             }
         }
-    }
-
-    /// #3664 P2: synthetic_named_exports 모듈의 fallback 대상 export 를 resolve.
-    /// `synthetic_named_exports`("default" 또는 string target)를 resolveExportChain 으로 따라가
-    /// canonical SymbolRef 반환. 모듈이 synthetic 아니거나 target 자체도 missing 이면 null.
-    fn synthExportFallback(self: *const Linker, mod: ModuleIndex) ?SymbolRef {
-        const sm = self.graph.getModule(mod) orelse return null;
-        const target = sm.synthetic_named_exports orelse return null;
-        return self.resolveExportChain(mod, target, 0);
     }
 
     /// re-export 체인을 따라가서 canonical export를 찾는다.
@@ -1554,7 +1535,7 @@ pub const Linker = struct {
                 return entry.result;
             }
 
-            const result = self.resolveExportChainInner(module_idx, name, depth);
+            const result = self.resolveExportChainInner(module_idx, name, depth, true);
 
             const owned_key = self.allocator.dupe(u8, cache_key) catch return result;
             const mutable_self: *Linker = @constCast(self);
@@ -1564,15 +1545,20 @@ pub const Linker = struct {
             return result;
         }
 
-        return self.resolveExportChainInner(module_idx, name, depth);
+        return self.resolveExportChainInner(module_idx, name, depth, true);
     }
 
     /// resolveExportChain 내부 구현 (캐시 없이).
+    /// `allow_synthetic`: synthetic_named_exports fallback(#3664 P2)을 적용할지. 직접 named import·
+    /// named re-export forwarding 경로는 true, `export *`(re_export_all)는 false — Rollup 은 synthetic
+    /// 이름을 non-enumerable 로 보아 star 로 전파하지 않으며, true 면 임의 이름이 synthetic.member 로
+    /// 잘못 resolve 되어 missing_export 진단이 억제된다(code-review max 적발).
     fn resolveExportChainInner(
         self: *const Linker,
         module_idx: ModuleIndex,
         name: []const u8,
         depth: u32,
+        allow_synthetic: bool,
     ) ?SymbolRef {
         if (depth > max_chain_depth) return null;
 
@@ -1599,7 +1585,8 @@ pub const Linker = struct {
                                     .export_name = name,
                                 };
                             }
-                            if (self.resolveOrCjsFallback(source_mod, entry.binding.local_name, depth + 1)) |result| {
+                            // named re-export forwarding 은 synthetic 허용(barrel `export {foo} from synth`).
+                            if (self.resolveOrCjsFallback(source_mod, entry.binding.local_name, depth + 1, true)) |result| {
                                 return result;
                             }
                         }
@@ -1623,7 +1610,7 @@ pub const Linker = struct {
                     if (ib.import_record_index < m_local.import_records.len) {
                         const source_mod = m_local.import_records[ib.import_record_index].resolved;
                         if (!source_mod.isNone()) {
-                            return self.resolveExportChainInner(source_mod, ib.imported_name, depth + 1);
+                            return self.resolveExportChainInner(source_mod, ib.imported_name, depth + 1, true);
                         }
                     }
                     break;
@@ -1645,9 +1632,33 @@ pub const Linker = struct {
                     if (!source_mod.isNone()) {
                         // CJS fallback은 실제 `module.exports`/`exports.*` 소스에만 유효하다.
                         // 런타임 값이 비어 있는 type barrel이 임의의 이름을 소유하면 안 된다.
-                        if (self.resolveOrCjsFallback(source_mod, name, depth + 1)) |result| {
+                        // synthetic 도 같은 이유로 star 전파 금지(allow_synthetic=false) — Rollup 동일.
+                        if (self.resolveOrCjsFallback(source_mod, name, depth + 1, false)) |result| {
                             return result;
                         }
+                    }
+                }
+            }
+        }
+
+        // 3. #3664 P2: synthetic_named_exports — 정적/re-export/export* 어디서도 못 찾으면 fallback
+        // 대상(default/named) export 의 member 로 해석한다. target export 를 resolve 하고 synthetic_member
+        // 에 원래 이름을 담아 codegen 이 `{target local}.{member}` 로 rename 하게 한다. 이 한 곳에서
+        // 처리하므로 직접 named import 와 barrel re-export forwarding 이 통합되고 tree_shaker 도
+        // resolveExportChain 으로 자동 따라온다. target 자기 참조(default→default)는 가드 + depth 로
+        // bounded(무한 재귀 방지).
+        if (allow_synthetic) {
+            if (m.synthetic_named_exports) |target| {
+                if (!std.mem.eql(u8, target, name)) {
+                    if (self.resolveExportChainInner(module_idx, target, depth + 1, true)) |result| {
+                        // nested synthetic(target 자체가 또 synthetic 의 member)은 단일 member access
+                        // 로 표현 불가 → bail(missing). 단일 hop synthetic 만 지원.
+                        if (result.synthetic_member != null) return null;
+                        return .{
+                            .module_index = result.module_index,
+                            .export_name = result.export_name,
+                            .synthetic_member = name,
+                        };
                     }
                 }
             }
@@ -1658,8 +1669,8 @@ pub const Linker = struct {
 
     /// resolveExportChain + CJS fallback. CJS 모듈은 정적 export가 없으므로
     /// resolve 실패 시 CJS 모듈 자체를 반환하여 소비자가 require_xxx()로 접근.
-    fn resolveOrCjsFallback(self: *const Linker, source_mod: ModuleIndex, name: []const u8, depth: u32) ?SymbolRef {
-        if (self.resolveExportChainInner(source_mod, name, depth)) |result| return result;
+    fn resolveOrCjsFallback(self: *const Linker, source_mod: ModuleIndex, name: []const u8, depth: u32, allow_synthetic: bool) ?SymbolRef {
+        if (self.resolveExportChainInner(source_mod, name, depth, allow_synthetic)) |result| return result;
         if (self.graph.getModule(source_mod)) |sm| {
             if (sm.wrap_kind == .cjs and sm.has_cjs_export_signal) return .{ .module_index = source_mod, .export_name = name };
         }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -770,7 +770,7 @@ pub fn buildMetadataForAst(
                 // lazy(inline-requires) 대상이 아니다. lazy 로 두면 아래 appendEsmInitCall 이 스킵돼
                 // target(default) export 가 init_xxx() 호출 전에 참조됨 → 미초기화 ReferenceError
                 // (code-review max 적발: RN/Metro inline_requires + esm-wrapped sideEffects:false).
-                const is_synthetic_binding = if (resolved) |rb| rb.synthetic_member != null else false;
+                const is_synthetic_binding = if (resolved) |rb| rb.canonical.synthetic_member != null else false;
                 lazy_esm_import = self.inline_requires and
                     m.wrap_kind == .esm and
                     rec.kind == .static_import and
@@ -945,7 +945,7 @@ pub fn buildMetadataForAst(
                     // access 로 rename(`{target_name}.{member}`). 정적으로 export 안 된 named import 를
                     // default export 객체의 member 참조로 치환. owned(allocPrint)라 lazy 와 같은
                     // 소유권 경로(owned_nested_renames)로 등록.
-                    const synth_member: ?[]const u8 = if (resolved) |rb| rb.synthetic_member else null;
+                    const synth_member: ?[]const u8 = if (resolved) |rb| rb.canonical.synthetic_member else null;
                     const rename_value = if (synth_member) |member|
                         try std.fmt.allocPrint(self.allocator, "{s}.{s}", .{ target_name, member })
                     else if (lazy_esm_import)
@@ -1408,6 +1408,10 @@ pub fn buildCrossModuleConstValuesProfiled(
             defer scope.end();
             break :blk self.resolveExportChain(rec.resolved, ib.imported_name, 0) orelse continue;
         };
+        // #3664 P2: synthetic 바인딩(`{target}.{member}`)은 cross-module const 인라인 대상이 아니다.
+        // canon 은 target export(예 scalar default 42)를 가리키지만 실제 값은 그 member 라, 인라인하면
+        // import 이름이 target 전체 값으로 잘못 치환된다(rename 경로와도 충돌). synthetic 은 skip.
+        if (canon.synthetic_member != null) continue;
         const Lookup = struct {
             sem: @import("../module.zig").ModuleSemanticData,
             sym_idx: usize,

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -1386,17 +1386,10 @@ pub const TreeShaker = struct {
         const canonical = blk: {
             var resolve_scope = profile.begin(.shake_fixpoint_bfs_seed_export_resolve);
             defer resolve_scope.end();
-            const tm_idx = @as(u32, @intCast(target_mod));
-            if (self.linker.resolveExportChain(@enumFromInt(tm_idx), imported_name, 0)) |c| break :blk c;
-            // #3664 P2: synthetic_named_exports → 정적 export 없는 import 를 target(default) export 로
-            // seed 해 그 export(및 default 객체 모듈)가 tree-shaking 에서 생존하게 한다. codegen 의
-            // `_default.foo` 가 참조하는 default export 가 dead-code 제거되지 않도록.
-            if (self.graph.getModule(@enumFromInt(tm_idx))) |tm| {
-                if (tm.synthetic_named_exports) |st| {
-                    if (self.linker.resolveExportChain(@enumFromInt(tm_idx), st, 0)) |c| break :blk c;
-                }
-            }
-            return;
+            // #3664 P2: synthetic_named_exports 는 resolveExportChain 이 canonical(target export, 보통
+            // default)로 직접 해석하므로 별도 분기 없이 그 export(및 객체 모듈)가 여기서 seed 되어
+            // tree-shaking 생존한다. codegen 의 `_default.foo` 가 dead `_default` 를 참조하지 않도록.
+            break :blk self.linker.resolveExportChain(@enumFromInt(@as(u32, @intCast(target_mod))), imported_name, 0) orelse return;
         };
         const canon_mod = canonical.module_index.toU32();
         const canon_m = self.graph.getModule(canonical.module_index) orelse return;


### PR DESCRIPTION
## 배경

#3664 P2(syntheticNamedExports) follow-up — 사용자 요청으로 **barrel re-export forwarding** 지원: `export { foo } from './synth'`(synth가 synthetic)를 통해 `import { foo } from './re'` 도 default member 로 해석.

## 구현 — synthetic 처리 통합

synthetic 을 `resolveExportChainInner` **한 곳**으로 통합. 직접 named import 와 named re-export 가 같은 경로로 `canonical.synthetic_member` 를 받고, tree_shaker 도 `resolveExportChain` 으로 자동 따라옵니다(P2 의 synthExportFallback + tree_shaker 분기 제거).

- `SymbolRef.synthetic_member` (ResolvedBinding 에서 이동). HashMap 키/eql 미사용이라 안전(별도 `bundler_symbol.SymbolRef` union 은 불변).
- `resolveExportChainInner`: 정적/re-export/export* 미해결 시 synthetic target export 의 member 로 fallback, `synthetic_member=원래 이름`. metadata 가 `{target local}.{member}` rename.

## `/code-review max` fix

- **`export *` 는 synthetic 전파 금지** (`allow_synthetic` 파라미터): Rollup 은 synthetic 이름을 non-enumerable 로 보아 star 로 forwarding 하지 않습니다. 통합이 모든 경로에 synthetic 을 열어 `export * from synth` + `import {neverExists}` 가 `_default.neverExists`(undefined)로 새고 missing_export 진단이 억제되던 것 차단(named re-export=true, export*=false).
- **nested synthetic bail**: target 이 또 synthetic 의 member 면 단일 member access 로 표현 불가 → null(missing). 단일 hop 만 지원.
- **scalar synthetic const-inline 가드**: cross-module const 인라인이 synthetic 바인딩을 target 전체 값으로 오치환하지 않도록 skip(codegen 이 const_values 를 renames 보다 먼저 처리 — load-bearing).

2차 `/code-review max` 결과 **버그 0** — export* 가드(hardcoded-true 재귀가 leak 재오픈 안 함), cycle bounded(depth 100), const-inline 가드 load-bearing, SymbolRef 필드 안전 전부 확인.

## 검증

- `plugin-synthetic-named-exports.ts` **4개**: 직접 import / barrel re-export forwarding / **export* 비전파 가드** / synthetic 없는 모듈 가드
- `zig build test` 통과, build-plugins **58** + vite-plugin **27** pass / 회귀 0, `tsc` 통과, ReleaseFast napi

Refs #3664

🤖 Generated with [Claude Code](https://claude.com/claude-code)