### PR TITLE
feat(bundler): CSS chunk path 충돌 자동 disambiguate (same-stem multi-entry)

### DIFF
--- a/packages/core/test/core/option-combinations/core-options/splitting.ts
+++ b/packages/core/test/core/option-combinations/core-options/splitting.ts
@@ -6,6 +6,7 @@ import {
   describe,
   expect,
   join,
+  mkdirSync,
   removeOptionCombinationFixture,
   test,
   writeFileSync,
@@ -111,5 +112,97 @@ describe('옵션 조합 통합 테스트 - core options - splitting', () => {
     // 는 `new URL("./<basename>",import.meta.url)` 형태이므로 그대로 검증.
     const dynCssFullBase = dynCss!.path.split(/[\\/]/).pop() ?? '';
     expect(dynJs!.text).toContain(`new URL("./${dynCssFullBase}",import.meta.url)`);
+  });
+
+  // 회귀 가드: 두 entry 가 같은 stem(예: pages/a/index.tsx + pages/b/index.tsx)
+  // 일 때 chunkNames='[name]' 기본 패턴이 두 청크 모두 'index' 로 만들어 CSS
+  // 출력 경로 'index.css' 가 충돌 → writeFileSync last-write-wins 로 한쪽 CSS
+  // 가 silent 손실되던 pre-existing 버그(multi-owner 화 이후 표면 확대).
+  // fix 후: 충돌이 발생하는 청크 그룹 안에서만 content-hash disambiguator 가
+  // 자동 부여돼 둘 다 보존된다(같은 stem 그룹 밖의 청크는 안정 파일명 유지).
+  test('splitting + CSS — 두 entry 동일 stem 시 CSS path 충돌 회피(자동 hash)', async () => {
+    mkdirSync(join(dir, 'pages-a'), { recursive: true });
+    mkdirSync(join(dir, 'pages-b'), { recursive: true });
+    writeFileSync(
+      join(dir, 'pages-a', 'index.ts'),
+      'import "./styles.css";\nexport const a = 1;\n',
+    );
+    writeFileSync(join(dir, 'pages-a', 'styles.css'), '.page-a { color: red; }\n');
+    writeFileSync(
+      join(dir, 'pages-b', 'index.ts'),
+      'import "./styles.css";\nexport const b = 2;\n',
+    );
+    writeFileSync(join(dir, 'pages-b', 'styles.css'), '.page-b { color: blue; }\n');
+
+    const result = await build({
+      entryPoints: [join(dir, 'pages-a', 'index.ts'), join(dir, 'pages-b', 'index.ts')],
+      splitting: true,
+      entryNames: '[name]',
+      chunkNames: '[name]',
+      // cssNames 는 기본('[name]') — 의도적으로 충돌 조건을 만든다.
+    });
+    expect(result.errors.length).toBe(0);
+
+    const css = result.outputFiles.filter((f) => f.path.endsWith('.css'));
+    const js = result.outputFiles.filter((f) => f.path.endsWith('.js'));
+    // 두 entry 의 CSS 가 모두 outputFiles 에 보존돼야 한다(충돌 silent 손실 금지).
+    const aCss = css.find((c) => c.text.includes('.page-a'));
+    const bCss = css.find((c) => c.text.includes('.page-b'));
+    expect(aCss).toBeDefined();
+    expect(bCss).toBeDefined();
+
+    // 그리고 *서로 다른* path 여야 한다(같은 path 면 디스크 쓰기 시 last-wins).
+    expect(aCss!.path).not.toBe(bCss!.path);
+
+    // outputFiles 안에 중복 path 가 없어야 한다(전반적 invariant).
+    const cssPathSet = new Set(css.map((c) => c.path));
+    expect(cssPathSet.size).toBe(css.length);
+
+    // ★ prologue href 정합: 각 entry JS 의 link prologue 가 *자기* 청크의
+    // disambiguated CSS basename 을 가리켜야 한다(엉뚱한 청크 CSS 참조 시 cascade
+    // 깨짐 + 404 가능). 두 entry 모두 같은 stem 'index' 이므로 JS path 만으론
+    // 구별 불가 → 자기 모듈 본문 마커 (transformer 후 'const a = 1' / 'const b = 2'
+    // + 'export { a }' / 'export { b }') 로 식별. multi-owner 정책상 entry JS
+    // 청크는 자기 CSS link 를 가진다.
+    const aJs = js.find((j) => j.text.includes('const a = 1'));
+    const bJs = js.find((j) => j.text.includes('const b = 2'));
+    expect(aJs).toBeDefined();
+    expect(bJs).toBeDefined();
+    const aCssBase = aCss!.path.split(/[\\/]/).pop()!;
+    const bCssBase = bCss!.path.split(/[\\/]/).pop()!;
+    expect(aJs!.text).toContain(`new URL("./${aCssBase}",import.meta.url)`);
+    expect(bJs!.text).toContain(`new URL("./${bCssBase}",import.meta.url)`);
+    // 그리고 cross-reference 가 *없어야* 한다 — aJs 에 bCss basename, bJs 에
+    // aCss basename 이 들어가면 disambiguator 가 잘못된 그룹을 매핑한 것.
+    expect(aJs!.text).not.toContain(bCssBase);
+    expect(bJs!.text).not.toContain(aCssBase);
+  });
+
+  // 회귀 가드: disambiguator 결정성 — 같은 input 두 번 빌드해도 동일한 path
+  // 가 나와야 한다(content-hash 기반이라 결정적이어야 함). HashMap 순회 순서
+  // 등으로 비결정성이 새어들면 CI 가 떨어지거나 CDN 캐시 히트율이 무너진다.
+  test('splitting + CSS — disambiguator 결과는 결정적(두 번 빌드 동일 path)', async () => {
+    mkdirSync(join(dir, 'det-a'), { recursive: true });
+    mkdirSync(join(dir, 'det-b'), { recursive: true });
+    writeFileSync(join(dir, 'det-a', 'index.ts'), 'import "./s.css";\nexport const a = 1;\n');
+    writeFileSync(join(dir, 'det-a', 's.css'), '.det-a { color: red; }\n');
+    writeFileSync(join(dir, 'det-b', 'index.ts'), 'import "./s.css";\nexport const b = 2;\n');
+    writeFileSync(join(dir, 'det-b', 's.css'), '.det-b { color: blue; }\n');
+
+    const opts = {
+      entryPoints: [join(dir, 'det-a', 'index.ts'), join(dir, 'det-b', 'index.ts')],
+      splitting: true,
+      entryNames: '[name]',
+      chunkNames: '[name]',
+    };
+    const r1 = await build(opts);
+    const r2 = await build(opts);
+    expect(r1.errors.length).toBe(0);
+    expect(r2.errors.length).toBe(0);
+
+    const pickCssByMarker = (r: typeof r1, marker: string) =>
+      r.outputFiles.find((f) => f.path.endsWith('.css') && f.text.includes(marker))!.path;
+    expect(pickCssByMarker(r1, '.det-a')).toBe(pickCssByMarker(r2, '.det-a'));
+    expect(pickCssByMarker(r1, '.det-b')).toBe(pickCssByMarker(r2, '.det-b'));
   });
 });

