### PR TITLE
fix(bundler): #3755 putModule OOM rollback shared backing 더블 free + dangling map entry

### DIFF
--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -8,7 +8,21 @@ const std = @import("std");
 const Module_mod = @import("module.zig");
 const Module = Module_mod.Module;
 const PathRef = Module_mod.PathRef;
+const CachedResolvedDep = Module_mod.CachedResolvedDep;
 const types = @import("types.zig");
+
+/// (#3755) putModule clone OOM rollback helper. 이미 .owned 로 변환된 partial
+/// slot 들의 alloc 을 free + shared backing 이 graph 쪽 module 과 공유라는 점을 고려해
+/// .specifier="" (PathRef.deinit no-op variant) 로 sanitize. 그렇지 않으면 graph
+/// 쪽 module.deinit 가 같은 freed slice 를 또 free → double-free.
+fn rollbackOomCloned(items: []CachedResolvedDep, allocator: std.mem.Allocator) void {
+    for (items) |*dep| {
+        dep.path.deinit(allocator);
+        if (dep.resolve_dir) |rd| rd.deinit(allocator);
+        dep.path = .{ .specifier = "" };
+        dep.resolve_dir = null;
+    }
+}
 
 /// PR #3749 Phase 3 (C): cache-borrowed (interned) PathRef 를 store-owned 로 clone.
 /// specifier/plugin 은 별도 lifetime (parse_arena 양도 + plugin context) — clone 안 함.
