### PR TITLE
fix(transformer): #3680 V1/V8 정밀 fix (revert 후속, 원본 의도 복구)

### DIFF
--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -1444,11 +1444,25 @@ test "#3680-F7: object literal method 의 super 가 outer class 로 leak 방지 
 
 // === post-review 2nd-round V1~V8 회귀 가드 ===
 
-// V1 revert (receiver 부분): descriptor 를 trailing 으로 옮기는 fix 가 static block IIFE
-// 의 descriptor 참조 (예: `static { S.#n += 10 }`) 를 TDZ 위반으로 깨뜨려 revert. 결과로
-// descriptor 의 init 안 super.method() receiver 가 module top-level `this=undefined` 인
-// spec 위반은 다시 노출되나, static block 사용 케이스가 더 빈번하므로 trade-off.
-// 별도 PR 로 정밀 fix 추적 (descriptor 와 IIFE 의 emit 순서 정밀 control 필요).
+// V1 정밀 fix (post-merge): descriptor 를 class declaration 뒤, static block IIFE 앞에
+// 명시적으로 emit (lowerPrivateMembers 가 별도 array `static_descriptors_out` 으로
+// caller 에게 넘김). receiver=D 가 init 후 평가되어 spec valid + IIFE 가 descriptor 의
+// _x 등 참조 가능.
+test "#3680-V1: static private field init 의 super.method() receiver 가 class 이름 (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Base { static factor(){return this?.name ?? "no-this"} }
+        \\class D extends Base {
+        \\  static #x = super.factor();
+        \\  static get() { return D.#x; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // descriptor 가 emit 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _x={writable:true,value:") != null);
+    // receiver 가 raw this 가 아니라 class 식별자 D
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.factor.call(this)") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Base.factor.call(D)") != null);
+}
 
 // V2: F1 의 non-derived class 의 static private field init 안 super → 'Object'/'Function.prototype' fallback.
 test "#3680-V2: non-derived class 의 static private field init 안 super → fallback (es2021)" {
@@ -1558,12 +1572,32 @@ test "#3680-V7: class 내 object literal property value super → outer class lo
     try std.testing.expect(std.mem.indexOf(u8, r.output, "super.foo()") == null);
 }
 
