### PR TITLE
feat(bundler): CSS external @import URL preserve (cross-chunk @import, #3321 P0-3)

### DIFF
--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -43,11 +43,20 @@ pub fn emitCssBundle(
         }
     }.lessThan);
 
-    // CSS 소스 연결 (@import strip)
+    // CSS 소스 연결 (@import strip).
+    // external @import URL 은 strip 후 별도 보존 — 출력 최상단에 emit.
+    // OOM 시 silent drop 회피 — collect / appendTo / appendCssModules 모두
+    // error 시 null 반환 (사용자가 빌드 실패로 인지). planCssChunks 의 try
+    // 패턴과 일치.
     var output: std.ArrayListUnmanaged(u8) = .empty;
     defer output.deinit(allocator);
 
-    appendCssModules(allocator, &output, css_modules.items) catch {};
+    var ext_imports = ExternalImportCollector.init(allocator);
+    defer ext_imports.deinit(allocator);
+    for (css_modules.items) |mod| ext_imports.collectFromModule(allocator, mod) catch return null;
+    ext_imports.appendTo(allocator, &output) catch return null;
+
+    appendCssModules(allocator, &output, css_modules.items) catch return null;
 
     if (output.items.len == 0) return null;
 
@@ -74,12 +83,114 @@ fn appendCssModule(
     mod: *const Module,
 ) !void {
     const strip_end: u32 = if (mod.css_data) |cd| cd.strip_end else 0;
-    const stripped = if (strip_end > 0 and strip_end < mod.source.len) mod.source[strip_end..] else mod.source;
+    // strip_end == source.len 케이스: @import 들로만 채워진 CSS (예: index aggregator
+    // 가 모두 external @import). 옛 가드 `strip_end < source.len` 은 false →
+    // 원본 통째 emit → ExternalImportCollector 의 prepend 와 합쳐져 같은 @import
+    // 2회 출력. `<=` 로 boundary 포함시 빈 슬라이스 반환 → trimmed.len == 0 으로
+    // early return.
+    const stripped = if (strip_end > 0 and strip_end <= mod.source.len) mod.source[strip_end..] else mod.source;
     const trimmed = std.mem.trim(u8, stripped, " \t\n\r");
     if (trimmed.len == 0) return;
     try buf.appendSlice(allocator, stripped);
     if (stripped.len > 0 and stripped[stripped.len - 1] != '\n') {
         try buf.append(allocator, '\n');
+    }
+}
+
+/// External @import URL (`http:`/`https:`/`//`/`data:`) 을 dedup 수집 + 출력 CSS
+/// 상단에 보존 (#3321 P0-3, esbuild parity). CSS spec 상 모든 @import 는 모든
+/// 일반 규칙보다 *앞* 에 와야 하므로 chunk 본문 emit 보다 먼저 호출.
+///
+/// dedup key = (specifier, condition_tail) tuple — `@import "x" print` 와
+/// `@import "x" screen` 은 서로 다른 항목 (media-query 별 lookup 동작이 달라
+/// silent drop 금지). condition_tail 도 함께 보존 emit.
+///
+/// 등장 순서 (모듈 emit 순회 시 첫 발견) 보존 — 결정적.
+const ExternalImportEntry = struct {
+    specifier: []const u8,
+    condition_tail: []const u8,
+};
+const ExternalImportCollector = struct {
+    /// key = "<specifier>\x00<condition_tail>" — `\x00` 은 CSS spec 상 합법
+    /// URL/condition 에 등장 불가라 안전한 separator.
+    seen: std.StringHashMap(void),
+    list: std.ArrayListUnmanaged(ExternalImportEntry),
+
+    fn init(allocator: std.mem.Allocator) ExternalImportCollector {
+        return .{
+            .seen = std.StringHashMap(void).init(allocator),
+            .list = .empty,
+        };
+    }
+
+    fn deinit(self: *ExternalImportCollector, allocator: std.mem.Allocator) void {
+        var kit = self.seen.keyIterator();
+        while (kit.next()) |k| allocator.free(k.*);
+        self.seen.deinit();
+        self.list.deinit(allocator);
+    }
+
+    /// 모듈의 import_records 에서 external @import specifier 를 수집.
+    /// entry 의 specifier/condition_tail 슬라이스는 record 가 가리키는 모듈
+    /// parse_arena 소유 — chunk emit 동안만 사용하므로 안전.
+    ///
+    /// OOM 안전성: list.append 가 먼저 성공해야 seen.put 한다. 순서 반대면
+    /// seen 만 들어가고 list 비어 `found_existing` 으로 영구 skip → silent
+    /// drop 회귀.
+    fn collectFromModule(self: *ExternalImportCollector, allocator: std.mem.Allocator, mod: *const Module) !void {
+        for (mod.import_records) |rec| {
+            if (!rec.is_external) continue;
+            if (rec.specifier.len == 0) continue;
+            const composite_key = try std.fmt.allocPrint(allocator, "{s}\x00{s}", .{ rec.specifier, rec.css_condition_tail });
+            errdefer allocator.free(composite_key);
+            const gop = try self.seen.getOrPut(composite_key);
+            if (gop.found_existing) {
+                allocator.free(composite_key);
+                continue;
+            }
+            // append 실패하면 errdefer 가 key 회수 + getOrPut 한 entry 도 제거.
+            self.list.append(allocator, .{
+                .specifier = rec.specifier,
+                .condition_tail = rec.css_condition_tail,
+            }) catch |e| {
+                _ = self.seen.remove(composite_key);
+                return e;
+            };
+        }
+    }
+
+    /// 수집된 external specifier 를 `@import "<url>"<tail>;\n` 형태로 buf 에
+    /// prepend 가능한 위치(보통 buf 시작 또는 banner 직후)에 emit. 호출자가
+    /// buf 의 적절한 시점에 호출해야 한다.
+    ///
+    /// specifier 안의 `"` 는 CSS spec 의 `\22` escape (16진수+공백) 로 안전
+    /// 출력 — `data:text/css,body{content:"x"}` 같은 quote-포함 URL 도 invalid
+    /// CSS / injection 표면 없이 보존.
+    fn appendTo(self: *const ExternalImportCollector, allocator: std.mem.Allocator, buf: *std.ArrayListUnmanaged(u8)) !void {
+        for (self.list.items) |entry| {
+            try buf.appendSlice(allocator, "@import \"");
+            try appendCssStringEscaped(allocator, buf, entry.specifier);
+            try buf.append(allocator, '"');
+            if (entry.condition_tail.len > 0) {
+                try buf.appendSlice(allocator, entry.condition_tail);
+            }
+            try buf.appendSlice(allocator, ";\n");
+        }
+    }
+};
+
+/// CSS double-quoted string literal 안전 escape. `"` → `\22 `, `\` → `\\`.
+/// CSS spec §4.3.5 (Escape): hex escape `\<1-6 hex digits>` 다음 공백 1개로
+/// terminate. 다음 문자가 hex 면 ambiguity → 항상 trailing space 부착.
+fn appendCssStringEscaped(allocator: std.mem.Allocator, buf: *std.ArrayListUnmanaged(u8), s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '"' => try buf.appendSlice(allocator, "\\22 "),
+            '\\' => try buf.appendSlice(allocator, "\\\\"),
+            '\n' => try buf.appendSlice(allocator, "\\A "),
+            '\r' => try buf.appendSlice(allocator, "\\D "),
+            else => try buf.append(allocator, c),
+        }
     }
 }
 
