### PR TITLE
feat(bundler): 비-splitting CSS path 충돌 자동 disambiguate

### DIFF
--- a/packages/core/test/core/option-combinations/core-options/splitting.ts
+++ b/packages/core/test/core/option-combinations/core-options/splitting.ts
@@ -205,4 +205,63 @@ describe('옵션 조합 통합 테스트 - core options - splitting', () => {
     expect(pickCssByMarker(r1, '.det-a')).toBe(pickCssByMarker(r2, '.det-a'));
     expect(pickCssByMarker(r1, '.det-b')).toBe(pickCssByMarker(r2, '.det-b'));
   });
+
+  // 회귀 가드: splitting:false (=비-splitting / preserve-modules) 모드에서도
+  // 두 entry 가 같은 stem 이면 CSS 출력 경로가 충돌 → 한쪽 silent 손실되던
+  // pre-existing 버그. splitting:true 경로는 PR #3686 에서 처리됐고, 본 가드
+  // 는 비-splitting 경로(`bundler.zig:1879` 의 emitCssBundle 루프) 도 같은
+  // disambiguator 정책을 따르는지 검증한다.
+  test('splitting:false + CSS — 두 entry 동일 stem 시 CSS path 충돌 회피', async () => {
+    mkdirSync(join(dir, 'ns-a'), { recursive: true });
+    mkdirSync(join(dir, 'ns-b'), { recursive: true });
+    writeFileSync(join(dir, 'ns-a', 'index.ts'), 'import "./s.css";\nconst a = 1;\n');
+    writeFileSync(join(dir, 'ns-a', 's.css'), '.ns-a { color: red; }\n');
+    writeFileSync(join(dir, 'ns-b', 'index.ts'), 'import "./s.css";\nconst b = 2;\n');
+    writeFileSync(join(dir, 'ns-b', 's.css'), '.ns-b { color: blue; }\n');
+
+    const result = await build({
+      entryPoints: [join(dir, 'ns-a', 'index.ts'), join(dir, 'ns-b', 'index.ts')],
+      splitting: false,
+      entryNames: '[name]',
+    });
+    expect(result.errors.length).toBe(0);
+
+    const css = result.outputFiles.filter((f) => f.path.endsWith('.css'));
+    const aCss = css.find((c) => c.text.includes('.ns-a'));
+    const bCss = css.find((c) => c.text.includes('.ns-b'));
+    // 두 entry CSS 모두 보존(충돌 silent 손실 금지).
+    expect(aCss).toBeDefined();
+    expect(bCss).toBeDefined();
+    // 서로 다른 path 여야 한다.
+    expect(aCss!.path).not.toBe(bCss!.path);
+    // 전체 outputFiles 안에 중복 path 가 없어야 한다(전반적 invariant).
+    const cssPathSet = new Set(css.map((c) => c.path));
+    expect(cssPathSet.size).toBe(css.length);
+  });
+
+  // 회귀 가드: 비-splitting 모드의 disambiguator 결정성 — 같은 input 두 번
+  // 빌드해도 동일한 disambiguated path 가 나와야 한다(splitting 경로의 결정성
+  // 가드와 같은 invariant 를 비-splitting 경로에도 적용).
+  test('splitting:false + CSS — disambiguator 결과는 결정적(두 번 빌드 동일 path)', async () => {
+    mkdirSync(join(dir, 'nsd-a'), { recursive: true });
+    mkdirSync(join(dir, 'nsd-b'), { recursive: true });
+    writeFileSync(join(dir, 'nsd-a', 'index.ts'), 'import "./s.css";\nconst a = 1;\n');
+    writeFileSync(join(dir, 'nsd-a', 's.css'), '.nsd-a { color: red; }\n');
+    writeFileSync(join(dir, 'nsd-b', 'index.ts'), 'import "./s.css";\nconst b = 2;\n');
+    writeFileSync(join(dir, 'nsd-b', 's.css'), '.nsd-b { color: blue; }\n');
+
+    const opts = {
+      entryPoints: [join(dir, 'nsd-a', 'index.ts'), join(dir, 'nsd-b', 'index.ts')],
+      splitting: false,
+      entryNames: '[name]',
+    };
+    const r1 = await build(opts);
+    const r2 = await build(opts);
+    expect(r1.errors.length).toBe(0);
+    expect(r2.errors.length).toBe(0);
+    const pickCssByMarker = (r: typeof r1, marker: string) =>
+      r.outputFiles.find((f) => f.path.endsWith('.css') && f.text.includes(marker))!.path;
+    expect(pickCssByMarker(r1, '.nsd-a')).toBe(pickCssByMarker(r2, '.nsd-a'));
+    expect(pickCssByMarker(r1, '.nsd-b')).toBe(pickCssByMarker(r2, '.nsd-b'));
+  });
 });

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1880,6 +1880,14 @@ pub const Bundler = struct {
                         css_output_files.append(self.allocator, css_out) catch {};
                     }
                 }
