### PR TITLE
fix(graph): buildIncremental 가 user-set project_root 보존 (#65 follow-up)

### DIFF
--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -655,9 +655,10 @@ pub fn buildIncremental(
     // entry_dir 계산: entry point들의 공통 부모 디렉토리 ([dir] 패턴용).
     // 매 buildIncremental 시 entry_points 로부터 재계산 — watch 모드에서 entry
     // 추가/삭제 시 stale 회피 (Issue #65). computeEntryDir 는 O(N) pure fn.
+    // project_root 는 user-set 옵션 (RN/Metro `projectRoot`) 보존을 위해 강제
+    // invalidate 하지 않는다 — 자동 추론은 *최초* 빈 값일 때만.
     if (entry_points.len > 0) {
         self.entry_dir = computeEntryDir(entry_points);
-        self.project_root = "";
     }
     if (self.project_root.len == 0 and self.entry_dir.len > 0) {
         self.project_root = graph_project_root.findProjectRoot(self.allocator, self.entry_dir) catch self.entry_dir;

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -1432,8 +1432,41 @@ test "F4 (#65): buildIncremental 가 stale entry_dir 를 강제 재계산" {
     // entry_dir 가 entry path 의 dirname 으로 갱신됐어야.
     const expected = std.fs.path.dirname(entry) orelse "";
     try std.testing.expectEqualStrings(expected, graph.entry_dir);
-    // entry_dir 변경에 따라 project_root 도 재추론 — stale 값 무효화.
-    // project_root 는 findProjectRoot 가 entry_dir prefix 또는 위로 찾아 set.
-    try std.testing.expect(graph.project_root.len > 0);
-    try std.testing.expect(!std.mem.eql(u8, graph.project_root, "/some/stale/parent/dir"));
+}
+
+// F4 follow-up (post-review F1) — user-set project_root 보존:
+// buildIncremental 가 entry_dir 갱신 시 project_root 를 함부로 invalidate
+// 하면 RN/Metro 의 `projectRoot` 명시 설정이 watch session 중 자동 추론값
+// 으로 silently 덮어쓰여진다. 자동 추론은 *최초* 빈 값일 때만.
+test "F4 follow-up: buildIncremental 는 user-set project_root 를 보존" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "src/index.ts", "export const X = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "src/index.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var store = module_store_mod.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    try populateStoreForChangedFilesTest(&cache, &store, entry);
+
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+    // RN/Metro 시뮬레이션 — user 가 monorepo root 명시.
+    const user_project_root = "/repo/monorepo-root";
+    graph.project_root = user_project_root;
+
+    var empty: std.StringHashMap(void) = .init(std.testing.allocator);
+    defer empty.deinit();
+
+    const r = try graph.buildIncremental(&.{entry}, &store, &empty);
+    defer std.testing.allocator.free(r.reparsed_indices);
+
+    // user-set project_root 보존 — buildIncremental 이 강제 invalidate 하면
+    // RN/Metro asset httpServerLocation 어긋남.
+    try std.testing.expectEqualStrings(user_project_root, graph.project_root);
 }


### PR DESCRIPTION
## Summary

PR #3704 (#65 F4 fix) 머지 후 **누락된 `/code-review max`** 사후 review 에서 발견한 critical finding F1 fix.

`buildIncremental` 가 `self.project_root = ""` 를 entry_points 가 있을 때 무조건 실행해 user-supplied `graph.project_root` (RN/Metro `projectRoot` 옵션) 가 매 incremental 빌드마다 silently 덮어쓰여지던 회귀.

## 문제

```zig
// PR #3704 코드
if (entry_points.len > 0) {
    self.entry_dir = computeEntryDir(entry_points);
    self.project_root = "";  // ← user-set project_root 강제 invalidate
}
```

RN/Metro 사용자가 monorepo root 를 `projectRoot` 로 명시했어도 watch session 의 첫 incremental 부터 자동 추론값으로 덮어쓰여짐 → asset httpServerLocation 어긋남.

## Fix

`self.project_root = ""` 라인 제거. 자동 추론은 *최초* 빈 값일 때만 (다음 분기 `if (self.project_root.len == 0 ...)` 가 처리).

entry_dir 재계산은 그대로 유지 — F4 watch stale invariant 보존.

## E2E 회귀 가드 (`graph_test.zig`)

PR #3704 의 단위 테스트는 `computeEntryDir` pure fn 만 검증이라 실제 `buildIncremental` mutation 가드 미흡 — 본 PR 의 e2e 가드로 보강:

1. **F4 entry_dir 재계산**: stale entry_dir 시뮬레이션 후 `buildIncremental` 호출 → entry_points 의 dirname 으로 갱신 검증
2. **F4 follow-up project_root 보존**: user 가 `/repo/monorepo-root` 명시 → `buildIncremental` 후에도 동일 값 유지 (RN/Metro 시나리오)

## 검증

| 검증 | 결과 |
|---|---|
| zig build test | 전체 pass |
| packages/core bun test | 1021/1021 pass |

## 경위 + 후속

PR #3700 / #3703 / #3704 머지 시 `/code-review max` 누락 → 사후 review 에서 F1 critical + F4 가드 부족 발견. 본 PR 에서 처리. 다른 finding 들 (Rollup dynamic chunk parity / CI napi cache-dir / preserve-modules drift 등) 은 pre-existing 또는 별도 PR scope — issue 로 추적 예정.

## Test plan

- [x] zig build test pass
- [x] bun test 1021/1021 pass
- [x] F4 + project_root 보존 e2e 가드 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)