### PR TITLE
fix(build): separate .zig-cache-napi for build:napi script (#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 zig-out/
 zig-cache/
 .zig-cache/
+# Issue #54: napi build 는 별도 cache root — `zig build napi` 와 `zig build test`
+# 동시 실행 시 cache 슬롯 corruption 으로 25 fail flaky (ast_walk_test 등) 회피.
+.zig-cache-napi/
 
 # Node/Bun
 node_modules/

--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -463,3 +463,31 @@ watch({
   },
 });
 ```
+
+## 5. Local dev — `zig build napi` 와 `zig build test` 동시 실행 cache 분리
+
+`zig build napi` (background) 와 `zig build test` 를 같은 `.zig-cache/` 공유로 동시에 돌리면 Zig 0.15.2 build system 의 cache 슬롯 corruption 으로 무관 영역 — 특히 `parser/ast_walk_test` 같은 단위 테스트 — 에서 25 fail flaky 가 일관 발생한다(Issue #54).
+
+### 증상
+
+```sh
+# concurrent
+$ bun run build:napi & zig build test
+# → parser/ast_walk_test 영역 25 fail
+```
+
+직렬 실행 시 통과. fresh `.zig-cache` 단독 `zig build test` 도 통과. 트리거 = *concurrent build 가 같은 cache root* 사용.
+
+### Fix
+
+`packages/core/package.json` 의 `build:napi` script 는 `--cache-dir .zig-cache-napi` 로 별도 cache root 사용 (Issue #54). 다른 호출 사이트 (CI, 사용자 직접 `zig build napi` 호출) 도 concurrent test 와 같이 돌릴 때는 다음 패턴:
+
+```sh
+zig build napi --cache-dir .zig-cache-napi
+```
+
+`.gitignore` 에 `.zig-cache-napi/` 등록됨.
+
+### CI 영향
+
+CI (`ci.yml` 의 `test` job) 는 `zig build` 후 `zig build test` 가 *순차* 실행이라 concurrent 트리거 없음 — 영향 0.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     }
   },
   "scripts": {
-    "build:napi": "cd ../.. && zig build napi",
+    "build:napi": "cd ../.. && zig build napi --cache-dir .zig-cache-napi",
     "build:js:esm": "bun build index.ts --outdir dist --format esm --target node",
     "build:js:cjs": "node bin/zntc.mjs --bundle index.ts --outfile dist/index.cjs --format=cjs --platform=node --packages=external",
     "build:js": "bun run build:js:esm && bun run build:js:cjs",


### PR DESCRIPTION
## Summary

Issue #54 — `zig build napi` + `zig build test` 동시 실행 시 같은 `.zig-cache/` 슬롯 corruption 으로 무관 영역 (`parser/ast_walk_test` 등) 25 fail flaky 발생. cache root 분리로 회피.

## 원인

PR B 시리즈 작업 중 발견. `zig build napi` 를 background 로 돌리면서 `zig build test` foreground 실행 시 25 fail. 같은 환경에서:
- 직렬 실행 → 통과
- fresh `.zig-cache` 단독 실행 → 통과
- 동시 실행 + 같은 cache root → 25 fail

트리거는 *concurrent build 가 같은 cache root 공유* (Zig 0.15.2 build system 의 cache 슬롯 corruption).

## Fix

`packages/core/package.json` 의 `build:napi` script 에 `--cache-dir .zig-cache-napi` 추가:

```diff
- "build:napi": "cd ../.. && zig build napi",
+ "build:napi": "cd ../.. && zig build napi --cache-dir .zig-cache-napi",
```

- `.gitignore` 에 `.zig-cache-napi/` 등록
- `docs/DEBUG.md` 에 §5 로컬 dev 노트 추가 — 증상/Fix/CI 영향 설명

## CI 영향

CI (`ci.yml` 의 `test` job) 는 `zig build` 후 `zig build test` 가 *순차* 실행이라 concurrent 트리거 없음 — 영향 0.

## 검증

`bun run build:napi` (background) + `zig build test` (foreground) 동시 실행 3회 반복 — 모두 통과 (0/3 fail). 이전 같은 cache 공유로는 PR B 작업 중 25 fail 일관 재현 (memory `feedback_zig_cache_concurrent`).

## Test plan

- [x] `bun run build:napi` + `zig build test` 동시 실행 3회 — 모두 통과
- [x] CI 영향 없음 (순차 실행 보존)
- [x] `.gitignore` + `docs/DEBUG.md` 사이드카

🤖 Generated with [Claude Code](https://claude.com/claude-code)