### PR TITLE
fix(dev): sass @import reverse-dep tracking — partial 변경 시 root scss 재컴파일

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -1947,6 +1947,12 @@ async function runServe(opts, config, { appDev = null } = {}) {
               } else {
                 await rebuildAppDevFull();
               }
+            } else if (paths.some((p) => p.endsWith('.scss') || p.endsWith('.sass'))) {
+              // #71: sass 변경인데 fast-path 자격 없음(다른 root scss 가 @import 하는 partial,
+              // 또는 다중 sass 변경) → full pipeline rebuild 로 dirty 의 transitive dependents 까지
+              // 재컴파일. CSS-only 분기(afterBundle = postcss only)는 sass 를 재컴파일하지 않아
+              // partial 변경 시 root scss 가 stale 로 남는다(code-review max 적발).
+              await rebuildAppDevFull(paths);
             } else if (cssChanges.length === 1 && paths.length === 1) {
               await rebuildAppDevCss(cssChanges[0]);
             } else {

--- a/packages/web/src/dev-controller.test.ts
+++ b/packages/web/src/dev-controller.test.ts
@@ -3,11 +3,13 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import {
   cleanupPostcssTempRoot,
   createAppDevController,
   prepareAppCssPipelineRoot,
+  recordSassReverseDep,
 } from './dev-controller.ts';
 
 const fallbackRequire = createRequire(import.meta.url);
@@ -149,6 +151,32 @@ describe('createAppDevController', () => {
     expect(c.isSassOnlyChange('/x/style.css')).toBe(false);
   });
 
+  // #71: 실제 sass @use 컴파일로 reverse-dep 맵이 채워지는지(partial → 그것을 쓰는 root scss).
+  // isSassOnlyChange 는 이 맵을 toTemp 후 조회하므로, 맵이 맞으면 fast-path 라우팅도 정확하다.
+  test('prepareAppCssPipelineRoot — @use partial 의 reverse-dep 을 채운다(#71)', async () => {
+    touch('src/style.scss', "@use './vars';\n.x { color: vars.$c; }\n");
+    touch('src/_vars.scss', '$c: red;\n');
+    const reverseDep = new Map<string, Set<string>>();
+    const result = await prepareAppCssPipelineRoot(
+      dir,
+      join(dir, 'dist'),
+      { mode: 'development' },
+      'silent',
+      'dev',
+      deps(),
+      { sassReverseDep: reverseDep },
+    );
+    expect(result).not.toBeNull();
+    if (!result) return;
+    const varsTemp = join(result.tempRoot, 'src', '_vars.scss');
+    const styleTemp = join(result.tempRoot, 'src', 'style.scss');
+    // _vars.scss 의 dependent 에 style.scss — partial 변경 시 style 을 재컴파일하도록.
+    expect(reverseDep.get(varsTemp)?.has(styleTemp)).toBe(true);
+    // self(style)는 reverse 에서 제외.
+    expect(reverseDep.has(styleTemp)).toBe(false);
+    cleanupPostcssTempRoot(result.tempRoot);
+  });
+
   test('hrefFor — .css 는 base + rel, 그 외엔 primary fallback', () => {
     const c = controller();
     expect(c.hrefFor(join(dir, 'style.css'))).toBe('/style.css');
@@ -159,5 +187,22 @@ describe('createAppDevController', () => {
   test('rebuildScssIncremental — pipelineRoot 없으면 null', async () => {
     const c = controller();
     expect(await c.rebuildScssIncremental(join(dir, 'x.scss'))).toBeNull();
+  });
+});
+
+describe('recordSassReverseDep (#71)', () => {
+  test('reverse-dep 구축 + self 제외 + 누적', () => {
+    const map = new Map<string, Set<string>>();
+    const style = '/t/style.scss';
+    // loadedUrls 에 self(style) 도 포함되지만 reverse 에서 제외돼야 한다.
+    recordSassReverseDep(map, style, [pathToFileURL('/t/_vars.scss'), pathToFileURL(style)]);
+    expect(map.get('/t/_vars.scss')?.has(style)).toBe(true);
+    expect(map.has(style)).toBe(false); // self 제외 — style 이 자기 자신의 dep 으로 기록되지 않음
+
+    // 다른 root 가 같은 partial 을 import → dependents 누적.
+    const theme = '/t/theme.scss';
+    recordSassReverseDep(map, theme, [pathToFileURL('/t/_vars.scss')]);
+    expect(map.get('/t/_vars.scss')?.size).toBe(2);
+    expect(map.get('/t/_vars.scss')?.has(theme)).toBe(true);
   });
 });

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -9,6 +9,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { loadEnv, prepareAppDevSync } from '@zntc/core';
 
@@ -87,6 +88,10 @@ export interface PrepareAppCssPipelineRootOptions {
   dirtyPaths?: readonly string[] | null;
   /** 이전 prep 의 stylePipelineFiles + styleSourceFiles — 구조 변화 없으면 재사용. */
   cache?: PipelineCache | null;
+  /** sass @import reverse-dep 맵(tempRoot 기준 path): dep → 그 dep 을 import 한 파일들. dev 세션이
+   *  소유하고 prep 마다 갱신/조회한다. dirty 한 sass 가 다른 root scss 의 dep 이면 그 root 도 재컴파일
+   *  대상에 transitive 추가 — partial(`_x.scss`) 변경 시 stale CSS 방지 (#71). */
+  sassReverseDep?: Map<string, Set<string>> | null;
 }
 
 export interface AppCssPipelineResult {
@@ -233,6 +238,31 @@ function copyAppRootForPostcss(
  * Incremental — existingTempRoot + dirtyPaths 가 있으면 그 파일만 cp / 삭제 처리,
  * cache 가 있으면 stylePipelineFiles / styleSourceFiles tree walk 도 skip.
  */
+/** #71: sass `loadedUrls`(전이 @import, 자기 자신 포함)로 reverse-dep 맵(dep → 그것을 import 한
+ *  파일들)을 갱신. self/비-file URL 제외. dep 맵은 누적 — 삭제된 import 의 stale entry 는 과잉
+ *  재컴파일(느릴 뿐 correctness 안전)이라 정리하지 않는다. */
+export function recordSassReverseDep(
+  reverseDep: Map<string, Set<string>>,
+  file: string,
+  loadedUrls: readonly URL[],
+): void {
+  for (const url of loadedUrls) {
+    let dep: string;
+    try {
+      dep = fileURLToPath(url);
+    } catch {
+      continue;
+    }
+    if (dep === file) continue;
+    let set = reverseDep.get(dep);
+    if (!set) {
+      set = new Set();
+      reverseDep.set(dep, set);
+    }
+    set.add(file);
+  }
+}
+
 export async function prepareAppCssPipelineRoot(
   root: string,
   outdir: string,
@@ -242,7 +272,12 @@ export async function prepareAppCssPipelineRoot(
   deps: AppDevControllerDeps,
   options: PrepareAppCssPipelineRootOptions = {},
 ): Promise<AppCssPipelineResult | null> {
-  const { existingTempRoot = null, dirtyPaths = null, cache = null } = options;
+  const {
+    existingTempRoot = null,
+    dirtyPaths = null,
+    cache = null,
+    sassReverseDep = null,
+  } = options;
   const { fallbackRequire, cliNodeModules } = deps;
   const configPath = findPostcssConfig(root);
   // F1 cache: 이전 prep 의 stylePipelineFiles 를 재사용. 호출자가 구조 변화 (.scss/.module.css
@@ -267,6 +302,10 @@ export async function prepareAppCssPipelineRoot(
   }
 
   const toTemp = (path: string): string => join(tempRoot, relative(root, path));
+  // #71: sass 컴파일이 보고한 전이 @import(loadedUrls)로 reverse-dep 맵을 갱신. null 이면 no-op.
+  const recordSassDeps = (file: string, loadedUrls: readonly URL[]): void => {
+    if (sassReverseDep) recordSassReverseDep(sassReverseDep, file, loadedUrls);
+  };
   // F2 cache: styleSourceFiles 도 cache 재사용 — 구조 변화 없으면 .html/.js/.ts 트리 walk 회피.
   // postcss-only 경로 (preprocessor/module 모두 없음) 면 dead 라 빈 배열.
   const styleSourceFiles = !needsSource
@@ -284,6 +323,22 @@ export async function prepareAppCssPipelineRoot(
   if (isIncremental && dirtyPaths) {
     const dirtyTempPaths = dirtyPaths.map(toTemp);
     dirtySassSet = new Set(dirtyTempPaths.filter((p) => isCssPreprocessorFile(p)));
+    // #71: dirty sass 를 @import 한 root scss 도 재컴파일 대상에 transitive 추가(reverse-dep).
+    // partial(`_vars.scss`)만 dirty 여도 그것을 쓰는 `style.scss` 가 stale 로 남지 않도록.
+    if (sassReverseDep) {
+      const queue = [...dirtySassSet];
+      while (queue.length > 0) {
+        const dep = queue.pop() as string;
+        const dependents = sassReverseDep.get(dep);
+        if (!dependents) continue;
+        for (const dependent of dependents) {
+          if (!dirtySassSet.has(dependent)) {
+            dirtySassSet.add(dependent);
+            queue.push(dependent);
+          }
+        }
+      }
+    }
     dirtyModuleSet = new Set(dirtyTempPaths.filter((p) => isCssModuleFile(p)));
     // dirty `.module.scss` → sass 산출물 `.module.css` 도 css-modules dirty 입력에 포함.
     for (const sassDirty of dirtySassSet) {
@@ -305,7 +360,9 @@ export async function prepareAppCssPipelineRoot(
     styleSourceFiles,
     logLevel,
     fallbackRequire,
-    isIncremental ? { dirtyOnly: dirtySassSet, dirtySources: dirtySourceList } : undefined,
+    isIncremental
+      ? { dirtyOnly: dirtySassSet, dirtySources: dirtySourceList, onDeps: recordSassDeps }
+      : { onDeps: recordSassDeps },
   );
   // Incremental 모드에서 dirty 가 모두 non-CSS 면 postcss prep 도 skip — 이미 이전 prep
   // 결과가 tempRoot 에 살아 있다. CSS / SCSS / postcss config 가 dirty 일 때만 재실행.
@@ -386,6 +443,10 @@ export function createAppDevController(
   const base = normalizeBase(opts.base ?? opts.publicPath ?? '/');
   let cssDeps = new Set<string>();
   let cssDirDeps = new Set<string>();
+  // #71: sass @import reverse-dep 맵(tempRoot 기준 path). prepare(full pipeline) 와 fast-path
+  // (rebuildScssIncremental) 가 갱신하고, isSassOnlyChange 가 조회해 dep 있는 파일은 fast-path
+  // 박탈 → full pipeline 의 transitive 재컴파일로 dependents 까지 갱신. 세션 내내 누적.
+  const sassReverseDep = new Map<string, Set<string>>();
   let primaryHref: string | null = null;
   let pipelineRoot: string | null = null;
   // F1+F2 cache (incremental prep 에서 재사용). 구조 변화 (스타일 파일 추가/삭제) 시
@@ -412,6 +473,10 @@ export function createAppDevController(
         cleanupPostcssTempRoot(pipelineRoot);
         pipelineRoot = null;
         pipelineCache = null;
+        // #71: 새 tempRoot 가 mkdtemp 되므로 이전 tempRoot 기준의 reverse-dep 키는 모두 dead.
+        // 정리하지 않으면 prepare(null) 가 반복될 때 누적된다(현재 watch 는 단일 tempRoot 라 무해하나
+        // 방어적으로 clear — code-review max).
+        sassReverseDep.clear();
       }
       // 구조 변화 — 새 .scss/.module.css 가 추가됐거나 삭제됐을 가능성. cache 무효화.
       if (
@@ -429,8 +494,8 @@ export function createAppDevController(
         'dev',
         deps,
         reuseRoot
-          ? { existingTempRoot: pipelineRoot, dirtyPaths, cache: pipelineCache }
-          : undefined,
+          ? { existingTempRoot: pipelineRoot, dirtyPaths, cache: pipelineCache, sassReverseDep }
+          : { sassReverseDep },
       );
       pipelineRoot = pipeline?.tempRoot ?? null;
       pipelineCache = pipeline?.cache ?? null;
@@ -521,9 +586,16 @@ export function createAppDevController(
       return false;
     },
     isSassOnlyChange(absPath) {
-      // Sass fast-path 자격 — non-module `.scss/.sass` 단일 변경. import dep 추적 없으므로
-      // 이 파일을 import 한 다른 sass 파일은 갱신 누락 가능 (BACKLOG #71 deps tracking).
-      return isCssPreprocessorFile(absPath) && !isCssModulePreprocessorFile(absPath);
+      // Sass fast-path 자격 — non-module `.scss/.sass` 단일 변경.
+      if (!isCssPreprocessorFile(absPath) || isCssModulePreprocessorFile(absPath)) return false;
+      // #71: 다른 root scss 가 @import 하는 파일(reverse-dep 보유)은 fast-path 박탈 — 단일 파일만
+      // 재컴파일하면 그것을 쓰는 root scss 가 stale 로 남는다. full pipeline 의 transitive 재컴파일로
+      // dependents 까지 갱신하도록 false 반환. (reverseDep 은 tempRoot 기준이라 toTemp 로 조회.)
+      if (pipelineRoot) {
+        const temp = join(pipelineRoot, relative(root, absPath));
+        if (sassReverseDep.has(temp)) return false;
+      }
+      return true;
     },
     async rebuildScssIncremental(absPath) {
       // pipelineRoot 가 없으면 fast-path 진입 못함 (full reload 로 fallback).
@@ -535,6 +607,9 @@ export function createAppDevController(
       mirrorFile(absPath, srcTemp);
       const sass = loadSassCompiler(root, fallbackRequire);
       const result = compileSassFile(sass, srcTemp, pipelineRoot);
+      // #71: 이 파일이 새로 @import 하게 된 partial 을 reverse-dep 에 반영 — 다음 그 partial 변경
+      // 시 fast-path 박탈되어 이 root 가 재컴파일된다.
+      if (result.loadedUrls) recordSassReverseDep(sassReverseDep, srcTemp, result.loadedUrls);
       const cssTempPath = cssPreprocessorOutputPath(srcTemp);
       writeFileSync(cssTempPath, result.css);
       // 컴파일된 CSS 도 outdir 에 mirror 해서 dev server 가 서빙 가능하게.

--- a/packages/web/src/style/sass.ts
+++ b/packages/web/src/style/sass.ts
@@ -15,6 +15,9 @@ interface SassCompileOptions {
 
 interface SassCompileResult {
   css: string;
+  /** dart-sass 가 컴파일에 사용한 전이 @import/@use URL 목록(자기 자신 포함). dev watch 의
+   *  reverse-dep 추적용 — partial(`_x.scss`) 변경 시 이를 import 한 root scss 를 재컴파일 (#71). */
+  loadedUrls?: URL[];
 }
 
 export const CSS_PREPROCESSOR_EXTENSIONS: ReadonlySet<string> = new Set(['.scss', '.sass']);
@@ -99,6 +102,9 @@ export interface TransformCssPreprocessorOptions {
   dirtyOnly?: ReadonlySet<string> | null;
   /** dirty source files — `rewriteSassReferences` 의 대상 한정. null 이면 sourceFiles 전체. */
   dirtySources?: readonly string[] | null;
+  /** 컴파일한 파일별 전이 @import/@use 의존(loadedUrls)을 보고하는 콜백. dev watch 가
+   *  reverse-dep 맵을 구축해 partial 변경 시 root scss 를 재컴파일하는 데 쓴다 (#71). */
+  onDeps?: (file: string, loadedUrls: readonly URL[]) => void;
 }
 
 /**
@@ -117,7 +123,7 @@ export function transformCssPreprocessors(
   options: TransformCssPreprocessorOptions = {},
 ): string[] {
   if (files.length === 0) return [];
-  const { dirtyOnly = null, dirtySources = null } = options;
+  const { dirtyOnly = null, dirtySources = null, onDeps = null } = options;
   const targets = dirtyOnly ? files.filter((f) => dirtyOnly.has(f)) : files;
   if (targets.length === 0) return files.map(cssPreprocessorOutputPath);
 
@@ -138,6 +144,7 @@ export function transformCssPreprocessors(
     const cssPath = cssPreprocessorOutputPath(file);
     writeFileSync(cssPath, result.css);
     writeFileSync(cssPreprocessorProxyPath(file), buildCssPreprocessorProxy(cssPath));
+    if (onDeps && result.loadedUrls) onDeps(file, result.loadedUrls);
   }
 
   rewriteSassReferences(dirtySources ?? sourceFiles);


### PR DESCRIPTION
## 배경

출시 후 안정화 검증 중 발견(docs/BACKLOG.md #71). dev watch 에서 `style.scss` 가 `@use './vars'`(partial `_vars.scss`)할 때, **`_vars.scss` 를 수정해도 `style.css` 가 재컴파일 안 돼 stale 로 남던** correctness 버그. 루트커즈 = dart-sass `loadedUrls`(전이 @import 목록)를 버려서 reverse-dep 맵이 없던 것.

## 구현

- **sass.ts**: `SassCompileResult.loadedUrls` 노출 + `transformCssPreprocessors` 의 `onDeps` 콜백으로 컴파일별 전이 의존 보고.
- **dev-controller**: 세션 reverse-dep 맵(dep → dependents) 구축(`recordSassReverseDep`). full pipeline 의 `dirtySassSet` 을 reverse-dep 으로 **transitive 확장** + fast-path(`rebuildScssIncremental`)도 갱신. `isSassOnlyChange` 는 dependents 있는 partial 의 fast-path 자격 박탈.

## `/code-review max` fix — end-to-end dispatch dead-end

리뷰가 핵심 결함을 잡았습니다: dev-controller 만 고치면 **무동작**이었습니다. `isSassOnlyChange=false`(partial)가 zntc.mjs 디스패처에서 full rebuild 로 라우팅되지 않고 **CSS-only 분기(afterBundle = postcss only, sass 미재컴파일)**로 새서 여전히 stale.

- **zntc.mjs 디스패처**: fast-path 자격 없는 sass 변경(dependents 보유 partial / 다중)을 `rebuildAppDevFull`(full pipeline, transitive 재컴파일)로 라우팅.
- reverse-dep 맵을 `!reuseRoot`(새 tempRoot) 시 `clear()` — stale 키 누적 방어.

자동 테스트만으론 dispatch 갭을 못 잡아, **수정 후 dev server 재현**으로 end-to-end 검증했습니다(이전 dispatch dead-end 를 놓친 교훈).

## 검증

- **dev server 재현**: `_vars.scss` 변경 → `style.css` 가 `rgb(1,2,3)` → **`rgb(9,8,7)` 로 갱신** 확인. 로그 `[serve] rebuilt`(rebuildAppDevFull 분기) = 의도된 라우팅.
- `dev-controller.test` **12 pass**(reverse-dep 통합 + `recordSassReverseDep` 단위 self-제외/누적) + web **158 pass** / 회귀 0, `tsc` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)