### PR TITLE
refactor(bundler): .external/.custom owns_path 대칭화 (#3763 후속)

### DIFF
--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -208,8 +208,10 @@ pub const ResolvedModule = union(fs.Namespace) {
         data: []const u8,
     },
     /// 번들 미포함 — 런타임 import 유지.
+    /// `owns_path` (default true): `.file` 과 동일 시맨틱 (PR #3763 후속).
     external: struct {
         path: []const u8,
+        owns_path: bool = true,
     },
     /// browser 필드 false 매핑 — 빈 CJS 로 대체 (esbuild "(disabled)" 방식).
     /// module_type 보존 — resolve_cache 의 cache lookup 정보 손실 방지.
@@ -220,10 +222,14 @@ pub const ResolvedModule = union(fs.Namespace) {
         owns_path: bool = true,
     },
     /// 사용자 plugin 의 자유 namespace.
+    /// `owns_path` (default true): path *및* name 둘 다 동일 owner 가정 — 모든
+    /// 기존/예상 caller 가 같은 allocator 로 dupe 또는 둘 다 borrow. 분리 필요 시 future
+    /// RFC.
     custom: struct {
         name: []const u8,
         path: []const u8,
         plugin_data: ?*anyopaque = null,
+        owns_path: bool = true,
     },
 };
 

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -858,15 +858,15 @@ pub const ResolveCache = struct {
     /// 원본 path / resolve_dir 는 free, pool 의 interned slice 가리키는 ResolvedModule 반환.
     /// plugin runner 가 alloc 한 결과를 caller-borrow invariant 에 맞춤.
     ///
-    /// **interning 적용 variant**: `.file`, `.disabled`, `.virtual` — owns_path discriminator
-    /// 로 borrow vs owned 분기.
-    /// **pass-through**: `.dataurl`/`.external`/`.custom` (resolve_imports.zig:349
-    /// unreachable — 현재 미사용. future plugin layer 활성화 시 동일 패턴 적용).
+    /// **interning 적용 variant**: `.file`, `.disabled`, `.virtual`, `.external`, `.custom`
+    /// — owns_path discriminator 로 borrow vs owned 분기.
+    /// **pass-through**: `.dataurl` (data 가 base64 큰 메모리라 pool 부적합 — 별도 RFC).
     ///
-    /// owner ambiguity 해소 — `owns_path: bool` discriminator (.file/.disabled default
-    /// true, .virtual default false):
-    /// - `owns_path=true` 면 intern + 원본 free (NAPI bridge / native resolver dupe).
-    /// - `owns_path=false` 면 intern 만 (runtime_helper / borrow specifier).
+    /// owner ambiguity 해소 — `owns_path: bool` discriminator:
+    /// - `.file/.disabled/.external/.custom` default true (native resolver / NAPI bridge dupe)
+    /// - `.virtual` default false (runtime_helper borrow 가 더 흔함)
+    /// - `owns_path=true` 면 intern + 원본 free
+    /// - `owns_path=false` 면 intern 만 (caller 가 owner 유지)
     ///
     /// 반환된 ResolvedModule 의 path 는 항상 path_pool 의 interned slice (caller borrow
     /// only) — owns_path=false 로 명시.
@@ -906,10 +906,40 @@ pub const ResolveCache = struct {
                 if (v.owns_path) self.allocator.free(v.path);
                 break :blk .{ .virtual = .{ .path = interned, .plugin_data = v.plugin_data, .owns_path = false } };
             },
-            // external/custom — resolve_imports.zig:349 가 unreachable 로 닫혀 있어 현재
-            // 도달 안 함. dataurl 도 동일. pass-through 유지 (future plugin layer 가
-            // 활성화 시 owns_path 패턴 동일 적용).
-            .dataurl, .external, .custom => m,
+            // (#3763 후속) .external/.custom 도 .virtual 와 같은 owns_path 패턴 — intern +
+            // 조건부 free. 현재 resolve_imports.zig:349 가 unreachable 라 도달 안 함이지만,
+            // future plugin layer 활성화 시 dangling/leak 방지 가능.
+            .external => |e| blk: {
+                const interned = pool: {
+                    errdefer if (e.owns_path) self.allocator.free(e.path);
+                    break :pool try self.path_pool.intern(e.path);
+                };
+                if (e.owns_path) self.allocator.free(e.path);
+                break :blk .{ .external = .{ .path = interned, .owns_path = false } };
+            },
+            .custom => |c| blk: {
+                // name + path 모두 같은 owner 가정 (owns_path discriminator).
+                const paths = pool: {
+                    errdefer if (c.owns_path) {
+                        self.allocator.free(c.name);
+                        self.allocator.free(c.path);
+                    };
+                    break :pool try self.path_pool.internPair(c.name, c.path);
+                };
+                if (c.owns_path) {
+                    self.allocator.free(c.name);
+                    self.allocator.free(c.path);
+                }
+                break :blk .{ .custom = .{
+                    .name = paths[0],
+                    .path = paths[1].?,
+                    .plugin_data = c.plugin_data,
+                    .owns_path = false,
+                } };
+            },
+            // .dataurl — mime + data 별도 lifecycle. data 가 base64 큰 메모리라 path_pool
+            // 부적합. 현 resolve_imports.zig:349 unreachable. 별도 RFC 에서 처리.
+            .dataurl => m,
         };
     }
 

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -451,3 +451,79 @@ test "internResolvedModule: .disabled owns_path=true / false" {
         else => return error.TestUnexpectedResult,
     }
 }
