### PR TITLE
refactor(bundler): PathRef.plugin variant 제거 — production unused (#3759 sweep deferred)

### DIFF
--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -22,7 +22,7 @@ fn appendResolvedDep(
     dep: CachedResolvedDep,
 ) !void {
     // PR #3749 Phase 3 (C): dep.path 는 PathRef variant — caller 가 lifetime 명시.
-    // graph 가 추가 dupe 안 함. interned/specifier/plugin variant 는 borrow,
+    // graph 가 추가 dupe 안 함. interned/specifier variant 는 borrow,
     // owned variant 는 caller-alloc + module.deinit 시 자동 free.
     const mod_ptr = self.modules.at(mod_idx);
     try mod_ptr.resolved_deps.append(self.allocator, dep);
@@ -335,7 +335,7 @@ pub fn applyResolveResult(
                 // addModule 이 path 를 dupe 하므로 graph 가 owner. v.path 는 이미
                 // `internResolvedModule` 이 path_pool 에 intern 한 borrow slice → .interned
                 // 로 wrap (PathRef 의미 정합: .interned = path_pool 소유, caller borrow).
-                // clone 비용은 .plugin 과 동일 (clonePathRefIfNeeded 가 둘 다 .owned 로 dupe).
+                // putModule 의 clonePathRefIfNeeded 가 .interned → .owned dupe.
                 const dep_idx = try self.addModule(v.path);
                 const request_changed = try graph_requested_exports.requestDependencyExports(self, mod_idx, rec_i, record, dep_idx);
                 try appendResolvedDep(self, mod_idx, .{

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -40,12 +40,14 @@ pub const OPTIONAL_MISSING_MODULE_PREFIX = "(optional-missing):";
 /// 각 variant 는 *path 의 ownership* 명시:
 ///   - interned: `ResolveCache.path_pool` 소유 — borrow, free 금지 (cache.deinit 시 reclaim).
 ///   - specifier: `Module.parse_arena` 소유 — borrow, free 금지 (module.deinit 시 destroyParseArena).
-///   - plugin: plugin context lifetime — borrow, free 금지 (plugin 이 own).
 ///   - owned: caller (graph allocator) alloc — free 필수.
+///
+/// (#3759 sweep) `.plugin` variant 제거: PR #3761 후 `internResolvedModule` 가 plugin
+/// 경로의 path 도 path_pool 로 intern → caller 는 `.interned` 로 wrap. production 에서
+/// `.plugin` set 위치 0.
 pub const PathRef = union(enum) {
     interned: []const u8,
     specifier: []const u8,
-    plugin: []const u8,
     owned: []const u8,
 
     /// variant 무관 byte slice 접근.

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -28,17 +28,16 @@ fn rollbackOomCloned(items: []CachedResolvedDep, allocator: std.mem.Allocator) v
     }
 }
 
-/// PR #3749 Phase 3 (C) + H2 (plugin layer): cache/plugin-borrowed PathRef 를 store-owned
-/// 로 clone.
+/// PR #3749 Phase 3 (C): cache-borrowed PathRef 를 store-owned 로 clone.
 /// - `.interned`: path_pool (cache) 소유 — cache deinit 시 dangling 위험 → clone.
-/// - `.plugin`: plugin context (build) 소유 — graph deinit 시 dangling 위험 → clone (H2).
 /// - `.specifier`: parse_arena 소유 — parse_arena 가 store 로 양도되어 store 와 같은
 ///   lifetime → clone 안 함.
 /// - `.owned`: 이미 자체 owner → clone 안 함.
 /// **명시 enumeration** (M3): 새 PathRef variant 추가 시 compile error 로 결정 강제.
+/// 새 variant default 정책: lifetime < store 면 clone, lifetime >= store 면 pass-through.
 fn clonePathRefIfNeeded(allocator: std.mem.Allocator, ref: PathRef) !PathRef {
     return switch (ref) {
-        .interned, .plugin => |s| .{ .owned = try allocator.dupe(u8, s) },
+        .interned => |s| .{ .owned = try allocator.dupe(u8, s) },
         .specifier, .owned => ref,
     };
 }
@@ -136,13 +135,11 @@ pub const PersistentModuleStore = struct {
         cached_module.dynamic_imports = .empty;
         cached_module.dynamic_importers = .empty;
 
-        // PR #3749 Phase 3 (C) + H2 #3755: cache/plugin-borrowed path 를 store-owned 로
-        // clone.
+        // PR #3749 Phase 3 (C): cache-borrowed path 를 store-owned 로 clone.
         // - .interned: cache (path_pool) 가 build 종료 시 deinit (per-build Bundler) →
         //   store 가 *자체 owner* 가 되어야 dangling 안 됨.
-        // - .plugin (H2): plugin 이 alloc 한 path (graph_allocator 경유) → graph deinit
-        //   시 dangling 위험 → clone.
         // - .specifier (parse_arena), .owned (자체) 는 store 와 같은 lifetime → clone 안 함.
+        // (plugin 경로의 .plugin variant 는 #3761 후 production 미사용 → 본 PR 에서 제거.)
         //
         // H1 fix: OOM 시 swallow 금지. rollback 은 (1) partial-cloned slot sanitize
         // (rollbackOomCloned) + (2) had_existing dangling map entry 제거 + specs leak
@@ -465,62 +462,6 @@ test "PersistentModuleStore: putModule had_existing + OOM rollback 시 map entry
     try testing.expect(!store.modules.contains("/virtual/oom-had-existing.ts"));
 }
 
-// Regression H2 (#3755 deferred → 본 PR 5 plugin layer): clonePathRefIfNeeded 가
-// .plugin variant 를 pass-through 하면 plugin context 가 free 한 후 store 에 dangling.
-// 시나리오: plugin 이 alloc 한 virtual path 가 .plugin 으로 dep 에 들어감 → putModule →
-// 같은 path 의 graph_allocator slice 가 graph deinit 시 free → store 에 dangling.
-// Fix: clonePathRefIfNeeded 가 .plugin 도 .owned 로 clone.
-test "PersistentModuleStore: plugin variant 가 store-owned 로 clone (H2)" {
-    const testing = std.testing;
-
-    var store = PersistentModuleStore.init(testing.allocator);
-    defer store.deinit();
-
-    var module = Module.init(@enumFromInt(0), "/virtual/h2.ts");
-    var deps: std.ArrayListUnmanaged(CachedResolvedDep) = .empty;
-    // .plugin variant — graph_allocator alloc 가정.
-    const plugin_path = try testing.allocator.dupe(u8, "\x00plugin:virtual-mod");
-    defer testing.allocator.free(plugin_path);
-    try deps.append(testing.allocator, .{ .kind = .static_import, .target = .virtual, .path = .{ .plugin = plugin_path } });
-    module.resolved_deps = deps;
-    defer module.deinit(testing.allocator);
-
-    store.putModule("/virtual/h2.ts", &module, 1);
-    // 핵심: store 에 들어간 dep.path 가 .owned (store-owned) + 원본 plugin_path 와 *다른*
-    // 포인터여야 한다 (review sweep — ptr identity 검증으로 alias-vs-dupe 회귀 검출).
-    const cached = store.modules.getPtr("/virtual/h2.ts") orelse return error.CacheMiss;
-    try testing.expect(cached.module.resolved_deps.items.len == 1);
-    const cached_path = cached.module.resolved_deps.items[0].path;
-    try testing.expect(cached_path == .owned); // ← clone 강제 검증
-    try testing.expect(cached_path.owned.ptr != plugin_path.ptr); // ← deep-copy 검증
-    try testing.expectEqualStrings("\x00plugin:virtual-mod", cached_path.owned);
-}
-
-// Regression H2 + #3755: .plugin variant 의 clone OOM rollback. .interned 경로만
-// 회귀 test 가 있고 .plugin 경로는 없어 rollbackOomCloned 의 .plugin 처리 회귀
-// 시 silent (sweep review).
-test "PersistentModuleStore: putModule .plugin variant OOM rollback (H2 + #3755)" {
-    const testing = std.testing;
-
-    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 2 });
-    const alloc = failing.allocator();
-    var store = PersistentModuleStore.init(alloc);
-    defer store.deinit();
-
-    var module = Module.init(@enumFromInt(0), "/virtual/plugin-oom.ts");
-    var deps: std.ArrayListUnmanaged(CachedResolvedDep) = .empty;
-    defer module.deinit(testing.allocator);
-    // 혼합: .interned + .plugin — 두 variant 모두 clone 대상.
-    try deps.append(testing.allocator, .{ .kind = .static_import, .target = .file, .path = .{ .interned = "a/b" } });
-    try deps.append(testing.allocator, .{ .kind = .static_import, .target = .virtual, .path = .{ .plugin = "\x00plug:x" } });
-    try deps.append(testing.allocator, .{ .kind = .static_import, .target = .file, .path = .{ .interned = "c/d" } });
-    module.resolved_deps = deps;
-
-    // OOM 3번째 alloc → items[0..1] 가 clone 됨 (.owned), 3번째에서 실패 → rollback.
-    store.putModule("/virtual/plugin-oom.ts", &module, 1);
-
-    // sanitize 검증: items[0..1] 가 .specifier="" 로 정리되어 module.deinit 가 no-op.
-    try testing.expect(module.resolved_deps.items[0].path == .specifier);
-    try testing.expect(module.resolved_deps.items[1].path == .specifier);
-    try testing.expect(module.resolved_deps.items[2].path == .interned); // 미처리 슬롯 원본 보존
-}
+// H2/.plugin OOM rollback test 들은 `.plugin` variant 제거 (production unused) 와 함께
+// 삭제 — `.interned` 케이스는 위 #3755 의 첫 OOM rollback test 가 이미 동일하게 커버.
+// rollbackOomCloned 는 PathRef variant 무관 (PathRef.deinit 호출 일관).


### PR DESCRIPTION
## 요약
PR #3761 `internResolvedModule` 가 plugin 경로 path 도 path_pool 로 intern 한 후
`resolve_imports.zig:344` 가 `.{ .interned = v.path }` 로 wrap → `.plugin` variant
set 위치 production 0 건.

`.plugin` 잔존 시 신규 contributor 가 잘못된 ownership 모델 (외부 context borrow)
선택할 risk + variant tag 비트 / switch 분기 낭비.

## 변경
- `src/bundler/module.zig`: PathRef union 에서 `.plugin` 제거 + doc 정리
- `src/bundler/module_store.zig`:
  - clonePathRefIfNeeded switch 에서 `.plugin` 분기 제거
  - putModule inline 코멘트 정리
  - H2/.plugin OOM rollback test 2개 삭제 — `.interned` 케이스가 이미 #3755 첫
    OOM rollback test 로 동일하게 커버 (`rollbackOomCloned` 는 PathRef variant
    무관, `PathRef.deinit` 호출 일관)
- `src/bundler/graph/resolve_imports.zig`: 코멘트 stale `.plugin` 참조 2건 정리 (sweep finding)

## /code-review max
5-angle 통합 sweep — 새 finding 은 모두 doc stale references (review 후 fix).
코드/lifetime/FFI/NAPI/wrapper enumeration 모두 OK 확인. rollbackOomCloned 커버리지는
`.interned` test 가 PathRef variant 무관 deinit 일관성을 검증.

## Test plan
- [x] `zig build test` 전체 통과 (5571 → 5569, .plugin test 2개만 줄어듦)
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)