--- a/packages/core/test/core/option-combinations/helpers.ts
+++ b/packages/core/test/core/option-combinations/helpers.ts
@@ -8,6 +8,7 @@ export {
   describe,
   expect,
   join,
+  mkdirSync,
   readFileSync,
   rmSync,
   test,

--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -222,7 +222,96 @@ pub fn planCssChunks(
         });
     }
 
+    // 두 entry 가 같은 stem(예: pages/a/index.tsx + pages/b/index.tsx) 이면
+    // cssPathForChunk 가 둘 다 같은 path 를 반환해 writeOutputFiles 가 한쪽을
+    // overwrite — silent CSS 손실. JS 청크 placeholder 와 달리 CSS 는 안정
+    // 파일명(app-builder HTML link rewrite 호환) 을 위해 hash 를 강제하지 않는
+    // 정책이라, 충돌이 *발생한 그룹에 한해서만* content-hash 를 자동 부여한다.
+    // 그룹 내 contents 가 모두 같으면(우연한 동일 emit) overwrite 가 무해하므로
+    // 건드리지 않는다 — 안정 파일명 invariant 유지.
+    try disambiguatePathCollisions(allocator, out_list.items);
+
     return out_list.toOwnedSlice(allocator);
+}
+
+/// out_list 안에서 같은 `path` 를 가지면서 `contents` 가 서로 다른 항목들에
+/// 한해 content-hash disambiguator 를 자동 부여한다. 같은 path + 같은 contents
+/// 인 그룹은 그대로 둔다(disk write last-wins 가 무해).
+///
+/// 두 패스로 처리한다:
+/// 1패스: items[i].path 만 읽어 groups + new_paths(인덱스 i → 새 path 또는 null).
+/// 2패스: groups 를 *완전히 폐기* 한 뒤 items[i].path 를 free 하고 new_path 로 swap.
+/// 이렇게 분리하면 groups 의 키(= items[i].path 슬라이스) 가 살아있는 동안엔
+/// free 가 발생하지 않아 use-after-free 가능성이 원천 차단된다 — 향후
+/// disambiguate 본문에 groups 재조회를 추가하는 패치에도 안전.
+fn disambiguatePathCollisions(
+    allocator: std.mem.Allocator,
+    items: []CssChunkPlanEntry,
+) !void {
+    if (items.len < 2) return;
+
+    // 새 path 후보(없으면 null) — 1패스 결과를 2패스로 전달.
+    const new_paths = try allocator.alloc(?[]const u8, items.len);
+    defer allocator.free(new_paths);
+    @memset(new_paths, null);
+    // 1패스 도중 alloc 한 new_path 중 2패스에 도달 못한(=중간 OOM) 것을 정리.
+    errdefer for (new_paths) |p| if (p) |s| allocator.free(s);
+
+    {
+        var groups = std.StringHashMap(std.ArrayListUnmanaged(usize)).init(allocator);
+        defer {
+            var vit = groups.valueIterator();
+            while (vit.next()) |list| list.deinit(allocator);
+            groups.deinit();
+        }
+        for (items, 0..) |e, i| {
+            const gop = try groups.getOrPut(e.path);
+            if (!gop.found_existing) gop.value_ptr.* = .empty;
+            try gop.value_ptr.append(allocator, i);
+        }
+
+        var git = groups.iterator();
+        while (git.next()) |grp| {
+            const idxs = grp.value_ptr.items;
+            if (idxs.len < 2) continue;
+            const ref = items[idxs[0]].contents;
+            var all_same = true;
+            for (idxs[1..]) |i| {
+                if (!std.mem.eql(u8, items[i].contents, ref)) {
+                    all_same = false;
+                    break;
+                }
+            }
+            if (all_same) continue;
+
+            for (idxs) |i| {
+                // 1패스에선 alloc 만 — items[i].path 는 아직 안 건드린다.
+                new_paths[i] = try insertContentHash(allocator, items[i].path, items[i].contents);
+            }
+        }
+        // 여기서 defer 블록이 돌며 groups 를 완전 해제. 이 시점 이후엔 groups 가
+        // items[i].path 를 더 이상 키로 보지 않으므로 2패스의 free 가 안전.
+    }
+
+    // 2패스: 1패스에서 new_path 가 할당된 인덱스만 old 를 free 하고 swap.
+    for (items, 0..) |*e, i| {
+        if (new_paths[i]) |np| {
+            allocator.free(e.path);
+            e.path = np;
+            new_paths[i] = null; // 더 이상 errdefer 가 회수하지 않게 비운다.
+        }
+    }
+}
+
+/// `path` 의 마지막 `.css` 확장자 직전에 `-<hash8>` 를 삽입한다. 확장자가
+/// 없으면 끝에 그대로 붙인다(현재 경로 생성기는 항상 `.css` 보장).
+fn insertContentHash(allocator: std.mem.Allocator, path: []const u8, contents: []const u8) ![]const u8 {
+    const h = wyhash.hashHex8(contents);
+    if (std.mem.endsWith(u8, path, ".css")) {
+        const stem = path[0 .. path.len - 4];
+        return std.fmt.allocPrint(allocator, "{s}-{s}.css", .{ stem, h });
+    }
+    return std.fmt.allocPrint(allocator, "{s}-{s}", .{ path, h });
 }
 
 /// `plan` 의 path/contents 소유권을 OutputFile 로 이전한다(plan 컨테이너는
