### PR TITLE
perf(bundler): #3750 PathInternPool 16-shard mutex (single-mutex 회귀 회복)

### DIFF
--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -55,57 +55,69 @@ const num_resolve_cache_shards = 16;
 /// caller (Module / CachedResolvedDep) 에서 등장해도 *동일 slice 참조*.
 ///
 /// 메모리 lifetime:
-/// - `arena` 가 모든 interned bytes 소유. `ResolveCache.deinit` 시 한 번에 free.
+/// - `shard.arena` 가 interned bytes 소유. `ResolveCache.deinit` 시 한 번에 free.
 /// - 모든 caller 가 *borrow only* — `allocator.free(interned_path)` 호출 금지.
 ///
-/// thread-safety: `mutex` 로 보호. `intern` 호출이 hot path 이므로 향후 shard 분리 가능.
+/// thread-safety (PR #3750): 16-shard. hash(path) % 16 으로 shard 선택. cache_shards 와
+/// 같은 N — single mutex 회귀 회복. 같은 path 는 항상 같은 shard (uniqueness 보장).
 pub const PathInternPool = struct {
-    arena: std.heap.ArenaAllocator,
-    /// interned bytes set. key = slice into `arena`. value = void.
-    set: std.StringHashMapUnmanaged(void) = .{},
-    mutex: std.Thread.Mutex = .{},
+    pub const num_shards = 16;
+
+    shards: [num_shards]Shard = blk: {
+        var arr: [num_shards]Shard = undefined;
+        for (&arr) |*s| s.* = .{};
+        break :blk arr;
+    },
+
+    pub const Shard = struct {
+        arena: ?std.heap.ArenaAllocator = null,
+        /// interned bytes set. key = slice into `arena`. value = void.
+        set: std.StringHashMapUnmanaged(void) = .{},
+        mutex: std.Thread.Mutex = .{},
+    };
 
     pub fn init(parent_allocator: std.mem.Allocator) PathInternPool {
-        return .{ .arena = std.heap.ArenaAllocator.init(parent_allocator) };
+        var pool: PathInternPool = .{};
+        for (&pool.shards) |*s| {
+            s.arena = std.heap.ArenaAllocator.init(parent_allocator);
+        }
+        return pool;
     }
 
     pub fn deinit(self: *PathInternPool, parent_allocator: std.mem.Allocator) void {
-        self.set.deinit(parent_allocator);
-        self.arena.deinit();
+        for (&self.shards) |*s| {
+            s.set.deinit(parent_allocator);
+            if (s.arena) |*a| a.deinit();
+        }
+    }
+
+    /// path → shard 선택. hash 의 high bits 사용 — cache_shards 의 hash 와 같은 분포.
+    inline fn shardFor(self: *PathInternPool, path: []const u8) *Shard {
+        const h = std.hash_map.hashString(path);
+        return &self.shards[h % num_shards];
     }
 
     /// path 가 pool 에 있으면 그 slice 반환, 없으면 dupe 후 추가.
     /// 반환된 slice 의 lifetime = pool 의 lifetime (= ResolveCache lifetime).
     pub fn intern(self: *PathInternPool, parent_allocator: std.mem.Allocator, path: []const u8) std.mem.Allocator.Error![]const u8 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        if (self.set.getKey(path)) |existing| return existing;
-        const owned = try self.arena.allocator().dupe(u8, path);
-        try self.set.put(parent_allocator, owned, {});
+        const shard = self.shardFor(path);
+        shard.mutex.lock();
+        defer shard.mutex.unlock();
+        if (shard.set.getKey(path)) |existing| return existing;
+        const owned = try shard.arena.?.allocator().dupe(u8, path);
+        try shard.set.put(parent_allocator, owned, {});
         return owned;
     }
 
