### PR TITLE
ci: leak gate atexit + tokenize smoke (SIGSEGV 위치 isolate)

### DIFF
--- a/.github/workflows/napi-leak-gate.yml
+++ b/.github/workflows/napi-leak-gate.yml
@@ -96,9 +96,7 @@ jobs:
 
       - name: NAPI smoke test (self-host Debug build 부팅 검증)
         # 본격 build:js 전에 Debug NAPI 가 정상 dlopen + symbol resolve 되는지
-        # smoke. SIGSEGV 가 여기서 노출되면 build:js fail 보다 진단이 단순.
-        # 이전 run #26336187926 이 build:js:cjs (node + Debug zntc.node self-host)
-        # 단계에서 SIGSEGV — 진짜 원인 분리에 필요.
+        # smoke. 이전 run #26336685916 통과 → dlopen + init 정상.
         run: |
           node -e "
             const addon = require('./packages/core/zntc.node');
@@ -106,7 +104,34 @@ jobs:
             console.log('NAPI smoke: dlopen + symbol resolve OK');
           "
 
+      - name: NAPI atexit smoke (Linux-specific dumpLeaksAtExit 검증)
+        # 가장 light path — require + process exit (atexit 발화) 만.
+        # SIGSEGV 시 atexit 의 dumpLeaksAtExit/detectLeaks 가 Linux 환경
+        # 특이 문제 (DWARF/stderr fd/stack trace) — PR #3713 의 mutex.tryLock
+        # + detectLeaks fix 가 Linux glibc 환경에서 다른 동작 가능성.
+        run: |
+          node -e "
+            const addon = require('./packages/core/zntc.node');
+            console.log('atexit smoke: require done, exiting...');
+          " || { echo "::error::atexit smoke SIGSEGV — dumpLeaksAtExit Linux 문제"; exit 1; }
+          echo "atexit smoke: process exit clean"
+
+      - name: NAPI tokenize smoke (NAPI call path 검증)
+        # tokenize 는 가장 단순 NAPI call — string in/out, 다른 NAPI helpers
+        # (parseBuildOptions 등) 안 거침. SIGSEGV 시 transpile/tokenize 자체
+        # NAPI 경로의 latent bug. 통과 시 build:js 의 더 복잡한 옵션 path 문제.
+        run: |
+          node -e "
+            const addon = require('./packages/core/zntc.node');
+            const result = addon.tokenize('var x = 1;', 'test.js');
+            console.log('tokenize OK:', typeof result, Array.isArray(result) ? 'len=' + result.length : '');
+          " || { echo "::error::tokenize smoke SIGSEGV — NAPI tokenize/transpile path 문제"; exit 1; }
+          echo "tokenize smoke: NAPI call OK"
+
       - name: Build JS wrapper + dts
+        # 이전 run #26336187926 + #26336685916 모두 이 step 에서 SIGSEGV.
+        # 위 atexit/tokenize smoke 가 통과했다면 build:js:cjs 의 `node bin/zntc.mjs
+        # --bundle` 의 더 복잡한 NAPI call path (napiBuild/napiBuildSync) 문제.
         run: cd packages/core && bun run build:js && bun run build:dts
 
       - name: 1-min dev probe (Bun graceful exit)


### PR DESCRIPTION
## 배경

[run #26336685916](https://github.com/ohah/zntc/actions/runs/26336685916) 분석:
- ✅ NAPI smoke test (`require` + `Object.keys`) 통과 → dlopen + init 정상
- ❌ `Build JS wrapper + dts` (`node bin/zntc.mjs --bundle index.ts ...`) SIGSEGV (즉시, panic 메시지 없음)

dlopen 자체는 OK 지만 build/transpile NAPI call path **또는** atexit `dumpLeaksAtExit` 의 Linux 환경 특이 문제. 두 후보 isolate 필요.

## 변경 (1 파일 +28/-3)

진단 step 2개 추가:

### NAPI atexit smoke
```sh
node -e "
  const addon = require('./packages/core/zntc.node');
  console.log('atexit smoke: require done, exiting...');
" || { echo "::error::atexit smoke SIGSEGV — dumpLeaksAtExit Linux 문제"; exit 1; }
```
가장 light path. process exit 시 atexit 발화 → `dumpLeaksAtExit` (PR #3713 의 mutex.tryLock + detectLeaks) 실행. **SIGSEGV 시 atexit 자체가 Linux 환경 (DWARF stack trace / stderr fd lifecycle / pthread mutex 동작 차이) 에서 crash**.

### NAPI tokenize smoke
```sh
node -e "
  const addon = require('./packages/core/zntc.node');
  const result = addon.tokenize('var x = 1;', 'test.js');
  console.log('tokenize OK:', typeof result);
"
```
가장 단순 NAPI call — `napiTokenize` (transpile_entry.zig:130) 가 `getStringArg` + `Scanner.init` + token loop. **SIGSEGV 시 transpile/tokenize 경로의 latent bug** (PR #3691~#3713 미커버).

## 가설 분기 (workflow_dispatch 재실행 → 결과로)

| 시나리오 | 의미 | 후속 |
|---|---|---|
| **atexit smoke SIGSEGV** | `dumpLeaksAtExit` Linux 환경 문제 | PR #3713 mutex.tryLock 또는 detectLeaks 재검토 |
| **tokenize smoke SIGSEGV** | NAPI tokenize/transpile 경로 latent bug | Scanner.init / token loop / native_alloc.free 점검 |
| **둘 다 통과, Build JS SIGSEGV** | `napiBuild`/`napiBuildSync` 의 specific 옵션 path | parseBuildOptions 의 path 추가 진단 |

## 검증

- `tokenize` NAPI signature 확인: `tokenize(source, filename)` ([transpile_entry.zig:130](../blob/main/packages/core/src/napi/transpile_entry.zig#L130))
- bash `||` 가 node SIGSEGV (exit 139) 시 정상 분기 진입
- 코드 변경 0, workflow 만 변경

## 영향

- **ZNTC core release 빌드 영향 0** — workflow file 만
- **진단력 추가 강화** — 다음 run 으로 위 3 가설 중 어느 분기인지 명확