### PR TITLE
fix(bundler): renderChunk plugin chunk_name 을 실제 filename stem 과 동기 (F8 post-review)

### DIFF
--- a/packages/core/test/core/bundle-options-exposure/preserve-modules.ts
+++ b/packages/core/test/core/bundle-options-exposure/preserve-modules.ts
@@ -46,4 +46,53 @@ describe('BundleOptions: 전체 옵션 노출 > preserve modules', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // F8 post-review 회귀 가드: renderChunk plugin hook 의 `chunk_name` 이
+  // 실제 *filename 의 stem* 과 동기되어야 한다. 옛 코드는 preserve_modules /
+  // explicit_file_name 시 chunkPlaceholderStem 결과 (entry_names 패턴) 만
+  // 보내 filename 과 drift — plugin (예: visualizer manifest) 이 chunk_name
+  // 으로 path 만들면 실제 파일과 mismatch.
+  test('F8: renderChunk 의 chunk_name 이 preserveModules filename stem 과 동기', async () => {
+    const dir = createPreserveModulesFixture();
+    const capturedNames: string[] = [];
+    try {
+      const result = await build({
+        entryPoints: [join(dir, 'mod-entry.ts')],
+        preserveModules: true,
+        preserveModulesRoot: dir,
+        plugins: [
+          {
+            name: 'capture-render-chunk',
+            setup(build) {
+              build.onRenderChunk({ filter: /.*/ }, ({ chunk }) => {
+                capturedNames.push(chunk);
+                return null;
+              });
+            },
+          },
+        ],
+      });
+      expect(result.errors.length).toBe(0);
+
+      // 각 output 파일의 path stem (ext 제거) 가 renderChunk 가 받은 name 과
+      // 정확히 *순수 stem* (확장자 미포함) 으로 일치해야.
+      const jsOutputs = result.outputFiles.filter((f) => /\.[mc]?js$/.test(f.path));
+      expect(jsOutputs.length).toBeGreaterThanOrEqual(2);
+
+      const filenameStems = jsOutputs.map((f) => f.path.replace(/\.[mc]?js$/, ''));
+
+      // 1:1 invariant — capturedNames cardinality 가 chunks 수와 같아야.
+      // renderChunk hook 이 청크당 정확히 1회 호출되는지 가드.
+      expect(capturedNames.length).toBe(jsOutputs.length);
+
+      // *순수 stem* 매처 (확장자 포함 형태 reject) — drift 시 'mod-a.js' 같은
+      // 확장자 박힌 name 이 들어와도 fail 시켜 회귀 가드 무력화 방지.
+      for (const stem of filenameStems) {
+        const exactMatch = capturedNames.includes(stem);
+        expect(exactMatch).toBe(true);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -919,13 +919,38 @@ pub fn emitChunks(
             (options.format == .umd or options.format == .amd))
             try format_wrapper.emitFormatEpilogue(&chunk_output, allocator, options.format, &.{});
 
-        // Plugin: renderChunk 훅 — 청크 완성 후, footer 전
+        // Plugin: renderChunk 훅 — 청크 완성 후, footer 전.
+        // F8 post-review fix — plugin 에 전달되는 chunk_name 을 *실제 filename 의
+        // stem* 과 동기. 옛 코드는 chunkPlaceholderStem 결과 (entry_names 패턴 적용)
+        // 만 보내 preserve_modules / explicit_file_name 시 filename 과 drift —
+        // plugin (예: visualizer manifest) 이 chunk_name 으로 path 만들면 실제
+        // 파일과 mismatch.
         if (options.plugins.len > 0) {
             const runner = plugin_mod.PluginRunner.init(options.plugins);
             var rc_stem_buf: std.ArrayListUnmanaged(u8) = .empty;
             defer rc_stem_buf.deinit(allocator);
-            try chunkPlaceholderStem(chunk, &rc_stem_buf, allocator, options);
-            const rc_chunk_name = rc_stem_buf.items;
+            const rc_chunk_name: []const u8 = blk: {
+                if (chunk.explicit_file_name) |efn| {
+                    // explicit fileName 의 stem (실제 ext 제외) — efn 의 ext 가
+                    // options.out_extension_js 와 다를 수 있어 `std.fs.path.extension`
+                    // 으로 실제 ext 추출 (review F1 fix).
+                    const efn_ext = std.fs.path.extension(efn);
+                    const stem_part = efn[0 .. efn.len - efn_ext.len];
+                    try rc_stem_buf.appendSlice(allocator, stem_part);
+                    break :blk rc_stem_buf.items;
+                }
+                if (options.preserve_modules and chunk.rel_dir != null) {
+                    // preserve-modules: computePreserveModulesPath 결과의 stem.
+                    const pm_path = try computePreserveModulesPath(allocator, chunk.rel_dir.?, ext, options.preserve_modules_root);
+                    defer allocator.free(pm_path);
+                    const pm_ext = std.fs.path.extension(pm_path);
+                    const stem_part = pm_path[0 .. pm_path.len - pm_ext.len];
+                    try rc_stem_buf.appendSlice(allocator, stem_part);
+                    break :blk rc_stem_buf.items;
+                }
+                try chunkPlaceholderStem(chunk, &rc_stem_buf, allocator, options);
+                break :blk rc_stem_buf.items;
+            };
             var hook_ctx: plugin_mod.HookContext = .{};
             defer hook_ctx.deinit();
             const chunk_rc_result = runner.runRenderChunk(chunk_output.items, rc_chunk_name, allocator, &hook_ctx) catch |err| switch (err) {


### PR DESCRIPTION
## Summary

PR #3700 (B-4b sub-3) 사후 `/code-review max` finding F8 — plugin `renderChunk` hook 의 `chunk_name` argument 가 실제 filename 의 stem 과 drift. preserve_modules / explicit_file_name 시 mismatch.

## 문제

옛 코드: 항상 `chunkPlaceholderStem(chunk)` 결과 (entry_names 패턴 적용 stem) 만 plugin 에 전달.

실제 filename 결정 로직:
- `explicit_file_name` chunk: verbatim efn
- `preserve_modules + rel_dir`: `computePreserveModulesPath(rel_dir)`
- 그 외: `chunkPlaceholderStem` + ext

→ 첫 두 케이스에서 *chunk_name (plugin)* 과 *filename (disk)* 가 다름. visualizer/manifest plugin 이 chunk_name 으로 path 만들면 실제 파일과 mismatch.

## Fix

`rc_chunk_name` 계산을 filename 결정 분기와 동기:
1. `explicit_file_name` → efn 의 stem (`std.fs.path.extension(efn)` 으로 실제 ext 추출 + strip)
2. `preserve_modules and rel_dir != null` → `computePreserveModulesPath` 결과의 stem
3. 그 외 → `chunkPlaceholderStem` (기존)

## review 반영

**F1 (ext mismatch)**: `endsWith(ext)` 가 `.mjs`/`.cjs`/`.json` 등 다른 확장자에서 fail → `std.fs.path.extension(efn)` 으로 실제 ext 추출.

**F2-F4 (test 강화)**:
- 1:1 invariant: `capturedNames.length === jsOutputs.length`
- strict 매처: `capturedNames.includes(stem)` (확장자 포함 형태 reject)
- `/\.[mc]?js$/` 로 다양한 ext 커버

## 검증

| 검증 | 결과 |
|---|---|
| zig build test | pass |
| packages/core bun test | 1025/1025 pass |
| preserve-modules test (F8 가드 포함) | 3/3 pass |

## 후속 (별도 PR — review F5-F7)

- branch 3 fallback 의 hash placeholder 가 plugin chunk_name 에 baked (F6)
- Rollup chunk object full parity (F7)
- helper virtual module sanitize id collision (F5)

## Test plan

- [x] /code-review max — 7 finding 중 F1/F2/F3/F4 본 PR 안 fix
- [x] preserve_modules + plugin renderChunk e2e 검증
- [x] explicit_file_name + ext mismatch (`.mjs` 등) 가드

🤖 Generated with [Claude Code](https://claude.com/claude-code)