### PR TITLE
fix(bundler): chunkPlaceholderStem discriminator — manualChunks 는 chunk_names (PR B-4b sub-3)

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -1858,14 +1858,22 @@ fn chunkPlaceholderStem(
     allocator: std.mem.Allocator,
     options: *const EmitOptions,
 ) !void {
-    const is_entry = chunk.name != null;
+    // PR B-4b sub-3: 정확한 discriminator 는 `chunk.kind`. 옛 `chunk.name != null`
+    // 검사는 manualChunks 청크도 name 이 set 돼 있어 entry_names 패턴이 잘못
+    // 적용 → manualChunks 청크 path 가 `[dir]/[name]` (sub-2 새 default) 로
+    // 변환되며 dir="" 라 stem="vendor" 만 남음. lazy 청크와 cross-chunk import
+    // 계산 시 src_dir="vendor" == dep_stem="vendor" → `./.js` 깨짐.
+    const is_entry = chunk.kind == .entry_point;
     const base_name = chunk.name orelse "chunk";
     const pattern = if (is_entry) options.entry_names else options.chunk_names;
+    // manualChunks / common 청크는 dir 정보 없음(entry-relative dir 미상). entry
+    // 청크만 name_dir 사용해 `[dir]/[name]` 효과 발현.
+    const dir = if (is_entry) (chunk.name_dir orelse "") else "";
 
     var hash_buf: [HASH_PLACEHOLDER_PREFIX.len + HASH_PLACEHOLDER_LEN]u8 = undefined;
     buildPlaceholder(chunk, &hash_buf);
 
-    try applyNamingPatternWithDir(out, allocator, pattern, base_name, &hash_buf, chunk.name_dir orelse "");
+    try applyNamingPatternWithDir(out, allocator, pattern, base_name, &hash_buf, dir);
 }
 
 /// 모듈 인덱스 기반 해시 (placeholder 식별자용, content hash 아님).

--- a/tests/integration/tests/manual-chunks-smoke.test.ts
+++ b/tests/integration/tests/manual-chunks-smoke.test.ts
@@ -176,13 +176,20 @@ describe('manualChunks smoke (실제 번들 실행)', () => {
       },
     });
 
-    // lazy 는 vendor 가 아닌 별도 async chunk 에 있어야
+    // lazy 는 vendor manualChunk 가 아닌 별도 async chunk 에 있어야.
+    // PR B-4b sub-3: 새 default `[dir]/[name]` 하에서 lazy 모듈의 source path 가
+    // `vendor/lazy.ts` 라 자연스럽게 lazy chunk path 에 `vendor/` 가 prefix 로
+    // 붙는다 — manualChunks 와 무관. test 의 *intent* 는 lazy 가 manualChunks
+    // 의 vendor chunk 와 *다른* 청크라는 것.
     const lazyChunk = result.outputFiles.find((o) => o.text.includes('LAZY_VENDOR'));
     expect(lazyChunk).toBeDefined();
