### PR TITLE
fix(transformer): private method 내 super.x → SyntaxError 수정 (#3680)

### DIFF
--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -1321,6 +1321,128 @@ test "#3680: private method 내 super.method = v 쓰기 → __superSet (es2021)"
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(Base.prototype,\"y\"") != null);
 }
 
+// #3680 post-review F1: static private field initializer 안의 super 는
+// descriptor `var _x = { value: <init> }` 로 빠지면서 module top-level 에 emit 되므로
+// super lowering 필요. (review C3: raw `super.factor()` 가 top-level 로 leak → SyntaxError.)
+test "#3680-F1: static private field init 안의 super → static form lowering (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Base { static factor(){return 7} }
+        \\class D extends Base {
+        \\  static #x = super.factor();
+        \\  static get() { return D.#x; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // descriptor 형태 — value 위치
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _x={writable:true,value:") != null);
+    // raw super 가 남지 않음
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "value:super.factor") == null);
+    // static super 는 Base.factor (instance form Base.prototype.factor 가 아님)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.factor.call") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.prototype.factor") == null);
+}
+
+// #3680 post-review F2: extends 없는 class 의 private method 안의 super 도 spec valid
+// (home object [[Prototype]] = Object.prototype). 추출된 standalone fn 에 raw super
+// 남으면 SyntaxError. (review S2.)
+test "#3680-F2: non-derived class 의 private method 안 super → Object.prototype lowering (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class D {
+        \\  #m() { return super.toString.call(this); }
+        \\  run() { return this.#m(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _m_fn") != null);
+    // raw super 가 standalone fn 안에 남으면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super.toString") == null);
+    // Object.prototype 기준 lowering (__superGet 인자 base = Object.prototype)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(Object.prototype,\"toString\"") != null);
+}
+
+// #3680 post-review F3: static private method 안 super 는 instance form 이 아닌 static form.
+// (review C1: `static #m(){ super.x }` → `Base.prototype.x.call(this)` (instance) → TypeError.)
+test "#3680-F3: static private method 안 super → static form (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Base { static greet(){return "static-base"} }
+        \\class D extends Base {
+        \\  static #call() { return super.greet(); }
+        \\  static run() { return D.#call(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _call_fn") != null);
+    // static super 는 Base.greet (instance Base.prototype.greet 아님)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.greet.call(this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.prototype.greet") == null);
+}
+
+// #3680 post-review F4: update_expression `super.x++` outer guard 가 needsSuperLowering 누락.
+// 추출된 standalone fn body 안에서도 lowering 진입해야 함. (review S1.)
+test "#3680-F4: extracted fn 안 super.x++ → lowering (chrome 80 target)" {
+    var r = try e2eFull(std.testing.allocator,
+        \\class Base { constructor(){ this.x = 10 } }
+        \\class D extends Base {
+        \\  #m() { return super.x++; }
+        \\  run() { return this.#m(); }
+        \\}
+    , .{ .unsupported = helpers.compat.browserslistToUnsupported("chrome 80").? }, .{ .minify_whitespace = true }, ".ts");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _m_fn") != null);
+    // raw `super.x++` 가 남으면 안 됨, invalid LHS `__superGet(...)++` 형태도 fail
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super.x++") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ")++") == null);
+    // update_expression lowering 흔적: __superSet
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(Base.prototype,\"x\"") != null);
+}
+
+// #3680 post-review F5: outer derived class 의 추출된 private method 안에 inner non-derived class.
+// inner 의 super 는 Object.prototype 기준이어야 하고, outer 의 Base 로 leak 되면 안 됨.
+// (review C6.)
+test "#3680-F5: inner non-derived class 가 outer Base 누수 방지 (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Base { greet(){return "FROM_BASE"} }
+        \\class Outer extends Base {
+        \\  #m() {
+        \\    class Inner {
+        \\      #n() { return typeof super.greet === "function" ? super.greet() : "no-greet"; }
+        \\      run() { return this.#n(); }
+        \\    }
+        \\    return new Inner().run();
+        \\  }
+        \\  run() { return this.#m(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _n_fn") != null);
+    // inner 의 standalone fn 이 outer Base.prototype 으로 lowering 되면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.prototype.greet") == null);
+    // inner 는 non-derived 라 super.greet → Object.prototype.greet (없음) lowering 되거나
+    // 또는 그대로 inner class body 안에서 native 유지
+    try std.testing.expect(
+        std.mem.indexOf(u8, r.output, "Object.prototype.greet") != null or
+        std.mem.indexOf(u8, r.output, "super.greet") != null);
+}
+
+// #3680 post-review F7: 추출된 private method body 안의 object literal method 의 super 는
+// outer class 가 아닌 object 의 home object 기준 — outer Base 로 leak 되면 안 됨.
+// (review C8.)
+test "#3680-F7: object literal method 의 super 가 outer class 로 leak 방지 (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Base { greet(){return "FROM_BASE"} }
+        \\class D extends Base {
+        \\  #m() {
+        \\    const o = { foo(){ return typeof super.greet === "function" ? super.greet() : "no-greet"; } };
+        \\    return o.foo();
+        \\  }
+        \\  run() { return this.#m(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // object literal method 안에서 outer Base.prototype 으로 lowering 되면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.prototype.greet") == null);
+}
+
 // nested class: standalone fn 안의 *inner* class body 의 `super.x` 는
 // inner class lexical context 가 valid 하므로 inner super 로 lowering 돼야 한다.
 // outer extracted fn flag 가 inner class 안으로 새지 않는지 회귀 가드.

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -1356,8 +1356,8 @@ test "#3680-F2: non-derived class 의 private method 안 super → Object.protot
     try std.testing.expect(std.mem.indexOf(u8, r.output, "function _m_fn") != null);
     // raw super 가 standalone fn 안에 남으면 안 됨
     try std.testing.expect(std.mem.indexOf(u8, r.output, "super.toString") == null);
-    // Object.prototype 기준 lowering (__superGet 인자 base = Object.prototype)
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(Object.prototype,\"toString\"") != null);
+    // Object.prototype 기준 lowering — V6 fix 로 globalThis.Object.prototype 사용 (user shadow 차단).
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "globalThis.Object.prototype") != null);
 }
 
 // #3680 post-review F3: static private method 안 super 는 instance form 이 아닌 static form.
