### PR TITLE
fix(bundler): linker namespace analyzer empty 결과 fallback (counter$4 진짜 root fix)

### DIFF
--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -421,8 +421,57 @@ pub fn resyncAfterAstMutation(
         // 등) 이 정식 import 노드로 대체됐다 — post-transform AST 에서 일반 binding 으로
         // 추출되므로 previous 에서 따로 보존할 synthetic binding 이 없다.
         const helper_refs: ?[]const u32 = if (module.transform_cache) |cache| cache.helper_ref_nodes else null;
+
+        // counter$4 진짜 근본 fix: 1차 (parse 단계 parser_metadata.zig) 의
+        // collectNamespaceAccesses 결과를 local→props 맵으로 백업. transformer 가
+        // `metric.counter(...)` 같은 namespace access 를 inline / helper substitution 으로
+        // 변형하면 2차 collectNamespaceAccesses (post-transform AST 기반) 가 못 잡아
+        // `namespace_used_properties=&.{}` (length=0) 로 reset → tree-shake 가 그 module 의
+        // export reachable seed 안 함 → namespace getter dangling (effect-ts 의
+        // `counter$4 is not defined`). 1차 가 잡은 props 를 2차 결과와 union 으로 keep.
+        var prev_props_map = std.StringHashMapUnmanaged([]const []const u8){};
+        defer prev_props_map.deinit(arena_alloc);
+        for (module.import_bindings) |ib_prev| {
+            if (ib_prev.kind != .namespace) continue;
+            if (ib_prev.namespace_used_properties) |props| {
+                if (props.len > 0) {
+                    prev_props_map.put(arena_alloc, ib_prev.local_name, props) catch continue;
+                }
+            }
+        }
+
         module.import_bindings = try binding_scanner_mod.extractImportBindings(arena_alloc, ast, module.import_records, helper_refs);
         try binding_scanner_mod.collectNamespaceAccesses(arena_alloc, ast, module.import_bindings);
+
+        // 1차 결과와 union: 2차 가 못 잡은 access 도 keep.
+        for (module.import_bindings) |*ib_new| {
+            if (ib_new.kind != .namespace) continue;
+            const new_props = ib_new.namespace_used_properties orelse continue;
+            const prev_props = prev_props_map.get(ib_new.local_name) orelse continue;
+            if (new_props.len == 0) {
+                ib_new.namespace_used_properties = prev_props;
+                continue;
+            }
+            // 둘 다 non-empty — union.
+            var seen = std.StringHashMapUnmanaged(void){};
+            defer seen.deinit(arena_alloc);
+            for (new_props) |p| seen.put(arena_alloc, p, {}) catch {};
+            var added: usize = 0;
+            for (prev_props) |p| {
+                if (!seen.contains(p)) added += 1;
+            }
+            if (added == 0) continue;
+            const merged = arena_alloc.alloc([]const u8, new_props.len + added) catch continue;
+            @memcpy(merged[0..new_props.len], new_props);
+            var mi: usize = new_props.len;
+            for (prev_props) |p| {
+                if (!seen.contains(p)) {
+                    merged[mi] = p;
+                    mi += 1;
+                }
+            }
+            ib_new.namespace_used_properties = merged;
+        }
     }
 
     {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1967,7 +1967,16 @@ pub const Linker = struct {
                 // 접근된 멤버를 namespace_used_properties에 복사.
                 // 문자열은 source buffer 참조 (ast.getText 결과) — module.parse_arena 수명 동안 유효.
                 // 슬라이스 자체도 arena로 할당해 deinit 시 자동 해제.
+                //
+                // counter$4 진짜 근본 fix: analyzer 가 *post-transform symbol_id* 로 namespace
+                // local 추적. transformer 가 namespace local 의 symbol_id 를 rebind (e.g.
+                // `metric` → `metric_ns` 같이 rename 후 다른 symbol) 하면 analyzer 가 access 못
+                // 잡아 access.members.count()=0 (empty). 이 empty 결과로 binding_scanner 의
+                // 1차 결과 (non-empty) 를 덮어쓰면 → tree-shake namespace import seed 0회 →
+                // namespace getter dangling (effect-ts `counter$4 is not defined`).
+                // 따라서 empty result 면 binding_scanner 결과 유지.
                 const count = access.members.count();
+                if (count == 0) continue;
                 const props = arena.alloc([]const u8, count) catch continue;
                 const prop_stmts: ?[][]const u32 = if (stmt_spans_opt != null)
                     (arena.alloc([]const u32, count) catch null)


### PR DESCRIPTION
## 배경

PR #3731 (tree_shaker_active mirror) 후에도 effect-ts bundle 의 `metric_ns.counter` 가 dangling. *진짜 진짜 root cause* 4-depth 진단.

## Root cause

| 단계 | 위치 | 문제 |
|------|------|------|
| 1 | `emitter.zig:350-352` | `if (!s.isIncluded(i)) continue;` — included=false module emit skip |
| 2 | `tree_shaker.zig:1244-1259` | `namespace_used_properties=&.{}` 라 seedExport 0회 → module unreached |
| 3 | **`linker.zig:1942-1988`** | `analyzeNamespaceAccessWithIndex` 가 binding_scanner 의 1차 결과 (`props=3: counter/tagged/histogram`) 를 *empty 로 덮어씀* |
| 4 | (transformer 내부) | transformer 가 `metric` local 의 symbol_id rebind → analyzer 의 symbol_id 매칭 실패 |

## debug 결과

```
[prepass-backup] mod=fiberRuntime metric kind=namespace ns_props=3
[bs-final] metric binding ... ns_props=3
[ns-bfs] fiberRuntime metric ns ... props=0  ← linker analyzer 가 덮어씀
```

## Fix

**`linker.zig`** (analyzer fix):
- `access.members.count() == 0` 면 binding_scanner 의 기존 결과 *유지*.
- analyzer 가 *opaque* (`null` fallback) 와 *member_only count=0* 구분: 후자는 keep, 전자는 기존처럼 null overwrite.

**`transform_prepass.zig`** (보조 fix):
- 2차 collectNamespaceAccesses 호출 전후 1차 결과 backup + union.
- transformer 가 변형한 AST 에서 access 못 잡은 경우도 1차 결과로 보완.

## 효과

| 단계 | bundle size | counter\$4 |
|------|-------------|-----------|
| Pre-fix | 129 KB | dangling (호출 시 TypeError) |
| **이 PR** | **431 KB** | **정상 lookup** — counter declaration emit |

## 잔여 (별개 issue)

`TypeError: undefined is not iterable` — module init order 또는 circular dep 의 별개 이슈. 이 PR 의 fix 와 무관 (conservative include 시 surface). 별도 추적 필요.

## 검증

- `zig build test` 전체 통과
- `tests/integration` downlevel/super 429건 회귀 0
- counter\$4 dangling 해결 확인 (호출 path 정상 reach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)