### PR TITLE
feat(plugin): implicitlyLoadedAfterOneOf 관계 데이터 배선 (#3664 P3)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1894,6 +1894,7 @@ type NativeEmitFileFn = (file: {
   chunkId?: string;
   chunkName?: string;
   chunkFileName?: string;
+  chunkImplicitlyLoadedAfterOneOf?: string[];
 }) => string | null;
 // #1880 PR6: native getFileName 콜백. reference id → 최종 출력 파일명(미등록이면 null).
 type NativeGetFileNameFn = (referenceId: string) => string | null;
@@ -3085,6 +3086,7 @@ function createRollupPluginContext(
         name?: unknown;
         source?: unknown;
         id?: unknown;
+        implicitlyLoadedAfterOneOf?: unknown;
       };
       // type:'chunk' (#1880 PR7-2b/2c): id(graph 모듈/신규)를 별도 chunk 로 분리. name 은 [name]
       // 패턴, fileName 은 명시 출력명. this.getFileName(refId) 로 최종 파일명 조회(PR7-2c).
@@ -3094,6 +3096,17 @@ function createRollupPluginContext(
             `@zntc/core [${pluginName}]: this.emitFile({ type: 'chunk' }) 는 비어있지 않은 id(모듈 specifier)가 필요합니다 (#1880 PR7-2b).`,
           );
         }