@@ -1441,6 +1441,155 @@ test "#3680-F7: object literal method 의 super 가 outer class 로 leak 방지 
     defer r.deinit();
     // object literal method 안에서 outer Base.prototype 으로 lowering 되면 안 됨
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.prototype.greet") == null);
+}
+
+// === post-review 2nd-round V1~V8 회귀 가드 ===
+
+// V1: F1 이 current_super_static_receiver 미설정 → module top-level this=undefined.
+// 정답: descriptor 의 .call(this) 가 아니라 class 자체를 receiver 로 사용 (D 의 span).
+test "#3680-V1: static private field init 의 super.method() receiver 가 class 이름 (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Base { static factor(){return this?.name ?? "no-this"} }
+        \\class D extends Base {
+        \\  static #x = super.factor();
+        \\  static get() { return D.#x; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // descriptor 가 module top-level 로 빠지므로 receiver 는 D 여야 함.
+    // .call(this) 가 아니라 .call(D) (또는 __superGet 의 receiver 인자 D).
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _x={writable:true,value:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.factor.call(this)") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.factor.call(D)") != null);
+}
+
+// V2: F1 의 non-derived class 의 static private field init 안 super → 'Object'/'Function.prototype' fallback.
+test "#3680-V2: non-derived class 의 static private field init 안 super → fallback (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class D {
+        \\  static #x = super.toString;
+        \\  static run() { return typeof D.#x; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // raw super 가 module top-level 로 leak 되면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "value:super.toString") == null);
+    // static 컨텍스트에서 non-derived 의 home object [[Prototype]] 은 Function.prototype.
+    // 그러나 D 자체는 함수이므로 D.[[Prototype]] = Function.prototype.
+    // 따라서 super.toString 은 Function.prototype.toString 또는 D.__proto__.toString.
+    // 정답: __superGet/등이 Function.prototype 을 base 로 lowering. ('Object' 만 emit 되면 V5 와 동일 fail.)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Function.prototype") != null);
+}
+
+// V3: F3 의 conditional set 으로 outer is_static=true 가 inner non-static method 로 leak.
+test "#3680-V3: outer static private method 안 inner instance method → 정상 instance lowering (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Other { foo(){return "INSTANCE_FOO"} static foo(){return "STATIC_FOO"} }
+        \\class D {
+        \\  static #m() {
+        \\    class Inner extends Other {
+        \\      #n() { return super.foo(); }
+        \\      run() { return this.#n(); }
+        \\    }
+        \\    return new Inner();
+        \\  }
+        \\  static call() { return D.#m().run(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // Inner 의 _n_fn body 는 instance form: Other.prototype.foo.call(this)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _n_fn") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Other.prototype.foo.call(this)") != null);
+    // static form 으로 emit 되면 안 됨
+    const tmp_idx = std.mem.indexOf(u8, r.output, "function _n_fn") orelse unreachable;
+    const tail = r.output[tmp_idx..];
+    try std.testing.expect(std.mem.indexOf(u8, tail, "Other.foo.call(this)") == null);
+}
+
+// V4: V3 와 동일 root cause — visitClass fast path 가 is_static/static_receiver 미reset.
+// V3 가 pass 하면 V4 의 fix 도 적용된 셈이지만, fast-path entry 의 reset 자체를 직접 확인.
+test "#3680-V4: outer static method 안 inner derived class → instance method 정상 (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class B { greet(){return "INSTANCE"} static greet(){return "STATIC"} }
+        \\class O {
+        \\  static call() {
+        \\    class I extends B { run(){ return super.greet(); } }
+        \\    return new I().run();
+        \\  }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // I 의 run() 은 native ES2021 라 raw super.greet() 그대로 (lowering 안 됨).
+    // 다만 inner is_static leak 이 있다면 lowering 활성화돼 잘못된 form emit 됨.
+    // raw super.greet() 만 emit 돼야 함.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super.greet()") != null);
+    // B.greet.call(this) (static form) 이 emit 되면 leak 발생.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "B.greet.call(this)") == null);
+}
+
+// V5: non-derived class static private method 안 super 가 Function.prototype 기준 lowering.
+test "#3680-V5: non-derived class static private method 안 super → Function.prototype (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class D {
+        \\  static #m() { return typeof super.toString; }
+        \\  static run() { return this.#m(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // 정답: Function.prototype 기준. raw `Object` (no .prototype) 만 emit 되면 spec 위반.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Function.prototype") != null);
+}
+
+// V6: F2 의 'Object' identifier 가 user-shadow 에 안전한 root-scope symbol 사용.
+// codegen 출력 자체로는 검증 어려움 — runtime 검증을 위해 별도 e2e 시나리오 작성 가능하나
+// 단위 테스트 측면에선 globalThis 사용 또는 symbol_id 부착 확인.
+test "#3680-V6: F2 의 super-base ref 는 globalThis.Object 또는 root-scope binding (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class D {
+        \\  #m() { return super.toString.call(this); }
+        \\  run() { return this.#m(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // user 가 같은 모듈에 `const Object = ...` shadow 했을 때도 safe 하려면
+    // globalThis.Object.prototype 또는 root-scope-attached Object 가 emit 되어야 함.
+    // 단순화: globalThis.Object 형태 검증 (안전한 방법 중 하나).
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "globalThis.Object.prototype") != null);
+}
+
+// V7: F7 reset 이 method body 안에서만 적용되도록 — property VALUE position 의 super 는 보존.
+test "#3680-V7: class 내 object literal property value super → outer class lowering 유지 (es5)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Base { foo(){return "BASE_FOO"} }
+        \\class D extends Base {
+        \\  m() { return { y: super.foo() }; }
+        \\}
+    , .es5);
+    defer r.deinit();
+    // value position 의 super.foo() 는 enclosing class 의 super 로 lowering.
+    // raw `super.foo()` 가 emit 되면 ES5 lowered output 안에서 SyntaxError.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super.foo()") == null);
+}
+
+// V8: F6 의 member-expression extends — side effect 가 super-prop access 마다 중복되지 않도록 temp alias.
+test "#3680-V8: extends getBase() 의 side effect 가 super.x access 마다 중복 안 됨 (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\let count = 0;
+        \\function getBase() { count++; return class { foo(){return "X"} }; }
+        \\class D extends getBase() {
+        \\  #m() { return super.foo() + "|" + super.foo(); }
+        \\  run() { return this.#m(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // _m_fn body 안에서 `getBase()` 호출이 직접 inline 되면 부작용 중복.
+    // temp alias 가 적용되면 _super (또는 temp 변수) 이름이 사용되어 getBase() 는
+    // class extends 자리에서 1회만 evaluated 됨.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _m_fn") != null);
+    // `getBase().prototype.foo` 같은 직접 inline 이 _m_fn 안에서 발생하면 fail.
+    const fn_idx = std.mem.indexOf(u8, r.output, "function _m_fn") orelse unreachable;
+    const fn_tail = r.output[fn_idx..];
+    try std.testing.expect(std.mem.indexOf(u8, fn_tail, "getBase()") == null);
 }
 
 // nested class: standalone fn 안의 *inner* class body 의 `super.x` 는

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -1419,8 +1419,7 @@ test "#3680-F5: inner non-derived class 가 outer Base 누수 방지 (es2021)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.prototype.greet") == null);
     // inner 는 non-derived 라 super.greet → Object.prototype.greet (없음) lowering 되거나
     // 또는 그대로 inner class body 안에서 native 유지
-    try std.testing.expect(
-        std.mem.indexOf(u8, r.output, "Object.prototype.greet") != null or
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.prototype.greet") != null or
         std.mem.indexOf(u8, r.output, "super.greet") != null);
 }
 

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -1268,3 +1268,78 @@ test "#x in obj: es2022 타겟에서는 보존 (native 지원)" {
     // es2022에서는 private field가 native 지원이므로 #x in o 그대로 보존
     try std.testing.expect(std.mem.indexOf(u8, r.output, "#x in o") != null);
 }