@@ -89,6 +200,30 @@ fn appendCssModules(
     css_modules: []const *const Module,
 ) !void {
     for (css_modules) |mod| try appendCssModule(allocator, buf, mod);
+}
+
+/// CSS 모듈 트리를 dep-first 로 순회하며 external @import URL 을 collector
+/// 에 모은다. emit 트리 순회와 동일한 deps-before-importer 순서로 등장 순서
+/// 결정성을 유지 (collector 의 list 가 first-seen order 보존).
+fn collectExternalImportsTree(
+    graph: *const ModuleGraph,
+    idx: ModuleIndex,
+    collector: *ExternalImportCollector,
+    visited: *std.AutoHashMap(ModuleIndex, void),
+    allocator: std.mem.Allocator,
+) !void {
+    if (idx.isNone()) return;
+    if (visited.contains(idx)) return;
+    try visited.put(idx, {});
+    const mod = graph.getModule(idx) orelse return;
+    if (mod.module_type != .css) return;
+    for (mod.dependencies.items) |dep| {
+        if (graph.getModule(dep)) |dm| {
+            if (dm.module_type == .css)
+                try collectExternalImportsTree(graph, dep, collector, visited, allocator);
+        }
+    }
+    try collector.collectFromModule(allocator, mod);
 }
 
 /// 한 CSS 모듈을 그 @import(css→css) 의존을 먼저 인라인한 뒤 emit 한다.
