### PR TITLE
fix(bundler): #3763/#3764 retro review — .custom aliasing assert + plugin_test/NAPI 명시

### DIFF
--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -707,6 +707,7 @@ fn NapiPluginAdapter(comptime Self: type) type {
                 return .{ .disabled = .{
                     .path = alloc.dupe(u8, id_path) catch return error.OutOfMemory,
                     .module_type = .js,
+                    .owns_path = true, // (retro review) default 와 동일하지만 명시 — default flip 방지.
                 } };
             }
 
@@ -726,6 +727,7 @@ fn NapiPluginAdapter(comptime Self: type) type {
                 return .{ .file = .{
                     .path = alloc.dupe(u8, path) catch return error.OutOfMemory,
                     .module_type = .js,
+                    .owns_path = true, // (retro review) default 와 동일하지만 명시 — default flip 방지.
                 } };
             }
             return null;

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -222,9 +222,11 @@ pub const ResolvedModule = union(fs.Namespace) {
         owns_path: bool = true,
     },
     /// 사용자 plugin 의 자유 namespace.
-    /// `owns_path` (default true): path *및* name 둘 다 동일 owner 가정 — 모든
-    /// 기존/예상 caller 가 같은 allocator 로 dupe 또는 둘 다 borrow. 분리 필요 시 future
-    /// RFC.
+    /// `owns_path` (default true): path *및* name 둘 다 동일 owner 가정.
+    /// **invariant**: `owns_path=true` 시 `name.ptr != path.ptr` — 같은 slice 를 둘 다
+    /// 가리키면 `internResolvedModule` 가 double-free 시도 (debug assert 로 잡힘).
+    /// mixed owner (name borrow + path owned 등) 필요하면 future RFC (`owns_name`/`owns_path`
+    /// 분리). 현재 모든 caller 가 동일 owner 라 단일 flag 충분.
     custom: struct {
         name: []const u8,
         path: []const u8,

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -43,11 +43,13 @@ test "PluginRunner: empty plugins is no-op" {
 
 fn testResolveIdHook(_: ?*anyopaque, specifier: []const u8, _: ?[]const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?plugin_mod.ResolvedModule {
     if (std.mem.eql(u8, specifier, "virtual:config")) {
-        return .{ .file = .{
-            .path = try allocator.dupe(u8, "/virtual/config.js"),
-            .module_type = .js,
-            .owns_path = true, // default 와 동일하지만 명시 — alloc.dupe 의도 표기.
-        } };
+        return .{
+            .file = .{
+                .path = try allocator.dupe(u8, "/virtual/config.js"),
+                .module_type = .js,
+                .owns_path = true, // default 와 동일하지만 명시 — alloc.dupe 의도 표기.
+            },
+        };
     }
     return null;
 }

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -46,6 +46,7 @@ fn testResolveIdHook(_: ?*anyopaque, specifier: []const u8, _: ?[]const u8, allo
         return .{ .file = .{
             .path = try allocator.dupe(u8, "/virtual/config.js"),
             .module_type = .js,
+            .owns_path = true, // default 와 동일하지만 명시 — alloc.dupe 의도 표기.
         } };
     }
     return null;
@@ -633,10 +634,13 @@ const ResolvedModule = plugin_mod.ResolvedModule;
 const ModuleType = @import("types.zig").ModuleType;
 
 test "ResolvedModule: file variant 보존" {
+    // (retro review) static literal fixture — owns_path=false 명시. default true 라
+    // 누군가 이 fixture 를 internResolvedModule 에 넘기면 static literal free → panic.
     const m: ResolvedModule = .{ .file = .{
         .path = "/abs/foo.ts",
         .module_type = .ts,
         .is_module_field = true,
+        .owns_path = false,
     } };
     switch (m) {
         .file => |f| {
@@ -649,6 +653,7 @@ test "ResolvedModule: file variant 보존" {
 }
 
 test "ResolvedModule: virtual / dataurl / external / disabled / custom variant" {
+    // 모든 fixture 가 static literal — owns_path=false 로 borrow 명시.
     const v: ResolvedModule = .{ .virtual = .{ .path = "virtual:foo" } };
     switch (v) {
         .virtual => |x| try std.testing.expectEqualStrings("virtual:foo", x.path),
@@ -664,13 +669,13 @@ test "ResolvedModule: virtual / dataurl / external / disabled / custom variant" 
         else => return error.TestUnexpectedResult,
     }
 
-    const e: ResolvedModule = .{ .external = .{ .path = "react" } };
+    const e: ResolvedModule = .{ .external = .{ .path = "react", .owns_path = false } };
     switch (e) {
         .external => |x| try std.testing.expectEqualStrings("react", x.path),
         else => return error.TestUnexpectedResult,
     }
 
-    const dis: ResolvedModule = .{ .disabled = .{ .path = "/abs/disabled.js", .module_type = .js } };
+    const dis: ResolvedModule = .{ .disabled = .{ .path = "/abs/disabled.js", .module_type = .js, .owns_path = false } };
     switch (dis) {
         .disabled => |x| {
             try std.testing.expectEqualStrings("/abs/disabled.js", x.path);
@@ -679,7 +684,7 @@ test "ResolvedModule: virtual / dataurl / external / disabled / custom variant" 
         else => return error.TestUnexpectedResult,
     }
 
-    const c: ResolvedModule = .{ .custom = .{ .name = "my-plugin", .path = "/x" } };
+    const c: ResolvedModule = .{ .custom = .{ .name = "my-plugin", .path = "/x", .owns_path = false } };
     switch (c) {
         .custom => |x| {
             try std.testing.expectEqualStrings("my-plugin", x.name);

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -893,7 +893,10 @@ pub const ResolveCache = struct {
                     .owns_path = false,
                 } };
             },
+            // .disabled — internDisabled helper 가 동일 errdefer + sub-scope-equivalent
+            // 패턴 보유 (line 670-675). 다른 variant 의 inline blk 패턴과 다르지만 동작 동일.
             .disabled => |d| try self.internDisabled(d.path, d.module_type, d.owns_path),
+            // (이하 .virtual/.external/.custom) inline sub-scope 패턴:
             // owner ambiguity 해소 — owns_path=true 만 free.
             // intern 실패 시 errdefer 가 free, 성공 시 explicit free 후 break — explicit
             // free 와 errdefer 가 같은 slice 를 노리지 않도록 errdefer 는 intern 호출
@@ -918,7 +921,12 @@ pub const ResolveCache = struct {
                 break :blk .{ .external = .{ .path = interned, .owns_path = false } };
             },
             .custom => |c| blk: {
-                // name + path 모두 같은 owner 가정 (owns_path discriminator).
+                // (retro review P0) name + path 둘 다 같은 owner 가정 (owns_path 단일).
+                // c.name.ptr == c.path.ptr (aliasing) + owns_path=true 면 free 두 번 →
+                // double-free. invariant: caller 가 동일 slice 를 둘 다 가리키지 않게 하거나
+                // owns_path=false 로 borrow 명시. mixed owner 케이스는 future RFC (owns_name
+                // + owns_path 분리).
+                if (c.owns_path) std.debug.assert(c.name.ptr != c.path.ptr);
                 const paths = pool: {
                     errdefer if (c.owns_path) {
                         self.allocator.free(c.name);


### PR DESCRIPTION
## 요약
PR #3763 + #3764 retro `/code-review max` (3 angle 통합) 의 다중 angle 일치 P0/P1
finding fix.

## P0 — .custom name+path aliasing double-free (3+ angle 일치)
`internResolvedModule.custom` 가 owns_path=true 시 `self.allocator.free(c.name)`
+ `self.allocator.free(c.path)` 호출. `c.name.ptr == c.path.ptr` (aliasing) 면
double-free → GPA panic / glibc abort.

**Fix**: `if (c.owns_path) std.debug.assert(c.name.ptr != c.path.ptr);` debug
guard. `plugin.zig` 의 `.custom` doc 에 invariant 명시 — mixed owner 필요 시
future RFC (owns_name + owns_path 분리).

## P1 — plugin_test fixture default trap (2 angle 일치)
static literal 로 `.file/.external/.disabled/.custom` 생성한 fixture 가 default
`owns_path=true` 에 silent 의존. 향후 누군가 이 fixture 를 `internResolvedModule`
에 넘기면 static literal free → SIGSEGV.

**Fix**: 모든 static-literal fixture 에 `owns_path=false` 명시. `testResolveIdHook`
(alloc.dupe) 는 `owns_path=true` 명시 — default 동작 그대로지만 의도 표기.

## P1 — NAPI bridge default 미명시 (1 angle)
`packages/core/src/napi/plugin_bridge.zig` 의 `.file/.disabled` 가 default
`owns_path=true` 에 silent 의존. default flip 시 silent leak 회귀.

**Fix**: 두 곳에 `owns_path=true` 명시.

## Minor — comment placement
`internResolvedModule` 의 sub-scope errdefer 코멘트가 `.disabled` 와 `.virtual`
사이에 위치 → `.disabled` 설명으로 오독. `.disabled` 위 (helper delegation
설명) / `.virtual` 위 (inline sub-scope) 로 분리.

## Deferred (별도 RFC)
- default 비대칭 해소 (.virtual=false vs 나머지=true) — 모든 default 제거로 caller
  강제 명시. plugin author API hazard 근본 해결.
- .dataurl owns_path 적용 (data 가 base64 — pool 부적합, 별도 lifecycle)
- .external/.custom intern 코드 production 도달 (resolve_imports.zig:350
  unreachable 해제 — 현재 dead code)
- OOM injection test framework (모든 errdefer happy-path 만 검증)

## Test plan
- [x] `zig build test` 전체 통과 (5572)
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)