### PR TITLE
refactor(bundler): #3749 Phase 3 (C) — PathRef enum 으로 lifetime 컴파일러 강제

### DIFF
--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -21,16 +21,11 @@ fn appendResolvedDep(
     mod_idx: usize,
     dep: CachedResolvedDep,
 ) !void {
+    // PR #3749 Phase 3 (C): dep.path 는 PathRef variant — caller 가 lifetime 명시.
+    // graph 가 추가 dupe 안 함. interned/specifier/plugin variant 는 borrow,
+    // owned variant 는 caller-alloc + module.deinit 시 자동 free.
     const mod_ptr = self.modules.at(mod_idx);
-    const path_owned = try self.allocator.dupe(u8, dep.path);
-    errdefer self.allocator.free(path_owned);
-    const resolve_dir_owned = if (dep.resolve_dir) |dir| try self.allocator.dupe(u8, dir) else null;
-    errdefer if (resolve_dir_owned) |dir| self.allocator.free(dir);
-
-    var owned_dep = dep;
-    owned_dep.path = path_owned;
-    owned_dep.resolve_dir = resolve_dir_owned;
-    try mod_ptr.resolved_deps.append(self.allocator, owned_dep);
+    try mod_ptr.resolved_deps.append(self.allocator, dep);
 }
 
 pub fn replayCachedResolvedDeps(self: *ModuleGraph, mod_idx: usize) !void {
@@ -42,7 +37,7 @@ pub fn replayCachedResolvedDeps(self: *ModuleGraph, mod_idx: usize) !void {
         switch (dep.target) {
             .file, .virtual => {
                 var s_am = profile.begin(.graph_discover_incr_replay_add_module);
-                const dep_idx = try self.addModuleWithResolveDir(dep.path, dep.resolve_dir);
+                const dep_idx = try self.addModuleWithResolveDir(dep.path.bytes(), if (dep.resolve_dir) |rd| rd.bytes() else null);
                 s_am.end();
                 if (dep.target_is_module_field or mod_ptr.is_module_field) {
                     self.modules.at(@intFromEnum(dep_idx)).is_module_field = true;
@@ -57,13 +52,13 @@ pub fn replayCachedResolvedDeps(self: *ModuleGraph, mod_idx: usize) !void {
                 // (inclusive totals 가 합쳐져 percentage 가 100% 초과). addDisabledModule
                 // 만 _other 로 측정하고 link 부분은 replayLinkResolvedDep 가 자체 측정.
                 var s_o = profile.begin(.graph_discover_incr_replay_other);
-                const dep_idx = try self.addDisabledModule(dep.path);
+                const dep_idx = try self.addDisabledModule(dep.path.bytes());
                 s_o.end();
                 try replayLinkResolvedDep(self, mod_index, mod_idx, dep, dep_idx);
             },
             .optional_missing => {
                 var s_o = profile.begin(.graph_discover_incr_replay_other);
-                const dep_idx = try self.addOptionalMissingModule(dep.path);
+                const dep_idx = try self.addOptionalMissingModule(dep.path.bytes());
                 s_o.end();
                 try replayLinkResolvedDep(self, mod_index, mod_idx, dep, dep_idx);
             },
@@ -71,7 +66,7 @@ pub fn replayCachedResolvedDeps(self: *ModuleGraph, mod_idx: usize) !void {
                 // external 은 replayLinkResolvedDep 를 거치지 않고 inline 하므로
                 // 동일한 sub-phase 로 명시 분해 (다른 분기와 측정 대칭성 유지).
                 var s_am = profile.begin(.graph_discover_incr_replay_add_module);
-                const ext_idx = try self.addExternalModule(dep.path);
+                const ext_idx = try self.addExternalModule(dep.path.bytes());
                 s_am.end();
                 if (dep.record_index) |rec_idx| {
                     if (rec_idx < mod_ptr.import_records.len) {
@@ -94,7 +89,7 @@ pub fn replayCachedResolvedDeps(self: *ModuleGraph, mod_idx: usize) !void {
                 var s_o = profile.begin(.graph_discover_incr_replay_other);
                 defer s_o.end();
                 const rec_idx = dep.record_index orelse continue;
-                const path_dupe = try self.allocator.dupe(u8, dep.path);
+                const path_dupe = try self.allocator.dupe(u8, dep.path.bytes());
                 try self.worker_entries.append(self.allocator, .{
                     .resolved_path = path_dupe,
                     .source_module = mod_index,
@@ -175,8 +170,8 @@ pub fn applyContextDepResults(self: *ModuleGraph, mod_idx: usize) !void {
                 try appendResolvedDep(self, mod_idx, .{
                     .kind = dep.kind,
                     .target = .file,
-                    .path = f.path,
-                    .resolve_dir = f.resolve_dir,
+                    .path = .{ .interned = f.path },
+                    .resolve_dir = if (f.resolve_dir) |d| .{ .interned = d } else null,
                     .target_is_module_field = f.is_module_field,
                     .is_context_dep = true,
                 });
@@ -236,7 +231,7 @@ pub fn applyResolveResult(
                 .record_index = @intCast(rec_i),
                 .kind = record.kind,
                 .target = .disabled,
-                .path = record.specifier,
+                .path = .{ .specifier = record.specifier },
             });
             try recordResolvedDep(self, mod_index, mod_idx, rec_i, dep_idx, record.kind);
             return;
@@ -251,7 +246,7 @@ pub fn applyResolveResult(
                 .record_index = @intCast(rec_i),
                 .kind = record.kind,
                 .target = .optional_missing,
-                .path = record.specifier,
+                .path = .{ .specifier = record.specifier },
             });
             try recordResolvedDep(self, mod_index, mod_idx, rec_i, dep_idx, record.kind);
             return;
@@ -271,7 +266,7 @@ pub fn applyResolveResult(
                 .record_index = @intCast(rec_i),
                 .kind = record.kind,
                 .target = .disabled,
-                .path = record.specifier,
+                .path = .{ .specifier = record.specifier },
             });
             try recordResolvedDep(self, mod_index, mod_idx, rec_i, dep_idx, record.kind);
             return;
@@ -299,8 +294,8 @@ pub fn applyResolveResult(
                         .record_index = @intCast(rec_i),
                         .kind = record.kind,
                         .target = .worker,
-                        .path = f.path,
-                        .resolve_dir = f.resolve_dir,
+                        .path = .{ .interned = f.path },
+                        .resolve_dir = if (f.resolve_dir) |d| .{ .interned = d } else null,
                         .target_is_module_field = f.is_module_field,
                     });
                     return;
@@ -315,8 +310,8 @@ pub fn applyResolveResult(
                     .record_index = @intCast(rec_i),
                     .kind = record.kind,
                     .target = .file,
-                    .path = f.path,
-                    .resolve_dir = f.resolve_dir,
+                    .path = .{ .interned = f.path },
+                    .resolve_dir = if (f.resolve_dir) |d| .{ .interned = d } else null,
                     .target_is_module_field = f.is_module_field,
                 });
                 try recordResolvedDep(self, mod_index, mod_idx, rec_i, dep_idx, record.kind);
@@ -331,7 +326,7 @@ pub fn applyResolveResult(
                     .record_index = @intCast(rec_i),
                     .kind = record.kind,
                     .target = .disabled,
-                    .path = record.specifier,
+                    .path = .{ .specifier = record.specifier },
                 });
                 try recordResolvedDep(self, mod_index, mod_idx, rec_i, dep_idx, record.kind);
             },
@@ -346,7 +341,7 @@ pub fn applyResolveResult(
                     .record_index = @intCast(rec_i),
                     .kind = record.kind,
                     .target = .virtual,
-                    .path = v.path,
+                    .path = .{ .plugin = v.path },
                 });
                 try recordResolvedDep(self, mod_index, mod_idx, rec_i, dep_idx, record.kind);
                 if (request_changed) try resolveDeferredRequestedImportsIfReady(self, dep_idx);
@@ -367,7 +362,7 @@ pub fn applyResolveResult(
             .record_index = @intCast(rec_i),
             .kind = record.kind,
             .target = .external,
-            .path = record.specifier,
+            .path = .{ .specifier = record.specifier },
         });
         if (record.kind == .dynamic_import) {
             try self.linkDynamicImport(mod_index, ext_idx);

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -36,12 +36,40 @@ pub const OPTIONAL_MISSING_MODULE_PREFIX = "(optional-missing):";
 /// `ImportRecord.resolved` 는 빌드마다 새로 배정되는 ModuleIndex라 다음 rebuild에서
 /// 직접 재사용할 수 없다. 대신 resolve 결과를 path/specifier 기반으로 보존했다가
 /// cache-hit 모듈에서 graph edge를 다시 구성한다.
+/// PR #3749 Phase 3: path slice 의 *lifetime invariant* 를 type system 으로 강제.
+/// 각 variant 는 *path 의 ownership* 명시:
+///   - interned: `ResolveCache.path_pool` 소유 — borrow, free 금지 (cache.deinit 시 reclaim).
+///   - specifier: `Module.parse_arena` 소유 — borrow, free 금지 (module.deinit 시 destroyParseArena).
+///   - plugin: plugin context lifetime — borrow, free 금지 (plugin 이 own).
+///   - owned: caller (graph allocator) alloc — free 필수.
+pub const PathRef = union(enum) {
+    interned: []const u8,
+    specifier: []const u8,
+    plugin: []const u8,
+    owned: []const u8,
+
+    /// variant 무관 byte slice 접근.
+    pub inline fn bytes(self: PathRef) []const u8 {
+        return switch (self) {
+            inline else => |s| s,
+        };
+    }
+
+    /// variant 별 free. owned 만 실제 free, 나머지 no-op.
+    pub fn deinit(self: PathRef, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .owned => |s| allocator.free(s),
+            else => {},
+        }
+    }
+};
+
 pub const CachedResolvedDep = struct {
     record_index: ?u32 = null,
     kind: types.ImportKind,
     target: Target,
-    path: []const u8,
-    resolve_dir: ?[]const u8 = null,
+    path: PathRef,
+    resolve_dir: ?PathRef = null,
     target_is_module_field: bool = false,
     is_context_dep: bool = false,
 
@@ -733,8 +761,8 @@ pub const Module = struct {
         if (self.resolve_dir) |dir| allocator.free(dir);
         if (self.federation_id) |id| allocator.free(id); // #3318 P1-1 (setBoundary alloc)
         for (self.resolved_deps.items) |dep| {
-            allocator.free(dep.path);
-            if (dep.resolve_dir) |dir| allocator.free(dir);
+            dep.path.deinit(allocator);
+            if (dep.resolve_dir) |dir| dir.deinit(allocator);
         }
         self.resolved_deps.deinit(allocator);
         if (self.alias_table) |*t| t.deinit();

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -7,7 +7,19 @@
 const std = @import("std");
 const Module_mod = @import("module.zig");
 const Module = Module_mod.Module;
+const PathRef = Module_mod.PathRef;
 const types = @import("types.zig");
+
+/// PR #3749 Phase 3 (C): cache-borrowed (interned) PathRef 를 store-owned 로 clone.
+/// specifier/plugin 은 별도 lifetime (parse_arena 양도 + plugin context) — clone 안 함.
+/// owned 는 이미 자체 owner — clone 안 함.
+/// **명시 enumeration** (M3): 새 PathRef variant 추가 시 compile error 로 결정 강제.
+fn clonePathRefIfNeeded(allocator: std.mem.Allocator, ref: PathRef) !PathRef {
+    return switch (ref) {
+        .interned => |s| .{ .owned = try allocator.dupe(u8, s) },
+        .specifier, .plugin, .owned => ref,
+    };
+}
 
 pub const PersistentModuleStore = struct {
     allocator: std.mem.Allocator,
@@ -60,8 +72,8 @@ pub const PersistentModuleStore = struct {
         cached.module.dynamic_importers.deinit(self.allocator);
         if (cached.module.resolve_dir) |dir| self.allocator.free(dir);
         for (cached.module.resolved_deps.items) |dep| {
-            self.allocator.free(dep.path);
-            if (dep.resolve_dir) |dir| self.allocator.free(dir);
+            dep.path.deinit(self.allocator);
+            if (dep.resolve_dir) |dir| dir.deinit(self.allocator);
         }
         cached.module.resolved_deps.deinit(self.allocator);
         // import_specifiers 해제
@@ -98,6 +110,40 @@ pub const PersistentModuleStore = struct {
         cached_module.importers = .empty;
         cached_module.dynamic_imports = .empty;
         cached_module.dynamic_importers = .empty;
+
+        // PR #3749 Phase 3 (C): cache-borrowed (interned) path 를 store-owned 로 clone.
+        // cache 가 build 종료 시 deinit 되므로 (per-build Bundler 패턴) store 가 *자체 owner*
+        // 가 되어야 dangling 안 됨. specifier (parse_arena) / plugin variant 는 별도 lifetime
+        // 관리 — Module.parse_arena 가 store 로 양도 + plugin context 는 외부 lifetime.
+        //
+        // H1 fix: OOM 시 swallow 금지 — partial clone 으로 .interned 가 store 에 남으면
+        // path_pool 사망 시 UAF. 실패 시 *전체 putModule abort* (이미 처리된 dep 의 owned
+        // alloc 은 leak 이지만 store 에 진입 안 함 → cache lifetime 안 후속 read 없음).
+        for (cached_module.resolved_deps.items, 0..) |*dep, i| {
+            const new_path = clonePathRefIfNeeded(self.allocator, dep.path) catch {
+                // 부분 clone rollback: 이미 owned 로 변환된 entry 정리.
+                var j: usize = 0;
+                while (j < i) : (j += 1) {
+                    cached_module.resolved_deps.items[j].path.deinit(self.allocator);
+                    if (cached_module.resolved_deps.items[j].resolve_dir) |rd| rd.deinit(self.allocator);
+                }
+                return;
+            };
+            const new_rd = if (dep.resolve_dir) |rd|
+                clonePathRefIfNeeded(self.allocator, rd) catch {
+                    new_path.deinit(self.allocator);
+                    var j: usize = 0;
+                    while (j < i) : (j += 1) {
+                        cached_module.resolved_deps.items[j].path.deinit(self.allocator);
+                        if (cached_module.resolved_deps.items[j].resolve_dir) |rd2| rd2.deinit(self.allocator);
+                    }
+                    return;
+                }
+            else
+                null;
+            dep.path = new_path;
+            dep.resolve_dir = new_rd;
+        }
         // #3664: implicitlyLoadedAfterOneOf 양방향 관계 리스트도 ModuleIndex ArrayList backing 을
         // graph module 과 공유 → 위 4개와 동일하게 store 복사본은 빈 상태로(graph deinit 이 원본
         // 해제, store 가 dangling 안 되도록). 다음 rebuild 의 injectEmittedChunks 가 재구성.


### PR DESCRIPTION
## 배경

PR #3748 Phase 1+2 의 follow-up. issue #3749 의 Phase 3 — `CachedResolvedDep.path` 의 dupe 제거 시도가 *cache 가 build 별 새로 생성* 되는 패턴에서 dangling. **PathRef enum 으로 lifetime 을 type system 으로 강제** + putModule clone 으로 lifetime mismatch 해결.

## design

```zig
pub const PathRef = union(enum) {
    interned: []const u8,   // cache.path_pool 소유 (borrow)
    specifier: []const u8,  // module.parse_arena 소유 (borrow)
    plugin: []const u8,     // plugin context lifetime (borrow)
    owned: []const u8,      // graph allocator alloc (free 필수)
};
```

caller 가 variant 명시 → compile 시점에 lifetime contract 명확.

## 변경

### `src/bundler/module.zig`
PathRef 정의 + `bytes()` + `deinit()`. CachedResolvedDep.path 가 PathRef. Module.deinit 가 variant 별 자동 처리.

### `src/bundler/graph/resolve_imports.zig`
- `appendResolvedDep` 의 dupe 제거 — variant 그대로 store.
- 모든 caller 가 variant 명시:
  - file/worker → `.interned` (cache)
  - disabled/optional/external → `.specifier` (parse_arena)
  - virtual → `.plugin`
- replay 의 read 사이트 `dep.path.bytes()`.

### `src/bundler/module_store.zig`
- `clonePathRefIfNeeded`: **interned → owned** (store allocator dupe). cache 가 build 별 새로 생성 되는 패턴에서 store 가 자체 owner 가 됨.
- putModule 시 각 dep 의 interned 를 store-owned 로 clone.

## /code-review max 5 angle 적용

| ID | severity | finding | 적용 |
|----|---------|---------|------|
| **H1** | MED | clonePathRefIfNeeded OOM swallow → store 에 .interned 잔류 | ✅ rollback + abort putModule |
| **M3** | MED | else => ref exhaustiveness 회피 | ✅ 명시 enumeration (compile-time 강제) |
| H2 | MED | .plugin variant doc-실사용 불일치 | future PR 5 plugin layer |
| L4/L5 | LOW | freeCachedModule 순서, appendResolvedDep errdefer | future 정리 |

## root cause 추적 결과

처음 *dupe 제거만* 시도 (Phase 3 의 단순 design) → `incremental_bench_v2: cache hit on no-change` test crash. 원인:
- test 가 *Bundler 마다 새 cache* (b.deinit 시 cache deinit).
- 첫 build 의 store transfer 시점에 dep.path 가 *옛 cache.path_pool slice* 가리킴.
- 두번째 build (cache 새로 생성) 에서 replay 시 옛 slice = dangling.

**fix**: PathRef.owned variant 추가 + putModule 시 interned → owned clone. *cache lifetime 무관* 하게 store 가 자체 owner.

## E2E

| 항목 | 결과 |
|------|------|
| zig build test 전체 | ✅ pass (incremental_bench_v2 의 옛 fail 해결) |
| tests/integration (3909 tests) | main 25 fail vs branch **3 fail** (회귀 0건) |
| effect-ts | ✅ \`43\` |

## 측정

- baseline (PR #3748 Phase 1+2): 93.5ms wall (ReleaseFast)
- Phase 3 (C): 107ms (variance + clone overhead — single build 에선 dep dupe 절감 미미)
- **correctness 가 핵심 가치** — incremental cache hit UAF 회귀 방지, *type system 의 lifetime invariant*.

## 후속

- H2 plugin variant — PR 5 plugin layer 에서 .virtual 도 cache intern.
- 메모리 절감 정량화 — 큰 monorepo (RN, MUI) 측정 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)