### PR TITLE
feat(bundler): chunks 의 entry/chunk_names 에 [dir] 토큰 지원 (PR B 기술 토대)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1197,6 +1197,7 @@ const chunks = @import("emitter/chunks.zig");
 pub const emitChunks = chunks.emitChunks;
 pub const contentHash = chunks.contentHash;
 pub const applyNamingPattern = chunks.applyNamingPattern;
+pub const applyNamingPatternWithDir = chunks.applyNamingPatternWithDir;
 const computeAllUsedNames = chunks.computeAllUsedNames;
 
 /// JS 예약어이거나 유효한 식별자가 아니면 프로퍼티 키에 따옴표가 필요.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -1784,6 +1784,18 @@ fn chunkRegistryId(
 /// 청크의 placeholder stem을 반환한다 (확장자 없음).
 /// cross-chunk import 등 content가 아직 없는 시점에서 사용.
 /// 최종 출력 시 placeholder를 content hash로 치환한다.
+///
+/// **현재 정책 (PR A)**: `[dir]` 토큰을 `applyNamingPatternWithDir` 가 인식·
+/// 처리는 하지만, 이 호출 시점에선 항상 빈 dir 전달 → 패턴에 `[dir]` 가 있어도
+/// 토큰+인접 슬래시가 함께 제거된다(leading-slash 방지). 즉 PR A 는
+/// 기존 동작(literal `[dir]` 가 패턴에 있을 일은 없음)을 *정확히* 보존하고,
+/// `[dir]` 의 실제 dir 채우기는 PR B 가 안전한 신규 필드와 함께 도입한다.
+///
+/// `chunk.rel_dir` 을 raw 로 전달하지 않는 이유: preserve-modules 에서
+/// `rel_dir` 은 *원본 모듈의 절대 경로(.ts/.tsx 확장자 포함)* 로 misnomer
+/// (chunk.zig:205, :999). 그대로 `[dir]` 에 노출하면 stem 에 절대경로+ext 가
+/// raw 로 들어가 출력이 망가진다(`/abs/foo.ts/foo.js` 류). PR B 가 의미 명확한
+/// entry-relative dir 필드와 함께 이 호출도 갱신할 예정.
 fn chunkPlaceholderStem(chunk: *const Chunk, buf: []u8, options: *const EmitOptions) []const u8 {
     const is_entry = chunk.name != null;
     const base_name = chunk.name orelse "chunk";
@@ -1792,7 +1804,7 @@ fn chunkPlaceholderStem(chunk: *const Chunk, buf: []u8, options: *const EmitOpti
     var hash_buf: [HASH_PLACEHOLDER_PREFIX.len + HASH_PLACEHOLDER_LEN]u8 = undefined;
     buildPlaceholder(chunk, &hash_buf);
 
-    return applyNamingPattern(buf, pattern, base_name, &hash_buf);
+    return applyNamingPatternWithDir(buf, pattern, base_name, &hash_buf, "");
 }
 
 /// 모듈 인덱스 기반 해시 (placeholder 식별자용, content hash 아님).
@@ -1921,7 +1933,29 @@ fn replacePlaceholders(allocator: std.mem.Allocator, input: []const u8, placehol
 /// naming pattern을 적용한다.
 /// [name] → base_name, [hash] → hash_str 로 치환.
 /// buf에 결과를 쓰고 슬라이스를 반환.
+/// [dir] 토큰을 지원하려면 `applyNamingPatternWithDir` 를 사용한다 — 이
+/// 4-arg 변형은 dir = "" 로 위임하므로 패턴에 [dir] 가 있어도 빈 dir 정리
+/// 규칙(leading-slash 제거)이 동일 적용된다.
 pub fn applyNamingPattern(buf: []u8, pattern: []const u8, name: []const u8, hash_str: []const u8) []const u8 {
+    return applyNamingPatternWithDir(buf, pattern, name, hash_str, "");
+}
+
+/// `applyNamingPattern` 의 [dir] 토큰 지원 변형.
+/// [name] → name, [hash] → hash_str, [dir] → dir 로 치환.
+/// dir 안 Windows 백슬래시는 URL 구분자 `/` 로 정규화한다.
+///
+/// **빈 dir 정리 규칙** — esbuild 와 동일 의미:
+/// [dir] 가 빈 문자열로 치환될 때, 토큰 *바로 다음* 문자가 `/` 면 그
+/// 슬래시도 함께 skip 한다. 단일 entry 가 cwd 루트에 있거나(entry_dir
+/// 미설정) 패턴이 `dist/[dir]/[name]` 같이 중간에 [dir] 가 있을 때
+/// leading/double-slash 가 생기지 않도록.
+pub fn applyNamingPatternWithDir(
+    buf: []u8,
+    pattern: []const u8,
+    name: []const u8,
+    hash_str: []const u8,
+    dir: []const u8,
+) []const u8 {
     var dst: usize = 0;
     var i: usize = 0;
     while (i < pattern.len) {
@@ -1935,6 +1969,19 @@ pub fn applyNamingPattern(buf: []u8, pattern: []const u8, name: []const u8, hash
             @memcpy(buf[dst..end], hash_str[0 .. end - dst]);
             dst = end;
             i += "[hash]".len;
+        } else if (i + "[dir]".len <= pattern.len and std.mem.eql(u8, pattern[i..][0.."[dir]".len], "[dir]")) {
+            if (dir.len > 0) {
+                for (dir) |c| {
+                    if (dst >= buf.len) break;
+                    buf[dst] = if (c == '\\') '/' else c;
+                    dst += 1;
+                }
+                i += "[dir]".len;
+            } else {
+                // 빈 dir — 토큰만 skip + 인접한 '/' 도 함께 skip (esbuild parity).
+                i += "[dir]".len;
+                if (i < pattern.len and pattern[i] == '/') i += 1;
+            }
         } else {
             if (dst < buf.len) {
                 buf[dst] = pattern[i];

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -1115,6 +1115,54 @@ test "naming pattern: no placeholders" {
     try std.testing.expectEqualStrings("bundle", result);
 }
 
+// PR A: [dir] 토큰 지원 — applyNamingPatternWithDir 회귀 가드.
+// 기존 applyNamingPattern 시그니처는 그대로 유지하면서 dir 정보를 받는 변형
+// 추가. default 변경(별도 PR)의 기술적 토대.
+
+test "naming pattern: [dir]/[name] with dir" {
+    var buf: [128]u8 = undefined;
+    const result = emitter.applyNamingPatternWithDir(&buf, "[dir]/[name]", "index", "abcdef01", "pages-a");
+    try std.testing.expectEqualStrings("pages-a/index", result);
+}
+
+test "naming pattern: empty dir → leading slash 제거" {
+    // 단일 entry cwd 루트 또는 entry_dir 미설정 → dir == "" → [dir]/ 토큰이
+    // leading slash 만들지 않도록 [dir]+다음 '/' 를 함께 skip 한다(esbuild parity).
+    var buf: [128]u8 = undefined;
+    const result = emitter.applyNamingPatternWithDir(&buf, "[dir]/[name]", "main", "abc12345", "");
+    try std.testing.expectEqualStrings("main", result);
+}
+
+test "naming pattern: 중간 [dir]+빈 문자열 → 인접 '/' skip" {
+    // "dist/[dir]/[name]" 같이 [dir] 가 다른 path 컴포넌트 사이에 있을 때
+    // 빈 dir 면 "dist//main" 이 아니라 "dist/main" 이 되어야 한다.
+    var buf: [128]u8 = undefined;
+    const result = emitter.applyNamingPatternWithDir(&buf, "dist/[dir]/[name]", "main", "abc12345", "");
+    try std.testing.expectEqualStrings("dist/main", result);
+}
+
+test "naming pattern: [dir]/[name]-[hash] 전 토큰 결합" {
+    var buf: [128]u8 = undefined;
+    const result = emitter.applyNamingPatternWithDir(&buf, "[dir]/[name]-[hash]", "index", "abcdef01", "pages-b");
+    try std.testing.expectEqualStrings("pages-b/index-abcdef01", result);
+}
+
+test "naming pattern: windows 백슬래시 정규화" {
+    var buf: [128]u8 = undefined;
+    const result = emitter.applyNamingPatternWithDir(&buf, "[dir]/[name]", "x", "h", "win\\sub");
+    try std.testing.expectEqualStrings("win/sub/x", result);
+}
+
+test "naming pattern: applyNamingPattern (기존 시그니처) 호환 — dir 없는 호출은 그대로" {
+    // 옛 API 호환: dir 인자가 없는 4-arg 호출은 [dir] 토큰이 패턴에 있어도
+    // 빈 dir 로 동작 — leading-slash 정리 동일 적용.
+    var buf: [128]u8 = undefined;
+    const r1 = emitter.applyNamingPattern(&buf, "[name]", "x", "h");
+    try std.testing.expectEqualStrings("x", r1);
+    const r2 = emitter.applyNamingPattern(&buf, "[dir]/[name]", "x", "h");
+    try std.testing.expectEqualStrings("x", r2);
+}
+
 test "naming pattern: entry-names with hash" {
     // --entry-names=[name]-[hash] 설정 시 엔트리 청크에도 hash가 붙는지 확인
     var tmp = std.testing.tmpDir(.{});


### PR DESCRIPTION
## 배경 — JS chunk path 충돌, 다른 번들러 정책 비교

PR #3686 / #3687 가 CSS path 충돌(두 entry 같은 stem 시 `index.css` last-write-wins) 을 disambiguator 로 해소했지만, JS chunk 도 같은 충돌이 그대로 남아있음. probe:

\`\`\`
=== splitting:true JS outputFiles ===
   index.js | PA_MARKER
   index.js | PB_MARKER
paths: { 'index.js': 2 }     ← 한쪽 silent overwrite
\`\`\`

조사한 4개 비교군:

| 번들러 | 같은 stem 두 entry 처리 | 사용자 알림 |
|---|---|---|
| **esbuild** | default `[dir]/[name]` 자동 unique; `[name]` 강제 시 build error | loud |
| **rollup / rolldown / vite** | 자동 numeric suffix (`index.js` + `index2.js`) | silent |
| **webpack** | entry 가 반드시 named key — 충돌 케이스 자체 없음 | 모델 자체 다름 |
| **zntc(현재)** | **silent overwrite** (writeFileSync last-wins) | **알림 없음 (최악)** |

옵션 1 (loud error) / 2 (silent suffix) / 3 (default 변경) 중 **장기·근본 관점에서 옵션 3 채택**:
- 충돌 *근본 원인* 해결(default 자체가 안전 → 충돌 케이스 자체가 발생 안 함).
- Invariant "unique entry path → unique output path" 강력.
- esbuild parity — 가까운 비교군 사용자 마이그레이션 무비용.
- MF/RN/monorepo 확장성.

## 본 PR (PR A — 기술적 토대, 영향 0)

옵션 3 의 default 변경 자체는 별도 PR B 작업이며, **선행 차단** 으로 `chunks.applyNamingPattern` 의 `[dir]` 토큰 미지원이 있음(assets/loaders 경로엔 지원, chunks 엔 미지원). 본 PR 은 이 기술적 토대만 추가하고 **default 변경 없음, 호출자도 dir 활성화 안 함**.

### 변경

**\`src/bundler/emitter/chunks.zig\`**
- \`applyNamingPattern(buf, pattern, name, hash_str)\` 본문을 새 \`applyNamingPatternWithDir(..., dir)\` 으로 추출. 기존 시그니처는 \`dir=\"\"\` 위임으로 보존.
- \`[dir]\` 토큰 처리 추가 + 빈-dir leading/double-slash 정리 (esbuild parity) + Windows 백슬래시 정규화.
- \`chunkPlaceholderStem\` 는 새 변형 호출하되 **항상 \`dir=\"\"\` 전달** — PR A 의 약속(영향 0) 정확 지킴.

**\`src/bundler/emitter.zig\`**
- \`applyNamingPatternWithDir\` pub re-export.

**\`src/bundler/emitter_test.zig\`**
- 신규 단위 테스트 6개: \`[dir]/[name]\` 정상, 빈 dir 시 leading-slash 제거, 중간 [dir] + 빈 dir → 인접 \`/\` skip, [dir]+[name]+[hash] 결합, Windows 백슬래시 정규화, 4-arg 기존 호환.

### 검증

| 항목 | 결과 |
|---|---|
| \`zig build test\` | exit 0, 신규 6 단위 + 기존 [name]/[hash] 4 단위 통과 |
| 통합 (css/chunk/manual-chunks) | 105/105 |
| 기존 사용자 영향 | **0** (default 패턴 \`[name]\` 에 [dir] 없음, 호출자도 dir=\"\") |

## /code-review max 결과 분류

### 본 PR 안에서 처리한 안전화 (F1, CONFIRMED)

**\`chunkPlaceholderStem\` 가 \`chunk.rel_dir\` 를 raw 로 [dir] 에 전달하면 위험**:
- preserve-modules 에서 \`chunk.rel_dir\` 은 *원본 모듈의 절대 경로(.ts/.tsx 확장자 포함)* 로 misnomer(chunk.zig:205, :999).
- 그대로 [dir] 에 노출하면 stem 에 절대경로+ext 가 raw 로 들어가 출력이 망가짐(\`/abs/foo.ts/foo.js\` 류).
- 해소: 호출자에서 항상 \`dir=\"\"\` 전달. docstring 에 사유 명시 — PR B 가 의미 명확한 entry-relative dir 신규 필드와 함께 갱신할 예정.

### 별도 follow-up — PR B 작업 scope

| ID | 항목 | 판정 |
|---|---|---|
| F2 | 빈 dir 시 adjacent-slash skip 이 *trailing* 한쪽만. `[name]/[dir]` 또는 `[dir]` 단독 패턴 시 dangling slash / 빈 stem | PLAUSIBLE(degenerate 패턴) |
| F3 | 128B \`stem_buf\` silent truncate (긴 dir 시) | PLAUSIBLE(future-trigger, 현재 dir=\"\") |
| F4 | dir 안 sanitize 부재 (\`/abs\`, \`..\`, NUL, Windows drive letter) | PLAUSIBLE(future-trigger) |
| F5 | CSS \`applyCssChunkName\` 의 [dir] 미지원 비대칭 → JS/CSS 출력 불일치 가능 | PLAUSIBLE(future-trigger) |
| F6 | 4-arg 시그니처 silent behavior change (literal \`[dir]\` → skip). src 내 외부 호출자 0 | 의도된 변경, 영향 0 |
| F7 | pattern 안 백슬래시 미정규화 — Windows-only edge | PLAUSIBLE(Windows-only) |

## PR B (별도, 예정) — entryNames default = \`[dir]/[name]\`

1. 5개 default 정의(zig 4 + NAPI 1) 갱신
2. 12 strict-eq 테스트 + 3 TS strict-eq 갱신
3. \`chunk.rel_dir\` 의미 정리 — preserve-modules 의 \`m.path\` raw 와 분리된 entry-relative dir 신규 필드 도입 + sanitize
4. MF manifest publicPath join 검증 (high-risk 단일 점검)
5. app-builder default 동기화 결정
6. CSS 측 [dir] 지원 동시 적용 (F5 해소)
7. RFC + 마이그레이션 가이드 + breaking notes (semver-major)