### PR TITLE
refactor(bundler): owns_path default 제거 — caller 강제 명시 (deferred 1)

### DIFF
--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -907,7 +907,7 @@ fn countedResolveHook(
     const counter: *ResolveCounter = @ptrCast(@alignCast(ctx.?));
     counter.count += 1;
     if (std.mem.eql(u8, specifier, "alias:dep")) {
-        return .{ .file = .{ .path = try allocator.dupe(u8, counter.target) } };
+        return .{ .file = .{ .path = try allocator.dupe(u8, counter.target), .owns_path = true } };
     }
     return null;
 }

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -220,11 +220,11 @@ pub const ResolvedModule = union(fs.Namespace) {
         owns_path: bool,
     },
     /// 사용자 plugin 의 자유 namespace.
-    /// `owns_path` (default 없음): path *및* name 둘 다 동일 owner 가정.
+    /// `owns_path`: path *및* name 둘 다 동일 owner 가정 (단일 flag).
     /// **invariant**: `owns_path=true` 시 `name.ptr != path.ptr` — 같은 slice 를 둘 다
     /// 가리키면 `internResolvedModule` 가 double-free 시도 (debug assert 로 잡힘).
     /// mixed owner (name borrow + path owned 등) 필요하면 future RFC (`owns_name`/`owns_path`
