### PR TITLE
fix(napi): atexit → napi_add_env_cleanup_hook (Linux dlopen 호환) + leak-gate workflow 비활성

### DIFF
--- a/.github/workflows/napi-leak-gate.yml
+++ b/.github/workflows/napi-leak-gate.yml
@@ -1,34 +1,38 @@
-name: NAPI Leak Gate
+name: NAPI Leak Gate (disabled until Zig 0.16)
 
 # dev/watch RSS 누수 회귀 가드 (PR #3691~#3713 epic 후속).
 # Debug GPA leak detector (`packages/core/src/napi/common.zig` 의 debug_gpa) 가
 # 1분 dev probe 후 process 종료 시 stack trace 포함 leak 리포트 dump. 회귀
 # 발생 시 leak entries > 0 또는 panic 으로 즉시 차단.
 #
-# 매 PR 마다 돌리면 NAPI Build job 에 5분+ 추가 → main push + nightly + 수동
-# 트리거로 분리. PR 회귀 의심 시 `workflow_dispatch` 수동 실행 가능.
+# **현재 비활성화** — Zig 0.15.2 + Linux x86_64 + libc shared library 의
+# DebugAllocator `captureStackTrace` 가 frame pointer chain unwinding 시 SEGV
+# (Zig issue #25025). 0.16.0 milestone 에서 fix 됐으나 ZTS 는 0.15.2 사용.
+# Zig 0.16 업그레이드 epic (issue #1514) 머지 후 다시 활성화 — 그 때 아래
+# `on:` 트리거 (`push.branches`, `schedule.cron`) 의 주석을 제거.
+#
+# **macOS local 측정은 정상 동작** — `docs/DEBUG.md` / Starlight guide 의
+# 1분 dev probe 스크립트로 직접 사용 가능. 회귀 의심 시 macOS 에서 수동 측정.
 #
 # **임시 측정 인프라**: Debug NAPI 빌드 한정. ReleaseFast (production) 영향 0.
 # 기대값: leak entries=0, panics=0, rebuilt≥5 (touch-probe 정상 작동 검증).
 
 on:
-  push:
-    branches: [main]
-    paths:
-      # NAPI / measurement infra / 메모리 ownership 가능 영역 (review max 의
-      # path filter 보강 — bundler 외 parser/transformer/codegen 도 cover).
-      - "packages/core/src/napi/**"
-      - "src/bundler/**"
-      - "src/parser/**"
-      - "src/transformer/**"
-      - "src/codegen/**"
-      - "src/transpile.zig"
-      - "examples/web/**"
-      - ".github/workflows/napi-leak-gate.yml"
+  # push / schedule 비활성. workflow_dispatch 만 유지 — Zig 0.16 후 수동 검증.
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - "packages/core/src/napi/**"
+  #     - "src/bundler/**"
+  #     - "src/parser/**"
+  #     - "src/transformer/**"
+  #     - "src/codegen/**"
+  #     - "src/transpile.zig"
+  #     - "examples/web/**"
+  #     - ".github/workflows/napi-leak-gate.yml"
   workflow_dispatch:
-  schedule:
-    # 매일 04:00 UTC (KST 13:00) — main 의 매일 1회 검증 (path filter 무관 cover)
-    - cron: "0 4 * * *"
+  # schedule:
+  #   - cron: "0 4 * * *"
 
 concurrency:
   group: napi-leak-gate-${{ github.ref }}

--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -506,8 +506,8 @@ CI workflows 의 모든 `zig build napi` 호출은 *일관성 + 향후 paralleli
 dev/watch RSS 누수 / NAPI native_alloc 누수 추적용 임시 측정 인프라.
 `packages/core/src/napi/common.zig` 의 `debug_gpa` (Debug 빌드 한정,
 `std.heap.DebugAllocator`) 가 모든 NAPI 진입점 의 `native_alloc` 을 공유,
-process 종료 시 `atexit` 가 `detectLeaks()` 호출 → stack trace 포함 leak
-리포트를 stderr 로 dump.
+process 정상 종료 시 NAPI env cleanup hook (`napi_add_env_cleanup_hook`) 가
+`detectLeaks()` 호출 → stack trace 포함 leak 리포트를 stderr 로 dump.
 
 ### 배경 (#dev-leak-investigation, 2026-05-23)
 
@@ -589,8 +589,8 @@ HashMap 내부 6 프레임에 caller 가 다 가려져 불충분.
   직접 비교 금지. **Debug↔Debug, before↔after fix delta** 만 valid
 - **perf 왜곡**: `thread_safe=true` mutex 로 모든 alloc 직렬화. wall-clock /
   sub-phase ns 절대값 무의미, 상대 ratio 만
