### PR TITLE
fix(bundler): manualChunks 흡수 후 빈 entry chunk 가 placeholder 치환 누락

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -1741,18 +1741,28 @@ fn resolveContentHashes(
 ) !void {
     if (outputs.len == 0) return;
 
-    // 1단계: 각 청크의 placeholder hash와 content hash를 계산
+    // 1단계: 각 청크의 placeholder hash와 content hash를 계산.
+    // emitChunks 가 `chunk.modules.items.len == 0` 청크(mergeSmallChunks /
+    // manualChunks 흡수 후 빈 entry chunk 등)를 skip 하므로 sorted_indices
+    // 와 outputs 는 1:1 이 아니다. *비어있지 않은* 청크만 outputs 순서대로
+    // 매칭해야 path 의 placeholder 가 올바른 chunk index hash 로 빌드되어
+    // 치환된다.
     var infos = try allocator.alloc(PlaceholderInfo, outputs.len);
     defer allocator.free(infos);
 
-    for (sorted_indices, 0..) |ci, out_idx| {
+    var chunks_to_outputs = try allocator.alloc(usize, outputs.len);
+    defer allocator.free(chunks_to_outputs);
+
+    var out_idx: usize = 0;
+    for (sorted_indices) |ci| {
         if (out_idx >= outputs.len) break;
         const chunk = &chunk_graph.chunks.items[ci];
+        if (chunk.modules.items.len == 0) continue;
 
         buildPlaceholder(chunk, &infos[out_idx].placeholder);
-
-        // content hash 계산
         contentHash(outputs[out_idx].contents, &infos[out_idx].real_hash);
+        chunks_to_outputs[out_idx] = ci;
+        out_idx += 1;
     }
 
     // 2단계: 모든 출력에서 모든 placeholder를 content hash로 단일패스 치환.
@@ -1775,17 +1785,16 @@ fn resolveContentHashes(
 
     // 3단계: imports 메타 채우기 (rolldown `chunk.imports` 호환).
     // path 가 content-hash 까지 확정된 이후에 각 chunk 의 cross_chunk_imports 를
-    // 최종 filename 배열로 변환. chunk idx → output idx 역매핑으로 O(N) lookup.
+    // 최종 filename 배열로 변환. 1단계의 `chunks_to_outputs` (out_idx → chunk_idx)
+    // 를 역매핑해 빈 청크 skip 과 일관된 매핑을 유지한다.
     var chunk_to_out = try allocator.alloc(?usize, chunk_graph.chunks.items.len);
     defer allocator.free(chunk_to_out);
     @memset(chunk_to_out, null);
-    for (sorted_indices, 0..) |ci, out_idx| {
-        if (out_idx >= outputs.len) break;
-        chunk_to_out[ci] = out_idx;
+    for (chunks_to_outputs[0..out_idx], 0..) |ci, oi| {
+        chunk_to_out[ci] = oi;
     }
 
-    for (sorted_indices, 0..) |ci, out_idx| {
-        if (out_idx >= outputs.len) break;
+    for (chunks_to_outputs[0..out_idx], 0..) |ci, oi| {
         const chunk = &chunk_graph.chunks.items[ci];
         if (chunk.cross_chunk_imports.items.len == 0) continue;
 
@@ -1798,7 +1807,7 @@ fn resolveContentHashes(
             const dep_out = chunk_to_out[@intFromEnum(dep_ci)] orelse continue;
             try imps.append(allocator, try allocator.dupe(u8, outputs[dep_out].path));
         }
-        outputs[out_idx].imports = try imps.toOwnedSlice(allocator);
+        outputs[oi].imports = try imps.toOwnedSlice(allocator);
     }
 }
 

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -213,7 +213,10 @@ pub fn emitChunks(
 
     for (sorted_indices) |ci| {
         const chunk = &chunk_graph.chunks.items[ci];
-        // mergeSmallChunks 로 비워진 청크는 출력하지 않는다(entry 는 비지 않음).
+        // 비워진 청크는 출력하지 않는다 — mergeSmallChunks 가 비운 common 청크,
+        // manualChunks 가 모듈을 흡수해 비어버린 entry 청크 모두 포함. 동일한
+        // skip 이 resolveContentHashes 에서도 반복돼야 outputs↔sorted_indices
+        // 매핑이 어긋나지 않는다 (placeholder 치환 누락 회귀 가드).
         if (chunk.modules.items.len == 0) continue;
 
         var chunk_output: std.ArrayList(u8) = .empty;
@@ -1767,15 +1770,21 @@ fn resolveContentHashes(
 
     // 2단계: 모든 출력에서 모든 placeholder를 content hash로 단일패스 치환.
     // O(N*M) → O(M) (M=content 길이, N=청크 수).
+    // `infos[0..out_idx]` 슬라이스로 매칭 — 빈 청크 skip 으로 미초기화 trailing
+    // entry 가 생기는 경우(현재 invariant 상 미발생, 미래 predicate drift 가드)
+    // 가 replaceAllPlaceholders 의 byte-window 매칭에서 garbage 와 충돌해 silent
+    // corruption 을 일으키지 않게 한다. chunks_to_outputs[0..out_idx] 슬라이싱과
+    // 동형.
     const ph_total = HASH_PLACEHOLDER_PREFIX.len + HASH_PLACEHOLDER_LEN;
+    const infos_init = infos[0..out_idx];
     for (outputs) |*out| {
         // contents: 모든 placeholder를 한 번의 스캔으로 치환
-        const new_contents = try replaceAllPlaceholders(allocator, out.contents, infos, ph_total);
+        const new_contents = try replaceAllPlaceholders(allocator, out.contents, infos_init, ph_total);
         allocator.free(out.contents);
         out.contents = new_contents;
 
         // path도 동일하게 치환
-        const new_path = try replaceAllPlaceholders(allocator, out.path, infos, ph_total);
+        const new_path = try replaceAllPlaceholders(allocator, out.path, infos_init, ph_total);
         allocator.free(out.path);
         out.path = new_path;
 

--- a/tests/integration/tests/runtime-helper-virtual-module.test.ts
+++ b/tests/integration/tests/runtime-helper-virtual-module.test.ts
@@ -52,8 +52,12 @@ describe('runtime helper virtual module (#1961)', () => {
 
     const fs = await import('node:fs');
     const files = fs.readdirSync(outDir).filter((f) => f.endsWith('.js'));
+    // dynamic chunk(`greet`) 와 common helper chunk 는 모두 chunk_names 패턴
+    // `[name]-[hash]` (Rollup parity, F5 post-review). stem 으로 찾는다.
+    const greetName = files.find((f) => f === 'greet.js' || f.startsWith('greet-'));
+    expect(greetName).toBeDefined();
     const main = fs.readFileSync(join(outDir, 'main.js'), 'utf8');
-    const greet = fs.readFileSync(join(outDir, 'greet.js'), 'utf8');
+    const greet = fs.readFileSync(join(outDir, greetName!), 'utf8');
 
     const helperChunkName = files.find((f) => f.startsWith('chunk-'));
     expect(helperChunkName).toBeDefined();


### PR DESCRIPTION
## 요약

`manualChunks` 가 entry 모듈을 별도 청크로 흡수하면 원래 entry chunk 가
modules 0개로 비어버립니다. `emitChunks` 는 빈 청크를 skip 해 output 을
만들지 않지만 `resolveContentHashes` 는 `sorted_indices[i] ↔ outputs[i]`
1:1 매핑을 가정해 placeholder 를 빌드합니다.

결과: 빈 청크 index 의 modules-hash 로 `info[0]` 이 채워지고, 실제 `outputs[0]`
의 path 에 들어간 placeholder(manual chunk modules-hash 기반)와 매칭이 안 됨
→ raw `\x00ZHd77380a4` (NUL + ZH + 8 hex) 가 path 에 leak → 파일시스템
NUL byte path 거부로 write 실패.

이번 회귀는 `manualChunks NAPI bridge` 두 가드와 `runtime-helper-virtual-module`
세 테스트로 노출됐습니다:

```
(fail) manualChunks NAPI bridge > 버그픽스: manualChunks 병합된 동적 import 대상은 namespace 스냅샷으로 재작성
(fail) manualChunks NAPI bridge > 버그픽스: 병합된 동적 대상의 타-청크 re-export 는 크래시 없이 제외(.local 정상)
(fail) runtime helper virtual module (#1961) > dynamic chunk async/await + target=es5: __generator/__async 가 named import 으로 분배
```

## 수정

### 1. `resolveContentHashes` 가 빈 청크 skip — outputs 순서 일관성 (src/bundler/emitter/chunks.zig)

`emitChunks` 의 line 217 skip 과 동일한 predicate (`chunk.modules.items.len == 0`)
를 `resolveContentHashes` 에도 적용. 새 `chunks_to_outputs` (out_idx → chunk_idx)
배열을 1단계에서 빌드해 3단계 imports 메타에서도 재사용 — 동일 패턴 버그가
imports 메타에도 잠재했습니다.

추가 가드:
- 2단계 `replaceAllPlaceholders` 호출 시 `infos[0..out_idx]` 슬라이스 — 미래
  predicate drift 시 trailing uninit entry 가 byte-window 매칭과 충돌해 silent
  corruption 을 일으키지 않게 함 (cheap defense, 기존 `chunks_to_outputs[0..out_idx]`
  슬라이싱과 동형).
- line 216 comment 갱신 — `entry 는 비지 않음` → `manualChunks 흡수 후 entry
  도 빌 수 있음` 명시.

### 2. runtime-helper-virtual-module 테스트 update (tests/integration/tests/runtime-helper-virtual-module.test.ts)

`d1b57b12` (F5 post-review) 가 dynamic chunk 를 `chunkNames` (default
`[name]-[hash]`) 로 routing (Rollup parity, 의도된 breaking). 테스트가 literal
`greet.js` 를 읽어 ENOENT — stem-prefix 탐색 (`greet.js` 또는 `greet-*`) 으로
변경.

## Zig 초보자 노트

- `chunk_graph.chunks.items` 는 원본 청크 배열, `sorted_indices` 는 entry→common
  순으로 정렬된 인덱스 배열. 이 인덱스가 emit 의 *생성 순서* 와 같지만, 빈 청크
  skip 때문에 outputs 의 *저장* 순서와 어긋날 수 있습니다.
- placeholder = `\x00ZH` + 8 hex (chunk modules 기반 hash). 청크별로 유일해야
  path/content/sourcemap 어디서 만나도 정확히 그 청크의 최종 content-hash 로
  치환됩니다.
- `allocator.alloc(T, n)` 은 zero-init 가 아닙니다 — 호출 측에서 명시적으로
  쓰지 않으면 garbage. 슬라이스로 사용 범위를 좁히는 게 안전합니다.

## 검증

- tests/integration/tests/manual-chunks.test.ts 44/44 pass (회귀 가드 2건 포함)
- tests/integration/tests/runtime-helper-virtual-module.test.ts 2/2 pass
- `zig build test` exit 0
- broader `bun test` 3884 pass — 별개 23 TSC class snapshot fail 은 `runZntc`
  (CLI transpile) 경유 transformer #3680 follow-up 영역이라 chunk emit 과 무관

## 코드 리뷰

`/code-review max` 적용 결과:
- F1 (infos uninit, REFUTED today but PLAUSIBLE on predicate drift) → cheap
  defense `infos[0..out_idx]` 슬라이스 반영
- F3 (`chunk_to_out[@intFromEnum(dep_ci)]` OOB) → REFUTED. `getModuleChunk` +
  `isNone()` 가드로 `ChunkIndex.none` 도달 차단 확인 (chunk.zig:1264/1397/1456/1474)
- stale comment → 갱신
- 나머지(test predicate fragility, dead break, missing regression) → manual-chunks.test.ts
  의 기존 2건이 핵심 회귀 가드로 작동하므로 추가 작업 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)