### PR TITLE
refactor(bundler): .dataurl owns_payload discriminator + mime intern (deferred 2)

### DIFF
--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -204,8 +204,13 @@ pub const ResolvedModule = union(fs.Namespace) {
     /// `owns_payload` (default 없음): mime + data 둘 다 동일 owner 가정. data 가 base64
     /// 큰 메모리라 path_pool intern 부적합 — `internResolvedModule` 가 mime 만 intern,
     /// data 는 그대로. owns_payload=true 면 mime + data 원본 free.
+    /// **invariant** (review finding): owns_payload=true 시 `mime.ptr != data.ptr` —
+    /// 같은 slice aliasing 시 double-free (debug assert 차단).
+    /// **caller contract** (owns_payload=false): data 의 lifetime 이 *ResolveCache lifetime
+    /// 이상* 이어야 함 — internResolvedModule 후 반환 ResolvedModule 의 data 가 caller
+    /// borrow 그대로 (mime 만 pool 소유). 다른 variant 와 비대칭이라 caller 가 주의 필요.
     /// 현재 `resolve_imports.zig:349` 가 unreachable 라 production 도달 안 함 — future
-    /// plugin layer 활성화 시 처리 RFC.
+    /// plugin layer 활성화 시 별도 RFC (data 도 별도 arena intern 또는 emitter 즉시 consume).
     dataurl: struct {
         mime: []const u8,
         data: []const u8,

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -201,9 +201,15 @@ pub const ResolvedModule = union(fs.Namespace) {
         owns_path: bool,
     },
     /// data: URL — 인라인 base64 asset.
+    /// `owns_payload` (default 없음): mime + data 둘 다 동일 owner 가정. data 가 base64
+    /// 큰 메모리라 path_pool intern 부적합 — `internResolvedModule` 가 mime 만 intern,
+    /// data 는 그대로. owns_payload=true 면 mime + data 원본 free.
+    /// 현재 `resolve_imports.zig:349` 가 unreachable 라 production 도달 안 함 — future
+    /// plugin layer 활성화 시 처리 RFC.
     dataurl: struct {
         mime: []const u8,
         data: []const u8,
+        owns_payload: bool,
     },
     /// 번들 미포함 — 런타임 import 유지.
     /// `owns_path` (default 없음): caller 강제 명시.

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -662,7 +662,7 @@ test "ResolvedModule: virtual / dataurl / external / disabled / custom variant" 
         else => return error.TestUnexpectedResult,
     }
 
-    const d: ResolvedModule = .{ .dataurl = .{ .mime = "image/png", .data = "AAAA" } };
+    const d: ResolvedModule = .{ .dataurl = .{ .mime = "image/png", .data = "AAAA", .owns_payload = false } };
     switch (d) {
         .dataurl => |x| {
             try std.testing.expectEqualStrings("image/png", x.mime);

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -967,14 +967,16 @@ pub const ResolveCache = struct {
                     // 면 원본도 free (caller 가 임시 alloc 했다는 의미).
                     self.allocator.free(du.data);
                 }
-                break :blk .{ .dataurl = .{
-                    .mime = interned_mime,
-                    // data 는 caller 가 free 했으므로 dangling 슬라이스 반환 안 됨 —
-                    // future RFC: data 도 path_pool 외 별도 arena 로 intern 또는 emitter
-                    // 가 즉시 consume. 현재 unreachable 이라 안전.
-                    .data = if (du.owns_payload) "" else du.data,
-                    .owns_payload = false,
-                } };
+                break :blk .{
+                    .dataurl = .{
+                        .mime = interned_mime,
+                        // data 는 caller 가 free 했으므로 dangling 슬라이스 반환 안 됨 —
+                        // future RFC: data 도 path_pool 외 별도 arena 로 intern 또는 emitter
+                        // 가 즉시 consume. 현재 unreachable 이라 안전.
+                        .data = if (du.owns_payload) "" else du.data,
+                        .owns_payload = false,
+                    },
+                };
             },
         };
     }

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -949,7 +949,11 @@ pub const ResolveCache = struct {
             // 큰 메모리, pool 부적합). owns_payload=true 면 둘 다 free.
             // 현 resolve_imports.zig:349 unreachable — production 도달 안 함이지만
             // future plugin layer 활성화 시 owner discipline 보장.
+            //
+            // (review finding) `.custom` 처럼 mime.ptr == data.ptr aliasing 시 double-free
+            // → debug assert 로 차단. errdefer 도 같은 두 free 라 동일 위험.
             .dataurl => |du| blk: {
+                if (du.owns_payload) std.debug.assert(du.mime.ptr != du.data.ptr);
                 const interned_mime = pool: {
                     errdefer if (du.owns_payload) {
                         self.allocator.free(du.mime);

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -858,9 +858,9 @@ pub const ResolveCache = struct {
     /// 원본 path / resolve_dir 는 free, pool 의 interned slice 가리키는 ResolvedModule 반환.
     /// plugin runner 가 alloc 한 결과를 caller-borrow invariant 에 맞춤.
     ///
-    /// **interning 적용 variant**: `.file`, `.disabled`, `.virtual`, `.external`, `.custom`
-    /// — owns_path discriminator 로 borrow vs owned 분기.
-    /// **pass-through**: `.dataurl` (data 가 base64 큰 메모리라 pool 부적합 — 별도 RFC).
+    /// **interning 적용 variant**: 모든 variant — owns_path/owns_payload discriminator
+    /// 로 borrow vs owned 분기.
+    /// `.dataurl` 는 mime 만 intern (data 는 base64 큰 메모리, pool 부적합).
     ///
     /// owner ambiguity 해소 — `owns_path: bool` discriminator:
     /// - `.file/.disabled/.external/.custom` default true (native resolver / NAPI bridge dupe)
@@ -945,9 +945,33 @@ pub const ResolveCache = struct {
                     .owns_path = false,
                 } };
             },
-            // .dataurl — mime + data 별도 lifecycle. data 가 base64 큰 메모리라 path_pool
-            // 부적합. 현 resolve_imports.zig:349 unreachable. 별도 RFC 에서 처리.
-            .dataurl => m,
+            // (deferred 2) .dataurl mime 만 intern (짧고 재사용 가능), data 는 그대로 (base64
+            // 큰 메모리, pool 부적합). owns_payload=true 면 둘 다 free.
+            // 현 resolve_imports.zig:349 unreachable — production 도달 안 함이지만
+            // future plugin layer 활성화 시 owner discipline 보장.
+            .dataurl => |du| blk: {
+                const interned_mime = pool: {
+                    errdefer if (du.owns_payload) {
+                        self.allocator.free(du.mime);
+                        self.allocator.free(du.data);
+                    };
+                    break :pool try self.path_pool.intern(du.mime);
+                };
+                if (du.owns_payload) {
+                    self.allocator.free(du.mime);
+                    // data 는 caller 가 borrow 시점 결정 — 본 PR 은 intern 안 함. owns_payload=true
+                    // 면 원본도 free (caller 가 임시 alloc 했다는 의미).
+                    self.allocator.free(du.data);
+                }
+                break :blk .{ .dataurl = .{
+                    .mime = interned_mime,
+                    // data 는 caller 가 free 했으므로 dangling 슬라이스 반환 안 됨 —
+                    // future RFC: data 도 path_pool 외 별도 arena 로 intern 또는 emitter
+                    // 가 즉시 consume. 현재 unreachable 이라 안전.
+                    .data = if (du.owns_payload) "" else du.data,
+                    .owns_payload = false,
+                } };
+            },
         };
     }
 

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -527,3 +527,44 @@ test "internResolvedModule: .custom owns_path=true / false (name + path)" {
         else => return error.TestUnexpectedResult,
     }
 }
