### PR TITLE
feat(bundler): CSS multi-owner replication for code splitting

### DIFF
--- a/packages/core/test/core/option-combinations/core-options/splitting.ts
+++ b/packages/core/test/core/option-combinations/core-options/splitting.ts
@@ -33,4 +33,83 @@ describe('옵션 조합 통합 테스트 - core options - splitting', () => {
     expect(result.errors.length).toBe(0);
     expect(result.outputFiles.length).toBeGreaterThanOrEqual(2);
   });
+
+  // 회귀 가드: splitting + 두 entry 가 같은 shared CSS 를 import 할 때 한
+  // 청크만 owner 가 되고 다른 청크 `.css` 에서는 shared 규칙이 누락되던
+  // single-owner dedup 버그. esbuild/webpack 처럼 도달 가능한 모든 청크에
+  // shared CSS 를 인라인 복제(cascade 보존, 페이지 독립 로드 가능)해야 한다.
+  // 동적 청크도 자기가 import 한 CSS 가 별도 `.css` 로 emit 되고, JS 청크에
+  // `<link>` prologue 가 주입돼야 단독 로드 시 스타일 적용된다.
+  test('splitting + CSS — shared CSS 가 도달 모든 청크에 인라인 + 동적 청크도 자기 CSS 가짐', async () => {
+    writeFileSync(join(dir, 'a.css'), '.a { color: red; }\n');
+    writeFileSync(join(dir, 'b.css'), '.b { color: blue; }\n');
+    writeFileSync(join(dir, 'common.css'), '.common { font-size: 14px; }\n');
+    writeFileSync(
+      join(dir, 'a-entry.ts'),
+      'import "./a.css";\nimport "./common.css";\nimport("./dyn-a").then(m => m.run());\nexport const a = 1;\n',
+    );
+    writeFileSync(
+      join(dir, 'b-entry.ts'),
+      'import "./b.css";\nimport "./common.css";\nexport const b = 2;\n',
+    );
+    writeFileSync(
+      join(dir, 'dyn-a.ts'),
+      'import "./common.css";\nexport function run() { return "dyn"; }\n',
+    );
+
+    const result = await build({
+      entryPoints: [join(dir, 'a-entry.ts'), join(dir, 'b-entry.ts')],
+      splitting: true,
+      entryNames: '[name]',
+      chunkNames: '[name]',
+    });
+    expect(result.errors.length).toBe(0);
+
+    const css = result.outputFiles.filter((f) => f.path.endsWith('.css'));
+    const js = result.outputFiles.filter((f) => f.path.endsWith('.js'));
+
+    const findCss = (stem: string) =>
+      css.find((f) => {
+        const base = f.path.split(/[\\/]/).pop() ?? '';
+        return base.startsWith(stem) && base.endsWith('.css');
+      });
+    const findJs = (stem: string) =>
+      js.find((f) => {
+        const base = f.path.split(/[\\/]/).pop() ?? '';
+        return base.startsWith(stem) && base.endsWith('.js');
+      });
+
+    const aCss = findCss('a-entry');
+    const bCss = findCss('b-entry');
+    const dynCss = findCss('dyn-a');
+    const dynJs = findJs('dyn-a');
+
+    // 각 entry CSS 자체는 있어야(기존 동작)
+    expect(aCss).toBeDefined();
+    expect(bCss).toBeDefined();
+
+    // ★ 회귀 가드 1: shared CSS(.common) 가 b 청크에도 인라인돼야 한다.
+    // 버그 시: a 가 min-rank owner 라 b.css 에 .common 누락 → b 페이지에서
+    // .common 미적용. 복제(multi-owner) 적용 시 양쪽 모두 포함.
+    expect(aCss!.text).toContain('.common');
+    expect(bCss!.text).toContain('.common');
+
+    // ★ 회귀 가드 2: 동적 청크 dyn-a 가 자기 .css 를 가져야 한다.
+    // 버그 시: dyn-a 는 common 의 owner 가 아니라 청크 CSS 자체가 emit 되지
+    // 않음 → dyn-a 단독 진입 시 스타일 미적용. 복제 후엔 dyn-a.css 도 emit.
+    expect(dynCss).toBeDefined();
+    expect(dynCss!.text).toContain('.common');
+
+    // ★ 회귀 가드 3: 동적 청크 JS 에 `<link>` prologue(런타임 CSS 로더)가
+    // 주입돼야 동적 import 시 자기 CSS 가 로드된다. emitter 가 chunk_css_hrefs
+    // 를 동적 청크까지 채워야 한다(엔트리뿐 아니라).
+    expect(dynJs).toBeDefined();
+    expect(dynJs!.text).toMatch(/document\.createElement\(["']link["']\)/);
+    // 그리고 prologue 의 *정확한* URL 토큰이 dyn-a 자체 CSS basename 을
+    // 가리켜야 한다. 단순 substring(예: 'dyn-a') 은 chunk header/주석/모듈
+    // path 에도 등장해 prologue href 오류를 잡지 못한다(tautology). prologue
+    // 는 `new URL("./<basename>",import.meta.url)` 형태이므로 그대로 검증.
+    const dynCssFullBase = dynCss!.path.split(/[\\/]/).pop() ?? '';
+    expect(dynJs!.text).toContain(`new URL("./${dynCssFullBase}",import.meta.url)`);
+  });
 });

--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -100,7 +100,9 @@ fn emitCssModuleTree(
 ) !void {
     if (idx.isNone()) return;
     if (visited.contains(idx)) return;
-    visited.put(idx, {}) catch return;
+    // 함수가 `!void` 라 OOM 은 propagate — `catch return` 으로 삼키면 silent skip 되어
+    // @import 서브트리가 emit 누락된다.
+    try visited.put(idx, {});
     const mod = graph.getModule(idx) orelse return;
     if (mod.module_type != .css) return;
     for (mod.dependencies.items) |dep| {
@@ -124,11 +126,14 @@ pub const CssChunkPlanEntry = struct {
 /// 청크 prologue 에 주입할 수 있다. CSS 파일명은 CSS 내용 해시 기반이라 JS
 /// 청크 해시와 독립적으로 이 시점에 확정된다.
 ///
-/// 각 CSS 모듈은 그것을 import 하는 JS 모듈이 속한 청크 중
-/// `(chunk.exec_order, importer.exec_index)` 가 가장 앞서는 단 하나의 청크에
-/// 귀속된다(전역 dedup — 공유 CSS 가 여러 청크에 복제되지 않음).
-/// CSS→CSS(@import) 의존은 같은 귀속 청크로 함께 묶인다.
-/// 반환 슬라이스/각 항목의 path/contents 는 모두 `allocator` 소유.
+/// 각 CSS 모듈은 그것을 import 하는 JS 모듈이 속한 *모든* 청크에 인라인
+/// 복제된다(esbuild/webpack 동치 — single-owner min-rank dedup 폐기). 이유:
+/// shared CSS 가 한 owner 청크에만 들어가면 다른 페이지/동적 청크가 단독
+/// 진입될 때 그 규칙이 cascade 에 없어 미적용. dedup 은 청크 단위로만
+/// (같은 청크 안에서 여러 JS 모듈이 같은 CSS 도달해도 1회).
+/// CSS→CSS(@import) 의존은 emit 시점에 청크별로 다시 인라인된다(쓰는 곳마다
+/// 존재 — #3321 P0-4). 반환 슬라이스/각 항목의 path/contents 는 모두
+/// `allocator` 소유.
 pub fn planCssChunks(
     allocator: std.mem.Allocator,
     graph: *const ModuleGraph,
@@ -138,11 +143,22 @@ pub fn planCssChunks(
     const n_chunks = chunk_graph.chunkCount();
     if (n_chunks == 0) return allocator.alloc(CssChunkPlanEntry, 0);
 
-    // 1패스: CSS 모듈 → 귀속 청크(최소 rank 우승). owner_rank/visited 는 DFS 중에만 필요.
-    var owner = std.AutoHashMap(ModuleIndex, ChunkIndex).init(allocator);
-    defer owner.deinit();
-    var owner_rank = std.AutoHashMap(ModuleIndex, u64).init(allocator);
-    defer owner_rank.deinit();
+    // 1패스: CSS 모듈 → 도달 가능한 *모든* 청크에 등재(esbuild/webpack 동치 —
+    // single-owner dedup 폐기). 이유: ① b 페이지가 a-only 인 shared 규칙을
+    // 잃어 .common 미적용 ② 동적 청크가 부모 청크 owner 의 CSS 에만 의존해
+    // 단독 진입 시 스타일 미적용 — cascade 와 청크 독립 로드 의미가 깨졌다.
+    // dedup 은 청크 단위로만(같은 청크 내 같은 CSS 가 여러 JS 모듈 경로로
+    // 도달해도 1번). 청크 간 복제는 허용 — 동적 청크가 자기 CSS 를
+    // <link> 로 가져가도록 `chunk_css_hrefs` 도 자동으로 채워진다.
+    var chunk_mods = std.AutoHashMap(u32, std.ArrayListUnmanaged(*const Module)).init(allocator);
+    defer {
+        var vit = chunk_mods.valueIterator();
+        while (vit.next()) |list| list.deinit(allocator);
+        chunk_mods.deinit();
+    }
+    // (chunk_idx, css_module_idx) 쌍 dedup — 한 청크 내 같은 CSS 1회.
+    var chunk_seen = std.AutoHashMap(ChunkCssKey, void).init(allocator);
+    defer chunk_seen.deinit();
     var visited = std.AutoHashMap(ModuleIndex, void).init(allocator);
     defer visited.deinit();
 
@@ -151,31 +167,13 @@ pub fn planCssChunks(
         if (m.module_type == .css) continue;
         const ci = chunk_graph.getModuleChunk(m.index);
         if (ci.isNone()) continue;
-        const ch = chunk_graph.getChunk(ci);
-        const rank: u64 = (@as(u64, ch.exec_order) << 32) | @as(u64, m.exec_index);
         visited.clearRetainingCapacity();
         for (m.dependencies.items) |dep| {
-            walkCssOwner(graph, chunk_graph, dep, ci, rank, &owner, &owner_rank, &visited);
+            try walkCssOwner(allocator, graph, chunk_graph, dep, ci, &chunk_mods, &chunk_seen, &visited);
         }
     }
 
-    if (owner.count() == 0) return allocator.alloc(CssChunkPlanEntry, 0);
-
-    // owner 를 청크별 역색인으로 1회 변환 (청크마다 owner 전체를 재스캔하지 않도록).
-    var chunk_mods = std.AutoHashMap(u32, std.ArrayListUnmanaged(*const Module)).init(allocator);
-    defer {
-        var vit = chunk_mods.valueIterator();
-        while (vit.next()) |list| list.deinit(allocator);
-        chunk_mods.deinit();
-    }
-    var oit = owner.iterator();
-    while (oit.next()) |e| {
-        const mm = graph.getModule(e.key_ptr.*) orelse continue;
-        if (mm.module_type != .css or mm.css_data == null) continue;
-        const gop = try chunk_mods.getOrPut(@intFromEnum(e.value_ptr.*));
-        if (!gop.found_existing) gop.value_ptr.* = .empty;
-        try gop.value_ptr.append(allocator, mm);
-    }
+    if (chunk_mods.count() == 0) return allocator.alloc(CssChunkPlanEntry, 0);
 
     var out_list: std.ArrayListUnmanaged(CssChunkPlanEntry) = .empty;
     errdefer {
@@ -214,6 +212,9 @@ pub fn planCssChunks(
         const css_path = try cssPathForChunk(allocator, chunk_graph.getChunk(cidx), css_names, buf.items);
         errdefer allocator.free(css_path);
         const contents = try buf.toOwnedSlice(allocator);
+        // toOwnedSlice 후 buf 가 비워지므로 defer buf.deinit 은 contents 를 회수하지 않는다.
+        // out_list.append 가 실패하면 contents 는 어디에도 매여 있지 않아 누수 — errdefer 보호.
+        errdefer allocator.free(contents);
         try out_list.append(allocator, .{
             .chunk_index = @intCast(chunk_idx),
             .path = css_path,
@@ -269,39 +270,50 @@ pub fn emitCssChunks(
     return planToOutputFiles(allocator, plan);
 }
 
-/// CSS 서브그래프를 DFS 하며 각 CSS 모듈의 귀속 청크를 최소 rank 로 갱신한다.
-/// 자체 chunk 를 가진 JS 모듈은 멈춘다(호출부 개별 순회가 처리 — 과귀속 방지).
-/// 단 chunk 미할당 JS(= tree-shaken 된 `.css.js` 류 side-effect proxy: Sass/CSS
-/// Modules 가 `import "./x.scss"` → proxy → `import "./x.css"` 로 생성)는 통과해
-/// 그 너머 CSS 를 현재 청크에 귀속한다 — 통과 안 하면 splitting 경로에서 CSS 가
-/// 통째로 누락된다(#3330).
-/// `visited` 는 JS 모듈(루트)마다 clear 되며 `rank` 는 한 루트 안에서 불변 →
-/// 같은 루트 내 재방문은 정보가 없어 skip 해도 안전하고, 다른 루트(다른 rank)
-/// 에서는 visited 가 비워져 재평가되므로 최소 rank 가 누락되지 않는다.
+/// `chunk_mods`/`chunk_seen` 의 청크 dedup 키. AutoHashMap 이 자동 hash/eql.
+const ChunkCssKey = struct { chunk: u32, css: ModuleIndex };
+
+/// CSS 서브그래프를 DFS 하며 각 JS 청크 `ci` 가 도달 가능한 CSS 모듈을
+/// `chunk_mods[ci]` 에 등재한다(per-chunk dedup). single-owner min-rank 정책은
+/// 페이지/동적 청크 독립 로드 시 cascade 와 적용성을 깨므로 폐기 — 도달 모든
+/// 청크에 인라인 복제(esbuild/webpack 동치). 자체 chunk 를 가진 JS 모듈에서
+/// 멈추는 것은 그대로(과귀속 방지: 그 청크는 자기 순회에서 자기 CSS 를
+/// 등재한다). chunk 미할당 JS(= tree-shaken 된 `.css.js` 류 side-effect proxy:
+/// Sass/CSS Modules 가 `import "./x.scss"` → proxy → `import "./x.css"` 로
+/// 생성)는 통과해 그 너머 CSS 를 현재 청크에 귀속한다 — 통과 안 하면
+/// splitting 경로에서 CSS 가 통째로 누락된다(#3330).
+/// `visited` 는 JS 모듈(루트)마다 clear — 한 루트 안 재방문은 새 정보 없음.
+/// 다른 청크 루트에서는 visited 가 비워져 재평가되므로 누락되지 않는다.
+/// JS 가 import 한 CSS 는 등재하고 멈춘다 — 그 CSS 가 @import 한 CSS 는
+/// emit 시점에 `emitCssModuleTree` 가 인라인(@import 의미: 쓰는 곳마다 존재,
+/// #3321 P0-4).
 fn walkCssOwner(
+    allocator: std.mem.Allocator,
     graph: *const ModuleGraph,
     chunk_graph: *const ChunkGraph,
     idx: ModuleIndex,
     ci: ChunkIndex,
-    rank: u64,
-    owner: *std.AutoHashMap(ModuleIndex, ChunkIndex),
-    owner_rank: *std.AutoHashMap(ModuleIndex, u64),
+    chunk_mods: *std.AutoHashMap(u32, std.ArrayListUnmanaged(*const Module)),
+    chunk_seen: *std.AutoHashMap(ChunkCssKey, void),
     visited: *std.AutoHashMap(ModuleIndex, void),
-) void {
+) !void {
     if (idx.isNone()) return;
     if (visited.contains(idx)) return;
-    visited.put(idx, {}) catch return;
+    // 함수가 `!void` 로 바뀌었으니 visited.put OOM 도 try 로 propagate.
+    // 옛 `catch return` 은 silent skip → CSS 서브트리 누락 + 호출자가 OOM 도
+    // 감지 못함. 같은 함수 내 chunk_seen/chunk_mods 가 try 를 쓰는 것과도 일관.
+    try visited.put(idx, {});
     const mod = graph.getModule(idx) orelse return;
 
     if (mod.module_type == .css) {
-        // JS 가 import 한 CSS 만 소유(min-rank 단일 소유 = dedup). 그 CSS 가
-        // @import 한 CSS 는 여기서 소유하지 않는다 — emit 시 청크별로 인라인
-        // 복제(@import 의미: 쓰는 곳마다 존재)되어야 하므로(#3321 P0-4).
-        const better = if (owner_rank.get(idx)) |r| rank < r else true;
-        if (better) {
-            owner.put(idx, ci) catch return;
-            owner_rank.put(idx, rank) catch return;
-        }
+        if (mod.css_data == null) return;
+        const ci_u32 = @intFromEnum(ci);
+        // 청크 단위 dedup — 같은 청크 안에서 여러 JS 모듈이 같은 CSS 도달해도 1회.
+        const seen_gop = try chunk_seen.getOrPut(.{ .chunk = ci_u32, .css = idx });
+        if (seen_gop.found_existing) return;
+        const list_gop = try chunk_mods.getOrPut(ci_u32);
+        if (!list_gop.found_existing) list_gop.value_ptr.* = .empty;
+        try list_gop.value_ptr.append(allocator, mod);
         return;
     }
 
@@ -309,7 +321,7 @@ fn walkCssOwner(
     // chunk 미할당(tree-shaken side-effect proxy)만 통과해 너머 CSS 를 찾는다.
     if (!chunk_graph.getModuleChunk(mod.index).isNone()) return;
     for (mod.dependencies.items) |dep| {
-        walkCssOwner(graph, chunk_graph, dep, ci, rank, owner, owner_rank, visited);
+        try walkCssOwner(allocator, graph, chunk_graph, dep, ci, chunk_mods, chunk_seen, visited);
     }
 }
 

--- a/tests/integration/tests/css-code-splitting.test.ts
+++ b/tests/integration/tests/css-code-splitting.test.ts
@@ -65,7 +65,12 @@ describe('CSS code splitting (per-chunk CSS)', () => {
     expect(aCss!.path).not.toBe(bCss!.path);
   });
 
-  test('여러 라우트가 공유하는 CSS 는 중복 없이 한 청크에만 들어간다', async () => {
+  // 두 동적 라우트가 같은 shared.css 를 import 한다. 두 라우트는 서로 독립
+  // 로드되므로(엔트리에서 정적으로 shared 를 import 하지 않음), shared 규칙은
+  // 도달 가능한 *모든* 청크(여기서는 양쪽 라우트 청크)에 인라인 복제돼야
+  // 한다. esbuild/webpack 동치 — single-owner dedup 은 한쪽 페이지에서
+  // .shared 미적용을 일으켜 cascade 와 청크 독립 로드 의미가 깨졌었다.
+  test('여러 라우트가 공유하는 CSS 는 도달 모든 청크에 인라인 복제된다', async () => {
     const fixture = await createFixture({
       'entry.ts': `
         export async function load(which: string) {
@@ -88,8 +93,14 @@ describe('CSS code splitting (per-chunk CSS)', () => {
 
     const css = cssFiles(result.outputFiles!);
     const sharedHits = css.filter((c) => c.text.includes('color: green'));
-    // shared.css 규칙은 정확히 한 청크 CSS 에만 존재해야 한다 (중복 금지)
-    expect(sharedHits.length).toBe(1);
+    // shared 규칙이 양쪽 라우트 청크 CSS 에 모두 들어가야 한다(복제 ≥ 2).
+    expect(sharedHits.length).toBeGreaterThanOrEqual(2);
+    // 동시에 단일 청크 내에서 중복 emit 은 없어야 한다(per-chunk dedup).
+    for (const c of sharedHits) {
+      const m = c.text.match(/color:\s*green/g);
+      expect(m).not.toBeNull();
+      expect(m!.length).toBe(1);
+    }
   });
 
   // P0-4 (#3321): 서로 다른 청크의 CSS 가 같은 CSS 를 @import 하면, 그


### PR DESCRIPTION
## 배경

기존 `planCssChunks` 는 single-owner min-rank dedup 정책이었다 — 같은 CSS 모듈은 import 한 JS 가 속한 청크들 중 `(chunk.exec_order, importer.exec_index)` 가 가장 앞서는 단 하나의 청크에만 귀속. 코드는 짧지만 두 가지 cascade 문제가 있었다:

1. **shared CSS 가 다른 페이지에서 미적용** — 두 entry 가 같은 shared.css 를 import 하면 한 entry 의 CSS 에만 들어가, 다른 entry 진입 시 shared 규칙이 cascade 에 부재.
2. **동적 청크의 독립 로드 실패** — 동적 import 청크가 부모 청크 owner 의 CSS 에만 의존해, 그 동적 청크를 단독으로 진입(예: route URL 직접 입력)하면 자기 CSS 가 emit 되지 않아 unstyled.

esbuild/webpack 은 같은 케이스에서 도달 가능한 *모든* 청크에 CSS 를 인라인 복제해 cascade·독립 로드 의미를 보존한다. 이 PR 은 ZNTC 도 같은 정책으로 이전한다.

## 변경

### `src/bundler/css_emitter.zig`

| 옛 정책 (single-owner) | 새 정책 (multi-owner) |
|---|---|
| `owner: AutoHashMap(ModuleIndex → ChunkIndex)` + `owner_rank` 로 최소 rank 선택 | `chunk_mods: AutoHashMap(u32 → ArrayList(*Module))` 에 도달 모든 청크에 등재 |
| 한 CSS = 한 청크 (전역 dedup) | 청크 단위 dedup (같은 청크 내 1회), 청크 간엔 복제 |
| 동적 청크가 owner 인 CSS 만 자기 link href 보유 | 모든 청크가 자기 도달 CSS 를 link prologue 로 가져옴 |

- `walkCssOwner` 가 도달 모든 `(chunk, css)` 쌍을 `chunk_mods` 에 등재. JS 가 자체 chunk 를 가지면 멈춤(과귀속 방지 — 그 청크 자기 순회가 자기 CSS 를 등재). chunk 미할당 JS(tree-shaken `.css.js` 류 side-effect proxy) 만 통과(#3330).
- CSS→CSS `@import` 의존은 emit 시점 `emitCssModuleTree` 가 청크별로 인라인(#3321 P0-4 유지). 단일 청크 내 같은 CSS 가 여러 경로로 도달해도 1회만.
- 동적 청크 JS prologue 가 자기 CSS basename 의 `<link>` 를 주입하도록 `chunk_css_hrefs` 가 자동으로 동적 청크까지 채워진다.

### `/code-review max` 결과 반영 fix (4건)

1. **`visited.put(idx, {}) catch return;` → `try visited.put(...)`** (walkCssOwner + emitCssModuleTree)
   함수가 `!void` 로 바뀌었으니 OOM 은 propagate 해야 한다. catch return 으로 삼키면 (a) 같은 함수 내 chunk_seen/chunk_mods 가 try 를 쓰는 것과 일관성 깨지고, (b) silent skip 으로 CSS 서브트리 누락 + 호출자가 OOM 도 감지 못함.
2. **`contents` 누수 보호** (planCssChunks ~line 213)
   `toOwnedSlice` 후 buf 가 비워지므로 `defer buf.deinit` 이 contents 를 회수하지 않는다. `out_list.append` 가 OOM 으로 실패하면 contents 가 어디에도 매여있지 않아 누수 — `errdefer allocator.free(contents)` 로 보호.
3. **doc-comment 갱신**
   planCssChunks 위 doc 이 'single-owner min-rank' 정책을 그대로 명시하고 있었다(stale). multi-owner / esbuild·webpack 동치로 갱신.
4. **테스트 prologue 가드 tautology 제거**
   새 splitting+CSS 테스트의 `expect(dynJs.text).toContain('dyn-a')` 는 chunk header/주석/모듈 path 에도 등장하는 stem 이라 prologue href 가 잘못 채워져도 통과. `new URL(\"./<basename>\",import.meta.url)` 전체 토큰 매치로 강화.

### 테스트

- **신규** `packages/core/test/core/option-combinations/core-options/splitting.ts` — splitting+CSS 옵션 조합: shared CSS 가 도달 모든 청크에 인라인, 동적 청크가 자기 CSS + link prologue 를 가지는지 검증.
- **갱신** `tests/integration/tests/css-code-splitting.test.ts` — '여러 라우트가 공유하는 CSS' 가드의 `sharedHits.length` `===1` → `>=2` (multi-owner), 그리고 청크 내부 중복 emit 은 여전히 1회임도 확인.
- **불변** 같은 파일의 다른 11 회귀 가드(도달성 분리, P0-4 cross-chunk @import 복제, 결정적 파일명 등)는 그대로 통과.

## 검증

| 항목 | 결과 |
|---|---|
| `zig build test` (전체 단위) | exit 0, fail/error/panic/leak 없음 |
| `packages/core` 풀 테스트 | 1015 pass / 0 fail (이전 1013 + 신규 2) |
| `tests/integration/tests/css-code-splitting.test.ts` | 12/12 |
| sibling code-splitting (`css-bundle`, `css-library-smoke`, `manual-chunks*`, `cjs-`, `iife-`, `umd-amd-`) | 140/140 |
| `tests/integration/tests/es5-rn.test.ts` (sanity, CSS 무관) | 30/30 |

## 후속 PR 후보 (이번 범위 밖)

`/code-review max` 가 surfacing 한 추가 항목 중 이번 PR 에서 다루지 않는 것 — 대부분 pre-existing 이거나 정책 결정이 필요:

- **`planChunkHrefs` 의 subdir loss** (pre-existing): `std.fs.path.basename` 으로 디렉토리를 잃어, `css_names=\"assets/[name]\"` 같은 패턴에서 동적 청크 link href 가 JS 청크와 같은 디렉토리 기준이 되어 404. 별도 fix PR 권장.
- **`cssPathForChunk` + 기본 `css_names=\"[name]\"` 충돌**: 두 entry 가 같은 stem(예: `pages/a/index.tsx`, `pages/b/index.tsx`)이면 둘 다 `index.css` 로 emit → writeFileSync last-write-wins. multi-owner 로 표면이 커졌으나 pre-existing. content-hash 강제 또는 planToOutputFiles dedup 필요.
- **OOM 시 silent global CSS drop** (정책 결정): `planCssChunks` 호출자(bundler.zig)가 `catch null` 로 흡수해, 한 청크의 한 CSS 등재 실패가 전체 CSS plan 폐기로 번진다. 옛 single-owner 시대엔 walkCssOwner 가 `catch return` 으로 부분 손실에 그쳤지만 이제 `!void` 라 fail-fast. partial-on-error 로 되돌릴지 / loud failure 로 user 에게 노출할지 검토 필요.
- **`appendCssModule` strip_end edge case**: 전체가 `@import` 인 CSS 파일(strip_end == source.len)이면 조건이 false 로 떨어져 전체 source(= `@import` 라인 포함) 가 emit 됨. 실제 reach 가 있는지 확인 후 fix.

## 메모

- 빌드 산출물(`zig-out/`, `.zig-cache/`)은 commit 에 포함하지 않음.
- 새 분기에서 작업 — rebase only merge 정책 준수.