### PR TITLE
test(css): @charset/@layer/@import condition_tail 영구 회귀 가드 4건 추가

### DIFF
--- a/tests/integration/tests/css-bundle.test.ts
+++ b/tests/integration/tests/css-bundle.test.ts
@@ -816,4 +816,120 @@ describe('CSS Bundling', () => {
     expect(css).toMatch(/@import\s+"https:\/\/cdn\/x\.css"\s+print\s*;/);
     expect(css).toMatch(/@import\s+"https:\/\/cdn\/x\.css"\s+screen\s*;/);
   });
+
+  // ── post-merge 검증 (manual repro 로 통과 확인) 영구 회귀 가드. PR #3746
+  // (#3321 P0-3 external @import) + #3752 (#3747 @charset/@layer) 의 보존
+  // 메커니즘이 단일 bundle 경로 외에도 정확히 작동하는지 확정.
+  it('#3747 nested 3-level @import — 각 단계의 @charset/@layer 가 deps-first 순서로 보존', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './top.css';`,
+      'deep.css': `@charset "UTF-8";\n@layer deep_reset;\n.deep {}`,
+      'mid.css': `@import "./deep.css";\n@layer mid_layer;\n.mid {}`,
+      'top.css': `@import "./mid.css";\n@layer top_layer;\n.top {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    // @charset 살아있고 첫 byte
+    expect(css.trimStart().startsWith('@charset "UTF-8"')).toBe(true);
+    // 3 단계 @layer 모두 보존 + deps-first (deep → mid → top)
+    const deepIdx = css.indexOf('@layer deep_reset');
+    const midIdx = css.indexOf('@layer mid_layer');
+    const topIdx = css.indexOf('@layer top_layer');
+    expect(deepIdx).toBeGreaterThanOrEqual(0);
+    expect(midIdx).toBeGreaterThanOrEqual(0);
+    expect(topIdx).toBeGreaterThanOrEqual(0);
+    expect(deepIdx).toBeLessThan(midIdx);
+    expect(midIdx).toBeLessThan(topIdx);
+    // 본문도 deps-first
+    expect(css.indexOf('.deep')).toBeLessThan(css.indexOf('.mid'));
+    expect(css.indexOf('.mid')).toBeLessThan(css.indexOf('.top'));
+  });
+
+  it('#3747 multi-chunk (--splitting) — 각 chunk 가 자기 모듈의 @charset/@layer 캡처', async () => {
+    const fixture = await createFixture({
+      'entry-a.ts': `import './a.css';\nconsole.log("a");`,
+      'entry-b.ts': `import './b.css';\nconsole.log("b");`,
+      'a.css': `@charset "UTF-8";\n@layer reset, base;\n.a {}`,
+      'b.css': `@charset "UTF-8";\n@layer theme;\n.b {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const distDir = join(fixture.dir, 'dist');
+    await import('node:fs/promises').then((m) => m.mkdir(distDir, { recursive: true }));
+    const result = await runZntc([
+      '--bundle',
+      join(fixture.dir, 'entry-a.ts'),
+      join(fixture.dir, 'entry-b.ts'),
+      '--splitting',
+      '--outdir',
+      distDir,
+      '--format=esm',
+    ]);
+    expect(result.exitCode).toBe(0);
+
+    const cssA = await readFile(join(distDir, 'entry-a.css'), 'utf-8');
+    const cssB = await readFile(join(distDir, 'entry-b.css'), 'utf-8');
+    // 각 chunk 자기 @charset + @layer
+    expect(cssA.trimStart().startsWith('@charset "UTF-8"')).toBe(true);
+    expect(cssA).toMatch(/@layer\s+reset\s*,\s*base/);
+    expect(cssA).toContain('.a');
+    expect(cssA).not.toContain('.b');
+    expect(cssB.trimStart().startsWith('@charset "UTF-8"')).toBe(true);
+    expect(cssB).toContain('@layer theme');
+    expect(cssB).not.toContain('@layer reset');
+    expect(cssB).toContain('.b');
+    expect(cssB).not.toContain('.a');
+  });
+
+  it('#3321 P0-3 @import url() + layer() + supports() 복합 condition_tail 보존', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';`,
+      'style.css':
+        `@import url("https://cdn/x.css") layer(reset);\n` +
+        `@import url("https://cdn/y.css") layer(theme) supports(display: grid);\n` +
+        `.app {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    // layer() / supports() condition tail 보존 (url() form 은 quoted form 으로 정규화)
+    expect(css).toMatch(/@import\s+"https:\/\/cdn\/x\.css"\s+layer\(reset\)\s*;/);
+    expect(css).toMatch(
+      /@import\s+"https:\/\/cdn\/y\.css"\s+layer\(theme\)\s+supports\(display:\s*grid\)\s*;/,
+    );
+  });
+
+  it('#3747 bare @layer + block-form @layer 공존 — bare 만 상단 prepend, block-form 은 본문', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';`,
+      'style.css':
+        `@layer reset, base;\n` + `@layer reset {\n  .reset { margin: 0; }\n}\n` + `.app {}`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const css = await readFile(join(fixture.dir, 'index.css'), 'utf-8');
+    // bare 선언 + block-form 둘 다 출력에 살아있음
+    const bareIdx = css.search(/@layer\s+reset\s*,\s*base\s*;/);
+    const blockIdx = css.search(/@layer\s+reset\s*\{/);
+    expect(bareIdx).toBeGreaterThanOrEqual(0);
+    expect(blockIdx).toBeGreaterThanOrEqual(0);
+    // bare 가 block-form 보다 앞 (prepend 동작)
+    expect(bareIdx).toBeLessThan(blockIdx);
+    // body 본문도 살아있음
+    expect(css).toContain('.reset { margin: 0; }');
+    expect(css).toContain('.app');
+  });
 });


### PR DESCRIPTION
## 요약

PR #3746 (#3321 P0-3 external @import URL preserve) + PR #3752 (#3747 @charset/
@layer top-of-file preserve) merge 후 manual repro 9 시나리오 검증 — 모두
PASS. 그 중 **코드 경로 다양 / 보존 메커니즘 핵심** 4 시나리오를 영구
integration test 로 승격.

## 추가 가드 (4건)

| # | 시나리오 | 검증 |
|---|---|---|
| 1 | 3-level nested @import (top → mid → deep) 각 단계 @charset/@layer | deps-first 순서 + @charset 첫 byte + body 순서 |
| 2 | multi-chunk (`--splitting`, 2 entries) per-chunk 캡처 | `planCssChunks` 경로 (단일 bundle 과 다른 코드 경로). cssA ↔ cssB 모듈 격리 |
| 3 | `@import url() + layer() + supports()` 복합 condition_tail | 다중 condition 정확 보존, url() → quoted form 정규화 |
| 4 | bare `@layer reset, base;` + block-form `@layer reset { ... }` 공존 | bare 상단 prepend, block-form 본문 잔류 |

## 검증

- CSS bundle 45/45 pass (41 기존 + 4 신규)
- 4 가드 모두 GREEN, 기존 가드 회귀 0
- `zig build test` exit 0 (이전 PR HEAD 대비 production 코드 변경 0)

## 배경

post-merge 후 사용자 요청으로 "더 필요한 테스트 케이스 없어?" 확인 작업.
manual repro 9 시나리오 모두 통과했지만, 그 중 핵심 4 시나리오는 향후
다른 변경이 회귀시킬 위험이 있어 영구 가드로 승격.

## 코드 변경 0

production 코드 (`src/bundler/css_*.zig`) 무수정 — test 만 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)