### PR TITLE
fix(napi): dumpLeaksAtExit — deinit() → detectLeaks() + mutex.tryLock (atexit UAF 회피)

### DIFF
--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -50,7 +50,25 @@ extern fn atexit(?*const fn () callconv(.c) void) c_int;
 
 fn dumpLeaksAtExit() callconv(.c) void {
     if (comptime builtin.mode != .Debug) return;
-    _ = debug_gpa.deinit();
+    // `deinit()` (stdlib debug_allocator.zig:500) 가 detectLeaks 후 `self.* =
+    // undefined` 로 GPA 상태 무효화 → atexit 발화 시점에 detached watch worker
+    // (`thread.detach()`, watch.zig) / TsconfigCache napi_wrap finalizer / late
+    // libc destructor 가 후속 native_alloc.alloc/free 호출 시 undefined memory
+    // dereference → segfault (PR #3695 review HIGH #1).
+    //
+    // `detectLeaks()` (debug_allocator.zig:449) 는 leak stack trace 만 stderr 에
+    // dump 하고 state 유지 → 동시 in-flight alloc/free 가 후속에 진행해도 안전.
+    // 단, detectLeaks 자체가 `self.buckets` / `self.large_allocations` 를 lock
+    // 없이 iterate → 동시 alloc/free 가 mutate 하면 torn pointer read / iterator
+    // desync 위험 (review max HIGH catch). `mutex.tryLock` 으로 best-effort
+    // serialize: worker 가 mid-alloc 이면 skip (leak dump 일부 손실) → deadlock
+    // 보다 안전 (`lock` 은 worker 가 강제 kill 시 영구 hang).
+    if (debug_gpa.mutex.tryLock()) {
+        defer debug_gpa.mutex.unlock();
+        _ = debug_gpa.detectLeaks();
+    }
+    // large_allocations HashMap 자체는 leak (deinit 만 free) — process 종료
+    // 직전이라 OS 가 회수.
 }
 
 /// `napi_register_module_v1` 의 중복 호출 race 방지 atomic flag. Node


### PR DESCRIPTION
## 배경

PR #3695 `/code-review max` HIGH #1 (atexit deinit UAF) 실해소 — measurement infra HIGH trade-off 중 마지막 큰 항목.

이전 `_ = debug_gpa.deinit();` 는 stdlib `debug_allocator.zig:500-506` 의 4 단계 실행:
1. detectLeaks → leak stderr dump
2. freeRetainedMetadata (`retain_metadata=false` 라 skip)
3. `self.large_allocations.deinit(self.backing_allocator)`
4. **`self.* = undefined`** ← GPA 상태 무효화

atexit 발화 시점에 detached watch worker (`thread.detach()`, `watch.zig:1300+`) / TsconfigCache `napi_wrap` finalizer / late libc destructor 가 후속 `native_alloc.alloc/free` 호출 시 undefined memory dereference → **segfault**.

## Fix

`detectLeaks()` (`debug_allocator.zig:449`) 만 호출 — leak stack trace 만 stderr 에 dump 하고 state 유지.

**`/code-review max` HIGH catch (review 진행 중 발견)**: `detectLeaks` 가 mutex 없이 buckets/large_allocations iterate → race. `mutex.tryLock` 으로 best-effort serialize.

```diff
 fn dumpLeaksAtExit() callconv(.c) void {
     if (comptime builtin.mode != .Debug) return;
-    _ = debug_gpa.deinit();
+    if (debug_gpa.mutex.tryLock()) {
+        defer debug_gpa.mutex.unlock();
+        _ = debug_gpa.detectLeaks();
+    }
 }
```

| 시나리오 | 동작 |
|---|---|
| worker idle | `tryLock` 획득 → detectLeaks 안전 → leak dump |
| worker mid-alloc | `tryLock` 실패 → leak dump skip (deadlock 회피) |
| 비-Debug | `comptime` early-out, 코드 자체 elide |

`lock` 대신 `tryLock` 인 이유: worker 가 process exit 시점에 강제 kill 되면 mutex 영구 hang → main thread 의 lock 호출이 deadlock. tryLock 은 best-effort skip 으로 안전.

## 검증

- `zig build` ✓
- `zig build napi -Dnapi-optimize=Debug` ✓
- `zig build test` (5482/5513 passed) — 25 fail 은 main baseline 동일 (`transformer.plugins.rn_codegen.snapshot_test` 의 stale fixture, 우리 변경과 무관 검증)
- 20s dev probe (3 rebuild): panic 0, leak entries 0, rebuilt 3 정상
- `/code-review max` 5-angle 풀 사이클 → HIGH catch (mutex race) 즉시 fix 반영

## Trade-off (수용)

- **`self.large_allocations` HashMap backing storage leak** — `deinit` 가 free 하던 HashMap 자체는 미 회수. process 종료 직전이라 OS 회수 → 무관 (user-tracked nativeAlloc 회계 미포함)
- **tryLock 실패 시 leak dump skip** — worker idle 시점에 실패는 매우 드묾. measurement noise 허용 범위

## 영향

- **ZNTC core release 빌드 영향 0** — `comptime builtin.mode != .Debug` early-out 으로 dead code 제거
- **Debug 빌드 measurement infra 견고화** — detached worker 가 atexit 직후에도 native_alloc 호출해도 UAF 없음. dev/watch 측정의 post-shutdown crash 위험 차단

## 잔여 follow-up (선택, ROI 낮음)

- macOS arm64 page_size 측정 검증 — c_allocator backing vs page_allocator backing 의 실제 RSS 차이 (review LOW)
- chunk.name watch session unbounded growth — rebuild-varying name 패턴 한정 (PR #3705 LOW, 일반 사용 ROI 0)