+
+// #3680: private method 안의 `super.x` 가 standalone fn (_call_fn) 에 추출되면
+// 그 함수는 class body 밖이라 `super` 키워드가 SyntaxError. 따라서 super
+// property access 를 super-call lowering path 로 강제 lowering.
+// - `super.m(args)` (call form) → `Base.prototype.m.call(this, args)` (lowerSuperMethodCall)
+// - `super.x` (bare get) → `__superGet(Base.prototype, "x", this)` (lowerSuperMember, getter 보존)
+// - `super.y = v` (set) → `__superSet(...)` (lowerSuperPropertyAssignment, setter 보존)
+test "#3680: private method 내 super.method() → Base.prototype.x.call(this) (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Base { greet(){return "base"} }
+        \\class D extends Base {
+        \\  #call() { return super.greet(); }
+        \\  run() { return this.#call(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // standalone fn 추출
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _call_fn") != null);
+    // standalone fn 안에 raw `super.` 키워드가 남으면 안 됨 (#3680 회귀 가드)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return super.greet") == null);
+    // method call 형태는 `Base.prototype.greet.call(this)` 로 lowering
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.prototype.greet.call(this)") != null);
+}
+
+test "#3680: private method 내 super.prop 읽기 → __superGet (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Base { constructor(){this.x=1} }
+        \\class D extends Base {
+        \\  #read() { return super.x; }
+        \\  run() { return this.#read(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _read_fn") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return super.x") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superGet(Base.prototype,\"x\",this)") != null);
+}
+
+test "#3680: private method 내 super.method = v 쓰기 → __superSet (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Base { set y(v){this._y=v} }
+        \\class D extends Base {
+        \\  #write(v) { super.y = v; }
+        \\  run(v) { this.#write(v); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _write_fn") != null);
+    // standalone fn 안에 raw `super.y =` 가 남으면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super.y=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__superSet(Base.prototype,\"y\"") != null);
+}
+
+// nested class: standalone fn 안의 *inner* class body 의 `super.x` 는
+// inner class lexical context 가 valid 하므로 inner super 로 lowering 돼야 한다.
+// outer extracted fn flag 가 inner class 안으로 새지 않는지 회귀 가드.
+test "#3680: nested class — inner super 가 outer extracted fn flag 의 영향 안 받음 (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class B1 { f(){return 1} }
+        \\class B2 { f(){return 2} }
+        \\class D extends B1 {
+        \\  #outer() {
+        \\    class Inner extends B2 {
+        \\      g(){ return super.f(); }
+        \\    }
+        \\    return new Inner().g();
+        \\  }
+        \\  run() { return this.#outer(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _outer_fn") != null);
+    // inner class super.f() 는 es2021 에서 native 그대로 emit (inner class body context 라 valid).
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super.f()") != null);
+}

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -105,14 +105,18 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const saved_super_old_idx = self.current_super_class_old_idx;
             const saved_super_static = self.current_super_is_static;
             const saved_super_static_receiver = self.current_super_static_receiver;
+            // #3680: inner class body 안의 super 는 lexical 로 valid — outer standalone fn flag reset.
+            const saved_super_in_extracted_fn = self.current_super_in_extracted_fn;
             self.current_super_class = super_span;
             self.current_super_class_old_idx = super_idx;
             self.current_super_is_static = false;
             self.current_super_static_receiver = null;
+            self.current_super_in_extracted_fn = false;
             defer self.current_super_class = saved_super;
             defer self.current_super_class_old_idx = saved_super_old_idx;
             defer self.current_super_is_static = saved_super_static;
             defer self.current_super_static_receiver = saved_super_static_receiver;
+            defer self.current_super_in_extracted_fn = saved_super_in_extracted_fn;
 
             // 클래스 바디 멤버 분류 (visitNode 호출 없이 metadata 만 수집).
             var cm = try classifyMembers(self, body_idx, span);
@@ -343,14 +347,18 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const saved_super_old_idx = self.current_super_class_old_idx;
             const saved_super_static = self.current_super_is_static;
             const saved_super_static_receiver = self.current_super_static_receiver;
+            // #3680: inner class body 안의 super 는 lexical 로 valid — outer standalone fn flag reset.
+            const saved_super_in_extracted_fn = self.current_super_in_extracted_fn;
             self.current_super_class = super_span;
             self.current_super_class_old_idx = super_idx;
             self.current_super_is_static = false;
             self.current_super_static_receiver = null;
+            self.current_super_in_extracted_fn = false;
             defer self.current_super_class = saved_super;
             defer self.current_super_class_old_idx = saved_super_old_idx;
             defer self.current_super_is_static = saved_super_static;
             defer self.current_super_static_receiver = saved_super_static_receiver;
+            defer self.current_super_in_extracted_fn = saved_super_in_extracted_fn;
 
             // 바디 멤버 분류 (visitNode 호출 없이 metadata 만 수집).
             var cm = try classifyMembers(self, body_idx, span);

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -164,7 +164,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
             // static private field → descriptor 객체 선언: var _x = { writable: true, value: initValue }
             for (cm.static_private_fields.items) |pf| {
-                try self.scratch.append(self.allocator, try es_helpers.buildStaticPrivateFieldDescriptor(self, pf.name, pf.init, span));
+                // V1 fix: class_name_span 전달 → static_receiver 보정
+                try self.scratch.append(self.allocator, try es_helpers.buildStaticPrivateFieldDescriptor(self, pf.name, pf.init, span, name_span));
                 self.runtime_helpers.class_static_private_field = true;
             }
             try emitInstanceInits(self, &cm, span);
@@ -473,7 +474,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
             // static private field → descriptor 객체 선언
             for (cm.static_private_fields.items) |pf| {
-                try self.scratch.append(self.allocator, try es_helpers.buildStaticPrivateFieldDescriptor(self, pf.name, pf.init, span));
+                // V1 fix: class_name_span 전달
+                try self.scratch.append(self.allocator, try es_helpers.buildStaticPrivateFieldDescriptor(self, pf.name, pf.init, span, name_span));
                 self.runtime_helpers.class_static_private_field = true;
             }
             try emitPrivateMethodArtifacts(self, cm.private_methods.items, null, span);

--- a/src/transformer/es2015_class/super_props.zig
+++ b/src/transformer/es2015_class/super_props.zig
@@ -120,8 +120,9 @@ pub fn SuperProps(comptime Transformer: type) type {
 
         /// super.method(args) → Parent.prototype.method.call(this, args)
         /// static method 안에서는 Parent.method.call(this, args)
+        /// V2/V5: non-derived class (current_super_class=null) 도 lowering — buildSuperBaseRef 가
+        /// Object.prototype / Function.prototype 으로 fallback.
         pub fn lowerSuperMethodCall(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
-            _ = self.current_super_class orelse return self.visitCallExpression(node);
             const e = node.data.extra;
             const callee_idx: NodeIndex = self.readNodeIdx(e, 0);
             const args_start = self.readU32(e, 1);
@@ -278,8 +279,28 @@ pub fn SuperProps(comptime Transformer: type) type {
             return es_helpers.makeStaticMember(self, class_ref, proto_prop, span);
         }
 
+        /// V2/V5/V6 fix: non-derived class (current_super_class=null) 에서도 spec 상
+        /// super 가 valid 하므로 home object [[Prototype]] 으로 fallback emit.
+        /// - instance method: `globalThis.Object.prototype`
+        /// - static method:   `globalThis.Function.prototype`
+        ///   (class 자체가 함수이므로 D.[[Prototype]] = Function.prototype.)
+        /// `globalThis` 사용으로 user 의 `const Object = ...` shadow 에 영향 안 받음
+        /// (ES2017 표준). 우리 transpile 타깃이 ES2017 이하면 일반 `Object` 로 fallback 가능하나
+        /// 현 시점 default target 은 ES2021+ 이라 globalThis 안전.
+        fn buildNonDerivedSuperBase(self: *Transformer, span: Span) Transformer.Error!NodeIndex {
+            const root_name = if (self.current_super_is_static) "Function" else "Object";
+            const global_ref = try es_helpers.makeIdentifierRef(self, "globalThis");
+            const root_ref = try es_helpers.makeIdentifierRef(self, root_name);
+            const proto_ref = try es_helpers.makeIdentifierRef(self, "prototype");
+            const global_root = try es_helpers.makeStaticMember(self, global_ref, root_ref, span);
+            return es_helpers.makeStaticMember(self, global_root, proto_ref, span);
+        }
+
         fn buildSuperBaseRef(self: *Transformer, span: Span) Transformer.Error!NodeIndex {
-            const super_class_span = self.current_super_class orelse return NodeIndex.none;
+            const super_class_span = self.current_super_class orelse {
+                // non-derived class — fallback to spec home object [[Prototype]]
+                return buildNonDerivedSuperBase(self, span);
+            };
             if (self.current_super_is_static) {
                 return self.makeIdentifierRefWithSymbol(super_class_span, self.current_super_class_old_idx);
             }
@@ -299,7 +320,8 @@ pub fn SuperProps(comptime Transformer: type) type {
         }
 
         fn buildSuperPropGet(self: *Transformer, prop_arg: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            _ = self.current_super_class orelse return prop_arg;
+            // V2/V5: current_super_class=null 인 non-derived 케이스도 lowering — buildSuperBaseRef
+            // 가 Object.prototype / Function.prototype 으로 fallback.
             const helper = try es_helpers.makeRuntimeHelperRef(self, "__superGet");
             const base = try buildSuperBaseRef(self, span);
             const receiver = try buildSuperReceiver(self, span);
@@ -308,7 +330,6 @@ pub fn SuperProps(comptime Transformer: type) type {
         }
 
         fn buildSuperPropSet(self: *Transformer, prop_arg: NodeIndex, value: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            _ = self.current_super_class orelse return value;
             const helper = try es_helpers.makeRuntimeHelperRef(self, "__superSet");
             const base = try buildSuperBaseRef(self, span);
             const receiver = try buildSuperReceiver(self, span);
@@ -506,8 +527,8 @@ pub fn SuperProps(comptime Transformer: type) type {
 
         /// super["method"](args) → Parent.prototype["method"].call(this, args)
         /// static method 안에서는 Parent["method"].call(this, args)
+        /// V2/V5: non-derived class 도 lowering — buildSuperBaseRef fallback.
         pub fn lowerSuperComputedMethodCall(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
-            _ = self.current_super_class orelse return self.visitCallExpression(node);
             const e = node.data.extra;
             const callee_idx: NodeIndex = self.readNodeIdx(e, 0);
             const args_start = self.readU32(e, 1);

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -298,6 +298,10 @@ pub fn ES2022(comptime Transformer: type) type {
             // 하고 current_private_* 를 호출자가 set/restore 한다(이중-visit 회피, decorator strip
             // 방지). fast path 는 false(기존 동작: visit + defer 복원).
             skip_visit_and_keep_private: bool,
+            // V1 fix (#3680 post-review): class_declaration 위치이면 static descriptor 를
+            // trailing_nodes 로 emit (class 뒤). class_expression 위치이면 false — expression
+            // context 라 trailing comma-stitching 발생하므로 pre_stmts 유지.
+            static_descriptors_trailing: bool,
         ) Transformer.Error!bool {
             const body_node = self.ast.getNode(body_idx);
             const body_start = body_node.data.list.start;
@@ -388,11 +392,19 @@ pub fn ES2022(comptime Transformer: type) type {
                 self.current_private_fields = saved_private_fields;
             };
 
+            // V1 fix: static descriptor 는 receiver=D 를 사용하므로 D 가 init 된 *뒤* 에
+            // 평가되어야 한다 (descriptor 가 class 앞에 emit 되면 TDZ ReferenceError).
+            // class_declaration 위치이면 trailing_nodes 에 emit 해 class 뒤에 stitching.
+            // class_expression 위치이면 expression context 라 trailing 가 comma stitching 발생
+            // (`const W = (...)(),var _m = ...`) → pre_stmts 그대로 두고 receiver=D 사용 자체가
+            // IIFE 안의 `_a` (class 의 local binding) 라 trailing 불필요.
+            // caller hint `static_descriptors_trailing` 로 분기.
+            const desc_target = if (static_descriptors_trailing) &self.trailing_nodes else pre_stmts;
             for (field_mappings.items, field_init_idx.items) |m, init_val| {
-                if (m.class_name != null) {
-                    // static: `var _x = { writable: true, value: init };` — init이 descriptor 내부.
-                    const desc = try es_helpers.buildStaticPrivateFieldDescriptor(self, m.var_name, init_val, span);
-                    try pre_stmts.append(self.allocator, desc);
+                if (m.class_name) |cname| {
+                    const cname_span = try self.ast.addString(cname);
+                    const desc = try es_helpers.buildStaticPrivateFieldDescriptor(self, m.var_name, init_val, span, cname_span);
+                    try desc_target.append(self.allocator, desc);
                     self.runtime_helpers.class_static_private_field = true;
                 } else {
                     const wm_decl = try es_helpers.buildWeakCollectionDecl(self, "WeakMap", m.var_name, span);
@@ -400,10 +412,11 @@ pub fn ES2022(comptime Transformer: type) type {
                 }
             }
             for (method_mappings.items) |m| {
-                if (m.class_name != null) {
+                if (m.class_name) |cname| {
                     const fn_ref = try es_helpers.makeIdentifierRef(self, m.func_name);
-                    const desc = try es_helpers.buildStaticPrivateFieldDescriptor(self, m.weakset_name, fn_ref, span);
-                    try pre_stmts.append(self.allocator, desc);
+                    const cname_span = try self.ast.addString(cname);
+                    const desc = try es_helpers.buildStaticPrivateFieldDescriptor(self, m.weakset_name, fn_ref, span, cname_span);
+                    try desc_target.append(self.allocator, desc);
                     self.runtime_helpers.class_static_private_field = true;
                 } else {
                     const ws_decl = try es_helpers.buildWeakCollectionDecl(self, "WeakSet", m.weakset_name, span);

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -17,6 +17,10 @@ const Span = token_mod.Span;
 
 /// static private field descriptor 선언 생성: `var _x = { writable: true, value: initValue };`
 /// __classStaticPrivateFieldSpecGet/Set 헬퍼가 descriptor 객체의 value/get/set 슬롯을 읽는다.
+///
+/// #3680-F1: descriptor 는 class body 밖 (모듈 top-level / IIFE) 에 emit 되므로 init 안의
+/// `super.x` 는 raw 로 두면 SyntaxError. init visit 동안 `current_super_in_extracted_fn=true`
+/// + `current_super_is_static=true` 로 강제 lowering (static private field → static super 의미).
 pub fn buildStaticPrivateFieldDescriptor(self: anytype, var_name: []const u8, init_idx: NodeIndex, span: Span) !NodeIndex {
     const scratch_top = self.scratch.items.len;
     defer self.scratch.shrinkRetainingCapacity(scratch_top);
@@ -33,6 +37,14 @@ pub fn buildStaticPrivateFieldDescriptor(self: anytype, var_name: []const u8, in
         .span = span,
         .data = .{ .binary = .{ .left = writable_key, .right = true_val, .flags = 0 } },
     }));
+
+    // #3680-F1: init 안 super 강제 lowering 컨텍스트 (static, extracted)
+    const saved_in_extracted = self.current_super_in_extracted_fn;
+    const saved_super_is_static = self.current_super_is_static;
+    self.current_super_in_extracted_fn = true;
+    self.current_super_is_static = true;
+    defer self.current_super_in_extracted_fn = saved_in_extracted;
+    defer self.current_super_is_static = saved_super_is_static;
 
     const value_key = try makeIdentifierRef(self, "value");
     const value_init = if (!init_idx.isNone()) try self.visitNode(init_idx) else try makeVoidZero(self, span);
@@ -1317,6 +1329,27 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
     const saved_super_in_extracted_fn = self.current_super_in_extracted_fn;
     self.current_super_in_extracted_fn = true;
     defer self.current_super_in_extracted_fn = saved_super_in_extracted_fn;
+    // #3680-F3: static private method 의 super 는 instance form 이 아닌 static form
+    // (`Base.x.call(this)`) 으로 lowering 되어야 한다. method flags 에서 static-ness 를
+    // 읽어 current_super_is_static 도 동기.
+    const saved_super_is_static = self.current_super_is_static;
+    if ((method_flags & ast_mod.MethodFlags.is_static) != 0) {
+        self.current_super_is_static = true;
+    }
+    defer self.current_super_is_static = saved_super_is_static;
+    // #3680-F2: non-derived class 의 method 안 `super.x` 도 spec valid — home object 의
+    // [[Prototype]] 은 Object.prototype (또는 static method 면 Function.prototype, 우리는
+    // 클래스 자체가 함수이므로 동일 base 사용). current_super_class==null 인 채로
+    // standalone fn 으로 추출되면 raw `super.x` 가 leak 되어 SyntaxError. 임시로
+    // "Object" span 을 set 해 buildSuperBaseRef 가 Object.prototype 을 만들도록 한다.
+    const saved_super_class = self.current_super_class;
+    const saved_super_class_old_idx = self.current_super_class_old_idx;
+    if (self.current_super_class == null) {
+        self.current_super_class = try self.ast.addString("Object");
+        self.current_super_class_old_idx = .none;
+    }
+    defer self.current_super_class = saved_super_class;
+    defer self.current_super_class_old_idx = saved_super_class_old_idx;
 
     const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -1295,6 +1295,11 @@ pub fn fillThisArgumentsCaptures(self: anytype, buf: *[2]NodeIndex, span: Span) 
 /// private generator method (`*#name`) / async method 를 `_name_fn` 으로 꺼낼 때
 /// method flags(is_async, is_generator)를 function flags로 옮겨 호이스팅한다.
 /// 이 매핑이 없으면 `function* _fn` 을 잃어 `yield` 가 일반 함수에 노출돼 SyntaxError (#1564).
+///
+/// #3680: 추출된 함수 body 는 class lexical context 밖이라 raw `super` 키워드가
+/// SyntaxError. params/body visit 동안 `current_super_in_extracted_fn` 을 켜서
+/// `super.x` 등을 `__superGet(Parent.prototype, "x", this)` 로 lowering 한다.
+/// nested class body 진입 시 visitClass 가 다시 false 로 reset.
 pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeIndex, span: Span) !NodeIndex {
     const method_node = self.ast.getNode(method_idx);
     const params_list_old = self.ast.functionParamsList(method_node);
@@ -1307,6 +1312,11 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
     defer popArrowEnv(self, arrow_env);
 
     const saved_temp_counter = self.temp_var_counter;
+
+    // #3680: standalone fn body visit 동안 super property lowering 강제
+    const saved_super_in_extracted_fn = self.current_super_in_extracted_fn;
+    self.current_super_in_extracted_fn = true;
+    defer self.current_super_in_extracted_fn = saved_super_in_extracted_fn;
 
     const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -21,7 +21,12 @@ const Span = token_mod.Span;
 /// #3680-F1: descriptor 는 class body 밖 (모듈 top-level / IIFE) 에 emit 되므로 init 안의
 /// `super.x` 는 raw 로 두면 SyntaxError. init visit 동안 `current_super_in_extracted_fn=true`
 /// + `current_super_is_static=true` 로 강제 lowering (static private field → static super 의미).
-pub fn buildStaticPrivateFieldDescriptor(self: anytype, var_name: []const u8, init_idx: NodeIndex, span: Span) !NodeIndex {
+///
+/// V1 fix: `class_name_span` 이 주어지면 init visit 동안 current_super_static_receiver 를
+/// 그 class 의 이름으로 set — 그러면 buildSuperReceiver 가 raw `this` 가 아닌 class 식별자를
+/// receiver 로 사용. 추출 위치가 module top-level (this=undefined in ESM) 인 점을 보정한다.
+/// `null` 이면 호출자가 class 이름 없는 컨텍스트 (익명 IIFE 등) — fallback 으로 raw `this` 유지.
+pub fn buildStaticPrivateFieldDescriptor(self: anytype, var_name: []const u8, init_idx: NodeIndex, span: Span, class_name_span: ?Span) !NodeIndex {
     const scratch_top = self.scratch.items.len;
     defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
@@ -38,13 +43,17 @@ pub fn buildStaticPrivateFieldDescriptor(self: anytype, var_name: []const u8, in
         .data = .{ .binary = .{ .left = writable_key, .right = true_val, .flags = 0 } },
     }));
 
-    // #3680-F1: init 안 super 강제 lowering 컨텍스트 (static, extracted)
+    // #3680-F1: init 안 super 강제 lowering 컨텍스트 (static, extracted).
+    // V1 fix: class_name_span 으로 static_receiver 설정 — module top-level this=undefined 문제 해결.
     const saved_in_extracted = self.current_super_in_extracted_fn;
     const saved_super_is_static = self.current_super_is_static;
+    const saved_super_static_receiver = self.current_super_static_receiver;
     self.current_super_in_extracted_fn = true;
     self.current_super_is_static = true;
+    if (class_name_span) |s| self.current_super_static_receiver = s;
     defer self.current_super_in_extracted_fn = saved_in_extracted;
     defer self.current_super_is_static = saved_super_is_static;
+    defer self.current_super_static_receiver = saved_super_static_receiver;
 
     const value_key = try makeIdentifierRef(self, "value");
     const value_init = if (!init_idx.isNone()) try self.visitNode(init_idx) else try makeVoidZero(self, span);
@@ -1329,27 +1338,19 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
     const saved_super_in_extracted_fn = self.current_super_in_extracted_fn;
     self.current_super_in_extracted_fn = true;
     defer self.current_super_in_extracted_fn = saved_super_in_extracted_fn;
-    // #3680-F3: static private method 의 super 는 instance form 이 아닌 static form
-    // (`Base.x.call(this)`) 으로 lowering 되어야 한다. method flags 에서 static-ness 를
-    // 읽어 current_super_is_static 도 동기.
+    // #3680-F3 (post-review V3): static private method 의 super 는 instance form 이 아닌
+    // static form (`Base.x.call(this)`) 으로 lowering 되어야 한다. method flags 에서
+    // static-ness 를 읽어 current_super_is_static 도 동기.
+    // V3 fix: outer scope 의 is_static=true (예: outer static private field init / static method)
+    // 가 inner non-static method 로 leak 되지 않도록 *unconditional clamp* — 항상 method 의
+    // 실제 static-ness 로 set (이전: static 일 때만 true set, instance 일 때 outer 값 그대로 유지).
     const saved_super_is_static = self.current_super_is_static;
-    if ((method_flags & ast_mod.MethodFlags.is_static) != 0) {
-        self.current_super_is_static = true;
-    }
+    self.current_super_is_static = (method_flags & ast_mod.MethodFlags.is_static) != 0;
     defer self.current_super_is_static = saved_super_is_static;
-    // #3680-F2: non-derived class 의 method 안 `super.x` 도 spec valid — home object 의
-    // [[Prototype]] 은 Object.prototype (또는 static method 면 Function.prototype, 우리는
-    // 클래스 자체가 함수이므로 동일 base 사용). current_super_class==null 인 채로
-    // standalone fn 으로 추출되면 raw `super.x` 가 leak 되어 SyntaxError. 임시로
-    // "Object" span 을 set 해 buildSuperBaseRef 가 Object.prototype 을 만들도록 한다.
-    const saved_super_class = self.current_super_class;
-    const saved_super_class_old_idx = self.current_super_class_old_idx;
-    if (self.current_super_class == null) {
-        self.current_super_class = try self.ast.addString("Object");
-        self.current_super_class_old_idx = .none;
-    }
-    defer self.current_super_class = saved_super_class;
-    defer self.current_super_class_old_idx = saved_super_class_old_idx;
+    // V2/V5/V6 후속 fix: 이전 F2 의 'Object' span hijack 은 제거. buildSuperBaseRef 가
+    // current_super_class=null 인 경우 spec home object [[Prototype]] (Object.prototype /
+    // Function.prototype) 으로 fallback 하도록 super_props.zig 에서 처리. 여기선 super_class 를
+    // 그대로 두고 (null 인 채로 needsSuperLowering 통과) lowering pipeline 가 알아서 처리.
 
     const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -155,6 +155,12 @@ pub const Transformer = struct {
     /// nested class body 진입 시 (visitClass) false 로 reset (inner class lexical
     /// context 는 super 키워드가 valid).
     current_super_in_extracted_fn: bool = false,
+    /// V7: object literal 안에서 visit 중인지 (nested 가능). visitMethodDefinition 이
+    /// 이 flag 를 보고 method body 의 super context 를 reset 한다 — object literal method
+    /// 의 super 는 home object [[Prototype]] 기준이라 outer class super 와 무관.
+    /// property VALUE 위치는 enclosing class 의 super 를 그대로 사용해야 하므로
+    /// object_expression dispatch 가 아닌 method_definition 진입 시에만 reset.
+    in_object_literal_depth: u32 = 0,
 
     /// ES2015 generator: labeled break/continue를 위한 label 스택.
     /// labeled_statement 진입 시 push, 퇴장 시 pop.
@@ -270,9 +276,15 @@ pub const Transformer = struct {
     ///   IIFE/`Class.foo = …` 로 들어내져 super 가 더 이상 lexical 로 의미를 가지지 않음
     /// - `current_super_in_extracted_fn`: ES2022 private method 가 standalone fn 으로
     ///   추출돼 class body 밖에서 정의되는 동안 (#3680) — super 키워드 자체가 invalid
-    /// - `current_super_class != null`: derived class 안 (extends 가 있어 super 의미 자체가 존재)
+    ///
+    /// V2/V5 fix: 기존 `current_super_class != null` 후행 가드 제거. non-derived class 의
+    /// extracted method/static field init 도 super lowering 이 필요하며 (super 는 spec 상
+    /// home object [[Prototype]] = Object.prototype 또는 Function.prototype 으로 valid),
+    /// 이 경우 buildSuperBaseRef 가 fallback 으로 적절한 base 를 생성한다. derived class 가
+    /// 아닌데 위 3 flag 도 모두 false 면 (즉 평범한 native class method) 어차피 false 반환 ⇒
+    /// 가드 제거가 일반 native class method 의 raw super 를 건드릴 위험 없음.
     pub inline fn needsSuperLowering(self: *const Transformer) bool {
-        return (self.options.unsupported.class or self.current_super_is_static or self.current_super_in_extracted_fn) and self.current_super_class != null;
+        return self.options.unsupported.class or self.current_super_is_static or self.current_super_in_extracted_fn;
     }
 
     /// 현재 scope 의 private field 가 `WeakMap.get/set` lowering 대상인지 판정.

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -148,6 +148,13 @@ pub const Transformer = struct {
     current_super_is_static: bool = false,
     /// static field/block 처럼 `this` 표현식이 사라지는 위치에서 super receiver로 사용할 class 이름.
     current_super_static_receiver: ?Span = null,
+    /// #3680: private method 가 standalone function (`_name_fn`) 으로 추출돼 class body
+    /// 밖에서 정의되는 동안 true. 추출된 함수는 `super` 키워드가 SyntaxError 이므로
+    /// `super.x` / `super.method()` / `super.y = v` 등 super property 접근을
+    /// `__superGet(Parent.prototype, "x", this)` 형태로 강제 lowering 해야 한다.
+    /// nested class body 진입 시 (visitClass) false 로 reset (inner class lexical
+    /// context 는 super 키워드가 valid).
+    current_super_in_extracted_fn: bool = false,
 
     /// ES2015 generator: labeled break/continue를 위한 label 스택.
     /// labeled_statement 진입 시 push, 퇴장 시 pop.
@@ -261,9 +268,11 @@ pub const Transformer = struct {
     /// - `unsupported.class`: ES2015 미만 타겟이라 class 자체가 lowering 됨
     /// - `current_super_is_static`: target 이 class 를 지원해도 static field init/static block 은
     ///   IIFE/`Class.foo = …` 로 들어내져 super 가 더 이상 lexical 로 의미를 가지지 않음
+    /// - `current_super_in_extracted_fn`: ES2022 private method 가 standalone fn 으로
+    ///   추출돼 class body 밖에서 정의되는 동안 (#3680) — super 키워드 자체가 invalid
     /// - `current_super_class != null`: derived class 안 (extends 가 있어 super 의미 자체가 존재)
     pub inline fn needsSuperLowering(self: *const Transformer) bool {
-        return (self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null;
+        return (self.options.unsupported.class or self.current_super_is_static or self.current_super_in_extracted_fn) and self.current_super_class != null;
     }
 
     /// 현재 scope 의 private field 가 `WeakMap.get/set` lowering 대상인지 판정.

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -41,6 +41,10 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
         self.current_super_class = self.ast.getNode(super_idx).span;
     }
     defer self.current_super_class = saved_super_class;
+    // #3680: inner class body 안의 super 는 lexical 로 valid — outer standalone fn flag reset.
+    const saved_super_in_extracted_fn = self.current_super_in_extracted_fn;
+    self.current_super_in_extracted_fn = false;
+    defer self.current_super_in_extracted_fn = saved_super_in_extracted_fn;
 
     // #3/#4 fix(이중-visit 회피): lowerPrivateMembers 를 skip_visit_and_keep_private=true 로 호출하면
     // current_private_* 를 호출자가 set/복원해야 한다(lowerPrivateMembers 내부 defer 가 건너뛴다).

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -49,6 +49,13 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
     }
     defer self.current_super_class = saved_super_class;
     defer self.current_super_class_old_idx = saved_super_class_old_idx;
+    // V4 fix: es2015_class.zig (IIFE path) parity — outer is_static/static_receiver 누수 차단.
+    const saved_super_is_static = self.current_super_is_static;
+    const saved_super_static_receiver = self.current_super_static_receiver;
+    self.current_super_is_static = false;
+    self.current_super_static_receiver = null;
+    defer self.current_super_is_static = saved_super_is_static;
+    defer self.current_super_static_receiver = saved_super_static_receiver;
     // #3680: inner class body 안의 super 는 lexical 로 valid — outer standalone fn flag reset.
     const saved_super_in_extracted_fn = self.current_super_in_extracted_fn;
     self.current_super_in_extracted_fn = false;
@@ -119,6 +126,8 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
             has_super,
             class_name_text,
             true, // skip_visit_and_keep_private — public member 는 classifyClassMember 가 단일 visit.
+            // V1 fix: class_declaration 위치이면 static descriptor trailing emit.
+            node.tag == .class_declaration,
         );
         if (had_any) body_idx = new_body_pl;
     }

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -37,10 +37,18 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
     // 경로가 이 set 을 누락하면 lowerPrivateMembers 의 standalone fn body visit / classifyClassMember
     // 의 method body visit 에서 super-prop lowering 이 null/stale 참조로 깨진다.
     const saved_super_class = self.current_super_class;
+    const saved_super_class_old_idx = self.current_super_class_old_idx;
+    // #3680-F5/F6: inner class 가 extends 없으면 null 로 명시적 reset (outer 누수 차단).
+    // F6: super_class 와 동시에 old_idx 도 set — fast path 에서도 super lowering 활성화돼 symbol propagation 필요.
     if (has_super) {
         self.current_super_class = self.ast.getNode(super_idx).span;
+        self.current_super_class_old_idx = super_idx;
+    } else {
+        self.current_super_class = null;
+        self.current_super_class_old_idx = .none;
     }
     defer self.current_super_class = saved_super_class;
+    defer self.current_super_class_old_idx = saved_super_class_old_idx;
     // #3680: inner class body 안의 super 는 lexical 로 valid — outer standalone fn flag reset.
     const saved_super_in_extracted_fn = self.current_super_in_extracted_fn;
     self.current_super_in_extracted_fn = false;

--- a/src/transformer/transformer/class_visit.zig
+++ b/src/transformer/transformer/class_visit.zig
@@ -31,6 +31,12 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
             self.current_super_class = self.ast.getNode(super_idx).span;
         }
         defer self.current_super_class = saved_super_class;
+        // #3680: 우리가 outer standalone fn body 안에서 visit 중이라도 inner class body 의
+        // `super` 는 lexical 로 valid 하므로 flag 를 reset. (inner private method 가 다시
+        // 추출되면 buildStandaloneFunc 가 다시 true 로 set.)
+        const saved_super_in_extracted_fn = self.current_super_in_extracted_fn;
+        self.current_super_in_extracted_fn = false;
+        defer self.current_super_in_extracted_fn = saved_super_in_extracted_fn;
 
         var current_body_idx = self.readNodeIdx(e, ast_mod.ClassExtra.body);
 

--- a/src/transformer/transformer/class_visit.zig
+++ b/src/transformer/transformer/class_visit.zig
@@ -24,7 +24,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         else
             try self.visitNode(raw_name_idx);
         const super_idx = self.readNodeIdx(e, ast_mod.ClassExtra.super);
-        const new_super = try self.visitNode(super_idx);
+        var new_super = try self.visitNode(super_idx);
 
         const saved_super_class = self.current_super_class;
         const saved_super_class_old_idx = self.current_super_class_old_idx;
@@ -32,15 +32,44 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         // 끊어야 한다 (else null reset 누락 시 outer Base 누수 → 새 flag 로 silent miscompile).
         // F6: fast path 도 super_class 와 동시에 old_idx 를 set — 새 flag 로 fast path 에서도 super
         // lowering 이 활성화되니 symbol propagation (minify rename 등) 을 위해 필요.
+        // V8: extends 표현식이 단순 식별자가 아니면 (`extends getBase()` / `extends pkg.Base` 등)
+        // current_super_class 를 raw span 으로 set 시 매 super-prop access 마다 표현식 텍스트가
+        // inline 되어 side effect 가 중복 평가됨. class_declaration 위치에서는 temp 변수로 hoist:
+        //   `var _<n> = <super expr>; class D extends _<n> {...}` 형태.
+        // class_expression 위치는 statement hoist 불가 → fallback 으로 raw super 그대로 두되
+        // current_super_class 만 set (호출자가 super-prop 을 inline 평가하는 비용 감수).
         if (!super_idx.isNone()) {
-            self.current_super_class = self.ast.getNode(super_idx).span;
-            self.current_super_class_old_idx = super_idx;
+            const super_node = self.ast.getNode(super_idx);
+            const is_simple_id = super_node.tag == .identifier_reference or super_node.tag == .binding_identifier;
+            if (!is_simple_id and node.tag == .class_declaration) {
+                const tmp_span = try es_helpers.makeTempVarSpan(self);
+                const tmp_binding = try es_helpers.makeBindingIdentifier(self, tmp_span);
+                const declarator = try es_helpers.makeDeclarator(self, tmp_binding, new_super, node.span);
+                const var_decl = try es_helpers.makeVarDeclaration(self, &.{declarator}, .@"var", node.span);
+                try self.pending_nodes.append(self.allocator, var_decl);
+                new_super = try es_helpers.makeIdentifierRefFromSpan(self, tmp_span);
+                self.current_super_class = tmp_span;
+                self.current_super_class_old_idx = .none;
+            } else {
+                self.current_super_class = super_node.span;
+                self.current_super_class_old_idx = super_idx;
+            }
         } else {
             self.current_super_class = null;
             self.current_super_class_old_idx = .none;
         }
         defer self.current_super_class = saved_super_class;
         defer self.current_super_class_old_idx = saved_super_class_old_idx;
+        // V4 fix: es2015_class.zig (IIFE path) 와 일관성 — class 진입 시 is_static/static_receiver
+        // 도 outer 의 누수 차단. 예: outer static private field init (V3 시나리오) 에서 inner class
+        // 진입 시 is_static=true 가 그대로 leak 되면 inner instance method 가 static form 으로 잘못
+        // lowering 됨.
+        const saved_super_is_static = self.current_super_is_static;
+        const saved_super_static_receiver = self.current_super_static_receiver;
+        self.current_super_is_static = false;
+        self.current_super_static_receiver = null;
+        defer self.current_super_is_static = saved_super_is_static;
+        defer self.current_super_static_receiver = saved_super_static_receiver;
         // #3680: 우리가 outer standalone fn body 안에서 visit 중이라도 inner class body 의
         // `super` 는 lexical 로 valid 하므로 flag 를 reset. (inner private method 가 다시
         // 추출되면 buildStandaloneFunc 가 다시 true 로 set.)
@@ -101,6 +130,8 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
                 has_super,
                 class_name_text,
                 false, // fast path 는 lowerPrivateMembers 가 통째 visit + 복원 (기존 동작).
+                // V1 fix: class_declaration 위치이면 static descriptor 를 trailing 으로 emit.
+                node.tag == .class_declaration,
             );
             if (had_any) {
                 current_body_idx = new_body;

--- a/src/transformer/transformer/class_visit.zig
+++ b/src/transformer/transformer/class_visit.zig
@@ -27,10 +27,20 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         const new_super = try self.visitNode(super_idx);
 
         const saved_super_class = self.current_super_class;
+        const saved_super_class_old_idx = self.current_super_class_old_idx;
+        // #3680-F5/F6: inner class 가 extends 없으면 outer 의 current_super_class 를 명시적으로 null 로
+        // 끊어야 한다 (else null reset 누락 시 outer Base 누수 → 새 flag 로 silent miscompile).
+        // F6: fast path 도 super_class 와 동시에 old_idx 를 set — 새 flag 로 fast path 에서도 super
+        // lowering 이 활성화되니 symbol propagation (minify rename 등) 을 위해 필요.
         if (!super_idx.isNone()) {
             self.current_super_class = self.ast.getNode(super_idx).span;
+            self.current_super_class_old_idx = super_idx;
+        } else {
+            self.current_super_class = null;
+            self.current_super_class_old_idx = .none;
         }
         defer self.current_super_class = saved_super_class;
+        defer self.current_super_class_old_idx = saved_super_class_old_idx;
         // #3680: 우리가 outer standalone fn body 안에서 visit 중이라도 inner class body 의
         // `super` 는 lexical 로 valid 하므로 flag 를 reset. (inner private method 가 다시
         // 추출되면 buildStandaloneFunc 가 다시 true 로 set.)

--- a/src/transformer/transformer/members.zig
+++ b/src/transformer/transformer/members.zig
@@ -87,6 +87,26 @@ pub fn visitMethodDefinition(self: *Transformer, node: Node) Error!NodeIndex {
     self.needs_this_var = false;
     self.needs_arguments_var = false;
     self.super_call_this_alias = false;
+    // V7 fix: object literal method 의 super 는 home object [[Prototype]]=Object.prototype
+    // 기준이라 outer class super 와 무관. 이 method 가 object literal 의 일부이면
+    // (in_object_literal_depth>0) super context 5종을 reset 한다. class method 면 no-op.
+    const saved_super_class_v7 = self.current_super_class;
+    const saved_super_class_old_idx_v7 = self.current_super_class_old_idx;
+    const saved_super_is_static_v7 = self.current_super_is_static;
+    const saved_super_static_receiver_v7 = self.current_super_static_receiver;
+    const saved_super_in_extracted_fn_v7 = self.current_super_in_extracted_fn;
+    if (self.in_object_literal_depth > 0) {
+        self.current_super_class = null;
+        self.current_super_class_old_idx = .none;
+        self.current_super_is_static = false;
+        self.current_super_static_receiver = null;
+        self.current_super_in_extracted_fn = false;
+    }
+    defer self.current_super_class = saved_super_class_v7;
+    defer self.current_super_class_old_idx = saved_super_class_old_idx_v7;
+    defer self.current_super_is_static = saved_super_is_static_v7;
+    defer self.current_super_static_receiver = saved_super_static_receiver_v7;
+    defer self.current_super_in_extracted_fn = saved_super_in_extracted_fn_v7;
 
     const is_ctor = (flags & ast_mod.MethodFlags.is_static) == 0 and
         es_helpers.isConstructorKey(self, self.readNodeIdx(e, ast_mod.MethodExtra.key));

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -149,6 +149,26 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
 
         // object_expression: spread(ES2018) / method shorthand / computed property(ES2015) 다운레벨링
         .object_expression => {
+            // #3680-F7: object literal method 의 super 는 home object ([[Prototype]]=Object.prototype)
+            // 기준이라 outer class super context 와 무관. 추출된 private method body 안에 nested
+            // object literal 이 있을 때 outer class super 가 method body 로 누수돼 잘못 lowering
+            // 되는 것을 막기 위해 object literal 진입 시 super context 를 완전히 reset/restore.
+            const saved_super_class = self.current_super_class;
+            const saved_super_class_old_idx = self.current_super_class_old_idx;
+            const saved_super_is_static = self.current_super_is_static;
+            const saved_super_static_receiver = self.current_super_static_receiver;
+            const saved_super_in_extracted_fn = self.current_super_in_extracted_fn;
+            self.current_super_class = null;
+            self.current_super_class_old_idx = .none;
+            self.current_super_is_static = false;
+            self.current_super_static_receiver = null;
+            self.current_super_in_extracted_fn = false;
+            defer self.current_super_class = saved_super_class;
+            defer self.current_super_class_old_idx = saved_super_class_old_idx;
+            defer self.current_super_is_static = saved_super_is_static;
+            defer self.current_super_static_receiver = saved_super_static_receiver;
+            defer self.current_super_in_extracted_fn = saved_super_in_extracted_fn;
+
             // Plugin visitor 훅 — 기본 방문 전 선취권 (null 반환 시 default 진행)
             if (try self.dispatchVisitor(.on_object_expression, idx)) |replacement| return replacement;
             if (self.options.unsupported.object_spread) {

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -149,25 +149,15 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
 
         // object_expression: spread(ES2018) / method shorthand / computed property(ES2015) 다운레벨링
         .object_expression => {
-            // #3680-F7: object literal method 의 super 는 home object ([[Prototype]]=Object.prototype)
-            // 기준이라 outer class super context 와 무관. 추출된 private method body 안에 nested
-            // object literal 이 있을 때 outer class super 가 method body 로 누수돼 잘못 lowering
-            // 되는 것을 막기 위해 object literal 진입 시 super context 를 완전히 reset/restore.
-            const saved_super_class = self.current_super_class;
-            const saved_super_class_old_idx = self.current_super_class_old_idx;
-            const saved_super_is_static = self.current_super_is_static;
-            const saved_super_static_receiver = self.current_super_static_receiver;
-            const saved_super_in_extracted_fn = self.current_super_in_extracted_fn;
-            self.current_super_class = null;
-            self.current_super_class_old_idx = .none;
-            self.current_super_is_static = false;
-            self.current_super_static_receiver = null;
-            self.current_super_in_extracted_fn = false;
-            defer self.current_super_class = saved_super_class;
-            defer self.current_super_class_old_idx = saved_super_class_old_idx;
-            defer self.current_super_is_static = saved_super_is_static;
-            defer self.current_super_static_receiver = saved_super_static_receiver;
-            defer self.current_super_in_extracted_fn = saved_super_in_extracted_fn;
+            // V7 fix: 이전 F7 가 object_expression 진입 시 super context 5종을 일괄 reset 했으나,
+            // 그러면 object 의 property VALUE 위치 (`{ y: super.foo() }`) 의 super 도 reset 되어
+            // outer class 의 super lowering 이 비활성화됨 → ES5 등 class-lowering 타깃에서 raw super
+            // leak. spec: object literal METHOD body 만 home object [[Prototype]]=Object.prototype
+            // 으로 super 가 다르고, VALUE position 의 super 는 enclosing class 의 super 그대로.
+            // 따라서 reset 은 method 진입 시점 (visitMethodDefinition) 으로 좁히고, 여기서는
+            // depth 만 증감해 method 가 자신이 object literal 의 일부인지 알 수 있게 한다.
+            self.in_object_literal_depth += 1;
+            defer self.in_object_literal_depth -= 1;
 
             // Plugin visitor 훅 — 기본 방문 전 선취권 (null 반환 시 default 진행)
             if (try self.dispatchVisitor(.on_object_expression, idx)) |replacement| return replacement;

--- a/src/transformer/transformer/node_helpers.zig
+++ b/src/transformer/transformer/node_helpers.zig
@@ -201,14 +201,20 @@ pub fn visitUnaryExtra(self: anytype, node: Node) Error!NodeIndex {
     const op_flags = self.readU32(e, 1);
 
     // private field update: this.#x++ -> _x.set(this, _x.get(this) + 1)
-    if (node.tag == .update_expression and (self.options.unsupported.class or self.options.unsupported.class_private_field)) {
+    // super property update: super.x++ -> __superSet 기반 lowering
+    // (#3680-F4) needsSuperLowering 케이스도 outer 가드에 포함 — 추출된 standalone fn body
+    // 안에서 `super.x++` 가 그대로 leak 되면 raw `super` SyntaxError 또는 invalid LHS `(__superGet(...))++`
+    // 가 emit 된다. 두 lowering 은 독립적으로 가드한다 (super 와 private field 는 서로 다른 operand).
+    if (node.tag == .update_expression) {
         const operand = self.ast.getNode(operand_idx);
         if (self.needsSuperLowering()) {
             if (es2015_class.ES2015Class(Transformer).lowerSuperPropertyUpdate(self, operand, op_flags, node.span)) |result| {
                 return try result;
             }
         }
-        if (operand.tag == .private_field_expression) {
+        if ((self.options.unsupported.class or self.options.unsupported.class_private_field) and
+            operand.tag == .private_field_expression)
+        {
             if (es2015_class.ES2015Class(Transformer).lowerPrivateFieldUpdate(self, operand, op_flags, node.span)) |result| {
                 return try result;
             }


### PR DESCRIPTION
## 배경

closes #3680

`class D extends Base { #call(){ return super.greet(); } }` 같은 코드가 `lowerPrivateMembers` → `buildStandaloneFunc` 로 인해 `function _call_fn(){ return super.greet(); }` 형태로 class body 밖에 추출되면 raw `super` 키워드가 SyntaxError 를 일으켜 런타임 실패. fast path 도 동일 (private + extends 만 있으면 experimental-decorators 무관 재현).

## 핵심 변경

`Transformer.current_super_in_extracted_fn: bool` 신설 → `needsSuperLowering()` 에 OR 조건 추가. `buildStandaloneFunc` 가 params/body visit 동안 flag set/restore. 추출된 standalone fn body 안의 `super.x` / `super.method()` / `super.y = v` 가 `__superGet` / `Base.prototype.method.call(this)` / `__superSet` 형태로 lowering.

## 작업 단계 (3 commit + 1 fmt)

1. **`588d148f` 원본 fix** — 새 flag + 4 visitClass entry 에 reset 추가
2. **`6c9479ef` 1차 post-review (F1~F7)** — `/code-review max` 가 surface 한 7건 사각지대 일괄 처리
3. **`892069a2` 2차 post-review (V1~V8)** — 추가 review 가 surface 한 8건 추가 처리
4. **`ee146519` zig fmt**

## F1~F7 (1차 review)

| ID | 위치 | 내용 |
| -- | ---- | ---- |
| F1 | `es_helpers.zig:buildStaticPrivateFieldDescriptor` | static private field init 안의 super → flag set 으로 lowering 활성화 |
| F2 | `es_helpers.zig:buildStandaloneFunc` | non-derived class 의 super → `globalThis.Object.prototype` fallback |
| F3 | `es_helpers.zig:buildStandaloneFunc` | static private method 의 `super` → static form (`Base.x.call(this)`) lowering |
| F4 | `node_helpers.zig:visitUnaryExtra` | `super.x++` outer guard widening (needsSuperLowering 도 포함) |
| F5 | `class_visit.zig` / `class_decorator.zig` | inner class extends 없을 때 `current_super_class=null` 명시 reset |
| F6 | `class_visit.zig` / `class_decorator.zig` | `current_super_class_old_idx` 동기 set — minify rename 따라가도록 |
| F7 | `node_dispatch.zig:object_expression` | object literal method 의 super context reset (V7 에서 더 정밀화) |

## V1~V8 (2차 review, 모두 verifier reproduce + node 런타임 검증)

| ID | 위치 | 내용 |
| -- | ---- | ---- |
| V1 | `es_helpers.zig:buildStaticPrivateFieldDescriptor` + `es2022.zig:lowerPrivateMembers` | `static_receiver` 를 class_name_span 으로 set + descriptor 를 class_declaration 위치이면 `trailing_nodes` 로 옮겨 TDZ 회피 (receiver=D 가 init 후 평가) |
| V2 | `transformer.zig:needsSuperLowering` + `super_props.zig:buildSuperBaseRef` | `current_super_class != null` 후행 가드 제거 + null 일 때 `globalThis.{Object,Function}.prototype` fallback (`buildNonDerivedSuperBase`) |
| V3 | `es_helpers.zig:buildStandaloneFunc` | F3 conditional set → unconditional clamp (`is_static = (flags & is_static) != 0`) |
| V4 | `class_visit.zig` / `class_decorator.zig` | 5 종 super flag 일관 save+reset (`is_static`, `static_receiver` 추가) |
| V5 | `super_props.zig:buildNonDerivedSuperBase` | static 분기 — Function.prototype 사용 (Object.keys/assign 등 spec divergence 해결) |
| V6 | `super_props.zig:buildNonDerivedSuperBase` | `globalThis.X.prototype` 사용 → user shadow 차단 (`const Object = ...` 등) |
| V7 | `node_dispatch.zig:object_expression` + `members.zig:visitMethodDefinition` | object_expression 의 광범위 reset 제거 → depth counter 만 증감 + visitMethodDefinition 진입 시 depth>0 면 reset (property VALUE 위치 super 보존) |
| V8 | `class_visit.zig:visitClass` | `extends getBase()` / `extends pkg.Base` 의 표현식 텍스트가 super-prop access 마다 inline 중복되지 않도록 `var _<n> = <super expr>; class D extends _<n> {...}` 형태로 temp alias hoist |

## 검증

### 런타임 검증 (node)

| 시나리오 | 이전 동작 | fix 이후 |
| ------- | -------- | -------- |
| 원본 #3680 | `SyntaxError: 'super' keyword unexpected here` | `base` 정상 출력 |
| V1 (static field init super.method) | `no-this` (this=undefined) | `D` (정답) |
| V2 (non-derived static field) | `SyntaxError` | `function` (Function.prototype lookup) |
| V3 (nested static→instance) | `STATIC_FOO` (leak) | `INSTANCE_FOO` (정답) |
| V5 (non-derived static super.toString typeof) | spec 위반 (Object 의 own) | `function` (Function.prototype) |
| V7 (object property value super, es5) | `SyntaxError` | `{ y: 'BASE_FOO' }` |
| V8 (`extends getBase()` 부작용) | `count=3` (중복 evaluation) | `count=1` |

V6 의 lowering output 자체는 fix (`globalThis.Object.prototype` 사용) 이지만, runtime helper `__superGet` 내부의 `Object.getOwnPropertyDescriptor` 는 여전히 user shadow 영향 받음 → 별개 issue 로 후속 처리.

### 자동화 회귀

- `zig build test` 전체 (5526 pass, 0 fail, 4 skipped)
- `tests/integration` downlevel/super 그룹 266건 회귀 0
- #3680 + F1~F7 + V1~V8 회귀 테스트 모두 green

## Test plan

- [x] `zig build test` 전체 통과
- [x] `bun test tests/integration/tests/downlevel.test.ts` 등 회귀 0
- [x] 원본 #3680 repro 코드 node 실행 → `base` 출력 확인
- [x] V1~V8 각 케이스 node 실행 spec-aligned 결과 확인
- [x] `/code-review max` 2회 실행 → 모든 finding fix 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)