### PR TITLE
refactor(bundler): .file/.disabled owns_path 대칭화 — .virtual 와 일관 (multi-angle finding)

### DIFF
--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -183,11 +183,16 @@ fn deepMergeMetaValue(base: *std.json.Value, add: std.json.Value) std.mem.Alloca
 /// rolldown 의 풍부한 ResolvedId 와 비슷하지만 tag 가 fs.Namespace 와 통일.
 pub const ResolvedModule = union(fs.Namespace) {
     /// fs 또는 plugin 이 제공한 실제 파일. 절대 경로 + module_type + ESM hint.
+    /// `owns_path` (default true): caller 가 path/resolve_dir 를 자체 alloc 했음 →
+    /// `internResolvedModule` 가 intern 후 원본 free. static literal / parse_arena borrow
+    /// 면 false 명시. 모든 production caller (native resolver + NAPI bridge + plugin_test)
+    /// 가 dupe 이므로 true 가 호환 default. future plugin layer 의 borrow 케이스만 false.
     file: struct {
         path: []const u8,
         resolve_dir: ?[]const u8 = null,
         module_type: ModuleType = .unknown,
         is_module_field: bool = false,
+        owns_path: bool = true,
     },
     /// 메모리 모듈 (plugin only). plugin_data 로 plugin context 전달.
     /// (#3759) `owns_path`: plugin 이 path 를 자체 alloc 했으면 true → bundler 가 intern
@@ -208,9 +213,11 @@ pub const ResolvedModule = union(fs.Namespace) {
     },
     /// browser 필드 false 매핑 — 빈 CJS 로 대체 (esbuild "(disabled)" 방식).
     /// module_type 보존 — resolve_cache 의 cache lookup 정보 손실 방지.
+    /// `owns_path` (default true): `.file` 과 동일 시맨틱.
     disabled: struct {
         path: []const u8,
         module_type: ModuleType = .unknown,
+        owns_path: bool = true,
     },
     /// 사용자 plugin 의 자유 namespace.
     custom: struct {

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -632,17 +632,19 @@ pub const ResolveCache = struct {
     }
 
     /// path 는 *interned* (path_pool 소유). caller 는 borrow only — free 안 함.
+    /// owns_path=false 명시로 caller-borrow 시맨틱 type-level 표명.
     fn fileResult(path: []const u8, resolve_dir: ?[]const u8, module_type: ModuleType, is_module_field: bool) ResolvedModule {
         return .{ .file = .{
             .path = path,
             .resolve_dir = resolve_dir,
             .module_type = module_type,
             .is_module_field = is_module_field,
+            .owns_path = false,
         } };
     }
 
     fn disabledResult(path: []const u8, module_type: ModuleType) ResolvedModule {
-        return .{ .disabled = .{ .path = path, .module_type = module_type } };
+        return .{ .disabled = .{ .path = path, .module_type = module_type, .owns_path = false } };
     }
 
     /// PR resolve interning helper — resolver 가 alloc 한 path 를 intern + 원본 free.
@@ -662,6 +664,7 @@ pub const ResolveCache = struct {
             .resolve_dir = paths[1],
             .module_type = result.module_type,
             .is_module_field = result.is_module_field,
+            .owns_path = false,
         } };
     }
 
@@ -671,7 +674,7 @@ pub const ResolveCache = struct {
         errdefer if (owns_input) self.allocator.free(path);
         const interned = try self.path_pool.intern(path);
         if (owns_input) self.allocator.free(path);
-        return .{ .disabled = .{ .path = interned, .module_type = module_type } };
+        return .{ .disabled = .{ .path = interned, .module_type = module_type, .owns_path = false } };
     }
 
     /// 캐시에 엔트리 저장. 기존 키가 있으면 이전 키 free (value 의 path 는 pool 소유).
