### PR TITLE
fix(napi): DebugAllocator backing=c_allocator + backing_allocator_zeroes=false

### DIFF
--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -19,7 +19,27 @@ pub const NullableStringPair = struct { []const u8, ?[]const u8 };
 // 모든 NAPI 파일이 `common.nativeAlloc()` 1개 인스턴스를 공유해야 cross-file
 // alloc/free (예: watch.zig 가 transpile_entry 결과 free) 시 false leak 이
 // 안 뜬다.
-var debug_gpa: std.heap.DebugAllocator(.{ .stack_trace_frames = 16 }) = .init;
+//
+// `backing_allocator = c_allocator` 명시 (default = page_allocator 대신).
+// page_allocator backing 은 size_class 마다 fresh page (macOS ≥64KB, Linux 4KB-
+// 1MB) 점유 → small-alloc 다양성 시 RSS 인플레이션이 측정 시그널을 왜곡
+// (#dev-leak-investigation PR #3695 review MEDIUM). c_allocator (libc malloc)
+// 는 baseline c_allocator release 빌드와 동일 backing — Debug vs Release delta
+// 가 GPA overhead 보다 진짜 leak signal 을 더 잘 노출.
+//
+// **`backing_allocator_zeroes = false` 필수**: Config default = `true` 가
+// "backing 이 zero page 를 준다" 가정하고 DebugAllocator 의 `usedBits` /
+// `requestedSizes` zero-pass 를 스킵한다 (stdlib debug_allocator.zig:793-796).
+// 그러나 `c_allocator` (libc malloc/posix_memalign) 는 zero-fill 보장 없음 →
+// usedBits[1..]/requestedSizes[*] garbage → false-positive double-free panic
+// 또는 phantom leak. stdlib 자체 테스트 `debug_allocator.zig:1287-1292` 가
+// 동일 non-page backing 패턴에 이 flag 를 false 로 명시.
+var debug_gpa: std.heap.DebugAllocator(.{
+    .stack_trace_frames = 16,
+    .backing_allocator_zeroes = false,
+}) = .{
+    .backing_allocator = std.heap.c_allocator,
+};
 
 pub fn nativeAlloc() std.mem.Allocator {
     if (comptime builtin.mode == .Debug) return debug_gpa.allocator();


### PR DESCRIPTION
## 배경

PR #3695 (`/code-review max` MEDIUM #5) 의 measurement infra trade-off 두번째 실해소. dev/watch RSS 측정 시 `DebugAllocator` 의 default `page_allocator` backing 이 size_class 마다 fresh page (macOS arm64 ≥16KB, Linux 4KB-1MB) 점유 → small-alloc 다양성 시 RSS 인플레이션이 측정 시그널을 왜곡. baseline release 빌드의 `c_allocator` 와 동일 backing 으로 전환해 Debug↔Release delta 가 진짜 leak signal 을 더 잘 노출.

## 🚨 `/code-review max` HIGH catch — fix 적용

stdlib `debug_allocator.zig:155` 의 `Config.backing_allocator_zeroes` default 는 **`true`** 로, "backing 이 zero page 를 준다" 가정하고 DebugAllocator 가 자체 `usedBits` / `requestedSizes` zero-pass 를 **SKIP** 한다 (line 793-796). 그러나 `c_allocator` (libc malloc / posix_memalign) 는 zero-fill 보장 없음.

이 mismatch 가 일으키는 결정적 버그:
- **`usedBits` 의 word 1..N** (`slot_count > 64`) 가 garbage → free path 의 `is_used` 판정 (debug_allocator.zig:882-895) 가 **false-positive double-free panic** 또는 silent slot 재사용
- **safety-mode 의 `requestedSizes[*]`** garbage → free 시 line 900-902 가 **"Invalid free" panic** 또는 size-mismatch error
- **deinit 의 leak walk** 가 garbage 1-bit 슬롯을 **phantom leak** 으로 dump → 측정 인프라가 측정 시그널 자체를 오염

**결정적 증거**: stdlib 자체 테스트 `debug_allocator.zig:1287-1292` 가 동일 non-page backing 패턴에 `.backing_allocator_zeroes = false` 를 **명시 설정**:
```zig
.{
    .backing_allocator_zeroes = false,
    .backing_allocator = std.testing.allocator,
}
```

review max 3 angle 합의 (B/D/E) — `/code-review max` 의 multi-cycle 가치 재확인.

## 변경 (1 파일 +21/-1)

```diff
-var debug_gpa: std.heap.DebugAllocator(.{ .stack_trace_frames = 16 }) = .init;
+var debug_gpa: std.heap.DebugAllocator(.{
+    .stack_trace_frames = 16,
+    .backing_allocator_zeroes = false,
+}) = .{
+    .backing_allocator = std.heap.c_allocator,
+};
```

## 검증

- `zig build` ✓
- `zig build napi -Dnapi-optimize=Debug` ✓
- `zig build test` ✓ (5421 tests, 회귀 0)
- **20s dev probe (3 rebuild)**: panic 0, leak entries 0, rebuilt 3 정상 → review max F1 의 우려된 false-positive panic 없음 확인
- `/code-review max` 5-angle 풀 사이클 + Phase 2 verify: F1 HIGH 즉시 fix 반영, 잔여는 LOW (trade-off 수용)

## 잔여 LOW/MEDIUM trade-off

(review max 가 발견했으나 수용)

- **macOS arm64 default page_size = 16KiB**: small-alloc 다양성 시 c_allocator 도 페이지 단위 alloc — RSS 개선 효과가 darwin-arm64 에서 ROI 약화 가능. 실 measurement 비교는 별도 follow-up
- **per-allocation `posix_memalign` 오버헤드** — large path 가 mmap 대신 malloc. signal 방향 (Debug vs Release delta) 검증 별도
- **`.{ .backing_allocator = ... }` partial literal** — stdlib 의 `.init` deprecation 문구와 미세한 grey zone. 0.15.2 compile 통과, 향후 zig upgrade 시 warning 가능

## 영향

- **ZNTC core release 빌드 영향 0** — `comptime builtin.mode != .Debug` 분기로 atomic 변수/연산 dead-code 제거 + `std.heap.c_allocator` 직접 반환
- **Debug 빌드 measurement infra 정확도 개선** — backing zero 가정 mismatch 제거로 leak detector 의 false-positive 차단. dev/watch RSS 측정이 baseline release c_allocator 와 일관된 backing