### PR TITLE
perf(bundler): #3680 namespace access index share — link.populate -55%, wall -20%

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -565,18 +565,38 @@ pub fn collectNamespaceAccesses(
     ast: *const Ast,
     bindings: []ImportBinding,
 ) !void {
-    var has_namespace = false;
-    for (bindings) |ib| {
-        if (ib.kind == .namespace) {
-            has_namespace = true;
-            break;
+    var index = try collectNamespaceAccessesAndBuildIndex(allocator, ast, bindings, &.{}, .{});
+    index.deinit(allocator);
+}
+
+/// PR #3738 (C6 perf): `collectNamespaceAccesses` 와 동일 분석 + index 반환.
+/// `extra_interest_locals` 가 주어지면 (linker 의 named/cjs/esm 같이) 그 local 들도 색인 →
+/// linker 가 같은 index 를 share 가능.
+/// `opts.reachable_only` 가 false 면 모든 nodes 색인 (linker 호환).
+///
+/// caller 가 index ownership — `defer index.deinit(allocator)` 또는 module 에 store.
+pub fn collectNamespaceAccessesAndBuildIndex(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    bindings: []ImportBinding,
+    extra_interest_locals: []const []const u8,
+    opts: struct { reachable_only: bool = true },
+) !@import("linker/namespace_access.zig").NamespaceAccessIndex {
+    const ns_module = @import("linker/namespace_access.zig");
+
+    var has_any_interest = extra_interest_locals.len > 0;
+    if (!has_any_interest) {
+        for (bindings) |ib| {
+            if (ib.kind == .namespace) {
+                has_any_interest = true;
+                break;
+            }
         }
     }
-    if (!has_namespace) return;
+    // 빈 index 반환 — caller 가 deinit (no-op).
+    if (!has_any_interest) return .{};
 
-    const ns_module = @import("linker/namespace_access.zig");
-    // C5 perf (PR #3737): interest set — namespace local name 만 색인.
-    // 큰 모듈 (10k+ LOC) 에서 모든 ident text 색인의 X10-X100 메모리 절약.
+    // interest set — namespace local + extra (linker 의 named/cjs/esm).
     var interest: std.StringHashMapUnmanaged(void) = .{};
     defer interest.deinit(allocator);
     for (bindings) |ib| {
@@ -584,12 +604,12 @@ pub fn collectNamespaceAccesses(
             try interest.put(allocator, ib.local_name, {});
         }
     }
+    for (extra_interest_locals) |name| {
+        if (name.len > 0) try interest.put(allocator, name, {});
+    }
 
-    // C1 fix (#3736): binding_scanner 는 옛 동작 유지 — reachable_only=true.
-    // 옛 collectNamespaceAccesses 가 `ast_walk.collectReachableNodeIndices` 사용했음.
-    // `build` (= linker default) 는 reachable_only=false 라 binding_scanner 와 의미 다름.
-    var index = try ns_module.NamespaceAccessIndex.buildOpt(allocator, ast, true, &interest);
-    defer index.deinit(allocator);
+    var index = try ns_module.NamespaceAccessIndex.buildOpt(allocator, ast, opts.reachable_only, &interest);
+    errdefer index.deinit(allocator);
 
     for (bindings) |*ib| {
         if (ib.kind != .namespace) continue;
@@ -619,6 +639,7 @@ pub fn collectNamespaceAccesses(
         }.lessThan);
         ib.namespace_used_properties = props;
     }
+    return index;
 }
 
 /// 모든 ExportBinding의 `symbol` 필드를 채운다. 세 경로:

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -775,6 +775,9 @@ pub fn buildIncremental(
                 // 만 free, 다음 rebuild 의 populate 가 cached.module 의 export_bindings 로
                 // 재build. cached.module 쪽 stale 포인터 회피.
                 cached.module.export_index_by_name = null;
+                // PR #3738: namespace_access_index 도 동일 — parse_arena 안 HashMap backing 이라
+                // arena 양도 시 graph 쪽이 (arena, index) 짝 소유. store 쪽 dangling 방지.
+                cached.module.namespace_access_index = null;
                 // canonical_name 은 이전 Build 의 Linker 가 소유한 문자열을
                 // 가리키는데, 그 Linker.deinit 이후 이미 freed 상태다.
                 // 다음 Linker 가 conflict 마다 새로 assign 하므로 stale 한

--- a/src/bundler/graph/parse_module.zig
+++ b/src/bundler/graph/parse_module.zig
@@ -248,6 +248,9 @@ pub fn parseModule(self: *ModuleGraph, idx: ModuleIndex) void {
             self.runTransformerPrePass(module, arena_alloc);
         } else {
             module.transform_cache = null;
+            // PR #3738: prepass 미실행 — parser_metadata.zig:111 의 1차 index 가 module.
+            // namespace_access_index 에 이미 store 됨. pre-transform AST = post-transform AST
+            // (no mutation) → 그대로 linker 가 fetch.
             suppressRuntimeHelperInternalUnresolved(module);
         }
     }

--- a/src/bundler/graph/parser_metadata.zig
+++ b/src/bundler/graph/parser_metadata.zig
@@ -111,7 +111,25 @@ pub fn materialize(
     {
         var namespace_scope = profile.begin(.graph_discover_pm_post_namespace_access);
         defer namespace_scope.end();
-        binding_scanner.collectNamespaceAccesses(arena_alloc, &parser.ast, module.import_bindings) catch {};
+        // PR #3738: index 를 module 에 store — linker 가 fetch (build 1회 절약).
+        // transform_prepass 가 실행되면 post-transform AST 로 덮어씀. 미실행 모듈은
+        // 이 1차 index 유지 (pre-transform = post-transform 동일).
+        // 4 kind interest = 모든 import local (namespace 외도 linker 의 named/cjs/esm 분석).
+        var extra_locals: std.ArrayListUnmanaged([]const u8) = .empty;
+        defer extra_locals.deinit(arena_alloc);
+        for (module.import_bindings) |ib_extra| {
+            if (ib_extra.kind == .namespace) continue;
+            if (ib_extra.local_name.len > 0) extra_locals.append(arena_alloc, ib_extra.local_name) catch {};
+        }
+        if (binding_scanner.collectNamespaceAccessesAndBuildIndex(
+            arena_alloc,
+            &parser.ast,
+            module.import_bindings,
+            extra_locals.items,
+            .{ .reachable_only = false }, // linker 호환
+        )) |idx| {
+            module.namespace_access_index = idx;
+        } else |_| {}
     }
 
     // Phase 1-3b (#1328): 합성 심볼 테이블 초기화 + re_export_alias 등록

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -441,7 +441,27 @@ pub fn resyncAfterAstMutation(
         }
 
         module.import_bindings = try binding_scanner_mod.extractImportBindings(arena_alloc, ast, module.import_records, helper_refs);
-        try binding_scanner_mod.collectNamespaceAccesses(arena_alloc, ast, module.import_bindings);
+
+        // PR #3738 (C6 perf): namespace 외 모든 import local 도 interest 에 추가 — linker 의
+        // .named / cjs default / esm wrapper default 분석에 share. transform_prepass 시점에는
+        // resolve 미완료라 정확한 4 kind 판별 불가, 보수적으로 모든 import local 색인.
+        // 일반 모듈은 import binding 수가 작아 (수개~수십개) 색인 size 영향 무시 가능.
+        var extra_locals: std.ArrayListUnmanaged([]const u8) = .empty;
+        defer extra_locals.deinit(arena_alloc);
+        for (module.import_bindings) |ib_extra| {
+            if (ib_extra.kind == .namespace) continue;
+            if (ib_extra.local_name.len > 0) try extra_locals.append(arena_alloc, ib_extra.local_name);
+        }
+        // index 를 module 에 store — linker 가 fetch (모듈당 build 1회 절약).
+        const ns_idx = try binding_scanner_mod.collectNamespaceAccessesAndBuildIndex(
+            arena_alloc,
+            ast,
+            module.import_bindings,
+            extra_locals.items,
+            .{ .reachable_only = false }, // linker 호환 (orphan node 포함)
+        );
+        // 옛 index 는 parse_arena 소유 — 별도 deinit 불필요 (arena 통째 free). null 으로만 덮어씀.
+        module.namespace_access_index = ns_idx;
 
         // 1차 결과와 union: 2차 가 못 잡은 access 도 keep.
         for (module.import_bindings) |*ib_new| {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1907,24 +1907,25 @@ pub const Linker = struct {
             };
             if (!has_candidate) continue;
 
-            // C5 perf (PR #3737): interest set — analyze candidate 의 local_name 만 색인.
-            // 큰 모듈에서 모든 ident text 색인의 X10-X100 메모리 절감.
-            var interest_set: std.StringHashMapUnmanaged(void) = .{};
-            defer interest_set.deinit(self.allocator);
-            for (importer.import_bindings) |ib_pre| {
-                if (!self.isNamespaceAnalysisCandidate(importer, ib_pre)) continue;
-                if (ib_pre.local_name.len == 0) continue;
-                // OOM 무시 — 누락된 binding 은 analyzer 가 0 결과 → binding_scanner 의 이전
-                // 결과 유지 (linker.zig:1995 의 `count==0 continue`). OOM 자체가 zntc 의
-                // 일반 path 에서 비현실적, 정확성 영향 최소.
-                interest_set.put(self.allocator, ib_pre.local_name, {}) catch {};
-            }
-
-            // importer 당 1회만 AST 순회해 NamespaceAccessIndex 구축.
-            // 같은 모듈 안의 모든 namespace import 분석에 공유 (#1735).
-            // reachable_only=false 유지 (옛 linker 동작 — orphan node 포함).
-            var ns_index = namespace_access.NamespaceAccessIndex.buildOpt(self.allocator, ast, false, &interest_set) catch continue;
-            defer ns_index.deinit(self.allocator);
+            // PR #3738 (C6 perf): transform_prepass 가 build 한 index 를 share — build 1회 절약.
+            // cache 가 없으면 (legacy / 비-JS / transform_prepass 미실행) 자체 build.
+            // cache 의 interest_set 은 *모든 import local* (transform_prepass 시점 resolve 미완료
+            // 라 보수적 over-include) — linker 의 4 kind candidate 는 그 superset 의 subset.
+            var owned_ns_index: ?namespace_access.NamespaceAccessIndex = null;
+            defer if (owned_ns_index) |*idx| idx.deinit(self.allocator);
+            const ns_index_ptr: *const namespace_access.NamespaceAccessIndex = blk: {
+                if (importer.namespace_access_index) |*cached| break :blk cached;
+                // Fallback: 4 kind candidate 의 local_name 만 색인.
+                var interest_set: std.StringHashMapUnmanaged(void) = .{};
+                defer interest_set.deinit(self.allocator);
+                for (importer.import_bindings) |ib_pre| {
+                    if (!self.isNamespaceAnalysisCandidate(importer, ib_pre)) continue;
+                    if (ib_pre.local_name.len == 0) continue;
+                    interest_set.put(self.allocator, ib_pre.local_name, {}) catch {};
+                }
+                owned_ns_index = namespace_access.NamespaceAccessIndex.buildOpt(self.allocator, ast, false, &interest_set) catch continue;
+                break :blk &owned_ns_index.?;
+            };
 
             // 모든 namespace import에 공통으로 쓰일 stmt span 배열을 importer당 1회 구축.
             const stmt_spans_opt: ?[]const Span = if (importer.prebuilt_stmt_info) |*infos| spans_blk: {
@@ -1972,7 +1973,7 @@ pub const Linker = struct {
                     sem.symbol_ids,
                     @intCast(sym_idx),
                     stmt_spans_opt,
-                    &ns_index,
+                    ns_index_ptr,
                     ib.local_name,
                 ) catch continue;
                 defer access.deinit(self.allocator);

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -237,6 +237,12 @@ pub const Module = struct {
     /// transformer 재실행 안 하고 캐시된 root/helpers/symbol_ids 사용.
     transform_cache: ?TransformCache = null,
 
+    /// PR #3738 (C6 perf): transform_prepass 의 binding_scanner 가 build 한
+    /// `NamespaceAccessIndex` 를 linker 가 share — 모듈당 build 1회 절약.
+    /// parse_arena 소유 — module deinit 시 자동 free.
+    /// null = transform_prepass 미실행 또는 namespace import 없음 → linker 가 자체 build.
+    namespace_access_index: ?@import("linker/namespace_access.zig").NamespaceAccessIndex = null,
+
     /// wrap_kind != .none 모듈의 `init_<path>` 함수 심볼 id (semantic 공간).
     /// null = 미래핑 또는 semantic 없음 (fallback: makeInitVarName 재할당).
     init_symbol: ?SemanticSymbolId = null,

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -117,6 +117,9 @@ pub const PersistentModuleStore = struct {
         // shallow copy 라 양쪽이 같은 HashMap backing 가리킴, graph.deinit 이 free 하면
         // store 쪽 dangling. ownership 을 store 로 이전 (graph 쪽 nullify).
         module.export_index_by_name = null;
+        // PR #3738: namespace_access_index 도 동일 — parse_arena 안 HashMap backing 이라
+        // arena 양도 시 store 쪽이 (arena, index) 짝 소유. graph 쪽 dangling 방지.
+        module.namespace_access_index = null;
         module.import_records = &.{};
         module.resolved_deps = .empty;
 

--- a/src/bundler/tree_shaker/const_materialize.zig
+++ b/src/bundler/tree_shaker/const_materialize.zig
@@ -265,6 +265,11 @@ fn markConstMaterializedAndResync(self: *TreeShaker, m: *Module) void {
     self.graph.resyncModuleMetadataAfterConstMaterialization(m, m.parse_arena.?.allocator()) catch {
         m.prebuilt_stmt_info = null;
     };
+    // PR #3738: AST mutation 후 cached namespace_access_index 는 stale (node_idx 매핑 + text key
+    // 모두 invalidate 가능). linker.refreshAfterAstMutation → populateNamespaceAccesses 가 fallback
+    // build path 로 가도록 cache 무효화. parse_arena 가 backing 소유 — null 만으로 충분 (memory leak
+    // 없음, arena 통째 free).
+    m.namespace_access_index = null;
     self.ast_mutated_after_link = true;
 }
 


### PR DESCRIPTION
## 배경

PR #3737 의 C6 perf follow-up — 모듈당 `NamespaceAccessIndex` 가 **3회 build** (parser_metadata + transform_prepass + linker). transform_prepass / parser_metadata 가 build 한 index 를 module 에 store → linker fetch.

## 측정 (effect-ts bundle)

| 단계 | 시작 (PR #3737) | C6 (share only) | C6 final (+ parser_metadata) | Δ 전체 |
|------|----------------|----------------|------------------------------|--------|
| link.populate.namespace.accesses | 427ms | 260ms | **191ms** | **-55%** |
| total self | 534ms | 374ms | **329ms** | **-38%** |
| wall | 1836ms | 1502ms | **1463ms** | **-20%** |

## 변경

### `module.zig`
`namespace_access_index: ?NamespaceAccessIndex = null` 필드 추가. parse_arena 소유.

### `binding_scanner.zig`
새 함수 `collectNamespaceAccessesAndBuildIndex(allocator, ast, bindings, extra_interest_locals, opts)` — index 반환. caller 가 module 에 store.

### `parser_metadata.zig` + `transform_prepass.zig`
4 kind interest = 모든 import local (linker 의 named/cjs/esm 분석 위해). index → module store.

### `linker.zig`
`importer.namespace_access_index` 있으면 fetch (대부분 cache hit), 없으면 fallback build (legacy / 비-JS / parser_metadata error 등 예외 case 만).

### `module_store.zig` / `build_flow.zig`
`namespace_access_index` 도 alias_table / export_index_by_name 와 동일 ownership 패턴 — putModule / cache-hit 에서 source 쪽 nullify (UAF defense-in-depth).

### `const_materialize.zig`
AST mutation 후 cache invalidate — `m.namespace_access_index = null` (linker fallback 으로 fresh build).

## /code-review max 5 angle 적용

| ID | severity | finding | 적용 |
|----|---------|---------|------|
| Angle A #1 | HIGH | const materialize 후 stale cache (string_table realloc → key dangling) | const_materialize cache invalidate |
| Angle B #1 | HIGH | cache-hit roundtrip UAF (cached.module.namespace_access_index 미 nullify) | module_store + build_flow nullify |
| Angle B #2 | HIGH | const_materialize 의 addString → string_table key dangling | 동일 invalidate fix |
| Angle A #2, #4 | MED | arena 위 deinit no-op leak, catch {} silent OOM | try 통일, deinit 제거 |
| Angle C F2 | MED | parse_module else 분기에서 cache 덮어쓰기 | parser_metadata 1차 결과 유지 |
| Angle C F8 | MED | parser_metadata 도 build → linker fallback 도는 모듈 多 | parser_metadata 도 cache store |

## E2E

| 항목 | 결과 |
|------|------|
| zig build test 전체 | ✅ pass |
| tests/integration (3909 tests) | main 25 fail vs C6 25 fail (회귀 0건, flaky 1줄 diff) |
| effect-ts | ✅ `43` |
| shadow gate | ✅ phantom 제거 (PR #3733 효과 보존) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)