### PR TITLE
cleanup(bundler): #3680 옵션 B — 보수 fallback 제거 (옵션 A 후속)

### DIFF
--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -422,56 +422,11 @@ pub fn resyncAfterAstMutation(
         // 추출되므로 previous 에서 따로 보존할 synthetic binding 이 없다.
         const helper_refs: ?[]const u32 = if (module.transform_cache) |cache| cache.helper_ref_nodes else null;
 
-        // counter$4 진짜 근본 fix: 1차 (parse 단계 parser_metadata.zig) 의
-        // collectNamespaceAccesses 결과를 local→props 맵으로 백업. transformer 가
-        // `metric.counter(...)` 같은 namespace access 를 inline / helper substitution 으로
-        // 변형하면 2차 collectNamespaceAccesses (post-transform AST 기반) 가 못 잡아
-        // `namespace_used_properties=&.{}` (length=0) 로 reset → tree-shake 가 그 module 의
-        // export reachable seed 안 함 → namespace getter dangling (effect-ts 의
-        // `counter$4 is not defined`). 1차 가 잡은 props 를 2차 결과와 union 으로 keep.
-        var prev_props_map = std.StringHashMapUnmanaged([]const []const u8){};
-        defer prev_props_map.deinit(arena_alloc);
-        for (module.import_bindings) |ib_prev| {
-            if (ib_prev.kind != .namespace) continue;
-            if (ib_prev.namespace_used_properties) |props| {
-                if (props.len > 0) {
-                    prev_props_map.put(arena_alloc, ib_prev.local_name, props) catch continue;
-                }
-            }
-        }
-
+        // PR #3733 옵션 A 로 linker analyzer (namespace_access.zig) 가 transformer rebind 후에도
+        // text fallback 으로 정확히 추적 — transform_prepass 의 1차/2차 binding_scanner 결과 union
+        // 보수 fallback 은 더 이상 필요 없음. analyzer 결과가 ground truth.
         module.import_bindings = try binding_scanner_mod.extractImportBindings(arena_alloc, ast, module.import_records, helper_refs);
         try binding_scanner_mod.collectNamespaceAccesses(arena_alloc, ast, module.import_bindings);
-
-        // 1차 결과와 union: 2차 가 못 잡은 access 도 keep.
-        for (module.import_bindings) |*ib_new| {
-            if (ib_new.kind != .namespace) continue;
-            const new_props = ib_new.namespace_used_properties orelse continue;
-            const prev_props = prev_props_map.get(ib_new.local_name) orelse continue;
-            if (new_props.len == 0) {
-                ib_new.namespace_used_properties = prev_props;
-                continue;
-            }
-            // 둘 다 non-empty — union.
-            var seen = std.StringHashMapUnmanaged(void){};
-            defer seen.deinit(arena_alloc);
-            for (new_props) |p| seen.put(arena_alloc, p, {}) catch {};
-            var added: usize = 0;
-            for (prev_props) |p| {
-                if (!seen.contains(p)) added += 1;
-            }
-            if (added == 0) continue;
-            const merged = arena_alloc.alloc([]const u8, new_props.len + added) catch continue;
-            @memcpy(merged[0..new_props.len], new_props);
-            var mi: usize = new_props.len;
-            for (prev_props) |p| {
-                if (!seen.contains(p)) {
-                    merged[mi] = p;
-                    mi += 1;
-                }
-            }
-            ib_new.namespace_used_properties = merged;
-        }
     }
 
     {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1969,15 +1969,10 @@ pub const Linker = struct {
                 // 문자열은 source buffer 참조 (ast.getText 결과) — module.parse_arena 수명 동안 유효.
                 // 슬라이스 자체도 arena로 할당해 deinit 시 자동 해제.
                 //
-                // counter$4 진짜 근본 fix: analyzer 가 *post-transform symbol_id* 로 namespace
-                // local 추적. transformer 가 namespace local 의 symbol_id 를 rebind (e.g.
-                // `metric` → `metric_ns` 같이 rename 후 다른 symbol) 하면 analyzer 가 access 못
-                // 잡아 access.members.count()=0 (empty). 이 empty 결과로 binding_scanner 의
-                // 1차 결과 (non-empty) 를 덮어쓰면 → tree-shake namespace import seed 0회 →
-                // namespace getter dangling (effect-ts `counter$4 is not defined`).
-                // 따라서 empty result 면 binding_scanner 결과 유지.
+                // PR #3733 옵션 A 이후 analyzer 가 text fallback 으로 transformer rebind 후에도 정확.
+                // count==0 면 실제로 namespace 가 사용 안 됨 — `&.{}` 로 덮어써도 정상 (tree-shake 가
+                // 이 module 의 export 를 seed 안 함). 보수 empty-continue fallback 제거.
                 const count = access.members.count();
-                if (count == 0) continue;
                 const props = arena.alloc([]const u8, count) catch continue;
                 const prop_stmts: ?[][]const u32 = if (stmt_spans_opt != null)
                     (arena.alloc([]const u32, count) catch null)


### PR DESCRIPTION
## 배경

PR #3733 옵션 A 의 *analyzer text fallback + 게이팅* 으로 linker 가 transformer rebind 후에도 정확한 `namespace_used_properties` 계산. 그 결과 PR #3732 의 보수 fallback 들은 더 이상 필요 없음.

## 변경

### 1. `src/bundler/graph/transform_prepass.zig`

1차 binding_scanner 결과를 backup 한 후 2차와 union 하던 `prev_props_map` 로직 (48 lines) 제거 → 단순 `extractImportBindings + collectNamespaceAccesses` 2-step 으로 환원.

### 2. `src/bundler/linker.zig`

`if (count == 0) continue;` empty-continue 제거. analyzer 가 empty 결과 내면 그게 정확 — `namespace_used_properties = &.{}` 로 덮어쓰는 게 정상 (tree-shake 가 이 module 의 export 를 seed 안 함).

## E2E 검증

| 항목 | 결과 |
|------|------|
| `zig build test` 전체 | ✅ pass |
| `tests/integration` 전체 (3909 tests) | main 25 fail vs B **25 fail** (회귀 0건, pre-existing 만) |
| effect-ts | ✅ `43` (counter$4 + Array.from(undefined) 둘 다 해결) |
| lodash-es | ✅ `24` |
| namespace tree-shake (단순) | ✅ 미사용 export 제거 |
| metric rebind 패턴 (effect-ts mini) | ✅ 미사용 summary 제거 |
| shadow 게이팅 | ✅ function param M 의 phantom 제거 (옵션 A 게이팅 정확) |

## diff

```
src/bundler/graph/transform_prepass.zig | 51 ++-------------------------------
src/bundler/linker.zig                  | 11 ++-----
2 files changed, 6 insertions(+), 56 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)