-- **SIGTERM atexit 발동**: 호스트 런타임 의존. Bun 환경 검증, Node 환경에선
-  `process.exit(0)` 명시 권장
+- **NAPI env cleanup hook 발동**: 호스트 런타임의 정상 종료 경로 의존
+  (Node/Bun 모두 env destroy 시 자동 호출). SIGKILL 등 비정상 종료에선 미발화
 - **`tryLock`-based detectLeaks**: worker thread 가 mid-alloc 시 leak dump 일부
   손실 (희박, deadlock 회피 trade-off)
 - **shutdown noise**: watch 의 long-lived cache (PersistentModuleStore 등)

--- a/documents/src/content/docs/guides/debug-napi-leaks.md
+++ b/documents/src/content/docs/guides/debug-napi-leaks.md
@@ -1,12 +1,13 @@
 ---
 title: NAPI 누수 측정 (Debug GPA leak detector)
-description: dev/watch RSS 누수 / NAPI native_alloc 누수 추적용 측정 도구 사용법 — Debug 빌드 한정 std.heap.DebugAllocator + atexit dump
+description: dev/watch RSS 누수 / NAPI native_alloc 누수 추적용 측정 도구 사용법 — Debug 빌드 한정 std.heap.DebugAllocator + NAPI env cleanup hook dump
 ---
 
 ZNTC 내부 contributor 용 측정 인프라. `packages/core/src/napi/common.zig` 의
 `debug_gpa` (Debug 빌드 한정, `std.heap.DebugAllocator`) 가 모든 NAPI 진입점
-의 `native_alloc` 을 공유, process 종료 시 `atexit` 가 `detectLeaks()` 호출
-→ stack trace 포함 leak 리포트를 stderr 로 dump.
+의 `native_alloc` 을 공유, process 정상 종료 시 NAPI env cleanup hook
+(`napi_add_env_cleanup_hook`) 가 `detectLeaks()` 호출 → stack trace 포함
+leak 리포트를 stderr 로 dump.
 
 **Production 사용자 영향 0** — ReleaseFast 빌드는 `comptime builtin.mode != .Debug`
 early-out 으로 dead code 제거, `std.heap.c_allocator` 그대로 사용.
@@ -50,7 +51,7 @@ for i in $(seq 1 20); do
   sleep 3
 done
 
-# SIGTERM → atexit 발화 → leak dump
+# SIGTERM → Node 정상 종료 → env cleanup hook 발화 → leak dump
 kill -TERM $DEV_PID
 sleep 3
 kill -KILL $DEV_PID 2>/dev/null
@@ -102,8 +103,8 @@ bottom-up stack trace — NAPI 진입점 (가장 깊은 프레임) 부터 실제
   **직접 비교 금지**. Debug↔Debug, before↔after fix delta 만 valid
 - **perf 왜곡**: `thread_safe=true` mutex 로 모든 alloc 직렬화. wall-clock /
   sub-phase ns 절대값 무의미, 상대 ratio 만