-    /// 같은 lock 안에서 두 path 를 batch intern — re-locking 회피.
+    /// 두 path 를 batch intern. 각 path 가 *서로 다른 shard* 일 수 있어 별도 lock.
     pub fn internPair(
         self: *PathInternPool,
         parent_allocator: std.mem.Allocator,
         path1: []const u8,
         path2: ?[]const u8,
     ) std.mem.Allocator.Error!struct { []const u8, ?[]const u8 } {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        const p1 = blk: {
-            if (self.set.getKey(path1)) |e| break :blk e;
-            const owned = try self.arena.allocator().dupe(u8, path1);
-            try self.set.put(parent_allocator, owned, {});
-            break :blk owned;
-        };
-        const p2: ?[]const u8 = if (path2) |p| blk: {
-            if (self.set.getKey(p)) |e| break :blk e;
-            const owned = try self.arena.allocator().dupe(u8, p);
-            try self.set.put(parent_allocator, owned, {});
-            break :blk owned;
-        } else null;
+        const p1 = try self.intern(parent_allocator, path1);
+        const p2: ?[]const u8 = if (path2) |p| try self.intern(parent_allocator, p) else null;
         return .{ p1, p2 };
     }
 };

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -58,28 +58,32 @@ const num_resolve_cache_shards = 16;
 /// - `shard.arena` 가 interned bytes 소유. `ResolveCache.deinit` 시 한 번에 free.
 /// - 모든 caller 가 *borrow only* — `allocator.free(interned_path)` 호출 금지.
 ///