-// V8 revert: 이전 fix (extends 표현식 temp hoist) 는 bundler tree-shaker 의 reachability
-// 분석을 깨뜨려 effect-ts 의 `class extends TaggedError(...)` 같은 패턴에서 silent
-// dead-code-eliminate 발생 (`TaggedError is not defined` ReferenceError). 정밀 fix
-// (bundler reference 분석 강화 또는 hoist 를 linker 후 단계로 이동) 는 별도 PR 추적.
-// 회귀 가드 후퇴 — `extends getBase()` 의 side-effect 중복 평가는 다시 노출되나
-// effect-ts 의 SyntaxError 보다 영향 범위가 작다.
+// V8 정밀 fix (post-merge): extends 표현식이 non-identifier (e.g. `extends getBase()`)
+// 일 때 super-prop lowering 을 `Object.getPrototypeOf(<ClassName>.prototype).foo.call(this)`
+// 형태로 emit. extends 표현식 자체는 class declaration 위치에서 1회만 평가되고 (spec
+// 준수), super-prop access 마다 class 의 prototype chain (고정값) 만 참조 → 부작용 없음.
+// bundler tree-shaker 도 ClassName identifier reference 만 보면 되므로 자연스럽게 추적.
+test "#3680-V8: extends getBase() 의 side effect 가 super.x access 마다 중복 안 됨 (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\let count = 0;
+        \\function getBase() { count++; return class { foo(){return "X"} }; }
+        \\class D extends getBase() {
+        \\  #m() { return super.foo() + "|" + super.foo(); }
+        \\  run() { return this.#m(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _m_fn") != null);
+    // _m_fn body 만 추출 (function _m_fn(...) { ... } 안쪽) — class D extends getBase() 의 매치 회피.
+    const fn_start = std.mem.indexOf(u8, r.output, "function _m_fn") orelse unreachable;
+    const body_open = std.mem.indexOfScalarPos(u8, r.output, fn_start, '{') orelse unreachable;
+    const body_close = std.mem.indexOfScalarPos(u8, r.output, body_open, '}') orelse unreachable;
+    const fn_body = r.output[body_open .. body_close + 1];
+    // _m_fn body 안에 `getBase()` 가 inline 되면 부작용 중복 (회귀).
+    try std.testing.expect(std.mem.indexOf(u8, fn_body, "getBase()") == null);
+    // prototype chain 통해 base 참조
+    try std.testing.expect(std.mem.indexOf(u8, fn_body, "Object.getPrototypeOf(D.prototype)") != null);
+}
 
 // nested class: standalone fn 안의 *inner* class body 의 `super.x` 는
 // inner class lexical context 가 valid 하므로 inner super 로 lowering 돼야 한다.

--- a/src/transformer/es2015_class/super_props.zig
+++ b/src/transformer/es2015_class/super_props.zig
@@ -296,11 +296,34 @@ pub fn SuperProps(comptime Transformer: type) type {
             return es_helpers.makeStaticMember(self, global_root, proto_ref, span);
         }
 
+        /// V8 정밀 fix: extends 가 non-identifier (e.g. `extends getBase()`) 일 때
+        /// `Object.getPrototypeOf(<ClassName>.prototype)` 형태로 emit — class declaration
+        /// 시 고정된 prototype chain 을 1회 참조로 활용.
+        fn buildSuperBaseViaProtoChain(self: *Transformer, class_name_span: Span, span: Span) Transformer.Error!NodeIndex {
+            // base = ClassName.prototype (instance) / ClassName (static)
+            const class_ref = try self.makeIdentifierRefWithSymbol(class_name_span, self.current_super_class_old_idx);
+            const arg = if (self.current_super_is_static) class_ref else blk: {
+                const proto_prop = try es_helpers.makeIdentifierRef(self, "prototype");
+                break :blk try es_helpers.makeStaticMember(self, class_ref, proto_prop, span);
+            };
+            // Object.getPrototypeOf(arg) — V6 와 동일하게 globalThis.Object 사용해 user shadow 차단.
+            const global_ref = try es_helpers.makeIdentifierRef(self, "globalThis");
+            const object_ref = try es_helpers.makeIdentifierRef(self, "Object");
+            const get_proto_ref = try es_helpers.makeIdentifierRef(self, "getPrototypeOf");
+            const global_object = try es_helpers.makeStaticMember(self, global_ref, object_ref, span);
+            const callee = try es_helpers.makeStaticMember(self, global_object, get_proto_ref, span);
+            return es_helpers.makeCallExpr(self, callee, &.{arg}, span);
+        }
+
         fn buildSuperBaseRef(self: *Transformer, span: Span) Transformer.Error!NodeIndex {
             const super_class_span = self.current_super_class orelse {
                 // non-derived class — fallback to spec home object [[Prototype]]
                 return buildNonDerivedSuperBase(self, span);
             };
+            // V8: extends 가 non-identifier 일 때 raw text inline 대신 prototype chain 통해 참조
+            if (self.current_super_via_proto_chain) {
+                return buildSuperBaseViaProtoChain(self, super_class_span, span);
+            }
             if (self.current_super_is_static) {
                 return self.makeIdentifierRefWithSymbol(super_class_span, self.current_super_class_old_idx);
             }

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -298,10 +298,11 @@ pub fn ES2022(comptime Transformer: type) type {
             // 하고 current_private_* 를 호출자가 set/restore 한다(이중-visit 회피, decorator strip
             // 방지). fast path 는 false(기존 동작: visit + defer 복원).
             skip_visit_and_keep_private: bool,
-            // V1 fix (#3680 post-review): class_declaration 위치이면 static descriptor 를
-            // trailing_nodes 로 emit (class 뒤). class_expression 위치이면 false — expression
-            // context 라 trailing comma-stitching 발생하므로 pre_stmts 유지.
-            static_descriptors_trailing: bool,
+            // V1 정밀 fix (#3680 post-merge): static private field/method descriptor 를
+            // 별도 array 로 받음 — caller 가 emit 순서를 제어. null 이면 pre_stmts 에 그대로
+            // (기존 동작). non-null 이면 caller 가 class declaration 뒤, static block IIFE
+            // 앞에 emit 해야 한다 (receiver=D 가 init 후 평가 + IIFE 가 descriptor 참조 가능).
+            static_descriptors_out: ?*std.ArrayList(NodeIndex),
         ) Transformer.Error!bool {
             const body_node = self.ast.getNode(body_idx);
             const body_start = body_node.data.list.start;
@@ -392,15 +393,10 @@ pub fn ES2022(comptime Transformer: type) type {
                 self.current_private_fields = saved_private_fields;
             };
 
-            // V1 의 descriptor trailing reorder 는 revert: static block IIFE 가 descriptor 를
-            // 참조하는 경우 (예: `static { S.#n += 10 }`) IIFE 도 trailing 위치에 emit 되어
-            // descriptor 보다 *앞에* 평가되면서 `attempted to get private static field before
-            // its declaration` TypeError. 따라서 descriptor 는 pre_stmts 유지 (class 앞).
-            // 결과: descriptor 안 super.foo() 의 receiver `this` 가 module top-level 에서
-            // undefined 가 되는 spec 위반은 다시 노출되나, static block 사용 케이스 (실제 코드)
-            // 가 더 흔하다.
-            _ = static_descriptors_trailing;
-            const desc_target = pre_stmts;
+            // V1 정밀 fix: static descriptor 를 caller 가 지정한 별도 array 로 분리. caller 는
+            // class declaration 뒤, static block IIFE 앞에 emit 해야 한다. caller 가 별도 array
+            // 를 주지 않으면 (e.g. assign-semantics path) pre_stmts 사용 (기존 동작).
+            const desc_target = static_descriptors_out orelse pre_stmts;
             for (field_mappings.items, field_init_idx.items) |m, init_val| {
                 if (m.class_name) |cname| {
                     const cname_span = try self.ast.addString(cname);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -161,6 +161,16 @@ pub const Transformer = struct {
     /// property VALUE 위치는 enclosing class 의 super 를 그대로 사용해야 하므로
     /// object_expression dispatch 가 아닌 method_definition 진입 시에만 reset.
     in_object_literal_depth: u32 = 0,
+    /// V8 정밀 fix: `class D extends getBase()` 같은 non-identifier extends 의 super
+    /// lowering 시 `getBase().prototype.foo.call(this)` 형태로 inline 하면 super-prop
+    /// access 마다 extends 표현식 (getBase()) 이 재평가됨 (spec 위반 — class declaration
+    /// 시점에 1회만 평가되어야). 또한 hoisted `var _<n> = getBase()` 도 bundler
+    /// tree-shaker reachability graph 와 충돌. 해결: current_super_class 를 class 자체의
+    /// 이름으로 set 하고 이 flag 를 true 로 set → buildSuperBaseRef 가 instance 의 경우
+    /// `Object.getPrototypeOf(D.prototype)`, static 의 경우 `Object.getPrototypeOf(D)`
+    /// 형태로 emit. D 의 prototype chain 은 class declaration 시 고정되므로 1회 평가 보장
+    /// + bundler 도 D identifier 의 reference 추적이 자연스러움.
+    current_super_via_proto_chain: bool = false,
 
     /// ES2015 generator: labeled break/continue를 위한 label 스택.
     /// labeled_statement 진입 시 push, 퇴장 시 pop.

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -126,8 +126,10 @@ pub fn visitClassWithAssignSemantics(self: *Transformer, node: Node) Error!NodeI
             has_super,
             class_name_text,
             true, // skip_visit_and_keep_private — public member 는 classifyClassMember 가 단일 visit.
-            // V1 fix: class_declaration 위치이면 static descriptor trailing emit.
-            node.tag == .class_declaration,
+            // V1 정밀 fix: assign-semantics path 는 emit 흐름이 복잡 (decorator __decorateClass
+            // 호출과 얽힘) — 단순 분리로는 부족하니 별도 array 사용 안 하고 기존 pre_stmts 유지.
+            // descriptor 의 receiver=D TDZ 문제는 이 path 에서는 별도로 처리하지 않음 (덜 빈번).
+            null,
         );
         if (had_any) body_idx = new_body_pl;
     }

--- a/src/transformer/transformer/class_visit.zig
+++ b/src/transformer/transformer/class_visit.zig
@@ -33,17 +33,31 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         // F6: fast path 도 super_class 와 동시에 old_idx 를 set — 새 flag 로 fast path 에서도 super
         // lowering 이 활성화되니 symbol propagation (minify rename 등) 을 위해 필요.
         //
-        // V8 revert: extends 표현식이 non-identifier 일 때 temp 변수로 hoist 하던 동작을
-        // 되돌린다. hoisted `var _<n> = <super expr>` 가 bundler tree-shaker 의 reachability
-        // graph 에 포함되지 않아 RHS 의 reference (예: effect-ts 의 `TaggedError`) 가
-        // dead-code-eliminated → `TaggedError is not defined` ReferenceError. 정밀 fix
-        // (bundler reference 분석 강화 또는 hoist 를 linker 후 단계로 이동) 는 별도 PR.
-        // 결과: `extends getBase()` 의 side-effect 가 super-prop access 마다 중복 평가될 수
-        // 있는 V8 의 silent regression 은 다시 노출되지만, effect-ts 같은 실제 패키지의
-        // SyntaxError 보다 영향 범위가 작다.
+        // V8 정밀 fix: extends 가 non-identifier (e.g. `extends getBase()`) 이고 class 가
+        // named (class_declaration / named class_expression) 이면 super-prop lowering 이
+        // raw extends text 를 매 access 마다 inline 하지 않도록 — current_super_class 를
+        // class 자체의 이름으로 set 하고 `current_super_via_proto_chain=true` 로 mark.
+        // buildSuperBaseRef 가 이 flag 보고 `Object.getPrototypeOf(<ClassName>.prototype)`
+        // 형태로 emit → extends 표현식 1회만 평가됨 (spec) + bundler tree-shake 자연스러움.
+        // anonymous class_expression 은 class 자체에 referenceable name 이 없어 fallback
+        // (기존 raw extends text inline; side-effect 중복 가능하나 anon class extends getBase()
+        // + private member 조합 자체가 극히 드묾).
+        const saved_super_via_proto_chain = self.current_super_via_proto_chain;
+        self.current_super_via_proto_chain = false;
+        defer self.current_super_via_proto_chain = saved_super_via_proto_chain;
         if (!super_idx.isNone()) {
-            self.current_super_class = self.ast.getNode(super_idx).span;
-            self.current_super_class_old_idx = super_idx;
+            const super_node = self.ast.getNode(super_idx);
+            const is_simple_id = super_node.tag == .identifier_reference or super_node.tag == .binding_identifier;
+            // class self name: raw_name_idx (source 의 binding) 우선, 없으면 visit 결과 new_name.
+            const class_name_span_opt: ?Span = self.getClassNameSpan(raw_name_idx) orelse self.getClassNameSpan(new_name);
+            if (!is_simple_id and class_name_span_opt != null) {
+                self.current_super_class = class_name_span_opt;
+                self.current_super_class_old_idx = if (!raw_name_idx.isNone()) raw_name_idx else NodeIndex.none;
+                self.current_super_via_proto_chain = true;
+            } else {
+                self.current_super_class = super_node.span;
+                self.current_super_class_old_idx = super_idx;
+            }
         } else {
             self.current_super_class = null;
             self.current_super_class_old_idx = .none;
@@ -100,6 +114,12 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         var had_private_methods = false;
         var had_private_fields = false;
 
+        // V1 정밀 fix: static descriptor 를 별도 array 로 받아 *class declaration 뒤,
+        // static block IIFE 앞* 에 emit 한다 (receiver=D 가 init 후 평가되도록 + IIFE 가
+        // descriptor 참조 가능하도록).
+        var static_descriptors: std.ArrayList(NodeIndex) = .empty;
+        defer static_descriptors.deinit(self.allocator);
+
         if (lower_pm or lower_pf) {
             const has_super = !self.readNodeIdx(e, 1).isNone();
             const class_name_text: ?[]const u8 = if (self.getClassNameSpan(new_name)) |s|
@@ -107,6 +127,10 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
             else
                 null;
             var new_body: NodeIndex = .none;
+            // class_declaration 위치에서만 별도 array 사용 (class_expression 은 expression
+            // context 라 별도 statement emit 불가 — pre_stmts 유지).
+            const desc_out: ?*std.ArrayList(NodeIndex) =
+                if (node.tag == .class_declaration) &static_descriptors else null;
             const had_any = try es2022.ES2022(Transformer).lowerPrivateMembers(
                 self,
                 current_body_idx,
@@ -120,8 +144,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
                 has_super,
                 class_name_text,
                 false, // fast path 는 lowerPrivateMembers 가 통째 visit + 복원 (기존 동작).
-                // V1 fix: class_declaration 위치이면 static descriptor 를 trailing 으로 emit.
-                node.tag == .class_declaration,
+                desc_out,
             );
             if (had_any) {
                 current_body_idx = new_body;
@@ -179,6 +202,11 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
                     try self.pending_nodes.append(self.allocator, stmt);
                 }
                 try self.pending_nodes.append(self.allocator, class_result);
+                // V1 정밀 fix: static descriptor 는 class 뒤, static block IIFE 앞에 emit.
+                // receiver=D 가 init 후 평가됨 + IIFE 가 descriptor (_n 등) 참조 가능.
+                for (static_descriptors.items) |desc| {
+                    try self.pending_nodes.append(self.allocator, desc);
+                }
                 for (static_block_iifes.items) |iife| {
                     try self.pending_nodes.append(self.allocator, iife);
                 }
@@ -211,6 +239,11 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
                 try self.pending_nodes.append(self.allocator, stmt);
             }
             try self.pending_nodes.append(self.allocator, class_result);
+            // V1 정밀 fix: static descriptor 를 class 뒤에 emit (static block 없이 private
+            // member 만 있는 경로).
+            for (static_descriptors.items) |desc| {
+                try self.pending_nodes.append(self.allocator, desc);
+            }
             return .none;
         }
 


### PR DESCRIPTION
## 배경

PR #3724 (revert) 의 동작은 그대로 유지하면서, V1/V8 의 원본 의도 (spec-correct lowering) 를 **다른 메커니즘으로 복구**.

## V8 정밀 fix — extends 표현식 평가 1회 보장 (spec) + bundler 호환

| | 이전 (V8 origin) | revert 이후 | 이 PR |
|--|-----------------|-------------|-------|
| **lowering 형태** | `var _<n> = getBase(); class D extends _<n>{}` + `_<n>.prototype.foo.call(this)` | `class D extends getBase(){}` + `getBase().prototype.foo.call(this)` | `class D extends getBase(){}` + `Object.getPrototypeOf(D.prototype).foo.call(this)` |
| **`getBase()` 평가** | 1회 | super-prop access 마다 (spec 위반) | 1회 (class declaration 위치) |
| **bundler tree-shake** | hoisted var 가 reference graph 누락 → effect-ts breakage | 영향 없음 | 영향 없음 (extends raw 그대로) |
| **spec** | OK (단 bundler breakage) | 위반 (silent regression) | OK |

구현:
- `Transformer.current_super_via_proto_chain: bool` 신설
- `visitClass` 가 extends 가 non-identifier 이고 class 가 named 이면 `current_super_class` 를 *class 자체의 이름* 으로 set + flag true
- `buildSuperBaseRef` 가 flag 보고 instance: `Object.getPrototypeOf(<ClassName>.prototype)`, static: `Object.getPrototypeOf(<ClassName>)` emit

## V1 정밀 fix — descriptor 위치 control

| | 이전 (V1 origin) | revert 이후 | 이 PR |
|--|-----------------|-------------|-------|
| **descriptor 위치** | trailing_nodes (모든 후행 statement 뒤) | pre_stmts (class 앞) | 별도 array → class 뒤 + IIFE 앞 |
| **receiver=D TDZ** | 회피 (단 IIFE 충돌) | 회귀 (this=undefined) | 회피 |
| **IIFE descriptor 참조** | 깨짐 (descriptor 가 IIFE 뒤) | OK | OK |

구현:
- `lowerPrivateMembers` signature 에 `static_descriptors_out: ?*std.ArrayList(NodeIndex)` 추가
- `class_visit.zig` (fast path) 가 class_declaration 위치이면 별도 array 로 받음
- emit 순서: `static_key_memos → pre_stmts → class_result → static_descriptors → static_block_iifes`
- `class_decorator.zig` (assign-semantics path) 는 emit 흐름 복잡으로 `null` 전달 (기존 동작 유지)

## 검증

| 시나리오 | 결과 |
|---------|-----|
| `effect-ts` E2E bundle → node | `43` (정답) — TaggedError 정상 |
| `static block + private static field` | `28` (정답) — TDZ 없음 |
| V8 회귀 케이스 (`extends getBase()`) | `X|X count=1` (spec 정답, count 중복 없음) |
| V1 케이스 (`static #x = super.factor()`) | `D` (정답) — receiver=class 식별자 |
| 원본 #3680 repro | `base` (정답, 회귀 없음) |

자동화:
- `zig build test` 전체 통과
- `tests/integration/downlevel-edge` 0 fail
- V1/V8 회귀 테스트 복구 (assertion 갱신)

## Test plan

- [x] effect-ts bundle direct reproduction → node `43`
- [x] downlevel-edge static block + private static field → node `28`
- [x] V8 회귀 케이스 spec 검증 (count=1)
- [x] V1 케이스 receiver=D 검증
- [x] zig build test 전체 + integration 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)