### PR TITLE
fix(bundler): #3759 NAPI plugin virtual path leak (owner discriminator)

### DIFF
--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -720,6 +720,7 @@ fn NapiPluginAdapter(comptime Self: type) type {
                 if (graph_plugins_mod.isPluginVirtualId(path)) {
                     return .{ .virtual = .{
                         .path = alloc.dupe(u8, path) catch return error.OutOfMemory,
+                        .owns_path = true, // (#3759) bundler 가 intern 후 원본 free.
                     } };
                 }
                 return .{ .file = .{

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -331,17 +331,17 @@ pub fn applyResolveResult(
                 try recordResolvedDep(self, mod_index, mod_idx, rec_i, dep_idx, record.kind);
             },
             .virtual => |v| {
-                // #1961: virtual module 은 plugin 의 load 훅이 source 채움. addModule 이
-                // path 를 dupe 하므로 graph 가 owner. v.path 는 plugin 이 borrow 한
-                // specifier (runtime_helper_modules) 일 수 있어 free 안 함 — plugin 이
-                // alloc 했으면 plugin context lifetime 동안 살아있어야 한다는 규약.
+                // #1961 + #3759: virtual module 은 plugin 의 load 훅이 source 채움.
+                // addModule 이 path 를 dupe 하므로 graph 가 owner. v.path 는 이미
+                // `internResolvedModule` 이 path_pool 에 intern 한 borrow slice → .interned
+                // 로 wrap (의미 정합 + putModule clone 비용 절감).
                 const dep_idx = try self.addModule(v.path);
                 const request_changed = try graph_requested_exports.requestDependencyExports(self, mod_idx, rec_i, record, dep_idx);
                 try appendResolvedDep(self, mod_idx, .{
                     .record_index = @intCast(rec_i),
                     .kind = record.kind,
                     .target = .virtual,
-                    .path = .{ .plugin = v.path },
+                    .path = .{ .interned = v.path },
                 });
                 try recordResolvedDep(self, mod_index, mod_idx, rec_i, dep_idx, record.kind);
                 if (request_changed) try resolveDeferredRequestedImportsIfReady(self, dep_idx);

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -334,7 +334,8 @@ pub fn applyResolveResult(
                 // #1961 + #3759: virtual module 은 plugin 의 load 훅이 source 채움.
                 // addModule 이 path 를 dupe 하므로 graph 가 owner. v.path 는 이미
                 // `internResolvedModule` 이 path_pool 에 intern 한 borrow slice → .interned
-                // 로 wrap (의미 정합 + putModule clone 비용 절감).
+                // 로 wrap (PathRef 의미 정합: .interned = path_pool 소유, caller borrow).
+                // clone 비용은 .plugin 과 동일 (clonePathRefIfNeeded 가 둘 다 .owned 로 dupe).
                 const dep_idx = try self.addModule(v.path);
                 const request_changed = try graph_requested_exports.requestDependencyExports(self, mod_idx, rec_i, record, dep_idx);
                 try appendResolvedDep(self, mod_idx, .{

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -190,9 +190,12 @@ pub const ResolvedModule = union(fs.Namespace) {
         is_module_field: bool = false,
     },
     /// 메모리 모듈 (plugin only). plugin_data 로 plugin context 전달.
+    /// (#3759) `owns_path`: plugin 이 path 를 자체 alloc 했으면 true → bundler 가 intern
+    /// 후 원본 free. static literal / borrowed specifier 면 false (default).
     virtual: struct {
         path: []const u8,
         plugin_data: ?*anyopaque = null,
+        owns_path: bool = false,
     },
     /// data: URL — 인라인 base64 asset.
     dataurl: struct {

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -886,9 +886,14 @@ pub const ResolveCache = struct {
             },
             .disabled => |d| try self.internDisabled(d.path, d.module_type, true),
             // #3759: owner ambiguity 해소 — owns_path=true 만 free.
+            // intern 실패 시 errdefer 가 free, 성공 시 explicit free 후 break — explicit
+            // free 와 errdefer 가 같은 slice 를 노리지 않도록 errdefer 는 intern 호출
+            // 영역만 감싼다 (sub-scope blk 로 격리).
             .virtual => |v| blk: {
-                errdefer if (v.owns_path) self.allocator.free(v.path);
-                const interned = try self.path_pool.intern(v.path);
+                const interned = pool: {
+                    errdefer if (v.owns_path) self.allocator.free(v.path);
+                    break :pool try self.path_pool.intern(v.path);
+                };
                 if (v.owns_path) self.allocator.free(v.path);
                 break :blk .{ .virtual = .{ .path = interned, .plugin_data = v.plugin_data, .owns_path = false } };
             },

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -855,11 +855,17 @@ pub const ResolveCache = struct {
     /// 원본 path / resolve_dir 는 free, pool 의 interned slice 가리키는 ResolvedModule 반환.
     /// plugin runner 가 alloc 한 결과를 caller-borrow invariant 에 맞춤.
     ///
-    /// **interning 적용 variant**: `.file`, `.disabled` (caller borrow only, free 금지).
-    /// **pass-through variant** (`.virtual`, `.dataurl`, `.external`, `.custom`): m 그대로 반환.
-    /// 이 variant 들은 *runtime_helper_modules* (virtual) / future plugin layer 에서 사용.
-    /// path 의 owner = plugin context (lifetime borrow per resolve_imports.zig:338-342 contract).
-    /// **간 leak 경고**: plugin path 가 단명 allocator alloc 면 누수. 향후 PR 5 에서 interning.
+    /// **interning 적용 variant**: `.file`, `.disabled`, `.virtual` (owns_path=true)
+    /// — caller borrow only, free 금지.
+    /// **pass-through**: `.virtual` (owns_path=false, runtime_helper_modules 등 borrow),
+    /// `.dataurl`/`.external`/`.custom` (resolve_imports.zig:349 unreachable — 현재 미사용).
+    ///
+    /// #3759 fix: `.virtual` 의 owner ambiguity 해소 — `owns_path: bool` discriminator.
+    /// - NAPI bridge (plugin_bridge.zig:722): graph_allocator dupe → `owns_path=true`.
+    /// - runtime_helper_modules (resolveIdHook): specifier borrow → `owns_path=false`.
+    ///
+    /// `owns_path=true` 면 intern + 원본 free (single-owner invariant).
+    /// `owns_path=false` 면 intern 만 (caller 가 owner 유지 — graph 가 dupe).
     pub fn internResolvedModule(self: *ResolveCache, m: ResolvedModule) !ResolvedModule {
         return switch (m) {
             .file => |f| blk: {
@@ -879,9 +885,17 @@ pub const ResolveCache = struct {
                 } };
             },
             .disabled => |d| try self.internDisabled(d.path, d.module_type, true),
-            // virtual/dataurl/external/custom — 옛 동작 유지 (runtime_helper_modules 등 정상 path).
-            // path owner = plugin context. interning 은 PR 5 plugin layer 영역.
-            .virtual, .dataurl, .external, .custom => m,
+            // #3759: owner ambiguity 해소 — owns_path=true 만 free.
+            .virtual => |v| blk: {
+                errdefer if (v.owns_path) self.allocator.free(v.path);
+                const interned = try self.path_pool.intern(v.path);
+                if (v.owns_path) self.allocator.free(v.path);
+                break :blk .{ .virtual = .{ .path = interned, .plugin_data = v.plugin_data, .owns_path = false } };
+            },
+            // external/custom — resolve_imports.zig:349 가 unreachable 로 닫혀 있어 현재
+            // 도달 안 함. dataurl 도 동일. pass-through 유지 (future plugin layer 가
+            // 활성화 시 owns_path 패턴 동일 적용).
+            .dataurl, .external, .custom => m,
         };
     }
 

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -345,10 +345,12 @@ test "internResolvedModule: .virtual owns_path=false 시 borrow 유지 (#3759)" 
     // runtime_helper_modules 처럼 static literal / parse_arena borrow 시뮬레이트.
     const static_path: []const u8 = "\x00zntc:runtime/extends";
 
-    const result = try cache.internResolvedModule(.{ .virtual = .{
-        .path = static_path,
-        .owns_path = false, // ← borrow only — bundler 가 free 시도 금지
-    } });
+    const result = try cache.internResolvedModule(.{
+        .virtual = .{
+            .path = static_path,
+            .owns_path = false, // ← borrow only — bundler 가 free 시도 금지
+        },
+    });
 
     switch (result) {
         .virtual => |v| {

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -307,3 +307,58 @@ test "resolveThreadSafe: 동작 검증" {
         else => return error.TestUnexpectedResult,
     }
 }
+
+// ============================================================
+// #3759 — internResolvedModule .virtual owns_path discriminator
+// ============================================================
+
+test "internResolvedModule: .virtual owns_path=true 시 원본 free + intern (#3759)" {
+    const testing = std.testing;
+    var cache = ResolveCache.init(testing.allocator, .{});
+    defer cache.deinit();
+
+    // NAPI bridge 처럼 graph_allocator (= testing.allocator) 로 dupe 한 path 시뮬레이트.
+    const dup_path = try testing.allocator.dupe(u8, "\x00plugin:virtual-mod");
+
+    const result = try cache.internResolvedModule(.{ .virtual = .{
+        .path = dup_path,
+        .owns_path = true,
+    } });
+
+    // 반환된 path 는 path_pool 의 interned slice — dup_path 와 *다른* 포인터.
+    switch (result) {
+        .virtual => |v| {
+            try testing.expectEqualStrings("\x00plugin:virtual-mod", v.path);
+            try testing.expect(v.path.ptr != dup_path.ptr); // ← intern 확인
+            try testing.expect(!v.owns_path); // ← 반환값은 항상 owns_path=false (caller borrow)
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    // testing.allocator 의 leak detection: dup_path 가 free 안 되었다면 test fail.
+}
+
+test "internResolvedModule: .virtual owns_path=false 시 borrow 유지 (#3759)" {
+    const testing = std.testing;
+    var cache = ResolveCache.init(testing.allocator, .{});
+    defer cache.deinit();
+
+    // runtime_helper_modules 처럼 static literal / parse_arena borrow 시뮬레이트.
+    const static_path: []const u8 = "\x00zntc:runtime/extends";
+
+    const result = try cache.internResolvedModule(.{ .virtual = .{
+        .path = static_path,
+        .owns_path = false, // ← borrow only — bundler 가 free 시도 금지
+    } });
+
+    switch (result) {
+        .virtual => |v| {
+            try testing.expectEqualStrings("\x00zntc:runtime/extends", v.path);
+            // path_pool 에 dupe 되어 *다른* slice 반환.
+            try testing.expect(v.path.ptr != static_path.ptr);
+            try testing.expect(!v.owns_path);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    // 만약 fix 가 owns_path 무시하고 항상 free 했다면 static literal free → panic.
+    // 통과 자체가 borrow 시맨틱 보존 증거.
+}


### PR DESCRIPTION
## 요약
PR H2 (#3760) `/code-review max` Angle C/sweep 발견 (P1 leak).

`resolve_cache.internResolvedModule` 의 `.virtual` 분기가 pass-through 라 plugin
이 graph_allocator 로 dupe 한 path 가 아무도 free 안 함 → 매 build 마다 leak.
Vue/Svelte SFC / Vite virtual modules 처럼 plugin resolveId 빈번한 dev 환경에서
watch 누적 RSS.

## Root cause = owner ambiguity
같은 `.virtual` variant 가 두 가지 owner 를 동시에 표현:
- **NAPI bridge** (plugin_bridge.zig:722): `alloc.dupe(graph_allocator)` — caller 가 free
- **runtime_helper_modules.resolveIdHook** (line 399): `specifier` borrow — free 금지
  (static literal / parse_arena slice)

이전 시도 (모두 free) 가 helper 모듈 panic 시킴.

## Fix
`ResolvedModule.virtual` 에 `owns_path: bool = false` discriminator 추가:
- NAPI bridge: `owns_path = true` 명시 — bundler 가 intern 후 free
- runtime_helper: default false — borrow only

`internResolvedModule` 의 `.virtual` 분기:
- 항상 path_pool 로 intern (single-owner invariant)
- `owns_path=true` 시 원본 free

caller `resolve_imports.zig:344` 의 `.{ .plugin = v.path }` → `.{ .interned = v.path }`
(internResolvedModule 결과는 path_pool slice — variant 의미 정합).

`.external/.custom` 도 동일 ambiguity 잠재. 현재 caller `resolve_imports.zig:349`
가 `unreachable` 로 닫혀 있어 미도달 — pass-through 유지, future plugin layer
활성화 시 같은 owns_path 패턴 적용 예정.

## /code-review max (4 angle + sweep)
Commit 2 (review fix):
- **회귀 test 부재** (3 angle 일치): owns_path=true (NAPI-style intern+free) + owns_path=false (helper borrow) 양 경로 test 추가
- **errdefer + explicit free 중복 footgun** (Angle A/sweep): sub-scope `pool: blk: { errdefer ... }` 로 격리, success path 에서 errdefer 자동 dismiss
- **comment "clone 비용 절감" 거짓** (Angle B): clonePathRefIfNeeded 가 둘 다 dupe — 정정

Deferred (별도 RFC):
- **`.file/.disabled` owns_path 대칭** (Angle A/sweep/B/C 다수): 같은 ambiguity 잠재
- **`.dataurl/.external/.custom` pass-through 일관 처리**
- **`.plugin` PathRef variant** production unused — 제거 가능
- **runtime owns_path validation**: plugin 이 owns_path 잘못 설정 시 guard

## Test plan
- [x] `zig build test` 전체 통과 (새 test 2개)
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)