@@ -119,24 +133,25 @@ pub const PersistentModuleStore = struct {
         // H1 fix: OOM 시 swallow 금지 — partial clone 으로 .interned 가 store 에 남으면
         // path_pool 사망 시 UAF. 실패 시 *전체 putModule abort* (이미 처리된 dep 의 owned
         // alloc 은 leak 이지만 store 에 진입 안 함 → cache lifetime 안 후속 read 없음).
+        // (#3755) shared backing 주의: `cached_module = module.*` shallow copy 라
+        // `cached_module.resolved_deps.items` 가 `module.resolved_deps.items` 와 같은
+        // 백킹을 가리킨다. clone 루프가 `dep.path = new_path` 로 element 를 mutate 하면
+        // graph 쪽 module 도 함께 .owned 로 바뀐다. OOM 시 rollback 가 그 .owned 를 free
+        // 해도 graph 쪽 module 에 그대로 dangling 으로 남아 graph.deinit 가 같은 슬라이스
+        // 를 또 free → double-free.
+        //
+        // Fix: rollback 시 해당 슬롯을 `.specifier = ""` (PathRef.deinit no-op variant)
+        // 로 sanitize. graph 쪽 module.deinit 의 `dep.path.deinit(allocator)` 는 .specifier
+        // 분기라 free 안 함. resolve_dir 도 null 로.
         for (cached_module.resolved_deps.items, 0..) |*dep, i| {
             const new_path = clonePathRefIfNeeded(self.allocator, dep.path) catch {
-                // 부분 clone rollback: 이미 owned 로 변환된 entry 정리.
-                var j: usize = 0;
-                while (j < i) : (j += 1) {
-                    cached_module.resolved_deps.items[j].path.deinit(self.allocator);
-                    if (cached_module.resolved_deps.items[j].resolve_dir) |rd| rd.deinit(self.allocator);
-                }
+                rollbackOomCloned(cached_module.resolved_deps.items[0..i], self.allocator);
                 return;
             };
             const new_rd = if (dep.resolve_dir) |rd|
                 clonePathRefIfNeeded(self.allocator, rd) catch {
                     new_path.deinit(self.allocator);
-                    var j: usize = 0;
-                    while (j < i) : (j += 1) {
-                        cached_module.resolved_deps.items[j].path.deinit(self.allocator);
-                        if (cached_module.resolved_deps.items[j].resolve_dir) |rd2| rd2.deinit(self.allocator);
-                    }
+                    rollbackOomCloned(cached_module.resolved_deps.items[0..i], self.allocator);
                     return;
                 }
             else
@@ -329,4 +344,53 @@ test "PersistentModuleStore: parse_arena ownership 왕복 후 alloc 정상 (#269
 
     store.putModule("\x00zntc:runtime/extends", &mod2, 2);
     mod2.deinit(allocator);
+}
+
+// Regression #3755: putModule OOM rollback 시 cached_module = module.* shallow copy 의
+// resolved_deps shared backing 에 partial-cloned .owned 슬라이스가 남아 graph.deinit
+// (= 여기 module.deinit) 에서 double-free.
+//
+// 시나리오:
+//   1) module.resolved_deps 에 .interned variant N 개 등록.
+//   2) FailingAllocator 로 N 번째 clone 에서 OOM 유도.
+//   3) putModule 의 rollback 이 items[0..K] 의 .owned 를 free.
+//   4) 과거 버그: module.resolved_deps.items[0..K] 가 같은 backing 이라 .owned (freed)
+//      를 그대로 가리킴 → 이어지는 module.deinit 가 또 .deinit 호출 → double-free.
+//   Fix: rollback 시 해당 슬롯을 .specifier="" (no-op variant) 로 덮어 graph 쪽이
+//        free 시도하지 않도록 sanitize.
+test "PersistentModuleStore: putModule OOM rollback double-free 차단 (#3755)" {
+    const testing = std.testing;
+
+    // FailingAllocator — extractImportSpecifiers (import_records 비어 alloc 0) + clone
+    // 0/1 성공 후 clone 2 (= 3번째 dupe) 에서 OOM. rollback 가 items[0..1] free.
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 2 });
+    const alloc = failing.allocator();
+
+    var store = PersistentModuleStore.init(alloc);
+    defer store.deinit();
+
+    var module = Module.init(@enumFromInt(0), "/virtual/oom.ts");
+    // resolved_deps 3개를 .interned variant 로 등록 — clone 시 .owned 로 변환 시도.
+    // FailingAllocator 가 중간에서 OOM → rollback 실행.
+    var deps: std.ArrayListUnmanaged(CachedResolvedDep) = .empty;
+    defer module.deinit(testing.allocator); // ← 의도된 free path. double-free 면 GPA panic.
+    // module 의 backing 은 testing.allocator (graph) 가 책임 — Module.init 의 default
+    // ArrayList 는 unmanaged 이므로 caller alloc 선택.
+    try deps.append(testing.allocator, .{ .kind = .static_import, .target = .file, .path = .{ .interned = "a/b" } });
+    try deps.append(testing.allocator, .{ .kind = .static_import, .target = .file, .path = .{ .interned = "c/d" } });
+    try deps.append(testing.allocator, .{ .kind = .static_import, .target = .file, .path = .{ .interned = "e/f" } });
+    module.resolved_deps = deps;
+
+    // OOM 가 putModule 안에서 발생해도 panic/crash 없이 return — graph 쪽 deinit 안전.
+    store.putModule("/virtual/oom.ts", &module, 1);
+
+    // module.resolved_deps.items 는 sanitize 되어 .specifier 또는 .interned 만 남아
+    // module.deinit 의 dep.path.deinit 가 no-op. (.owned 였다면 freed slice 재 free).
+    for (module.resolved_deps.items) |dep| {
+        switch (dep.path) {
+            .owned => return error.RollbackLeftOwnedDangling,
+            else => {},
+        }
+    }
+    // module.deinit 는 defer 에서 호출 — double-free 발생 시 testing.allocator 가 패닉.
 }

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -15,6 +15,10 @@ const types = @import("types.zig");
 /// slot 들의 alloc 을 free + shared backing 이 graph 쪽 module 과 공유라는 점을 고려해
 /// .specifier="" (PathRef.deinit no-op variant) 로 sanitize. 그렇지 않으면 graph
 /// 쪽 module.deinit 가 같은 freed slice 를 또 free → double-free.