-    /// 분리). 현재 모든 caller 가 동일 owner 라 단일 flag 충분.
+    /// 분리).
     custom: struct {
         name: []const u8,
         path: []const u8,

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -183,24 +183,22 @@ fn deepMergeMetaValue(base: *std.json.Value, add: std.json.Value) std.mem.Alloca
 /// rolldown 의 풍부한 ResolvedId 와 비슷하지만 tag 가 fs.Namespace 와 통일.
 pub const ResolvedModule = union(fs.Namespace) {
     /// fs 또는 plugin 이 제공한 실제 파일. 절대 경로 + module_type + ESM hint.
-    /// `owns_path` (default true): caller 가 path/resolve_dir 를 자체 alloc 했음 →
-    /// `internResolvedModule` 가 intern 후 원본 free. static literal / parse_arena borrow
-    /// 면 false 명시. 모든 production caller (native resolver + NAPI bridge + plugin_test)
-    /// 가 dupe 이므로 true 가 호환 default. future plugin layer 의 borrow 케이스만 false.
+    /// `owns_path` (default 없음): caller 가 명시 강제 — true 면 자체 alloc
+    /// (`internResolvedModule` 가 intern 후 원본 free), false 면 borrow (static literal /
+    /// parse_arena slice).
     file: struct {
         path: []const u8,
         resolve_dir: ?[]const u8 = null,
         module_type: ModuleType = .unknown,
         is_module_field: bool = false,
-        owns_path: bool = true,
+        owns_path: bool, // default 없음 — caller 명시 강제 (silent leak/panic 차단)
     },
     /// 메모리 모듈 (plugin only). plugin_data 로 plugin context 전달.
-    /// (#3759) `owns_path`: plugin 이 path 를 자체 alloc 했으면 true → bundler 가 intern
-    /// 후 원본 free. static literal / borrowed specifier 면 false (default).
+    /// `owns_path` (default 없음): caller 강제 명시.
     virtual: struct {
         path: []const u8,
         plugin_data: ?*anyopaque = null,
-        owns_path: bool = false,
+        owns_path: bool,
     },
     /// data: URL — 인라인 base64 asset.
     dataurl: struct {
@@ -208,21 +206,21 @@ pub const ResolvedModule = union(fs.Namespace) {
         data: []const u8,
     },
     /// 번들 미포함 — 런타임 import 유지.
-    /// `owns_path` (default true): `.file` 과 동일 시맨틱 (PR #3763 후속).
+    /// `owns_path` (default 없음): caller 강제 명시.
     external: struct {
         path: []const u8,
-        owns_path: bool = true,
+        owns_path: bool,
     },
     /// browser 필드 false 매핑 — 빈 CJS 로 대체 (esbuild "(disabled)" 방식).
     /// module_type 보존 — resolve_cache 의 cache lookup 정보 손실 방지.
-    /// `owns_path` (default true): `.file` 과 동일 시맨틱.
+    /// `owns_path` (default 없음): caller 강제 명시.
     disabled: struct {
         path: []const u8,
         module_type: ModuleType = .unknown,
-        owns_path: bool = true,
+        owns_path: bool,
     },
     /// 사용자 plugin 의 자유 namespace.
-    /// `owns_path` (default true): path *및* name 둘 다 동일 owner 가정.
+    /// `owns_path` (default 없음): path *및* name 둘 다 동일 owner 가정.
     /// **invariant**: `owns_path=true` 시 `name.ptr != path.ptr` — 같은 slice 를 둘 다
     /// 가리키면 `internResolvedModule` 가 double-free 시도 (debug assert 로 잡힘).
     /// mixed owner (name borrow + path owned 등) 필요하면 future RFC (`owns_name`/`owns_path`
@@ -231,7 +229,7 @@ pub const ResolvedModule = union(fs.Namespace) {
         name: []const u8,
         path: []const u8,
         plugin_data: ?*anyopaque = null,
-        owns_path: bool = true,
+        owns_path: bool,
     },
 };
 

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -656,7 +656,7 @@ test "ResolvedModule: file variant 보존" {
 
 test "ResolvedModule: virtual / dataurl / external / disabled / custom variant" {
     // 모든 fixture 가 static literal — owns_path=false 로 borrow 명시.
-    const v: ResolvedModule = .{ .virtual = .{ .path = "virtual:foo" } };
+    const v: ResolvedModule = .{ .virtual = .{ .path = "virtual:foo", .owns_path = false } };
     switch (v) {
         .virtual => |x| try std.testing.expectEqualStrings("virtual:foo", x.path),
         else => return error.TestUnexpectedResult,

--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -396,7 +396,9 @@ fn resolveIdHook(
     if (!isVirtualId(specifier)) return null;
     const short = specifier[ID_PREFIX.len..];
     if (findModule(short) == null) return null;
-    return .{ .virtual = .{ .path = specifier } };
+    // specifier 는 Module.import_records[i].specifier slice 의 borrow — parse_arena 소유.
+    // owns_path=false: bundler 가 free 시도 금지.
+    return .{ .virtual = .{ .path = specifier, .owns_path = false } };
 }
 
 fn loadHook(


### PR DESCRIPTION
## 요약
PR #3765 deferred 1 — runtime owns_path validation. type system 강화로 caller 가
owns_path 를 매번 명시하도록 강제.

## Root cause
이전: `.virtual` default=false vs `.file/.disabled/.external/.custom` default=true.
비대칭 default 가 silent leak/panic 위험 (multi-angle review 일치 P0):
- plugin author 가 다른 variant 따라 작성하다 default 차이 놓치면 alloc dupe →
  borrow 오인 (leak) 또는 borrow → owned 오인 (free panic).

## Fix
모든 path-bearing variant 의 `owns_path: bool` 에서 `= true/= false` default 제거 —
누락 시 compile error.

## 변경된 caller (compile error 가 모두 발견)
- `runtime_helper_modules.zig:399`: borrow specifier → `owns_path=false`
- `graph_test.zig:910`: alloc.dupe → `owns_path=true`
- `plugin_test.zig:659`: static literal → `owns_path=false`

NAPI bridge, native resolver, internResolvedModule 내부는 PR #3765 에서 이미 명시.

## /code-review max
5-angle 통합 review. **P0/P1 새 finding 0건** — compile-time 강제로 모든 silent
risk 차단. P3 minor 3건 중 1건 (doc 톤) commit 2 에 적용. 나머지 deferred:
- NAPI bridge dupe+owns_path 헬퍼 함수화 (drift 방지)
- `bool` → `enum Owner { owned, borrowed }` (self-documenting)

## Test plan
- [x] `zig build` (production) 통과
- [x] `zig build test` 전체 통과 (5571)
- [x] ReleaseFast 빌드 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)