### PR TITLE
fix(napi): chunk.name leak — NapiManualChunksResolver dedup cache

### DIFF
--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -1039,6 +1039,28 @@ pub const NapiSyncPlugin = struct {
 
 pub const NapiManualChunksResolver = struct {
     tsfn: c.napi_threadsafe_function,
+    /// JS resolver 가 반환한 chunk name 의 dedup cache. parseJsResult 가
+    /// `native_alloc.dupe` 한 owned slice 를 보관, 같은 이름이 다시 반환되면
+    /// cache hit 으로 기존 slice 재사용 → 중복 alloc 0. chunk graph 가 이
+    /// slice 들을 borrow 하지만 free 책임은 없음 (record-form `mc.name` 와
+    /// 동일 borrow 패턴). resolver.deinit 에서 일괄 free.
+    ///
+    /// **Lifetime invariant**: `chunk_graph` (Bundler.bundle() 내부 local) 의
+    /// lifetime 동안 cache 가 유지되어야 borrow 가 안전. build_async/build_sync
+    /// 는 build 마다 새 resolver 생성·소멸. watch 는 watch session 동안 동일
+    /// resolver 재사용 → rebuild 마다 cache 가 단조 증가 (bounded by unique JS
+    /// 반환 name 집합 — 일반 사용 시 'vendor'/'react' 등 소수, 악의적 JS 가
+    /// rebuild-varying name 반환 시만 unbounded). rebuild N+1 시작 시 N 의
+    /// chunk_graph 는 이미 deinit 되어 cache slice borrow 없음 — 단, 의도적
+    /// dedup 정책상 clear 안 함.
+    ///
+    /// **TSFN UAF 회피**: `napi_release_threadsafe_function(release)` 는 비동기
+    /// 라 deinit 직후 `destroy(self)` 가 in-flight callJsCallback (self 를
+    /// ctx_ptr 로 deref) 와 race 가능. 호출자가 'deinit 시점에 in-flight TSFN
+    /// 없음' invariant 보장 — buildCompleteTsfn 은 worker 의 동기 resolve() 가
+    /// 모두 끝나고 completion_tsfn 받은 후에 실행, WatchAsyncData.deinit 도
+    /// stop_flag 로 worker 종료 후. 향후 caller flow 변경 시 이 invariant 보전.
+    name_cache: std.StringHashMap(void),
 
     const CallContext = struct {
         id: []const u8,
@@ -1179,8 +1201,9 @@ pub const NapiManualChunksResolver = struct {
     }
 
     /// threadsafe function 의 call_js 콜백 (main thread).
-    fn callJsCallback(env: c.napi_env, js_callback: c.napi_value, _: ?*anyopaque, data: ?*anyopaque) callconv(.c) void {
+    fn callJsCallback(env: c.napi_env, js_callback: c.napi_value, ctx_ptr: ?*anyopaque, data: ?*anyopaque) callconv(.c) void {
         const ctx: *CallContext = @ptrCast(@alignCast(data.?));
+        const self: *NapiManualChunksResolver = @ptrCast(@alignCast(ctx_ptr.?));
 
         var js_id: c.napi_value = undefined;
         _ = c.napi_create_string_utf8(env, ctx.id.ptr, ctx.id.len, &js_id);
@@ -1239,11 +1262,31 @@ pub const NapiManualChunksResolver = struct {
         defer native_alloc.free(tmp);
         var written: usize = 0;
         _ = c.napi_get_value_string_utf8(env, js_result, tmp.ptr, len + 1, &written);
-        const out = native_alloc.dupe(u8, tmp[0..written]) catch {
+        const slice = tmp[0..written];
+
+        // dedup cache: 같은 chunk name 이 반복 반환되어도 alloc 1회. chunk_graph
+        // 가 이 slice 를 borrow (deinit 시 free 안 함) — resolver.deinit 가 일괄
+        // 회수. ZNTC 일반 사용 시 manualChunks resolver 가 'vendor' / 'react'
+        // 같은 소수의 group name 을 N 개 모듈에 반복 반환 → cache hit 비율 매우
+        // 높음.
+        const gop = self.name_cache.getOrPut(slice) catch {
             signalResult(ctx, null);
             return;
         };
-        signalResult(ctx, out);
+        if (gop.found_existing) {
+            signalResult(ctx, gop.key_ptr.*);
+            return;
+        }
+        const owned = native_alloc.dupe(u8, slice) catch {
+            // miss-but-OOM: 방금 추가한 reserved slot 제거 (slice tmp 는 곧 free).
+            _ = self.name_cache.remove(slice);
+            signalResult(ctx, null);
+            return;
+        };
+        // hashmap key 를 owned slice 로 update — getOrPut 직후의 borrow (tmp) 가
+        // defer 로 곧 free 되므로 owned 로 갈아끼우지 않으면 dangling key 가 됨.
+        gop.key_ptr.* = owned;
+        signalResult(ctx, owned);
     }
 
     fn signalResult(ctx: *CallContext, result: ?[]const u8) void {
@@ -1273,6 +1316,12 @@ pub const NapiManualChunksResolver = struct {
 
     pub fn deinit(self: *NapiManualChunksResolver) void {
         _ = c.napi_release_threadsafe_function(self.tsfn, c.napi_tsfn_release);
+        // dedup cache 의 owned chunk name slice 들 free + map deinit. chunk_graph
+        // 가 이 resolver 의 lifetime 동안만 cache 의 slice 를 borrow 하므로
+        // 안전.
+        var it = self.name_cache.keyIterator();
+        while (it.next()) |k| native_alloc.free(k.*);
+        self.name_cache.deinit();
         native_alloc.destroy(self);
     }
 };
@@ -1285,7 +1334,10 @@ pub fn installManualChunksResolver(
     opts: *BundleOptions,
 ) ?*NapiManualChunksResolver {
     const resolver = native_alloc.create(NapiManualChunksResolver) catch return null;
-    resolver.* = .{ .tsfn = undefined };
+    resolver.* = .{
+        .tsfn = undefined,
+        .name_cache = std.StringHashMap(void).init(native_alloc),
+    };
 
     var resource_name: c.napi_value = undefined;
     _ = c.napi_create_string_utf8(env, "zntc_manual_chunks", "zntc_manual_chunks".len, &resource_name);
@@ -1302,6 +1354,9 @@ pub fn installManualChunksResolver(
         NapiManualChunksResolver.callJsCallback,
         &resolver.tsfn,
     ) != c.napi_ok) {
+        // StringHashMap.init 은 zero-alloc 이라 현재 leak 0 이지만, 추후 init
+        // 변경 시 fragile — defensive deinit.
+        resolver.name_cache.deinit();
         native_alloc.destroy(resolver);
         return null;
     }


### PR DESCRIPTION
## 배경

dev/watch RSS 누수 epic (PR #3691/#3695/#3696) 의 `/code-review max` sweep 에서 발견된 **pre-existing latent leak**. PR #3695 가 도입한 Debug GPA detector 가 manualChunks 사용 시 매 resolver 호출 stack 으로 표시하던 측정 noise — 실제 production 사용자도 manualChunks function-form 사용 시 발현.

## Root cause

`packages/core/src/napi/plugin_bridge.zig:NapiManualChunksResolver.parseJsResult` 가 JS resolver 반환값 마다:
```zig
const out = native_alloc.dupe(u8, tmp[0..written]) catch { ... };
signalResult(ctx, out);
```
→ worker thread 의 `resolve()` 가 받음 → bundler `chunk.zig:ensureNameSlot` 이 `effective_names` ArrayList 에 borrow append → `Chunk.name` 으로 차용.

`Chunk.deinit` (chunk.zig:240) 는 `self.name` 을 **free 안 함** — record-form `BundleOptions.ManualChunkEntry.name` (string literal / `owned_strings` 보관) borrow 와 동일 contract. **function-form 의 dupe 결과만 owner 없음** → per-resolver-call 영구 leak.

ZNTC chunk 측 변경 없이 resolver 측에서 ownership 해결하는 것이 최소 scope.

## 변경 (1 파일 +59/-4)

`packages/core/src/napi/plugin_bridge.zig`:
- `NapiManualChunksResolver` 에 `name_cache: std.StringHashMap(void)` 필드 추가
- `callJsCallback` (TSFN main-thread callback) signature 변경: `_: ?*anyopaque` → `ctx_ptr: ?*anyopaque` 로 resolver self 획득
- parseJsResult 로직 변경:
  ```zig
  const gop = self.name_cache.getOrPut(slice) catch { signalResult(ctx, null); return; };
  if (gop.found_existing) { signalResult(ctx, gop.key_ptr.*); return; }
  const owned = native_alloc.dupe(u8, slice) catch {
      _ = self.name_cache.remove(slice);  // OOM rollback (slice=tmp, content-eql 로 매칭)
      signalResult(ctx, null);
      return;
  };
  gop.key_ptr.* = owned;  // tmp borrow → owned 로 hashmap key 교체 (dangling 방지)
  signalResult(ctx, owned);
  ```
- `deinit` 에 cache cleanup 추가:
  ```zig
  var it = self.name_cache.keyIterator();
  while (it.next()) |k| native_alloc.free(k.*);
  self.name_cache.deinit();
  ```
- `installManualChunksResolver` 에 `name_cache: .init(native_alloc)` 초기화 + TSFN-create 실패 경로 defensive `name_cache.deinit()`

## `/code-review max` 5-angle 검증

**진짜 bug 0건** — 모두 low/info docstring/defensive cleanup:

| Finding | 처리 |
|---|---|
| Lifetime invariant (build_async/sync = per-build / watch = per-session) docstring | docstring 명시 ✓ |
| TSFN `release` 비동기 + destroy 시 in-flight callback UAF 위험 | docstring 에 caller invariant ("deinit 시 in-flight 없음") 명시 ✓ |
| Watch session 의 cache 단조 증가 (rebuild-varying JS name 시 unbounded) | docstring 에 bounded 한계 명시 ✓ (의도된 dedup 정책) |
| `installManualChunksResolver` TSFN-fail 경로의 `name_cache.deinit()` 누락 | defensive `name_cache.deinit()` 추가 ✓ (현재 zero-alloc init 라 실 leak 0) |

검증된 invariants (5-angle 전수):
- **Thread safety**: `name_cache` 는 main thread (TSFN callback) 만 mutate, worker 는 per-call stack `CallContext.result` 만 read
- **HashMap key 교체 안전성**: `std.hash_map.StringContext` 가 content-based hash + `mem.eql` 비교 → tmp pointer → owned pointer 변경 시 hashmap invariant 유지
- **OOM rollback**: `name_cache.remove(slice)` 가 content-eql 로 매칭, tmp slice 가 freed 되어도 hashmap 에 dangling key 없음
- **Borrow lifetime**: `chunk_graph` (Bundler.bundle() local) 가 `resolver.name_cache` 보다 짧은 lifetime → chunk_graph 가 borrow 한 slice 가 항상 살아있는 동안 chunk_graph 가 활성
- **buildResultToJS**: `napi_create_string_utf8` 이 V8 heap 으로 copy → 네이티브 pointer JS 측 retention 0

## 검증

- `zig build` ✓
- `zig build test` ✓ (5421 tests, 회귀 0)
- `/code-review max` 5-angle: 진짜 bug 0

## 영향

- **ZNTC core 일반 사용 영향 0** — manualChunks resolver 미사용 시 코드 경로 안 지나감
- **manualChunks function-form 사용 시**: 매 resolver 호출 = dupe 1회 (cache miss) 또는 alloc 0 (cache hit). 일반 use case ('vendor', 'react' 등 소수 group name) 에서 cache hit ratio 매우 높음
- **leak 측정 noise 제거** — Debug GPA dump 에 더 이상 NapiManualChunksResolver.parseJsResult stack 으로 표시 안 됨

## Follow-up (선택)

- watch 의 rebuild-boundary cache clear API 추가 (rebuild-varying JS name 패턴 대응) — 일반 사용 시 ROI 낮음
- 또는 LRU 제한 (cache 크기 cap)