### PR TITLE
fix(bundler): #3680 통합 안전망 — 옵션 B revert + escape 색인 (3-layer)

### DIFF
--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -422,11 +422,56 @@ pub fn resyncAfterAstMutation(
         // 추출되므로 previous 에서 따로 보존할 synthetic binding 이 없다.
         const helper_refs: ?[]const u32 = if (module.transform_cache) |cache| cache.helper_ref_nodes else null;
 
-        // PR #3733 옵션 A 로 linker analyzer (namespace_access.zig) 가 transformer rebind 후에도
-        // text fallback 으로 정확히 추적 — transform_prepass 의 1차/2차 binding_scanner 결과 union
-        // 보수 fallback 은 더 이상 필요 없음. analyzer 결과가 ground truth.
+        // counter$4 진짜 근본 fix: 1차 (parse 단계 parser_metadata.zig) 의
+        // collectNamespaceAccesses 결과를 local→props 맵으로 백업. transformer 가
+        // `metric.counter(...)` 같은 namespace access 를 inline / helper substitution 으로
+        // 변형하면 2차 collectNamespaceAccesses (post-transform AST 기반) 가 못 잡아
+        // `namespace_used_properties=&.{}` (length=0) 로 reset → tree-shake 가 그 module 의
+        // export reachable seed 안 함 → namespace getter dangling (effect-ts 의
+        // `counter$4 is not defined`). 1차 가 잡은 props 를 2차 결과와 union 으로 keep.
+        var prev_props_map = std.StringHashMapUnmanaged([]const []const u8){};
+        defer prev_props_map.deinit(arena_alloc);
+        for (module.import_bindings) |ib_prev| {
+            if (ib_prev.kind != .namespace) continue;
+            if (ib_prev.namespace_used_properties) |props| {
+                if (props.len > 0) {
+                    prev_props_map.put(arena_alloc, ib_prev.local_name, props) catch continue;
+                }
+            }
+        }
+
         module.import_bindings = try binding_scanner_mod.extractImportBindings(arena_alloc, ast, module.import_records, helper_refs);
         try binding_scanner_mod.collectNamespaceAccesses(arena_alloc, ast, module.import_bindings);
+
+        // 1차 결과와 union: 2차 가 못 잡은 access 도 keep.
+        for (module.import_bindings) |*ib_new| {
+            if (ib_new.kind != .namespace) continue;
+            const new_props = ib_new.namespace_used_properties orelse continue;
+            const prev_props = prev_props_map.get(ib_new.local_name) orelse continue;
+            if (new_props.len == 0) {
+                ib_new.namespace_used_properties = prev_props;
+                continue;
+            }
+            // 둘 다 non-empty — union.
+            var seen = std.StringHashMapUnmanaged(void){};
+            defer seen.deinit(arena_alloc);
+            for (new_props) |p| seen.put(arena_alloc, p, {}) catch {};
+            var added: usize = 0;
+            for (prev_props) |p| {
+                if (!seen.contains(p)) added += 1;
+            }
+            if (added == 0) continue;
+            const merged = arena_alloc.alloc([]const u8, new_props.len + added) catch continue;
+            @memcpy(merged[0..new_props.len], new_props);
+            var mi: usize = new_props.len;
+            for (prev_props) |p| {
+                if (!seen.contains(p)) {
+                    merged[mi] = p;
+                    mi += 1;
+                }
+            }
+            ib_new.namespace_used_properties = merged;
+        }
     }
 
     {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1969,10 +1969,15 @@ pub const Linker = struct {
                 // 문자열은 source buffer 참조 (ast.getText 결과) — module.parse_arena 수명 동안 유효.
                 // 슬라이스 자체도 arena로 할당해 deinit 시 자동 해제.
                 //
-                // PR #3733 옵션 A 이후 analyzer 가 text fallback 으로 transformer rebind 후에도 정확.
-                // count==0 면 실제로 namespace 가 사용 안 됨 — `&.{}` 로 덮어써도 정상 (tree-shake 가
-                // 이 module 의 export 를 seed 안 함). 보수 empty-continue fallback 제거.
+                // counter$4 진짜 근본 fix: analyzer 가 *post-transform symbol_id* 로 namespace
+                // local 추적. transformer 가 namespace local 의 symbol_id 를 rebind (e.g.
+                // `metric` → `metric_ns` 같이 rename 후 다른 symbol) 하면 analyzer 가 access 못
+                // 잡아 access.members.count()=0 (empty). 이 empty 결과로 binding_scanner 의
+                // 1차 결과 (non-empty) 를 덮어쓰면 → tree-shake namespace import seed 0회 →
+                // namespace getter dangling (effect-ts `counter$4 is not defined`).
+                // 따라서 empty result 면 binding_scanner 결과 유지.
                 const count = access.members.count();
+                if (count == 0) continue;
                 const props = arena.alloc([]const u8, count) catch continue;
                 const prop_stmts: ?[][]const u32 = if (stmt_spans_opt != null)
                     (arena.alloc([]const u32, count) catch null)

--- a/src/bundler/linker/namespace_access.zig
+++ b/src/bundler/linker/namespace_access.zig
@@ -70,6 +70,11 @@ pub const NamespaceAccessIndex = struct {
     /// 즉 build → analyze 동안 ast 가 mutate (transformer 의 addString 등) 되면 invalidate. 단일 단계 사용 강제.
     accesses_by_obj_text: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(IdentAccess)) = .{},
 
+    /// escape 색인 (F1 fix): 모든 identifier_reference 의 `text → [(node_idx, span_start)...]`.
+    /// text fallback 진입 시 `idents_by_text[local_name]` 의 각 node_idx 가 `prop_by_obj` 에
+    /// 있으면 member-obj, 없으면 escape (value position) — opaque return 으로 over-prune 회피.
+    idents_by_text: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(IdentRef)) = .{},
+
     pub const DeclRange = struct { start: u32, end: u32 };
 
     pub const IdentAccess = struct {
@@ -77,11 +82,16 @@ pub const NamespaceAccessIndex = struct {
         obj_span_start: u32,
     };
 
+    pub const IdentRef = struct {
+        node_idx: u32,
+        span_start: u32,
+    };
+
     pub fn build(allocator: std.mem.Allocator, ast: *const Ast) std.mem.Allocator.Error!NamespaceAccessIndex {
         var self: NamespaceAccessIndex = .{};
         errdefer self.deinit(allocator);
         const node_count = ast.nodes.items.len;
-        for (ast.nodes.items) |node| {
+        for (ast.nodes.items, 0..) |node, node_i| {
             if (node.tag == .static_member_expression or node.tag == .private_field_expression) {
                 const e = node.data.extra;
                 if (!ast.hasExtra(e, 2)) continue;
@@ -100,6 +110,16 @@ pub const NamespaceAccessIndex = struct {
                     .prop_node_idx = prop_idx,
                     .obj_span_start = obj_node.span.start,
                 });
+            } else if (node.tag == .identifier_reference) {
+                // F1 fix: escape 검사용 — 모든 identifier_reference 의 text 색인.
+                const text = ast.getText(node.span);
+                if (text.len == 0) continue;
+                const gop = try self.idents_by_text.getOrPut(allocator, text);
+                if (!gop.found_existing) gop.value_ptr.* = .empty;
+                try gop.value_ptr.append(allocator, .{
+                    .node_idx = @intCast(node_i),
+                    .span_start = node.span.start,
+                });
             } else if (node.tag == .import_declaration) {
                 try self.decl_ranges.append(allocator, .{ .start = node.span.start, .end = node.span.end });
             }
@@ -113,6 +133,9 @@ pub const NamespaceAccessIndex = struct {
         var it = self.accesses_by_obj_text.valueIterator();
         while (it.next()) |list| list.deinit(allocator);
         self.accesses_by_obj_text.deinit(allocator);
+        var it2 = self.idents_by_text.valueIterator();
+        while (it2.next()) |list| list.deinit(allocator);
+        self.idents_by_text.deinit(allocator);
     }
 };
 
@@ -200,6 +223,24 @@ pub fn analyzeNamespaceAccessWithIndex(
     if (symbol_matched == 0) {
         if (ns_local_name) |local_name| {
             if (local_name.len > 0) {
+                // F1 fix: escape 검사 — `idents_by_text[local]` 의 어떤 identifier_reference 가
+                // `prop_by_obj` 에 없으면 (member-obj 아닌 value-position 사용) opaque 로 처리.
+                // 예: `import * as M from 'x'; const ref = M; ref.foo()` — `M` 이 const init 의
+                // RHS 로 escape. 안 잡으면 over-prune 으로 dangling.
+                if (index.idents_by_text.get(local_name)) |refs| {
+                    for (refs.items) |ir| {
+                        // decl range 안의 identifier (import specifier 자체 등) 는 skip.
+                        if (isInDecl(ir.span_start, ir.span_start + 1, index.decl_ranges.items)) continue;
+                        if (!index.prop_by_obj.contains(ir.node_idx)) {
+                            // escape detected — over-prune 방지 위해 opaque.
+                            access.deinit(allocator);
+                            access.members = .{};
+                            access.kind = .@"opaque";
+                            return access;
+                        }
+                    }
+                }
+
                 if (index.accesses_by_obj_text.get(local_name)) |list| {
                     for (list.items) |ia| {
                         // decl range 의 identifier (import specifier 자체) 는 skip.

--- a/src/bundler/namespace_access_test.zig
+++ b/src/bundler/namespace_access_test.zig
@@ -371,3 +371,37 @@ test "옵션 A: symbol matched = 0 (rebind 시뮬레이션) 일 때만 fallback 
     defer h.deinit(std.testing.allocator);
     try expectMembers(&h.access, &.{ "counter", "histogram" });
 }
+
+// F1 fix (PR #3735): text fallback escape 검출 — value-position 사용 시 opaque.
+// 옵션 B 의 회귀 case: symbol_matched=0 + escape 동시 발생 시 옛 코드는 member_only 로
+// over-prune. 새 코드는 escape 감지해서 opaque 반환 → 모든 export 살림.
+test "F1: text fallback escape detection — namespace 가 const init 의 RHS 로 escape 하면 opaque" {
+    var h = try runAccessWithFallback(std.testing.allocator,
+        \\import * as M from './mod';
+        \\const ref = M;
+        \\export const x = M.a;
+    , "M", true);
+    defer h.deinit(std.testing.allocator);
+    // escape 감지 → opaque (members 무관)
+    try std.testing.expectEqual(NamespaceAccess.Kind.@"opaque", h.access.kind);
+}
+
+test "F1: text fallback escape detection — namespace 가 function call argument 로 escape 하면 opaque" {
+    var h = try runAccessWithFallback(std.testing.allocator,
+        \\import * as M from './mod';
+        \\sink(M);
+        \\M.x();
+    , "M", true);
+    defer h.deinit(std.testing.allocator);
+    try std.testing.expectEqual(NamespaceAccess.Kind.@"opaque", h.access.kind);
+}
+
+test "F1: text fallback escape detection — member-obj only 면 escape 아님 (정상 member_only)" {
+    var h = try runAccessWithFallback(std.testing.allocator,
+        \\import * as M from './mod';
+        \\M.a();
+        \\M.b();
+    , "M", true);
+    defer h.deinit(std.testing.allocator);
+    try expectMembers(&h.access, &.{ "a", "b" });
+}


### PR DESCRIPTION
## 배경

PR #3734 (옵션 B) 의 보수 fallback 제거가 사후 `code-review max` 에서 **다층 회귀 위험 (F1-F8)** 발견. 옵션 A analyzer 가 ground truth 라는 전제가 두 path 에서 깨짐.

## Code-review max — F1-F8

| ID | 위치 | 회귀 case |
|----|------|----------|
| F1 | namespace_access.zig text fallback | escape (bare identifier) 미감지 → symbol_matched=0 + escape 시 over-prune |
| F2 | transform_prepass.zig | text-rewrite transform 시 post-transform AST 에 노드 자체 부재 → analyzer 0건 |
| F3 | namespace_access.zig:200 | partial rebind: symbol_matched > 0 → fallback skip → subset 만 |
| F4 | tree_shaker.zig:1296 `.named` virtual ns | `&.{}` non-null → for-loop 0회 + return → inner_src 모듈 seed 누락 |
| F5 | tree_shaker.zig:2240 CJS default | `&.{}` 시 else 가 'default' 만 mark → non-default exports 제거 |
| F6 | chunks.zig:2127 `areAllReExportNsConsumersPrecise` | null→false vs `&.{}`→true semantic flip |
| F7 | linker.zig:1077 mangler | `&.{}` → reservation 0건 → silent collision (RFC #3288) |
| F8 | linker.zig:1914 `.named` candidate | `&.{}` not null → second populate 시 skip → const inline 누락 |

## 3-layer 통합 안전망

| Layer | 회복 case | 변경 |
|-------|----------|------|
| 1. transform_prepass `prev_props_map` union 복원 | F2, F3 일부 | PR #3734 revert |
| 2. linker `if (count == 0) continue;` 복원 | F4-F8 | PR #3734 revert |
| 3. analyzer text fallback escape 색인 + 검사 | F1 | **신규** |

옵션 A 의 `symbol_matched=0` 게이팅은 **유지** — shadow false-positive 회피 (PR #3733 효과 보존).

## 다른 번들러 비교

| 번들러 | escape 처리 | 우리와 비교 |
|--------|------------|------------|
| webpack | `EXPORTS_OBJECT_REFERENCED` (전체 keep) | **F1 fix 와 동치** |
| rollup | `deoptimizePath(UNKNOWN)` → `includeAllExports` | escape 동치 |
| esbuild | visit 패스 안 lowering 동시 — stale 구조적 회피 | 더 robust 아키텍처 |
| oxc/rolldown | transformer 후 semantic 재구축 | 가장 robust, 미래 작업 |

옵션 A 의 text fallback 자체는 unique — 다른 번들러는 *분석을 transformer 와 같은 패스에 합치거나 재구축*. F1 fix 로 escape 안전망은 표준화.

## E2E 검증

| 항목 | 결과 |
|------|------|
| zig build test 전체 | ✅ pass |
| tests/integration (3909 tests) | main 25 fail vs **B 25 fail (회귀 0건)** |
| effect-ts | ✅ `43`, bundle 313 KB |
| lodash-es | ✅ `24` |
| shadow 게이팅 보존 (`phantom` 제거) | ✅ PR #3733 효과 유지 |
| F1 escape 시나리오 | ✅ 모든 export 보존 (escape 감지) |
| 신규 unit 테스트 | F1 escape 3건 (RHS / call arg / member-only baseline) |

## diff

```
src/bundler/graph/transform_prepass.zig | 51 +++ (옵션 B revert)
src/bundler/linker.zig                  | 11 +++ (옵션 B revert)
src/bundler/linker/namespace_access.zig | 43 ++++ (F1 신규)
src/bundler/namespace_access_test.zig   | 34 ++++ (F1 회귀 테스트)
4 files changed, 132 insertions(+), 7 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)