### PR TITLE
feat(bundler): CSS applyCssChunkName 에 [dir] 토큰 지원 (PR B-2, F5 해소)

### DIFF
--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -478,6 +478,9 @@ fn cssPathForChunk(
 /// 강제 삽입은 app-builder 의 안정 파일명(`[name]`→`main.css`, HTML link
 /// rewrite) 기대를 깨므로 하지 않는다. 캐시 버스팅이 필요하면 css_names 에
 /// `[hash]` 를 넣는다(JS 청크의 entry_names/chunk_names 와 동일 계약).
+/// `[dir]` 토큰을 지원하려면 `applyCssChunkNameWithDir` 를 사용한다 — 이
+/// 4-arg 변형은 dir = "" 로 위임하므로 패턴에 [dir] 가 있어도 빈 dir 정리
+/// 규칙(leading-slash 제거)이 동일 적용된다.
 /// chunks.zig 의 `applyNamingPattern` 과 분리 유지 — 그쪽은 buffer 기반·[ext]
 /// 처리이고 여기는 CSS 전용(.css 보장)이라 의미가 다르다.
 fn applyCssChunkName(
@@ -485,6 +488,28 @@ fn applyCssChunkName(
     pattern: []const u8,
     stem: []const u8,
     contents: []const u8,
+) ![]const u8 {
+    return applyCssChunkNameWithDir(allocator, pattern, stem, contents, "");
+}
+
+/// `applyCssChunkName` 의 [dir] 토큰 지원 변형. JS 의
+/// `chunks.applyNamingPatternWithDir` 와 동일 규칙으로 [dir] 을 처리해 JS/
+/// CSS naming 일관성을 유지한다(F5: PR B-2 의 목적).
+///
+/// **빈 dir 정리 규칙** — esbuild parity:
+/// [dir] 가 빈 문자열로 치환될 때, 토큰 *바로 다음* 문자가 `/` 면 그
+/// 슬래시도 함께 skip 해 leading/double-slash 를 방지한다.
+/// dir 안 Windows 백슬래시는 URL 구분자 `/` 로 정규화한다.
+///
+/// 현재 PR(B-2)에선 `applyCssChunkName` 만 새 함수에 위임하고, 호출자
+/// (`cssPathForChunk`) 는 여전히 4-arg 시그니처로 dir 정보 미전달 — PR B-4
+/// 가 호출자도 `chunk.name_dir` 활용하도록 활성화 예정.
+fn applyCssChunkNameWithDir(
+    allocator: std.mem.Allocator,
+    pattern: []const u8,
+    stem: []const u8,
+    contents: []const u8,
+    dir: []const u8,
 ) ![]const u8 {
     var out: std.ArrayListUnmanaged(u8) = .empty;
     errdefer out.deinit(allocator);
@@ -497,6 +522,17 @@ fn applyCssChunkName(
             const h = wyhash.hashHex8(contents);
             try out.appendSlice(allocator, &h);
             i += "[hash]".len;
+        } else if (std.mem.startsWith(u8, pattern[i..], "[dir]")) {
+            if (dir.len > 0) {
+                for (dir) |c| {
+                    try out.append(allocator, if (c == '\\') '/' else c);
+                }
+                i += "[dir]".len;
+            } else {
+                // 빈 dir — 토큰만 skip + 인접한 '/' 도 함께 skip (esbuild parity).
+                i += "[dir]".len;
+                if (i < pattern.len and pattern[i] == '/') i += 1;
+            }
         } else {
             try out.append(allocator, pattern[i]);
             i += 1;
@@ -637,6 +673,64 @@ test "applyCssChunkName: hash depends only on contents (determinism + sensitivit
     const h = wyhash.hashHex8(".s{color:red}");
     try std.testing.expect(std.mem.indexOf(u8, r1, &h) != null);
     try std.testing.expect(std.mem.indexOf(u8, r4, &h) != null);
+}
+
+// PR B-2: applyCssChunkNameWithDir — JS chunks 의 applyNamingPatternWithDir
+// 와 동일한 [dir] 토큰 정책을 CSS naming 에도 적용. 기존 applyCssChunkName
+// 시그니처는 보존(dir = "" 로 위임). 호출자(cssPathForChunk) 가 활성화하는
+// 시점은 PR B-4 — 본 PR scope 에선 함수만 추가, 영향 0.
+
+test "applyCssChunkNameWithDir: [dir]/[name] with dir" {
+    const a = std.testing.allocator;
+    const r = try applyCssChunkNameWithDir(a, "[dir]/[name]", "main", ".x{}", "pages-a");
+    defer a.free(r);
+    try std.testing.expectEqualStrings("pages-a/main.css", r);
+}
+
+test "applyCssChunkNameWithDir: 빈 dir → leading slash 제거" {
+    // 단일 entry cwd 루트 또는 entry_dir 미설정 → dir == "" → [dir]/ 토큰이
+    // leading slash 만들지 않도록 [dir]+다음 '/' 를 함께 skip (esbuild parity).
+    const a = std.testing.allocator;
+    const r = try applyCssChunkNameWithDir(a, "[dir]/[name]", "main", ".x{}", "");
+    defer a.free(r);
+    try std.testing.expectEqualStrings("main.css", r);
+}
+
+test "applyCssChunkNameWithDir: 중간 [dir]+빈 문자열 → 인접 '/' skip" {
+    // "assets/[dir]/[name]" + 빈 dir → "assets/main.css" (double-slash 방지).
+    const a = std.testing.allocator;
+    const r = try applyCssChunkNameWithDir(a, "assets/[dir]/[name]", "main", ".x{}", "");
+    defer a.free(r);
+    try std.testing.expectEqualStrings("assets/main.css", r);
+}
+
+test "applyCssChunkNameWithDir: [dir]/[name]-[hash] 전 토큰 결합" {
+    const a = std.testing.allocator;
+    const h = wyhash.hashHex8(".x{}");
+    const r = try applyCssChunkNameWithDir(a, "[dir]/[name]-[hash]", "main", ".x{}", "pages-b");
+    defer a.free(r);
+    const expect = try std.fmt.allocPrint(a, "pages-b/main-{s}.css", .{h});
+    defer a.free(expect);
+    try std.testing.expectEqualStrings(expect, r);
+}
+
+test "applyCssChunkNameWithDir: Windows 백슬래시 정규화" {
+    const a = std.testing.allocator;
+    const r = try applyCssChunkNameWithDir(a, "[dir]/[name]", "x", ".x{}", "win\\sub");
+    defer a.free(r);
+    try std.testing.expectEqualStrings("win/sub/x.css", r);
+}
+
+test "applyCssChunkName (기존 시그니처) 호환 — dir 없는 호출은 그대로" {
+    // 옛 API 호환: dir 인자가 없는 4-arg 호출은 [dir] 토큰이 패턴에 있어도
+    // 빈 dir 로 동작 — leading-slash 정리 동일 적용.
+    const a = std.testing.allocator;
+    const r1 = try applyCssChunkName(a, "[name]", "x", ".x{}");
+    defer a.free(r1);
+    try std.testing.expectEqualStrings("x.css", r1);
+    const r2 = try applyCssChunkName(a, "[dir]/[name]", "x", ".x{}");
+    defer a.free(r2);
+    try std.testing.expectEqualStrings("x.css", r2);
 }
 
 test "cssPathForChunk: [name] → chunk.name.css (안정 파일명, 강제 hash 없음)" {


### PR DESCRIPTION
## 배경 (F5 해소)

PR #3688 (PR A) 가 JS chunks 측 `applyNamingPattern` 에 [dir] 토큰을 추가했으나 CSS 측 `applyCssChunkName` 은 미지원 상태였다. PR #3688 의 \`/code-review max\` 가 surfacing 한 **F5 비대칭** (JS/CSS 출력 path 불일치) 을 해소한다.

PR B-2 는 동일 규칙을 CSS naming 에 적용 — *기술적 토대만*, 호출자 미사용, **기존 사용자 영향 0**.

## 변경

### \`src/bundler/css_emitter.zig\`

**\`applyCssChunkName(a, p, s, c)\` 본문 → 새 \`applyCssChunkNameWithDir(a, p, s, c, dir)\` 로 추출**. 기존 4-arg 시그니처는 \`dir = \"\"\` 위임으로 보존 (PR A 의 \`applyNamingPattern\` / \`applyNamingPatternWithDir\` 와 동일 패턴).

**[dir] 토큰 규칙** (JS 측 \`applyNamingPatternWithDir\` 와 정확히 동일):
- dir.len > 0 → byte-by-byte 복사, Windows 백슬래시 → forward `/` 정규화
- dir.len == 0 → 토큰 + 인접 `/` 함께 skip (esbuild parity, leading/double-slash 방지)

**호출자 \`cssPathForChunk\` 는 변경 안 함** — 여전히 4-arg 호출 → dir 정보 미전달. PR B-4 (default 변경) 가 호출자에서 `chunk.name_dir` 활용하도록 활성화 예정.

**Zig 단위 테스트 6개**:
1. \`[dir]/[name]\` + dir → \"pages-a/main.css\"
2. 빈 dir → leading-slash 제거 (\`main.css\`)
3. 중간 [dir]+빈 dir → 인접 `/` skip (\`assets/main.css\`)
4. 전 토큰 결합 \`[dir]/[name]-[hash]\` 
5. Windows 백슬래시 정규화
6. 4-arg 기존 시그니처 호환

## 검증

| 항목 | 결과 |
|---|---|
| \`zig build test\` | 5/5 steps succeeded — 신규 6 + 기존 7 단위 모두 통과, leak 0 |
| 통합 (css/manual-chunks) | 92/92 — 회귀 없음 |
| 기존 사용자 영향 | **0** (호출자 미사용, default \`css_names\` 도 \`[name]\` 이라 [dir] 토큰 미포함) |

## /code-review max 결과 분류

### 의도된 변경 (CONFIRMED-as-intentional, 본 PR 의도)

| ID | 항목 |
|---|---|
| C5 | 4-arg signature 의 silent behavior change — 이전엔 literal `[dir]` 가 패턴에 있으면 그대로 출력, 이제 토큰 인식 + 빈 dir skip. src 내 외부 호출자 0. PR A 의 F6 mirror 의도 |

### 별도 follow-up (PR B-3 scope — degenerate/sharp-edge 가드)

| ID | 항목 | 비고 |
|---|---|---|
| C1 | \`[dir]\` 단독/stem 누락 패턴 + 빈 dir → \`.css\` (빈 stem) → 모든 청크 collision | 사용자가 의도적 작성 안 함; silent loss 가능 |
| C2 | dir 값이 \`.css\` 로 끝나면 자동 \`.css\` skip — confusing | edge case |
| C3 | stem 끝이 \`.css\` 포함 → 자동 추가 skip → 다른 chunk 와 collision | **pre-existing**, PR B-2 가 도입한 게 아님 |
| C4 | 빈 dir + 토큰 직후 \`.\` → leading-dot 파일 | esbuild parity, design |
| C6 | \`endsWith \".css\"\` 대소문자 구분 → \`.CSS\` 패턴 시 이중 추가 | **pre-existing** |
| C7 | byte-level \`\\\` 정규화 — 비-UTF-8 dir 입력 시 false positive | 실용 risk 0 (zntc UTF-8 보장), doc 명시 |

### Process risk (CONFIRMED)

| ID | 항목 |
|---|---|
| C8 | PR B-4 누락 시 사용자 \`[dir]\` 토큰이 영원히 empty (호출자 영구 stub). roadmap/issue tracker 의 PR B-4 의존 명시 필요 |

## PR B 시퀀스

| PR | 내용 | 영향 |
|---|---|---|
| #3688 (PR A) | chunks \`[dir]\` 토큰 지원 | 0 |
| #3689 (PR B-1) | Chunk.name_dir + sanitizeNameDir | 0 |
| **현재** (PR B-2) | CSS \`applyCssChunkName\` 에 [dir] 지원 | 0 |
| PR B-3 (다음) | sanitize/degenerate 정밀화 (Windows drive letter, mid-path \`//\`, control bytes, 단일 \`.\`, 빈 stem 패턴 가드) | 0 |
| PR B-4 (breaking) | default \`[name]\` → \`[dir]/[name]\` + chunkPlaceholderStem/cssPathForChunk 가 chunk.name_dir 활용 + 5개 정의 + 12 strict-eq 갱신 + MF publicPath 검증 + app-builder 동기화 + RFC | semver-major |