### PR TITLE
docs: stale 정리 — CSS 완료 반영 + dead-lever 종결 + sass dep tracking 해결

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -44,7 +44,7 @@ D053에서 "Phase 6(minifier/bundler)에서 추가"로 예정됐던 semantic 확
 |---|------|------|---------------|
 | 61 | `Reference[]` 배열 (read/write 종류 + 정확한 위치) | ✅ RFC #1634 완료 | `references: ArrayList(Reference)` 재도입 (`node_index, scope_id, symbol_id, stmt_idx, kind`). mangler liveness / StmtInfo / 후속 최적화의 공통 입력. `ReferenceFlags` bitset 풍부화 (declare/type 구분) 는 별도 후속 이슈 |
 | 62 | `is_reassigned` / `is_read` 개별 플래그 | ⚪ 필드 자체 미추가 | `write_count`/`reference_count` scalar가 같은 정보 제공 (let const promotion, tree-shake 기준) — 실질 대체 완료 |
-| 63 | Dead store 분석 | 🟡 부분 완료 | top-level/direct block/function declaration body의 straight-line pure overwrite 제거 완료. #61 `Reference[]` 기반 일반 dead store와 branch/loop/try control-flow 분석은 후속 이슈 |
+| 63 | Dead store 분석 | 부분 완료 + 종결 | straight-line pure overwrite(top-level/direct block/function body) 제거 완료. 일반 dead store/branch·loop·try control-flow 는 measure 상 **ROI 0 확정으로 종결** (esbuild 도 부작용 RHS 보존, dead_store ON/OFF 절감 0%; 이슈 #1644 closed) |
 
 ※ #60 (`is_exported`/`is_default_export` 세팅) 은 #1633 에서 해결됨.
 
@@ -57,7 +57,7 @@ CSS Modules + Sass 도입 (PR #2225) 후 식별된 후속 작업.
 | # | 항목 | 비고 |
 |---|------|------|
 | ~~70~~ | ~~dev rebuild full re-prep (cpSync) 비용~~ | ✅ 해결: `prepare(dirtyPaths)` 가 incremental — 변경 파일만 cpSync, sass/css-modules transform 도 dirty 입력만 재처리, postcss prep 호출 자체도 CSS 관련 dirty 가 없으면 skip. JS-only 변경은 cpSync (dirty 만) + rewriter (dirty 만) 만 수행 — 풀 prep 의 비용 거의 전부 회피. |
-| ~~71~~ | ~~`.scss` 단일 파일 fast-path~~ | ✅ 해결: 단일 non-module `.scss/.sass` 변경은 `isCssOnlyChange=true` 로 분류되어 `rebuildScssIncremental` 진입 — 그 파일만 sass.compile + tempRoot/outdir 갱신 + `CssUpdate` broadcast. import dep 추적 없으므로 다른 sass 파일이 이 파일을 import 하면 갱신 누락 (별 issue 로 sass loadPaths dep tracking) |
+| ~~71~~ | ~~`.scss` 단일 파일 fast-path + dep tracking~~ | ✅ 해결: 단일 non-module `.scss/.sass` 변경은 `rebuildScssIncremental` fast-path. **dep tracking 도 해결**(PR #3675): dart-sass `loadedUrls`(전이 @import)로 reverse-dep 맵 구축 → partial(`_x.scss`) 변경 시 그것을 @import 한 root scss 를 transitive 재컴파일(dependents 있으면 fast-path 박탈 → full pipeline rebuild). |
 | ~~72~~ | ~~E2E `setTimeout(2000-2500)` → readiness poll~~ | ✅ 해결 (PR #3532): `tests/e2e/tests/wait-for-server.ts` 폴링 helper 도입, `zntc-app-builder-e2e.test.ts` 의 서버 기동 `setTimeout` 12곳 일괄 대체 + 로컬 중복 helper 제거. 200 한정이 아니라 **임의 HTTP 응답 = bind 완료** (error-overlay fixture 가 500/에러 HTML 을 주므로). |
 | ~~74~~ | ~~크로스-스위트 `waitForServer` 통합~~ | ✅ 해결: `tests/test-helpers/wait-for-server.ts` 정본을 `@zntc/test-helpers` 워크스페이스로 추출, `packages/core/test/cli/helpers.ts`(호환 wrapper)·`tests/integration/tests/devserver-sse-mcp.test.ts`(직접 사용)가 공유 모듈 import. 실질 중복 제거 완료. |
 | ~~73~~ | ~~Dev mode 에서 bundler 가 CSS chunk 를 emit 하지 않음~~ | ✅ 해결: bundler 측은 그대로 두고, JS 파이프라인이 sass / css-modules 컴파일 산출물을 tempRoot → outdir 로 mirror 하고 HTML 에 `<link>` 를 주입. inline `<style>` 우회 (`buildDevStyleInjector`) 제거. |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -228,8 +228,8 @@ esbuild / rolldown / rspack 기준으로 ZNTC에 빠진 기능 목록.
 - ~~**Virtual modules**~~ — ✅ 완료. `\0` prefix 기반 virtual module 지원 (플러그인 resolveId/load)
 - ~~**Stage 3 decorators**~~ — ✅ 완료. TC39 Stage 3 데코레이터 다운레벨링 (method/getter/setter/field/accessor/class, initializer 체이닝, MobX 6 호환). ES5 타겟 포함 (dispatch 수정 #1389). `accessor #x` (private key, #1511) + `accessor [k]` (computed key, #1524) ES5 direct path 까지 구현 — Babel/esbuild/oxc parity.
 - **Module Concatenation 고도화** — `XL` | rspack/rolldown 수준 scope hoisting
-- **innerGraph** — `L` | 🟡 부분 완료. 순수 local statement, overwritten assignment, overwritten declaration initializer, direct block/function declaration body의 straight-line dead store 제거 완료. 남은 범위: reference 기반 일반 dead store, branch/loop/try control-flow 분석.
-- **lazyBarrel** — `L` | 🟡 부분 완료. 순수 re-export / local re-export / namespace barrel (`import * as X; export { X }`, `re_export_namespace`) emit skip 완료. `requested_exports.zig` + `linker.zig:1237` + `tree_shaker.zig:1220` 에서 namespace 경계 명시 처리. 남은 범위: **wrapper-barrel body mutation 정밀 분석** — 현재 `isWrapperBarrel` 가 lodash-es `lodash.default.js` 같이 imported binding 을 mutate 하는 패턴을 통째 lazy 비활성화 (보수적). mutation 영역만 부분 lazy 적용은 미완.
+- **innerGraph** — `L` | 부분 완료 + **남은 범위 종결**. straight-line dead store(순수 local statement, overwritten assignment/declaration initializer, direct block/function body) 제거 완료. 남은 범위(reference 기반 일반 dead store, branch/loop/try control-flow)는 measure 상 **ROI 0 확정으로 종결** — dead_store OFF/ON 127 lib 절감 0%, esbuild 도 부작용 가능 RHS 의 dead-store 는 보존(semantic-preserving). 이슈 #1030/#1644 closed.
+- **lazyBarrel** — `L` | 부분 완료 + **wrapper-barrel 정밀화 폐기**. 순수 re-export / local re-export / namespace barrel emit skip 완료(`requested_exports.zig` + `linker.zig` + `tree_shaker.zig` 의 namespace 경계 처리). 남은 wrapper-barrel body mutation 정밀화는 **폐기·재시도 금지** — PoC 가 smoke win 0(실적용처 없음, esbuild/rolldown/rspack 도 미구현하며 더 작은 결과).
 - ~~**realContentHash**~~ — ✅ 완료. SHA-256 기반 `[hash]` 패턴 (emitter/chunks.zig)
 - ~~**sourcemapDebugIds**~~ — ✅ 완료. `--sourcemap-debug-ids` UUID v4, 번들+소스맵 매칭
 - ~~**shimMissingExports**~~ — ✅ 완료. `--shim-missing-exports` 롤다운 호환
@@ -248,7 +248,7 @@ esbuild / rolldown / rspack 기준으로 ZNTC에 빠진 기능 목록.
 | **Lazy compilation**         | XL     | ❌      | ❌                | ✅             | ❌  | 온디맨드 모듈 컴파일 (dev 시작 가속)                                             |
 | ~~**Stage 3 decorators**~~   | ✅     | ❌      | ✅                | ✅             | ✅  | TC39 Stage 3 데코레이터 (legacy + Stage 3)                                       |
 | **mangleProps**              | XL     | ✅      | ❌                | ❌             | ❌  | cross-module 프로퍼티 난독화                                                     |
-| **lazyBarrel**               | L      | ❌      | ✅                | ❌             | 🟡  | barrel re-export 컴파일 생략 — 순수/local/namespace barrel 처리 완료, wrapper-barrel mutation 정밀화 미완 |
+| **lazyBarrel**               | L      | ❌      | ✅                | ❌             | 🟡  | barrel re-export 컴파일 생략 — 순수/local/namespace barrel 처리 완료, wrapper-barrel mutation 정밀화는 폐기(ROI 0, PoC smoke win 0) |
 | ~~**import.meta.glob**~~     | ✅     | ❌      | ✅                | ❌             | ✅  | Vite 호환 glob import                                                            |
 | ~~**플러그인 N-API**~~       | ✅     | ✅ (Go) | ✅ (Rust)         | ✅             | ✅  | in-process NAPI + async 훅 + Vite 어댑터                                         |
 | ~~**HMR module-level**~~     | ✅     | ❌      | ✅                | ✅             | ✅  | `import.meta.hot.accept()`                                                       |
@@ -287,24 +287,25 @@ esbuild / rolldown / rspack 기준으로 ZNTC에 빠진 기능 목록.
   Module Concatenation 고도화 — rspack/rolldown 수준 scope hoisting
   Module Federation 🟡 RFC #3318 P1 진행 중 — 컨테이너 init/named share scope/strictVersion/manifest 게시 (런타임 동적 remote 빌드검증은 설계 한계)
   manualChunks ✅ 완료 — Rollup 호환 (record + function + meta API 13/14 필드)
-  innerGraph 🟡 부분 완료 — straight-line local dead store 제거 완료. 다음: reference 기반 일반 dead store/control-flow 확장
+  innerGraph 부분 완료 — straight-line local dead store 제거 완료. 일반 dead store/control-flow 는 ROI 0 확정으로 종결 (#1030/#1644 closed)
   Rollup ModuleInfo Phase B (#1880) — plugin context API + meta 필드 (1.5~2주)
   Rollup ModuleInfo Phase C (#1881) — ESTree adapter (info.ast, 2~4주)
 ```
 
-### 기술부채 & 구조적 제약
+### CSS / 비-JS 모듈 처리 (구현 완료)
 
-현재 번들러는 **JS 전용으로 설계**되어 있음. 배치 A~D는 이 구조에 영향 없이 안전하게 구현 가능.
-CSS 번들링/플러그인 API는 JS 전용 경계를 넘어야 함.
+CSS 는 Phase 1 에 도입됐고, 아래 계층이 모두 CSS 모듈(`ast`/`semantic` = null)을 안전하게 처리한다 —
+초기의 "JS 전용 설계" 가정은 제거 완료(2026-05 measure 로 debug/ReleaseFast 빌드에서 crash 0 확인).
 
-**JS 전용 구조 — 수정이 필요한 계층 (CSS/플러그인 시):**
-| 계층 | 파일 | 필요한 변경 |
+| 계층 | 파일 | CSS 처리 (완료) |
 |------|------|-----------|
-| Module 구조체 | module.zig | CSS 모듈 진입 시 null 방어 체크 또는 전용 필드 |
-| Linker | linker.zig | CSS 모듈은 link() 시 스킵하거나 별도 경로 |
-| Tree Shaker | tree_shaker.zig | CSS는 ast=null → side_effects=true 고정 |
-| Emitter 필터 | emitter.zig | CSS 포함으로 필터 확장 + 타입별 emit 분기 |
-| Chunk | chunk.zig | CSS 별도 청크 타입 추가 |
+| Module 구조체 | module.zig | 전용 `css_data` 필드, `ast`/`semantic` = null |
+| Linker | linker.zig | `m.semantic orelse continue` 가드로 CSS skip |
+| Tree Shaker | tree_shaker.zig | `m.semantic`/`ast orelse continue`, `side_effects=true` 로 생존 |
+| Emitter 필터 | emitter.zig | `isJavaScriptLike` 필터로 CSS 제외 |
+| Chunk | chunk.zig | `if (!m.module_type.isJavaScriptLike()) continue` — CSS 는 `css_emitter` 전용 경로 |
+
+알려진 minor: CSS-only entry point(`zntc --bundle x.css`)는 `.css` 가 silent drop(crash 아님, 백로그).
 
 ### 최근 버그 수정
 


### PR DESCRIPTION
## 배경

초기 출시 후 안정화 준비로 docs(BACKLOG/ROADMAP) + 이슈 37개를 전수 조사한 결과, **완료/종결된 항목이 미해결로 남은 stale**를 정리합니다.

## 변경

- **ROADMAP "기술부채" CSS 표** (미래형 → 완료): "JS 전용 설계, CSS 진입 시 null 방어 필요"는 stale 이었습니다. CSS 는 Phase 1 도입됐고 `linker`(`m.semantic orelse continue`)·`tree_shaker`·`chunk`(`isJavaScriptLike`)·`css_emitter` 전용 경로가 안전 처리합니다(measure 로 debug/ReleaseFast crash 0 확인). 표를 "구현 완료"로 갱신, CSS-only entry `.css` silent drop minor 만 잔존 표기.
- **innerGraph / lazyBarrel** (🟡 "남은 범위" → ROI 0 종결): 일반 dead store/control-flow 는 measure 상 절감 0%(esbuild 도 부작용 RHS 보존), wrapper-barrel 정밀화는 PoC smoke win 0. 이슈 **#1030/#1644 closed** 반영.
- **BACKLOG #71** sass dep tracking 해결(PR #3675), **#63** dead store 종결(#1644).

## 잔여 (별도, minor)

SIMD "추가 확장 여지"(ROADMAP:116/394 — scan 은 메모리 바운드 확정과 모순)·`.d.ts`(DECISIONS D017 vs ROADMAP:115) stale 은 이번에 미반영.

문서만 변경이라 코드 테스트 영향 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)