+        // #3664: implicitlyLoadedAfterOneOf — 지정 시 string[] 이어야 한다. 잘못된 값을 silent-drop
+        // 하면 사용자가 선언한 load-order 관계가 조용히 사라지므로 id 와 동일하게 throw 로 surfacing.
+        if (
+          f.implicitlyLoadedAfterOneOf !== undefined &&
+          (!Array.isArray(f.implicitlyLoadedAfterOneOf) ||
+            !f.implicitlyLoadedAfterOneOf.every((x) => typeof x === 'string'))
+        ) {
+          throw new Error(
+            `@zntc/core [${pluginName}]: this.emitFile({ type: 'chunk' }) 의 implicitlyLoadedAfterOneOf 는 문자열 id 배열이어야 합니다 (#3664).`,
+          );
+        }
         const chunkRef = fn({
           chunkId: f.id,
           chunkName: typeof f.name === 'string' && f.name.length > 0 ? f.name : undefined,
@@ -3101,6 +3114,13 @@ function createRollupPluginContext(
           // 미지정이면 name 기반 [name]-[hash]. getFileName(refId) 가 둘 다 최종명 반환 (#1880 PR7-2c/2d).
           chunkFileName:
             typeof f.fileName === 'string' && f.fileName.length > 0 ? f.fileName : undefined,
+          // #3664: implicitlyLoadedAfterOneOf — 이 chunk 가 로드되기 전 먼저 로드되는 모듈 id 들.
+          // getModuleInfo(manualChunks meta)로 양방향 관계 조회 가능. (청크 중복제거 최적화는 follow-up)
+          // 위에서 검증됨 → 여기선 undefined 이거나 유효한 string[]. 빈 배열은 undefined 로.
+          chunkImplicitlyLoadedAfterOneOf:
+            Array.isArray(f.implicitlyLoadedAfterOneOf) && f.implicitlyLoadedAfterOneOf.length > 0
+              ? (f.implicitlyLoadedAfterOneOf as string[])
+              : undefined,
         });
         if (typeof chunkRef !== 'string') {
           throw new Error(

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -424,7 +424,13 @@ pub const NapiPlugin = struct {
             defer if (chunk_name) |n| native_alloc.free(n);
             const chunk_file_name = getObjectString(env, argv[0], "chunkFileName", native_alloc);
             defer if (chunk_file_name) |f| native_alloc.free(f);
-            const cref = store.emitChunk(chunk_id, chunk_name, chunk_file_name) catch return js_null;
+            // #3664: implicitlyLoadedAfterOneOf — chunk 가 로드되기 전 먼저 로드되는 모듈 id 들.
+            const implicit = common.getObjectStringArray(env, argv[0], "chunkImplicitlyLoadedAfterOneOf", native_alloc);
+            defer if (implicit) |arr| {
+                for (arr) |s| native_alloc.free(s);
+                native_alloc.free(arr);
+            };
+            const cref = store.emitChunk(chunk_id, chunk_name, chunk_file_name, implicit orelse &.{}) catch return js_null;
             var js_cref: c.napi_value = undefined;
             if (c.napi_create_string_utf8(env, cref.ptr, cref.len, &js_cref) != c.napi_ok) return js_null;
             return js_cref;

--- a/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
+++ b/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
@@ -331,4 +331,93 @@ describe('@zntc/core build + plugins - this.emitFile chunk (PR7-2b-i)', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // #3664 P3: implicitlyLoadedAfterOneOf — emit chunk 가 "이들 중 하나 로드 후 로드"된다는 관계를
+  // 양방향으로 graph 에 기록. getModuleInfo(manualChunks meta)로 조회. (청크 중복제거는 follow-up)
+  test('implicitlyLoadedAfterOneOf 관계가 getModuleInfo 양방향으로 보고된다', async () => {
+    let workerAfter: string[] | undefined;
+    let mainBefore: string[] | undefined;
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-implicit-'));
+    const mainPath = join(dir, 'main.ts');
+    const workerPath = join(dir, 'worker.ts');
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-implicit',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          async function (this: RollupPluginContext, args: { path: string }) {
+            const r = await this.resolve('./worker.ts', args.path);
+            // worker 는 main(이 모듈)이 먼저 로드된 뒤에 implicitly 로드된다고 선언.
+            this.emitFile({ type: 'chunk', id: r!.id, implicitlyLoadedAfterOneOf: [args.path] });
+            return null;
+          },
+        );
+      },
+    };
+    try {
+      writeFileSync(workerPath, 'export const w = 99;\nconsole.log("wk");\n');
+      writeFileSync(mainPath, 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [mainPath],
+        plugins: [plugin],
+        splitting: true,
+        // graph-wide getModuleInfo 는 manualChunks meta 에서만 노출. main(entry)은 항상 호출되므로
+        // 거기서 조회한다. 키는 graph 가 준 id(realpath)를 써야 함 — tmpdir /var→/private/var
+        // symlink 때문에 테스트가 만든 경로와 graph 키가 다를 수 있다(직접 join 경로로 조회 금지).
+        manualChunks: (id, meta) => {
+          if (id.includes('main.ts')) {
+            mainBefore = meta.getModuleInfo(id)?.implicitlyLoadedBefore as string[];
+            const workerKey = mainBefore?.find((p) => p.includes('worker.ts'));
+            if (workerKey) {
+              workerAfter = meta.getModuleInfo(workerKey)?.implicitlyLoadedAfterOneOf as string[];
+            }
+          }
+          return null;
+        },
+      });
+      expect(result.errors.length).toBe(0);
+      // 정방향: worker.implicitlyLoadedAfterOneOf 에 main 포함.
+      expect(workerAfter).toBeDefined();
+      expect(workerAfter!.some((p) => p.includes('main.ts'))).toBe(true);
+      // 역방향: main.implicitlyLoadedBefore 에 worker 포함.
+      expect(mainBefore).toBeDefined();
+      expect(mainBefore!.some((p) => p.includes('worker.ts'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('implicitlyLoadedAfterOneOf 의 id 가 graph 에 없으면 build 진단', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-implicit-bad-'));
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-implicit-bad',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          async function (this: RollupPluginContext, args: { path: string }) {
+            const r = await this.resolve('./worker.ts', args.path);
+            // graph 에 없는 id — Rollup 도 "유일 chunk 연결 불가" 에러.
+            this.emitFile({
+              type: 'chunk',
+              id: r!.id,
+              implicitlyLoadedAfterOneOf: [join(dir, 'ghost.ts')],
+            });
+            return null;
+          },
+        );
+      },
+    };
+    try {
+      writeFileSync(join(dir, 'worker.ts'), 'export const w = 1;\n');
+      writeFileSync(join(dir, 'main.ts'), 'export const x = 1;\n');
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/bundler/emit_store.zig
+++ b/src/bundler/emit_store.zig
@@ -26,6 +26,10 @@ pub const EmittedChunk = struct {
     /// 최종 출력 파일명 (#1880 PR7-2c). 명시 fileName 이면 emit 시 즉시 set(hash 없음);
     /// name/auto 면 청킹+렌더 후 bundler 가 back-fill([name]-[hash] 확정). getFileName 이 read.
     file_name: ?[]const u8 = null,
+    /// `implicitlyLoadedAfterOneOf` (Rollup #3606, #3664): 이 chunk 가 로드되기 전 먼저 로드돼
+    /// 있다고 보장되는 모듈 id 들. injectEmittedChunks 가 resolve 해 양방향 관계를 graph 에 기록.
+    /// 각 string + 바깥 slice 모두 `EmitStore.allocator` 소유.
+    implicitly_loaded_after_one_of: []const []const u8 = &.{},
 };
 
 /// plugin `this.emitFile` 수집소 (#1880 PR5).
@@ -67,6 +71,8 @@ pub const EmitStore = struct {
         for (self.chunks.items) |chk| {
             self.allocator.free(chk.reference_id);
             self.allocator.free(chk.id);
+            for (chk.implicitly_loaded_after_one_of) |s| self.allocator.free(s);
+            if (chk.implicitly_loaded_after_one_of.len > 0) self.allocator.free(chk.implicitly_loaded_after_one_of);
             if (chk.name) |n| self.allocator.free(n);
             if (chk.file_name) |f| self.allocator.free(f);
         }
@@ -124,7 +130,13 @@ pub const EmitStore = struct {
     /// chunk emit 요청을 등록하고 reference id ("chunk-N") 를 반환한다 (#1880 PR7-2).
     /// id/name/file_name 은 dupe 로 소유. file_name 명시(fileName) 면 getFileName 즉시 가능;
     /// 미지정(name/auto)이면 bundler 가 청킹 후 `setChunkFileName` 으로 back-fill (PR7-2c).
-    pub fn emitChunk(self: *EmitStore, id: []const u8, name: ?[]const u8, file_name: ?[]const u8) ![]const u8 {
+    pub fn emitChunk(
+        self: *EmitStore,
+        id: []const u8,
+        name: ?[]const u8,
+        file_name: ?[]const u8,
+        implicitly_loaded_after_one_of: []const []const u8,
+    ) ![]const u8 {
         const reference_id = try std.fmt.allocPrint(self.allocator, "chunk-{d}", .{self.counter});
         errdefer self.allocator.free(reference_id);
         const id_owned = try self.allocator.dupe(u8, id);
@@ -133,11 +145,30 @@ pub const EmitStore = struct {
         errdefer if (name_owned) |n| self.allocator.free(n);
         const fname_owned: ?[]const u8 = if (file_name) |f| try self.allocator.dupe(u8, f) else null;
         errdefer if (fname_owned) |f| self.allocator.free(f);
+        // implicitlyLoadedAfterOneOf: 각 string + 바깥 slice 를 dupe 로 소유.
+        const implicit_owned: []const []const u8 = if (implicitly_loaded_after_one_of.len > 0) blk: {
+            const arr = try self.allocator.alloc([]const u8, implicitly_loaded_after_one_of.len);
+            var done: usize = 0;
+            errdefer {
+                for (arr[0..done]) |s| self.allocator.free(s);
+                self.allocator.free(arr);
+            }
+            for (implicitly_loaded_after_one_of, 0..) |s, i| {
+                arr[i] = try self.allocator.dupe(u8, s);
+                done = i + 1;
+            }
+            break :blk arr;
+        } else &.{};
+        errdefer if (implicit_owned.len > 0) {
+            for (implicit_owned) |s| self.allocator.free(s);
+            self.allocator.free(implicit_owned);
+        };
         try self.chunks.append(self.allocator, .{
             .reference_id = reference_id,
             .id = id_owned,
             .name = name_owned,
             .file_name = fname_owned,
+            .implicitly_loaded_after_one_of = implicit_owned,
         });
         self.counter += 1;
         return reference_id;
@@ -206,8 +237,8 @@ test "emitChunk 는 chunk-N reference id 를 발급하고 요청을 수집한다
     var store = EmitStore.init(testing.allocator, "[name]-[hash]");
     defer store.deinit();
 
-    const c0 = try store.emitChunk("./worker.ts", null, null);
-    const c1 = try store.emitChunk("./route.ts", "route", null);
+    const c0 = try store.emitChunk("./worker.ts", null, null, &.{});
+    const c1 = try store.emitChunk("./route.ts", "route", null, &.{});
     try testing.expectEqualStrings("chunk-0", c0);
     try testing.expectEqualStrings("chunk-1", c1);
     try testing.expectEqual(@as(usize, 2), store.chunks.items.len);
@@ -224,11 +255,11 @@ test "emitChunk file_name: 명시 fileName 은 즉시 getFileName, auto 는 setC
     defer store.deinit();
 
     // 명시 fileName → 즉시 조회 가능 (hash 없음).
-    const c_explicit = try store.emitChunk("/abs/lib.ts", null, "lib.js");
+    const c_explicit = try store.emitChunk("/abs/lib.ts", null, "lib.js", &.{});
     try testing.expectEqualStrings("lib.js", store.getFileName(c_explicit).?);
 
     // auto(name) → 청킹 전 null, back-fill 후 확정.
-    const c_auto = try store.emitChunk("/abs/worker.ts", "worker", null);
+    const c_auto = try store.emitChunk("/abs/worker.ts", "worker", null, &.{});
     try testing.expect(store.getFileName(c_auto) == null);
     try store.setChunkFileName("/abs/worker.ts", "worker-abc12345.js");
     try testing.expectEqualStrings("worker-abc12345.js", store.getFileName(c_auto).?);
@@ -244,7 +275,7 @@ test "asset/chunk reference id 는 공유 카운터로 서로 유니크하다" {
     defer store.deinit();
 
     const a0 = try store.emitAsset("a.css", "x");
-    const c1 = try store.emitChunk("./b.ts", null, null);
+    const c1 = try store.emitChunk("./b.ts", null, null, &.{});
     const a2 = try store.emitAsset("c.css", "y");
     try testing.expectEqualStrings("asset-0", a0);
     try testing.expectEqualStrings("chunk-1", c1);

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -346,6 +346,76 @@ fn injectEmittedChunks(self: *ModuleGraph) !void {
             }
         }
     }
+
+    // implicitlyLoadedAfterOneOf (#3664): 모든 emit chunk 가 graph 에 추가된 *뒤* 양방향 관계를
+    // 배선한다. fixpoint 안에서 하면 parent 가 더 나중 패스에 추가되는 emit chunk 일 때 미존재로
+    // 오판해 헛 진단이 난다 → 루프 종료 후 일괄 처리(이때 모든 emit chunk 가 path_to_module 에 있음).
+    // 인덱스는 이후 finalizeGraph 의 renumber 가 remap 한다(renumber.zig).
+    for (store.chunks.items) |chk| {
+        if (chk.implicitly_loaded_after_one_of.len == 0) continue;
+        const e_idx = resolveExistingModuleIndex(self, source_dir, chk.id) orelse continue;
+        try wireImplicitlyLoaded(self, e_idx, chk.implicitly_loaded_after_one_of, source_dir);
+    }
+}
+
+/// implicitlyLoadedAfterOneOf (#3664, Rollup #3606): emit chunk(e_idx)이 "이들 중 하나가 먼저
+/// 로드된 뒤에 로드"된다는 관계를 양방향으로 graph 에 기록한다. E.implicitly_loaded_after_one_of
+/// += [parent], parent.implicitly_loaded_before += [E]. getModuleInfo(manualChunks meta)가 보고.
+/// **데이터만** — 이 관계를 chunk 중복제거에 반영하는 최적화는 follow-up. 부모 id 는 이미 graph 에
+/// 있어야 한다(Rollup 도 "유일 chunk 연결" 요구) → 미존재 시 진단(silent drop 금지).
+fn wireImplicitlyLoaded(self: *ModuleGraph, e_idx: ModuleIndex, ids: []const []const u8, source_dir: []const u8) !void {
+    if (ids.len == 0) return;
+    const ei = @intFromEnum(e_idx);
+    if (ei >= self.modules.count()) return;
+    for (ids) |raw_id| {
+        const parent_idx = resolveExistingModuleIndex(self, source_dir, raw_id) orelse {
+            self.addDiag(
+                .plugin_error,
+                .@"error",
+                raw_id,
+                .{ .start = 0, .end = 0 },
+                .resolve,
+                "this.emitFile({ type: 'chunk', implicitlyLoadedAfterOneOf }) id is not in the module graph.",
+                "Pass an id reachable from an existing entry (a user entry or a previously emitted chunk).",
+            );
+            continue;
+        };
+        if (parent_idx == e_idx) continue; // self-reference 무시
+        const pi = @intFromEnum(parent_idx);
+        if (pi >= self.modules.count()) continue;
+        try appendUniqueModuleIndex(self.allocator, &self.modules.at(ei).implicitly_loaded_after_one_of, parent_idx);
+        try appendUniqueModuleIndex(self.allocator, &self.modules.at(pi).implicitly_loaded_before, e_idx);
+    }
+}
+
+fn appendUniqueModuleIndex(allocator: std.mem.Allocator, list: *std.ArrayList(ModuleIndex), val: ModuleIndex) !void {
+    for (list.items) |x| {
+        if (x == val) return;
+    }
+    try list.append(allocator, val);
+}
+
+/// id 를 *이미 graph 에 있는* 모듈 index 로 해석한다 (신규 추가 안 함 — implicit 부모는 존재해야).
+/// graph 키(abs/이미 등록)면 직접, 상대/bare 면 resolve 후 abs 로 lookup. 미존재면 null.
+fn resolveExistingModuleIndex(self: *ModuleGraph, source_dir: []const u8, id: []const u8) ?ModuleIndex {
+    if (self.path_to_module.get(id)) |idx| return idx;
+    if (std.fs.path.isAbsolute(id)) return null; // abs 는 위에서 이미 시도됨
+    const resolved = self.resolve_cache.resolveThreadSafe(source_dir, id, .static_import) catch return null;
+    const m_union = resolved orelse return null;
+    switch (m_union) {
+        .file => |f| {
+            defer {
+                self.allocator.free(f.path);
+                if (f.resolve_dir) |d| self.allocator.free(d);
+            }
+            return self.path_to_module.get(f.path);
+        },
+        .disabled => |d| {
+            self.allocator.free(d.path);
+            return null;
+        },
+        else => return null,
+    }
 }
 
 fn applyRuntimePolyfills(self: *ModuleGraph, runtime_indices: *std.ArrayList(ModuleIndex)) !void {

--- a/src/bundler/graph/renumber.zig
+++ b/src/bundler/graph/renumber.zig
@@ -97,6 +97,10 @@ pub fn renumberModulesDeterministically(
         remapList(&m.importers, old_to_new);
         remapList(&m.dynamic_imports, old_to_new);
         remapList(&m.dynamic_importers, old_to_new);
+        // #3664: implicitlyLoadedAfterOneOf 양방향 관계도 ModuleIndex 보유 → renumber 시 remap.
+        // (injectEmittedChunks 가 renumber 전에 채우므로 안 하면 stale 인덱스 → 엉뚱한 모듈 보고.)
+        remapList(&m.implicitly_loaded_after_one_of, old_to_new);
+        remapList(&m.implicitly_loaded_before, old_to_new);
         for (m.import_records) |*rec| {
             if (rec.resolved.isNone()) continue;
             rec.resolved = @enumFromInt(old_to_new[rec.resolved.toU32()]);

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -254,6 +254,14 @@ pub const Module = struct {
     /// 나를 dynamic import 하는 모듈들 (역방향). `ModuleGraph.linkDynamicImport` 가 채움.
     dynamic_importers: std.ArrayList(ModuleIndex),
 
+    /// `this.emitFile({ type:'chunk', implicitlyLoadedAfterOneOf })` (Rollup #3606, #3664):
+    /// 이 모듈이 implicitly 로드되기 전에 이들 중 하나가 먼저 로드돼 있다고 plugin 이 보장한 모듈들.
+    /// injectEmittedChunks 가 채우고 getModuleInfo 가 보고(manualChunks meta). 데이터만 —
+    /// 청크 중복제거 최적화는 follow-up.
+    implicitly_loaded_after_one_of: std.ArrayList(ModuleIndex) = .empty,
+    /// 위의 역방향 — 이 모듈이 먼저 로드된 뒤 implicitly 로드되는 모듈들.
+    implicitly_loaded_before: std.ArrayList(ModuleIndex) = .empty,
+
     module_type: ModuleType,
     /// 모듈의 로딩 방식 (file/dataurl/text/binary/copy 등).
     /// addModule에서 확장자 또는 --loader 옵션으로 결정.
@@ -655,6 +663,8 @@ pub const Module = struct {
         self.importers.deinit(allocator);
         self.dynamic_imports.deinit(allocator);
         self.dynamic_importers.deinit(allocator);
+        self.implicitly_loaded_after_one_of.deinit(allocator);
+        self.implicitly_loaded_before.deinit(allocator);
         if (self.resolve_dir) |dir| allocator.free(dir);
         if (self.federation_id) |id| allocator.free(id); // #3318 P1-1 (setBoundary alloc)
         for (self.resolved_deps.items) |dep| {

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -98,6 +98,11 @@ pub const PersistentModuleStore = struct {
         cached_module.importers = .empty;
         cached_module.dynamic_imports = .empty;
         cached_module.dynamic_importers = .empty;
+        // #3664: implicitlyLoadedAfterOneOf 양방향 관계 리스트도 ModuleIndex ArrayList backing 을
+        // graph module 과 공유 → 위 4개와 동일하게 store 복사본은 빈 상태로(graph deinit 이 원본
+        // 해제, store 가 dangling 안 되도록). 다음 rebuild 의 injectEmittedChunks 가 재구성.
+        cached_module.implicitly_loaded_after_one_of = .empty;
+        cached_module.implicitly_loaded_before = .empty;
 
         // parse_arena / alias_table 소유권 이전: module → store.
         // alias_table 은 AliasTable struct (ArrayList backing) 로 graph module 과

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -216,10 +216,10 @@ pub fn getModuleInfo(graph_opaque: ?*const anyopaque, id: []const u8) ?ModuleInf
         .code = if (m.is_external or m.source.len == 0) null else m.source,
         .is_included = m.is_included,
         .exports = if (m.is_external) &.{} else m.exported_names,
-        // Phase B (plugin context API) 까지 placeholder 값.
         .synthetic_named_exports = m.synthetic_named_exports != null,
-        .implicitly_loaded_after_one_of = &.{},
-        .implicitly_loaded_before = &.{},
+        // #3664: injectEmittedChunks 가 채운 implicitlyLoadedAfterOneOf 양방향 관계 (Rollup 호환).
+        .implicitly_loaded_after_one_of = m.implicitly_loaded_after_one_of.items,
+        .implicitly_loaded_before = m.implicitly_loaded_before.items,
         .meta = m.plugin_meta,
     };
 }


### PR DESCRIPTION
## 무엇을

plugin `this.emitFile({ type:'chunk', implicitlyLoadedAfterOneOf:[...] })` 의 "이 chunk 는 이들 중 하나가 먼저 로드된 뒤 로드된다"는 관계를 graph 에 **양방향 기록**하고 `getModuleInfo` 로 보고합니다 (Rollup [#3606](https://github.com/rollup/rollup/pull/3606) 호환).

**데이터 배선 parity 만** 구현합니다 — 이 관계를 chunk 중복제거에 반영하는 최적화(implicit edge → reachability)는 별도 follow-up(dynamic-edge 매핑)으로 진행합니다.

## 왜

#3664 의 남은 항목. 지금까지 `implicitlyLoadedAfterOneOf`/`implicitlyLoadedBefore` 는 항상 빈 배열 placeholder 였습니다. 채우면 Rollup 호환 plugin(특히 멀티페이지 HTML — 페이지별 chunk emit)이 관계를 정확히 읽을 수 있습니다.

## 변경

- **`EmittedChunk.implicitly_loaded_after_one_of`**(소유) + `emitChunk` 파라미터.
- **`index.ts`**: `f.implicitlyLoadedAfterOneOf` → native `chunkImplicitlyLoadedAfterOneOf`. 지정 시 `string[]` 검증, 위반하면 **throw**(`id` 와 동일 — silent-drop 으로 load-order 선언이 조용히 사라지는 것 방지).
- **`plugin_bridge`**: `getObjectStringArray` 로 배열 읽어 전달.
- **`Module.implicitly_loaded_after_one_of` / `_before`**(양방향) + deinit.
- **`build_flow`**: fixpoint 루프 **종료 후** 일괄 wiring(모든 emit chunk 가 graph 에 든 뒤 → parent 가 나중 emit chunk 라도 resolve). 부모 미존재 시 진단(Rollup 의 "유일 chunk 연결" 요구 동형).
- **`types.getModuleInfo`**: placeholder `&.{}` → 실제 Module 필드 보고.

> 관측 경로: graph-wide `getModuleInfo` 는 manualChunks `meta` 에만 노출되므로, 관계도 그 surface 로 조회합니다(테스트도 동일).

## code-review max 반영 (모두 수정)

- **renumber 누락 (데이터 정합성, 최고 심각도)**: `renumberModulesDeterministically` 가 dependencies 등은 remap 하나 신규 `implicitly_loaded_*` ModuleIndex 리스트는 안 함 → injectEmittedChunks(renumber 전)에 채운 인덱스가 stale → 엉뚱한 모듈 보고. `remapList` 2개 추가.
- **cache-hit aliasing (메모리 안전)**: `module_store.putModule` 이 4개 edge 리스트만 `.empty` reset → 신규 2개가 graph 와 backing 공유 → 증분 리빌드 double-free(`alias_table` 와 동일 버그류). `.empty` reset 추가.
- **forward-ref 타이밍**: inline wiring → post-loop 일괄 pass 로 이동(나중 emit 되는 parent 에 대한 헛 진단 방지).
- 검증으로 기각: emitChunk errdefer(double-free 없음), append aliasing(StableSegmentedList 안정 포인터), self-ref guard.

## 한계 (follow-up)

- **(2) chunk 중복제거 최적화** 미포함 — implicit edge 를 splitter reachability 에 반영하는 건 별도 PR.
- 테스트는 2-모듈이라 renumber 가 identity 순열 → renumber remap 회귀를 직접 잡진 못함(다중 entry fixture 는 follow-up). 단 경로 정확성(`includes('main.ts')`/`worker.ts`)은 검증.

## 검증

- `plugin-emit-chunk.ts` **+2** (양방향 관계 manualChunks meta 조회 / 미해결 id 진단). 전체 emit-chunk 11개.
- build-plugins **61 pass** 회귀 0, `zig build test` 통과, `tsc` 통과, ReleaseFast napi.

Refs #3664

🤖 Generated with [Claude Code](https://claude.com/claude-code)