+
+// .dataurl owns_payload — mime 만 intern, data 는 caller lifecycle (deferred 2).
+test "internResolvedModule: .dataurl owns_payload=true / false" {
+    const testing = std.testing;
+    var cache = ResolveCache.init(testing.allocator, .{});
+    defer cache.deinit();
+
+    // owns_payload=true: caller alloc 한 mime + data 둘 다 free, mime 만 intern.
+    const dup_mime = try testing.allocator.dupe(u8, "image/png");
+    const dup_data = try testing.allocator.dupe(u8, "BASE64DATA");
+    const r1 = try cache.internResolvedModule(.{ .dataurl = .{
+        .mime = dup_mime,
+        .data = dup_data,
+        .owns_payload = true,
+    } });
+    switch (r1) {
+        .dataurl => |du| {
+            try testing.expectEqualStrings("image/png", du.mime);
+            try testing.expect(du.mime.ptr != dup_mime.ptr); // mime intern
+            try testing.expect(!du.owns_payload);
+            // data 는 free 됐으므로 "" 반환 (future RFC 까지 안전 placeholder).
+            try testing.expectEqualStrings("", du.data);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    // owns_payload=false: static literal — bundler 가 free 안 함.
+    const r2 = try cache.internResolvedModule(.{ .dataurl = .{
+        .mime = "text/plain",
+        .data = "literal-data",
+        .owns_payload = false,
+    } });
+    switch (r2) {
+        .dataurl => |du| {
+            try testing.expectEqualStrings("text/plain", du.mime);
+            try testing.expectEqualStrings("literal-data", du.data);
+            try testing.expect(!du.owns_payload);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -567,4 +567,20 @@ test "internResolvedModule: .dataurl owns_payload=true / false" {
         },
         else => return error.TestUnexpectedResult,
     }
+
+    // owns_payload=false + heap-alloc borrow case (review finding) — caller 가 alloc
+    // 한 data 슬라이스의 ptr identity 가 보존되어야 함 (intern 회귀 검출).
+    const borrow_data = try testing.allocator.dupe(u8, "heap-borrow-data");
+    defer testing.allocator.free(borrow_data);
+    const r3 = try cache.internResolvedModule(.{ .dataurl = .{
+        .mime = "application/octet-stream",
+        .data = borrow_data,
+        .owns_payload = false,
+    } });
+    switch (r3) {
+        .dataurl => |du| {
+            try testing.expect(du.data.ptr == borrow_data.ptr); // borrow 무손상
+        },
+        else => return error.TestUnexpectedResult,
+    }
 }


### PR DESCRIPTION
## 요약
PR #3765 deferred 2 — `.dataurl` mime/data lifecycle. ResolvedModule 의 마지막
variant 도 owner discipline 적용 — 모든 variant 가 type-level owner discriminator
보유.

## 변경
- `ResolvedModule.dataurl` 에 `owns_payload: bool` 추가 (default 없음 — deferred 1
  PR #3766 의 caller 강제 명시 패턴과 일관)
- `internResolvedModule` 의 `.dataurl` 분기 추가:
  - mime 만 path_pool intern (짧고 재사용 가능)
  - data 는 그대로 (base64 큰 메모리, pool 부적합)
  - owns_payload=true 면 mime + data 원본 free
  - 반환 data 는 owns_payload=true 시 "" placeholder (future RFC 까지 안전)
- doc 갱신 — 모든 variant 가 owner discriminator 보유 명시
- aliasing assert (review finding): `.custom` 처럼 mime.ptr != data.ptr invariant
- caller contract (review finding): owns_payload=false 시 data lifetime 명시
- heap-alloc borrow test 보강 (review finding): allocator leak detector 우회 차단

## Current impact
`resolve_imports.zig:349` 가 `.dataurl, .external, .custom => unreachable` 라
production 도달 안 함 → 기존 동작 동일. future plugin layer 활성화 시 owner
discipline + UAF/leak 방지 type-level 보장.

## /code-review max
5-angle 통합 review. 5 finding 중 P2 3건 commit 2 에 적용:
- aliasing assert + caller contract doc + heap-alloc borrow test

Deferred (future RFC):
- `.data = ""` placeholder 가 future emit caller 활성화 시 silent corruption 위험
- data 도 별도 arena intern 또는 emitter 즉시 consume 패턴

## Test plan
- [x] `zig build test` 전체 통과
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)