@@ -551,4 +640,113 @@ test "cssPathForChunk: falls back to filename stem then chunk index" {
     const r2 = try cssPathForChunk(a, &ch2, "[name]-[hash]", "c");
     defer a.free(r2);
     try std.testing.expect(std.mem.startsWith(u8, r2, "chunk7-"));
+}
+
+test "insertContentHash: .css 확장자 직전에 -<hash> 삽입" {
+    const a = std.testing.allocator;
+    const r = try insertContentHash(a, "index.css", ".x{}");
+    defer a.free(r);
+    const h = wyhash.hashHex8(".x{}");
+    const expect = try std.fmt.allocPrint(a, "index-{s}.css", .{h});
+    defer a.free(expect);
+    try std.testing.expectEqualStrings(expect, r);
+}
+
+test "insertContentHash: subdir 보존" {
+    const a = std.testing.allocator;
+    const r = try insertContentHash(a, "assets/page.css", ".y{}");
+    defer a.free(r);
+    const h = wyhash.hashHex8(".y{}");
+    const expect = try std.fmt.allocPrint(a, "assets/page-{s}.css", .{h});
+    defer a.free(expect);
+    try std.testing.expectEqualStrings(expect, r);
+}
+
+test "insertContentHash: 확장자 없으면 끝에 -<hash>" {
+    const a = std.testing.allocator;
+    const r = try insertContentHash(a, "noext", ".z{}");
+    defer a.free(r);
+    const h = wyhash.hashHex8(".z{}");
+    const expect = try std.fmt.allocPrint(a, "noext-{s}", .{h});
+    defer a.free(expect);
+    try std.testing.expectEqualStrings(expect, r);
+}
+
+test "disambiguatePathCollisions: 같은 path + 다른 contents 면 양쪽에 hash 부여" {
+    const a = std.testing.allocator;
+    var items = [_]CssChunkPlanEntry{
+        .{ .chunk_index = 0, .path = try a.dupe(u8, "index.css"), .contents = try a.dupe(u8, ".a{}") },
+        .{ .chunk_index = 1, .path = try a.dupe(u8, "index.css"), .contents = try a.dupe(u8, ".b{}") },
+    };
+    defer {
+        for (items) |e| {
+            a.free(e.path);
+            a.free(e.contents);
+        }
+    }
+    try disambiguatePathCollisions(a, &items);
+    // 둘 다 path 가 변경(hash 부여) 됐어야 한다.
+    try std.testing.expect(!std.mem.eql(u8, items[0].path, items[1].path));
+    try std.testing.expect(std.mem.startsWith(u8, items[0].path, "index-"));
+    try std.testing.expect(std.mem.startsWith(u8, items[1].path, "index-"));
+    try std.testing.expect(std.mem.endsWith(u8, items[0].path, ".css"));
+    try std.testing.expect(std.mem.endsWith(u8, items[1].path, ".css"));
+}
+
+test "disambiguatePathCollisions: 같은 path + 같은 contents 면 그대로(stable 파일명 유지)" {
+    const a = std.testing.allocator;
+    var items = [_]CssChunkPlanEntry{
+        .{ .chunk_index = 0, .path = try a.dupe(u8, "index.css"), .contents = try a.dupe(u8, ".a{}") },
+        .{ .chunk_index = 1, .path = try a.dupe(u8, "index.css"), .contents = try a.dupe(u8, ".a{}") },
+    };
+    defer {
+        for (items) |e| {
+            a.free(e.path);
+            a.free(e.contents);
+        }
+    }
+    try disambiguatePathCollisions(a, &items);
+    try std.testing.expectEqualStrings("index.css", items[0].path);
+    try std.testing.expectEqualStrings("index.css", items[1].path);
+}
+
+test "disambiguatePathCollisions: 충돌 없는 그룹은 그대로" {
+    const a = std.testing.allocator;
+    var items = [_]CssChunkPlanEntry{
+        .{ .chunk_index = 0, .path = try a.dupe(u8, "a.css"), .contents = try a.dupe(u8, ".a{}") },
+        .{ .chunk_index = 1, .path = try a.dupe(u8, "b.css"), .contents = try a.dupe(u8, ".b{}") },
+    };
+    defer {
+        for (items) |e| {
+            a.free(e.path);
+            a.free(e.contents);
+        }
+    }
+    try disambiguatePathCollisions(a, &items);
+    try std.testing.expectEqualStrings("a.css", items[0].path);
+    try std.testing.expectEqualStrings("b.css", items[1].path);
+}
+
+test "disambiguatePathCollisions: 3 way 충돌 + 부분 contents 동일" {
+    const a = std.testing.allocator;
+    var items = [_]CssChunkPlanEntry{
+        .{ .chunk_index = 0, .path = try a.dupe(u8, "index.css"), .contents = try a.dupe(u8, ".a{}") },
+        .{ .chunk_index = 1, .path = try a.dupe(u8, "index.css"), .contents = try a.dupe(u8, ".a{}") },
+        .{ .chunk_index = 2, .path = try a.dupe(u8, "index.css"), .contents = try a.dupe(u8, ".c{}") },
+    };
+    defer {
+        for (items) |e| {
+            a.free(e.path);
+            a.free(e.contents);
+        }
+    }
+    try disambiguatePathCollisions(a, &items);
+    // 그룹 안 contents 가 *모두 같지는 않으므로* 전원에 hash 부여.
+    // (부분 동일을 미세하게 처리하면 결정성 + 단순성 모두 깨짐.)
+    try std.testing.expect(std.mem.startsWith(u8, items[0].path, "index-"));
+    try std.testing.expect(std.mem.startsWith(u8, items[1].path, "index-"));
+    try std.testing.expect(std.mem.startsWith(u8, items[2].path, "index-"));
+    // 같은 contents 인 0,1 은 같은 hash → 같은 path (디스크 overwrite 무해)
+    try std.testing.expectEqualStrings(items[0].path, items[1].path);
+    try std.testing.expect(!std.mem.eql(u8, items[0].path, items[2].path));
 }