@@ -206,7 +341,25 @@ pub fn planCssChunks(
 
         var buf: std.ArrayListUnmanaged(u8) = .empty;
         defer buf.deinit(allocator);
+
+        // External @import URL 을 chunk 단위 dedup 수집 후 chunk 본문 상단에
+        // emit (CSS spec: 모든 @import 가 일반 규칙보다 앞). chunk 간 emit 은
+        // 허용 (모듈이 여러 chunk 에 인라인되면 같은 external URL 도 각
+        // chunk 의 상단에 1번씩 등장 — 런타임 fetch dedup 은 브라우저 책임).
+        var ext_imports = ExternalImportCollector.init(allocator);
+        defer ext_imports.deinit(allocator);
+
         emit_visited.clearRetainingCapacity();
+        // external collect 는 emit 과 동일 dep 트리 순회 — emitCssModuleTree 가
+        // 본문 emit 도중 visited 를 마킹해 같은 dep 가 2번 walk 되지 않는다.
+        // 따라서 external 수집은 emit 전에 별도 일회 순회로 처리한다.
+        var collect_visited = std.AutoHashMap(ModuleIndex, void).init(allocator);
+        defer collect_visited.deinit();
+        for (list.items) |mod| {
+            try collectExternalImportsTree(graph, mod.index, &ext_imports, &collect_visited, allocator);
+        }
+        try ext_imports.appendTo(allocator, &buf);
+
         for (list.items) |mod| {
             try emitCssModuleTree(allocator, graph, mod.index, &buf, &emit_visited);
         }

--- a/src/bundler/css_scanner.zig
+++ b/src/bundler/css_scanner.zig
@@ -12,7 +12,38 @@ pub const CssImportRecord = struct {
     specifier: []const u8,
     /// 소스 코드에서의 위치 (@import 시작 ~ 세미콜론)
     span: Span,
+    /// External URL (`http:`/`https:`/`//` prefix) 여부. true 면 resolver 가
+    /// 건너뛰고 emitter 가 출력 CSS 상단에 그대로 보존한다 (esbuild parity).
+    is_external: bool = false,
+    /// specifier 끝 이후 ~ `;` 직전 까지의 raw tail (예: ` print`,
+    /// ` layer(reset)`, ` supports(display:flex) screen`). leading 공백 포함.
+    /// external @import 보존 시 그대로 재출력해 media-query/layer/supports
+    /// semantic 을 유지 (esbuild parity). 일반(inline) @import 에선 사용 안 함.
+    /// source 슬라이스 — 모듈 수명 내 유효.
+    condition_tail: []const u8 = "",
 };
+
+/// ASCII case-insensitive prefix 매칭. RFC3986: URL scheme 은 case-insensitive.
+fn startsWithIgnoreCaseAscii(s: []const u8, prefix: []const u8) bool {
+    if (s.len < prefix.len) return false;
+    for (prefix, 0..) |c, i| {
+        if (std.ascii.toLower(s[i]) != std.ascii.toLower(c)) return false;
+    }
+    return true;
+}
+
+/// CSS `@import` specifier 가 external URL 인지 판정.
+/// esbuild 기준: `http:`/`https:` protocol-prefixed 또는 `//` protocol-relative.
+/// data: URL 도 spec 상 valid `@import` 대상이라 external 로 처리해 resolver 우회.
+/// scheme 은 case-insensitive (RFC3986) — `HTTPS://` 도 external.
+pub fn isExternalCssSpecifier(specifier: []const u8) bool {
+    if (specifier.len < 2) return false;
+    if (std.mem.startsWith(u8, specifier, "//")) return true;
+    if (startsWithIgnoreCaseAscii(specifier, "http://")) return true;
+    if (startsWithIgnoreCaseAscii(specifier, "https://")) return true;
+    if (startsWithIgnoreCaseAscii(specifier, "data:")) return true;
+    return false;
+}
 
 /// CSS 소스에서 @import 규칙을 추출한다.
 /// @charset, 공백, 주석은 건너뛰고, 첫 번째 non-import 규칙에서 중단.
@@ -65,12 +96,29 @@ pub fn extractCssImports(allocator: std.mem.Allocator, source: []const u8) []con
 
             // url("...") 또는 "..." 또는 '...' 파싱
             const spec = extractSpecifier(source, pos, len) orelse break;
+            const tail_start = spec.end_pos;
             pos = skipToSemicolon(source, spec.end_pos, len);
+            // condition_tail = specifier 끝 이후 ~ `;` 직전 까지. external @import
+            // 재emit 시 media-query/layer/supports clause 보존용. `;` 자체는 제외
+            // — emitter 가 `";\n"` 으로 따로 붙임 (포함하면 double semicolon).
+            // `skipToSemicolon` 은 `;` *다음* 위치 반환 (source[pos-1]==';'), 또는
+            // `;` 미발견 시 len. trailing 공백/CR 은 함께 잡혀도 valid CSS 라 무해.
+            const tail_end: u32 = blk: {
+                if (pos > tail_start and pos <= len and source[pos - 1] == ';') break :blk pos - 1;
+                break :blk pos;
+            };
+            const tail_slice: []const u8 = if (tail_end > tail_start)
+                source[tail_start..tail_end]
+            else
+                "";
 
             if (count < MAX_IMPORTS) {
+                const specifier_slice = source[spec.start..spec.end];
                 results[count] = .{
-                    .specifier = source[spec.start..spec.end],
+                    .specifier = specifier_slice,
                     .span = .{ .start = start, .end = pos },
+                    .is_external = isExternalCssSpecifier(specifier_slice),
+                    .condition_tail = tail_slice,
                 };
                 count += 1;
             }
@@ -93,6 +141,23 @@ const SpecifierResult = struct {
     end_pos: u32,
 };
 
+/// CSS quoted string 의 닫는 quote 위치를 찾는다.
+/// CSS spec §4.3.5: `\` 다음 한 글자는 escape 로 specifier 종료 quote 가 아님.
+/// `\` 가 source 끝이면 자기 자신만 1바이트 소비 (방어).
+fn findClosingQuote(source: []const u8, start: u32, len: u32, quote: u8) u32 {
+    var p = start;
+    while (p < len) {
+        if (source[p] == '\\') {
+            // escape 다음 1바이트 skip (data: URL 에 `\"x\"` 같은 패턴 보존).
+            p += 2;
+            continue;
+        }
+        if (source[p] == quote) return p;
+        p += 1;
+    }
+    return p;
+}
+
 fn extractSpecifier(source: []const u8, pos: u32, len: u32) ?SpecifierResult {
     var p = pos;
     if (p >= len) return null;
@@ -107,7 +172,7 @@ fn extractSpecifier(source: []const u8, pos: u32, len: u32) ?SpecifierResult {
             const quote = source[p];
             p += 1;
             const start = p;
-            while (p < len and source[p] != quote) : (p += 1) {}
+            p = findClosingQuote(source, p, len, quote);
             const end = p;
             if (p < len) p += 1; // 닫는 따옴표
             p = skipWhitespace(source, p, len);
@@ -128,7 +193,7 @@ fn extractSpecifier(source: []const u8, pos: u32, len: u32) ?SpecifierResult {
         const quote = source[p];
         p += 1;
         const start = p;
-        while (p < len and source[p] != quote) : (p += 1) {}
+        p = findClosingQuote(source, p, len, quote);
         const end = p;
         if (p < len) p += 1; // 닫는 따옴표
         return .{ .start = start, .end = end, .end_pos = p };

--- a/src/bundler/graph/loaders.zig
+++ b/src/bundler/graph/loaders.zig
@@ -57,6 +57,11 @@ pub fn parseCssModule(self: *ModuleGraph, module: *Module) void {
                 .specifier = imp.specifier,
                 .kind = .side_effect,
                 .span = imp.span,
+                // External URL (`http:`/`https:`/`//`/`data:`) — resolver 가 skip
+                // 하고 emitter 가 출력 CSS 상단에 보존 (esbuild parity, #3321 P0-3).
+                .is_external = imp.is_external,
+                // media-query/layer/supports tail 보존 — external 재emit 시 사용.
+                .css_condition_tail = imp.condition_tail,
             };
         }
         module.import_records = records;

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -718,6 +718,12 @@ pub const ImportRecord = struct {
     /// (#2681). graph reachability 분석이 이 flag 를 보고 호출 사이트가 reachable
     /// 일 때만 source 모듈을 included 처리.
     in_lazy_callback: bool = false,
+    /// CSS `@import` 의 specifier 끝 이후 ~ `;` 직전 까지의 raw tail
+    /// (예: ` print`, ` layer(reset)`, ` supports(display:flex) screen`).
+    /// `is_external` external @import 보존 시 그대로 재출력해 media-query/
+    /// layer/supports semantic 을 유지 (esbuild parity). JS record 는 미사용
+    /// — 빈 string default.
+    css_condition_tail: []const u8 = "",
 };
 
 // ============================================================

--- a/tests/e2e/tests/css-external-import-e2e.test.ts
+++ b/tests/e2e/tests/css-external-import-e2e.test.ts
@@ -1,0 +1,188 @@
+import { test, expect } from '@playwright/test';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile, mkdir, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { serve, closeServer } from './serve';
+
+/**
+ * CSS external `@import` URL preservation E2E — bundler 가 보존한
+ * `@import "https://..."` 가 실제 브라우저에서 fetch + cascade 적용되는지
+ * 검증한다 (#3321 P0-3).
+ *
+ * 통합 테스트(bun test)는 출력 CSS 의 `@import` 라인 존재까지만 본다.
+ * 본 테스트는 page.route 로 external URL 응답을 mock 해서 실 브라우저
+ * 가 그 stylesheet 를 fetch + 적용하는 전 과정을 검증.
+ */
+const ZNTC_BIN = resolve(__dirname, '../../../zig-out/bin/zntc');
+
+const FIXTURE: Record<string, string> = {
+  'index.ts': `
+import "./style.css";
+const box = document.createElement('div');
+box.setAttribute('data-testid', 'box');
+box.textContent = 'hello';
+document.body.appendChild(box);
+(window as any).__loaded = true;
+`,
+  // 의도적으로 흔치 않은 색 → mock external 가 응답한 것만 적용 검증
+  'style.css':
+    `@import "https://cdn.zntc-e2e.test/external.css";\n` + `.local { color: rgb(7, 7, 7); }`,
+};
+
+test('external @import URL 이 브라우저 fetch + cascade 적용된다', async ({ page }) => {
+  const dir = await mkdtemp(join(tmpdir(), 'zntc-css-ext-e2e-'));
+  try {
+    for (const [name, content] of Object.entries(FIXTURE)) {
+      await writeFile(join(dir, name), content);
+    }
+    const dist = join(dir, 'dist');
+    await mkdir(dist, { recursive: true });
+
+    const build = spawnSync(
+      ZNTC_BIN,
+      [
+        '--bundle',
+        join(dir, 'index.ts'),
+        '-o',
+        join(dist, 'index.js'),
+        '--format=esm',
+        '--platform=browser',
+      ],
+      { stdio: 'pipe', timeout: 15000 },
+    );
+    expect(build.status, `ZNTC build failed: ${build.stderr?.toString().slice(0, 400)}`).toBe(0);
+
+    // bundler 가 external @import 를 보존했는지 빌드 산출물 단계 가드
+    const builtCss = await readFile(join(dist, 'index.css'), 'utf-8');
+    expect(builtCss).toContain('@import "https://cdn.zntc-e2e.test/external.css"');
+    expect(builtCss.indexOf('@import')).toBeLessThan(builtCss.indexOf('.local'));
+
+    await writeFile(
+      join(dist, 'index.html'),
+      `<!DOCTYPE html><html><head><meta charset="utf-8"><link rel="stylesheet" href="./index.css"></head><body><script type="module" src="./index.js"></script></body></html>`,
+    );
+
+    // mock external CSS — 실 네트워크 의존성 제거
+    let externalFetched = false;
+    await page.route('https://cdn.zntc-e2e.test/external.css', async (route) => {
+      externalFetched = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/css',
+        body: `[data-testid="box"] { background-color: rgb(3, 4, 5); }`,
+      });
+    });
+
+    const { server, port } = await serve(dist);
+    try {
+      const errors: string[] = [];
+      page.on('pageerror', (e) => errors.push(e.message));
+
+      await page.goto(`http://localhost:${port}/`);
+      await page.waitForFunction(() => (window as any).__loaded === true, {
+        timeout: 5000,
+      });
+
+      // 브라우저가 external @import URL 을 실제로 fetch 했는지
+      expect(externalFetched, 'external @import URL was not fetched by browser').toBe(true);
+
+      // external stylesheet 가 cascade 에 들어가 box 에 적용됐는지 (background)
+      // + 로컬 규칙 (.local 은 안 붙임) 과 별개로 background 만 검증.
+      const bg = await page.evaluate(() => {
+        const el = document.querySelector('[data-testid="box"]')!;
+        return getComputedStyle(el).backgroundColor;
+      });
+      expect(bg).toBe('rgb(3, 4, 5)');
+
+      expect(errors, `browser errors: ${errors.join(', ')}`).toHaveLength(0);
+    } finally {
+      await closeServer(server);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('external @import + media query → media clause 가 브라우저에 전달된다', async ({ page }) => {
+  const dir = await mkdtemp(join(tmpdir(), 'zntc-css-ext-mq-e2e-'));
+  try {
+    await writeFile(
+      join(dir, 'index.ts'),
+      `import "./style.css";\nconst box = document.createElement('div'); box.setAttribute('data-testid','b'); document.body.appendChild(box);\n(window as any).__loaded = true;\n`,
+    );
+    // media query 가 specifier 뒤에 살아있어야 함 — print only 라 viewport 에선 적용 X
+    await writeFile(
+      join(dir, 'style.css'),
+      `@import "https://cdn.zntc-e2e.test/print.css" print;\n` +
+        `[data-testid="b"] { color: rgb(2, 2, 2); }`,
+    );
+
+    const dist = join(dir, 'dist');
+    await mkdir(dist, { recursive: true });
+
+    const build = spawnSync(
+      ZNTC_BIN,
+      [
+        '--bundle',
+        join(dir, 'index.ts'),
+        '-o',
+        join(dist, 'index.js'),
+        '--format=esm',
+        '--platform=browser',
+      ],
+      { stdio: 'pipe', timeout: 15000 },
+    );
+    expect(build.status).toBe(0);
+
+    const builtCss = await readFile(join(dist, 'index.css'), 'utf-8');
+    // media clause 가 specifier 뒤에 살아있어야 함
+    expect(builtCss).toMatch(/@import\s+"https:\/\/cdn\.zntc-e2e\.test\/print\.css"\s+print\s*;/);
+
+    await writeFile(
+      join(dist, 'index.html'),
+      `<!DOCTYPE html><html><head><meta charset="utf-8"><link rel="stylesheet" href="./index.css"></head><body><script type="module" src="./index.js"></script></body></html>`,
+    );
+
+    let printFetched = false;
+    await page.route('https://cdn.zntc-e2e.test/print.css', async (route) => {
+      printFetched = true;
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/css',
+        // print 매체에서만 적용 — viewport 에선 영향 0
+        body: `[data-testid="b"] { color: rgb(255, 0, 0) !important; }`,
+      });
+    });
+
+    const { server, port } = await serve(dist);
+    try {
+      await page.goto(`http://localhost:${port}/`);
+      await page.waitForFunction(() => (window as any).__loaded === true, { timeout: 5000 });
+
+      // print-only stylesheet 라도 브라우저는 fetch 한다 (matchMedia 와 무관, lazy 가능)
+      // 핵심: viewport 에선 cascade 적용 X → local 의 rgb(2,2,2) 가 유지돼야 함.
+      const color = await page.evaluate(() => {
+        const el = document.querySelector('[data-testid="b"]')!;
+        return getComputedStyle(el).color;
+      });
+      expect(color).toBe('rgb(2, 2, 2)');
+
+      // print emulate 로 매체 전환 시 external print.css 가 cascade 진입
+      await page.emulateMedia({ media: 'print' });
+      // print 매체에선 fetch 트리거 (lazy load 됐을 수 있음)
+      await page.waitForFunction(() => true);
+      const colorPrint = await page.evaluate(() => {
+        const el = document.querySelector('[data-testid="b"]')!;
+        return getComputedStyle(el).color;
+      });
+      // print emulate 후 매체 매칭으로 external 규칙 적용 → red
+      expect(colorPrint).toBe('rgb(255, 0, 0)');
+      expect(printFetched, 'print-only external CSS was not fetched').toBe(true);
+    } finally {
+      await closeServer(server);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/tests/css-bundle.test.ts
+++ b/tests/integration/tests/css-bundle.test.ts
@@ -496,4 +496,190 @@ describe('CSS Bundling', () => {
     const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
     expect(css.indexOf('.a')).toBeLessThan(css.indexOf('.b'));
   });
+
+  // ── external @import URL preservation (#3321 P0-3 cross-chunk @import 재작성) ──
+  // esbuild parity: protocol-prefixed (`http:`/`https:`) 또는 protocol-relative
+  // (`//`) @import 는 *resolve 대상이 아님* — bundler 가 graph 에 등록 시도
+  // 하면 "Cannot resolve module" 로 실패. 정석은 external 로 인식해 출력
+  // CSS 상단에 그대로 보존 (런타임 fetch). 멀티 청크 / 멀티 importer 시에도
+  // 각 출력에서 dedup 된 1회 emit.
+  it('external http(s) @import URL → resolve 시도 안 함 + 출력에 보존', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';\nconsole.log("ok");`,
+      'style.css':
+        `@import "https://fonts.googleapis.com/css?family=Inter";\n` +
+        `.btn { font-family: "Inter"; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    // 빌드는 성공해야 함 (esbuild parity)
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    // external @import URL 은 출력에 보존
+    expect(css).toContain('@import "https://fonts.googleapis.com/css?family=Inter"');
+    expect(css).toContain('.btn');
+    // CSS spec: 모든 @import 는 모든 일반 규칙보다 먼저 와야 함
+    expect(css.indexOf('@import')).toBeLessThan(css.indexOf('.btn'));
+  });
+
+  it('protocol-relative // @import URL → 보존', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';\nconsole.log("ok");`,
+      'style.css': `@import "//cdn.example.com/reset.css";\n.app { color: red; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    expect(css).toContain('@import "//cdn.example.com/reset.css"');
+  });
+
+  it('external + 일반 @import 혼합 → external 보존, 일반 inline', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './main.css';\nconsole.log("ok");`,
+      'main.css':
+        `@import "https://example.com/normalize.css";\n` +
+        `@import "./local.css";\n` +
+        `.main { color: black; }`,
+      'local.css': `.local { color: blue; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    // external 보존
+    expect(css).toContain('@import "https://example.com/normalize.css"');
+    // 일반 @import 는 inline 됐으므로 제거
+    expect(css).not.toContain('./local.css');
+    expect(css).toContain('.local');
+    expect(css).toContain('.main');
+    // external @import 이 일반 규칙보다 앞에 있어야 함
+    expect(css.indexOf('@import')).toBeLessThan(css.indexOf('.main'));
+  });
+
+  // code-review max post-review 회귀 가드.
+  it('uppercase HTTPS scheme → external 로 인식, resolve 실패 안 함', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';\nconsole.log("ok");`,
+      'style.css': `@import "HTTPS://cdn.example.com/x.css";\n.a {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    expect(css).toContain('@import "HTTPS://cdn.example.com/x.css"');
+  });
+
+  it('external @import + media query → media clause 보존 (semantic preserve)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';\nconsole.log("ok");`,
+      'style.css':
+        `@import "https://cdn/print.css" print;\n` +
+        `@import "https://cdn/screen.css" screen and (max-width: 600px);\n` +
+        `.app {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    // print 키워드 / media query 가 specifier 뒤에 살아있어야 함
+    expect(css).toMatch(/@import\s+"https:\/\/cdn\/print\.css"\s+print\s*;/);
+    expect(css).toMatch(
+      /@import\s+"https:\/\/cdn\/screen\.css"\s+screen\s+and\s+\(max-width:\s*600px\)\s*;/,
+    );
+  });
+
+  it('순수 external @import 만 있는 CSS → 같은 @import 가 한 번만 출력 (double-emit 회피)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './only-ext.css';\nconsole.log("ok");`,
+      'only-ext.css': `@import "https://cdn/normalize.css";`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    const matches = css.match(/@import\s+"https:\/\/cdn\/normalize\.css"/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('같은 external URL 을 여러 모듈이 @import → chunk 내 1회 emit (dedup)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './a.css';\nimport './b.css';\nconsole.log("ok");`,
+      'a.css': `@import "https://cdn/normalize.css";\n.a {}`,
+      'b.css': `@import "https://cdn/normalize.css";\n.b {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    const matches = css.match(/@import\s+"https:\/\/cdn\/normalize\.css"/g) ?? [];
+    expect(matches.length).toBe(1);
+    expect(css).toContain('.a');
+    expect(css).toContain('.b');
+  });
+
+  it('data: URL with embedded escaped quote — backslash escape 보존 + emit 시 hex escape', async () => {
+    // scanner 가 `\"` 를 string terminator 로 오인하면 specifier 절단 → broken CSS.
+    // findClosingQuote 가 `\<char>` 를 escape sequence 로 인식해 다음 1바이트 skip
+    // 해야 한다. emitter 의 appendCssStringEscaped 가 `"` → `\22 ` 로 변환해
+    // round-trip 정확성 유지.
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';\nconsole.log("ok");`,
+      'style.css': `@import "data:text/css,body{content:\\"x\\"}";\n.app {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    // specifier 가 절단되지 않고 끝까지 보존 + closing `}` 와 `";` 가 모두 같은 라인에
+    expect(css).toContain('@import "data:text/css,body{content:');
+    expect(css).toContain('}";');
+    // 백슬래시 escape 가 CSS hex escape 로 변환됨 (\22 는 `"`, \\ 는 `\`)
+    expect(css).toMatch(/\\22/);
+    // 절단 후 dangling 본문이 emit 되지 않음 — 닫는 quote 다음에 `";\n` 만
+    const importLine = css.match(/^@import[^\n]+/m);
+    expect(importLine?.[0].endsWith('";')).toBe(true);
+  });
+
+  it('같은 URL 의 다른 media query → 서로 다른 @import 로 둘 다 emit (dedup key=specifier+tail)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';\nconsole.log("ok");`,
+      'style.css':
+        `@import "https://cdn/x.css" print;\n` +
+        `@import "https://cdn/x.css" screen;\n` +
+        `.app {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    expect(css).toMatch(/@import\s+"https:\/\/cdn\/x\.css"\s+print\s*;/);
+    expect(css).toMatch(/@import\s+"https:\/\/cdn\/x\.css"\s+screen\s*;/);
+  });
 });


### PR DESCRIPTION
## 요약

`@import "https://fonts.googleapis.com/css?family=Inter"` 같은 external URL
@import 이 일반 모듈 deps 와 동일하게 resolver 로 가서 `Cannot resolve module`
빌드 실패. esbuild/rolldown/rspack 모두 protocol-prefixed (`http:`/`https:`/
`//`/`data:`) @import 은 resolver 우회 + 출력 CSS 상단에 그대로 보존이 정석.

#3321 의 P0-3 ("분리 청크 간 `@import` 재작성") 의 직접 대응 — *cross-chunk*
의미를 external URL 보존으로 해석. 같은 청크 내 일반 @import 은 기존
emitCssModuleTree inline 정책 유지.

## TDD (8 회귀 가드)

`tests/integration/tests/css-bundle.test.ts`:

1. external http(s) URL → resolve 시도 안 함 + 출력 보존
2. protocol-relative `//` URL → 보존
3. external + 일반 혼합 → external 보존, 일반 inline
4. uppercase HTTPS scheme → external 인식 (case-insensitive)
5. media query → media clause 보존
6. 순수 external 만 있는 CSS → double-emit 회피
7. 같은 URL 여러 모듈 → chunk 내 1회 emit (dedup)
8. 같은 URL 다른 media → 둘 다 emit (dedup key=specifier+tail)

## 구현 — 3 layer

**css_scanner.zig**:
- `CssImportRecord.is_external` + `condition_tail` (specifier 이후 ~ `;` 직전)
- `isExternalCssSpecifier()` — ASCII case-insensitive 매칭

**types.zig + graph/loaders.zig**:
- `ImportRecord.css_condition_tail`
- raw → ImportRecord 전파. resolver 의 `is_external` 가드가 skip.

**css_emitter.zig**:
- `ExternalImportCollector` — dedup key = `<specifier>\\x00<condition_tail>`
  (NUL = CSS spec 안전 separator)
- `appendCssStringEscaped` — CSS spec §4.3.5 escape (`"` → `\\22 `, etc.)
- 단일 bundle / 멀티 chunk 둘 다 first-seen order 결정성

## `/code-review max` post-review 적용

5-angle review 가 8 finding 적발. 본 PR 반영:

| ID | 심각도 | fix |
|---|---|---|
| F1 | HIGH | OOM `catch {}` → `return null` (planCssChunks 의 `try` 와 정합) |
| F2 | HIGH | quote escape (`\\22`, `\\\\`, `\\A`, `\\D`) |
| F3 | HIGH | condition_tail 으로 media/layer/supports 보존 |
| F4 | HIGH | scheme ASCII case-insensitive |
| F5 | MEDIUM | dedup key = (specifier, condition_tail) |
| F6 | MEDIUM | collectFromModule OOM atomicity (errdefer rollback) |
| C-double-emit | MEDIUM | strip_end `<` → `<=` boundary 정정 |

deferred (별개 latent, pre-existing):
- @charset/@layer drop (strip_end 가 @import 만 보는 별개 latent — 별도 fix)
- url() / quote-form 정규화 (semantic 동치, 무해)

## Zig 초보자 노트

- `std.ascii.toLower` 는 ASCII 전용. URL scheme RFC3986 §3.1 case-insensitive
  처리에 정확.
- `ExternalImportCollector.deinit` 이 `seen` 의 key 도 free — `allocPrint`
  로 합성한 composite key 소유라 명시적 해제 필요.
- OOM 안전성 원칙: `list.append` 후에만 `seen.put` (반대 순서면 silent drop
  회귀). 새 collector 는 errdefer 로 rollback 보강.

## 검증

- 8 TDD 가드 GREEN (초기 3 RED → impl GREEN → post-review 5 추가 GREEN)
- CSS 전체 56/56 pass (bundle/code-splitting/library-smoke)
- `zig build test` exit 0
- broader integration 3910 pass / 0 fail (post-review 직전 측정;
  최종 push 후 CI 에서 추가 확인)

Closes #3321 의 P0-3 부분 (P0 다른 항목 + P1/P2/P3 는 별개 진행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)