### PR TITLE
ci: leak gate — configureProfile/transpile smoke + exit code 139 분기

### DIFF
--- a/.github/workflows/napi-leak-gate.yml
+++ b/.github/workflows/napi-leak-gate.yml
@@ -104,6 +104,42 @@ jobs:
             console.log('NAPI smoke: dlopen + symbol resolve OK');
           "
 
+      - name: NAPI configureProfile smoke (NAPI string getter path 검증)
+        # `configureProfile(['none'])` — non-empty 1-element 로 `parseStringArray`
+        # + `napi_get_value_string_utf8` (review max F5) 까지 cover.
+        # empty `[]` 면 fast path 라 string getter 미실행 → SIGSEGV isolation 약함.
+        # stderr 캡쳐 (review max F6) — failure 시 root cause 분석 가능.
+        run: |
+          mkdir -p /tmp/leak-probe
+          node -e "
+            const addon = require('./packages/core/zntc.node');
+            addon.configureProfile(['none']);
+            console.log('configureProfile OK');
+          " 2> /tmp/leak-probe/configureProfile.stderr.log
+          rc=$?
+          if [ $rc -eq 139 ]; then echo "::error::configureProfile SIGSEGV (139)"; cat /tmp/leak-probe/configureProfile.stderr.log; exit 1
+          elif [ $rc -ne 0 ]; then echo "::error::configureProfile non-zero exit ($rc)"; cat /tmp/leak-probe/configureProfile.stderr.log; exit 1
+          fi
+          echo "configureProfile smoke: OK"
+
+      - name: NAPI transpile smoke (full transpile path — Scanner + transformer + emitter)
+        # `transpile(source, filename)` 는 NAPI 진입점 중 가장 무겁다 (Scanner
+        # + parser + transformer + emitter chain). tokenize 보다 더 많은 NAPI
+        # path 거침. tokenize SIGSEGV (이전 run #26337129125) 가 Scanner-only
+        # 인지 더 깊은 path 인지 분기. exit code 139 (SIGSEGV) 와 다른 throw
+        # (exit 1) 구분 (review max F4).
+        run: |
+          node -e "
+            const addon = require('./packages/core/zntc.node');
+            const result = addon.transpile('var x = 1;', 'test.js');
+            console.log('transpile OK:', typeof result, result && result.code ? 'code.len=' + result.code.length : '');
+          " 2> /tmp/leak-probe/transpile.stderr.log
+          rc=$?
+          if [ $rc -eq 139 ]; then echo "::error::transpile SIGSEGV (139)"; cat /tmp/leak-probe/transpile.stderr.log; exit 1
+          elif [ $rc -ne 0 ]; then echo "::error::transpile non-zero exit ($rc) — NAPI throw or assertion"; cat /tmp/leak-probe/transpile.stderr.log; exit 1
+          fi
+          echo "transpile smoke: OK"
+
       - name: NAPI atexit smoke (Linux-specific dumpLeaksAtExit 검증)
         # 가장 light path — require + process exit (atexit 발화) 만.
         # SIGSEGV 시 atexit 의 dumpLeaksAtExit/detectLeaks 가 Linux 환경


### PR DESCRIPTION
## 배경

[run #26337129125](https://github.com/ohah/zntc/actions/runs/26337129125) 결과:
- ✅ NAPI smoke (`require + Object.keys`)
- ✅ **atexit smoke** (`require + exit`) → `dumpLeaksAtExit` 정상
- ❌ **tokenize smoke SIGSEGV** (core dumped, panic 메시지 없음)

dlopen + init + atexit 정상. tokenize 의 native code path 가 Linux Debug NAPI 에서 wild pointer. 진단 더 좁히기 위해 `configureProfile` (NAPI helper) + `transpile` (full path) smoke 추가.

## 변경 (1 파일 +36/-12)

진단 step 2개 (`NAPI atexit smoke` 직전):

### NAPI configureProfile smoke
```sh
node -e "addon.configureProfile(['none']);" 2> /tmp/leak-probe/configureProfile.stderr.log
```
- `['none']` 1-element 로 `parseStringArray` + `napi_get_value_string_utf8` (string getter) path cover (review max F5 — empty array fast path 우회)
- stderr capture (review max F6) — failure 시 root cause 분석

### NAPI transpile smoke
```sh
node -e "addon.transpile('var x = 1;', 'test.js');"
```
- Scanner + parser + transformer + emitter 전 path
- exit 139 (SIGSEGV) vs 1 (NAPI throw) 구분 (review max F4)

## `/code-review max` 5-angle 결과 반영

- F4: exit code 139 vs 1 분기로 error 메시지 정확도 ↑
- F5: `configureProfile([])` empty fast path → `['none']` 으로 string getter path cover
- F6: stderr capture + failure 시 cat

## 가설 분기 (workflow_dispatch 재실행 후)

| 시나리오 | 의미 | Linux Debug NAPI root |
|---|---|---|
| **configureProfile SIGSEGV** | NAPI helper / string getter / parseStringArray | common.zig 의 Linux 환경 문제 |
| **transpile SIGSEGV** | Scanner / parser / transformer path | transpile.zig 의 어떤 native code |
| **둘 다 통과 + tokenize SIGSEGV** | scanner.next() / getLineColumn / tokenText 특정 path | scanner.zig 의 Linux 환경 문제 |
| **모두 통과 + Build JS SIGSEGV** | `napiBuild` 의 specific 옵션 path | bundler.zig / build_*entry.zig |

## 검증

- `configureProfile` signature 확인 (`profile.zig:15`): `configureProfile(categories, level?)`, `parseStringArray` 호출 ✓
- `transpile` signature 확인 (`transpile_entry.zig:24`): `transpile(source, filename, optionsJson?, tsconfigCache?)`, 2-arg 호출 ✓
- 코드 변경 0 → `zig build` / `zig build test` 무관

## 영향

- **ZNTC core release 빌드 영향 0** — workflow file 만
- **Linux Debug NAPI root 좁힘** — 다음 run 으로 4 시나리오 중 어느 분기인지 명확