### PR TITLE
perf(bundler): #3680 C7 F3 — nested_bindings per-importer cache (-36% register.ns)

### DIFF
--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -410,6 +410,11 @@ pub fn buildMetadataForAst(
     var ns_target_to_var = std.AutoHashMap(u32, []const u8).init(self.allocator);
     defer ns_target_to_var.deinit();
 
+    // PR #3742 (C7 F3 follow-up): nested bindings set 도 caller-owned cache.
+    // 같은 importer 안 N 개 ns import → per-importer 1회 build (lazy init).
+    var nested_bindings_cache: ?std.StringHashMap(void) = null;
+    defer if (nested_bindings_cache) |*c| c.deinit();
+
     // CJS 모듈별 require_xxx 변수명 캐시 (같은 모듈에서 여러 named import 시 중복 생성 방지)
     var cjs_var_cache = std.AutoHashMap(u32, []const u8).init(self.allocator);
     defer {
@@ -822,6 +827,7 @@ pub fn buildMetadataForAst(
                     &ns_inline_list,
                     &owned_nested_renames,
                     &ns_target_to_var,
+                    &nested_bindings_cache,
                     force_inline,
                     false,
                     module_index,
@@ -886,6 +892,7 @@ pub fn buildMetadataForAst(
                                                 &ns_inline_list,
                                                 &owned_nested_renames,
                                                 &ns_target_to_var,
+                                                &nested_bindings_cache,
                                                 nsForceInline(self, ast, override_symbol_ids orelse sem.symbol_ids, @intCast(import_sym_id), module_index, ib.local_name),
                                                 false,
                                                 module_index,
@@ -917,6 +924,7 @@ pub fn buildMetadataForAst(
                                     &ns_inline_list,
                                     &owned_nested_renames,
                                     &ns_target_to_var,
+                                    &nested_bindings_cache,
                                     nsForceInline(self, ast, override_symbol_ids orelse sem.symbol_ids, @intCast(imp_sym), module_index, ib.local_name),
                                     true,
                                     module_index,

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -50,6 +50,11 @@ pub fn registerNamespaceRewrites(
     /// 같은 importer 안에서 여러 namespace import 가 같은 target source 의 inline ns_var
     /// 를 공유하도록 caller 가 owned. `cjs_var_cache` 와 같은 패턴 (`metadata.zig`).
     ns_target_to_var: *std.AutoHashMap(u32, []const u8),
+    /// PR #3742 (C7 F3 follow-up): nested bindings set 도 caller-owned cache.
+    /// 같은 importer 안 N 개 ns import 가 동일한 set 재build 회피 (per-importer 1회).
+    /// null 으로 시작, 첫 호출에서 lazy build. caller 가 `defer if (cache) |*c| c.deinit()`.
+    /// per-thread — emit thread 마다 별도 buildMetadataForAst → 별도 cache (caller stack frame).
+    nested_bindings_cache: *?std.StringHashMap(void),
     force_inline: bool,
     force_target_init: bool,
     importer_mod_idx: u32,
@@ -150,28 +155,40 @@ pub fn registerNamespaceRewrites(
     // 강제 비활성(kill-switch) — 안전 경로에서도 끌 수만 있고 켤 수는 없다.
     const ns_rewrite = !nsRewriteDisabled() and self.nsMemberRewriteSafe();
 
-    // PR #3741 (C7 perf): nested bindings 사전 set — `hasNestedBinding` 가 cached_exports
-    // 마다 *모든 nested scope 순회* (O(exports × scopes × names)). 호출 1회 precompute 후
-    // contains O(1) lookup 으로 변경 (O(scopes × names) + O(exports)).
-    // ns_rewrite=true 면 호출 자체 안 함 → skip.
-    var nested_bindings: std.StringHashMap(void) = std.StringHashMap(void).init(self.allocator);
-    defer nested_bindings.deinit();
-    if (!ns_rewrite) {
+    // PR #3741 (C7) + #3742 (F3 follow-up): caller-owned nested bindings cache.
+    // 같은 importer 의 N 개 ns import → cache 1회 build, 이후 fetch (per-importer 1회).
+    // ns_rewrite=true 면 cache 빌드 자체 skip — `nested_bindings_cache.*` 가 null 유지.
+    if (!ns_rewrite and nested_bindings_cache.* == null) {
         if (self.getModule(importer_mod_idx)) |importer_mod| {
             if (importer_mod.semantic) |sem| {
+                var nb = std.StringHashMap(void).init(self.allocator);
+                errdefer nb.deinit();
+                // F2: capacity hint — non-module-scope 의 entry 합 추정.
+                var est: usize = 0;
+                for (sem.scope_maps, 0..) |scope_map, scope_idx| {
+                    if (scope_idx == 0) continue;
+                    est += scope_map.count();
+                }
+                try nb.ensureTotalCapacity(@intCast(est));
                 for (sem.scope_maps, 0..) |scope_map, scope_idx| {
                     if (scope_idx == 0) continue;
                     var it = scope_map.iterator();
                     while (it.next()) |entry| {
-                        try nested_bindings.put(entry.key_ptr.*, {});
+                        try nb.put(entry.key_ptr.*, {});
                     }
                 }
+                nested_bindings_cache.* = nb;
             }
         }
     }
 
     for (cached_exports) |exp| {
-        if (!ns_rewrite and nested_bindings.contains(exp.exported)) {
+        const is_shadow = blk: {
+            if (ns_rewrite) break :blk false;
+            const nb = nested_bindings_cache.* orelse break :blk false;
+            break :blk nb.contains(exp.exported);
+        };
+        if (is_shadow) {
             has_shadow = true;
             continue;
         }


### PR DESCRIPTION
## 배경

PR #3741 (C7) 사후 review 의 F3 — `registerNamespaceRewrites` 가 *per-call* nested_bindings set build. 같은 importer 의 N 개 ns import → N 회 같은 set 재build.

→ caller-owned cache 로 *per-importer 1회* 만 build.

## 변경

### `src/bundler/linker/shared_namespace.zig`
- `registerNamespaceRewrites` signature 에 `nested_bindings_cache: *?StringHashMap(void)` 인자 추가
- cache.* == null + !ns_rewrite 면 lazy build (capacity hint = scope_maps entry 합 — F2)
- 이후 호출은 cache.* 가 not-null 이라 build skip

### `src/bundler/linker/metadata.zig`
- import_bindings scope 시작에 `var nested_bindings_cache: ?StringHashMap(void) = null;`
- 3 call sites 가 `&nested_bindings_cache` pass

## 측정 (effect-ts, 3x 평균)

| 카테고리 | C7 (PR #3741) | F3 | Δ vs C7 | Δ vs 시작 (PR #3737) |
|---------|---------------|-----|---------|---------------------|
| `metadata.register.ns.rewrites` | 2892ms | **~1864ms** | **-36%** | **-56%** |
| **wall** | 1390ms | **~1139ms** | **-18%** | **-38%** |

## /code-review max (3 angle 합집합)

| ID | severity | 적용 |
|----|---------|------|
| M1 capacity over-provision (sum vs union) | MED | future F4 (cached_exports intersection) 권장 |
| M2 @intCast overflow (4G entries) | LOW | precedent, 무해 |
| L1 per-thread 명시 | LOW | docstring 추가 |
| L2-L7 정합성 확인 | INFO | 변경 없음 |

**correctness/lifetime 회귀 없음** — semantic 동치 verified.

## E2E

| 항목 | 결과 |
|------|------|
| zig build test 전체 | ✅ pass |
| tests/integration (3909 tests) | main 25 fail vs F3 **3 fail** (회귀 0건, +22 통과) |
| effect-ts | ✅ \`43\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)