### PR TITLE
fix(bundler): tree_shaker_active mirror — namespace getter dangling 정확 elide

### DIFF
--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -317,6 +317,10 @@ pub const Module = struct {
     /// `TreeShaker.analyze` 가 finalize 후 set. 기본 false 라 tree-shaking 비활성 시
     /// 의미 없음 — chunk gen 단계에서도 `m.side_effects or entry_set.isSet` 으로 항상 alive 처리.
     is_included: bool = false,
+    /// counter$4 fix: tree_shaker.analyze 가 finalize 시점에 mirror — true 면 tree-shaker 가
+    /// active 라 `is_included`/`reachable_stmts` 가 의미 있다. false 면 tree_shaking=false /
+    /// dev_mode → 두 field 의 default 가 false/null 이라 잘못 dead 판정하면 안 됨 (fallback alive).
+    tree_shaker_active: bool = false,
     /// 이 모듈의 statement-level reachability bitset. tree_shaker 가 mirror 한 borrowed
     /// 참조 — owner 는 `TreeShaker.reachable_stmts`. tree_shaker.deinit 후엔 dangling
     /// 이므로 mangle / link 단계에서만 사용. null 이면 tree-shake 미수행 / 정보 없음.
@@ -506,7 +510,17 @@ pub const Module = struct {
     /// borrowed pointer 가 dangling — caller 가 lifetime 관리.
     pub fn isStatementAliveBySym(self: *const Module, sym_idx: usize) bool {
         const s2s = self.symbol_to_stmt orelse return true;
-        const rs = self.reachable_stmts orelse return true;
+        // counter$4 진짜 root cause: tree-shaker BFS 가 module 별 reachable_stmts 를 lazy-init
+        // (seed 된 module 만). seed 안 된 module 은 reachable_stmts=null — *그 module 의 어떤
+        // stmt 도 reachable 표시 안 됐다는 의미*.
+        // tree_shaker_active=true 케이스: rs=null 이면 module 자체가 BFS 에서 unreached →
+        //   진짜 dead. fallback true 는 false positive (namespace getter dangling 원인).
+        // tree_shaker_active=false 케이스 (tree_shaking=false / dev_mode): 모든 module 의 rs=null
+        //   이지만 *모두 alive*. fallback true 가 정답.
+        const rs = self.reachable_stmts orelse {
+            if (self.tree_shaker_active) return false; // active + unreached = dead
+            return true; // inactive — fallback alive
+        };
         if (sym_idx >= s2s.len) return true;
         const stmt_idx = s2s[sym_idx] orelse return true;
         return stmt_idx >= rs.capacity() or rs.isSet(stmt_idx);
@@ -523,13 +537,11 @@ pub const Module = struct {
     /// getter 가 dead declaration 을 reference (effect-ts 의 `counter$4 is not defined`
     /// 회귀 케이스).
     pub fn isLocalBindingAlive(self: *const Module, local_name: []const u8) bool {
-        // counter$4 진짜 fix: tree-shaker 가 active (reachable_stmts non-null) 일 때
-        // module 자체가 included=false 면 어떤 stmt 도 emit 안 됨 → 모든 binding dead.
-        // 이전엔 stmt-level reachable 만 봤지만 module 전체 drop 케이스 (effect-ts 의
-        // `internal/metric.js` 가 namespace 합성 후 module 자체 drop) 에서 false negative.
-        // tree-shaker 비활성 (tree_shaking=false / dev_mode) 면 is_included default false 라
-        // 잘못 dead 표시 — reachable_stmts 가 set 됐을 때만 included 체크.
-        if (self.reachable_stmts != null and !self.is_included) return false;
+        // counter$4 진짜 fix: tree_shaker_active && !is_included 면 module 자체가 emit 안 됨 →
+        // 모든 binding dead. 이전엔 stmt-level reachable 만 봤지만 module 전체 drop 케이스
+        // (effect-ts 의 `internal/metric.js` 가 namespace 합성 후 module 자체 drop) 에서
+        // false negative — namespace getter 가 dangling.
+        if (self.tree_shaker_active and !self.is_included) return false;
         const sem = self.semantic orelse return true;
         if (sem.scope_maps.len == 0) return true;
         if (sem.scope_maps[0].get(local_name)) |sym_idx| {

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -677,6 +677,11 @@ pub const TreeShaker = struct {
             for (0..mod_count) |i| {
                 const m = self.moduleAtMut(@intCast(i)) orelse continue;
                 m.is_included = self.included.isSet(i);
+                // counter$4 fix: tree_shaker_active=true mirror — isStatementAliveBySym /
+                // isLocalBindingAlive 가 reachable_stmts=null + is_included=false 케이스를
+                // *진짜 dead* 로 처리하기 위한 신호. tree_shaking=false 면 이 mirror 자체가
+                // 안 일어나서 default false 유지.
+                m.tree_shaker_active = true;
                 m.reachable_stmts = if (i < self.reachable_stmts.len) blk: {
                     if (self.reachable_stmts[i]) |*rs| break :blk rs;
                     break :blk null;


### PR DESCRIPTION
## 배경

PR #3730 (is_included 체크) 이 dev_mode/tree_shaking=false 케이스를 `reachable_stmts==null` 가드로 보호했으나, *tree_shaker active + module 자체 unreached* 케이스는 여전히 두 field 모두 default 값이라 dead 판정 불가 — `isStatementAliveBySym` 가 fallback `true` → namespace getter dangling.

## Root cause (debug 결과)

```
[ns2] target_mod=84 exp.local=counter$4 init_mod=null
      decl_mod_path=internal/metric.js
      decl_mod.is_included=false alive=true
```

`internal/metric.js` 가:
- tree-shaker active (전체 BFS 돌렸음)
- module 자체는 *unreached* (`is_included=false`)
- BFS 가 그 module 의 `reachable_stmts` lazy-init 안 함 → `null`

기존 fallback `rs orelse return true` 가 이 case 와 *tree_shaker 비활성* (dev_mode) 케이스 구분 못함.

## Fix

`Module.tree_shaker_active: bool` 신설. `TreeShaker.analyze` finalize mirror loop 가 모든 module 에 true 로 set. tree_shaking=false / dev_mode 면 mirror 자체가 안 일어나서 default false.

- `isStatementAliveBySym`: rs=null + `tree_shaker_active` → **dead** (실제 unreached)
- `isStatementAliveBySym`: rs=null + 비활성 → fallback alive
- `isLocalBindingAlive`: 진입 시 `tree_shaker_active && !is_included` → dead

## 효과 (PR 누적)

| | bundle size |
|--|-------------|
| pre-fix | 188 KB |
| PR #3729 (rename suffix) | 163 KB |
| PR #3730 (is_included) | 163 KB (가드만 — fallback 미진입) |
| **이 PR** | **129 KB** (-31%) |

## Known follow-up (이 PR scope 외)

`counter\$4` 호출 (`fiberRuntime` 의 `metric.counter("...")`) 자체가 reachable 인 경우 — declaration 도 keep 해야 spec correct. tree-shaker BFS 가 namespace import target 의 모든 export 의 stmt 를 reachable seed 하도록 강화 필요. 이 PR 은 *dangling getter 제거* 만 처리하며 *호출 reachable + declaration unreached* mismatch 는 별도 추적.

## 검증

- `zig build test` 전체 통과 (tree_shaking=false 케이스 `react_native inlineRequires: namespace import from export-star barrel initializes source getters` 등 보존)
- `tests/integration` downlevel/super 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)