### PR TITLE
fix(bundler): namespace getter dangling 부분 fix — isLocalBindingAlive rename suffix fallback

### DIFF
--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -515,11 +515,51 @@ pub const Module = struct {
     /// `local_name` 으로 module-scope binding 을 찾아 declaration stmt reachability
     /// 검사. semantic / scope_maps 가 없으면 true. namespace getter 빌더 (esm_wrap,
     /// shared_namespace) 가 사용.
+    ///
+    /// `local_name` 이 *post-rename final name* (e.g. cross-module collision 회피 후
+    /// `counter$4`) 인 경우 scope_maps lookup 이 fail (scope_maps 는 source name index).
+    /// fallback 으로 root-scope symbol 들의 nameText 와 비교 — symbol.nameText 가
+    /// rename 결과를 반영하므로 final name 매칭 가능. 이 fallback 이 없으면 namespace
+    /// getter 가 dead declaration 을 reference (effect-ts 의 `counter$4 is not defined`
+    /// 회귀 케이스).
     pub fn isLocalBindingAlive(self: *const Module, local_name: []const u8) bool {
         const sem = self.semantic orelse return true;
         if (sem.scope_maps.len == 0) return true;
-        const sym_idx = sem.scope_maps[0].get(local_name) orelse return true;
-        return self.isStatementAliveBySym(sym_idx);
+        if (sem.scope_maps[0].get(local_name)) |sym_idx| {
+            return self.isStatementAliveBySym(sym_idx);
+        }
+        // Fallback 1: scope_maps lookup 실패 (post-rename name 등). root-scope symbol 들의
+        // nameText 와 비교. symbol.nameText 가 rename 결과를 반영하므로 final name 매칭.
+        for (sem.symbols.items, 0..) |sym, i| {
+            if (!sym.scope_id.isNone()) {
+                if (sym.scope_id.toIndex() != 0) continue;
+            }
+            const name = self.symbolText(&sym) orelse continue;
+            if (std.mem.eql(u8, name, local_name)) {
+                return self.isStatementAliveBySym(i);
+            }
+        }
+        // Fallback 2: cross-module collision avoidance suffix (`$N`) 제거 후 다시 scope_maps
+        // lookup. effect-ts 같이 다른 module 의 동일 export 와 충돌해 `counter$4` 같이 rename
+        // 된 경우 — original `counter` 가 scope_maps 에 있어 정확한 reachability 판정 가능.
+        var trimmed = local_name;
+        if (std.mem.lastIndexOfScalar(u8, local_name, '$')) |dollar_idx| {
+            const tail = local_name[dollar_idx + 1 ..];
+            var all_digits = tail.len > 0;
+            for (tail) |c| {
+                if (c < '0' or c > '9') {
+                    all_digits = false;
+                    break;
+                }
+            }
+            if (all_digits) trimmed = local_name[0..dollar_idx];
+        }
+        if (!std.mem.eql(u8, trimmed, local_name)) {
+            if (sem.scope_maps[0].get(trimmed)) |sym_idx| {
+                return self.isStatementAliveBySym(sym_idx);
+            }
+        }
+        return true; // 모두 실패 — conservative true (false negative 회피)
     }
 
     /// exported_name으로 ExportBinding을 찾는다. #1338 Phase 4c-1 Export Registry.


### PR DESCRIPTION
## 배경 (effect-ts bundle 회귀 추가 진단)

PR #3727 (useDefineForClassFields fix) 후에도 effect-ts bundle 실행 시 `ReferenceError: counter\$4 is not defined` 잔존. namespace getter (`metric_ns`) 의 일부 property 가 dangling — declaration 이 dead-code-eliminated 됐는데 getter 는 emit.

## Root cause

`shared_namespace.zig:buildInlineObjectStr` 가 `isLocalBindingAlive(exp.local)` 로 alive 검사 후 getter emit. `exp.local` 은 *post-rename final name* (cross-module collision 회피 후 `counter\$4`, `tagMetrics\$1` 등). 그러나 `isLocalBindingAlive` 의 `sem.scope_maps[0]` 은 *original source name* index — post-rename lookup → 항상 fail → fallback `true` 반환 → dead getter 가 dangling reference 와 함께 emit.

**Debug 결과**:
```
[lba] mod=Effect.js name=tagMetrics$1 → no match, fallback=true
[lba] mod=Effect.js name=labelMetrics$1 → no match, fallback=true
[lba] mod=Effect.js name=withMetric$1 → no match, fallback=true
```

## Fix (`isLocalBindingAlive`)

두 단계 fallback 추가:

1. **symbolText 비교**: root-scope symbol 의 nameText 와 `local_name` 직접 비교. symbol.nameText 가 rename 결과를 반영하는 경우 final name 매칭 가능.
2. **rename suffix 제거**: `\$<digits>` suffix 제거 후 scope_maps 재 lookup. `counter\$4` → `counter` → 원본 sym_idx → 정확한 reachability 판정.

## 효과

- effect-ts bundle size: **188KB → 163KB** (~13% 감소, dead getter 제거)
- 다른 module 의 dangling getter 일부 제거 확인
- 회귀 0 — 단순 namespace + rename suffix 케이스 (`A.counter` vs `B.counter`) 정상 emit 유지

## Known follow-up (이 PR scope 외)

`counter\$4` 의 declaration (Metric.js:54 `export const counter = internal.counter`) 자체는 여전히 dead emit. 즉 이 PR 의 fix 가 *dead getter 제거* 는 부분적으로 해결하지만, *alive 처리되어야 할 getter (실제 source 에서 호출 — `metric_ns.counter("...")`) 의 declaration keep* 은 별도 issue — tree-shaker BFS seed 에 namespace getter 내 reference 포함되지 않음.

추가 작업 필요:
- Tree-shaker 가 namespace getter object 합성 결과를 인식 → getter 내 reference 도 reachable seed 로 처리.
- 또는 emitter 의 skip_nodes 적용 후 namespace getter 가 reference 하는 declaration 을 unskip.

## 검증

- `zig build test` 전체 통과
- `tests/integration` downlevel/super 그룹 429건 회귀 0
- effect-ts bundle: 일부 dangling 제거 (`counter\$4` 잔존은 별개 issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)