### PR TITLE
feat(bundler): innerGraph dead-store DCE 를 control-flow 블록 내부로 확장 (b1)

### DIFF
--- a/src/bundler/bundler_test/tree_shake/inner_graph_scope_writes.zig
+++ b/src/bundler/bundler_test/tree_shake/inner_graph_scope_writes.zig
@@ -266,7 +266,9 @@ test "TreeShaking: innerGraph preserves function body assignment captured by clo
     try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_AFTER_CAPTURE") != null);
 }
 
-test "TreeShaking: innerGraph preserves overwritten assignment inside control-flow block" {
+test "TreeShaking: innerGraph prunes overwritten assignment inside control-flow block (b1)" {
+    // innerGraph (ROADMAP b1): control-flow 블록 *내부* 의 straight-line dead store 도 제거한다.
+    // if-블록 본문에서 value 가 즉시 덮어써지므로 첫 write 는 dead → 제거, FINAL 은 유지.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts",
@@ -291,6 +293,105 @@ test "TreeShaking: innerGraph preserves overwritten assignment inside control-fl
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_IF_BLOCK_WRITE") != null);
+    // 덮어써진 첫 write 는 제거.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_IF_BLOCK_WRITE") == null);
+    // 최종 값은 유지(console.log 가 읽음).
     try std.testing.expect(std.mem.indexOf(u8, result.output, "INNER_GRAPH_IF_BLOCK_FINAL") != null);
+}
+
+test "TreeShaking: innerGraph keeps cross-branch write (b1 soundness — no CFG)" {
+    // soundness: `if(c) v=A; v=B; use(v)` 에서 v=A 는 else 경로에서 살아있어(B 만 실행 안 됨)
+    // 제거하면 안 된다. (b1) 은 *블록 내부* straight-line 만 보므로 분기 경계의 v=A 를 건드리지
+    // 않는다 — cross-branch DCE 미시도. v=A 가 보존돼야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let v = "CROSS_BRANCH_BASE";
+        \\if (Math.random()) { v = "CROSS_BRANCH_IF"; }
+        \\console.log(v);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 분기 밖 base write 는 else 경로에서 관측되므로 보존(cross-branch 미제거).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CROSS_BRANCH_BASE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CROSS_BRANCH_IF") != null);
+}
+
+test "TreeShaking: innerGraph keeps overwritten write inside try block (b1 soundness — throw observability)" {
+    // soundness(code-review 실증): try 안에서 두 write 사이 throw 가능 statement 가 있으면 첫
+    // write 는 catch 에서 관측될 수 있다 — throw 시 두번째 write 가 실행 안 되므로. (b1) 은 try/
+    // catch/finally 를 분석 대상에서 제외하므로 x=LIVE 가 보존돼야 한다(제거 시 catch 가 undefined).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let x;
+        \\try {
+        \\  x = "TRY_BLOCK_LIVE";
+        \\  globalThis.mayThrow();
+        \\  x = "TRY_BLOCK_DEAD";
+        \\} catch (e) {
+        \\  console.log(x);
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // throw 시 catch 가 읽는 첫 write 는 제거하면 안 된다(silent miscompile 방지).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "TRY_BLOCK_LIVE") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "TRY_BLOCK_DEAD") != null);
+}
+
+test "TreeShaking: innerGraph keeps read-between write inside control-flow block (b1 soundness)" {
+    // soundness: 블록 내부라도 두 write 사이에 read 가 있으면 첫 write 는 살아있다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\let v;
+        \\for (let i = 0; i < 1; i++) {
+        \\  v = "LOOP_READBETWEEN_FIRST";
+        \\  console.log(v);
+        \\  v = "LOOP_READBETWEEN_SECOND";
+        \\}
+        \\console.log(v);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_syntax = true,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 두 write 사이 read → 첫 write 보존.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LOOP_READBETWEEN_FIRST") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LOOP_READBETWEEN_SECOND") != null);
 }

--- a/src/bundler/emitter/dead_store.zig
+++ b/src/bundler/emitter/dead_store.zig
@@ -312,6 +312,68 @@ fn markDeadOverwrittenNestedStatementLists(
         }
     }
 
