### PR TITLE
feat(bundler): chunkPlaceholderStem/cssPathForChunk 가 chunk.name_dir 활용 (PR B-4a)

### DIFF
--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -465,12 +465,16 @@ fn cssPathForChunk(
     css_names: []const u8,
     contents: []const u8,
 ) ![]const u8 {
-    if (chunk.name) |n| return applyCssChunkName(allocator, css_names, n, contents);
-    if (chunk.filename) |f| return applyCssChunkName(allocator, css_names, std.fs.path.stem(f), contents);
+    // PR B-4a: chunk.name_dir 활성화 — `[dir]` 토큰이 패턴에 있으면 sanitize
+    // 거친 entry-relative dir 가 치환된다. default 패턴(`[name]`) 엔 [dir] 토큰이
+    // 없어 사용자 영향 0.
+    const dir = chunk.name_dir orelse "";
+    if (chunk.name) |n| return applyCssChunkNameWithDir(allocator, css_names, n, contents, dir);
+    if (chunk.filename) |f| return applyCssChunkNameWithDir(allocator, css_names, std.fs.path.stem(f), contents, dir);
     // "chunk" (5) + u32 십진 최대 10자리 = 15 < 16 → bufPrint 실패 불가.
     var idx_buf: [16]u8 = undefined;
     const idx_name = std.fmt.bufPrint(&idx_buf, "chunk{d}", .{@intFromEnum(chunk.index)}) catch unreachable;
-    return applyCssChunkName(allocator, css_names, idx_name, contents);
+    return applyCssChunkNameWithDir(allocator, css_names, idx_name, contents, dir);
 }
 
 /// `css_names` 패턴의 `[name]`/`[hash]` 를 충실히 치환하고 `.css` 확장자를

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -1785,17 +1785,24 @@ fn chunkRegistryId(
 /// cross-chunk import 등 content가 아직 없는 시점에서 사용.
 /// 최종 출력 시 placeholder를 content hash로 치환한다.
 ///
-/// **현재 정책 (PR A)**: `[dir]` 토큰을 `applyNamingPatternWithDir` 가 인식·
-/// 처리는 하지만, 이 호출 시점에선 항상 빈 dir 전달 → 패턴에 `[dir]` 가 있어도
-/// 토큰+인접 슬래시가 함께 제거된다(leading-slash 방지). 즉 PR A 는
-/// 기존 동작(literal `[dir]` 가 패턴에 있을 일은 없음)을 *정확히* 보존하고,
-/// `[dir]` 의 실제 dir 채우기는 PR B 가 안전한 신규 필드와 함께 도입한다.
+/// **현재 정책 (PR B-4a)**: `[dir]` 토큰을 `chunk.name_dir` 로 채운다(PR B-1
+/// 의 sanitize 거친 안전한 entry-relative dir; null/`""` 면 빈 dir 분기로
+/// leading-slash skip). default 패턴엔 `[dir]` 가 없어 사용자 영향 0 — 사용자가
+/// 명시적으로 `[dir]` 토큰을 entry_names/chunk_names 에 넣었을 때만 활성화.
+/// (`chunk.rel_dir` 은 preserve-modules 의 *절대 경로+파일명+ext* misnomer 라
+/// 사용 금지 — `chunk.name_dir` 은 PR B-1 이 도입한 분리된 안전 필드.)
 ///
-/// `chunk.rel_dir` 을 raw 로 전달하지 않는 이유: preserve-modules 에서
-/// `rel_dir` 은 *원본 모듈의 절대 경로(.ts/.tsx 확장자 포함)* 로 misnomer
-/// (chunk.zig:205, :999). 그대로 `[dir]` 에 노출하면 stem 에 절대경로+ext 가
-/// raw 로 들어가 출력이 망가진다(`/abs/foo.ts/foo.js` 류). PR B 가 의미 명확한
-/// entry-relative dir 필드와 함께 이 호출도 갱신할 예정.
+/// **PR B-4b (default 변경) 이전 필수 해소 — opt-in 사용자도 즉시 영향**:
+/// 1. cross-chunk import 의 `./{stem}{ext}` specifier(line ~438) 와 dynamic
+///    import rewrite(line ~1441) 의 relative base 가 importer chunk dir
+///    기준이 아니라 outDir 기준 — 두 청크가 서로 다른 dir 면 import 404.
+///    preserve-modules 분기는 `computeRelativeImportPath` 적용; splitting
+///    분기는 평면 `./` prefix 라 [dir] 활성화 시 깨짐.
+/// 2. 128B stack stem_buf 가 깊은 monorepo 경로(pages/admin/users/details/
+///    edit + [name]-[hash]+[ext]) 에서 silent truncation 가능. ArrayList 로
+///    교체 또는 buf 확장 필요.
+/// 3. manual chunk 의 name_dir 가 null — entry chunk 와 정책 비대칭. 같은
+///    name 의 entry/manual chunk 가 다른 path 로 emit 되는 surprise 가능.
 fn chunkPlaceholderStem(chunk: *const Chunk, buf: []u8, options: *const EmitOptions) []const u8 {
     const is_entry = chunk.name != null;
     const base_name = chunk.name orelse "chunk";
@@ -1804,7 +1811,7 @@ fn chunkPlaceholderStem(chunk: *const Chunk, buf: []u8, options: *const EmitOpti
     var hash_buf: [HASH_PLACEHOLDER_PREFIX.len + HASH_PLACEHOLDER_LEN]u8 = undefined;
     buildPlaceholder(chunk, &hash_buf);
 
-    return applyNamingPatternWithDir(buf, pattern, base_name, &hash_buf, "");
+    return applyNamingPatternWithDir(buf, pattern, base_name, &hash_buf, chunk.name_dir orelse "");
 }
 
 /// 모듈 인덱스 기반 해시 (placeholder 식별자용, content hash 아님).


### PR DESCRIPTION
## 배경

PR #3689 (B-1) 이 \`Chunk.name_dir\` 필드 + sanitize 를 도입했고, PR #3688 (A) / #3690 (B-2) 가 `[dir]` 토큰 처리를 chunks/CSS 양쪽에 추가했지만, 호출자(\`chunkPlaceholderStem\`/\`cssPathForChunk\`) 는 의도적으로 stub 상태(\`dir=\"\"\`)로 유지됐다.

본 PR (B-4a) 는 두 호출자를 활성화 — \`chunk.name_dir\` 을 \`[dir]\` 토큰 위치로 전달. **기존 사용자 영향 0** (default 패턴에 \`[dir]\` 없으므로 사용자가 명시적으로 entry_names/chunk_names/css_names 에 \`[dir]\` 를 넣을 때만 활성화). PR B-4b 의 default 변경(breaking) 의 기술적 토대.

## 변경

### \`src/bundler/emitter/chunks.zig\` (chunkPlaceholderStem)

\`\`\`zig
- return applyNamingPatternWithDir(buf, pattern, base_name, &hash_buf, \"\");
+ return applyNamingPatternWithDir(buf, pattern, base_name, &hash_buf, chunk.name_dir orelse \"\");
\`\`\`

### \`src/bundler/css_emitter.zig\` (cssPathForChunk)

3개 호출 모두 \`applyCssChunkName(...)\` → \`applyCssChunkNameWithDir(..., chunk.name_dir orelse \"\")\`.

### docstring

PR B-4b 의 default 변경 전 반드시 해소할 **blocker 3개** 를 docstring 에 명시.

## 검증

| 항목 | 결과 |
|---|---|
| \`zig build test\` | 5/5 succeeded, 0 fail |
| 통합 (css/cjs/cross-chunk/manual/iife) | **122/122** — 회귀 없음 |
| 기존 사용자 영향 | **0** (default 패턴 변경 없음) |

## /code-review max 결과 — PR B-4b blocker 식별

본 PR 자체는 영향 0 이나, *사용자가 \`[dir]\` 토큰을 명시적으로 패턴에 넣으면* 즉시 발현되는 위험들. PR B-4b 의 default 변경 시 *모든* 사용자에게 영향 — PR B-4b *이전* 반드시 해소 필요:

### Blocker #1 — cross-chunk import relative base

위치: \`chunks.zig:438\` (static cross-chunk import), \`chunks.zig:1441\` (dynamic import rewrite).

두 청크가 서로 다른 dir 일 때 \`import \"./stem.js\"\` 의 \`./\` 가 importer chunk dir 기준이 아니라 outDir 기준 — \`outDir/pages-a/index.js\` 에서 \`import \"./pages-b/lazy.js\"\` → \`outDir/pages-a/pages-b/lazy.js\` (404). preserve-modules 분기엔 \`computeRelativeImportPath\` 가 있지만 splitting 분기는 평면 \`./\` prefix. → splitting 분기에도 relative path 계산 필요.

### Blocker #2 — 128B stack stem_buf truncation

위치: \`chunks.zig:1802\`.

깊은 monorepo 경로(\`pages/admin/users/details/edit\` + \`[name]-[hash]+[ext]\`) 가 128B 초과 시 silent truncation. → ArrayList 또는 buf 확장.

### Blocker #3 — manual chunk name_dir = null 비대칭

위치: \`chunk.zig:820-821\` (manual chunk 생성).

manual chunk 는 \`chunk.name = name\` 만 set, \`chunk.name_dir\` 은 null 그대로. 같은 stem 의 entry/manual chunk 가 다른 path 로 emit 되는 surprise. → manual chunk 도 dir 정책 결정.

### 의도된 사용자 결정 / 별도 follow-up

- F6 renderChunk plugin chunkName dir prefix (Rollup-compat 호환성)
- F7 common chunk name_dir = null
- F8 preserve-modules + [dir] stem 일관성

## Sub-step 분리 의도

PR B-4 가 단일 PR 로는 너무 크다(~5 default 정의 + 12 strict-eq fixture + 다수 호출자 변경 + RFC). sub-step 분할:

- **B-4a (현재)**: 호출자 활성화만, 영향 0.
- **B-4b (다음, breaking)**: default \`[name]\` → \`[dir]/[name]\` + 위 3 blockers 해소 + 5개 default 정의 + 12 strict-eq 갱신 + MF publicPath 검증 + app-builder 동기화 + RFC + 마이그레이션 가이드. semver-major.

## 누적 PR B 시퀀스

| PR | 내용 | 영향 |
|---|---|---|
| #3688 (PR A) | chunks \`[dir]\` 토큰 지원 | 0 |
| #3689 (PR B-1) | Chunk.name_dir + sanitizeNameDir | 0 |
| #3690 (PR B-2) | CSS \`applyCssChunkName\` 에 \`[dir]\` 지원 | 0 |
| #3692 (PR B-3) | sanitize 정밀화 + CSS 가드 + F1 double-free fix | 0 |
| **현재** (B-4a) | 호출자 활성화 (chunkPlaceholderStem/cssPathForChunk) | 0 |
| PR B-4b (next, breaking) | default \`[name]\` → \`[dir]/[name]\` + 3 blocker 해소 + 5 default + 12 strict-eq + RFC | semver-major |