### PR TITLE
fix(bundler): CSS @charset / bare @layer top-of-file 선언 보존 (#3747)

### DIFF
--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -44,17 +44,27 @@ pub fn emitCssBundle(
     }.lessThan);
 
     // CSS 소스 연결 (@import strip).
-    // external @import URL 은 strip 후 별도 보존 — 출력 최상단에 emit.
+    // 보존 emit 영역 (출력 상단, CSS spec 순서):
+    //   1. @charset (있으면 첫 byte 여야 함, 첫 모듈의 것만)
+    //   2. external @import URL (#3321 P0-3)
+    //   3. bare @layer 선언 (#3747)
+    //   4. 본문 (strip_end 이후)
     // OOM 시 silent drop 회피 — collect / appendTo / appendCssModules 모두
-    // error 시 null 반환 (사용자가 빌드 실패로 인지). planCssChunks 의 try
-    // 패턴과 일치.
+    // error 시 null 반환.
     var output: std.ArrayListUnmanaged(u8) = .empty;
     defer output.deinit(allocator);
+
+    var prefix_decls = PrefixDeclCollector.init();
+    defer prefix_decls.deinit(allocator);
+    for (css_modules.items) |mod| prefix_decls.collectFromModule(allocator, mod) catch return null;
+    prefix_decls.appendCharsetTo(allocator, &output) catch return null;
 
     var ext_imports = ExternalImportCollector.init(allocator);
     defer ext_imports.deinit(allocator);
     for (css_modules.items) |mod| ext_imports.collectFromModule(allocator, mod) catch return null;
     ext_imports.appendTo(allocator, &output) catch return null;
+
+    prefix_decls.appendLayersTo(allocator, &output) catch return null;
 
     appendCssModules(allocator, &output, css_modules.items) catch return null;
 
@@ -179,6 +189,61 @@ const ExternalImportCollector = struct {
     }
 };
 
+/// 파일 상단 `@charset` / bare `@layer` 선언 보존 collector (#3747).
+///
+/// **@charset**: CSS spec 상 파일의 첫 byte 여야 valid, 1 stylesheet 에 1 개만
+/// 효력. 번들에서 첫 발견 모듈의 charset 만 emit, 이후는 silent drop.
+///
+/// **@layer (bare)**: cascade layer 순서 정의. 모듈 등장 순서대로 모두 emit
+/// (CSS spec: 추가 bare `@layer` 는 첫 등장이 ordering 고정 후 no-op 이라
+/// 안전).
+const PrefixDeclCollector = struct {
+    /// 첫 발견 @charset text (예: `@charset "UTF-8"`). null = 미발견.
+    charset_text: ?[]const u8 = null,
+    /// bare @layer 선언 텍스트 등장 순서.
+    layer_texts: std.ArrayListUnmanaged([]const u8) = .empty,
+
+    fn init() PrefixDeclCollector {
+        return .{};
+    }
+
+    fn deinit(self: *PrefixDeclCollector, allocator: std.mem.Allocator) void {
+        self.layer_texts.deinit(allocator);
+    }
+
+    fn collectFromModule(self: *PrefixDeclCollector, allocator: std.mem.Allocator, mod: *const Module) !void {
+        const cd = mod.css_data orelse return;
+        for (cd.prefix_decls) |pd| {
+            switch (pd.kind) {
+                .charset => {
+                    if (self.charset_text == null) self.charset_text = pd.text;
+                    // 이후 charset 은 silent drop (CSS spec: 1 개만 효력).
+                },
+                .layer_bare => {
+                    try self.layer_texts.append(allocator, pd.text);
+                },
+            }
+        }
+    }
+
+    /// emit 순서: @charset (있으면 1줄) → caller 가 그 다음에 external @import +
+    /// @layer 를 emit. 본 함수는 *charset* 만 prepend — @layer 는 별도 호출.
+    /// (CSS spec: @charset 은 반드시 첫 byte. @layer 와 @import 는 상호 자유 순서.)
+    fn appendCharsetTo(self: *const PrefixDeclCollector, allocator: std.mem.Allocator, buf: *std.ArrayListUnmanaged(u8)) !void {
+        if (self.charset_text) |t| {
+            try buf.appendSlice(allocator, t);
+            try buf.appendSlice(allocator, ";\n");
+        }
+    }
+
+    fn appendLayersTo(self: *const PrefixDeclCollector, allocator: std.mem.Allocator, buf: *std.ArrayListUnmanaged(u8)) !void {
+        for (self.layer_texts.items) |t| {
+            try buf.appendSlice(allocator, t);
+            try buf.appendSlice(allocator, ";\n");
+        }
+    }
+};
+
 /// CSS double-quoted string literal 안전 escape. `"` → `\22 `, `\` → `\\`.
 /// CSS spec §4.3.5 (Escape): hex escape `\<1-6 hex digits>` 다음 공백 1개로
 /// terminate. 다음 문자가 hex 면 ambiguity → 항상 trailing space 부착.
