### PR TITLE
fix(napi): leak_dump_registered atomic 전환 — Node worker_threads race 차단

### DIFF
--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -33,14 +33,22 @@ fn dumpLeaksAtExit() callconv(.c) void {
     _ = debug_gpa.deinit();
 }
 
-var leak_dump_registered: bool = false;
+/// `napi_register_module_v1` 의 중복 호출 race 방지 atomic flag. Node
+/// `worker_threads` / Vitest `pool='threads'` 등 한 process 안에서 다중 isolate
+/// 가 같은 .node 를 load 시 module init 이 동시에 호출될 수 있고, 공유 static
+/// 인 이 flag 의 non-atomic read+write 면 둘 다 false 관찰 → 둘 다 atexit
+/// 등록 → process 종료 시 `dumpLeaksAtExit` 두 번 호출 → 첫 deinit 가 `self.* =
+/// undefined` 로 GPA 무효화 후 두 번째 deinit 가 undefined memory deref →
+/// segfault. `.acq_rel` swap 으로 하나의 caller 만 등록 진입 보장.
+var leak_dump_registered: std.atomic.Value(bool) = .init(false);
 
 /// napi_register_module_v1 에서 1회 호출. SIGTERM/정상 exit 시 atexit handler
 /// 가 GPA.deinit() 를 호출해 leak 리포트(stack trace) 를 stderr 에 출력한다.
 pub fn registerLeakDump() void {
     if (comptime builtin.mode != .Debug) return;
-    if (leak_dump_registered) return;
-    leak_dump_registered = true;
+    // swap 결과가 이미 true 면 다른 caller 가 등록 완료한 상태 — skip. acq_rel
+    // 로 register 후 read 가 write 와 happens-before 정렬.
+    if (leak_dump_registered.swap(true, .acq_rel)) return;
     _ = atexit(&dumpLeaksAtExit);
 }
 


### PR DESCRIPTION
## 배경

PR #3695 (`/code-review max` HIGH #2) 에서 수용된 measurement infra trade-off 의 첫 실해소.

`packages/core/src/napi/common.zig` 의 `leak_dump_registered` 는 plain `bool` 이라 multi-threaded module init 시 race:

```
T1: read false   → (continues)
T2: read false   → (continues)
T1: write true   → atexit(&dumpLeaksAtExit)
T2: write true   → atexit(&dumpLeaksAtExit)   // duplicate
```

process exit 시 atexit handler 두 번 호출 → 첫 `debug_gpa.deinit()` 가 `self.* = undefined` 로 GPA 무효화 → 두 번째 deinit 가 undefined memory dereference → **segfault**.

## Trigger scenarios

- **Node `worker_threads`** — 같은 .node 가 여러 isolate 에 module-init 콜백 호출
- **Vitest `pool='threads'`** (default) — 동일 패턴
- 일반 single-thread NAPI 사용 (vite/rollup 일반 빌드) 시 무관

## 변경 (1 파일 +11/-3)

```diff
-var leak_dump_registered: bool = false;
+var leak_dump_registered: std.atomic.Value(bool) = .init(false);

 pub fn registerLeakDump() void {
     if (comptime builtin.mode != .Debug) return;
-    if (leak_dump_registered) return;
-    leak_dump_registered = true;
+    if (leak_dump_registered.swap(true, .acq_rel)) return;
     _ = atexit(&dumpLeaksAtExit);
 }
```

`swap(true, .acq_rel)` 가 prior 값 반환 → single winner 만 atexit 등록 진입.

## `/code-review max` 5-angle 결과

**진짜 bug 0건** — 모두 nit/info:

| 검증 | 결과 |
|---|---|
| `std.atomic.Value` Zig 0.15.2 API 일치 | `pub fn Value(comptime T)`, `pub fn init(value: T) Self`, `pub inline fn swap(self, operand, comptime order) T` — 확인 ✓ |
| `.acq_rel` ordering 정확성 | 정확하나 publication payload 없는 single-shot flag 라 `.seq_cst` / `.monotonic` 도 충분. over-fenced 라 안전 |
| 외부 reader 검사 | `leak_dump_registered` grep = decl + swap 2곳뿐, ABI-safe |
| WASM 영향 | `wasm_*entry.zig` 가 `common.zig` 미import — 영향 0 |
| Race 시나리오 유효성 | Node `worker_threads` / Vitest `pool='threads'` 에서 multi-isolate `napi_register_module_v1` 호출 — 실 race 가능 ✓ |
| atexit failure 처리 | POSIX `ATEXIT_MAX` 도달 시 무처리 — pre-existing, regression 아님 |
| `comptime` early-out | release 빌드에서 atomic 변수/연산 dead-code 제거 — overhead 0 |
| swap RMW 의 winner→loser 의존성 | 없음 (loser 는 단순 skip, payload 미참조). 의도 명확 |

## 검증

- `zig build` ✓
- `zig build test` ✓ (5421 tests, 회귀 0)
- `/code-review max` 5-angle: 진짜 bug 0

## 영향

- **ZNTC core release 빌드 영향 0** — `if (comptime builtin.mode != .Debug) return;` early-out 으로 atomic 코드 dead-code 제거
- **Debug 빌드 measurement infra 견고화** — Vitest pool='threads' / Node worker_threads 환경에서 leak detector 가 process exit 시 panic 없이 정상 dump

## Follow-up (선택, measurement infra 잔존 trade-off)

- `backing_allocator = c_allocator` override — Debug 빌드 RSS 측정 정확도 (현재 page_allocator default 라 size_class 별 page 점유)
- `detectLeaks()` 또는 NAPI env cleanup hook 전환 — atexit deinit() UAF with detached watch worker 회피
- `shrinkSlice` OOM fallback inner-element free — rare