@@ -855,37 +858,43 @@ pub const ResolveCache = struct {
     /// 원본 path / resolve_dir 는 free, pool 의 interned slice 가리키는 ResolvedModule 반환.
     /// plugin runner 가 alloc 한 결과를 caller-borrow invariant 에 맞춤.
     ///
-    /// **interning 적용 variant**: `.file`, `.disabled`, `.virtual` (owns_path=true)
-    /// — caller borrow only, free 금지.
-    /// **pass-through**: `.virtual` (owns_path=false, runtime_helper_modules 등 borrow),
-    /// `.dataurl`/`.external`/`.custom` (resolve_imports.zig:349 unreachable — 현재 미사용).
+    /// **interning 적용 variant**: `.file`, `.disabled`, `.virtual` — owns_path discriminator
+    /// 로 borrow vs owned 분기.
+    /// **pass-through**: `.dataurl`/`.external`/`.custom` (resolve_imports.zig:349
+    /// unreachable — 현재 미사용. future plugin layer 활성화 시 동일 패턴 적용).
     ///
-    /// #3759 fix: `.virtual` 의 owner ambiguity 해소 — `owns_path: bool` discriminator.
-    /// - NAPI bridge (plugin_bridge.zig:722): graph_allocator dupe → `owns_path=true`.
-    /// - runtime_helper_modules (resolveIdHook): specifier borrow → `owns_path=false`.
+    /// owner ambiguity 해소 — `owns_path: bool` discriminator (.file/.disabled default
+    /// true, .virtual default false):
+    /// - `owns_path=true` 면 intern + 원본 free (NAPI bridge / native resolver dupe).
+    /// - `owns_path=false` 면 intern 만 (runtime_helper / borrow specifier).
     ///
-    /// `owns_path=true` 면 intern + 원본 free (single-owner invariant).
-    /// `owns_path=false` 면 intern 만 (caller 가 owner 유지 — graph 가 dupe).
+    /// 반환된 ResolvedModule 의 path 는 항상 path_pool 의 interned slice (caller borrow
+    /// only) — owns_path=false 로 명시.
     pub fn internResolvedModule(self: *ResolveCache, m: ResolvedModule) !ResolvedModule {
         return switch (m) {
             .file => |f| blk: {
-                // errdefer: OOM 시 input 도 free (single-owner invariant 유지).
-                errdefer {
+                // errdefer 와 explicit free 분리 — sub-scope 로 errdefer 영역 격리.
+                const paths = pool: {
+                    errdefer if (f.owns_path) {
+                        self.allocator.free(f.path);
+                        if (f.resolve_dir) |d| self.allocator.free(d);
+                    };
+                    break :pool try self.path_pool.internPair(f.path, f.resolve_dir);
+                };
+                if (f.owns_path) {
                     self.allocator.free(f.path);
                     if (f.resolve_dir) |d| self.allocator.free(d);
                 }
-                const paths = try self.path_pool.internPair(f.path, f.resolve_dir);
-                self.allocator.free(f.path);
-                if (f.resolve_dir) |d| self.allocator.free(d);
                 break :blk .{ .file = .{
                     .path = paths[0],
                     .resolve_dir = paths[1],
                     .module_type = f.module_type,
                     .is_module_field = f.is_module_field,
+                    .owns_path = false,
                 } };
             },
-            .disabled => |d| try self.internDisabled(d.path, d.module_type, true),
-            // #3759: owner ambiguity 해소 — owns_path=true 만 free.
+            .disabled => |d| try self.internDisabled(d.path, d.module_type, d.owns_path),
+            // owner ambiguity 해소 — owns_path=true 만 free.
             // intern 실패 시 errdefer 가 free, 성공 시 explicit free 후 break — explicit
             // free 와 errdefer 가 같은 slice 를 노리지 않도록 errdefer 는 intern 호출
             // 영역만 감싼다 (sub-scope blk 로 격리).

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -364,3 +364,90 @@ test "internResolvedModule: .virtual owns_path=false 시 borrow 유지 (#3759)" 
     // 만약 fix 가 owns_path 무시하고 항상 free 했다면 static literal free → panic.
     // 통과 자체가 borrow 시맨틱 보존 증거.
 }
+
+// .file / .disabled owns_path 대칭화 (multi-angle finding) — .virtual 와 같은 패턴.
+test "internResolvedModule: .file owns_path=true 시 원본 free + intern" {
+    const testing = std.testing;
+    var cache = ResolveCache.init(testing.allocator, .{});
+    defer cache.deinit();
+
+    const dup_path = try testing.allocator.dupe(u8, "/abs/file.ts");
+    const dup_rd = try testing.allocator.dupe(u8, "/abs");
+
+    const result = try cache.internResolvedModule(.{ .file = .{
+        .path = dup_path,
+        .resolve_dir = dup_rd,
+        .module_type = .js,
+        .owns_path = true,
+    } });
+
+    switch (result) {
+        .file => |f| {
+            try testing.expectEqualStrings("/abs/file.ts", f.path);
+            try testing.expect(f.path.ptr != dup_path.ptr);
+            try testing.expect(f.resolve_dir != null);
+            try testing.expect(f.resolve_dir.?.ptr != dup_rd.ptr);
+            try testing.expect(!f.owns_path);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    // testing.allocator leak detection: dup_path/dup_rd 가 free 안 되면 fail.
+}
+
+test "internResolvedModule: .file owns_path=false 시 borrow 유지" {
+    const testing = std.testing;
+    var cache = ResolveCache.init(testing.allocator, .{});
+    defer cache.deinit();
+
+    // future plugin 이 static literal / parse_arena borrow path 를 .file 로 반환하는 케이스.
+    const static_path: []const u8 = "/abs/borrowed.ts";
+
+    const result = try cache.internResolvedModule(.{ .file = .{
+        .path = static_path,
+        .module_type = .js,
+        .owns_path = false,
+    } });
+
+    switch (result) {
+        .file => |f| {
+            try testing.expectEqualStrings("/abs/borrowed.ts", f.path);
+            try testing.expect(f.path.ptr != static_path.ptr); // intern 됐음
+            try testing.expect(!f.owns_path);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    // static literal free 안 됐다는 게 통과 자체로 증명 (free 시 panic).
+}
+
+test "internResolvedModule: .disabled owns_path=true / false" {
+    const testing = std.testing;
+    var cache = ResolveCache.init(testing.allocator, .{});
+    defer cache.deinit();
+
+    // owns_path=true (현 production 동작 — 모든 caller dupe).
+    const dup_path = try testing.allocator.dupe(u8, "/disabled/mod");
+    const r1 = try cache.internResolvedModule(.{ .disabled = .{
+        .path = dup_path,
+        .module_type = .js,
+        .owns_path = true,
+    } });
+    switch (r1) {
+        .disabled => |d| try testing.expect(d.path.ptr != dup_path.ptr),
+        else => return error.TestUnexpectedResult,
+    }
+
+    // owns_path=false (future borrow).
+    const static_path: []const u8 = "/disabled/static";
+    const r2 = try cache.internResolvedModule(.{ .disabled = .{
+        .path = static_path,
+        .module_type = .js,
+        .owns_path = false,
+    } });
+    switch (r2) {
+        .disabled => |d| {
+            try testing.expectEqualStrings("/disabled/static", d.path);
+            try testing.expect(!d.owns_path);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}


### PR DESCRIPTION
## 요약
PR #3760/#3761/#3762 `/code-review max` 의 다중 angle finding 후속.

`.file/.disabled` 도 `.virtual` 과 같은 owner ambiguity 잠재. 현재 production
모든 caller (native resolver + NAPI bridge + plugin_test) 가 dupe 라 free 가 항상
안전하지만, future plugin layer 가 borrow path 를 반환하면 static literal /
parse_arena slice free → panic.

#3759 PR 의 helper test panic 과 동일 패턴 — `.virtual` 만 fix 한 비대칭 finding.

## Fix
- `ResolvedModule.file`, `ResolvedModule.disabled` 에 `owns_path: bool = true`
  discriminator 추가
- `default true`: 기존 모든 caller 호환 (변경 없이 동작)
- `false` 명시 시: borrow 시맨틱 — `internResolvedModule` 가 intern 만, free 안 함
- `internResolvedModule` 의 `.file/.disabled` 분기 owns_path 분기 + sub-scope
  errdefer 격리 (.virtual 과 동일 패턴)
- 반환 `owns_path = false` 명시 — caller borrow 시맨틱 type-level 표명

## TDD
- `.file owns_path=true` → 원본 free + intern (testing.allocator leak detection)
- `.file owns_path=false` → borrow 유지 (free 시 panic — 통과 자체가 증거)
- `.disabled` 두 경로 모두

## Test plan
- [x] `zig build test` 전체 통과 (새 test 3개)
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)