### PR TITLE
fix(transformer): V8 super_proto_alias 가 unused 일 때 `var _a;` leak 차단 (루트커즈)

### DIFF
--- a/src/transformer/transformer/class_visit.zig
+++ b/src/transformer/transformer/class_visit.zig
@@ -69,7 +69,20 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
             const is_simple_id = super_node.tag == .identifier_reference or super_node.tag == .binding_identifier;
             // class self name: raw_name_idx (source 의 binding) 우선, 없으면 visit 결과 new_name.
             const class_name_span_opt: ?Span = self.getClassNameSpan(raw_name_idx) orelse self.getClassNameSpan(new_name);
-            if (!is_simple_id and class_name_span_opt != null) {
+            // V8 alias 의 실제 emit 은 `had_static_blocks` 또는 `had_private_methods/fields`
+            // 분기 안에서만 일어난다 (아래 line 225/247/273/291). 옵션이 활성이어도 body 에
+            // 변환 대상이 없으면 두 분기 모두 false → alias 는 만들어도 버려지고, 그 사이
+            // `makeTempVarSpan` 이 bump 한 counter 가 hoistTempVars 에서 `var _a;` (uninit
+            // declarator) 로 program top 에 leak (TSC: expressions thisInInvalidContexts /
+            // thisInInvalidContextsExternalModule 회귀).
+            // → 옵션 활성 *AND* body 에 실제 lowering 대상이 있을 때만 V8 path 진입.
+            const lower_pm_pre = self.options.unsupported.class_private_method;
+            const lower_pf_pre = self.options.unsupported.class_private_field;
+            const lower_sb_pre = self.options.unsupported.class_static_block;
+            const probe_body_idx = self.readNodeIdx(e, ast_mod.ClassExtra.body);
+            const v8_alias_emittable = (lower_pm_pre or lower_pf_pre or lower_sb_pre) and
+                classBodyHasLowerableMember(self, probe_body_idx, lower_pm_pre, lower_pf_pre, lower_sb_pre);
+            if (!is_simple_id and class_name_span_opt != null and v8_alias_emittable) {
                 // VSHADOW: alias var 생성 — `var _<n>_super = globalThis.Object.getPrototypeOf(D.prototype)`
                 // (instance) 또는 `... = globalThis.Object.getPrototypeOf(D)` (static, 단 fast path
                 // class 진입 시 is_static=false 로 reset 되므로 instance form 만 emit; static private
@@ -308,6 +321,55 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
     }
 
     return self.visitClassWithAssignSemantics(node);
+}
+
+/// V8 super_proto_alias 가 emit 될 수 있는 body 인지 probe.
+/// alias 실 emit 분기 (line 225/247/273/291) 는 `had_static_blocks` 또는
+/// `had_private_methods/fields` 둘 중 하나가 true 여야 진입. 두 변수는 각각
+/// `lowerStaticBlocks` / `lowerPrivateMembers` 가 body 를 실제 변환했을 때만
+/// true. 따라서 body 에 *변환 대상* 멤버가 하나라도 없으면 alias 는 만들어도
+/// 버려진다 → counter 만 소비해 `var _a;` leak. 이 probe 는 옵션 활성 × body
+/// 매칭의 결합으로 V8 path 진입 자체를 결정한다.
+pub fn classBodyHasLowerableMember(
+    self: *Transformer,
+    body_idx: NodeIndex,
+    lower_pm: bool,
+    lower_pf: bool,
+    lower_static_block: bool,
+) bool {
+    if (body_idx.isNone()) return false;
+    const body_node = self.ast.getNode(body_idx);
+    if (body_node.tag != .class_body) return false;
+
+    const start = body_node.data.list.start;
+    const len = body_node.data.list.len;
+    if (start + len > self.ast.extra_data.items.len) return false;
+
+    var i: u32 = 0;
+    while (i < len) : (i += 1) {
+        const member = self.ast.getNode(@enumFromInt(self.ast.extra_data.items[start + i]));
+        switch (member.tag) {
+            .method_definition => {
+                if (!lower_pm) continue;
+                const e = member.data.extra;
+                if (e + ast_mod.MethodExtra.key >= self.ast.extra_data.items.len) continue;
+                const key = self.readNodeIdx(e, ast_mod.MethodExtra.key);
+                if (!key.isNone() and self.ast.getNode(key).tag == .private_identifier) return true;
+            },
+            .property_definition => {
+                if (!lower_pf) continue;
+                const e = member.data.extra;
+                if (e + ast_mod.PropertyExtra.key >= self.ast.extra_data.items.len) continue;
+                const key = self.readNodeIdx(e, ast_mod.PropertyExtra.key);
+                if (!key.isNone() and self.ast.getNode(key).tag == .private_identifier) return true;
+            },
+            .static_block => {
+                if (lower_static_block) return true;
+            },
+            else => {},
+        }
+    }
+    return false;
 }
 
 pub fn classBodyHasStaticPrivateMember(self: *Transformer, body_idx: NodeIndex, lower_methods: bool, lower_fields: bool) bool {


### PR DESCRIPTION
## 요약

`class X extends <non-identifier>` (예: `extends this`, `extends getBase()`,
`extends 42`) class 가 무관한 `var _a;` 를 program top 에 leak — TSC baseline
2개 snapshot fail (`thisInInvalidContexts`, `thisInInvalidContextsExternalModule`)
의 직접 원인. main 에서도 `bun test` 시 재현됩니다.

```ts
class ErrClass3 extends this {}
// →
var _a;
class ErrClass3 extends this {}
```

## 루트커즈

`class_visit.zig` 의 V8 super_proto_alias path (#3680 follow-up) 진입 조건이
"extends 가 non-identifier 이고 class 가 named" 까지만. 그 안에서 무조건:

1. `makeTempVarSpan(self)` → `temp_var_counter` 1 bump (slot `_a` 점유)
2. `globalThis.Object.getPrototypeOf(X.prototype)` alias_decl 생성
3. `current_super_class = alias_span` set

alias_decl 의 실제 emit 은 `had_static_blocks` 또는 `had_private_methods/fields`
분기 안에서만 (line 225/247/273/291). 두 lowering 어느 것도 트리거되지 않으면
alias 는 만들어 두고 버려진다. 그러나 `temp_var_counter` 는 이미 bump 됐으므로
`hoistTempVars` 가 counter delta 만큼 program top 에 `var _a;` (uninit
declarator) emit. → unused `var _a;` leak.

## 수정 — body probe 기반 결합 가드

V8 path 진입을 두 조건의 결합으로 좁힙니다:

1. **옵션 활성**: `class_private_method` / `class_private_field` /
   `class_static_block` 중 하나 이상 `unsupported`.
2. **body 매칭**: 활성 옵션에 *실제로 대응* 되는 멤버 (private method /
   private field / static_block) 가 body 에 하나라도 존재.

`classBodyHasLowerableMember` helper 추가 — `had_static_blocks` /
`had_private_methods/fields` 가 true 가 될 수 있는 정확한 조건을 단일 pass
로 probe. 이 helper 가 false 면 alias 는 어차피 emit 안 될 운명이므로 V8
path 자체를 skip → counter bump 없음 → leak 차단.

## fix 진화 과정 (`/code-review max` 가 잡은 잔존 케이스)

**첫 시도 (부분 fix)**: `v8_lowering_active = lower_pm or lower_pf or static_block`
만 체크. `extends this` 등 단순 케이스는 통과하지만 `--target=es2020`
(lower_pf=true) 인데 body 에 private 없는 `class X extends getBase() {}` 는
여전히 leak. 옵션이 file scope 활성이라 진입했지만 body 가 match 안 되어
alias 가 버려졌다.

**`/code-review max` 적발**:

> When V8 fires on a class with `extends getBase()` AND a body containing
> **no** private fields/methods/static blocks, ... `var _b;` still dangles —
> exactly the regression the diff intends to fix, just narrowed in trigger
> surface.

→ 재현 확정 후 body probe 추가로 옵션×body 결합 가드로 재구성.

| 케이스 | 첫 fix | 본 PR |
|---|---|---|
| `class X extends this {}` (no options) | ✓ | ✓ |
| `--target=es2020`, body 에 private 없음 | ❌ `var _a;` leak | ✓ clean |
| V8 originally-targeted (private + super) | ✓ alias 정상 emit | ✓ alias 정상 emit |

## Zig 초보자 노트

- `temp_var_counter` 는 transformer 전역 카운터. 한 번 bump 하면 그 slot
  (`_a`/`_b`/…) 이 *예약* 됨. `hoistTempVars` 는 counter delta 보고 top 에
  `var _a;` declaration 만 emit (init 식은 별도 statement 로 들어가야
  하는데, 미사용 alias 경로엔 그 statement 자체가 없으므로 declarator 만
  dangling).
- counter 를 사후 revert 하기 어려운 이유: 그 사이에 다른 코드가 `_b` 등
  다음 slot 을 소비하면 numbering 이 어긋남. 가장 깔끔한 fix 는 *반드시
  사용할 때만* 진입해 bump 하지 않는 것.

## 검증

- TSC expressions 374/374 pass (회귀 가드 `thisInInvalidContexts*` 포함)
- TSC classes 460/460 pass
- TSC 전체 2211/2211 pass
- 잔존 leak 케이스 재현 확정 후 fix 통과:
  ```
  --target=es2020, class X extends getBase() { foo(){return 1;} }
  # before deeper fix: var _a; class X ...
  # after deeper fix:  class X extends getBase() { foo(){return 1;} }
  ```
- 원래 V8 fix 동작 preserved:
  ```
  class X extends getBase() { #priv(){super.bar();} foo(){this.#priv();} }
  # → var _a = globalThis.Object.getPrototypeOf(X.prototype); 정상 emit
  ```
- broader `bun test` 3906/3909 pass (1 flaky RN spawn 무관, 재실행 시 pass)
- `zig build test` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)