+///
+/// **Caller invariant**: `transferModulesToStore` (유일한 caller) 는 putModule 호출
+/// 후 module.resolved_deps 를 다시 사용하지 않는다 (loop 다음은 graph.deinit). 그러므로
+/// sanitize 된 .specifier="" 가 caller-visible silent corruption 으로 표면화하지 않음.
 fn rollbackOomCloned(items: []CachedResolvedDep, allocator: std.mem.Allocator) void {
     for (items) |*dep| {
         dep.path.deinit(allocator);
@@ -108,7 +112,10 @@ pub const PersistentModuleStore = struct {
         // import specifiers 복제 (store allocator 소유)
         const specs = self.extractImportSpecifiers(module) catch return;
 
-        // 기존 캐시가 있으면 제거
+        // 기존 캐시가 있으면 제거. (#3755 sweep) freeCachedModule 가 contents 만 free
+        // 하므로 entry 자체는 그대로 — 다음 단계에서 map.put 으로 *값* 만 update.
+        // OOM rollback 으로 put 에 도달 못하면 entry 가 dangling 으로 남기 때문에
+        // rollback 분기에서 반드시 `modules.remove(path)` 호출 필요.
         const had_existing = self.modules.contains(path);
         if (had_existing) {
             if (self.modules.getPtr(path)) |old| {
@@ -146,12 +153,14 @@ pub const PersistentModuleStore = struct {
         for (cached_module.resolved_deps.items, 0..) |*dep, i| {
             const new_path = clonePathRefIfNeeded(self.allocator, dep.path) catch {
                 rollbackOomCloned(cached_module.resolved_deps.items[0..i], self.allocator);
+                self.abortPutModule(path, had_existing, specs);
                 return;
             };
             const new_rd = if (dep.resolve_dir) |rd|
                 clonePathRefIfNeeded(self.allocator, rd) catch {
                     new_path.deinit(self.allocator);
                     rollbackOomCloned(cached_module.resolved_deps.items[0..i], self.allocator);
+                    self.abortPutModule(path, had_existing, specs);
                     return;
                 }
             else
@@ -211,6 +220,22 @@ pub const PersistentModuleStore = struct {
                 self.freeCachedModule(&orphan);
             };
         }
+    }
+
+    /// (#3755 sweep) putModule rollback 통합 cleanup. 다음 두 P0 시나리오 차단:
+    /// 1) had_existing 케이스에서 freeCachedModule(old) 만 했고 map.remove 안 했으면
+    ///    dangling CachedModule entry — 다음 getIfFresh UAF + 다음 putModule 의 freeCachedModule 가
+    ///    이미 freed 메모리 또 free → double-free. fetchRemove 로 key 까지 회수.
+    /// 2) specs (extractImportSpecifiers 결과) 가 N dupe + 1 slice alloc 인데 rollback
+    ///    early return 으로 free 안 됨 → 매 OOM 마다 누적 leak.
+    fn abortPutModule(self: *PersistentModuleStore, path: []const u8, had_existing: bool, specs: []const []const u8) void {
+        if (had_existing) {
+            if (self.modules.fetchRemove(path)) |kv| {
+                self.allocator.free(kv.key);
+            }
+        }
+        for (specs) |s| self.allocator.free(s);
+        self.allocator.free(specs);
     }
 
     fn extractImportSpecifiers(self: *PersistentModuleStore, module: *const Module) ![]const []const u8 {
@@ -386,11 +411,49 @@ test "PersistentModuleStore: putModule OOM rollback double-free 차단 (#3755)" 
 
     // module.resolved_deps.items 는 sanitize 되어 .specifier 또는 .interned 만 남아
     // module.deinit 의 dep.path.deinit 가 no-op. (.owned 였다면 freed slice 재 free).
-    for (module.resolved_deps.items) |dep| {
-        switch (dep.path) {
-            .owned => return error.RollbackLeftOwnedDangling,
-            else => {},
-        }
-    }
+    // sweep review: 단순 .owned 부재만이 아닌 *positive content* 검증 — 알로케이터 instrumentation
+    // 비의존 회귀 검출.
+    try testing.expect(module.resolved_deps.items[0].path == .specifier);
+    try testing.expectEqual(@as(usize, 0), module.resolved_deps.items[0].path.specifier.len);
+    try testing.expect(module.resolved_deps.items[1].path == .specifier);
+    try testing.expectEqual(@as(usize, 0), module.resolved_deps.items[1].path.specifier.len);
+    // i=2 슬롯은 clone 이 OOM 으로 mutate 전 → 원본 .interned 그대로 유지.
+    try testing.expect(module.resolved_deps.items[2].path == .interned);
+    try testing.expectEqualStrings("e/f", module.resolved_deps.items[2].path.interned);
     // module.deinit 는 defer 에서 호출 — double-free 발생 시 testing.allocator 가 패닉.
+}
+
+// Regression #3755 sweep: had_existing 경로 + clone OOM rollback 조합 시 map 에 dangling
+// CachedModule entry 가 남는다. 다음 getIfFresh 가 freed 메모리 반환 → UAF.
+test "PersistentModuleStore: putModule had_existing + OOM rollback 시 map entry 제거 (#3755)" {
+    const testing = std.testing;
+
+    var store = PersistentModuleStore.init(testing.allocator);
+    defer store.deinit();
+
+    // 첫 putModule — 정상 저장 (deps 없이).
+    var mod1 = Module.init(@enumFromInt(0), "/virtual/oom-had-existing.ts");
+    defer mod1.deinit(testing.allocator);
+    store.putModule("/virtual/oom-had-existing.ts", &mod1, 1);
+    try testing.expect(store.modules.contains("/virtual/oom-had-existing.ts"));
+
+    // 두번째 putModule — had_existing=true, clone loop 에서 OOM 유도. FailingAllocator 는
+    // alloc 만 fail injection 하고 free 는 underlying (testing.allocator) 로 passthrough
+    // 이므로, store.allocator 만 mid-test swap 해도 ledger 일관성 유지.
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    const orig_alloc = store.allocator;
+    store.allocator = failing.allocator();
+    defer store.allocator = orig_alloc; // deinit 도 testing.allocator 로 free 일관.
+
+    var mod2 = Module.init(@enumFromInt(0), "/virtual/oom-had-existing.ts");
+    var deps2: std.ArrayListUnmanaged(CachedResolvedDep) = .empty;
+    defer mod2.deinit(testing.allocator);
+    try deps2.append(testing.allocator, .{ .kind = .static_import, .target = .file, .path = .{ .interned = "x/y" } });
+    mod2.resolved_deps = deps2;
+    // 이 putModule 안: extractImportSpecifiers (empty import_records → 0 alloc),
+    // freeCachedModule(old) (alloc 0, free 만), cached_module = module.* (0 alloc),
+    // clone loop 첫 iter dupe → fail_index=0 OOM → rollback 분기 → abortPutModule.
+    store.putModule("/virtual/oom-had-existing.ts", &mod2, 2);
+    // 핵심 검증: rollback 가 map.remove 를 수행해 dangling entry 제거.
+    try testing.expect(!store.modules.contains("/virtual/oom-had-existing.ts"));
 }


### PR DESCRIPTION
## 요약
이슈 #3755 — PR #3749 Phase 3 (C) PathRef enum 도입 시 회귀.
PR #3751 (watch arena reset) `/code-review max` Angle C 발견.

## 버그 (P0 — 데이터 corruption)
`putModule` 의 clone OOM rollback 가 두 데이터 corruption 경로 노출:

### 1. Shared backing 더블 free
`var cached_module = module.*` shallow copy 로 `resolved_deps.items` 백킹 공유.
clone loop 가 `dep.path = new_path` 로 element mutate → graph 쪽 module 도
.owned 로 변형. OOM rollback 가 그 .owned 를 free 후 return → graph.deinit 시
같은 슬라이스 또 free → **double-free**.

### 2. had_existing + rollback dangling map entry (sweep review)
`freeCachedModule(old)` 가 contents 만 free 하고 map entry 안 지움. rollback
return → map 에 dangling CachedModule. 다음 `getIfFresh` UAF, 다음 `putModule`
의 `freeCachedModule(old)` double-free.

### 3. specs leak on rollback (sweep review)
`extractImportSpecifiers` 의 N dupe + 1 slice alloc 이 rollback early return 으로
free 안 됨.

## Fix
1. `rollbackOomCloned(items, allocator)`: free 후 슬롯을 `.specifier = ""`
   (PathRef.deinit no-op) 로 sanitize — shared backing 의 graph 쪽 deinit 안전.
2. `abortPutModule(path, had_existing, specs)`: `fetchRemove(path)` 로 dangling
   entry + key 회수 + specs 전부 free.
3. 두 rollback 분기 모두 두 helper 순서대로 호출.

## TDD
- `std.testing.FailingAllocator` 로 OOM 주입 — `fail_index=2` 로 3번째 alloc 실패.
- 수정 전: signal 6 (GPA double-free panic).
- 수정 후: pass.
- sweep review 후 추가 테스트:
  - **content positive assertion** (allocator instrumentation 비의존): sanitize 된
    슬롯의 `.specifier="".len == 0`, 미처리 슬롯의 `.interned=="e/f"` 원본 보존.
  - **had_existing rollback**: `store.allocator` mid-test swap 으로 OOM 유도, 이후
    `!modules.contains(path)` 검증.

## /code-review max
5 angle (line-by-line / removed-behavior / cross-file UAF / Zig pitfall / wrapper) +
sweep 진행. 위 P0 finding 모두 반영. Deferred:
- `.specifier=""` vs 새 `.empty` variant (PathRef ownership 의미론 — 별도 RFC)
- second-catch path test coverage
- fail_index=2 의 stdlib alloc-count drift fragility (`failing.alloc_index` assert
  로 lock 가능, 별도 hardening)

## Test plan
- [x] `zig build test` 전체 통과 (새 test 2개 포함)
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)