### PR TITLE
fix(transformer): #3680 post-merge — V1/V8 revert (effect-ts + static block 회귀)

### DIFF
--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -1444,23 +1444,11 @@ test "#3680-F7: object literal method 의 super 가 outer class 로 leak 방지 
 
 // === post-review 2nd-round V1~V8 회귀 가드 ===
 
-// V1: F1 이 current_super_static_receiver 미설정 → module top-level this=undefined.
-// 정답: descriptor 의 .call(this) 가 아니라 class 자체를 receiver 로 사용 (D 의 span).
-test "#3680-V1: static private field init 의 super.method() receiver 가 class 이름 (es2021)" {
-    var r = try e2eTarget(std.testing.allocator,
-        \\class Base { static factor(){return this?.name ?? "no-this"} }
-        \\class D extends Base {
-        \\  static #x = super.factor();
-        \\  static get() { return D.#x; }
-        \\}
-    , .es2021);
-    defer r.deinit();
-    // descriptor 가 module top-level 로 빠지므로 receiver 는 D 여야 함.
-    // .call(this) 가 아니라 .call(D) (또는 __superGet 의 receiver 인자 D).
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _x={writable:true,value:") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.factor.call(this)") == null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.factor.call(D)") != null);
-}
+// V1 revert (receiver 부분): descriptor 를 trailing 으로 옮기는 fix 가 static block IIFE
+// 의 descriptor 참조 (예: `static { S.#n += 10 }`) 를 TDZ 위반으로 깨뜨려 revert. 결과로
+// descriptor 의 init 안 super.method() receiver 가 module top-level `this=undefined` 인
+// spec 위반은 다시 노출되나, static block 사용 케이스가 더 빈번하므로 trade-off.
+// 별도 PR 로 정밀 fix 추적 (descriptor 와 IIFE 의 emit 순서 정밀 control 필요).
 
 // V2: F1 의 non-derived class 의 static private field init 안 super → 'Object'/'Function.prototype' fallback.
 test "#3680-V2: non-derived class 의 static private field init 안 super → fallback (es2021)" {
@@ -1570,26 +1558,12 @@ test "#3680-V7: class 내 object literal property value super → outer class lo
     try std.testing.expect(std.mem.indexOf(u8, r.output, "super.foo()") == null);
 }
 
-// V8: F6 의 member-expression extends — side effect 가 super-prop access 마다 중복되지 않도록 temp alias.
-test "#3680-V8: extends getBase() 의 side effect 가 super.x access 마다 중복 안 됨 (es2021)" {
-    var r = try e2eTarget(std.testing.allocator,
-        \\let count = 0;
-        \\function getBase() { count++; return class { foo(){return "X"} }; }
-        \\class D extends getBase() {
-        \\  #m() { return super.foo() + "|" + super.foo(); }
-        \\  run() { return this.#m(); }
-        \\}
-    , .es2021);
-    defer r.deinit();
-    // _m_fn body 안에서 `getBase()` 호출이 직접 inline 되면 부작용 중복.
-    // temp alias 가 적용되면 _super (또는 temp 변수) 이름이 사용되어 getBase() 는
-    // class extends 자리에서 1회만 evaluated 됨.
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _m_fn") != null);
-    // `getBase().prototype.foo` 같은 직접 inline 이 _m_fn 안에서 발생하면 fail.
-    const fn_idx = std.mem.indexOf(u8, r.output, "function _m_fn") orelse unreachable;
-    const fn_tail = r.output[fn_idx..];
-    try std.testing.expect(std.mem.indexOf(u8, fn_tail, "getBase()") == null);
-}
+// V8 revert: 이전 fix (extends 표현식 temp hoist) 는 bundler tree-shaker 의 reachability
+// 분석을 깨뜨려 effect-ts 의 `class extends TaggedError(...)` 같은 패턴에서 silent
+// dead-code-eliminate 발생 (`TaggedError is not defined` ReferenceError). 정밀 fix
+// (bundler reference 분석 강화 또는 hoist 를 linker 후 단계로 이동) 는 별도 PR 추적.
+// 회귀 가드 후퇴 — `extends getBase()` 의 side-effect 중복 평가는 다시 노출되나
+// effect-ts 의 SyntaxError 보다 영향 범위가 작다.
 
 // nested class: standalone fn 안의 *inner* class body 의 `super.x` 는
 // inner class lexical context 가 valid 하므로 inner super 로 lowering 돼야 한다.

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -392,14 +392,15 @@ pub fn ES2022(comptime Transformer: type) type {
                 self.current_private_fields = saved_private_fields;
             };
 
-            // V1 fix: static descriptor 는 receiver=D 를 사용하므로 D 가 init 된 *뒤* 에
-            // 평가되어야 한다 (descriptor 가 class 앞에 emit 되면 TDZ ReferenceError).
-            // class_declaration 위치이면 trailing_nodes 에 emit 해 class 뒤에 stitching.
-            // class_expression 위치이면 expression context 라 trailing 가 comma stitching 발생
-            // (`const W = (...)(),var _m = ...`) → pre_stmts 그대로 두고 receiver=D 사용 자체가
-            // IIFE 안의 `_a` (class 의 local binding) 라 trailing 불필요.
-            // caller hint `static_descriptors_trailing` 로 분기.
-            const desc_target = if (static_descriptors_trailing) &self.trailing_nodes else pre_stmts;
+            // V1 의 descriptor trailing reorder 는 revert: static block IIFE 가 descriptor 를
+            // 참조하는 경우 (예: `static { S.#n += 10 }`) IIFE 도 trailing 위치에 emit 되어
+            // descriptor 보다 *앞에* 평가되면서 `attempted to get private static field before
+            // its declaration` TypeError. 따라서 descriptor 는 pre_stmts 유지 (class 앞).
+            // 결과: descriptor 안 super.foo() 의 receiver `this` 가 module top-level 에서
+            // undefined 가 되는 spec 위반은 다시 노출되나, static block 사용 케이스 (실제 코드)
+            // 가 더 흔하다.
+            _ = static_descriptors_trailing;
+            const desc_target = pre_stmts;
             for (field_mappings.items, field_init_idx.items) |m, init_val| {
                 if (m.class_name) |cname| {
                     const cname_span = try self.ast.addString(cname);

--- a/src/transformer/transformer/class_visit.zig
+++ b/src/transformer/transformer/class_visit.zig
@@ -24,7 +24,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         else
             try self.visitNode(raw_name_idx);
         const super_idx = self.readNodeIdx(e, ast_mod.ClassExtra.super);
-        var new_super = try self.visitNode(super_idx);
+        const new_super = try self.visitNode(super_idx);
 
         const saved_super_class = self.current_super_class;
         const saved_super_class_old_idx = self.current_super_class_old_idx;
@@ -32,28 +32,18 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         // 끊어야 한다 (else null reset 누락 시 outer Base 누수 → 새 flag 로 silent miscompile).
         // F6: fast path 도 super_class 와 동시에 old_idx 를 set — 새 flag 로 fast path 에서도 super
         // lowering 이 활성화되니 symbol propagation (minify rename 등) 을 위해 필요.
-        // V8: extends 표현식이 단순 식별자가 아니면 (`extends getBase()` / `extends pkg.Base` 등)
-        // current_super_class 를 raw span 으로 set 시 매 super-prop access 마다 표현식 텍스트가
-        // inline 되어 side effect 가 중복 평가됨. class_declaration 위치에서는 temp 변수로 hoist:
-        //   `var _<n> = <super expr>; class D extends _<n> {...}` 형태.
-        // class_expression 위치는 statement hoist 불가 → fallback 으로 raw super 그대로 두되
-        // current_super_class 만 set (호출자가 super-prop 을 inline 평가하는 비용 감수).
+        //
+        // V8 revert: extends 표현식이 non-identifier 일 때 temp 변수로 hoist 하던 동작을
+        // 되돌린다. hoisted `var _<n> = <super expr>` 가 bundler tree-shaker 의 reachability
+        // graph 에 포함되지 않아 RHS 의 reference (예: effect-ts 의 `TaggedError`) 가
+        // dead-code-eliminated → `TaggedError is not defined` ReferenceError. 정밀 fix
+        // (bundler reference 분석 강화 또는 hoist 를 linker 후 단계로 이동) 는 별도 PR.
+        // 결과: `extends getBase()` 의 side-effect 가 super-prop access 마다 중복 평가될 수
+        // 있는 V8 의 silent regression 은 다시 노출되지만, effect-ts 같은 실제 패키지의
+        // SyntaxError 보다 영향 범위가 작다.
         if (!super_idx.isNone()) {
-            const super_node = self.ast.getNode(super_idx);
-            const is_simple_id = super_node.tag == .identifier_reference or super_node.tag == .binding_identifier;
-            if (!is_simple_id and node.tag == .class_declaration) {
-                const tmp_span = try es_helpers.makeTempVarSpan(self);
-                const tmp_binding = try es_helpers.makeBindingIdentifier(self, tmp_span);
-                const declarator = try es_helpers.makeDeclarator(self, tmp_binding, new_super, node.span);
-                const var_decl = try es_helpers.makeVarDeclaration(self, &.{declarator}, .@"var", node.span);
-                try self.pending_nodes.append(self.allocator, var_decl);
-                new_super = try es_helpers.makeIdentifierRefFromSpan(self, tmp_span);
-                self.current_super_class = tmp_span;
-                self.current_super_class_old_idx = .none;
-            } else {
-                self.current_super_class = super_node.span;
-                self.current_super_class_old_idx = super_idx;
-            }
+            self.current_super_class = self.ast.getNode(super_idx).span;
+            self.current_super_class_old_idx = super_idx;
         } else {
             self.current_super_class = null;
             self.current_super_class_old_idx = .none;


### PR DESCRIPTION
## 배경

PR #3722 (#3680 fix) 머지 후 CI 에서 두 회귀 발견. 직접 reproduce 로 root cause 식별 후 정밀 revert.

## 회귀 1 — effect-ts E2E `TaggedError is not defined`

**원인 (V8 fix)**: `class D extends getBase() {...}` 같은 non-identifier extends 표현식을 temp 변수로 hoist:
```js
var _<n> = <super expr>;
class D extends _<n> {...}
```
이 hoisted `var _<n>` 가 **bundler tree-shaker 의 reachability graph 에 포함되지 않아**, RHS 가 참조하는 identifier (effect-ts 의 `TaggedError` 등) 가 dead-code-eliminated → 런타임 `TaggedError is not defined` ReferenceError.

**Reproduce**: `import { Effect } from 'effect'` 번들 → bundle 안에 `var _e = TaggedError(...)` 만 emit, `TaggedError` declaration 자체 누락.

**fix**: V8 의 hoist 로직 제거. `class D extends getBase()` 에서 `getBase()` 표현식이 super-prop access 마다 inline 평가되는 silent regression 은 다시 노출되나, effect-ts (and other package-mode bundle) breakage 보다 영향 범위가 좁다.

**별도 PR 추적**: bundler 의 reference 분석 강화 또는 hoist 를 linker 후 단계로 이동 (정밀 fix).

## 회귀 2 — `static block + private static field` TypeError

**원인 (V1 descriptor reorder)**: static private field descriptor 를 `trailing_nodes` 로 옮긴 fix 가 static block IIFE 의 descriptor 참조 (`static { S.#n += 10 }`) 를 TDZ 위반으로 깨뜨림. IIFE 와 descriptor 가 모두 trailing 위치에 emit 되어 IIFE 가 descriptor 보다 *앞에* 평가되면서:

```
attempted to get private static field before its declaration
```

**Reproduce**:
```ts
class S {
  static #n = 1;
  static { S.#n += 10; for (let i = 0; i < 3; i++) S.#n++; }
  // ...
}
```
at `--target=es2020`.

**fix**: V1 의 descriptor reorder (`static_descriptors_trailing`) 만 revert. class_name_span 전달은 유지 (no harm). receiver 가 module top-level 에서 `this=undefined` 인 spec 위반은 다시 노출되나 static block 사용 케이스가 더 빈번.

**별도 PR 추적**: descriptor 와 static block IIFE 의 emit 순서 정밀 control (descriptor 가 IIFE 보다는 앞, class 보다는 뒤).

## 영향 범위

- 다른 fix (V2~V7, F1~F7, 원본 #3680 fix) 는 모두 유지.
- 회귀 테스트 `#3680-V1`, `#3680-V8` 도 후퇴 (주석으로 trade-off 명시, 별도 PR 가드 안내).

## 검증

- `effect-ts` bundle → node 실행 결과 `43` (정답)
- `downlevel-edge` 의 `static block + private static field` 시리즈 0 fail
- zig build test 전체 통과
- tests/integration 전체 약 3909건 통과 (runtime-helper-virtual-module fail 1건은 fixture build ENOENT 로 pre-existing flaky, 우리 PR 무관)
- 원본 #3680 repro + V2~V7 회귀 테스트 모두 green 유지

## Test plan

- [x] effect-ts bundle 직접 reproduce → `43` 출력 확인
- [x] static block + private static field reproduce → `28` 출력 확인
- [x] zig build test 전체 통과
- [x] tests/integration downlevel-edge 0 fail
- [x] 원본 #3680 회귀 + V2~V7 회귀 테스트 모두 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)