### PR DESCRIPTION
## 배경

두 entry 가 같은 stem (예: `pages/a/index.tsx` + `pages/b/index.tsx`) 일 때 `chunkNames='[name]'` 기본 패턴은 두 청크 모두 `'index'` 로 만든다. 결과 CSS 출력 경로 `'index.css'` 가 충돌 → `writeFileSync` last-write-wins → 한쪽 CSS silent 손실. multi-page Next/Nuxt 스타일 라우팅에서 흔히 발현하는 회귀.

Pre-existing 버그지만 PR #3685(multi-owner CSS replication) 이후 **표면이 확대**됐다 — 이전 single-owner dedup 정책에선 한 entry 만 owner 가 되어 충돌이 단일 entry 케이스로 감춰져 있었다.

## 변경

### `src/bundler/css_emitter.zig`

**`disambiguatePathCollisions` 추가** — `planCssChunks` 의 plan finalize 단계에 자동 충돌 해소.

| 입력 | 동작 |
|---|---|
| 같은 path + **다른** contents 그룹 | 각 항목에 `<stem>-<wyhash8>.css` 자동 부여 |
| 같은 path + **같은** contents 그룹 | 그대로 둔다 (overwrite 무해, 안정 파일명 유지) |
| 충돌 없는 항목 | 무변경 (app-builder HTML link rewrite 호환) |

