### PR TITLE
perf(bundler): #3751 watch mode 의 ResolveCache N-rebuild reset (arena monotonic growth 차단)

### DIFF
--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -76,6 +76,15 @@ pub const IncrementalBundler = struct {
     /// 첫 빌드 시엔 mtime 이 아직 Module 에 주입되지 않아 miss 만 발생 (B3 에서 확장).
     compiled_cache: CompiledOutputCache,
 
+    /// (#3751) `rebuild_reset_interval` 마다 `resolve_cache` 를 deinit + 재생성.
+    /// `PathInternPool.arena` 가 monotonic — file rename / 임시 .ts→.tsx / dynamic
+    /// import 패턴 → 옛 path 가 영원히 arena 에 남아 장기 watch (30+ 분) 후 RSS 단방향
+    /// 증가. Phase 3 (#3749) 후 `PersistentModuleStore` 가 `PathRef.owned` 으로
+    /// self-clone 하므로 reset 안전.
+    rebuild_count: usize = 0,
+    /// reset 주기. test 가 override 가능. 0 = reset 비활성.
+    rebuild_reset_interval: usize = 100,
+
     /// 모듈 단위 dev/HMR 캐시 엔트리.
     /// `code` = `__zntc_register` wrapper (HMR 경로).
     /// `compiled` / `input_hash` = compiled output cache 재사용용 (populate 는 별도 PR).
@@ -140,7 +149,20 @@ pub const IncrementalBundler = struct {
     }
 
     fn doBuild(self: *IncrementalBundler, is_first: bool) !RebuildResult {
-        // resolve_cache 초기화 (첫 빌드 시) 또는 재사용
+        // (#3751) N rebuild 마다 resolve_cache reset — arena monotonic growth 차단.
+        // is_first 가 아닌 경우에만, 그리고 reset_interval 도달 시. 빌드 *사이* 에서만
+        // 실행 (in-flight CachedResolvedDep 가 모두 store 로 owned-clone 된 상태).
+        if (!is_first and self.rebuild_reset_interval > 0 and
+            self.rebuild_count >= self.rebuild_reset_interval)
+        {
+            if (self.resolve_cache) |*rc| {
+                rc.deinit();
+                self.resolve_cache = null;
+            }
+            self.rebuild_count = 0;
+        }
+
+        // resolve_cache 초기화 (첫 빌드 시 또는 위 reset 직후) 또는 재사용
         if (self.resolve_cache == null) {
             self.resolve_cache = Bundler.initResolveCacheFromOptions(self.allocator, self.options);
         }
@@ -216,6 +238,9 @@ pub const IncrementalBundler = struct {
 
         self.updateCache(&result);
         if (is_first) self.needs_full_rebuild = false;
+        // (#3751) reset interval 카운터 — 빌드 *완료* 후 증가. error/fatal 경로는 카운트
+        // 안 함 (broken state 가 reset 시점을 좌우하지 않도록).
+        self.rebuild_count += 1;
 
         self.compiled_cache.logStats(if (is_first) "first=true " else "first=false ");
 

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -115,11 +115,19 @@ pub const IncrementalBundler = struct {
 
     /// 외부에서 캐시 전체 무효화 (Control API `/reset-cache` 등).
     /// 다음 rebuild()는 초기 빌드와 동일한 전체 재번들.
+    /// (#3751) `resolve_cache` 와 `rebuild_count` 도 reset — 자동 reset 과 대칭.
+    /// 사용자가 RSS 증가를 이유로 수동 reset 호출 시 path_pool arena 가 해제되지
+    /// 않는 비대칭을 차단 (/code-review max Angle B + E finding).
     pub fn reset(self: *IncrementalBundler) void {
         self.clearCache();
         self.persistent_store.deinit();
         self.persistent_store = module_store.PersistentModuleStore.init(self.allocator);
         self.compiled_cache.clear();
+        if (self.resolve_cache) |*rc| {
+            rc.deinit();
+            self.resolve_cache = null;
+        }
+        self.rebuild_count = 0;
         self.needs_full_rebuild = true;
     }
 
@@ -150,9 +158,14 @@ pub const IncrementalBundler = struct {
 
     fn doBuild(self: *IncrementalBundler, is_first: bool) !RebuildResult {
         // (#3751) N rebuild 마다 resolve_cache reset — arena monotonic growth 차단.
-        // is_first 가 아닌 경우에만, 그리고 reset_interval 도달 시. 빌드 *사이* 에서만
-        // 실행 (in-flight CachedResolvedDep 가 모두 store 로 owned-clone 된 상태).
-        if (!is_first and self.rebuild_reset_interval > 0 and
+        // 빌드 *사이* 에서만 실행 (in-flight CachedResolvedDep 가 모두 store 로 owned-clone
+        // 된 상태).
+        //
+        // is_first 가드 없이 `resolve_cache != null` 만 검사 — review Angle B/E finding:
+        // build_error → needs_full_rebuild=true 패턴에서 다음 rebuild 가 is_first=true 라
+        // `!is_first` 가드를 쓰면 영원히 reset skip 가능. resolve_cache 존재 여부로만
+        // 판단해야 cold/warm 무관하게 N 마다 trigger 됨.
+        if (self.resolve_cache != null and self.rebuild_reset_interval > 0 and
             self.rebuild_count >= self.rebuild_reset_interval)
         {
             if (self.resolve_cache) |*rc| {

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -1052,9 +1052,13 @@ test "IncrementalBundler: ResolveCache resets after rebuild_reset_interval rebui
             else => return error.TestUnexpectedResult,
         }
     }
-    const cache_after_first = &ib.resolve_cache.?;
+    // path_pool 의 *내용* fingerprint — entry path 를 intern 해 ptr 보관.
+    // ib.resolve_cache.? 자체 주소는 optional 의 in-place storage 라 reset 후에도
+    // 같은 주소를 갖는다 (review Angle A/D finding). 따라서 cache content 의 stable
+    // 식별자 — intern 한 slice 가 가리키는 arena 안 주소 — 로 reset 여부를 검증.
+    const interned_before = try ib.resolve_cache.?.path_pool.intern("/__test_fingerprint_3751");
 
-    // 2-3 번째 rebuild: 같은 cache 재사용.
+    // 2-3 번째 rebuild: 같은 cache 재사용 → 같은 path intern 은 같은 slice 반환.
     var i: usize = 0;
     while (i < 2) : (i += 1) {
         const r = try ib.rebuild();
@@ -1062,7 +1066,8 @@ test "IncrementalBundler: ResolveCache resets after rebuild_reset_interval rebui
             .success => |s| freeChanged(s.changed_modules),
             else => return error.TestUnexpectedResult,
         }
-        try std.testing.expectEqual(cache_after_first, &ib.resolve_cache.?);
+        const interned_again = try ib.resolve_cache.?.path_pool.intern("/__test_fingerprint_3751");
+        try std.testing.expectEqual(interned_before.ptr, interned_again.ptr);
     }
 
     // 4번째 rebuild = interval 도달 → reset 이 일어나야 함. resolve_cache 재생성으로
@@ -1077,4 +1082,39 @@ test "IncrementalBundler: ResolveCache resets after rebuild_reset_interval rebui
     }
     // rebuild_count 가 reset 후 1 로 복귀했어야 함.
     try std.testing.expect(ib.rebuild_count < ib.rebuild_reset_interval);
+    // 새 arena 에서 같은 path 를 intern → 이전 slice 와 *다른* ptr 이어야 함 (reset 입증).
+    const interned_after_reset = try ib.resolve_cache.?.path_pool.intern("/__test_fingerprint_3751");
+    try std.testing.expect(interned_before.ptr != interned_after_reset.ptr);
+}
+
+test "IncrementalBundler: reset() Control API 도 resolve_cache 같이 비움 (#3751)" {
+    // Angle B + E finding: 사용자 수동 reset 이 path_pool 을 안 건드리면 RSS 회복 안 됨.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var ib = IncrementalBundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+    });
+    defer ib.deinit();
+
+    // 첫 빌드.
+    {
+        const r = try ib.rebuild();
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    try std.testing.expect(ib.resolve_cache != null);
+    try std.testing.expect(ib.rebuild_count > 0);
+
+    // 수동 reset — resolve_cache 와 rebuild_count 모두 정리되어야 함.
+    ib.reset();
+    try std.testing.expect(ib.resolve_cache == null);
+    try std.testing.expectEqual(@as(usize, 0), ib.rebuild_count);
 }

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -1020,3 +1020,61 @@ test "IncrementalBundler: compiled_cache invalidates on file change" {
     // 모듈 수 변동 없으므로 엔트리 개수는 유지 (put 이 기존 entry 교체).
     try std.testing.expectEqual(entries_before, ib.compiled_cache.entries.count());
 }
+
+// ============================================================
+// #3751 — watch mode arena monotonic growth 방지
+// ============================================================
+
+test "IncrementalBundler: ResolveCache resets after rebuild_reset_interval rebuilds (#3751)" {
+    // 옵션 A: N rebuild 마다 resolve_cache deinit + 재생성.
+    // path_pool arena 가 monotonic 으로 자라는 것을 막아 watch mode RSS bound.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "console.log('hi');");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var ib = IncrementalBundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+    });
+    defer ib.deinit();
+
+    // 테스트 가속 — 기본 100 대신 3 rebuild 마다 reset.
+    ib.rebuild_reset_interval = 3;
+
+    // 첫 빌드 (resolve_cache 생성).
+    {
+        const r = try ib.rebuild();
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    const cache_after_first = &ib.resolve_cache.?;
+
+    // 2-3 번째 rebuild: 같은 cache 재사용.
+    var i: usize = 0;
+    while (i < 2) : (i += 1) {
+        const r = try ib.rebuild();
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+        try std.testing.expectEqual(cache_after_first, &ib.resolve_cache.?);
+    }
+
+    // 4번째 rebuild = interval 도달 → reset 이 일어나야 함. resolve_cache 재생성으로
+    // 내부 path_pool / cache_shards / dir_cache 모두 fresh. 다음 build 가 cold 지만
+    // arena 무한 증가 차단.
+    {
+        const r = try ib.rebuild();
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    // rebuild_count 가 reset 후 1 로 복귀했어야 함.
+    try std.testing.expect(ib.rebuild_count < ib.rebuild_reset_interval);
+}


### PR DESCRIPTION
## 요약
이슈 #3751 — `PathInternPool.arena` 가 monotonic. dev server / watch mode 의 수백~수천 rebuild 동안 file rename / 임시 .ts→.tsx / dynamic import 패턴 → 옛 path 가 영원히 arena 에 남음 → 장기 watch (30+ 분) 후 RSS 단방향 증가.

옵션 A 적용 (이슈 권장, 가장 단순): N rebuild 마다 `resolve_cache` deinit + 재생성.

## 안전성
Phase 3 (#3749) PathRef enum 으로 `PersistentModuleStore.putModule` 이 `interned → owned` 으로 self-clone — store 가 자체 owner. reset 시점에는 in-flight `CachedResolvedDep` 가 모두 owned-clone 된 상태 (빌드 사이에서만 reset 실행).

(별도: #3755 OOM rollback 시 shared backing 더블 free 버그 — pre-existing #3749 회귀, 본 PR 범위 밖이지만 안전성 claim 강화 위해 별도 추적.)

## 구현
- `IncrementalBundler.rebuild_count` + `rebuild_reset_interval` (기본 100, mutable for tests).
- `doBuild` 진입 시 `resolve_cache != null and count >= interval` → deinit + null + count=0.
- 빌드 성공 후 `rebuild_count += 1`.

## /code-review max — 5 angle + sweep
**Commit 2 (review fix, root cause)**:
- **Angle B + E (P0)**: `reset()` Control API 가 resolve_cache 안 건드려 비대칭 → 같이 deinit + count=0
- **Angle B + C (P1)**: `!is_first` 가드 → error→full rebuild 반복 시 영원히 reset skip → `resolve_cache != null` 으로 교체 (cold/warm 무관)
- **Angle A + D (P1)**: 테스트의 `&ib.resolve_cache.?` ptr 비교 무의미 (optional in-place storage) → fingerprint path intern 후 slice ptr 변화로 검증
- 추가 test: `reset()` 호출 후 resolve_cache==null + rebuild_count==0 검증

**Deferred (별도 이슈/RFC)**:
- #3755 OOM rollback shared backing 더블 free
- PathInternPool 만 정밀 reset (dir_cache 보존, p99 spike 감소) — 향후 RFC

## Test plan
- [x] `zig build test` 전체 통과 (새 test 2개 포함)
- [x] interval=3 시점 reset 동작 fingerprint 검증
- [x] reset() Control API 대칭 검증
- [ ] CI 통과
- [ ] 장기 watch RSS 실측 (별도 측정 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)