### PR TITLE
docs(rn_codegen): mod.zig 주석 stale 정리

### DIFF
--- a/src/transformer/plugins/rn_codegen/mod.zig
+++ b/src/transformer/plugins/rn_codegen/mod.zig
@@ -1,14 +1,14 @@
 //! RN View Config Codegen 모듈 — 진입점.
 //!
 //! `@react-native/codegen` 의 view config 인라인 기능을 ZNTC native 로 옮긴
-//! 플러그인 (#2348). 다음 단계:
+//! 플러그인 (#2348, 모든 단계 완료). 서브 모듈:
 //!
-//!   schema.zig            — Schema 데이터 구조 (PR #1, merged)
-//!   type_index.zig        — 같은 파일 내 type alias / interface 인덱싱 (PR #2)
-//!   schema_builder.zig    — TODO (PR #3): NativeProps AST → ComponentShape
-//!   view_config_emitter.zig — TODO (PR #4): ComponentShape → JS 문자열
-//!   validator.zig         — TODO (PR #5): SchemaValidator 동등 + 진단
-//!   ../rn_codegen_plugin.zig — 통합 + builtin / CLI / NAPI 노출 (PR #6, merged)
+//!   schema.zig              — Schema 데이터 구조
+//!   type_index.zig          — 같은 파일 내 type alias / interface 인덱싱
+//!   schema_builder.zig      — NativeProps AST → ComponentShape (inheritance/intersection/wrapper unwrap)
+//!   view_config_emitter.zig — ComponentShape → JS 문자열 (RN 0.78 GenerateViewConfigJs parity)
+//!   validator.zig           — duplicate-component check + error-code 매핑
+//!   ../rn_codegen_plugin.zig — 통합 + builtin / CLI / NAPI 노출 (graph/plugins.zig builtin / RN preset)
 //!
 //! 본 mod.zig 자체는 import 만 묶음. 외부에선 필요한 서브 모듈을 직접 import
 //! 하거나 본 파일을 통해 가져갈 수 있다.


### PR DESCRIPTION
## 배경

코드 TODO 묶음의 마지막 항목. `mod.zig:8-10` 의 'TODO (PR #3/#4/#5)' 표기는 stale — schema_builder/view_config_emitter/validator 가 #2348 으로 **모두 구현 완료**됐고 rn_codegen_plugin.zig가 graph/plugins.zig:56-57 builtin + main.zig:549 RN preset 에서 활성화됨(이전 measure 에이전트로 end-to-end 확정).

순수 doc 주석 7줄 변경 (코드 동작 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)