### PR TITLE
feat(bundler): implicitlyLoadedAfterOneOf chunk bit-collapse (#3664 P3-(2))

### DIFF
--- a/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
+++ b/packages/core/test/core/build-plugins/plugin-emit-chunk.ts
@@ -420,4 +420,56 @@ describe('@zntc/core build + plugins - this.emitFile chunk (PR7-2b-i)', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // #3664 (2): implicitlyLoadedAfterOneOf bit-collapse — main 과 emit chunk(worker)가 공유하는
+  // 모듈이 main chunk 로 흡수돼 별도 공통 청크가 생기지 않는다(Rollup #3606 chunk-shape 동형).
+  test('implicitlyLoadedAfterOneOf: 공유 모듈이 parent(main) chunk 로 흡수된다 (bit-collapse)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-emit-chunk-collapse-'));
+    const plugin: ZntcPlugin = {
+      name: 'emit-chunk-collapse',
+      setup(build) {
+        build.onTransform(
+          { filter: /main\.ts$/ },
+          async function (this: RollupPluginContext, args: { path: string }) {
+            const r = await this.resolve('./worker.ts', args.path);
+            // worker 는 main 이 먼저 로드된 뒤 로드 → 공유(shared)는 main chunk 에서 직접 참조 가능.
+            this.emitFile({ type: 'chunk', id: r!.id, implicitlyLoadedAfterOneOf: [args.path] });
+            return null;
+          },
+        );
+      },
+    };
+    try {
+      // 고유 마커 424242 로 shared 의 청크 귀속을 추적.
+      writeFileSync(join(dir, 'shared.ts'), 'export const SHARED = 424242;\n');
+      writeFileSync(
+        join(dir, 'main.ts'),
+        'import { SHARED } from "./shared.ts";\nexport const m = SHARED + 1;\n',
+      );
+      writeFileSync(
+        join(dir, 'worker.ts'),
+        'import { SHARED } from "./shared.ts";\nconsole.log(SHARED);\n',
+      );
+      const result = await build({
+        entryPoints: [join(dir, 'main.ts')],
+        plugins: [plugin],
+        splitting: true,
+      });
+      expect(result.errors.length).toBe(0);
+      const jsChunks = result.outputFiles.filter((f) => f.path.endsWith('.js'));
+      const mainChunk = jsChunks.find((f) => f.path.includes('main'));
+      const workerChunk = jsChunks.find((f) => f.path.includes('worker'));
+      expect(mainChunk).toBeDefined();
+      expect(workerChunk).toBeDefined();
+      // collapse: shared 정의(424242)가 main chunk 로 흡수된다(별도 공통 청크면 main 은 import 만 함).
+      expect(mainChunk!.text).toContain('424242');
+      // worker 는 shared 를 main chunk 에서 import — shared 가 main 으로 합쳐졌음을 직접 증명.
+      expect(workerChunk!.text).toMatch(/from\s*["']\.\/main[\w.-]*\.js["']/);
+      // main/worker 외 별도 공통 청크(shared 전용)가 생기지 않는다.
+      const otherChunks = jsChunks.filter((f) => f !== mainChunk && f !== workerChunk);
+      expect(otherChunks.length).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -459,6 +459,15 @@ fn addDynamicEntry(
     try entries.append(allocator, .{ .module_idx = idx, .is_dynamic = true });
 }
 
+/// entries 에서 module_idx 의 entry bit(= entries 인덱스)를 찾는다. 없으면 null(entry 청크 아님).
+/// #3664 (2) implicitlyLoadedAfterOneOf bit-collapse 의 parent/E bit lookup 용.
+fn entryBit(entries: []const EntryInfo, idx: ModuleIndex) ?u32 {
+    for (entries, 0..) |e, bit| {
+        if (e.module_idx == idx) return @intCast(bit);
+    }
+    return null;
+}
+
 pub fn generateChunks(
     allocator: std.mem.Allocator,
     graph: *const ModuleGraph,
@@ -797,6 +806,41 @@ pub fn generateChunks(
         for (splitting_info) |*bs| {
             if (!bs.hasAnyBitInRange(@intCast(entry_count), @intCast(manual_count))) continue;
             bs.clearBitRange(0, @intCast(entry_count));
+        }
+    }
+
+    // #3664 (2): implicitlyLoadedAfterOneOf bit-collapse. emit chunk E 가 "parent 중 하나 로드 후
+    // 로드"됨이 plugin 보장이면, E 와 parent 가 공유하는 모듈에서 E 비트를 지워 parent 의 청크
+    // 패턴으로 흡수한다 → 별도 공통 청크(파일) 1개를 줄인다(Rollup #3606 의 chunk-shape 최적화).
+    // ※ byte 중복은 ZNTC BitSet 모델상 원래 없음(공유 모듈은 항상 단일 공통 청크) — 이건 파일 수
+    //   감소이지 중복 제거가 아니다.
+    // soundness: parent 는 실제 entry 청크(bit 보유)여야 흡수가 안전(E 보다 먼저 로드 보장). entry
+    // 가 아니면 보수적으로 skip(정확성 유지, 최적화만 포기). E 의 facade(자기 모듈)는 e_bit 유지.
+    {
+        var ei: usize = 0;
+        while (ei < module_count) : (ei += 1) {
+            const em = graph.getModule(ModuleIndex.fromUsize(ei)) orelse continue;
+            if (!em.is_emitted_chunk_entry) continue;
+            const parents = em.implicitly_loaded_after_one_of.items;
+            // soundness — "one-of" 는 parent 중 *하나만* 로드 보장한다. parent 가 여럿이면 E 가 어느
+            // parent 뒤에 로드될지 알 수 없어, 한 parent 와만 공유하는 모듈을 그 parent chunk 로
+            // 합치면 다른 경로(다른 parent 뒤)에서 미로드 → 런타임 깨짐. 올바른 흡수는 "모든 parent
+            // 경로에서 보장되는 모듈"(intersection)뿐인데, 단일 parent 면 그게 곧 그 parent 와의
+            // 공유다. 따라서 **단일 parent 일 때만** 흡수하고, 다중 parent 는 보수적으로 skip한다
+            // (별도 공통 청크 유지 — 정확성 보존, 파일수 최적화만 포기). (Rollup #3606 intersection 의미)
+            if (parents.len != 1) continue;
+            const e_bit = entryBit(entries.items, ModuleIndex.fromUsize(ei)) orelse continue;
+            const p_bit = entryBit(entries.items, parents[0]) orelse continue; // parent 가 entry 청크 아니면 skip
+            if (p_bit == e_bit) continue;
+            // parent 는 eager(non-dynamic user entry)여야 E 보다 먼저 로드됨이 보장된다. lazy(dynamic
+            // import / 다른 emit chunk) parent 는 자기도 로드 안 될 수 있어 흡수가 unsound → skip.
+            if (entries.items[p_bit].is_dynamic) continue;
+            for (splitting_info, 0..) |*bs, mi| {
+                if (mi == ei) continue; // E facade 모듈은 e_bit 유지(E 청크 보존)
+                if (!bs.hasBit(e_bit)) continue;
+                if (!bs.hasBit(p_bit)) continue;
+                bs.clearBit(e_bit); // 단일 eager parent 와 공유 → parent 청크 패턴으로 흡수
+            }
         }
     }
 


### PR DESCRIPTION
## 무엇을

emit chunk E 가 `implicitlyLoadedAfterOneOf:[parent]` 로 "parent 로드 후 로드"됨을 보장하면, **E 와 parent 가 공유하는 모듈을 parent 의 청크로 흡수**해 별도 공통 청크(파일) 1개를 줄입니다 (Rollup [#3606](https://github.com/rollup/rollup/pull/3606) chunk-shape 최적화).

#3664 implicitlyLoaded 의 (2) 최적화 단계 — (1) 데이터 배선(#3670 머지)에 이어집니다.

## 설계상 솔직한 메모

ZNTC 의 **BitSet reachability 모델은 공유 모듈을 항상 단일 공통 청크로 분리**하므로, Rollup #3606 이 푸는 *byte 중복은 ZNTC 엔 원래 없습니다*. 이 변경은 **파일 수 감소**(공통 청크 → parent 흡수)이지 중복 제거가 아닙니다. (Plan 단계에서 추적·확인 — 커밋 메시지에 명시.)

## 구현 (`chunk.zig` `generateChunks`, Phase 2 후 / Phase 3 전)

- emit chunk E 의 **단일 parent 가 eager(non-dynamic) entry** 면, `e_bit` 와 parent bit 를 둘 다 가진 모듈에서 `e_bit` 를 지워 parent 청크 패턴으로 흡수 (manual-chunk bit-clear 패턴과 동형). E facade 모듈은 `e_bit` 유지(E 청크 보존).
- `entryBit` 헬퍼: `module_idx` → `entries` 인덱스(= splitting bit).

## code-review max 반영 (critical soundness)

- **multi-parent(one-of) 비정합성**: `[A, B]` 는 A·B 중 *하나* 로드만 보장. A 하고만 공유하는 모듈을 A 청크로 흡수하면 E 가 B 뒤에 로드된 경로에서 A 청크 미로드 → **런타임 깨짐**. 올바른 의미는 intersection(모든 parent 경로 보장)이고 단일 parent 면 곧 그 공유 → **단일 parent 일 때만 흡수**, 다중은 보수적 skip(정확성 유지). greedy `clearBit` 의 order-dependence 도 함께 해소.
- **lazy parent**: dynamic import / 다른 emit chunk parent 는 자기도 로드 안 될 수 있어 흡수 unsound → **non-dynamic entry parent 만 허용**. nested implicit chain(parent 가 emit chunk)도 이 게이트로 안전 skip.
- 검증으로 안전 확인: bit numbering(Phase 2 BFS 와 `entryBit` 동일 인덱스), bit 범위, `preserve_modules`(별도 함수라 구조적 제외).

## 검증

- `plugin-emit-chunk.ts` **+1** (단일 eager parent collapse — shared 가 main 으로 흡수, worker 는 main 에서 import, 별도 공통 청크 없음).
- build-plugins **62 pass** 회귀 0, `zig build test` 통과(청킹/splitting 회귀 0), ReleaseFast napi.

## 한계 (follow-up)

- 다중/lazy parent 흡수(intersection 정밀화) 미지원 — 보수적 skip(정확성 유지).
- `entryBit` O(n) — 대규모 emit chunk 시 map 화.

Refs #3664

🤖 Generated with [Claude Code](https://claude.com/claude-code)