### PR TITLE
fix(transformer): es2021+experimental-decorators 에서 class private member 다운레벨

### DIFF
--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -294,6 +294,10 @@ pub fn ES2022(comptime Transformer: type) type {
             lower_fields: bool,
             has_super: bool,
             class_name_text: ?[]const u8,
+            // #3/#4: assign-semantics(experimental_decorators) 경로용 — public member visit 을 skip
+            // 하고 current_private_* 를 호출자가 set/restore 한다(이중-visit 회피, decorator strip
+            // 방지). fast path 는 false(기존 동작: visit + defer 복원).
+            skip_visit_and_keep_private: bool,
         ) Transformer.Error!bool {
             const body_node = self.ast.getNode(body_idx);
             const body_start = body_node.data.list.start;
@@ -372,8 +376,17 @@ pub fn ES2022(comptime Transformer: type) type {
             const saved_private_fields = self.current_private_fields;
             self.current_private_methods = method_mappings.items;
             self.current_private_fields = field_mappings.items;
-            defer self.current_private_methods = saved_private_methods;
-            defer self.current_private_fields = saved_private_fields;
+            // #3/#4: skip_visit_and_keep_private 면 호출자가 classifyClassMember 가 finish 한 뒤
+            // 직접 복원 — defer 로 여기서 복원하면 호출자 visit 시점에 current_private 가 비어
+            // this.# rewrite 누락.
+            errdefer {
+                self.current_private_methods = saved_private_methods;
+                self.current_private_fields = saved_private_fields;
+            }
+            defer if (!skip_visit_and_keep_private) {
+                self.current_private_methods = saved_private_methods;
+                self.current_private_fields = saved_private_fields;
+            };
 
             for (field_mappings.items, field_init_idx.items) |m, init_val| {
                 if (m.class_name != null) {
@@ -463,7 +476,14 @@ pub fn ES2022(comptime Transformer: type) type {
                     }
                 }
 
-                const new_member = try self.visitNode(member_idx);
+                // #3/#4: skip_visit_and_keep_private 면 raw member 를 그대로 append — 호출자
+                // (assign-semantics)가 classifyClassMember 에서 단일 visit 한다(이중-visit + decorator
+                // strip 회피). ctor_pos 검색은 raw 든 visit 된 member 든 method_definition tag /
+                // constructor key 로 동작.
+                const new_member = if (skip_visit_and_keep_private)
+                    member_idx
+                else
+                    try self.visitNode(member_idx);
                 if (new_member.isNone()) continue;
 
                 if (ctor_pos == null) {

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -14,20 +14,104 @@ const Error = Transformer.Error;
 const class_visit_mod = @import("class_visit.zig");
 pub const visitClass = class_visit_mod.visitClass;
 const shouldDropClassExprName = class_visit_mod.shouldDropClassExprName;
+// #3/#4: assign-semantics 경로의 private member 다운레벨용 (fast path 와 공유).
+const classBodyHasStaticPrivateMember = class_visit_mod.classBodyHasStaticPrivateMember;
+const wrapClassExprInIIFE = class_visit_mod.wrapClassExprInIIFE;
+const es_helpers = @import("../es_helpers.zig");
+const es2022 = @import("../es2022.zig");
+const PrivateMethodMapping = Transformer.PrivateMethodMapping;
 
 /// useDefineForClassFields=false / experimentalDecorators 처리.
 /// 멤버를 개별 분류하여 instance field를 constructor로 이동하고,
 /// experimental decorator를 __decorateClass 호출로 변환한다.
 pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeIndex {
-    // TODO(es2021): apply same IIFE wrapping for class_expression with private methods — see wrapClassExprInIIFE in fast path
     const e = node.data.extra;
-    const has_super = !self.readNodeIdx(e, ast_mod.ClassExtra.super).isNone();
+    const super_idx = self.readNodeIdx(e, ast_mod.ClassExtra.super);
+    const has_super = !super_idx.isNone();
     const raw_name_idx = self.readNodeIdx(e, ast_mod.ClassExtra.name);
     var new_name = try self.visitNode(raw_name_idx);
-    const new_super = try self.visitNode(self.readNodeIdx(e, ast_mod.ClassExtra.super));
+    const new_super = try self.visitNode(super_idx);
 
-    // 원본 class_body를 직접 순회
-    const body_idx = self.readNodeIdx(e, ast_mod.ClassExtra.body);
+    // #4 fix(super_class): fast path(class_visit.zig)와 동일하게 private method body 내 super.x 가
+    // 올바른 super class span 으로 lowering 되도록 current_super_class 를 set. assign-semantics
+    // 경로가 이 set 을 누락하면 lowerPrivateMembers 의 standalone fn body visit / classifyClassMember
+    // 의 method body visit 에서 super-prop lowering 이 null/stale 참조로 깨진다.
+    const saved_super_class = self.current_super_class;
+    if (has_super) {
+        self.current_super_class = self.ast.getNode(super_idx).span;
+    }
+    defer self.current_super_class = saved_super_class;
+
+    // #3/#4 fix(이중-visit 회피): lowerPrivateMembers 를 skip_visit_and_keep_private=true 로 호출하면
+    // current_private_* 를 호출자가 set/복원해야 한다(lowerPrivateMembers 내부 defer 가 건너뛴다).
+    // 그래야 classifyClassMember 의 단일 visit 이 current_private set 상태로 this.# rewrite +
+    // decorator 수집을 둘 다 수행한다(이중-visit + decorator strip 회피).
+    const saved_private_methods_outer = self.current_private_methods;
+    const saved_private_fields_outer = self.current_private_fields;
+    defer {
+        self.current_private_methods = saved_private_methods_outer;
+        self.current_private_fields = saved_private_fields_outer;
+    }
+
+    // #3/#4: assign-semantics(experimental_decorators / useDefineForClassFields:false) 경로도
+    // private member 를 다운레벨해야 한다 — 안 하면 es2021 타깃에서 raw `#` 가 남아 실행 불가.
+    // fast path(class_visit.zig)와 동일하게 lowerPrivateMembers 로 new_body(private 제거 +
+    // this.# rewrite + ctor init prepend)를 만들고, weakset 선언(priv_pre_stmts)은 emitPrivatePrelude
+    // 가 class 정의 앞에 emit 한다. (lowerPrivateMembers 가 current_private 를 set 후 new_body 를
+    // 통째 visit 하므로 this.# 가 그 안에서 rewrite 된다.)
+    var body_idx = self.readNodeIdx(e, ast_mod.ClassExtra.body);
+    const lower_pm = self.options.unsupported.class_private_method;
+    const lower_pf = self.options.unsupported.class_private_field;
+    var priv_pre_stmts: std.ArrayList(NodeIndex) = .empty;
+    defer priv_pre_stmts.deinit(self.allocator);
+    var pm_mappings: std.ArrayList(PrivateMethodMapping) = .empty;
+    defer {
+        for (pm_mappings.items) |pm| {
+            self.allocator.free(pm.weakset_name);
+            self.allocator.free(pm.func_name);
+        }
+        pm_mappings.deinit(self.allocator);
+    }
+    var pf_mappings: std.ArrayList(Transformer.PrivateFieldMapping) = .empty;
+    defer {
+        for (pf_mappings.items) |pf| {
+            self.allocator.free(pf.var_name);
+        }
+        pf_mappings.deinit(self.allocator);
+    }
+    if (lower_pm or lower_pf) {
+        // class_expression + static private → 이름 부여(static init 참조 / IIFE).
+        if (node.tag == .class_expression and new_name.isNone() and
+            classBodyHasStaticPrivateMember(self, body_idx, lower_pm, lower_pf))
+        {
+            const tmp_span = try es_helpers.makeTempVarSpan(self);
+            new_name = try es_helpers.makeBindingIdentifier(self, tmp_span);
+        }
+        var new_body_pl: NodeIndex = .none;
+        var ctor_stmts_pl: std.ArrayList(NodeIndex) = .empty;
+        defer ctor_stmts_pl.deinit(self.allocator);
+        const class_name_text: ?[]const u8 = if (self.getClassNameSpan(new_name)) |s|
+            self.ast.getText(s)
+        else
+            null;
+        const had_any = try es2022.ES2022(Transformer).lowerPrivateMembers(
+            self,
+            body_idx,
+            &new_body_pl,
+            &priv_pre_stmts,
+            &ctor_stmts_pl,
+            &pm_mappings,
+            &pf_mappings,
+            lower_pm,
+            lower_pf,
+            has_super,
+            class_name_text,
+            true, // skip_visit_and_keep_private — public member 는 classifyClassMember 가 단일 visit.
+        );
+        if (had_any) body_idx = new_body_pl;
+    }
+
+    // 원본(또는 private 다운레벨된) class_body를 직접 순회
     const body_node = self.ast.getNode(body_idx);
     const body_members_start = body_node.data.list.start;
     const body_members_len = body_node.data.list.len;
@@ -205,6 +289,8 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
         const old_deco_start = self.readU32(e, ast_mod.ClassExtra.deco_start);
 
         if (has_any_decorator) {
+            // #3/#4: private weakset 선언은 `let Foo = class {...}` 분해 앞에 와야 한다.
+            for (priv_pre_stmts.items) |stmt| try self.pending_nodes.append(self.allocator, stmt);
             return try self.transformExperimentalDecorators(
                 node,
                 new_name,
@@ -240,6 +326,8 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
             none,                   0,                       0,
             new_decos.start,        new_decos.len,
         });
+        // #3/#4: private weakset 선언은 class 정의/static 할당 앞에.
+        for (priv_pre_stmts.items) |stmt| try self.pending_nodes.append(self.allocator, stmt);
         try self.pending_nodes.append(self.allocator, class_result);
         // static field: Foo.z = 2;
         for (static_field_assignments.items) |field| {
@@ -249,6 +337,31 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
         for (static_block_iifes.items) |iife| {
             try self.pending_nodes.append(self.allocator, iife);
         }
+        return .none;
+    }
+
+    // #3/#4: private member 다운레벨이 있었으면 weakset 선언(priv_pre_stmts)을 class 앞에 emit.
+    // class_expression 은 statement 위치가 아니므로 IIFE 로 래핑(fast path 와 동일), class_declaration
+    // 은 pending 에 prelude + class 를 순서대로 넣는다.
+    if (priv_pre_stmts.items.len > 0) {
+        const class_result = try self.addExtraNode(node.tag, node.span, &.{
+            @intFromEnum(new_name), @intFromEnum(new_super), @intFromEnum(new_body),
+            none,                   0,                       0,
+            new_decos.start,        new_decos.len,
+        });
+        if (node.tag == .class_expression) {
+            return wrapClassExprInIIFE(
+                self,
+                &.{},
+                priv_pre_stmts.items,
+                class_result,
+                &.{},
+                new_name,
+                node.span,
+            );
+        }
+        for (priv_pre_stmts.items) |stmt| try self.pending_nodes.append(self.allocator, stmt);
+        try self.pending_nodes.append(self.allocator, class_result);
         return .none;
     }
 

--- a/src/transformer/transformer/class_visit.zig
+++ b/src/transformer/transformer/class_visit.zig
@@ -84,6 +84,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
                 lower_pf,
                 has_super,
                 class_name_text,
+                false, // fast path 는 lowerPrivateMembers 가 통째 visit + 복원 (기존 동작).
             );
             if (had_any) {
                 current_body_idx = new_body;
@@ -189,7 +190,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
     return self.visitClassWithAssignSemantics(node);
 }
 
-fn classBodyHasStaticPrivateMember(self: *Transformer, body_idx: NodeIndex, lower_methods: bool, lower_fields: bool) bool {
+pub fn classBodyHasStaticPrivateMember(self: *Transformer, body_idx: NodeIndex, lower_methods: bool, lower_fields: bool) bool {
     if (body_idx.isNone()) return false;
     const body_node = self.ast.getNode(body_idx);
     if (body_node.tag != .class_body) return false;
@@ -227,7 +228,7 @@ fn classBodyHasStaticPrivateMember(self: *Transformer, body_idx: NodeIndex, lowe
     return false;
 }
 
-fn wrapClassExprInIIFE(
+pub fn wrapClassExprInIIFE(
     self: *Transformer,
     pre_stmts_a: []const NodeIndex,
     pre_stmts_b: []const NodeIndex,

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -3019,3 +3019,38 @@ test "#2471 regression: 100-key object destructuring + rest — all keys exclude
         try std.testing.expect(std.mem.indexOf(u8, code, needle) != null);
     }
 }
+
+// ============================================================
+// experimentalDecorators + private member 다운레벨 (#3/#4 회귀)
+// experimental_decorators(또는 useDefineForClassFields:false) 경로는
+// visitClassWithAssignSemantics 를 타는데, 이 경로가 lowerPrivateMembers 를
+// 호출하지 않아 es2021 타깃에서도 private member 가 raw `#` 로 남던 버그.
+// ============================================================
+
+test "experimentalDecorators + private: static #field update 다운레벨 (es2021)" {
+    // class C { static #n=0; @dec f=1; static inc(){ return C.#n++ } }
+    // es2021 타깃 → static private field 와 그 update(C.#n++)가 다운레벨돼야 한다.
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        "class C { static #n = 0; @dec f = 1; static inc() { return C.#n++; } }",
+        .{ .experimental_decorators = true, .unsupported = TransformOptions.compat.fromESTarget(.es2021) },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // raw `#n` 이 남으면 es2021 런타임에서 실행 불가 — 다운레벨 누락.
+    try std.testing.expect(std.mem.indexOf(u8, code, "#n") == null);
+}
+
+test "experimentalDecorators + private: class expression private method 다운레벨 (es2021)" {
+    // const C = class { #m(){return 1} run(){return this.#m()} @dec f=1 }
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        "const C = class { #m() { return 1; } run() { return this.#m(); } @dec f = 1; };",
+        .{ .experimental_decorators = true, .unsupported = TransformOptions.compat.fromESTarget(.es2021) },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "#m") == null);
+}


### PR DESCRIPTION
## 배경

`--experimental-decorators`(또는 `useDefineForClassFields:false`) 경로는 `visitClassWithAssignSemantics`를 타는데, 이 함수가 `lowerPrivateMembers`를 호출하지 않아 es2021 타깃에서도 private member(`#m`/`#field`)가 raw `#`로 남아 codegen unreachable crash / 런타임 실행 불가였습니다(`es2022.zig:704` + `class_decorator.zig:22` 동일 근원 TODO).

## 분해 설계 (이중-visit + decorator strip 회피)

**핵심 위험**: 단순히 `lowerPrivateMembers`를 통째 호출하면 그 내부 visit이 `visitMethodDefinition`의 decorator strip을 거치고, `classifyClassMember`가 새 body를 재 visit할 땐 이미 `deco_len=0`이라 `collectMemberDecorators`가 누락 → **method decorator silent drop** 회귀.

`/code-review max`가 이 회귀를 잡았고(VERIFIED: `class C { #p=1; @mdec method(){return this.#p} }`에서 `__decorateClass` 누락, `#p` 없으면 정상), measure로 재현됐습니다. 

**해결**: `lowerPrivateMembers`에 `skip_visit_and_keep_private` 플래그 추가
- **fast path**(class_visit.zig) = `false` — 기존 동작(통째 visit + defer 복원) 유지
- **assign-semantics** = `true` — public member는 raw로 append, `current_private_*`는 호출자가 set/복원, `classifyClassMember`의 **단일 visit**이 `this.#` rewrite + decorator 수집을 모두 수행

추가로 fast path 미러: `current_super_class` save/set/defer-restore를 assign-semantics 진입에도 적용(private method body 내 super-prop lowering 가드).

## 검증 (회귀 방어)

- **TDD 재현**: `transformer_test.zig` 2개(es2021 + experimental_decorators / static `#n++` + class_expr `#m`) red→green
- **전체 회귀**: `zig build test` 5417 통과, 회귀 0
- **measure 런타임 5 fixture**:
  - method decorator with private(`#p + @dec method`) → `__decorateClass([dec], C.prototype, "method", 1)` 정상 emit (회귀 완전 해결)
  - 기존 3 fixture(static `#n++` / class_expr `#m` / counter `#count`) 통과 유지
- **`/code-review max` 2회**: 통째 통합 시 회귀 적발 → 분해 재설계 후 회귀 해결 확인

## 범위 외 (기존 별개 버그, fast path도 동일 — 별도 follow-up)

- **private method 내 `super.x`**: `lowerPrivateMembers`/`buildStandaloneFunc`가 standalone fn으로 추출하며 class context 분리 → `super` 키워드 SyntaxError. fast path도 동일 케이스에서 깨짐(검증 완료)
- **field decorator(`@dec field`)**: ZNTC가 field decorator 자체 미지원(method만 `__decorateClass` emit) — private 유무와 무관(main/no-priv 비교로 확정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)