+    // innerGraph (ROADMAP): control-flow 구문의 *블록 본문 내부* straight-line dead store 도
+    // 분석한다. **분기 경계는 넘지 않는다** — 각 블록 본문에 기존(증명된) 분석을 그대로 적용할
+    // 뿐, cross-branch liveness 는 시도하지 않는다(예: `if(c) x=1; x=2;` 의 x=1 은 건드리지
+    // 않음). 자식 본문 노드로 재귀하면 그 노드가 block_statement 일 때 위 분기가 처리한다.
+    //
+    // **try/catch/finally 는 의도적으로 제외**한다(code-review: silent miscompile). try 영역 안에서는
+    // 두 write 사이의 throw 가능 statement(call 등)가 암묵 분기라, 첫 write 가 catch/finally/after-try
+    // 에서 관측될 수 있다(예: `try{ x=A; mayThrow(); x=B; }catch{ use(x) }` 에서 throw 시 x=A 가
+    // live). hasReadBetween 은 *read* 만 보고 throw 가능성을 모른다. try 영역은 오직 try_statement
+    // 재귀로만 도달하므로(그 안의 if/while 도 마찬가지) try 를 재귀 대상에서 빼면 try 영역 전체가
+    // 분석에서 제외돼 변경 전 soundness 와 동일해진다. try 밖 control-flow 는 핸들러가 없어 안전.
+    var bodies: [2]u32 = undefined;
+    var nb: usize = 0;
+    switch (node.tag) {
+        .if_statement => {
+            if (!node.data.ternary.b.isNone()) {
+                bodies[nb] = @intFromEnum(node.data.ternary.b);
+                nb += 1;
+            }
+            if (!node.data.ternary.c.isNone()) {
+                bodies[nb] = @intFromEnum(node.data.ternary.c);
+                nb += 1;
+            }
+        },
+        .while_statement, .do_while_statement, .labeled_statement => {
+            if (!node.data.binary.right.isNone()) {
+                bodies[nb] = @intFromEnum(node.data.binary.right);
+                nb += 1;
+            }
+        },
+        .for_in_statement, .for_of_statement, .for_await_of_statement => {
+            if (!node.data.ternary.c.isNone()) {
+                bodies[nb] = @intFromEnum(node.data.ternary.c);
+                nb += 1;
+            }
+        },
+        .for_statement => {
+            // extra: [init, test, update, body] — body 는 extra+3 (analyzer predeclare 와 동일).
+            const ex = node.data.extra;
+            if (ex + 3 < ast.extra_data.items.len) {
+                bodies[nb] = ast.extra_data.items[ex + 3];
+                nb += 1;
+            }
+        },
+        .switch_case => {
+            // extra: [test_expr, body.start, body.len]. case 본문 stmt list 직접 분석.
+            const ex = node.data.extra;
+            const extras = ast.extra_data.items;
+            if (ex + 2 < extras.len) {
+                const bs = extras[ex + 1];
+                const bl = extras[ex + 2];
+                if (bs + bl <= extras.len) {
+                    markDeadOverwrittenInStatementList(ast, extras[bs .. bs + bl], symbol_ids, symbols, ref_index, unresolved_globals, skip_nodes, module);
+                }
+            }
+        },
+        else => {},
+    }
+    for (bodies[0..nb]) |child| {
+        markDeadOverwrittenNestedStatementLists(ast, child, symbol_ids, symbols, ref_index, unresolved_globals, skip_nodes, module);
+    }
+
     markDeadOverwrittenFunctionBody(ast, node, symbol_ids, symbols, ref_index, unresolved_globals, skip_nodes, module);
 }
 


### PR DESCRIPTION
## 무엇을

ROADMAP의 innerGraph 정밀화. `dead_store` 의 straight-line "덮어써진 pure write" 제거를 **if/while/do-while/for/for-in/for-of/switch-case/labeled 의 블록 본문 내부** 에도 적용합니다. 지금까지는 walker 가 `block_statement`/함수 본문만 재귀해, if/loop 블록 한 단계만 들어가도 dead store 가 통째 보존됐습니다.

**분기 경계는 넘지 않습니다** — 각 블록 안 straight-line 만 분석(기존 검증된 분석 재사용), cross-branch liveness(`if(c) x=1; x=2;` 류)는 시도하지 않습니다(b2, CFG 필요 → follow-up).

## code-review max — CONFIRMED silent miscompile fix

리뷰가 **실증된 미스컴파일**을 잡았습니다(에이전트가 빌드·실행으로 확인):
- `try { x="LIVE"; mayThrow(); x="DEAD"; } catch { use(x) }` — 두 write 사이 throw 가능 statement 는 암묵 분기라, throw 시 `x="DEAD"` 미실행 + catch 가 `x="LIVE"` 를 읽음. `hasReadBetween` 은 read 만 보고 throw 를 몰라 `x="LIVE"` 를 오제거 → catch 가 undefined.
- **수정: try/catch/finally 를 재귀 대상에서 제외.** try 영역은 `try_statement` 재귀로만 도달하므로(그 안 if/while 도 마찬가지) try 케이스를 빼면 try 영역 전체가 분석에서 제외돼 **변경 전 soundness 와 동일**. try 밖 control-flow 는 핸들러가 없어 안전.
- 검증상 안전 확인: loop back-edge(마지막 write 는 forward overwrite 없어 보존; top-of-body read 는 ref_pos< write1), switch fallthrough(case 별 독립 분석), `with`(재귀 제외), AST 레이아웃(analyzer accessor 와 대조 일치).

## soundness 검증 (테스트)

- positive: if-블록 내 덮어써진 write 제거(negative→positive flip).
- negative(soundness): cross-branch write 보존(`if(c)v=A;v=B`), 블록 내 read-between 보존(loop), **try 영역 dead store 보존(throw 관측)**.

## 검증

- `zig build test` 전체 통과 (tree_shake/minify 회귀 0).
- smoke: mobx/rxjs **baseline MATCH**, immer/date-fns ✅ — 실 번들 정확성·크기 회귀 0.

## 한계 (follow-up)

cross-branch dead store(`x=1; if(c)x=2; else x=3; use(x)` → x=1 dead) 는 CFG/path-merge 필요 → 미지원(b2).

Refs: ROADMAP innerGraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)