### PR TITLE
ci: zig build napi --cache-dir .zig-cache-napi 통일 (F3 post-review)

### DIFF
--- a/.github/actions/setup-zntc/action.yml
+++ b/.github/actions/setup-zntc/action.yml
@@ -52,7 +52,7 @@ runs:
         if [ -n "${{ inputs.cpu }}" ]; then
           napi_args+=("-Dcpu=${{ inputs.cpu }}")
         fi
-        zig build napi "${napi_args[@]}"
+        zig build napi --cache-dir .zig-cache-napi "${napi_args[@]}"
       shell: bash
 
     - name: Build core JS wrapper

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,11 +52,11 @@ jobs:
 
       - name: Build NAPI module (Windows, MinGW ABI)
         if: runner.os == 'Windows'
-        run: zig build napi -Dtarget=x86_64-windows-gnu
+        run: zig build napi --cache-dir .zig-cache-napi -Dtarget=x86_64-windows-gnu
 
       - name: Build NAPI module
         if: runner.os != 'Windows'
-        run: zig build napi
+        run: zig build napi --cache-dir .zig-cache-napi
 
       - name: Build WASM module
         run: zig build wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,11 +141,11 @@ jobs:
 
       - name: Build NAPI module (Windows, MinGW ABI)
         if: runner.os == 'Windows'
-        run: zig build napi -Dtarget=x86_64-windows-gnu
+        run: zig build napi --cache-dir .zig-cache-napi -Dtarget=x86_64-windows-gnu
 
       - name: Build NAPI module
         if: runner.os != 'Windows'
-        run: zig build napi
+        run: zig build napi --cache-dir .zig-cache-napi
 
       # JS + dts 둘 다 emit. dts 는 web/server 의 `tsc --emitDeclarationOnly`
       # 가 `import { prepareAppDevSync } from "@zntc/core"` 의 declaration 을
@@ -269,9 +269,9 @@ jobs:
         shell: bash
         run: |
           if [ -n "${{ matrix.host_zig_target }}" ]; then
-            zig build napi -Dtarget=${{ matrix.host_zig_target }}
+            zig build napi --cache-dir .zig-cache-napi -Dtarget=${{ matrix.host_zig_target }}
           else
-            zig build napi
+            zig build napi --cache-dir .zig-cache-napi
           fi
           cp zig-out/lib/zntc.node packages/core/zntc.node
 
@@ -283,7 +283,7 @@ jobs:
       - name: Build platform NAPI (cross)
         if: matrix.zig_target != 'native' && matrix.zig_target != matrix.host_zig_target
         shell: bash
-        run: zig build napi -Dtarget=${{ matrix.zig_target }}
+        run: zig build napi --cache-dir .zig-cache-napi -Dtarget=${{ matrix.zig_target }}
 
       - name: Copy .node into platform sub-package
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build NAPI (ReleaseFast)
         shell: bash
-        run: zig build napi -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }}
+        run: zig build napi --cache-dir .zig-cache-napi -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }}
 
       - name: Locate zntc.node
         id: locate

--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -490,4 +490,11 @@ zig build napi --cache-dir .zig-cache-napi
 
 ### CI 영향
 
-CI (`ci.yml` 의 `test` job) 는 `zig build` 후 `zig build test` 가 *순차* 실행이라 concurrent 트리거 없음 — 영향 0.
+현재 CI 는 napi 와 test 가 *별도 job* (또는 같은 job 안 sequential) 실행이라 concurrent 트리거 없음 — race 측면 영향 0.
+
+CI workflows 의 모든 `zig build napi` 호출은 *일관성 + 향후 parallelize 대비* 로 `--cache-dir .zig-cache-napi` 적용(ci.yml/release.yml/benchmark.yml/actions/setup-zntc). trade-off:
+
+- `mlugg/setup-zig@v2` 의 GH cache 가 default `.zig-cache/` 만 cache → `.zig-cache-napi/` 는 매 run cold. NAPI 빌드 wall-time 분 단위 증가 가능.
+- setup-zntc composite action 은 `zig build` (core) 와 `zig build napi` 가 다른 cache dir 사용 → src/ 의 같은 module/.o 재사용 손실.
+
+후속(별도 PR 후보): `actions/cache@v4` 로 `.zig-cache-napi/` 명시 cache 추가해 cold cache 회피.


### PR DESCRIPTION
## Summary

PR #3703 (#54 fix) 가 packages/core 의 npm `build:napi` 만 `--cache-dir .zig-cache-napi` 적용. CI workflows 는 모두 default `.zig-cache/` → 향후 CI step parallelize 시 25 fail flaky (`parser/ast_walk_test`) 재발 위험.

## 변경

모든 `zig build napi` CI 호출 사이트에 `--cache-dir .zig-cache-napi` 통일:
- `.github/workflows/release.yml` build NAPI step
- `.github/workflows/ci.yml` napi job 의 host/cross build 5곳
- `.github/workflows/benchmark.yml` napi build 2곳
- `.github/actions/setup-zntc/action.yml` composite NAPI build step

## 동기 + Trade-off (사후 `/code-review max` 결과 반영)

- **현재 CI 영향 0**: napi 와 test 가 *별도 job* (또는 sequential) — *현시점 race 없음*. F3 는 **defensive change** (향후 parallelize 대비 + npm script 와의 일관성).
- **Trade-off**: `mlugg/setup-zig@v2` 의 GH cache 는 default `.zig-cache/` 만 cache → `.zig-cache-napi/` 매 run cold cache → NAPI 빌드 wall-time 분 단위 증가 가능. follow-up 으로 `actions/cache@v4` 추가 필요 (별도 PR).
- **Composite cost**: setup-zntc 의 core build (`zig build`) 와 napi build 가 다른 cache dir → src/ 의 같은 module/.o 재사용 손실. integration matrix 영향. trade-off 수용.

## docs

`docs/DEBUG.md §5` 의 CI 영향 절 정합화 — conditional 표현 → 일관 적용 + trade-off + follow-up 명시.

## 검증

CI 동작 변경 외 코드 영향 없음. yaml syntax 확인.

## 후속 (review finding)

- `actions/cache@v4` 추가로 `.zig-cache-napi/` 명시 cache (CI cold cache 회피)
- F4/F5/F8 별도 PR 순차 진행 중

## Test plan

- [x] /code-review max 5 angle × 15 finding — trade-off + docs 반영
- [x] 모든 napi CI 사이트 grep 통일 확인
- [x] yaml syntax 사용자 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)