+                // 두 entry 가 같은 stem(예: pages/a/index.tsx + pages/b/index.tsx)
+                // 이면 emitCssBundle 가 둘 다 같은 path 의 OutputFile 을 반환 →
+                // writeFileSync 가 한쪽을 overwrite (silent CSS 손실). splitting
+                // 경로(planCssChunks 내부 disambiguatePathCollisions)와 같은
+                // 정책으로 비-splitting 경로도 충돌 그룹에 한해 content-hash
+                // disambiguator 를 자동 부여한다. CSS 실패는 번들 실패로 번지지
+                // 않게 흡수(기존 css emit 의 관용과 동일).
+                css_emit.disambiguateOutputFilePaths(self.allocator, css_output_files.items) catch {};
             }
         }
 

--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -234,20 +234,61 @@ pub fn planCssChunks(
     return out_list.toOwnedSlice(allocator);
 }
 
-/// out_list 안에서 같은 `path` 를 가지면서 `contents` 가 서로 다른 항목들에
-/// 한해 content-hash disambiguator 를 자동 부여한다. 같은 path + 같은 contents
-/// 인 그룹은 그대로 둔다(disk write last-wins 가 무해).
-///
-/// 두 패스로 처리한다:
-/// 1패스: items[i].path 만 읽어 groups + new_paths(인덱스 i → 새 path 또는 null).
-/// 2패스: groups 를 *완전히 폐기* 한 뒤 items[i].path 를 free 하고 new_path 로 swap.
-/// 이렇게 분리하면 groups 의 키(= items[i].path 슬라이스) 가 살아있는 동안엔
-/// free 가 발생하지 않아 use-after-free 가능성이 원천 차단된다 — 향후
-/// disambiguate 본문에 groups 재조회를 추가하는 패치에도 안전.
+/// `planCssChunks` 내부에서 호출되는 CssChunkPlanEntry 용 wrapper.
+/// 정책/메커니즘은 `disambiguatePathCollisionsGeneric` docstring 참조.
 fn disambiguatePathCollisions(
     allocator: std.mem.Allocator,
     items: []CssChunkPlanEntry,
 ) !void {
+    return disambiguatePathCollisionsGeneric(CssChunkPlanEntry, allocator, items);
+}
+
+/// `disambiguatePathCollisions` 의 OutputFile 용 wrapper. 비-splitting /
+/// preserve-modules 경로(`bundler.zig` 의 `emitCssBundle` 루프) 가 entry 별
+/// 단일 CSS 를 `css_output_files` 에 모은 뒤, splitting 경로와 같은 정책으로
+/// path 충돌을 처리한다.
+///
+/// **호출자 계약** (`pub` 이지만 강한 invariant 의존):
+/// - `items[i].path` 와 `items[i].contents` 는 모두 인자 `allocator` 가 alloc 한
+///   슬라이스여야 한다 — 함수가 in-place 로 path 를 `free` + 새 path 로 swap.
+///   static literal/arena/다른 allocator 슬라이스를 섞으면 mismatched-free 로 UB.
+/// - `items` 안에 `.path` 외 다른 필드가 같은 path 문자열을 *참조* 하면(예:
+///   sourcemap 의 file:, module_ids 가 entry path 를 borrow), swap 이후
+///   그 참조는 stale 이 된다. 현재 CSS OutputFile 은 sourcemap/imports 등이
+///   default 이라 안전 — 향후 채우는 PR 은 같이 update 또는 dedup 정책 명시 필요.
+pub fn disambiguateOutputFilePaths(
+    allocator: std.mem.Allocator,
+    items: []OutputFile,
+) !void {
+    return disambiguatePathCollisionsGeneric(OutputFile, allocator, items);
+}
+
+/// path 충돌(`items[i].path` 가 동일 + `contents` 가 다름) 인 그룹에 한해
+/// content-hash disambiguator(`<stem>-<wyhash8>.css`) 를 자동 부여한다.
+/// 같은 path + 같은 contents 인 그룹은 그대로 둔다 — disk write last-wins
+/// 가 무해하고, app-builder HTML link rewrite 의 안정 파일명 invariant 유지.
+///
+/// `T` 는 `.path: []const u8` 와 `.contents: []const u8` 두 필드를 갖는
+/// 구조체여야 한다(`CssChunkPlanEntry`, `OutputFile`). 호출자가 잘못된 T 를
+/// 넘기지 않도록 함수 시작에서 `comptime` 가드한다.
+///
+/// **두 패스 정책** — StringHashMap key-lifetime safety:
+/// - 1패스: `items[i].path` 만 읽어 groups + new_paths(인덱스 i → 새 path 또는 null).
+/// - 2패스: groups 를 *완전히 폐기* 한 뒤 `items[i].path` 를 free 하고 new_path 로 swap.
+/// 이렇게 분리하면 groups 의 키(= `items[i].path` 슬라이스)가 살아있는 동안엔
+/// free 가 발생하지 않아 use-after-free 가능성이 원천 차단된다 — 향후 본문에
+/// groups 재조회를 추가하는 패치에도 안전. **2패스 본문에 fallible 호출을
+/// 추가하지 말 것** — `new_paths[i] = null` 로 비우기 전에 error 가 나면
+/// `errdefer` 가 swap 된 new path 를 again free 해 double-free 가 된다.
+fn disambiguatePathCollisionsGeneric(
+    comptime T: type,
+    allocator: std.mem.Allocator,
+    items: []T,
+) !void {
+    comptime {
+        if (!@hasField(T, "path")) @compileError("disambiguatePathCollisionsGeneric: T must have field 'path'");
+        if (!@hasField(T, "contents")) @compileError("disambiguatePathCollisionsGeneric: T must have field 'contents'");
+    }
     if (items.len < 2) return;
 
     // 새 path 후보(없으면 null) — 1패스 결과를 2패스로 전달.
@@ -749,4 +790,39 @@ test "disambiguatePathCollisions: 3 way 충돌 + 부분 contents 동일" {
     // 같은 contents 인 0,1 은 같은 hash → 같은 path (디스크 overwrite 무해)
     try std.testing.expectEqualStrings(items[0].path, items[1].path);
     try std.testing.expect(!std.mem.eql(u8, items[0].path, items[2].path));
+}
+
+test "disambiguateOutputFilePaths: OutputFile 충돌 그룹에도 동일 정책" {
+    const a = std.testing.allocator;
+    var items = [_]OutputFile{
+        .{ .path = try a.dupe(u8, "index.css"), .contents = try a.dupe(u8, ".a{}") },
+        .{ .path = try a.dupe(u8, "index.css"), .contents = try a.dupe(u8, ".b{}") },
+    };
+    defer {
+        for (items) |e| {
+            a.free(e.path);
+            a.free(e.contents);
+        }
+    }
+    try disambiguateOutputFilePaths(a, &items);
+    try std.testing.expect(!std.mem.eql(u8, items[0].path, items[1].path));
+    try std.testing.expect(std.mem.startsWith(u8, items[0].path, "index-"));
+    try std.testing.expect(std.mem.startsWith(u8, items[1].path, "index-"));
+}
+
+test "disambiguateOutputFilePaths: 같은 contents 면 stable 파일명 유지" {
+    const a = std.testing.allocator;
+    var items = [_]OutputFile{
+        .{ .path = try a.dupe(u8, "shared.css"), .contents = try a.dupe(u8, ".s{}") },
+        .{ .path = try a.dupe(u8, "shared.css"), .contents = try a.dupe(u8, ".s{}") },
+    };
+    defer {
+        for (items) |e| {
+            a.free(e.path);
+            a.free(e.contents);
+        }
+    }
+    try disambiguateOutputFilePaths(a, &items);
+    try std.testing.expectEqualStrings("shared.css", items[0].path);
+    try std.testing.expectEqualStrings("shared.css", items[1].path);
 }


### PR DESCRIPTION
## 배경

PR #3686 에서 splitting 경로의 두 entry 같은 stem CSS path 충돌(`'index.css'` last-write-wins) 을 해소했지만, `--no-splitting` / preserve-modules 모드(`bundler.zig:1879` 의 `emitCssBundle` 루프) 에는 같은 fix 가 적용되지 않아 사용자가 `splitting: false` 로 쓰면 fix 가 무력화됐다. 본 PR 은 비-splitting 경로에도 같은 disambiguator 정책을 일관 적용한다.

### Probe 결과 (probe.mjs)

```
=== CSS outputFiles (splitting:false) ===
index.css | .page-a { color: red; }
index.css | .page-b { color: blue; }
=== path counts === { 'index.css': 2 }
```

두 entry (`pages-a/index.tsx`, `pages-b/index.tsx`) 가 모두 `'index.css'` path 의 OutputFile 을 만든다 → `writeFileSync` last-wins → 한쪽 CSS silent 손실.

## 변경

### `src/bundler/css_emitter.zig`

- **`disambiguatePathCollisions` 본문 → `disambiguatePathCollisionsGeneric(comptime T, ...)` 로 추출.** `T` 는 `.path: []const u8` 와 `.contents: []const u8` 필드를 갖는 구조체여야 한다 — `comptime @hasField` 가드로 잘못된 T 는 컴파일 에러.
- **새 `pub fn disambiguateOutputFilePaths`** — OutputFile 슬라이스에 대해 같은 정책 적용. CssChunkPlanEntry 용 wrapper 와 generic 본문 공유.
- **2-패스 정책 / 호출자 계약 docstring 정리** — 이전엔 wrapper 위에 orphan 이었던 invariant(allocator ownership 일관성, OutputFile 내부 path 참조 부재, 2패스 fallible 호출 금지) 가 모두 generic 본문 위로 이동.
- **새 Zig 단위 테스트 2개** — OutputFile 충돌 그룹 가드 + 같은 contents 시 stable 파일명 유지.

### `src/bundler/bundler.zig`

비-splitting 경로(`else` 분기)의 `emitCssBundle` 루프 직후 한 줄:

```zig
css_emit.disambiguateOutputFilePaths(self.allocator, css_output_files.items) catch {};
```

CSS 실패는 번들 실패로 번지지 않게 흡수(기존 css emit 의 관용과 동일). [F1 follow-up 참고]

### 통합 테스트 (`splitting.ts`)

- **신규 가드 1: 비-splitting 충돌 회피** — 양쪽 CSS 보존, 서로 다른 path, outputFiles path Set 크기 일치.
- **신규 가드 2: 비-splitting 결정성** — 같은 input 두 번 빌드 → 동일한 disambiguated path.

## 검증

| 항목 | 결과 |
|---|---|
| `zig build test` | exit 0; css_emitter 신규 OutputFile 단위 2개 모두 통과 |
| `packages/core/.../splitting.ts` | 6/6 pass (기존 4 + 신규 2) |
| `tests/integration/css-code-splitting.test.ts` | 12/12 |
| 회귀 없음 | sibling CSS/manual-chunks 합쳐 124/124 (prior PR 와 동일) |

## /code-review max 결과 분류

**본 PR 안에서 처리한 안전화** (3건):

| ID | 항목 | 처리 |
|---|---|---|
| F3 | `disambiguateOutputFilePaths` 가 `pub` 인데 allocator/path-ownership invariant 미강제 | docstring 에 강한 계약 명시 (allocator 일관성, path 참조 부재) |
| F4 | generic T 의 `.path`/`.contents` 필드 보장이 doc-only | `comptime @hasField` 가드 추가 |
| F5 | 2-패스 정책 docstring orphan | generic 본문 위로 이전 + "2패스 fallible 호출 추가 금지" warning |

**별도 follow-up PR (본 PR scope 밖, 본문 명시)**:

- **F1 `disambiguateOutputFilePaths(...) catch {}` OOM 시 silent overwrite 회귀 재발** — CSS 실패 흡수 관용은 emit 자체 실패에 한정해야 하고, OOM 은 loud failure 가 안전. 정책 결정 필요(propagate vs `result.warnings` push vs `std.log.warn`). 이번 PR 은 기존 관용 따라 유지.
- **F2 비-splitting `css_output_files.append(...) catch {}` 가 OOM 시 OutputFile leak** — splitting 분기(1868-1871) 는 explicit free, 비-splitting 은 누락. 비대칭 정리 필요. Pre-existing.
- **F6 `wyhash.hashHex8` u32 truncation** — 이전 PR follow-up 에 이미 명시. 비-splitting 경로도 같은 함수 사용해 같은 birthday-paradox 영향.
- **F7 cross-array path collision** — disambiguator 는 `css_output_files` 내부만 봄. plugin `emitFile` 이나 사용자 `chunk_names` 와 cross conflict (css ↔ asset/JS) 는 검사 안 됨. Pre-existing scope.
- **F8 OutputFile fat-struct 값 복사** — 1패스 `for (items, 0..) |e, i|` 가 OutputFile 전체 value-copy. 큰 chunk 수에서 미세 cache 압박. Cosmetic, 우선순위 낮음.