### PR TITLE
fix(napi): Bundler.init owned ResolveCache leak (Site #2)

### DIFF
--- a/packages/core/src/napi/build_async_entry.zig
+++ b/packages/core/src/napi/build_async_entry.zig
@@ -49,6 +49,7 @@ const BuildAsyncData = struct {
 /// 독립 스레드에서 번들링 실행 (libuv 워커 미사용 → TSFN 데드락 방지)
 fn buildWorkerThread(async_data: *BuildAsyncData) void {
     var bundler = Bundler.init(native_alloc, async_data.options);
+    defer bundler.deinit();
     async_data.result = bundler.bundle() catch |err| {
         async_data.err_msg = @errorName(err);
         // 완료 TSFN 호출

--- a/packages/core/src/napi/build_sync_entry.zig
+++ b/packages/core/src/napi/build_sync_entry.zig
@@ -79,6 +79,7 @@ pub fn napiBuildSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c
     }
 
     var bundler = Bundler.init(native_alloc, bundle_opts);
+    defer bundler.deinit();
     var result = bundler.bundle() catch |err| {
         return throwError(env, @errorName(err));
     };

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -532,6 +532,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     if (bundle_opts.dev_mode and bundle_opts.sourcemap.enable) initial_opts.sourcemap.lazy = true;
 
     var bundler = Bundler.init(allocator, initial_opts);
+    defer bundler.deinit();
     var result = bundler.bundle() catch |err| {
         // 초기 빌드 실패 — rebuild 이벤트로 에러 전달
         const event = allocator.create(WatchRebuildEvent) catch {


### PR DESCRIPTION
## 배경

dev/watch RSS 누수 측정 인프라 (PR #3691 + #3695) 도입 후 1분 dev probe 87 leak entries 중 **67 entries** 가 `RealFS.listDir → DirEntryCache.buildEntrySet` stack — `project_watch_dev_leak_investigation.md` 의 Site #2 root cause.

`Bundler.init(allocator, opts)` 는 내부적으로:
```zig
return .{
    .allocator = allocator,
    .options = opts,
    .resolve_cache = initResolveCacheFromOptions(allocator, opts),  // owned
};
```
`ResolveCache.init` 가 내부적으로 `DirEntryCache.init(allocator)` + `RealpathCache.init(allocator)` + `cache_shards` 보유. `Bundler.deinit` 는 `resolve_cache_ref == null` (owned 인 경우) 일 때 `resolve_cache.deinit()` 호출 → cascade 로 `dir_cache.deinit` (모든 EntrySet + entry name slices free).

**3개 NAPI 진입점이 모두 `Bundler.init` 후 `Bundler.deinit()` 호출 누락** → owned `ResolveCache` (+ 모든 cache 내부 데이터) 영구 leak. ReleaseFast `c_allocator` 에서는 silent (process 종료까지 보유), Debug `DebugAllocator` (PR #3695) 에서는 atexit leak dump 에 dir entry name slices 로 노출.

## 변경 (3 파일 +3 lines)

```diff
 // packages/core/src/napi/watch.zig:534 (initial build in watchWorkerThread)
 var bundler = Bundler.init(allocator, initial_opts);
+defer bundler.deinit();
 var result = bundler.bundle() catch |err| { ... };
```

```diff
 // packages/core/src/napi/build_sync_entry.zig:81 (napiBuildSync)
 var bundler = Bundler.init(native_alloc, bundle_opts);
+defer bundler.deinit();
 var result = bundler.bundle() catch |err| { ... };
```

```diff
 // packages/core/src/napi/build_async_entry.zig:51 (buildWorkerThread)
 fn buildWorkerThread(async_data: *BuildAsyncData) void {
     var bundler = Bundler.init(native_alloc, async_data.options);
+    defer bundler.deinit();
     async_data.result = bundler.bundle() catch |err| { ... };
```

`watch.zig` 의 rebuild loop (line 748 `rebundler = Bundler.initWithResolveCache(...)`) 는 `defer rebundler.deinit()` 이미 보유. PR scope 외 패치 없음.

## 안전성 검증 (`/code-review max` 5-angle, 모든 angle `[]`)

**Angle B field-by-field BundleResult ownership 감사** — defer LIFO 가 `result.deinit` 후 `bundler.deinit` 실행, 또 `buildWorkerThread` 의 cross-thread transfer (worker bundler.deinit → main 에서 result consume) 시 dangling 여부 결정타:

| BundleResult field | 소유 allocator | 검증 site |
|---|---|---|
| `output` | `self.allocator` (bundler) | bundler.zig:1546/1641/1698 emit_result move |
| `sourcemap` | `self.allocator` | emitter.zig:1088 dupe |
| `sourcemap_builder` | heap | `moveToHeap(allocator)` |
| `outputs[].path/contents/module_ids/imports/exports` | `allocator` | chunks.zig:937-985, 967, 1725 — 각 dupe |
| `outputs_by_format` | `self.allocator` | bundler.zig:1653-1691 |
| `diagnostics` | `self.allocator` | copyDiagnostics deep dupe |
| `module_paths` | `self.allocator` | **bundler.zig:1763 `self.allocator.dupe(u8, m.path)` fresh dupe** |
| `module_dev_codes` | `allocator` | emitter.zig:857/909 |
| `asset_outputs` | `self.allocator` | bundler.zig:1789-1796 |
| `rn_asset_metadata` | `self.allocator` | loaders.zig:150 + toOwnedSlice |
| `metafile_json` | `self.allocator` | generateMetafileJson allocator-owned |
| `reparsed_paths` | `self.allocator` | bundler.zig:1135 dupe |

**결론**: 모든 `BundleResult` field 가 owned. `m.path` 는 `graph.path_arena` 소유로 `resolve_cache` 와 disjoint. `Bundler.deinit` 가 free 하는 것 (`resolve_cache` + `mf_eff_*`) 과 `BundleResult` 는 **zero shared pointer** — dangling 0.

**Angle E sweep**: 1016 `Bundler.init` + 5 `Bundler.initWithResolveCache` 호출 사이트 전수 검사. 3 사이트 외 누락 0:
- production 9 사이트 모두 cover: `main.zig`, `app/build.zig`, `dev_server.zig` (×2), `watch.zig` (×2 — initial + rebundler), `build_async_entry.zig`, `build_sync_entry.zig`, `incremental.zig`
- WASM 2 사이트는 arena allocator 기반 (`wasm_bundler_entry.zig:322, 394`) — arena.deinit 가 일괄 회수, benign
- test 1000+ 사이트 모두 paired

## 검증

- `zig build` ✓
- `zig build test` ✓ (5421 tests, 회귀 0)
- `/code-review max` 5-angle: 모든 angle `[]` (info-level 8 notes 만, 실제 bug 0)

## 측정 follow-up

이 PR 머지 후 Debug NAPI 재빌드 + 1분 dev probe 재실행 → leak entries 87 → ?? 감소 측정. listDir dupe 67 + ResolveCache HashMap 10 = 77 entries 가 이 fix 의 직접 영향 범위. 잔여 leak 가 있으면 Site #3 (`bundler.resolve_cache.ResolveCache.putCache` HashMap storage) 분석 진행 — 단, `Bundler.deinit` 가 `resolve_cache.deinit()` 호출하면 HashMap storage 도 같이 free 되므로 이 PR 으로 Site #3 도 동시 해결 가능성 높음.