@@ -200,6 +265,29 @@ fn appendCssModules(
     css_modules: []const *const Module,
 ) !void {
     for (css_modules) |mod| try appendCssModule(allocator, buf, mod);
+}
+
+/// CSS 모듈 트리를 dep-first 로 순회하며 @charset / @layer prefix decl 을
+/// collector 에 모은다 (#3747). external @import 와 동일한 deps-first 순회.
+fn collectPrefixDeclsTree(
+    graph: *const ModuleGraph,
+    idx: ModuleIndex,
+    collector: *PrefixDeclCollector,
+    visited: *std.AutoHashMap(ModuleIndex, void),
+    allocator: std.mem.Allocator,
+) !void {
+    if (idx.isNone()) return;
+    if (visited.contains(idx)) return;
+    try visited.put(idx, {});
+    const mod = graph.getModule(idx) orelse return;
+    if (mod.module_type != .css) return;
+    for (mod.dependencies.items) |dep| {
+        if (graph.getModule(dep)) |dm| {
+            if (dm.module_type == .css)
+                try collectPrefixDeclsTree(graph, dep, collector, visited, allocator);
+        }
+    }
+    try collector.collectFromModule(allocator, mod);
 }
 
 /// CSS 모듈 트리를 dep-first 로 순회하며 external @import URL 을 collector