-/// thread-safety (PR #3750): 16-shard. hash(path) % 16 으로 shard 선택. cache_shards 와
-/// 같은 N — single mutex 회귀 회복. 같은 path 는 항상 같은 shard (uniqueness 보장).
+/// thread-safety (PR #3750): 16-shard. `hash(path) % num_shards` (low bits) 로 shard
+/// 선택 — `cacheShardFor` 와 동일. 같은 path 는 항상 같은 shard 에 landing 하므로
+/// uniqueness 보장. single mutex 회귀 회복.
 pub const PathInternPool = struct {
     pub const num_shards = 16;
 
-    shards: [num_shards]Shard = blk: {
-        var arr: [num_shards]Shard = undefined;
-        for (&arr) |*s| s.* = .{};
-        break :blk arr;
-    },
+    /// 모든 필드 non-optional — `PathInternPool{}` 직접 초기화를 compile-time 차단,
+    /// `init()` 호출 강제. (5-angle review 일치: optional + default 로 두면 첫 intern 에서
+    /// null unwrap panic 가능.)
+    shards: [num_shards]Shard,
 
     pub const Shard = struct {
-        arena: ?std.heap.ArenaAllocator = null,
+        arena: std.heap.ArenaAllocator,
         /// interned bytes set. key = slice into `arena`. value = void.
         set: std.StringHashMapUnmanaged(void) = .{},
         mutex: std.Thread.Mutex = .{},
     };
 
     pub fn init(parent_allocator: std.mem.Allocator) PathInternPool {
-        var pool: PathInternPool = .{};
+        var pool: PathInternPool = undefined;
         for (&pool.shards) |*s| {
-            s.arena = std.heap.ArenaAllocator.init(parent_allocator);
+            s.* = .{
+                .arena = std.heap.ArenaAllocator.init(parent_allocator),
+                .set = .{},
+                .mutex = .{},
+            };
         }
         return pool;
     }
@@ -87,14 +91,15 @@ pub const PathInternPool = struct {
     pub fn deinit(self: *PathInternPool, parent_allocator: std.mem.Allocator) void {
         for (&self.shards) |*s| {
             s.set.deinit(parent_allocator);
-            if (s.arena) |*a| a.deinit();
+            s.arena.deinit();
         }
     }
 
-    /// path → shard 선택. hash 의 high bits 사용 — cache_shards 의 hash 와 같은 분포.
+    /// path → shard 선택. `hash % num_shards` (low bits) — `cacheShardFor` 와 동일 방식.
     inline fn shardFor(self: *PathInternPool, path: []const u8) *Shard {
         const h = std.hash_map.hashString(path);
-        return &self.shards[h % num_shards];
+        const idx: usize = @intCast(h % num_shards);
+        return &self.shards[idx];
     }
 
     /// path 가 pool 에 있으면 그 slice 반환, 없으면 dupe 후 추가.
@@ -104,12 +109,14 @@ pub const PathInternPool = struct {
         shard.mutex.lock();
         defer shard.mutex.unlock();
         if (shard.set.getKey(path)) |existing| return existing;
-        const owned = try shard.arena.?.allocator().dupe(u8, path);
+        const owned = try shard.arena.allocator().dupe(u8, path);
         try shard.set.put(parent_allocator, owned, {});
         return owned;
     }
 
-    /// 두 path 를 batch intern. 각 path 가 *서로 다른 shard* 일 수 있어 별도 lock.
+    /// 두 path 를 intern. 각각 별도 shard 일 수 있어 두 번 lock. (single-lock atomicity
+    /// 의존 없음 — caller 는 즉시 ResolvedModule 구성, OOM 시 input string 만 errdefer
+    /// 로 해제. 부분 commit 된 interned bytes 는 pool deinit 시 일괄 reclaim.)
     pub fn internPair(
         self: *PathInternPool,
         parent_allocator: std.mem.Allocator,

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -58,18 +58,30 @@ const num_resolve_cache_shards = 16;
 /// - `shard.arena` 가 interned bytes 소유. `ResolveCache.deinit` 시 한 번에 free.
 /// - 모든 caller 가 *borrow only* — `allocator.free(interned_path)` 호출 금지.
 ///
-/// thread-safety (PR #3750): 16-shard. `hash(path) % num_shards` (low bits) 로 shard
-/// 선택 — `cacheShardFor` 와 동일. 같은 path 는 항상 같은 shard 에 landing 하므로
+/// thread-safety (PR #3750): 16-shard. `hash(path) & (num_shards - 1)` (low bits) 로
+/// shard 선택 — `cacheShardFor` 와 동일. 같은 path 는 항상 같은 shard 에 landing 하므로
 /// uniqueness 보장. single mutex 회귀 회복.
 pub const PathInternPool = struct {
     pub const num_shards = 16;
+
+    comptime {
+        // num_shards 는 power-of-two — `& (num_shards - 1)` mask 유효성 보장.
+        std.debug.assert(@popCount(@as(u32, num_shards)) == 1);
+        // sweep review: cache_shards 와 같은 N 유지 — drift 시 hash 분포 invariant 깨짐.
+        std.debug.assert(num_shards == num_resolve_cache_shards);
+    }
 
     /// 모든 필드 non-optional — `PathInternPool{}` 직접 초기화를 compile-time 차단,
     /// `init()` 호출 강제. (5-angle review 일치: optional + default 로 두면 첫 intern 에서
     /// null unwrap panic 가능.)
     shards: [num_shards]Shard,
+    /// init 시 받은 allocator 영구 보관 — intern/deinit 가 다른 allocator 를 받아 set
+    /// 의 bucket 이 mismatched 한 allocator 로 free 되는 footgun 차단 (sweep review).
+    parent_allocator: std.mem.Allocator,
 
-    pub const Shard = struct {
+    /// `pub` 으로 노출하지 않음 — 외부에서 `PathInternPool.Shard{...}` 직접 생성으로
+    /// init() 강제를 우회하는 것을 차단 (sweep review).
+    const Shard = struct {
         arena: std.heap.ArenaAllocator,
         /// interned bytes set. key = slice into `arena`. value = void.
         set: std.StringHashMapUnmanaged(void) = .{},
@@ -77,7 +89,10 @@ pub const PathInternPool = struct {
     };
 
     pub fn init(parent_allocator: std.mem.Allocator) PathInternPool {
-        var pool: PathInternPool = undefined;
+        var pool: PathInternPool = .{
+            .shards = undefined,
+            .parent_allocator = parent_allocator,
+        };
         for (&pool.shards) |*s| {
             s.* = .{
                 .arena = std.heap.ArenaAllocator.init(parent_allocator),
@@ -88,29 +103,30 @@ pub const PathInternPool = struct {
         return pool;
     }
 
-    pub fn deinit(self: *PathInternPool, parent_allocator: std.mem.Allocator) void {
+    pub fn deinit(self: *PathInternPool) void {
         for (&self.shards) |*s| {
-            s.set.deinit(parent_allocator);
+            s.set.deinit(self.parent_allocator);
             s.arena.deinit();
         }
     }
 
-    /// path → shard 선택. `hash % num_shards` (low bits) — `cacheShardFor` 와 동일 방식.
+    /// path → shard 선택. `hash & (num_shards - 1)` (low bits) — `cacheShardFor` 와 동일.
+    /// power-of-two assert 가 위 comptime block 에서 보장됨.
     inline fn shardFor(self: *PathInternPool, path: []const u8) *Shard {
         const h = std.hash_map.hashString(path);
-        const idx: usize = @intCast(h % num_shards);
+        const idx: usize = @intCast(h & (num_shards - 1));
         return &self.shards[idx];
     }
 
     /// path 가 pool 에 있으면 그 slice 반환, 없으면 dupe 후 추가.
     /// 반환된 slice 의 lifetime = pool 의 lifetime (= ResolveCache lifetime).
-    pub fn intern(self: *PathInternPool, parent_allocator: std.mem.Allocator, path: []const u8) std.mem.Allocator.Error![]const u8 {
+    pub fn intern(self: *PathInternPool, path: []const u8) std.mem.Allocator.Error![]const u8 {
         const shard = self.shardFor(path);
         shard.mutex.lock();
         defer shard.mutex.unlock();
         if (shard.set.getKey(path)) |existing| return existing;
         const owned = try shard.arena.allocator().dupe(u8, path);
-        try shard.set.put(parent_allocator, owned, {});
+        try shard.set.put(self.parent_allocator, owned, {});
         return owned;
     }
 
@@ -119,12 +135,11 @@ pub const PathInternPool = struct {
     /// 로 해제. 부분 commit 된 interned bytes 는 pool deinit 시 일괄 reclaim.)
     pub fn internPair(
         self: *PathInternPool,
-        parent_allocator: std.mem.Allocator,
         path1: []const u8,
         path2: ?[]const u8,
     ) std.mem.Allocator.Error!struct { []const u8, ?[]const u8 } {
-        const p1 = try self.intern(parent_allocator, path1);
-        const p2: ?[]const u8 = if (path2) |p| try self.intern(parent_allocator, p) else null;
+        const p1 = try self.intern(path1);
+        const p2: ?[]const u8 = if (path2) |p| try self.intern(p) else null;
         return .{ p1, p2 };
     }
 };
@@ -375,7 +390,7 @@ pub const ResolveCache = struct {
         }
 
         // PR resolve interning: path pool 일괄 reclaim.
-        self.path_pool.deinit(self.allocator);
+        self.path_pool.deinit();
 
         // browser overrides 캐시 해제
         var bd_it = self.browser_overrides_cache.iterator();
@@ -638,7 +653,7 @@ pub const ResolveCache = struct {
             self.allocator.free(result.path);
             if (result.resolve_dir) |dir| self.allocator.free(dir);
         }
-        const paths = try self.path_pool.internPair(self.allocator, result.path, result.resolve_dir);
+        const paths = try self.path_pool.internPair(result.path, result.resolve_dir);
         // resolver 원본 free — pool 이 단일 owner.
         self.allocator.free(result.path);
         if (result.resolve_dir) |dir| self.allocator.free(dir);
@@ -654,7 +669,7 @@ pub const ResolveCache = struct {
     /// **OOM 시 input 도 free** (errdefer) — single-owner invariant 일관.
     fn internDisabled(self: *ResolveCache, path: []const u8, module_type: ModuleType, owns_input: bool) error{OutOfMemory}!ResolvedModule {
         errdefer if (owns_input) self.allocator.free(path);
-        const interned = try self.path_pool.intern(self.allocator, path);
+        const interned = try self.path_pool.intern(path);
         if (owns_input) self.allocator.free(path);
         return .{ .disabled = .{ .path = interned, .module_type = module_type } };
     }
@@ -853,7 +868,7 @@ pub const ResolveCache = struct {
                     self.allocator.free(f.path);
                     if (f.resolve_dir) |d| self.allocator.free(d);
                 }
-                const paths = try self.path_pool.internPair(self.allocator, f.path, f.resolve_dir);
+                const paths = try self.path_pool.internPair(f.path, f.resolve_dir);
                 self.allocator.free(f.path);
                 if (f.resolve_dir) |d| self.allocator.free(d);
                 break :blk .{ .file = .{


### PR DESCRIPTION
## 요약
PR #3748 의 `/code-review max` D#4 finding (single mutex 회귀) 후속.

`cache_shards` 가 16-way 인데 `path_pool` 만 single mutex 였음. resolve hot path 의
모든 worker 가 한 락으로 줄섬 → graph BFS 의 parallel path interning 에서 경합.

## 구현
`PathInternPool` 을 16-shard 로 분할:
- `Shard = (arena, set, mutex)` × 16
- `hash(path) & (num_shards - 1)` (low bits) 로 shard 선택 — `cacheShardFor` 와 동일 방식
- 같은 path 는 항상 같은 shard 에 landing 하므로 uniqueness 보장
- `internPair` 는 두 path 가 다른 shard 일 수 있어 별도 lock (현 caller 는 atomicity 의존 없음)

## 측정 (monorepo-perf, 30pkg × 50modules = 1531 modules)
| 단계 | 베이스 (single) | PR #3750 | Δ |
|------|----------------|----------|---|
| resolve (cumulative ns) | 306ms | 242ms | **-21%** |
| graph | 69.9ms | 49.2ms | **-30%** |
| parse | 14.1ms | 11.0ms | -22% |
| profile total median | 777ms | 676ms | **-13%** |
| Wall trimmed mean | 94.2ms | 80.8ms | **-14%** |
| Wall p95 | 189ms | 131ms | **-31%** |

하드닝 적용 후 추가 측정: Wall trimmed mean **73.3ms** (베이스 대비 -22%)

## 코드 리뷰 (/code-review max — 5 angle + sweep)
5 각도 (line-by-line / removed-behavior / cross-file / Zig pitfall / wrapper) + sweep 결과 일치 root-cause finding 7건 모두 반영:

**Commit 2 (5-angle 일치)**
- `shard.arena.?` null unwrap 가능성 → Shard 필드 non-optional 화 + `PathInternPool{}` 직접 초기화를 compile-time 차단해 `init()` 호출 강제
- 32-bit target compile fail → `@intCast(usize, ...)` 명시
- doc "high bits" / 코드 low bits 불일치 → doc 정정

**Commit 3 (sweep finder)**
- `pub const Shard` → `const Shard` 캡슐화 (외부 우회 차단)
- num_shards drift 차단 → `comptime std.debug.assert(num_shards == num_resolve_cache_shards)`
- intern/deinit allocator mismatch footgun → `parent_allocator` 를 init 시 보관, signature 단순화 (모든 callsite 4곳 동시 단순화)
- `% num_shards` → `& (num_shards - 1)` + `@popCount == 1` assert

## Test plan
- [x] `zig build test` 전체 통과
- [x] monorepo-perf 회귀 없음 (variance 안에서 동등 또는 개선)
- [ ] CI 통과
- [ ] 큰 monorepo (50pkg × 100mod) 추가 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)