### PR TITLE
feat(napi): debug-build leak detector + plugin_bridge OOB follow-up

### DIFF
--- a/packages/core/src/napi/benchmark.zig
+++ b/packages/core/src/napi/benchmark.zig
@@ -9,7 +9,7 @@ const transpile_mod = zntc_lib.transpile;
 const profile_mod = zntc_lib.profile;
 const bench_mod = zntc_lib.bench;
 
-const native_alloc = std.heap.c_allocator;
+const native_alloc = common.nativeAlloc();
 const throwError = common.throwError;
 const getObjectString = common.getObjectString;
 const getObjectStringArray = common.getObjectStringArray;

--- a/packages/core/src/napi/build_async_entry.zig
+++ b/packages/core/src/napi/build_async_entry.zig
@@ -9,7 +9,7 @@ const result_napi_mod = @import("result.zig");
 const plugin_bridge = @import("plugin_bridge.zig");
 const c = common.c;
 
-const native_alloc = std.heap.c_allocator;
+const native_alloc = common.nativeAlloc();
 
 const throwError = common.throwError;
 const getNamedProperty = common.getNamedProperty;

--- a/packages/core/src/napi/build_sync_entry.zig
+++ b/packages/core/src/napi/build_sync_entry.zig
@@ -11,7 +11,7 @@ const result_napi_mod = @import("result.zig");
 const plugin_bridge = @import("plugin_bridge.zig");
 const c = common.c;
 
-const native_alloc = std.heap.c_allocator;
+const native_alloc = common.nativeAlloc();
 
 const throwError = common.throwError;
 const getNamedProperty = common.getNamedProperty;