@@ -342,23 +430,34 @@ pub fn planCssChunks(
         var buf: std.ArrayListUnmanaged(u8) = .empty;
         defer buf.deinit(allocator);
 
-        // External @import URL 을 chunk 단위 dedup 수집 후 chunk 본문 상단에
-        // emit (CSS spec: 모든 @import 가 일반 규칙보다 앞). chunk 간 emit 은
-        // 허용 (모듈이 여러 chunk 에 인라인되면 같은 external URL 도 각
-        // chunk 의 상단에 1번씩 등장 — 런타임 fetch dedup 은 브라우저 책임).
+        // 보존 emit 영역 (chunk 단위 dedup, CSS spec 순서):
+        //   1. @charset (chunk 첫 모듈의 것, #3747)
+        //   2. external @import URL (#3321 P0-3)
+        //   3. bare @layer (#3747)
+        //   4. 본문
+        // chunk 간 emit 은 허용 (모듈이 여러 chunk 에 인라인되면 각 chunk 의
+        // 상단에 1 번씩 등장 — 런타임 fetch dedup 은 브라우저 책임).
+        var prefix_decls = PrefixDeclCollector.init();
+        defer prefix_decls.deinit(allocator);
         var ext_imports = ExternalImportCollector.init(allocator);
         defer ext_imports.deinit(allocator);
 
         emit_visited.clearRetainingCapacity();
-        // external collect 는 emit 과 동일 dep 트리 순회 — emitCssModuleTree 가
-        // 본문 emit 도중 visited 를 마킹해 같은 dep 가 2번 walk 되지 않는다.
-        // 따라서 external 수집은 emit 전에 별도 일회 순회로 처리한다.
+        // prefix decl / external collect 는 emit 과 동일 dep 트리 순회 —
+        // emitCssModuleTree 가 본문 emit 도중 visited 를 마킹해 같은 dep 가
+        // 2번 walk 되지 않으므로 별도 일회 순회.
         var collect_visited = std.AutoHashMap(ModuleIndex, void).init(allocator);
         defer collect_visited.deinit();
         for (list.items) |mod| {
+            try collectPrefixDeclsTree(graph, mod.index, &prefix_decls, &collect_visited, allocator);
+        }
+        collect_visited.clearRetainingCapacity();
+        for (list.items) |mod| {
             try collectExternalImportsTree(graph, mod.index, &ext_imports, &collect_visited, allocator);
         }
+        try prefix_decls.appendCharsetTo(allocator, &buf);
         try ext_imports.appendTo(allocator, &buf);
+        try prefix_decls.appendLayersTo(allocator, &buf);
 
         for (list.items) |mod| {
             try emitCssModuleTree(allocator, graph, mod.index, &buf, &emit_visited);

--- a/src/bundler/css_scanner.zig
+++ b/src/bundler/css_scanner.zig
@@ -23,6 +23,34 @@ pub const CssImportRecord = struct {
     condition_tail: []const u8 = "",
 };
 
+/// CSS 파일 상단의 `@charset` / bare `@layer` 선언. strip_end 가 통째로 잘라
+/// 버리던 항목들을 캡처해 emitter 가 본문 앞에 보존 emit (#3747).
+///
+/// `@charset "UTF-8"` — UA 가 인코딩 판정용, 파일 첫 byte 여야 valid. 번들엔
+/// 1개만 (첫 모듈 의 것). 추가는 silent drop.
+///
+/// bare `@layer reset, base, theme` — cascade layer 순서 정의. 본문 규칙
+/// 보다 *앞* 에 와야 의도된 순서 효력. 여러 모듈 의 bare @layer 는 source
+/// 등장 순서 보존.
+pub const CssPrefixDeclKind = enum { charset, layer_bare };
+pub const CssPrefixDecl = struct {
+    kind: CssPrefixDeclKind,
+    /// `@charset "UTF-8"` 또는 `@layer reset, base, theme` 형식의 raw text
+    /// (마지막 `;` 미포함 — emitter 가 통일된 `;\n` 부착).
+    text: []const u8,
+};
+
+/// CSS at-keyword 직후 byte 가 word boundary 인지 판정 — CSS whitespace
+/// (`' '`/`'\t'`/`'\n'`/`'\r'`/`'\x0c'`) 또는 `;` 또는 EOF.
+/// `startsWithAt(... "charset")` / `startsWithAt(... "layer")` 직후 가드로
+/// `@charsetXYZ`/`@layerOTHER` 같은 다른 at-rule 오인 차단 + multi-line
+/// `@layer\nreset, base;` 형식 보존.
+fn isAtKeywordBoundary(source: []const u8, pos_after_keyword: u32, len: u32) bool {
+    if (pos_after_keyword >= len) return true; // EOF
+    const c = source[pos_after_keyword];
+    return c == ' ' or c == '\t' or c == '\n' or c == '\r' or c == 0x0c or c == ';';
+}
+
 /// ASCII case-insensitive prefix 매칭. RFC3986: URL scheme 은 case-insensitive.
 fn startsWithIgnoreCaseAscii(s: []const u8, prefix: []const u8) bool {
     if (s.len < prefix.len) return false;
@@ -45,13 +73,24 @@ pub fn isExternalCssSpecifier(specifier: []const u8) bool {
     return false;
 }
 
-/// CSS 소스에서 @import 규칙을 추출한다.
-/// @charset, 공백, 주석은 건너뛰고, 첫 번째 non-import 규칙에서 중단.
-/// 반환된 specifier는 source의 슬라이스. 결과 배열은 allocator로 할당.
-pub fn extractCssImports(allocator: std.mem.Allocator, source: []const u8) []const CssImportRecord {
+/// CSS 소스에서 @import 규칙 + @charset/@layer prefix 선언을 추출한다.
+/// @charset, bare @layer, 공백, 주석은 건너뛰고, 첫 번째 non-import-like 규칙
+/// 에서 중단. 반환된 specifier/text 는 source 의 슬라이스 — caller (parse_arena)
+/// 가 소유. 결과 배열은 allocator 로 할당.
+///
+/// 이전 (#3747 fix 전): @charset / bare @layer 가 strip_end 영역에 들어가
+/// silent drop. 본 함수가 두 종류를 prefix_decls 로 캡처해 emitter 가 보존
+/// 가능하도록 함.
+pub fn extractCssImportsWithPrefixes(allocator: std.mem.Allocator, source: []const u8) struct {
+    imports: []const CssImportRecord,
+    prefix_decls: []const CssPrefixDecl,
+} {
     const MAX_IMPORTS = 64;
-    var results: [MAX_IMPORTS]CssImportRecord = undefined;
-    var count: usize = 0;
+    const MAX_PREFIX = 32;
+    var imp_buf: [MAX_IMPORTS]CssImportRecord = undefined;
+    var pre_buf: [MAX_PREFIX]CssPrefixDecl = undefined;
+    var imp_count: usize = 0;
+    var pre_count: usize = 0;
 
     var pos: u32 = 0;
     const len: u32 = @intCast(source.len);
@@ -67,22 +106,49 @@ pub fn extractCssImports(allocator: std.mem.Allocator, source: []const u8) []con
             continue;
         }
 
-        // @charset 스킵
-        if (startsWithAt(source, pos, len, "charset")) {
-            pos = skipToSemicolon(source, pos, len);
+        // @charset 캡처 — 선언 텍스트 보존 (마지막 `;` 미포함)
+        // word-boundary 가드: `@charsetXYZ` 같은 다른 at-rule 을 charset 으로
+        // 오인하지 않도록 다음 byte 가 CSS whitespace 또는 `;` 또는 EOF 일 때만
+        // 진입 (code-review max — Angle B2).
+        if (startsWithAt(source, pos, len, "charset") and isAtKeywordBoundary(source, pos + 8, len)) {
+            const start = pos;
+            const after_semi = skipToSemicolon(source, pos, len);
+            // skipToSemicolon 은 `;` *다음* 위치 반환. 텍스트는 `;` 제외.
+            const text_end: u32 = if (after_semi > start and after_semi <= len and source[after_semi - 1] == ';')
+                after_semi - 1
+            else
+                after_semi;
+            if (pre_count < MAX_PREFIX) {
+                pre_buf[pre_count] = .{ .kind = .charset, .text = source[start..text_end] };
+                pre_count += 1;
+            }
+            pos = after_semi;
             continue;
         }
 
-        // @layer (bare, 세미콜론으로 끝나는 형태만) 스킵
+        // @layer (bare, 세미콜론으로 끝나는 형태만) 캡처 — block-form 은 본문 규칙
         if (startsWithAt(source, pos, len, "layer")) {
-            // @layer가 블록 { 을 포함하면 non-import 규칙이므로 중단
-            const after = pos + 6; // "@layer" 길이
-            if (after < len and source[after] != ' ' and source[after] != '\t' and source[after] != ';') {
-                break; // @layer가 아닌 다른 at-rule
+            // word-boundary: `@layer` 다음은 CSS whitespace(LF/CR 포함) / `;` / EOF
+            // 여야 함. `@layerOTHER` 는 break (code-review max — Angle B1 fix:
+            // 옛 코드가 `' '/'\\t'/';'` 만 허용 → `@layer\\nreset;` 가 캡처
+            // 실패 + 후속 @import 까지 break 로 silent drop).
+            if (!isAtKeywordBoundary(source, pos + 6, len)) {
+                break; // @layer 가 아닌 다른 at-rule
             }
-            // 세미콜론까지만 스킵 (block @layer는 중단)
+            // 세미콜론까지 또는 `{` (block-form) 위치 찾기
             const semi_pos = skipToSemicolonOrBrace(source, pos, len);
-            if (semi_pos < len and source[semi_pos] == '{') break;
+            if (semi_pos < len and source[semi_pos] == '{') break; // block-form → 본문
+            const start = pos;
+            // skipToSemicolonOrBrace 는 `;` 발견 시 *다음* 위치 (source[pos-1]==';'),
+            // `{` 발견 시 `{` *직전* 위치 반환. 여기선 ; case 만 진입.
+            const text_end: u32 = if (semi_pos > start and semi_pos <= len and source[semi_pos - 1] == ';')
+                semi_pos - 1
+            else
+                semi_pos;
+            if (pre_count < MAX_PREFIX) {
+                pre_buf[pre_count] = .{ .kind = .layer_bare, .text = source[start..text_end] };
+                pre_count += 1;
+            }
             pos = semi_pos;
             continue;
         }
@@ -112,15 +178,15 @@ pub fn extractCssImports(allocator: std.mem.Allocator, source: []const u8) []con
             else
                 "";
 
-            if (count < MAX_IMPORTS) {
+            if (imp_count < MAX_IMPORTS) {
                 const specifier_slice = source[spec.start..spec.end];
-                results[count] = .{
+                imp_buf[imp_count] = .{
                     .specifier = specifier_slice,
                     .span = .{ .start = start, .end = pos },
                     .is_external = isExternalCssSpecifier(specifier_slice),
                     .condition_tail = tail_slice,
                 };
-                count += 1;
+                imp_count += 1;
             }
             continue;
         }
@@ -129,10 +195,31 @@ pub fn extractCssImports(allocator: std.mem.Allocator, source: []const u8) []con
         break;
     }
 
-    if (count == 0) return &.{};
-    const owned = allocator.alloc(CssImportRecord, count) catch return &.{};
-    @memcpy(owned, results[0..count]);
-    return owned;
+    const imports_out: []const CssImportRecord = if (imp_count == 0)
+        &.{}
+    else blk: {
+        const owned = allocator.alloc(CssImportRecord, imp_count) catch break :blk &.{};
+        @memcpy(owned, imp_buf[0..imp_count]);
+        break :blk owned;
+    };
+    const prefix_out: []const CssPrefixDecl = if (pre_count == 0)
+        &.{}
+    else blk: {
+        const owned = allocator.alloc(CssPrefixDecl, pre_count) catch break :blk &.{};
+        @memcpy(owned, pre_buf[0..pre_count]);
+        break :blk owned;
+    };
+    return .{ .imports = imports_out, .prefix_decls = prefix_out };
+}
+
+/// 기존 호출부 호환 wrapper — @import 만 반환. caller 가 prefix_decls 를 안
+/// 보므로 wrapper 가 즉시 해제 (안 하면 caller 의 `defer allocator.free(imports)`
+/// 가 prefix_decls 메모리는 그대로 leak — GPA 가 잡음). 신규 콜러는
+/// `extractCssImportsWithPrefixes` 사용 권장.
+pub fn extractCssImports(allocator: std.mem.Allocator, source: []const u8) []const CssImportRecord {
+    const result = extractCssImportsWithPrefixes(allocator, source);
+    if (result.prefix_decls.len > 0) allocator.free(result.prefix_decls);
+    return result.imports;
 }
 
 const SpecifierResult = struct {

--- a/src/bundler/graph/loaders.zig
+++ b/src/bundler/graph/loaders.zig
@@ -42,8 +42,9 @@ pub fn parseCssModule(self: *ModuleGraph, module: *Module) void {
         module.source = readModuleSourceWithMtime(self, module, arena_alloc, 100 * 1024 * 1024, .parse) orelse return;
     }
 
-    // @import 규칙 추출 (arena에 할당)
-    const raw_imports = css_scanner_mod.extractCssImports(arena_alloc, module.source);
+    // @import 규칙 + @charset / @layer prefix 선언 추출 (arena 에 할당, #3747)
+    const scan_result = css_scanner_mod.extractCssImportsWithPrefixes(arena_alloc, module.source);
+    const raw_imports = scan_result.imports;
     const import_count: u32 = @intCast(raw_imports.len);
 
     if (import_count > 0) {
@@ -67,8 +68,22 @@ pub fn parseCssModule(self: *ModuleGraph, module: *Module) void {
         module.import_records = records;
     }
 
-    const strip_end: u32 = if (import_count > 0) raw_imports[import_count - 1].span.end else 0;
-    module.css_data = .{ .import_count = import_count, .strip_end = strip_end };
+    // strip_end = max(last @import end, last prefix decl end + `;`) — 캡처되어
+    // emitter 가 별도 보존 emit 하는 모든 영역을 본문 source 에서 제외해 double
+    // emit 회피. prefix decl 의 `text` 슬라이스가 source slice 이므로 pointer
+    // 산술로 end offset 복원 (text + `;` 분 1 추가).
+    var strip_end: u32 = if (import_count > 0) raw_imports[import_count - 1].span.end else 0;
+    for (scan_result.prefix_decls) |pd| {
+        const text_end_offset: usize = @intFromPtr(pd.text.ptr) - @intFromPtr(module.source.ptr) + pd.text.len;
+        // `;` 다음까지 포함 (text 는 `;` 미포함 — emitter 가 따로 부착)
+        const decl_end: u32 = @intCast(@min(text_end_offset + 1, module.source.len));
+        if (decl_end > strip_end) strip_end = decl_end;
+    }
+    module.css_data = .{
+        .import_count = import_count,
+        .strip_end = strip_end,
+        .prefix_decls = scan_result.prefix_decls,
+    };
     module.exports_kind = .esm; // CSS는 ESM side-effect import로 처리
     module.side_effects = true; // CSS는 항상 side-effect
     module.state = .parsed;

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -409,6 +409,10 @@ pub const Module = struct {
         import_count: u32,
         /// 마지막 @import 규칙 끝의 byte offset. emit 시 이 위치 이후부터 출력.
         strip_end: u32 = 0,
+        /// 파일 상단 `@charset` / bare `@layer` 선언. strip_end 가 통째로
+        /// 잘라 silent drop 되던 것을 emitter 가 본문 앞에 보존 emit 하도록
+        /// 캡처 (#3747). parse_arena 소유 슬라이스, 모듈 수명 내 유효.
+        prefix_decls: []const @import("css_scanner.zig").CssPrefixDecl = &.{},
     };
 
     pub const State = enum {

--- a/tests/integration/tests/css-bundle.test.ts
+++ b/tests/integration/tests/css-bundle.test.ts
@@ -664,6 +664,140 @@ describe('CSS Bundling', () => {
     expect(importLine?.[0].endsWith('";')).toBe(true);
   });
 
+  // ── #3747 CSS @charset / @layer top-of-file 선언 보존 ──
+  // strip_end 가 마지막 @import 의 end 까지 전체를 잘라 그 앞의 @charset / 바
+  // @layer 선언이 silent drop. 루트커즈 fix: scanner 가 두 종류도 캡처하고
+  // emitter 가 본문 앞에 보존 emit. esbuild parity.
+  it('#3747 @charset "UTF-8"; 가 출력에 보존된다 (silent drop 회귀)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';`,
+      'style.css': `@charset "UTF-8";\n@import "./other.css";\nbody { color: red; }`,
+      'other.css': `.other {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    // @charset 은 파일의 첫 byte 여야 함 (CSS spec)
+    expect(css.trimStart().startsWith('@charset "UTF-8"')).toBe(true);
+    expect(css).toContain('.other');
+    expect(css).toContain('color: red');
+  });
+
+  it('#3747 bare @layer reset, base, theme; 가 출력에 보존된다', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';`,
+      'style.css': `@layer reset, base, theme;\n@import "./other.css";\n.app { color: red; }`,
+      'other.css': `.other {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    // @layer 선언이 출력에 살아있어야 함 — cascade layer 순서 정의용
+    expect(css).toMatch(/@layer\s+reset\s*,\s*base\s*,\s*theme/);
+    // 본문 보다 앞에 위치
+    expect(css.indexOf('@layer')).toBeLessThan(css.indexOf('.app'));
+  });
+
+  it('#3747 @charset + @layer + external @import 혼합 → 모두 보존, 순서 정확', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';`,
+      'style.css':
+        `@charset "UTF-8";\n` +
+        `@layer reset, base;\n` +
+        `@import "https://cdn/x.css";\n` +
+        `.app { color: blue; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    expect(css).toContain('@charset "UTF-8"');
+    expect(css).toMatch(/@layer\s+reset\s*,\s*base/);
+    expect(css).toContain('@import "https://cdn/x.css"');
+    expect(css).toContain('.app');
+    // 순서 invariant: charset → (layer/import 둘 다 가능) → body
+    expect(css.indexOf('@charset')).toBeLessThan(css.indexOf('.app'));
+    expect(css.indexOf('@layer')).toBeLessThan(css.indexOf('.app'));
+    expect(css.indexOf('@import')).toBeLessThan(css.indexOf('.app'));
+  });
+
+  it('#3747 multi-line @layer (`@layer\\nreset, base;`) → newline boundary 인식, 캡처 + 후속 @import 정상', async () => {
+    // code-review max Angle B1: 옛 boundary 가드가 `\n` 미인식 → break 로
+    // @layer + 후속 @import 둘 다 silent drop. fix 후 multi-line valid CSS 도
+    // 정상 캡처되어야 한다.
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';`,
+      'style.css': `@layer\nreset, base;\n@import "./other.css";\n.app {}`,
+      'other.css': `.other {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    // @layer 캡처 (newline 으로 분리된 형식)
+    expect(css).toMatch(/@layer\s+reset\s*,\s*base/);
+    // @import 가 inline 됨 — 캡처 가드가 break 로 빠지지 않아 후속 @import 까지 처리
+    expect(css).toContain('.other');
+    // raw `@import "./other.css"` 가 출력에 남지 않아야 함 (inline 됐다는 증거)
+    expect(css).not.toContain('@import "./other.css"');
+  });
+
+  it('#3747 @charsetXYZ (word-boundary 없는 fake at-rule) → charset 으로 캡처 안 됨', async () => {
+    // code-review max Angle B2: `@charsetXYZ "evil";` 가 `@charset` 으로
+    // 오인 캡처되어 출력 상단 hoist 되던 버그. word-boundary 가드 추가.
+    // 두 모듈 시나리오 — hoist 시 a 의 @charsetXYZ 가 b 본문보다 *앞* 으로
+    // 가고, fix 시엔 a 본문에 그대로 남아 b 본문 *뒤* 에 emit.
+    const fixture = await createFixture({
+      'index.ts': `import './b.css';\nimport './a.css';`,
+      'a.css': `@charsetXYZ "evil";\n.a {}`,
+      'b.css': `.b {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    // 핵심 invariant: @charsetXYZ 가 hoist 안 되면 a 본문에 머물러 b 본문 뒤에 위치.
+    const bIdx = css.indexOf('.b');
+    const fakeCharsetIdx = css.indexOf('@charsetXYZ');
+    expect(bIdx).toBeGreaterThanOrEqual(0);
+    expect(fakeCharsetIdx).toBeGreaterThanOrEqual(0);
+    expect(fakeCharsetIdx).toBeGreaterThan(bIdx);
+  });
+
+  it('#3747 여러 모듈의 @charset → 첫 발견 1개만 emit (CSS spec: 1개만 valid)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './a.css';\nimport './b.css';`,
+      'a.css': `@charset "UTF-8";\n.a {}`,
+      'b.css': `@charset "UTF-8";\n.b {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    const matches = css.match(/@charset/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
   it('같은 URL 의 다른 media query → 서로 다른 @import 로 둘 다 emit (dedup key=specifier+tail)', async () => {
     const fixture = await createFixture({
       'index.ts': `import './style.css';\nconsole.log("ok");`,


### PR DESCRIPTION
## 요약

CSS 모듈 상단의 `@charset "UTF-8";` / `@layer reset, base, theme;` (bare) 선언이
번들 출력에서 silent drop 되던 **pre-existing latent**. PR #3746 (external
@import URL preserve) 의 follow-up 으로 분리된 #3747 을 루트커즈 fix.

## 루트커즈

`graph/loaders.zig:parseCssModule` 의 strip_end = "마지막 @import 의 span.end"
만 봤음. emit 시 `source[strip_end..]` 만 출력 → @import 들로 들어가기 *전* 의
모든 텍스트 (@charset, @layer, 주석) 가 통째로 제거. scanner 는 두 종류를
*skip* 으로만 처리해 emitter 가 따로 살릴 단서 없었음.

## 수정 — 3 layer 루트커즈 fix

### css_scanner.zig

- `CssPrefixDeclKind { charset, layer_bare }` + `CssPrefixDecl { kind, text }`
- `extractCssImportsWithPrefixes()` — @import + prefix decl 단일 pass 추출
- `extractCssImports` 호환 wrapper 유지 (prefix_decls 메모리는 wrapper 가
  즉시 free — 안 하면 leak)
- @charset / bare @layer 를 skip 대신 *캡처* (text 슬라이스, `;` 제외)
- **`isAtKeywordBoundary()` word-boundary 가드** (code-review max 적발):
  - `@charsetXYZ "evil";` 가 charset 으로 오인 캡처 되던 버그 차단
  - `@layer\nreset, base;` (multi-line valid CSS) 가 boundary 미인식 → break
    로 silent drop 되던 버그 차단. CSS whitespace 정의 (LF/CR/FF 포함)

### module.zig + graph/loaders.zig

- `Module.CssData.prefix_decls` 필드 추가
- strip_end 확장: `max(last @import end, last prefix decl end + ";")` — prefix
  decl 도 emitter 가 별도 emit 하므로 본문 source 에서 제외 (double emit 회피)

### css_emitter.zig

- `PrefixDeclCollector` — first-charset-wins + 모든 @layer 등장 순서 보존
- emit 순서 (CSS spec):
  1. `@charset` (파일 첫 byte, 첫 모듈의 것만)
  2. external `@import` URL (#3321 P0-3, 기존)
  3. bare `@layer` (#3747, 신규)
  4. 본문 (strip_end 이후)
- 단일 bundle (`emitCssBundle`) + 멀티 chunk (`planCssChunks`) 둘 다 동형
- `collectPrefixDeclsTree` — external collect 와 동일 deps-first 순회

## TDD (6 회귀 가드, RED → GREEN)

`tests/integration/tests/css-bundle.test.ts`:

1. `@charset "UTF-8";` 보존 + 파일 첫 byte 위치
2. bare `@layer reset, base, theme;` 보존 + 본문 앞 위치
3. @charset + @layer + external @import 혼합 — CSS spec 순서
4. 여러 모듈 @charset → 첫 1 개만 emit
5. **multi-line `@layer\nreset, base;`** — newline boundary 인식, 캡처 + 후속
   @import 정상 (code-review max Angle B1 가드)
6. **`@charsetXYZ "evil";`** — word-boundary 가드, charset 오인 안 됨 (Angle B2)

## `/code-review max` post-review (5-angle, 8 finding)

| ID | 심각도 | 처리 |
|---|---|---|
| B1 | MEDIUM | `@layer\\n...` newline boundary fix |
| B2 | LOW | `@charsetXYZ` word-boundary fix (동일 helper) |
| B3/B4/B5/C1/D1 | LOW/INFO | deferred (의도 동작 / 무해 edge / 미래 보호) |

## 검증

- 6 TDD 회귀 가드 GREEN (RED → impl → GREEN)
- CSS 전체 63/63 pass (bundle / code-splitting / library-smoke)
- `zig build test` exit 0 (5565 tests, leak 0)
- NAPI rebuild OK

## 호환성

- `extractCssImports` 시그니처 불변 (wrapper). 외부 caller 영향 없음.
- `CssData` 필드 추가만 (기존 필드 유지). default `&.{}` 라 안전.

Closes #3747

🤖 Generated with [Claude Code](https://claude.com/claude-code)