### PR TITLE
ci: leak gate workflow fail-fast + NAPI smoke test (진단 강화)

### DIFF
--- a/.github/workflows/napi-leak-gate.yml
+++ b/.github/workflows/napi-leak-gate.yml
@@ -76,12 +76,38 @@ jobs:
         # default ReleaseFast 라 명시적 Debug 필수.
         run: zig build napi --cache-dir .zig-cache-napi -Dnapi-optimize=Debug
 
+      - name: Verify Debug NAPI build artifact (fail-fast)
+        # `|| true` 로 cp 실패를 마스킹하면 stale binary 로 진행 → 진단 불가.
+        # Debug NAPI 산출물 부재 시 즉시 fail-fast 로 환경 차이 즉시 노출.
+        run: |
+          ls -la zig-out/lib/
+          test -f zig-out/lib/zntc.node || { echo "::error::Debug NAPI build did not produce zig-out/lib/zntc.node"; exit 1; }
+          file zig-out/lib/zntc.node || true
+          ls -la zig-out/lib/zntc.node
+
+      - name: Copy .node to package (BEFORE build:js — Debug NAPI self-host)
+        # build:js:cjs 가 zntc self-host 로 bundle (`node bin/zntc.mjs --bundle`).
+        # `packages/core/index.ts:findAddon()` 이 `zig-out/lib/zntc.node` 를
+        # 최우선 resolve 라 사실 cp 안 해도 self-host 는 zig-out 의 .node 사용.
+        # 그래도 packages/core/zntc.node 도 명시 일치시켜 dev probe step 의
+        # examples/web 의 `bun run dev` (predev=build:js, zntc dev) 가 동일
+        # Debug binary 보장. `|| true` 제거 — cp 실패 시 fail-fast.
+        run: cp zig-out/lib/zntc.node packages/core/zntc.node
+
+      - name: NAPI smoke test (self-host Debug build 부팅 검증)
+        # 본격 build:js 전에 Debug NAPI 가 정상 dlopen + symbol resolve 되는지
+        # smoke. SIGSEGV 가 여기서 노출되면 build:js fail 보다 진단이 단순.
+        # 이전 run #26336187926 이 build:js:cjs (node + Debug zntc.node self-host)
+        # 단계에서 SIGSEGV — 진짜 원인 분리에 필요.
+        run: |
+          node -e "
+            const addon = require('./packages/core/zntc.node');
+            console.log('NAPI keys:', Object.keys(addon).slice(0, 5).join(','), '...');
+            console.log('NAPI smoke: dlopen + symbol resolve OK');
+          "
+
       - name: Build JS wrapper + dts
         run: cd packages/core && bun run build:js && bun run build:dts
-
-      - name: Copy .node to package
-        # ci.yml napi job 과 동일하게 `|| true` 로 path 차이 tolerate
-        run: cp zig-out/lib/zntc.node packages/core/zntc.node 2>/dev/null || true
 
       - name: 1-min dev probe (Bun graceful exit)
         run: |


### PR DESCRIPTION
## 배경

PR #3715 (NAPI Leak Gate workflow) 의 첫 자동 실행 [run #26336187926](https://github.com/ohah/zntc/actions/runs/26336187926) 이 `Build JS wrapper + dts` step 에서 **SIGSEGV** (Bun script `build:js:cjs` exit 139).

이전 PR 의 `/code-review max` HIGH catch 였던 `Debug GPA 가 self-host bundle 중 latent contract violation panic` 가능성 — 진짜 원인 분리 위해 진단 step 3개 추가.

## 변경 (1 파일 +30/-4)

### 1. Verify Debug NAPI build artifact (fail-fast)
```sh
test -f zig-out/lib/zntc.node || { echo "::error::..."; exit 1; }
file zig-out/lib/zntc.node || true
ls -la zig-out/lib/zntc.node
```
- 이전: `cp ... 2>/dev/null || true` 로 산출물 부재 시 silent pass → stale binary 로 진행
- 변경: zig build 가 silent fail 시 즉시 fail-fast

### 2. Copy .node to package (BEFORE build:js, `|| true` 제거)
- 순서: `Build JS wrapper + dts` 보다 **먼저** 실행
- `|| true` 제거 — cp 실패 시 fail-fast

`/code-review max` 가 보완: `packages/core/index.ts` 의 `findAddon()` 이 `zig-out/lib/zntc.node` 를 **최우선** resolve 라 self-host 는 사실 cp 와 무관. 그래도 `packages/core/zntc.node` 도 명시 일치시켜 후속 dev probe 의 `examples/web` 의 `bun run dev` (predev=build:js + zntc dev) 가 동일 Debug binary 보장.

### 3. NAPI smoke test (build:js 전에)
```sh
node -e "
  const addon = require('./packages/core/zntc.node');
  console.log('NAPI keys:', Object.keys(addon).slice(0, 5).join(','), '...');
  console.log('NAPI smoke: dlopen + symbol resolve OK');
"
```
- Debug NAPI 가 정상 dlopen + symbol resolve 검증
- SIGSEGV 가 여기서 노출되면 build:js 의 zntc bundle 이 아닌 단순 dlopen 단계 문제

## 가설 분기 (workflow_dispatch 재실행으로 판정)

| 시나리오 | 의미 | 후속 |
|---|---|---|
| **(a)** Verify step fail | `zig build napi` 산출물 부재 (cache/path 문제) | build.zig + actions/cache 디버그 |
| **(b)** Copy step fail | permission / fs 문제 | CI runner 환경 |
| **(c)** Smoke test SIGSEGV | Debug NAPI dlopen-level 또는 init-level latent bug — PR #3691~#3713 미커버한 새 root | **별도 fix PR 가치** |
| **(d)** Build JS step SIGSEGV | self-host bundle 의 특정 NAPI call 이 Debug GPA panic 트리거 | `build:js:cjs` 의 NAPI 호출 path 추적 |
| **(e)** 전부 통과 | step reorder 가 진짜 root 였음 (placebo 아님) | leak gate 활성 |

## `/code-review max` 5-angle 결과 — 모두 반영

| Finding | Severity | Fix |
|---|---|---|
| F1: `\|\| true` 가 cp 실패 마스킹 → silent pass | HIGH | `\|\| true` 제거 + Verify step 추가 |
| F2: motivation premise 보완 (`findAddon()` 우선순위) | MEDIUM | 주석 보강 |
| F3: Debug GPA 가 self-host build 중 panic 가능성 | HIGH | NAPI smoke test 로 분리 진단 |
| F4: zig build silent fail 마스킹 | MEDIUM | Verify step 으로 fail-fast |
| F5: 진단 정보 부족 | LOW | `ls -la`, `file` 출력 추가 |

## 검증

- YAML syntax OK (기존 패턴 유지)
- 코드 변경 0 → `zig build` / `zig build test` 무관
- 실 작동 검증: 머지 후 `workflow_dispatch` 수동 실행 + 결과 분석

## 영향

- **ZNTC core release 빌드 영향 0** — workflow file 만 변경
- **회귀 진단력 강화** — Debug NAPI 의 init-level latent bug 가 있다면 즉시 노출. 측정 인프라 자체의 자정 능력 향상