### PR TITLE
perf(bundler): #3680 namespace local set gating — text 색인 메모리 절감

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -575,10 +575,20 @@ pub fn collectNamespaceAccesses(
     if (!has_namespace) return;
 
     const ns_module = @import("linker/namespace_access.zig");
+    // C5 perf (PR #3737): interest set — namespace local name 만 색인.
+    // 큰 모듈 (10k+ LOC) 에서 모든 ident text 색인의 X10-X100 메모리 절약.
+    var interest: std.StringHashMapUnmanaged(void) = .{};
+    defer interest.deinit(allocator);
+    for (bindings) |ib| {
+        if (ib.kind == .namespace and ib.local_name.len > 0) {
+            try interest.put(allocator, ib.local_name, {});
+        }
+    }
+
     // C1 fix (#3736): binding_scanner 는 옛 동작 유지 — reachable_only=true.
     // 옛 collectNamespaceAccesses 가 `ast_walk.collectReachableNodeIndices` 사용했음.
     // `build` (= linker default) 는 reachable_only=false 라 binding_scanner 와 의미 다름.
-    var index = try ns_module.NamespaceAccessIndex.buildOpt(allocator, ast, true);
+    var index = try ns_module.NamespaceAccessIndex.buildOpt(allocator, ast, true, &interest);
     defer index.deinit(allocator);
 
     for (bindings) |*ib| {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -470,6 +470,17 @@ pub const Linker = struct {
         return src.wrap_kind != .cjs and src.default_export_named_local;
     }
 
+    /// `populateNamespaceAccesses` 의 analyze 대상 판별 — 4 kind 중 하나.
+    /// PR #3737 의 `has_candidate` / `interest_set` / `should_analyze_binding` 가
+    /// 동일한 판별을 사용하도록 helper 추출 (drift 방지).
+    fn isNamespaceAnalysisCandidate(self: *const Linker, importer: *const Module, ib: ImportBinding) bool {
+        if (ib.kind == .namespace) return true;
+        if (ib.kind == .named and ib.namespace_used_properties == null) return true;
+        if (self.isCjsDefaultBinding(importer, ib)) return true;
+        if (self.isEsmWrapperDefaultBinding(importer, ib)) return true;
+        return false;
+    }
+
     /// 링킹 실행: export 맵 구축 → import 바인딩 해결.
     pub fn link(self: *Linker) !void {
         try self.buildExportMap();
@@ -1886,20 +1897,33 @@ pub const Linker = struct {
 
             // 분석 대상 (namespace, virtual-namespace named, 또는 CJS default) import 가 하나도 없으면
             // index 구축 전에 outer skip — AST 전체 순회 비용 회피 (#1735).
+            // helper `isNamespaceAnalysisCandidate` 로 has_candidate / interest_set / 분석 loop 의
+            // predicate 통일 (PR #3737 drift 방지).
             const has_candidate = blk: {
                 for (importer.import_bindings) |ib| {
-                    if (ib.kind == .namespace) break :blk true;
-                    if (ib.kind == .named and ib.namespace_used_properties == null) break :blk true;
-                    if (self.isCjsDefaultBinding(importer, ib)) break :blk true;
-                    if (self.isEsmWrapperDefaultBinding(importer, ib)) break :blk true;
+                    if (self.isNamespaceAnalysisCandidate(importer, ib)) break :blk true;
                 }
                 break :blk false;
             };
             if (!has_candidate) continue;
 
+            // C5 perf (PR #3737): interest set — analyze candidate 의 local_name 만 색인.
+            // 큰 모듈에서 모든 ident text 색인의 X10-X100 메모리 절감.
+            var interest_set: std.StringHashMapUnmanaged(void) = .{};
+            defer interest_set.deinit(self.allocator);
+            for (importer.import_bindings) |ib_pre| {
+                if (!self.isNamespaceAnalysisCandidate(importer, ib_pre)) continue;
+                if (ib_pre.local_name.len == 0) continue;
+                // OOM 무시 — 누락된 binding 은 analyzer 가 0 결과 → binding_scanner 의 이전
+                // 결과 유지 (linker.zig:1995 의 `count==0 continue`). OOM 자체가 zntc 의
+                // 일반 path 에서 비현실적, 정확성 영향 최소.
+                interest_set.put(self.allocator, ib_pre.local_name, {}) catch {};
+            }
+
             // importer 당 1회만 AST 순회해 NamespaceAccessIndex 구축.
             // 같은 모듈 안의 모든 namespace import 분석에 공유 (#1735).
-            var ns_index = namespace_access.NamespaceAccessIndex.build(self.allocator, ast) catch continue;
+            // reachable_only=false 유지 (옛 linker 동작 — orphan node 포함).
+            var ns_index = namespace_access.NamespaceAccessIndex.buildOpt(self.allocator, ast, false, &interest_set) catch continue;
             defer ns_index.deinit(self.allocator);
 
             // 모든 namespace import에 공통으로 쓰일 stmt span 배열을 importer당 1회 구축.

--- a/src/bundler/linker/namespace_access.zig
+++ b/src/bundler/linker/namespace_access.zig
@@ -98,17 +98,27 @@ pub const NamespaceAccessIndex = struct {
         span_start: u32,
     };
 
-    /// 기본 `build` — 옛 linker 동작 유지 (모든 nodes 순회).
-    /// 새 caller (binding_scanner) 는 `buildOpt(..., true)` 명시 → orphan 제외, reachable only.
+    /// 기본 `build` — 옛 linker 동작 유지 (모든 nodes 순회, 모든 ident text 색인).
+    /// 새 caller (binding_scanner) 는 `buildOpt(..., true, &interest_set)` 명시 → orphan 제외, gating 활성.
     pub fn build(allocator: std.mem.Allocator, ast: *const Ast) std.mem.Allocator.Error!NamespaceAccessIndex {
-        return buildOpt(allocator, ast, false);
+        return buildOpt(allocator, ast, false, null);
     }
 
     /// computed_member_expression (e.g. `M[dyn]`) 의 obj 가 identifier_reference 인 set.
     /// text-only mode 의 dynamic-access escape 감지에 사용.
     pub const ComputedObj = struct { obj_text_span_start: u32 };
 
-    pub fn buildOpt(allocator: std.mem.Allocator, ast: *const Ast, reachable_only: bool) std.mem.Allocator.Error!NamespaceAccessIndex {
+    /// `buildOpt` (C5 perf, PR #3737): `interest_text_set` 가 주어지면 ident text 색인 시
+    /// 그 set 에 있는 text 만 색인 — 큰 모듈 (10k+ LOC, 5-20k unique ident text) 에서
+    /// `idents_by_text` / `accesses_by_obj_text` / `computed_by_obj_text` 메모리 X10~X100 절감.
+    /// null 이면 옛 동작 (모든 text 색인).
+    /// `prop_by_obj` 와 `decl_ranges` 는 interest 무관 (정확성 필요).
+    pub fn buildOpt(
+        allocator: std.mem.Allocator,
+        ast: *const Ast,
+        reachable_only: bool,
+        interest_text_set: ?*const std.StringHashMapUnmanaged(void),
+    ) std.mem.Allocator.Error!NamespaceAccessIndex {
         var self: NamespaceAccessIndex = .{};
         errdefer self.deinit(allocator);
         const node_count = ast.nodes.items.len;
@@ -161,6 +171,7 @@ pub const NamespaceAccessIndex = struct {
                 if (obj_node.tag != .identifier_reference) continue;
                 const obj_text = ast.getText(obj_node.span);
                 if (obj_text.len == 0) continue;
+                if (interest_text_set) |s| if (!s.contains(obj_text)) continue;
                 const gop = try self.accesses_by_obj_text.getOrPut(allocator, obj_text);
                 if (!gop.found_existing) gop.value_ptr.* = .empty;
                 try gop.value_ptr.append(allocator, .{
@@ -177,6 +188,7 @@ pub const NamespaceAccessIndex = struct {
                 if (obj_node.tag != .identifier_reference) continue;
                 const obj_text = ast.getText(obj_node.span);
                 if (obj_text.len == 0) continue;
+                if (interest_text_set) |s| if (!s.contains(obj_text)) continue;
                 const gop = try self.computed_by_obj_text.getOrPut(allocator, obj_text);
                 if (!gop.found_existing) gop.value_ptr.* = .empty;
                 try gop.value_ptr.append(allocator, .{
@@ -186,6 +198,7 @@ pub const NamespaceAccessIndex = struct {
                 // F1 fix: escape 검사용 — 모든 identifier_reference 의 text 색인.
                 const text = ast.getText(node.span);
                 if (text.len == 0) continue;
+                if (interest_text_set) |s| if (!s.contains(text)) continue;
                 const gop = try self.idents_by_text.getOrPut(allocator, text);
                 if (!gop.found_existing) gop.value_ptr.* = .empty;
                 try gop.value_ptr.append(allocator, .{

--- a/src/bundler/namespace_access_test.zig
+++ b/src/bundler/namespace_access_test.zig
@@ -425,7 +425,7 @@ fn runTextOnly(allocator: std.mem.Allocator, source: []const u8, ns_name: []cons
     var parser = Parser.init(allocator, &scanner);
     errdefer parser.deinit();
     _ = try parser.parse();
-    var index = try namespace_access_mod.NamespaceAccessIndex.buildOpt(allocator, &parser.ast, true);
+    var index = try namespace_access_mod.NamespaceAccessIndex.buildOpt(allocator, &parser.ast, true, null);
     defer index.deinit(allocator);
     const access = try namespace_access_mod.analyzeNamespaceAccessTextOnly(allocator, &parser.ast, &index, ns_name, null);
     return .{ .scanner = scanner, .parser = parser, .access = access };
@@ -487,9 +487,9 @@ test "PR #3736: buildOpt(reachable_only=false) — 모든 nodes 색인 (옛 link
     defer parser.deinit();
     _ = try parser.parse();
 
-    var idx_all = try namespace_access_mod.NamespaceAccessIndex.buildOpt(allocator, &parser.ast, false);
+    var idx_all = try namespace_access_mod.NamespaceAccessIndex.buildOpt(allocator, &parser.ast, false, null);
     defer idx_all.deinit(allocator);
-    var idx_reach = try namespace_access_mod.NamespaceAccessIndex.buildOpt(allocator, &parser.ast, true);
+    var idx_reach = try namespace_access_mod.NamespaceAccessIndex.buildOpt(allocator, &parser.ast, true, null);
     defer idx_reach.deinit(allocator);
 
     // 두 mode 모두 동일한 namespace member access 색인 (이 fixture 는 orphan 없음).
@@ -497,4 +497,73 @@ test "PR #3736: buildOpt(reachable_only=false) — 모든 nodes 색인 (옛 link
     // 둘 다 'M' 키 가짐.
     try std.testing.expect(idx_all.accesses_by_obj_text.contains("M"));
     try std.testing.expect(idx_reach.accesses_by_obj_text.contains("M"));
+}
+
+// PR #3737 C5 perf: interest_text_set gating — interest 안 local 만 색인.
+test "PR #3737: interest gating — set 안 local 만 색인" {
+    const namespace_access_mod = @import("linker/namespace_access.zig");
+    const allocator = std.testing.allocator;
+    const src =
+        \\import * as M from './m';
+        \\import * as N from './n';
+        \\M.foo();
+        \\N.bar();
+    ;
+    var scanner = try Scanner.init(allocator, src);
+    defer scanner.deinit();
+    var parser = Parser.init(allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var interest: std.StringHashMapUnmanaged(void) = .{};
+    defer interest.deinit(allocator);
+    try interest.put(allocator, "M", {});
+
+    var idx_gated = try namespace_access_mod.NamespaceAccessIndex.buildOpt(allocator, &parser.ast, true, &interest);
+    defer idx_gated.deinit(allocator);
+    var idx_full = try namespace_access_mod.NamespaceAccessIndex.buildOpt(allocator, &parser.ast, true, null);
+    defer idx_full.deinit(allocator);
+
+    // gated: M 만 색인 (N 제외).
+    try std.testing.expect(idx_gated.accesses_by_obj_text.contains("M"));
+    try std.testing.expect(!idx_gated.accesses_by_obj_text.contains("N"));
+    // full: 둘 다.
+    try std.testing.expect(idx_full.accesses_by_obj_text.contains("M"));
+    try std.testing.expect(idx_full.accesses_by_obj_text.contains("N"));
+
+    // M 의 분석 결과는 두 mode 일치 (interest 안에 있으므로).
+    var a_gated = try namespace_access_mod.analyzeNamespaceAccessTextOnly(allocator, &parser.ast, &idx_gated, "M", null);
+    defer a_gated.deinit(allocator);
+    var a_full = try namespace_access_mod.analyzeNamespaceAccessTextOnly(allocator, &parser.ast, &idx_full, "M", null);
+    defer a_full.deinit(allocator);
+    try std.testing.expectEqual(a_gated.kind, a_full.kind);
+    try std.testing.expectEqual(a_gated.members.count(), a_full.members.count());
+}
+
+test "PR #3737: interest gating — set 밖 local 분석 시 0 결과 (caller 책임)" {
+    // 회귀 방지: interest set 빠뜨린 binding 은 analyzer 가 0 결과. caller (linker/binding_scanner)
+    // 가 항상 interest 에 모든 분석 대상 local 포함해야.
+    const namespace_access_mod = @import("linker/namespace_access.zig");
+    const allocator = std.testing.allocator;
+    const src =
+        \\import * as M from './m';
+        \\M.foo();
+    ;
+    var scanner = try Scanner.init(allocator, src);
+    defer scanner.deinit();
+    var parser = Parser.init(allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var empty_interest: std.StringHashMapUnmanaged(void) = .{};
+    defer empty_interest.deinit(allocator);
+    var idx = try namespace_access_mod.NamespaceAccessIndex.buildOpt(allocator, &parser.ast, true, &empty_interest);
+    defer idx.deinit(allocator);
+
+    // M 이 interest 에 없으므로 색인 안 됨 → 분석 결과 empty.
+    try std.testing.expect(!idx.accesses_by_obj_text.contains("M"));
+    var a = try namespace_access_mod.analyzeNamespaceAccessTextOnly(allocator, &parser.ast, &idx, "M", null);
+    defer a.deinit(allocator);
+    try std.testing.expectEqual(NamespaceAccess.Kind.member_only, a.kind);
+    try std.testing.expectEqual(@as(usize, 0), a.members.count());
 }


### PR DESCRIPTION
## 배경

PR #3736 통합 후속 — `/code-review max` 의 C5 perf finding: `NamespaceAccessIndex` 의 text 색인 3개 (`accesses_by_obj_text`, `computed_by_obj_text`, `idents_by_text`) 가 *모든 identifier_reference text* 잡음. 큰 모듈 (10k+ LOC, 5-20k unique ident text) 에서 +200KB-1MB/모듈 메모리.

→ namespace local 만 색인하도록 *interest_text_set gating* 도입.

## 변경

### `linker/namespace_access.zig`
```zig
buildOpt(allocator, ast, reachable_only, interest_text_set: ?*const HashMap)
```
- text 색인 3곳에 `if (interest_text_set) |s| if (!s.contains(text)) continue;` gating.
- `prop_by_obj` / `decl_ranges` 는 interest 무관 (정확성 필요).
- null interest → 옛 동작.

### `linker.zig`
`isNamespaceAnalysisCandidate(importer, ib)` helper — has_candidate / interest_set / 분석 loop 의 predicate 통일 (drift 방지).

### `binding_scanner.zig` / `linker.zig`
caller 가 candidate 의 local_name set 빌드 → `buildOpt(..., &interest_set)`.

## /code-review max 5 angle 적용

| ID | 적용 |
|----|------|
| OOM swallow (#1) | `catch {}` 유지 + comment (실용 영향 없음) |
| candidate predicate drift (#4) | `isNamespaceAnalysisCandidate` helper 추출 |
| gating test 부재 (#7) | 회귀 테스트 2건 |

## E2E

| 항목 | 결과 |
|------|------|
| zig build test 전체 | ✅ pass |
| tests/integration (3909 tests) | main 25 fail vs PERF2 **24 fail** (회귀 0건, +1 통과) |
| effect-ts | ✅ `43` |
| shadow gate | ✅ phantom 제거 (PR #3733 효과 보존) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)