--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -1,6 +1,7 @@
 //! Shared NAPI helpers for the `@zntc/core` native entry.
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub const c = @cImport({
     @cDefine("NAPI_VERSION", "8");
@@ -8,6 +9,40 @@ pub const c = @cImport({
 });
 
 pub const NullableStringPair = struct { []const u8, ?[]const u8 };
+
+// ── NAPI 공용 allocator (#dev-leak-investigation) ─────────────────────────
+// debug 빌드: DebugAllocator → process 종료 시 atexit 으로 leak 리포트(stack
+// trace 포함) 를 stderr 로 dump. RSS 폭증의 root site 식별이 목적이므로 영구
+// 변경이 아닌 임시 측정 인프라다.
+// release 빌드: c_allocator 그대로 (overhead 0, 기존 동작 유지).
+//
+// 모든 NAPI 파일이 `common.nativeAlloc()` 1개 인스턴스를 공유해야 cross-file
+// alloc/free (예: watch.zig 가 transpile_entry 결과 free) 시 false leak 이
+// 안 뜬다.
+var debug_gpa: std.heap.DebugAllocator(.{ .stack_trace_frames = 16 }) = .init;
+
+pub fn nativeAlloc() std.mem.Allocator {
+    if (comptime builtin.mode == .Debug) return debug_gpa.allocator();
+    return std.heap.c_allocator;
+}
+
+extern fn atexit(?*const fn () callconv(.c) void) c_int;
+
+fn dumpLeaksAtExit() callconv(.c) void {
+    if (comptime builtin.mode != .Debug) return;
+    _ = debug_gpa.deinit();
+}
+
+var leak_dump_registered: bool = false;
+
+/// napi_register_module_v1 에서 1회 호출. SIGTERM/정상 exit 시 atexit handler
+/// 가 GPA.deinit() 를 호출해 leak 리포트(stack trace) 를 stderr 에 출력한다.
+pub fn registerLeakDump() void {
+    if (comptime builtin.mode != .Debug) return;
+    if (leak_dump_registered) return;
+    leak_dump_registered = true;
+    _ = atexit(&dumpLeaksAtExit);
+}
 
 pub fn throwError(env: c.napi_env, msg: [*:0]const u8) c.napi_value {
     _ = c.napi_throw_error(env, null, msg);

--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -179,7 +179,7 @@ fn copyBytesOrEmpty(alloc: std.mem.Allocator, data_ptr: ?*anyopaque, byte_len: u
 /// (`getStringArg` 와 동일 root cause). 정확히 `count` 길이로 줄여 반환한다.
 /// 1차 시도 `alloc.realloc` (대부분 in-place shrink); 실패 시 새 alloc + memcpy
 /// + 옛 free fallback. element 값 (slice 등 sub-alloc) 은 그대로 보존된다.
-fn shrinkSlice(comptime T: type, alloc: std.mem.Allocator, result: []T, count: usize) ?[]T {
+pub fn shrinkSlice(comptime T: type, alloc: std.mem.Allocator, result: []T, count: usize) ?[]T {
     if (count == result.len) return result;
     return alloc.realloc(result, count) catch blk: {
         const shrunk = alloc.alloc(T, count) catch {

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -21,7 +21,7 @@ const config_mod = zntc_lib.config;
 const TsConfig = config_mod.TsConfig;
 const tsconfig_merge = zntc_lib.tsconfig_merge;
 
-const native_alloc = std.heap.c_allocator;
+const native_alloc = common.nativeAlloc();
 
 const throwError = common.throwError;
 const getStringArg = common.getStringArg;

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -505,7 +505,15 @@ pub fn parseBuildOptions(
             valid_count += 1;
         }
         native_alloc.free(pairs);
-        loader_overrides = overrides[0..valid_count];
+        // unknown loader (`ParsedLoader.fromString → null`) skip 시 valid_count <
+        // pairs.len → backing alloc(pairs.len) vs return-slice (valid_count) size
+        // mismatch (`getStringArg` 와 동일 root cause, `c_allocator` silent /
+        // `DebugAllocator` panic). valid_count==0 면 overrides 자체 누수도 발생.
+        if (valid_count == 0) {
+            native_alloc.free(overrides);
+        } else {
+            loader_overrides = common.shrinkSlice(bundler_mod.types.LoaderOverride, native_alloc, overrides, valid_count) orelse return null;
+        }
     }
 
     const conditions = getObjectStringArray(env, opts_obj, "conditions", native_alloc);

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -1226,16 +1226,24 @@ pub const NapiManualChunksResolver = struct {
             return;
         }
 
-        // UTF-8 길이 측정 → 할당 → 복사. CallContext.result 는 native_alloc 소유.
+        // UTF-8 길이 측정 → NUL terminator 용 +1 임시 alloc → 정확 크기로 dupe →
+        // 임시 즉시 free. `bufsize=len+1` 호출이 buf 끝에 NUL 을 작성하므로
+        // alloc 크기 < bufsize 면 1바이트 OOB write (#dev-leak-investigation
+        // sweep). `common.getStringArg` 와 동일 root cause / contract.
         var len: usize = 0;
         _ = c.napi_get_value_string_utf8(env, js_result, null, 0, &len);
-        const buf = native_alloc.alloc(u8, len) catch {
+        const tmp = native_alloc.alloc(u8, len + 1) catch {
             signalResult(ctx, null);
             return;
         };
+        defer native_alloc.free(tmp);
         var written: usize = 0;
-        _ = c.napi_get_value_string_utf8(env, js_result, buf.ptr, len + 1, &written);
-        signalResult(ctx, buf[0..written]);
+        _ = c.napi_get_value_string_utf8(env, js_result, tmp.ptr, len + 1, &written);
+        const out = native_alloc.dupe(u8, tmp[0..written]) catch {
+            signalResult(ctx, null);
+            return;
+        };
+        signalResult(ctx, out);
     }
 
     fn signalResult(ctx: *CallContext, result: ?[]const u8) void {

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -8,7 +8,7 @@ const common = @import("common.zig");
 const result_mod = @import("result.zig");
 const c = common.c;
 
-const native_alloc = std.heap.c_allocator;
+const native_alloc = common.nativeAlloc();
 const getStringArg = common.getStringArg;
 const getNamedProperty = common.getNamedProperty;
 const getObjectBool = common.getObjectBool;

--- a/packages/core/src/napi/profile.zig
+++ b/packages/core/src/napi/profile.zig
@@ -6,7 +6,7 @@ const common = @import("common.zig");
 const c = common.c;
 
 const profile_mod = zntc_lib.profile;
-const native_alloc = std.heap.c_allocator;
+const native_alloc = common.nativeAlloc();
 const throwError = common.throwError;
 const getStringArg = common.getStringArg;
 const parseStringArray = common.parseStringArray;

--- a/packages/core/src/napi/transpile_entry.zig
+++ b/packages/core/src/napi/transpile_entry.zig
@@ -9,7 +9,7 @@ const common = @import("common.zig");
 const tsconfig_cache_mod = @import("tsconfig_cache.zig");
 const c = common.c;
 
-const native_alloc = std.heap.c_allocator;
+const native_alloc = common.nativeAlloc();
 
 const throwError = common.throwError;
 const getStringArg = common.getStringArg;

--- a/packages/core/src/napi/tsconfig_cache.zig
+++ b/packages/core/src/napi/tsconfig_cache.zig
@@ -6,7 +6,7 @@ const common = @import("common.zig");
 const c = common.c;
 
 const TsconfigCache = zntc_lib.tsconfig_cache.TsconfigCache;
-const native_alloc = std.heap.c_allocator;
+const native_alloc = common.nativeAlloc();
 const throwError = common.throwError;
 const unwrapNapi = common.unwrapNapi;
 

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -13,7 +13,7 @@ const options_mod = @import("options.zig");
 const plugin_bridge = @import("plugin_bridge.zig");
 const c = common.c;
 
-const native_alloc = std.heap.c_allocator;
+const native_alloc = common.nativeAlloc();
 const throwError = common.throwError;
 const unwrapNapi = common.unwrapNapi;
 const getStringArg = common.getStringArg;

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -22,7 +22,7 @@ const benchmark_mod = @import("napi/benchmark.zig");
 const profile_napi_mod = @import("napi/profile.zig");
 const c = common.c;
 
-const native_alloc = std.heap.c_allocator;
+const native_alloc = common.nativeAlloc();
 
 const transpile_entry = @import("napi/transpile_entry.zig");
 const build_sync_entry = @import("napi/build_sync_entry.zig");
@@ -34,6 +34,11 @@ const napiWatch = watch_mod.napiWatch;
 // ─── 모듈 등록 ───
 
 export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi_value {
+    // Debug 빌드 한정: DebugAllocator leak 리포트(stack trace) 를 process 종료 시
+    // stderr 로 dump 하는 atexit handler 1회 등록 (#dev-leak-investigation).
+    // ReleaseFast 에서는 no-op.
+    common.registerLeakDump();
+
     // ZNTC_DEBUG env 를 프로세스 시작 시 1회 파싱해 mask 초기화.
     // 개별 build/watch 호출마다 BundleOptions.debug 로 카테고리 추가 가능.
     @import("zntc_lib").debug_log.initFromEnv(native_alloc);


### PR DESCRIPTION
> **Base branch**: `fix/napi-string-leak` (PR #3691) — PR #3691 머지 후 자동 rebase 되어 main 으로 자동 변경.

## 배경

dev/watch RSS 누수 (project_watch_dev_leak_investigation.md: 233MB/5분, JS heap/external 안정 → NAPI native_alloc 누수 확정) 의 정확한 root site 식별을 위한 **임시 측정 인프라**. 추측 fix 대신 정확한 stack trace 기반 진단이 목적.

PR #3691 (NAPI string getter / sliced-result allocator contract fix) 가 이 인프라 도입의 직접 차단 요소를 해결 — 그 위에 인프라 추가 + sweep 결과 발견된 untouched site fix.

## 변경 (4 commit)

### Commit 1 — Debug-build leak detector

`packages/core/src/napi/common.zig`:
- `var debug_gpa: std.heap.DebugAllocator(.{ .stack_trace_frames = 16 }) = .init;` 모듈 scope 단일 인스턴스
- `pub fn nativeAlloc() std.mem.Allocator` — Debug → `debug_gpa.allocator()`, release → `std.heap.c_allocator` (`comptime builtin.mode == .Debug` 분기)
- `extern fn atexit(?*const fn () callconv(.c) void) c_int;` + `dumpLeaksAtExit` callconv(.c) handler + `registerLeakDump()` 1회 등록 가드

`packages/core/src/napi_entry.zig`:
- `napi_register_module_v1` 에서 `common.registerLeakDump()` 1회 호출

10개 NAPI 파일 (`benchmark`, `build_async_entry`, `build_sync_entry`, `options`, `plugin_bridge`, `profile`, `transpile_entry`, `tsconfig_cache`, `watch`, `napi_entry`):
- `const native_alloc = std.heap.c_allocator;` → `const native_alloc = common.nativeAlloc();`

### Commit 2 — `plugin_bridge.zig` OOB follow-up

PR #3691 의 `/code-review max` sweep 에서 발견된 PR #3691 의 동일 root cause 가 plugin_bridge 의 `NapiManualChunksResolver.parseJsResult` 에 untouched 로 잠재:

```zig
const buf = native_alloc.alloc(u8, len) catch { ... };   // ❌ 정확 len 바이트
_ = c.napi_get_value_string_utf8(env, js_result, buf.ptr, len + 1, &written);
//                                                        ^^^^^^^ bufsize=len+1
// → NAPI 가 buf[len] 에 NUL 작성 = 1바이트 OOB write
```

Fix: `common.getStringArg` 와 동일 패턴 — `len+1` 임시 alloc → 정확 크기 `dupe` → 임시 즉시 free.

### Commit 3 — `options.zig:494` `loader_overrides` follow-up (이번 review max 3rd cycle)

PR-2 자체에 대해 `/code-review max` 두 번째 사이클을 다시 돌렸을 때 Angle E 가 추가 발견한 동일 root cause untouched site:

```zig
const overrides = native_alloc.alloc(LoaderOverride, pairs.len) catch return null;
var valid_count: usize = 0;
for (pairs) |pair| {
    ...
    const parsed = ParsedLoader.fromString(pair[1]) orelse continue;  // ← partial skip
    overrides[valid_count] = .{ ... };
    valid_count += 1;
}
loader_overrides = overrides[0..valid_count];
// → freeOptionsTypedSlices 가 .len=valid_count 로 free, backing=pairs.len 불일치
```

추가로 `valid_count == 0` 시 `overrides[0..0]` 반환만 하고 backing alloc 누수.

Fix:
- `valid_count == 0` 분기: `overrides` 직접 free (loader_overrides 빈 sentinel 유지)
- `valid_count > 0` 분기: `common.shrinkSlice(LoaderOverride, ...)` 호출 (realloc shrink 우선, fallback alloc+memcpy+free)
- `common.shrinkSlice` 를 `pub fn` 으로 노출 (cross-file 재사용)

**Sweep 결과**: `options.zig` 의 다른 5개 alloc-and-fill site (296/424/441/467/480) 는 모두 full-fill 또는 early `return null` 패턴 — partial-fill 아님. 이 한 곳이 유일한 untouched mismatch.

## 사용

```bash
zig build napi -Dnapi-optimize=Debug
cp zig-out/lib/zntc.node packages/core/zntc.node

# 측정 (1분 dev probe 예)
cd examples/web
echo "// touch-probe 0" >> src/App.tsx
nohup bun run dev > /tmp/leak-probe/stdout.log 2> /tmp/leak-probe/stderr.log &
DEV_PID=$!
sleep 5
for i in $(seq 1 20); do sed -i.bak "s|// touch-probe .*|// touch-probe $i|" src/App.tsx; sleep 3; done
kill -TERM $DEV_PID

# leak 분석
grep -c "error(gpa): memory address" /tmp/leak-probe/stderr.log
grep "in _" /tmp/leak-probe/stderr.log | sort | uniq -c | sort -rn | head -20
```

## 측정 시 주의 (PR `/code-review max` 발견)

영구 변경이 아닌 **임시 디버깅 인프라** 라 다음 측정 왜곡 trade-off 수용:

- **RSS 인플레이션**: DebugAllocator backing default = `page_allocator` → small-alloc size_class 마다 page 점유. release `c_allocator` baseline 과 직접 비교 금지. **Debug↔Debug, before↔after fix delta** 만 valid
- **never-reuse-addresses** (Zig std 명시): rebuild 마다 새 page → 누수 0 도 RSS 증가 보임. 동일 빌드 동일 워크로드 비교만 의미
- **perf 왜곡**: `thread_safe=true` mutex 로 모든 alloc 직렬화. wall-clock / sub-phase ns 절대값 무의미, 상대 ratio 만
- **SIGTERM atexit**: 호스트 런타임 의존. Bun 측정 환경에선 작동 확인. Node 환경에선 `process.exit(0)` 명시 권장
- **shutdown noise**:
  - watch 의 PersistentModuleStore / ResolveCache 등 long-lived cache 는 `handle.stop()` 없이 종료 시 의도된 retention 이 leak 으로 노출됨 (측정자 noise)
  - cross-thread alloc/free 시 stack trace 가 alloc 시점 thread 캡처 → 누수 원인 함수 추적 시 ownership boundary (docs/ARCHITECTURE.md) 참조 필수
  - **chunk.name pre-existing latent leak**: `NapiManualChunksResolver` 의 dupe 결과가 `chunk.name` 으로 전달되지만 `Chunk.deinit` 가 free 안 함. 별도 follow-up 이슈/PR 필요 — 측정 시 manualChunks 사용 시 noise
- **ReleaseSafe**: `builtin.mode == .Debug` 분기라 ReleaseSafe / ReleaseSmall 도 `c_allocator` path. ReleaseSafe 빌드에서 leak detection 기대 시 잘못된 결론. 필요하면 분기 조건 확장
- **atexit deinit() UAF 위험**: `debug_gpa.deinit()` 이 `self.* = undefined` 로 GPA 상태 무효화. detached watch worker 가 종료 시 race 시 잠재 crash. 측정 후 follow-up 으로 `detectLeaks()` 또는 NAPI env cleanup hook 전환 검토
- **`leak_dump_registered` race**: non-atomic bool — Node `worker_threads` / Vitest pool='threads' 의 동시 register_module 시 race. 단일 NAPI 진입점이라 현 실측 시나리오에선 발현 안 함

## 검증

- `zig build` ✓
- `zig build napi -Dnapi-optimize=Debug` ✓
- `zig build test` ✓ (5421 tests, 회귀 0)
- 실측 1분 dev probe (examples/web, 20 rebuild) → leak detector startup 통과 + atexit dump 정상 + Site #2 (DirEntryCache 67/min) / Site #3 (ResolveCache 10/min) stack trace 캡처 확인

## Follow-up (별도 PR / 이슈)

- Site #2: `bundler.fs.RealFS.listDir → DirEntryCache.buildEntrySet` deinit ownership 점검
- Site #3: `bundler.resolve_cache.ResolveCache.HashMap` deinit ownership 점검
- `chunk.name` pre-existing leak — `NapiManualChunksResolver` dupe 결과의 lifecycle 정합 (chunk arena dupe 또는 명시적 free)
- (선택) review max medium/low findings: `backing_allocator = c_allocator` override, atomic bool, detectLeaks 전환, `shrinkSlice` OOM fallback inner-element free