**두 패스로 처리** — `/code-review max` 가 surfacing 한 키-슬라이스 lifetime fragility 를 원천 차단:

```zig
// 1패스: items[i].path 만 읽어 groups + new_paths(인덱스 → 새 path 또는 null).
// 2패스: groups 를 *완전히 폐기* 한 뒤 items[i].path 를 free 하고 new_path 로 swap.
```

이렇게 분리하면 `groups` 가 `items[i].path` 슬라이스를 키로 잡고 있는 동안엔 `free` 가 절대 발생하지 않아 use-after-free 가능성이 0. 향후 disambiguate 본문에 `groups` 재조회 한 줄을 추가하는 패치에도 안전하다.

**새 helper `insertContentHash`** — path 의 `.css` 직전(또는 끝)에 `-<hash8>` 삽입. `wyhash.hashHex8` 사용으로 결정적 + content-only 의존.

**새 Zig 단위 테스트 7개** — `insertContentHash` 3 case + `disambiguatePathCollisions` 4 case (충돌+다른/같은 contents, 충돌 없음, 3-way 부분 동일).

### 통합 테스트 (`packages/core/test/core/option-combinations/core-options/splitting.ts`)

**신규 가드 1: same-stem 충돌 회피**
- 양쪽 CSS 보존(`'.page-a'`/`'.page-b'` 마커)
- 서로 다른 path
- 전체 outputFiles path Set 크기 일치
- prologue href 정합: `new URL(\"./<basename>\",import.meta.url)` 의 *정확한* 토큰이 자기 청크 CSS basename 과 일치
- cross-reference 부재: aJs 에 bCss basename / bJs 에 aCss basename 이 들어가면 disambiguator 가 잘못된 그룹 매핑한 것 — 부재로 가드

