### PR TITLE
fix(transformer): private 동반 시 field decorator silent drop 회귀 fix

### DIFF
--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -463,15 +463,25 @@ pub fn ES2022(comptime Transformer: type) type {
                     if (!is_static and !key.isNone()) {
                         const key_node = self.ast.getNode(key);
                         if (key_node.tag != .private_identifier) {
-                            const lowered_key = if (key_node.tag == .computed_property_key) blk: {
-                                const memo = try es_helpers.memoizeComputedKey(self, key_node.data.unary.operand, member.span);
-                                try pre_stmts.append(self.allocator, memo.decl);
-                                break :blk memo.computed_key;
-                            } else key;
-                            const init_val: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.init);
-                            const init_stmt = try buildPublicFieldSetInit(self, lowered_key, init_val, span);
-                            try ctor_init_stmts.append(self.allocator, init_stmt);
-                            continue;
+                            // #3680 fix: decorator 가 있는 public field 는 ctor 이동을 skip.
+                            // buildPublicFieldSetInit 가 decorator 정보를 버리므로, ctor 로 옮기면
+                            // classifyClassMember 가 못 봐 kind=2 property decorator 수집(collectMember
+                            // Decorators + __decorateClass)이 우회됨 → silent drop. raw 로 fall
+                            // through(466) 해서 classifyClassMember(skip_visit_and_keep_private 경로)/
+                            // visitNode(fast path) 가 decorator + field 를 함께 처리한다.
+                            const field_deco_len = self.readU32(pe, ast_mod.PropertyExtra.deco_len);
+                            if (field_deco_len == 0) {
+                                const lowered_key = if (key_node.tag == .computed_property_key) blk: {
+                                    const memo = try es_helpers.memoizeComputedKey(self, key_node.data.unary.operand, member.span);
+                                    try pre_stmts.append(self.allocator, memo.decl);
+                                    break :blk memo.computed_key;
+                                } else key;
+                                const init_val: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.init);
+                                const init_stmt = try buildPublicFieldSetInit(self, lowered_key, init_val, span);
+                                try ctor_init_stmts.append(self.allocator, init_stmt);
+                                continue;
+                            }
+                            // decorator 있으면 fall through — 466 의 raw append (skip) 또는 visitNode (fast).
                         }
                     }
                 }

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -3054,3 +3054,18 @@ test "experimentalDecorators + private: class expression private method 다운�
     defer std.testing.allocator.free(code);
     try std.testing.expect(std.mem.indexOf(u8, code, "#m") == null);
 }
+
+// #3680 회귀 가드: experimental_decorators + private member 동반 시 public field decorator 가
+// silent drop 되지 않아야 한다. lowerPrivateMembers 의 lower_fields 분기가 deco_len>0 인 field 를
+// ctor 로 이동하면(decorator 정보 손실) classifyClassMember 가 못 보고 __decorateClass 가 미emit.
+test "experimentalDecorators + private: @dec field 가 private 동반에도 emit (#3680)" {
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        "function dec(t,k){return t} class C { #p = 1; @dec f = 2; }",
+        .{ .experimental_decorators = true, .unsupported = TransformOptions.compat.fromESTarget(.es2021) },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "__decorateClass") != null);
+}


### PR DESCRIPTION
## 배경

PR #3679 후속 hotfix. `/code-review max`가 적발한 silent miscompile 회귀 — 같은 클래스에 `#private`가 있으면 `@dec field`가 silently drop 되어 `__decorateClass` 호출이 emit 안 되는 비결정성.

## 루트커즈

`lowerPrivateMembers`의 public-field 분기(`es2022.zig:445-477`)가 `lower_fields=true`면 `deco_len` 확인 없이 public field를 ctor로 이동(`buildPublicFieldSetInit` → `continue`). decorator 정보가 그 과정에서 손실됨 → `classifyClassMember`가 못 봐 kind=2 property decorator 수집이 우회 → `__decorateClass([dec], C.prototype, "f", 2)` emit 누락.

**VERIFIED**: `class C { #p=1; @dec f=2 }` es2021+experimental-decorators → `__decorateClass` count = **0**. `#p`만 제거하면 count = **2**.

## 수정

`lowerPrivateMembers`의 public-field 분기에 **`deco_len > 0` 가드** — decorator 있으면 ctor 이동 skip, fall-through하여 `classifyClassMember`(`skip_visit_and_keep_private` 경로면 raw append, fast path면 `visitNode`)가 decorator + field를 함께 처리.

## 검증 (회귀 방어)

- 회귀 가드 테스트(`transformer_test.zig`) — `class C { #p=1; @dec f=2 }` → `__decorateClass` emit 확인 (red→green)
- `zig build test` 5417 통과 (회귀 0)
- measure 런타임: 올바른 identity decorator(`function dec(t,k){}` void)로 `"DEC CALLED f"` 호출 + `"3"` 정상 출력

## 명확화 (오해 방지)

이전 measure에서 본 `TypeError: Cannot assign to read only property 'f'`는 **fixture의 decorator 시그니처 문제**입니다 — TS legacy property decorator는 void 반환해야 spec. `dec(t,k){return t}`는 target(C.prototype object)을 반환해 esbuild 동형 `__decorateClass` 헬퍼가 그 object를 descriptor로 해석 → `defineProperty` writable default false → read-only → TypeError. **ZNTC 무관, esbuild도 동일 동작**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)