### PR TITLE
fix(napi): shrinkSlice OOM fallback inner-element leak — caller cleanup contract

### DIFF
--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -207,17 +207,21 @@ fn copyBytesOrEmpty(alloc: std.mem.Allocator, data_ptr: ?*anyopaque, byte_len: u
 /// (`getStringArg` 와 동일 root cause). 정확히 `count` 길이로 줄여 반환한다.
 /// 1차 시도 `alloc.realloc` (대부분 in-place shrink); 실패 시 새 alloc + memcpy
 /// + 옛 free fallback. element 값 (slice 등 sub-alloc) 은 그대로 보존된다.
-pub fn shrinkSlice(comptime T: type, alloc: std.mem.Allocator, result: []T, count: usize) ?[]T {
+///
+/// **OOM 시 `result` 미 free** — caller 가 `catch` 로 받아 element-specific
+/// inner cleanup (element 가 owned sub-alloc 보유 시) 후 `alloc.free(result)`
+/// 호출 책임. 이전 design 은 OOM 시 outer 만 free 하고 inner element 누수 —
+/// PR #3691 review max 의 잔여 finding (rare 지만 contract 정확성).
+pub fn shrinkSlice(comptime T: type, alloc: std.mem.Allocator, result: []T, count: usize) std.mem.Allocator.Error![]T {
     if (count == result.len) return result;
-    return alloc.realloc(result, count) catch blk: {
-        const shrunk = alloc.alloc(T, count) catch {
-            alloc.free(result);
-            return null;
-        };
+    if (alloc.realloc(result, count)) |shrunk| return shrunk else |_| {
+        // realloc 실패 (희박) → 새 alloc + memcpy + 옛 free. 새 alloc 도 실패
+        // 시 OOM error 반환 (result 유지, caller 가 cleanup).
+        const shrunk = try alloc.alloc(T, count);
         @memcpy(shrunk, result[0..count]);
         alloc.free(result);
-        break :blk shrunk;
-    };
+        return shrunk;
+    }
 }
 
 pub fn getObjectStringArray(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const []const u8 {
@@ -248,7 +252,11 @@ pub fn parseStringArray(env: c.napi_env, val: c.napi_value, alloc: std.mem.Alloc
         alloc.free(result);
         return null;
     }
-    return shrinkSlice([]const u8, alloc, result, count);
+    return shrinkSlice([]const u8, alloc, result, count) catch {
+        for (result[0..count]) |s| alloc.free(s);
+        alloc.free(result);
+        return null;
+    };
 }
 
 /// JS 객체의 키-값 쌍을 [2][]const u8 배열로 추출. { "key": "value", ... }
@@ -288,7 +296,14 @@ pub fn getObjectKeyValuePairs(env: c.napi_env, obj: c.napi_value, key: [*:0]cons
         alloc.free(result);
         return null;
     }
-    return shrinkSlice([2][]const u8, alloc, result, count);
+    return shrinkSlice([2][]const u8, alloc, result, count) catch {
+        for (result[0..count]) |pair| {
+            alloc.free(pair[0]);
+            alloc.free(pair[1]);
+        }
+        alloc.free(result);
+        return null;
+    };
 }
 
 /// fallback 옵션용 — 값이 boolean false이면 null 저장, 문자열이면 그대로. 그 외엔 스킵.
@@ -344,7 +359,14 @@ pub fn getObjectKeyValuePairsWithNullable(
         alloc.free(result);
         return null;
     }
-    return shrinkSlice(NullableStringPair, alloc, result, count);
+    return shrinkSlice(NullableStringPair, alloc, result, count) catch {
+        for (result[0..count]) |pair| {
+            alloc.free(pair[0]);
+            if (pair[1]) |v| alloc.free(v);
+        }
+        alloc.free(result);
+        return null;
+    };
 }
 
 pub fn setDoubleProp(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, value: f64) void {

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -513,7 +513,12 @@ pub fn parseBuildOptions(
         if (valid_count == 0) {
             native_alloc.free(overrides);
         } else {
-            loader_overrides = common.shrinkSlice(bundler_mod.types.LoaderOverride, native_alloc, overrides, valid_count) orelse return null;
+            // LoaderOverride.ext 는 owned_strings borrow, .loader/.module_type 은
+            // enum value — inner sub-alloc 없음. OOM catch 시 outer 만 free.
+            loader_overrides = common.shrinkSlice(bundler_mod.types.LoaderOverride, native_alloc, overrides, valid_count) catch {
+                native_alloc.free(overrides);
+                return null;
+            };
         }
     }
 


### PR DESCRIPTION
## 배경

PR #3691 `/code-review max` sweep 의 잔여 finding 실해소. PR #3691 의 `shrinkSlice` helper 가 도입한 새 failure path:

```zig
const shrunk = alloc.alloc(T, count) catch {
    alloc.free(result);  // ❌ outer 만 free
    return null;
};
```

realloc 실패 + alloc 실패 (둘 다 OOM) 시 outer `result` 만 free 하고 이미 채워진 `result[0..count]` 의 inner element (각 `getStringArg.dupe` slice 등) 누수. 실 빈도 매우 낮지만 contract 위반 + Debug GPA noise.

## 변경 (2 파일 +39/-12)

`shrinkSlice` signature 변경: `?[]T` → `std.mem.Allocator.Error![]T`. OOM 시 `result` 미 free, error 반환. caller 가 element-specific inner cleanup 책임.

```diff
-pub fn shrinkSlice(...) ?[]T {
+pub fn shrinkSlice(...) std.mem.Allocator.Error![]T {
     if (count == result.len) return result;
-    return alloc.realloc(result, count) catch blk: {
-        const shrunk = alloc.alloc(T, count) catch {
-            alloc.free(result);
-            return null;
-        };
+    if (alloc.realloc(result, count)) |shrunk| return shrunk else |_| {
+        const shrunk = try alloc.alloc(T, count);  // OOM 시 result 유지
         @memcpy(shrunk, result[0..count]);
         alloc.free(result);
-        break :blk shrunk;
-    };
+        return shrunk;
+    }
}
```

4 caller catch handler (element type 별):

| Caller | Element type | Inner cleanup |
|---|---|---|
| `common.parseStringArray` | `[]const u8` | `for ... \|s\| alloc.free(s);` |
| `common.getObjectKeyValuePairs` | `[2][]const u8` | `alloc.free(pair[0]); alloc.free(pair[1]);` |
| `common.getObjectKeyValuePairsWithNullable` | `NullableStringPair = struct { []const u8, ?[]const u8 }` | `alloc.free(pair[0]); if (pair[1]) \|v\| alloc.free(v);` |
| `options.zig` loader_overrides | `LoaderOverride = struct { ext, loader, module_type }` | 없음 (`.ext` 는 `owned_strings` borrow, `.loader`/`.module_type` 은 enum) |

각 catch handler 가 inner free 후 `alloc.free(result)` + `return null;`

## `/code-review max` 5-angle 결과

**진짜 bug 0건** — 3 angle 모두 `[]`:

| 검증 | 결과 |
|---|---|
| Zig 0.15.2 `Allocator.realloc` signature `Error!@TypeOf(old_mem)` | 일치 ✓ |
| error-union unwrap `if (...) \|x\| return x else \|_\| {...}` | valid Zig syntax ✓ |
| realloc OOM 시 `result` 미 free (Zig 표준 보장 `Allocator.zig:402-419`) | catch handler 의 result 접근 안전 ✓ |
| 4 caller catch return null vs surrounding `?T` 반환 시그니처 | 일치 ✓ |
| LoaderOverride ownership 모델 (`types.zig:644-651` + `options.zig:498` 의 `trackStr(owned_strings, pair[0])`) | inner sub-alloc 없음 확인 ✓ |
| 4 caller 외 추가 누락 (grep 전수) | 없음 ✓ |
| `@memcpy` panic risk (length mismatch / overlap) | shrunk.len == count == result[0..count].len, 별개 alloc → no overlap ✓ |
| success path 의 caller `result` UAF | catch 만 result 접근, success 경로는 미참조 ✓ |

## 검증

- `zig build` ✓
- `zig build test` ✓ (5421 tests, 회귀 0)
- `/code-review max` 5-angle: 진짜 bug 0

## 영향

- **ZNTC core release 빌드 영향 0** — shrinkSlice 가 NAPI 헬퍼 경로만 호출, release 빌드 c_allocator 동작 무변경
- **OOM fallback path 자체가 rare execution 경로** — realloc shrink 실패 + 새 alloc 실패 동시 케이스
- **Debug GPA noise 감소** — 향후 dev probe 측정 시 false-positive inner-element leak 보고 회피