**신규 가드 2: disambiguator 결정성**
- 같은 input 두 번 빌드 → 동일한 disambiguated path
- content-hash 기반이라 결정적이어야 함; HashMap 순회 비결정성이 새어들면 CI/CDN 캐시 깨짐

## 검증

| 항목 | 결과 |
|---|---|
| `zig build test` | exit 0; css_emitter 신규 단위 7개 모두 통과 |
| `packages/core/test/.../core-options/splitting.ts` | 4/4 pass (기존 3 + 신규 충돌 + 결정성) |
| `tests/integration/tests/css-code-splitting.test.ts` | 12/12 |
| sibling CSS/manual-chunks (`css-bundle`, `css-library-smoke`, `manual-chunks*`) | 124/124 |

## /code-review max 결과 분류

**본 PR 안에서 처리**:
- **F2 StringHashMap 키 lifetime fragility** → 두 패스 분리(위 설명).
- **F3 prologue href 통합 검증 누락** → 새 가드(cross-reference 부재 포함).
- **F4 disambiguator 결정성 통합 검증 누락** → 별도 테스트 추가.

**별도 follow-up PR (본 PR scope = multi-owner-amplified 표면 only)**:

- **F1 `emitCssBundle` 비-splitting 경로의 동일 충돌** — `bundler.zig:1879` 의 entry-별 호출이 결과 OutputFile 을 직접 append. splitting 경로의 `CssChunkPlanEntry` 와 다른 자료형 → 별도 helper 필요. `--no-splitting` 모드에선 이번 fix 가 무력화 (사용자 영향 있음, 우선 follow-up 후보).
- **F5 JS chunk 동일 충돌** — 두 entry `'index'` 가 `'index.js'` 두 번 emit. 본 PR scope = CSS 만. JS path 충돌은 같은 disambiguator 정책으로 처리하되 별도 PR. 사용자는 본 PR fix 만으로는 JS path collision 영향(런타임 import 깨짐)을 여전히 받는다.
- **F6 `wyhash.hashHex8` truncation** — u32(8 hex) 만 사용해 ~4e9 공간. 대형 multi-route(10k+) 빌드에서 birthday paradox(누적 ~1.25%) 로 다른 contents 두 청크가 같은 hash → 같은 disambiguated path 로 silent overwrite. u64(16 hex) 확장 또는 secondary disambiguator(group-내 순번 suffix) 필요 — 다른 호출자 영향 → 별도 PR.
- **F7 app-builder htmlReferencesPath stale** — 사용자가 HTML 에 `<link href=\"index.css\">` 를 직접 적은 경우, 자동 hash 후엔 dangling. HTML 인접 작업.
- **F8 MF expose CSS 이름 churn** — stable CSS asset 이름을 가정한 외부 consumer(CDN, host runtime preloadRemote 캐시) 가 build 간 이름 변경에 영향. RFC 차원 follow-up.

## 메모리 lifetime

`disambiguatePathCollisions` 의 errdefer 정책:
- 1패스 중 alloc 한 `new_path` 가 2패스 도달 전에 OOM 등으로 새어 나가면 `for (new_paths) |p| if (p) |s| allocator.free(s)` errdefer 가 회수.
- 2패스에서 swap 한 항목은 `new_paths[i] = null` 로 비워 errdefer 가 같은 슬라이스를 이중 free 하지 않는다.
- `groups` 의 defer 는 1패스 끝에서 그 자리에서 모두 해제 — 키 lifetime 은 `items[i].path` 가 아직 살아있는 1패스 동안만이라 dangling 가능성 0.

## 참고 — main 회귀 (PR 무관)

작업 도중 `zig build test` 에서 `src/parser/ast_walk_test.zig` 영역 25 fail 이 한 번 관측됐으나(stash 상태에서도 동일), .zig-cache 재생성 후 재빌드 시 재현되지 않았다. flaky 또는 CI 인프라성 — 이번 PR 과 직교, 별도 추적 필요.