+
+// .external / .custom owns_path 대칭화 — future plugin layer 안전성.
+test "internResolvedModule: .external owns_path=true / false" {
+    const testing = std.testing;
+    var cache = ResolveCache.init(testing.allocator, .{});
+    defer cache.deinit();
+
+    // owns_path=true
+    const dup_path = try testing.allocator.dupe(u8, "react");
+    const r1 = try cache.internResolvedModule(.{ .external = .{
+        .path = dup_path,
+        .owns_path = true,
+    } });
+    switch (r1) {
+        .external => |e| {
+            try testing.expectEqualStrings("react", e.path);
+            try testing.expect(e.path.ptr != dup_path.ptr);
+            try testing.expect(!e.owns_path);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    // owns_path=false
+    const static_path: []const u8 = "node:fs";
+    const r2 = try cache.internResolvedModule(.{ .external = .{
+        .path = static_path,
+        .owns_path = false,
+    } });
+    switch (r2) {
+        .external => |e| {
+            try testing.expectEqualStrings("node:fs", e.path);
+            try testing.expect(!e.owns_path);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "internResolvedModule: .custom owns_path=true / false (name + path)" {
+    const testing = std.testing;
+    var cache = ResolveCache.init(testing.allocator, .{});
+    defer cache.deinit();
+
+    // owns_path=true — name + path 모두 free.
+    const dup_name = try testing.allocator.dupe(u8, "my-ns");
+    const dup_path = try testing.allocator.dupe(u8, "/abs/custom");
+    const r1 = try cache.internResolvedModule(.{ .custom = .{
+        .name = dup_name,
+        .path = dup_path,
+        .owns_path = true,
+    } });
+    switch (r1) {
+        .custom => |c| {
+            try testing.expectEqualStrings("my-ns", c.name);
+            try testing.expectEqualStrings("/abs/custom", c.path);
+            try testing.expect(c.name.ptr != dup_name.ptr);
+            try testing.expect(c.path.ptr != dup_path.ptr);
+            try testing.expect(!c.owns_path);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    // owns_path=false — borrow.
+    const r2 = try cache.internResolvedModule(.{ .custom = .{
+        .name = "static-ns",
+        .path = "/abs/static",
+        .owns_path = false,
+    } });
+    switch (r2) {
+        .custom => |c| {
+            try testing.expectEqualStrings("static-ns", c.name);
+            try testing.expectEqualStrings("/abs/static", c.path);
+            try testing.expect(!c.owns_path);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}


### PR DESCRIPTION
## 요약
PR #3763 deferred — `.external/.custom` 도 `.virtual/.file/.disabled` 와 같은
owner discriminator 패턴 적용.

ResolvedModule 의 모든 path-bearing variant 가 type-level 로 owner 시맨틱 명시:
- `.file/.disabled/.external/.custom`: default `owns_path=true` (native resolver / NAPI bridge dupe)
- `.virtual`: default `owns_path=false` (runtime_helper borrow)
- `.dataurl`: data 가 base64 큰 메모리라 path_pool intern 부적합 — 별도 RFC

## 변경
- `ResolvedModule.external`, `ResolvedModule.custom` 에 `owns_path: bool = true` 추가
- `.custom` 의 name + path 는 동일 owner 가정 (분리 필요 시 future RFC)
- `internResolvedModule` 의 `.external/.custom` 분기 추가 — `.virtual` 와 동일 sub-scope
  errdefer 패턴
- 반환: `owns_path = false` 명시

## 현재 영향
`resolve_imports.zig:349` 가 `.dataurl, .external, .custom => unreachable` 라
production 도달 안 함 → 기존 동작 동일. future plugin layer 활성화 시
dangling/leak 방지 type-level 보장.

## TDD
- `.external owns_path=true / false` 두 경로
- `.custom owns_path=true / false` (name + path 동시 처리) 두 경로

## Test plan
- [x] `zig build test` 전체 통과 (새 test 2개)
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)