### PR TITLE
perf(lexer): 주석 스캔(single/multi-line)을 SIMD 로 확장 (ROADMAP SIMD)

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -971,6 +971,10 @@ pub const Scanner = struct {
     fn skipLineAndRecordComment(self: *Scanner, check_pure: bool) !void {
         const comment_start = self.current;
         while (!self.isAtEnd()) {
+            // SIMD fast path: 줄 끝 sentinel(\n/\r/0xE2[U+2028·2029 선두]) 전까지 16바이트씩 스킵.
+            // 0xE2 는 LS/PS 여부를 scalar 가 3바이트로 재확인한다(다른 0xE2 문자면 1바이트 전진).
+            self.simdSkipUntilAny(&.{ '\n', '\r', 0xE2 }, null);
+            if (self.isAtEnd()) break;
             const c = self.peek();
             if (c == '\n' or c == '\r') break;
             if (c == 0xE2 and self.current + 2 < self.source.len and
@@ -1027,6 +1031,11 @@ pub const Scanner = struct {
         const comment_start = self.current;
 
         while (!self.isAtEnd()) {
+            // SIMD fast path: 종료 '*' / 줄바꿈(\n·\r·0xE2[U+2028·2029 선두]) 전까지 16바이트씩
+            // 스킵. '*' 는 뒤 '/' 여부, 0xE2 는 LS/PS 여부를 scalar 가 재확인 → newline 추적
+            // (sourcemap)·'*/' 감지 모두 보존.
+            self.simdSkipUntilAny(&.{ '*', '\n', '\r', 0xE2 }, null);
+            if (self.isAtEnd()) break;
             const c = self.peek();
             if (c == '*' and self.peekAt(1) == '/') {
                 const comment_text = self.source[comment_start..self.current];


### PR DESCRIPTION
## 무엇을

scanner 의 skip 루프 **SIMD 커버리지를 완성**합니다. whitespace / 식별자 tail / 문자열 리터럴은 이미 `@Vector(16,u8)` SIMD인데 **주석만 scalar** 였습니다. 기존 `simdSkipUntilAny` 헬퍼를 재사용해 주석도 16바이트씩 sentinel 전까지 건너뜁니다(문자열 리터럴과 **동일 패턴**).

- `skipLineAndRecordComment`: `\n`/`\r`/`0xE2`(U+2028·2029 선두) 전까지 SIMD skip.
- `scanMultiLineComment` 본문: `*`/`\n`/`\r`/`0xE2` 전까지 SIMD skip — `*/` 감지 + newline 추적(sourcemap) 보존.

## 동작 불변 (순수 가산)

scalar 처리 위에 SIMD fast-path 를 삽입만 했습니다. `simdSkipUntilAny` 는 첫 sentinel 에서 **정지**(`@ctz`)하므로 scalar 가 같은 바이트를 보고 `current` 도 동일 → 출력 불변. `0xE2` 는 모든 0xE2 에서 멈춰 scalar 가 3바이트 LS/PS 재확인(원래 byte-by-byte 와 동일), lone `*` 은 else 분기에서 `+1`, <16바이트 tail 은 scalar 처리.

## 검증

- `zig build test` 전체 통과(scanner/comment/sourcemap 회귀 0).
- smoke **date-fns/rxjs baseline MATCH** (출력 byte 동일).
- `/code-review max` **[]**: sentinel 정지 · tail<16 · 0xE2 over-stop 안전 · lone `*` · newline 추적 · comment span · Flow 경로 6점 검증.

## ROI (정직히)

scanner 는 파이프라인의 **~0.02%** 라 total 빌드 시간 영향은 작습니다. 이 변경의 가치는 **SIMD 커버리지 일관성 완성**(모든 skip 루프가 SIMD)과 주석 많은 입력에서의 scanner-level 이득이며, **위험은 0**(proven 헬퍼·패턴 재사용, 동작 불변).

Refs: ROADMAP SIMD 확장

🤖 Generated with [Claude Code](https://claude.com/claude-code)