-- **SIGTERM atexit 발동**: 호스트 런타임 의존. Bun 환경 검증, Node 환경에선
-  `process.exit(0)` 명시 권장
+- **NAPI env cleanup hook 발동**: 호스트 런타임의 정상 종료 경로 의존
+  (Node/Bun 모두 env destroy 시 자동 호출). SIGKILL 등 비정상 종료에선 미발화
 - **`tryLock`-based detectLeaks**: worker thread 가 mid-alloc 시 leak dump
   일부 손실 (희박, deadlock 회피 trade-off)
 - **shutdown noise**: watch 의 long-lived cache (`PersistentModuleStore` /
@@ -156,6 +157,6 @@ assertion 추가 가능 (현재 수동).
 
 - 저장소 내부: [`docs/DEBUG.md`](https://github.com/ohah/zntc/blob/main/docs/DEBUG.md) 의 동일 섹션
 - 측정 인프라 코드: [`packages/core/src/napi/common.zig`](https://github.com/ohah/zntc/blob/main/packages/core/src/napi/common.zig)
-  의 `debug_gpa` / `nativeAlloc` / `dumpLeaksAtExit` / `registerLeakDump`
+  의 `debug_gpa` / `nativeAlloc` / `dumpLeaksOnEnvCleanup` / `registerLeakDump`
 - 9 PR EPIC history: PR #3691 / #3695 / #3696 / #3705 / #3707 / #3709 / #3711 /
   #3713

--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -46,23 +46,24 @@ pub fn nativeAlloc() std.mem.Allocator {
     return std.heap.c_allocator;
 }
 
-extern fn atexit(?*const fn () callconv(.c) void) c_int;
-
-fn dumpLeaksAtExit() callconv(.c) void {
+/// NAPI env cleanup hook (signature: `fn (?*anyopaque) callconv(.c) void`).
+///
+/// **Linux 호환성 fix (이전 `extern fn atexit` 에서 전환)**: Linux dynamic
+/// shared library (`.node`) 는 libc `atexit` symbol 을 dlopen 시 resolve 안
+/// 함 → `Error: undefined symbol: atexit` 으로 ERR_DLOPEN_FAILED. macOS
+/// dynamic linker 는 자동 resolve 하지만 Linux ld 는 crt symbol 을 dynamic
+/// link 안 함. `napi_add_env_cleanup_hook` 은 NAPI 표준 API — 양쪽 환경
+/// 모두 호환. (Linux x86_64 + libc + DebugAllocator 의 더 깊은 호환성 문제는
+/// Zig stdlib issue #25025 — 0.16.0 milestone fix. issue #1514 참고.)
+///
+/// `detectLeaks()` (debug_allocator.zig:449) 는 leak stack trace 만 stderr 에
+/// dump 하고 state 유지 → 동시 in-flight alloc/free 가 후속에 진행해도 안전.
+/// 단, detectLeaks 자체가 `self.buckets` / `self.large_allocations` 를 lock
+/// 없이 iterate → 동시 alloc/free 가 mutate 하면 torn pointer read / iterator
+/// desync 위험. `mutex.tryLock` 으로 best-effort serialize: worker 가
+/// mid-alloc 이면 skip (leak dump 일부 손실) → deadlock 보다 안전.
+fn dumpLeaksOnEnvCleanup(_: ?*anyopaque) callconv(.c) void {
     if (comptime builtin.mode != .Debug) return;
-    // `deinit()` (stdlib debug_allocator.zig:500) 가 detectLeaks 후 `self.* =
-    // undefined` 로 GPA 상태 무효화 → atexit 발화 시점에 detached watch worker
-    // (`thread.detach()`, watch.zig) / TsconfigCache napi_wrap finalizer / late
-    // libc destructor 가 후속 native_alloc.alloc/free 호출 시 undefined memory
-    // dereference → segfault (PR #3695 review HIGH #1).
-    //
-    // `detectLeaks()` (debug_allocator.zig:449) 는 leak stack trace 만 stderr 에
-    // dump 하고 state 유지 → 동시 in-flight alloc/free 가 후속에 진행해도 안전.
-    // 단, detectLeaks 자체가 `self.buckets` / `self.large_allocations` 를 lock
-    // 없이 iterate → 동시 alloc/free 가 mutate 하면 torn pointer read / iterator
-    // desync 위험 (review max HIGH catch). `mutex.tryLock` 으로 best-effort
-    // serialize: worker 가 mid-alloc 이면 skip (leak dump 일부 손실) → deadlock
-    // 보다 안전 (`lock` 은 worker 가 강제 kill 시 영구 hang).
     if (debug_gpa.mutex.tryLock()) {
         defer debug_gpa.mutex.unlock();
         _ = debug_gpa.detectLeaks();
@@ -74,20 +75,19 @@ fn dumpLeaksAtExit() callconv(.c) void {
 /// `napi_register_module_v1` 의 중복 호출 race 방지 atomic flag. Node
 /// `worker_threads` / Vitest `pool='threads'` 등 한 process 안에서 다중 isolate
 /// 가 같은 .node 를 load 시 module init 이 동시에 호출될 수 있고, 공유 static
-/// 인 이 flag 의 non-atomic read+write 면 둘 다 false 관찰 → 둘 다 atexit
-/// 등록 → process 종료 시 `dumpLeaksAtExit` 두 번 호출 → 첫 deinit 가 `self.* =
-/// undefined` 로 GPA 무효화 후 두 번째 deinit 가 undefined memory deref →
-/// segfault. `.acq_rel` swap 으로 하나의 caller 만 등록 진입 보장.
+/// 인 이 flag 의 non-atomic read+write 면 둘 다 false 관찰 → 둘 다 cleanup hook
+/// 등록 → env destroy 시 `dumpLeaksOnEnvCleanup` 두 번 호출 → 첫 deinit 가
+/// `self.* = undefined` 로 GPA 무효화 후 두 번째 deinit 가 undefined memory
+/// deref → segfault. `.acq_rel` swap 으로 하나의 caller 만 등록 진입 보장.
 var leak_dump_registered: std.atomic.Value(bool) = .init(false);
 
-/// napi_register_module_v1 에서 1회 호출. SIGTERM/정상 exit 시 atexit handler
-/// 가 GPA.deinit() 를 호출해 leak 리포트(stack trace) 를 stderr 에 출력한다.
-pub fn registerLeakDump() void {
+/// `napi_register_module_v1` 에서 1회 호출 (env 인자 전달). Node env (isolate)
+/// destroy 시 cleanup hook 이 `detectLeaks` 호출 → stack trace 포함 leak
+/// 리포트를 stderr 로 dump. process 정상 종료 시 env 도 destroy 되므로 동등.
+pub fn registerLeakDump(env: c.napi_env) void {
     if (comptime builtin.mode != .Debug) return;
-    // swap 결과가 이미 true 면 다른 caller 가 등록 완료한 상태 — skip. acq_rel
-    // 로 register 후 read 가 write 와 happens-before 정렬.
     if (leak_dump_registered.swap(true, .acq_rel)) return;
-    _ = atexit(&dumpLeaksAtExit);
+    _ = c.napi_add_env_cleanup_hook(env, &dumpLeaksOnEnvCleanup, null);
 }
 
 pub fn throwError(env: c.napi_env, msg: [*:0]const u8) c.napi_value {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -37,7 +37,7 @@ export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi
     // Debug 빌드 한정: DebugAllocator leak 리포트(stack trace) 를 process 종료 시
     // stderr 로 dump 하는 atexit handler 1회 등록 (#dev-leak-investigation).
     // ReleaseFast 에서는 no-op.
-    common.registerLeakDump();
+    common.registerLeakDump(env);
 
     // ZNTC_DEBUG env 를 프로세스 시작 시 1회 파싱해 mask 초기화.
     // 개별 build/watch 호출마다 BundleOptions.debug 로 카테고리 추가 가능.


### PR DESCRIPTION
## Summary

dev/watch leak detector epic (#3691 ~ #3713) 의 Linux 환경 호환성 정리. 본 PR
은 두 가지 작은 변경 + 사용자 향 문서의 표현 정합화 :

1. **`atexit` → `napi_add_env_cleanup_hook` 전환** — Linux dlopen 자체 차단
   해결 (가치 유지)
2. **NAPI Leak Gate workflow 비활성** — Zig stdlib issue 로 측정 도구 자체가
   Linux 에서 동작 불가, Zig 0.16 업그레이드 후 재활성
3. **docs/DEBUG.md + Starlight guide** — `atexit` 표현을 `napi env cleanup
   hook` 으로 일관화

## 1. atexit → napi_add_env_cleanup_hook

PR #3713 의 `extern fn atexit` 가 Linux dynamic shared library (`.node`)
dlopen 시 symbol 미 resolve → **ERR_DLOPEN_FAILED: undefined symbol: atexit**.
macOS dyld 는 자동 resolve 하지만 Linux ld 는 crt symbol 을 dynamic link
하지 않음.

NAPI 표준 `napi_add_env_cleanup_hook` 으로 전환. process 정상 종료 시 env
destroy → cleanup hook 발화 → `detectLeaks()` 호출 동일.

```diff
-extern fn atexit(?*const fn () callconv(.c) void) c_int;
-fn dumpLeaksAtExit() callconv(.c) void { ... }
-pub fn registerLeakDump() void {
-    _ = atexit(&dumpLeaksAtExit);
-}
+fn dumpLeaksOnEnvCleanup(_: ?*anyopaque) callconv(.c) void { ... }
+pub fn registerLeakDump(env: c.napi_env) void {
+    _ = c.napi_add_env_cleanup_hook(env, &dumpLeaksOnEnvCleanup, null);
+}
```

`leak_dump_registered` atomic 가드, `detectLeaks` + `mutex.tryLock` cleanup
로직, `backing_allocator = c_allocator` + `zeroes = false`,
`stack_trace_frames = 16` 등 측정 정확도 옵션 모두 그대로.

## 2. NAPI Leak Gate workflow 비활성

Linux x86_64 + libc shared library 의 DebugAllocator `captureStackTrace` 가
frame pointer chain unwinding 시 SEGV — **[Zig stdlib issue #25025](https://github.com/ziglang/zig/issues/25025)**.
0.16.0 milestone 에서 fix 됐으나 ZTS 는 0.15.2 사용 중. 위 atexit fix 도
dlopen 자체는 해결하지만 더 깊은 Debug GPA 호환성은 잔존.

Colima/Docker x86_64 emulation 재현으로 모든 우회 시도 확인 :
`backing_allocator` 변경, `stack_trace_frames=0`, `frame_init=false`,
DefaultLogScope 변경 등 — 전부 SIGSEGV (configureProfile / tokenize /
transpile / 가장 가벼운 require 만으로도 동일).

**측정 도구 자체 fix 불가능** — Zig 0.16 업그레이드 (이슈 #1514) 머지 후
재활성 예정.

```diff
-name: NAPI Leak Gate
+name: NAPI Leak Gate (disabled until Zig 0.16)
 on:
-  push:
-    branches: [main]
-    paths:
-      - "packages/core/src/napi/**"
-      ...
+  # push / schedule 비활성. workflow_dispatch (수동) 만 유지.
+  # push:
+  #   branches: [main]
+  #   ...
   workflow_dispatch:
-  schedule:
-    - cron: "0 4 * * *"
+  # schedule:
+  #   - cron: "0 4 * * *"
```

`workflow_dispatch` 만 남겨 GitHub UI 의 "Run workflow" 수동 트리거는 가능
(Zig 0.16 RC 등 검증용).

## 3. 문서 정합화

선행 코드 변경에 맞춰 사용자 향 문서의 표현 정합. 동작 의미 동일 (process
정상 종료 시 자동 dump) 이라 회귀 0, 정확성만 보강.

- `docs/DEBUG.md` — "process 종료 시 `atexit` 가 `detectLeaks()`" → "process
  정상 종료 시 NAPI env cleanup hook (`napi_add_env_cleanup_hook`) 가
  `detectLeaks()`" / trade-off 표현 동일 패턴
- `documents/src/content/docs/guides/debug-napi-leaks.md` — frontmatter
  description / 본문 / 스크립트 주석 / trade-off / 관련 자료 링크의
  `dumpLeaksAtExit` → `dumpLeaksOnEnvCleanup` 정리

workflow body 의 stale 표현은 비활성 상태 + Zig 0.16 재활성 시 큰 rewrite
예정이라 그 PR 에 함께 처리.

## 영향

- **ZNTC core release 빌드 영향 0** — ReleaseFast 는 `comptime builtin.mode !=
  .Debug` 분기로 atomic / cleanup hook / `debug_gpa` 모두 dead code, `std.heap.c_allocator` 직접 반환
- **macOS local 측정 그대로 작동** — atexit 가 cleanup hook 으로 변경됐지만
  process 정상 종료 시 env destroy → hook 발화 동일. docs/DEBUG.md +
  Starlight guide 의 1분 dev probe 스크립트 그대로 사용 가능
- **Linux 환경**:
  - dlopen 자체는 해결 (atexit symbol 차단 사라짐)
  - Debug GPA 측정 도구는 여전히 SIGSEGV (Zig issue #25025) — Zig 0.16 까지
    잠시 보류
- **회귀 가드**: workflow_dispatch 수동 트리거만 남김. Zig 0.16 재활성 후
  자동화

## `/code-review max` 검증

5-angle review 모두 PASS :

1. `napi_add_env_cleanup_hook` API signature 일치 — `node_api_types.h:15` 의
   `napi_cleanup_hook = void (*)(void* arg)` 와 우리 callback signature 일치
2. `node_api_basic_env` == `napi_env` (`NAPI_EXPERIMENTAL` 미정의 시
   non-const) — `napi_env` 직접 전달 valid
3. `leak_dump_registered` acq_rel swap 가드는 worker_threads 다중
   register_module_v1 중복 등록 방지에 cleanup hook 도 동등하게 유효
4. `workflow_dispatch` + `concurrency` 블록은 dispatch run 에도 적용 — UI "Run
   workflow" 수동 트리거 정상
5. ReleaseFast dead code elision 확인 — `comptime` 3중 분기 (nativeAlloc /
   dumpLeaksOnEnvCleanup / registerLeakDump)

## Test plan

- [x] `zig build` — Debug + ReleaseFast 모두 성공
- [x] `zig build napi -Dnapi-optimize=Debug` — macOS arm64
- [x] `zig build test` — 5514/5514 tests passed
- [x] `zig fmt --check src/` — pass
- [x] dev/watch 1분 probe 재실행 (macOS arm64) — `leak entries: 0` 유지
- [ ] Linux 자동화 — 보류 (Zig 0.16 까지)

## 후속

- 본 PR 머지 후 이슈 #1514 (Zig 0.15.2 → 0.16.0 upgrade) 에 본 발견사항
  comment :
  - Linux x86_64 + libc + DebugAllocator 호환성 issue (Zig stdlib #25025) 잔존
  - Zig 0.16 머지 후 `.github/workflows/napi-leak-gate.yml` 의 `push` /
    `schedule` 트리거 주석 해제 + workflow `name:` 의 "(disabled until Zig
    0.16)" suffix 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)