-    expect(lazyChunk!.path).not.toContain('vendor');
-    // manual 매칭된 static 모듈이 없으므로 vendor chunk 자체가 생성 안 됨
-    const vendorChunk = result.outputFiles.find((o) => o.path.includes('vendor'));
-    expect(vendorChunk).toBeUndefined();
+    // manual 매칭된 static 모듈이 없으므로 *manualChunks 의 vendor chunk* 자체가
+    // 생성 안 됨 (lazy 모듈은 dynamic import 라 vendor 흡수 거부 — Rollup 동일).
+    // 식별: lazyChunk 가 LAZY_VENDOR 마커 보유 + 같은 마커 가진 별도 청크 없음.
+    const manualVendorChunk = result.outputFiles.find(
+      (o) => o.path !== lazyChunk!.path && o.text.includes('LAZY_VENDOR'),
+    );
+    expect(manualVendorChunk).toBeUndefined();
   });
 
   test('realistic: dynamic entry 가 vendor dep 을 static import — 번들 구조 일치', async () => {
@@ -212,11 +219,16 @@ describe('manualChunks smoke (실제 번들 실행)', () => {
       manualChunks: (id) => (id.includes('/vendor/') ? 'vendor' : null),
     });
 
-    // 최소 3개 청크: entry, vendor, lazy
-    const vendor = result.outputFiles.find(
-      (o) => o.path.includes('vendor') && !o.path.includes('lazy'),
-    )!;
+    // 최소 3개 청크: entry, vendor (manual), lazy (async, source=vendor/lazy.ts).
+    // PR B-4b sub-3 식별 보정:
+    // - manual vendor chunk: SHARED_MARKER 함유 + lazy 마커 미함유.
+    // - lazy chunk: `lazy:` 마커 함유. source `vendor/lazy.ts` 라 새 default
+    //   `[dir]/[name]` 하에서 path 에 `vendor/` 가 prefix 로 붙음 — manualChunks
+    //   와 무관 (단지 source dir 의 자연스러운 반영).
     const lazyChunk = result.outputFiles.find((o) => o.text.includes('lazy:'))!;
+    const vendor = result.outputFiles.find(
+      (o) => o.text.includes('SHARED_MARKER') && o !== lazyChunk,
+    )!;
     const entry = result.outputFiles.find((o) => o.path.endsWith('entry.js'))!;
     expect(vendor).toBeDefined();
     expect(lazyChunk).toBeDefined();
@@ -225,8 +237,8 @@ describe('manualChunks smoke (실제 번들 실행)', () => {
     expect(vendor.text).toContain('SHARED_MARKER');
     expect(vendor.text).toMatch(/export\s*\{/);
 
-    // lazy chunk 는 vendor 가 아닌 별도 경로 + vendor 에서 SHARED import
-    expect(lazyChunk.path).not.toContain('vendor');
+    // lazy chunk 는 manual vendor chunk 와 *다른* 청크 + vendor 에서 SHARED import.
+    expect(lazyChunk.path).not.toBe(vendor.path);
     expect(lazyChunk.text).toMatch(/from\s*["'][^"']*vendor[^"']*["']/);
 
     // entry 도 vendor 에서 SHARED import, dynamic import("./lazy") 사용


### PR DESCRIPTION
## Summary

PR B-4b sub-2 의 new default `entry_names = "[dir]/[name]"` 가 발현된 후 드러난 critical cross-chunk import 버그 fix.

## 문제

`chunkPlaceholderStem` 의 `is_entry = chunk.name != null` 검사가 잘못 — manualChunks 청크 (`vendor` 등) 도 `chunk.name` 이 set 돼 있어 *entry chunk 가 아닌데* entry_names 패턴 (`[dir]/[name]`) 이 적용. manualChunks 청크는 `name_dir` 정보가 없어 `dir = ""` → 빈 dir + 인접 `/` skip → stem = `"vendor"` 가 dep_stem 으로 들어감.

cross-chunk import 계산 (`computeRelativePath`):
- importer (`vendor/lazy.js`) src_dir = `"vendor"`
- dep (vendor manual chunk) dep_stem = `"vendor"`
- 둘이 같아 common_len = src_dir.len, depth=0, dep_remaining=`""`
- → `"./" + "" + ".js"` = `"./.js"` — 완전히 깨진 import path

## Fix

정확한 discriminator 는 `chunk.kind == .entry_point`. manualChunks / common 청크는 chunk_names 패턴 (`[name]-[hash]`) 적용 + dir 강제 `""` — entry-relative dir 정보가 없으므로.

```zig
const is_entry = chunk.kind == .entry_point;
const pattern = if (is_entry) options.entry_names else options.chunk_names;
const dir = if (is_entry) (chunk.name_dir orelse "") else "";
```

검증 (probe):
- before: `import { SHARED } from "./.js";`  ❌
- after:  `import { SHARED } from "../vendor-278ce774.js";`  ✓

## Test fixture 동반 fix

`manualChunks smoke` 의 두 회귀 test 가 옛 default 가정 (`[name]` 평면) 하에 path 에 `"vendor"` substring 가 *없어야* 한다고 검증했지만, 새 default `[dir]/[name]` 하에서 lazy 모듈의 source path 가 `vendor/lazy.ts` 이면 chunk path 도 `vendor/lazy.js` 가 되는 게 *의도된 동작* (manualChunks 와 무관, 순수 source dir 반영).

test 의 *intent* 를 보존하도록 assertion 갱신 — "lazy 가 manualChunks 의 vendor chunk 와 *다른* 청크" 검증으로. content marker (`LAZY_VENDOR`, `SHARED_MARKER`) 기반 식별.

## 검증

| 검증 | 결과 |
|---|---|
| zig build test | 전체 pass |
| packages/core | 1021/1021 pass |
| manualChunks smoke (isolated) | 32/32 pass |
| manualChunks NAPI bridge (isolated) | 44/44 pass |

## 후속

- sub-3 의 *fixture* 부분 — RN example app `zntc-hermes.js` 등 9000줄+ 갱신은 별도 commit/PR.
- sub-4: RFC + 마이그레이션 가이드 + F4 watch test (issue #65).

## Test plan

- [x] zig build test 전체 pass
- [x] manualChunks smoke / NAPI bridge isolated 모두 pass
- [x] cross-chunk import path 가 정상 (`"./.js"` 깨짐 없음)
- [x] manualChunks 의 vendor chunk 는 chunk_names (`[name]-[hash]`) 적용 → 평면 path
- [x] entry chunk 는 entry_names (`[dir]/[name]`) 적용 → dir prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)