### PR TITLE
refactor(bundler): owns_path bool → Owner enum self-documenting (deferred 3)

### DIFF
--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -707,7 +707,7 @@ fn NapiPluginAdapter(comptime Self: type) type {
                 return .{ .disabled = .{
                     .path = alloc.dupe(u8, id_path) catch return error.OutOfMemory,
                     .module_type = .js,
-                    .owns_path = true, // (retro review) default 와 동일하지만 명시 — default flip 방지.
+                    .owner = .owned, // (retro review) default 와 동일하지만 명시 — default flip 방지.
                 } };
             }
 
@@ -721,13 +721,13 @@ fn NapiPluginAdapter(comptime Self: type) type {
                 if (graph_plugins_mod.isPluginVirtualId(path)) {
                     return .{ .virtual = .{
                         .path = alloc.dupe(u8, path) catch return error.OutOfMemory,
-                        .owns_path = true, // (#3759) bundler 가 intern 후 원본 free.
+                        .owner = .owned, // (#3759) bundler 가 intern 후 원본 free.
                     } };
                 }
                 return .{ .file = .{
                     .path = alloc.dupe(u8, path) catch return error.OutOfMemory,
                     .module_type = .js,
-                    .owns_path = true, // (retro review) default 와 동일하지만 명시 — default flip 방지.
+                    .owner = .owned, // (retro review) default 와 동일하지만 명시 — default flip 방지.
                 } };
             }
             return null;

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -907,7 +907,7 @@ fn countedResolveHook(
     const counter: *ResolveCounter = @ptrCast(@alignCast(ctx.?));
     counter.count += 1;
     if (std.mem.eql(u8, specifier, "alias:dep")) {
-        return .{ .file = .{ .path = try allocator.dupe(u8, counter.target), .owns_path = true } };
+        return .{ .file = .{ .path = try allocator.dupe(u8, counter.target), .owner = .owned } };
     }
     return null;
 }

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -177,15 +177,26 @@ fn deepMergeMetaValue(base: *std.json.Value, add: std.json.Value) std.mem.Alloca
     }
 }
 
-/// Plugin resolveId 응답의 통합 모델 (#1885).
-///
-/// origin 별 type-safe 분기 — esbuild 의 string namespace 보다 컴파일 타임 안전.
-/// path/payload ownership discriminator. `bool` trap 해소 — `.owned/.borrowed` 가
+/// Path/payload ownership discriminator. `bool` trap 해소 — `.owned/.borrowed` 가
 /// `true/false` 보다 self-documenting (deferred 3).
 /// - `.owned`: caller 가 자체 alloc → `internResolvedModule` 가 intern 후 원본 free
 /// - `.borrowed`: static literal / parse_arena slice 등 — bundler 가 free 시도 금지
-pub const Owner = enum { owned, borrowed };
+pub const Owner = enum {
+    owned,
+    borrowed,
 
+    pub inline fn isOwned(self: Owner) bool {
+        return self == .owned;
+    }
+
+    pub inline fn isBorrowed(self: Owner) bool {
+        return self == .borrowed;
+    }
+};
+
+/// Plugin resolveId 응답의 통합 모델 (#1885).
+///
+/// origin 별 type-safe 분기 — esbuild 의 string namespace 보다 컴파일 타임 안전.
 /// rolldown 의 풍부한 ResolvedId 와 비슷하지만 tag 가 fs.Namespace 와 통일.
 pub const ResolvedModule = union(fs.Namespace) {
     /// fs 또는 plugin 이 제공한 실제 파일. 절대 경로 + module_type + ESM hint.

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -180,33 +180,39 @@ fn deepMergeMetaValue(base: *std.json.Value, add: std.json.Value) std.mem.Alloca
 /// Plugin resolveId 응답의 통합 모델 (#1885).
 ///
 /// origin 별 type-safe 분기 — esbuild 의 string namespace 보다 컴파일 타임 안전.
+/// path/payload ownership discriminator. `bool` trap 해소 — `.owned/.borrowed` 가
+/// `true/false` 보다 self-documenting (deferred 3).
+/// - `.owned`: caller 가 자체 alloc → `internResolvedModule` 가 intern 후 원본 free
+/// - `.borrowed`: static literal / parse_arena slice 등 — bundler 가 free 시도 금지
+pub const Owner = enum { owned, borrowed };
+
 /// rolldown 의 풍부한 ResolvedId 와 비슷하지만 tag 가 fs.Namespace 와 통일.
 pub const ResolvedModule = union(fs.Namespace) {
     /// fs 또는 plugin 이 제공한 실제 파일. 절대 경로 + module_type + ESM hint.
-    /// `owns_path` (default 없음): caller 가 명시 강제 — true 면 자체 alloc
-    /// (`internResolvedModule` 가 intern 후 원본 free), false 면 borrow (static literal /
+    /// `owner` (default 없음): caller 가 명시 강제 — `.owned` 면 자체 alloc
+    /// (`internResolvedModule` 가 intern 후 원본 free), `.borrowed` 면 (static literal /
     /// parse_arena slice).
     file: struct {
         path: []const u8,
         resolve_dir: ?[]const u8 = null,
         module_type: ModuleType = .unknown,
         is_module_field: bool = false,
-        owns_path: bool, // default 없음 — caller 명시 강제 (silent leak/panic 차단)
+        owner: Owner, // default 없음 — caller 명시 강제 (silent leak/panic 차단)
     },
     /// 메모리 모듈 (plugin only). plugin_data 로 plugin context 전달.
-    /// `owns_path` (default 없음): caller 강제 명시.
+    /// `owner` (default 없음): caller 강제 명시.
     virtual: struct {
         path: []const u8,
         plugin_data: ?*anyopaque = null,
-        owns_path: bool,
+        owner: Owner,
     },
     /// data: URL — 인라인 base64 asset.
-    /// `owns_payload` (default 없음): mime + data 둘 다 동일 owner 가정. data 가 base64
+    /// `owner` (default 없음): mime + data 둘 다 동일 owner 가정. data 가 base64
     /// 큰 메모리라 path_pool intern 부적합 — `internResolvedModule` 가 mime 만 intern,
-    /// data 는 그대로. owns_payload=true 면 mime + data 원본 free.
-    /// **invariant** (review finding): owns_payload=true 시 `mime.ptr != data.ptr` —
+    /// data 는 그대로. `.owned` 면 mime + data 원본 free.
+    /// **invariant** (review finding): `.owned` 시 `mime.ptr != data.ptr` —
     /// 같은 slice aliasing 시 double-free (debug assert 차단).
-    /// **caller contract** (owns_payload=false): data 의 lifetime 이 *ResolveCache lifetime
+    /// **caller contract** (`.borrowed`): data 의 lifetime 이 *ResolveCache lifetime
     /// 이상* 이어야 함 — internResolvedModule 후 반환 ResolvedModule 의 data 가 caller
     /// borrow 그대로 (mime 만 pool 소유). 다른 variant 와 비대칭이라 caller 가 주의 필요.
     /// 현재 `resolve_imports.zig:349` 가 unreachable 라 production 도달 안 함 — future
@@ -214,33 +220,33 @@ pub const ResolvedModule = union(fs.Namespace) {
     dataurl: struct {
         mime: []const u8,
         data: []const u8,
-        owns_payload: bool,
+        owner: Owner, // 통일: payload (mime+data) owner
     },
     /// 번들 미포함 — 런타임 import 유지.
-    /// `owns_path` (default 없음): caller 강제 명시.
+    /// `owner` (default 없음): caller 강제 명시.
     external: struct {
         path: []const u8,
-        owns_path: bool,
+        owner: Owner,
     },
     /// browser 필드 false 매핑 — 빈 CJS 로 대체 (esbuild "(disabled)" 방식).
     /// module_type 보존 — resolve_cache 의 cache lookup 정보 손실 방지.
-    /// `owns_path` (default 없음): caller 강제 명시.
+    /// `owner` (default 없음): caller 강제 명시.
     disabled: struct {
         path: []const u8,
         module_type: ModuleType = .unknown,
-        owns_path: bool,
+        owner: Owner,
     },
     /// 사용자 plugin 의 자유 namespace.
-    /// `owns_path`: path *및* name 둘 다 동일 owner 가정 (단일 flag).
-    /// **invariant**: `owns_path=true` 시 `name.ptr != path.ptr` — 같은 slice 를 둘 다
+    /// `owner`: path *및* name 둘 다 동일 owner 가정 (단일 flag).
+    /// **invariant**: `.owned` 시 `name.ptr != path.ptr` — 같은 slice 를 둘 다
     /// 가리키면 `internResolvedModule` 가 double-free 시도 (debug assert 로 잡힘).
-    /// mixed owner (name borrow + path owned 등) 필요하면 future RFC (`owns_name`/`owns_path`
+    /// mixed owner (name borrow + path owned 등) 필요하면 future RFC (`owner_name`/`owner_path`
     /// 분리).
     custom: struct {
         name: []const u8,
         path: []const u8,
         plugin_data: ?*anyopaque = null,
-        owns_path: bool,
+        owner: Owner,
     },
 };
 

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -47,7 +47,7 @@ fn testResolveIdHook(_: ?*anyopaque, specifier: []const u8, _: ?[]const u8, allo
             .file = .{
                 .path = try allocator.dupe(u8, "/virtual/config.js"),
                 .module_type = .js,
-                .owns_path = true, // default 와 동일하지만 명시 — alloc.dupe 의도 표기.
+                .owner = .owned, // default 와 동일하지만 명시 — alloc.dupe 의도 표기.
             },
         };
     }
@@ -642,7 +642,7 @@ test "ResolvedModule: file variant 보존" {
         .path = "/abs/foo.ts",
         .module_type = .ts,
         .is_module_field = true,
-        .owns_path = false,
+        .owner = .borrowed,
     } };
     switch (m) {
         .file => |f| {
@@ -656,13 +656,13 @@ test "ResolvedModule: file variant 보존" {
 
 test "ResolvedModule: virtual / dataurl / external / disabled / custom variant" {
     // 모든 fixture 가 static literal — owns_path=false 로 borrow 명시.
-    const v: ResolvedModule = .{ .virtual = .{ .path = "virtual:foo", .owns_path = false } };
+    const v: ResolvedModule = .{ .virtual = .{ .path = "virtual:foo", .owner = .borrowed } };
     switch (v) {
         .virtual => |x| try std.testing.expectEqualStrings("virtual:foo", x.path),
         else => return error.TestUnexpectedResult,
     }
 
-    const d: ResolvedModule = .{ .dataurl = .{ .mime = "image/png", .data = "AAAA", .owns_payload = false } };
+    const d: ResolvedModule = .{ .dataurl = .{ .mime = "image/png", .data = "AAAA", .owner = .borrowed } };
     switch (d) {
         .dataurl => |x| {
             try std.testing.expectEqualStrings("image/png", x.mime);
@@ -671,13 +671,13 @@ test "ResolvedModule: virtual / dataurl / external / disabled / custom variant" 
         else => return error.TestUnexpectedResult,
     }
 
-    const e: ResolvedModule = .{ .external = .{ .path = "react", .owns_path = false } };
+    const e: ResolvedModule = .{ .external = .{ .path = "react", .owner = .borrowed } };
     switch (e) {
         .external => |x| try std.testing.expectEqualStrings("react", x.path),
         else => return error.TestUnexpectedResult,
     }
 
-    const dis: ResolvedModule = .{ .disabled = .{ .path = "/abs/disabled.js", .module_type = .js, .owns_path = false } };
+    const dis: ResolvedModule = .{ .disabled = .{ .path = "/abs/disabled.js", .module_type = .js, .owner = .borrowed } };
     switch (dis) {
         .disabled => |x| {
             try std.testing.expectEqualStrings("/abs/disabled.js", x.path);
@@ -686,7 +686,7 @@ test "ResolvedModule: virtual / dataurl / external / disabled / custom variant" 
         else => return error.TestUnexpectedResult,
     }
 
-    const c: ResolvedModule = .{ .custom = .{ .name = "my-plugin", .path = "/x", .owns_path = false } };
+    const c: ResolvedModule = .{ .custom = .{ .name = "my-plugin", .path = "/x", .owner = .borrowed } };
     switch (c) {
         .custom => |x| {
             try std.testing.expectEqualStrings("my-plugin", x.name);

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -509,7 +509,7 @@ pub const ResolveCache = struct {
                         .disabled => {
                             const disabled_path = std.fmt.allocPrint(self.allocator, "(disabled):{s}", .{effective_spec}) catch return error.OutOfMemory;
                             // interning: pool 에 store + 원본 free. cache + caller 둘 다 interned.
-                            const result = try self.internDisabled(disabled_path, .js, true);
+                            const result = try self.internDisabled(disabled_path, .js, .owned);
                             var store_scope = profile.begin(.resolve_cache_store);
                             defer store_scope.end();
                             if (thread_safe) cache_shard.mutex.lock();
@@ -567,7 +567,7 @@ pub const ResolveCache = struct {
         // cache 되어 graph 단계에서 일반 파싱 시도 → "No loader configured" 에러.
         if (result.disabled) {
             // interning: result.path free + pool intern + cache & caller borrow.
-            const disabled = try self.internDisabled(result.path, result.module_type, true);
+            const disabled = try self.internDisabled(result.path, result.module_type, .owned);
             if (result.resolve_dir) |dir| self.allocator.free(dir);
             var store_scope = profile.begin(.resolve_cache_store);
             defer store_scope.end();
@@ -581,7 +581,7 @@ pub const ResolveCache = struct {
             const override = self.getBrowserOverride(result.path);
             switch (override) {
                 .disabled => {
-                    const disabled = try self.internDisabled(result.path, result.module_type, true);
+                    const disabled = try self.internDisabled(result.path, result.module_type, .owned);
                     if (result.resolve_dir) |dir| self.allocator.free(dir);
                     var store_scope = profile.begin(.resolve_cache_store);
                     defer store_scope.end();
@@ -639,12 +639,12 @@ pub const ResolveCache = struct {
             .resolve_dir = resolve_dir,
             .module_type = module_type,
             .is_module_field = is_module_field,
-            .owns_path = false,
+            .owner = .borrowed,
         } };
     }
 
     fn disabledResult(path: []const u8, module_type: ModuleType) ResolvedModule {
-        return .{ .disabled = .{ .path = path, .module_type = module_type, .owns_path = false } };
+        return .{ .disabled = .{ .path = path, .module_type = module_type, .owner = .borrowed } };
     }
 
     /// PR resolve interning helper — resolver 가 alloc 한 path 를 intern + 원본 free.
@@ -664,17 +664,17 @@ pub const ResolveCache = struct {
             .resolve_dir = paths[1],
             .module_type = result.module_type,
             .is_module_field = result.is_module_field,
-            .owns_path = false,
+            .owner = .borrowed,
         } };
     }
 
-    /// disabled variant 용 — path 단일 intern. `owns_input=true` 면 원본 free.
+    /// disabled variant 용 — path 단일 intern. `owner == .owned` 면 원본 free.
     /// **OOM 시 input 도 free** (errdefer) — single-owner invariant 일관.
-    fn internDisabled(self: *ResolveCache, path: []const u8, module_type: ModuleType, owns_input: bool) error{OutOfMemory}!ResolvedModule {
-        errdefer if (owns_input) self.allocator.free(path);
+    fn internDisabled(self: *ResolveCache, path: []const u8, module_type: ModuleType, owner: plugin_mod.Owner) error{OutOfMemory}!ResolvedModule {
+        errdefer if (owner == .owned) self.allocator.free(path);
         const interned = try self.path_pool.intern(path);
-        if (owns_input) self.allocator.free(path);
-        return .{ .disabled = .{ .path = interned, .module_type = module_type, .owns_path = false } };
+        if (owner == .owned) self.allocator.free(path);
+        return .{ .disabled = .{ .path = interned, .module_type = module_type, .owner = .borrowed } };
     }
 
     /// 캐시에 엔트리 저장. 기존 키가 있으면 이전 키 free (value 의 path 는 pool 소유).
@@ -875,13 +875,13 @@ pub const ResolveCache = struct {
             .file => |f| blk: {
                 // errdefer 와 explicit free 분리 — sub-scope 로 errdefer 영역 격리.
                 const paths = pool: {
-                    errdefer if (f.owns_path) {
+                    errdefer if (f.owner == .owned) {
                         self.allocator.free(f.path);
                         if (f.resolve_dir) |d| self.allocator.free(d);
                     };
                     break :pool try self.path_pool.internPair(f.path, f.resolve_dir);
                 };
-                if (f.owns_path) {
+                if (f.owner == .owned) {
                     self.allocator.free(f.path);
                     if (f.resolve_dir) |d| self.allocator.free(d);
                 }
@@ -890,12 +890,12 @@ pub const ResolveCache = struct {
                     .resolve_dir = paths[1],
                     .module_type = f.module_type,
                     .is_module_field = f.is_module_field,
-                    .owns_path = false,
+                    .owner = .borrowed,
                 } };
             },
             // .disabled — internDisabled helper 가 동일 errdefer + sub-scope-equivalent
             // 패턴 보유 (line 670-675). 다른 variant 의 inline blk 패턴과 다르지만 동작 동일.
-            .disabled => |d| try self.internDisabled(d.path, d.module_type, d.owns_path),
+            .disabled => |d| try self.internDisabled(d.path, d.module_type, d.owner),
             // (이하 .virtual/.external/.custom) inline sub-scope 패턴:
             // owner ambiguity 해소 — owns_path=true 만 free.
             // intern 실패 시 errdefer 가 free, 성공 시 explicit free 후 break — explicit
@@ -903,22 +903,22 @@ pub const ResolveCache = struct {
             // 영역만 감싼다 (sub-scope blk 로 격리).
             .virtual => |v| blk: {
                 const interned = pool: {
-                    errdefer if (v.owns_path) self.allocator.free(v.path);
+                    errdefer if (v.owner == .owned) self.allocator.free(v.path);
                     break :pool try self.path_pool.intern(v.path);
                 };
-                if (v.owns_path) self.allocator.free(v.path);
-                break :blk .{ .virtual = .{ .path = interned, .plugin_data = v.plugin_data, .owns_path = false } };
+                if (v.owner == .owned) self.allocator.free(v.path);
+                break :blk .{ .virtual = .{ .path = interned, .plugin_data = v.plugin_data, .owner = .borrowed } };
             },
             // (#3763 후속) .external/.custom 도 .virtual 와 같은 owns_path 패턴 — intern +
             // 조건부 free. 현재 resolve_imports.zig:349 가 unreachable 라 도달 안 함이지만,
             // future plugin layer 활성화 시 dangling/leak 방지 가능.
             .external => |e| blk: {
                 const interned = pool: {
-                    errdefer if (e.owns_path) self.allocator.free(e.path);
+                    errdefer if (e.owner == .owned) self.allocator.free(e.path);
                     break :pool try self.path_pool.intern(e.path);
                 };
-                if (e.owns_path) self.allocator.free(e.path);
-                break :blk .{ .external = .{ .path = interned, .owns_path = false } };
+                if (e.owner == .owned) self.allocator.free(e.path);
+                break :blk .{ .external = .{ .path = interned, .owner = .borrowed } };
             },
             .custom => |c| blk: {
                 // (retro review P0) name + path 둘 다 같은 owner 가정 (owns_path 단일).
@@ -926,15 +926,15 @@ pub const ResolveCache = struct {
                 // double-free. invariant: caller 가 동일 slice 를 둘 다 가리키지 않게 하거나
                 // owns_path=false 로 borrow 명시. mixed owner 케이스는 future RFC (owns_name
                 // + owns_path 분리).
-                if (c.owns_path) std.debug.assert(c.name.ptr != c.path.ptr);
+                if (c.owner == .owned) std.debug.assert(c.name.ptr != c.path.ptr);
                 const paths = pool: {
-                    errdefer if (c.owns_path) {
+                    errdefer if (c.owner == .owned) {
                         self.allocator.free(c.name);
                         self.allocator.free(c.path);
                     };
                     break :pool try self.path_pool.internPair(c.name, c.path);
                 };
-                if (c.owns_path) {
+                if (c.owner == .owned) {
                     self.allocator.free(c.name);
                     self.allocator.free(c.path);
                 }
@@ -942,7 +942,7 @@ pub const ResolveCache = struct {
                     .name = paths[0],
                     .path = paths[1].?,
                     .plugin_data = c.plugin_data,
-                    .owns_path = false,
+                    .owner = .borrowed,
                 } };
             },
             // (deferred 2) .dataurl mime 만 intern (짧고 재사용 가능), data 는 그대로 (base64
@@ -953,15 +953,15 @@ pub const ResolveCache = struct {
             // (review finding) `.custom` 처럼 mime.ptr == data.ptr aliasing 시 double-free
             // → debug assert 로 차단. errdefer 도 같은 두 free 라 동일 위험.
             .dataurl => |du| blk: {
-                if (du.owns_payload) std.debug.assert(du.mime.ptr != du.data.ptr);
+                if (du.owner == .owned) std.debug.assert(du.mime.ptr != du.data.ptr);
                 const interned_mime = pool: {
-                    errdefer if (du.owns_payload) {
+                    errdefer if (du.owner == .owned) {
                         self.allocator.free(du.mime);
                         self.allocator.free(du.data);
                     };
                     break :pool try self.path_pool.intern(du.mime);
                 };
-                if (du.owns_payload) {
+                if (du.owner == .owned) {
                     self.allocator.free(du.mime);
                     // data 는 caller 가 borrow 시점 결정 — 본 PR 은 intern 안 함. owns_payload=true
                     // 면 원본도 free (caller 가 임시 alloc 했다는 의미).
@@ -973,8 +973,8 @@ pub const ResolveCache = struct {
                         // data 는 caller 가 free 했으므로 dangling 슬라이스 반환 안 됨 —
                         // future RFC: data 도 path_pool 외 별도 arena 로 intern 또는 emitter
                         // 가 즉시 consume. 현재 unreachable 이라 안전.
-                        .data = if (du.owns_payload) "" else du.data,
-                        .owns_payload = false,
+                        .data = if (du.owner == .owned) "" else du.data,
+                        .owner = .borrowed,
                     },
                 };
             },

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -632,7 +632,7 @@ pub const ResolveCache = struct {
     }
 
     /// path 는 *interned* (path_pool 소유). caller 는 borrow only — free 안 함.
-    /// owns_path=false 명시로 caller-borrow 시맨틱 type-level 표명.
+    /// `.borrowed` 명시로 caller-borrow 시맨틱 type-level 표명.
     fn fileResult(path: []const u8, resolve_dir: ?[]const u8, module_type: ModuleType, is_module_field: bool) ResolvedModule {
         return .{ .file = .{
             .path = path,
@@ -668,12 +668,12 @@ pub const ResolveCache = struct {
         } };
     }
 
-    /// disabled variant 용 — path 단일 intern. `owner == .owned` 면 원본 free.
+    /// disabled variant 용 — path 단일 intern. `owner.isOwned()` 면 원본 free.
     /// **OOM 시 input 도 free** (errdefer) — single-owner invariant 일관.
     fn internDisabled(self: *ResolveCache, path: []const u8, module_type: ModuleType, owner: plugin_mod.Owner) error{OutOfMemory}!ResolvedModule {
-        errdefer if (owner == .owned) self.allocator.free(path);
+        errdefer if (owner.isOwned()) self.allocator.free(path);
         const interned = try self.path_pool.intern(path);
-        if (owner == .owned) self.allocator.free(path);
+        if (owner.isOwned()) self.allocator.free(path);
         return .{ .disabled = .{ .path = interned, .module_type = module_type, .owner = .borrowed } };
     }
 
@@ -858,30 +858,30 @@ pub const ResolveCache = struct {
     /// 원본 path / resolve_dir 는 free, pool 의 interned slice 가리키는 ResolvedModule 반환.
     /// plugin runner 가 alloc 한 결과를 caller-borrow invariant 에 맞춤.
     ///
-    /// **interning 적용 variant**: 모든 variant — owns_path/owns_payload discriminator
+    /// **interning 적용 variant**: 모든 variant — Owner discriminator
     /// 로 borrow vs owned 분기.
     /// `.dataurl` 는 mime 만 intern (data 는 base64 큰 메모리, pool 부적합).
     ///
-    /// owner ambiguity 해소 — `owns_path: bool` discriminator:
+    /// owner ambiguity 해소 — Owner enum discriminator:
     /// - `.file/.disabled/.external/.custom` default true (native resolver / NAPI bridge dupe)
     /// - `.virtual` default false (runtime_helper borrow 가 더 흔함)
-    /// - `owns_path=true` 면 intern + 원본 free
-    /// - `owns_path=false` 면 intern 만 (caller 가 owner 유지)
+    /// - ``.owned`` 면 intern + 원본 free
+    /// - ``.borrowed`` 면 intern 만 (caller 가 owner 유지)
     ///
     /// 반환된 ResolvedModule 의 path 는 항상 path_pool 의 interned slice (caller borrow
-    /// only) — owns_path=false 로 명시.
+    /// only) — `.borrowed` 로 명시.
     pub fn internResolvedModule(self: *ResolveCache, m: ResolvedModule) !ResolvedModule {
         return switch (m) {
             .file => |f| blk: {
                 // errdefer 와 explicit free 분리 — sub-scope 로 errdefer 영역 격리.
                 const paths = pool: {
-                    errdefer if (f.owner == .owned) {
+                    errdefer if (f.owner.isOwned()) {
                         self.allocator.free(f.path);
                         if (f.resolve_dir) |d| self.allocator.free(d);
                     };
                     break :pool try self.path_pool.internPair(f.path, f.resolve_dir);
                 };
-                if (f.owner == .owned) {
+                if (f.owner.isOwned()) {
                     self.allocator.free(f.path);
                     if (f.resolve_dir) |d| self.allocator.free(d);
                 }
@@ -897,44 +897,44 @@ pub const ResolveCache = struct {
             // 패턴 보유 (line 670-675). 다른 variant 의 inline blk 패턴과 다르지만 동작 동일.
             .disabled => |d| try self.internDisabled(d.path, d.module_type, d.owner),
             // (이하 .virtual/.external/.custom) inline sub-scope 패턴:
-            // owner ambiguity 해소 — owns_path=true 만 free.
+            // owner ambiguity 해소 — `.owned` 만 free.
             // intern 실패 시 errdefer 가 free, 성공 시 explicit free 후 break — explicit
             // free 와 errdefer 가 같은 slice 를 노리지 않도록 errdefer 는 intern 호출
             // 영역만 감싼다 (sub-scope blk 로 격리).
             .virtual => |v| blk: {
                 const interned = pool: {
-                    errdefer if (v.owner == .owned) self.allocator.free(v.path);
+                    errdefer if (v.owner.isOwned()) self.allocator.free(v.path);
                     break :pool try self.path_pool.intern(v.path);
                 };
-                if (v.owner == .owned) self.allocator.free(v.path);
+                if (v.owner.isOwned()) self.allocator.free(v.path);
                 break :blk .{ .virtual = .{ .path = interned, .plugin_data = v.plugin_data, .owner = .borrowed } };
             },
-            // (#3763 후속) .external/.custom 도 .virtual 와 같은 owns_path 패턴 — intern +
+            // (#3763 후속) .external/.custom 도 .virtual 와 같은 Owner 패턴 — intern +
             // 조건부 free. 현재 resolve_imports.zig:349 가 unreachable 라 도달 안 함이지만,
             // future plugin layer 활성화 시 dangling/leak 방지 가능.
             .external => |e| blk: {
                 const interned = pool: {
-                    errdefer if (e.owner == .owned) self.allocator.free(e.path);
+                    errdefer if (e.owner.isOwned()) self.allocator.free(e.path);
                     break :pool try self.path_pool.intern(e.path);
                 };
-                if (e.owner == .owned) self.allocator.free(e.path);
+                if (e.owner.isOwned()) self.allocator.free(e.path);
                 break :blk .{ .external = .{ .path = interned, .owner = .borrowed } };
             },
             .custom => |c| blk: {
-                // (retro review P0) name + path 둘 다 같은 owner 가정 (owns_path 단일).
-                // c.name.ptr == c.path.ptr (aliasing) + owns_path=true 면 free 두 번 →
+                // (retro review P0) name + path 둘 다 같은 owner 가정 (Owner 단일).
+                // c.name.ptr == c.path.ptr (aliasing) + `.owned` 면 free 두 번 →
                 // double-free. invariant: caller 가 동일 slice 를 둘 다 가리키지 않게 하거나
-                // owns_path=false 로 borrow 명시. mixed owner 케이스는 future RFC (owns_name
-                // + owns_path 분리).
-                if (c.owner == .owned) std.debug.assert(c.name.ptr != c.path.ptr);
+                // `.borrowed` 로 borrow 명시. mixed owner 케이스는 future RFC (owner_name +
+                // owner_path 분리).
+                if (c.owner.isOwned()) std.debug.assert(c.name.ptr != c.path.ptr);
                 const paths = pool: {
-                    errdefer if (c.owner == .owned) {
+                    errdefer if (c.owner.isOwned()) {
                         self.allocator.free(c.name);
                         self.allocator.free(c.path);
                     };
                     break :pool try self.path_pool.internPair(c.name, c.path);
                 };
-                if (c.owner == .owned) {
+                if (c.owner.isOwned()) {
                     self.allocator.free(c.name);
                     self.allocator.free(c.path);
                 }
@@ -946,24 +946,24 @@ pub const ResolveCache = struct {
                 } };
             },
             // (deferred 2) .dataurl mime 만 intern (짧고 재사용 가능), data 는 그대로 (base64
-            // 큰 메모리, pool 부적합). owns_payload=true 면 둘 다 free.
+            // 큰 메모리, pool 부적합). `.owned` 면 둘 다 free.
             // 현 resolve_imports.zig:349 unreachable — production 도달 안 함이지만
             // future plugin layer 활성화 시 owner discipline 보장.
             //
             // (review finding) `.custom` 처럼 mime.ptr == data.ptr aliasing 시 double-free
             // → debug assert 로 차단. errdefer 도 같은 두 free 라 동일 위험.
             .dataurl => |du| blk: {
-                if (du.owner == .owned) std.debug.assert(du.mime.ptr != du.data.ptr);
+                if (du.owner.isOwned()) std.debug.assert(du.mime.ptr != du.data.ptr);
                 const interned_mime = pool: {
-                    errdefer if (du.owner == .owned) {
+                    errdefer if (du.owner.isOwned()) {
                         self.allocator.free(du.mime);
                         self.allocator.free(du.data);
                     };
                     break :pool try self.path_pool.intern(du.mime);
                 };
-                if (du.owner == .owned) {
+                if (du.owner.isOwned()) {
                     self.allocator.free(du.mime);
-                    // data 는 caller 가 borrow 시점 결정 — 본 PR 은 intern 안 함. owns_payload=true
+                    // data 는 caller 가 borrow 시점 결정 — 본 PR 은 intern 안 함. `.owned`
                     // 면 원본도 free (caller 가 임시 alloc 했다는 의미).
                     self.allocator.free(du.data);
                 }
@@ -973,7 +973,7 @@ pub const ResolveCache = struct {
                         // data 는 caller 가 free 했으므로 dangling 슬라이스 반환 안 됨 —
                         // future RFC: data 도 path_pool 외 별도 arena 로 intern 또는 emitter
                         // 가 즉시 consume. 현재 unreachable 이라 안전.
-                        .data = if (du.owner == .owned) "" else du.data,
+                        .data = if (du.owner.isOwned()) "" else du.data,
                         .owner = .borrowed,
                     },
                 };

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -322,7 +322,7 @@ test "internResolvedModule: .virtual owns_path=true 시 원본 free + intern (#3
 
     const result = try cache.internResolvedModule(.{ .virtual = .{
         .path = dup_path,
-        .owns_path = true,
+        .owner = .owned,
     } });
 
     // 반환된 path 는 path_pool 의 interned slice — dup_path 와 *다른* 포인터.
@@ -330,7 +330,7 @@ test "internResolvedModule: .virtual owns_path=true 시 원본 free + intern (#3
         .virtual => |v| {
             try testing.expectEqualStrings("\x00plugin:virtual-mod", v.path);
             try testing.expect(v.path.ptr != dup_path.ptr); // ← intern 확인
-            try testing.expect(!v.owns_path); // ← 반환값은 항상 owns_path=false (caller borrow)
+            try testing.expect(v.owner == .borrowed); // ← 반환값은 항상 owns_path=false (caller borrow)
         },
         else => return error.TestUnexpectedResult,
     }
@@ -348,7 +348,7 @@ test "internResolvedModule: .virtual owns_path=false 시 borrow 유지 (#3759)" 
     const result = try cache.internResolvedModule(.{
         .virtual = .{
             .path = static_path,
-            .owns_path = false, // ← borrow only — bundler 가 free 시도 금지
+            .owner = .borrowed, // ← borrow only — bundler 가 free 시도 금지
         },
     });
 
@@ -357,7 +357,7 @@ test "internResolvedModule: .virtual owns_path=false 시 borrow 유지 (#3759)" 
             try testing.expectEqualStrings("\x00zntc:runtime/extends", v.path);
             // path_pool 에 dupe 되어 *다른* slice 반환.
             try testing.expect(v.path.ptr != static_path.ptr);
-            try testing.expect(!v.owns_path);
+            try testing.expect(v.owner == .borrowed);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -378,7 +378,7 @@ test "internResolvedModule: .file owns_path=true 시 원본 free + intern" {
         .path = dup_path,
         .resolve_dir = dup_rd,
         .module_type = .js,
-        .owns_path = true,
+        .owner = .owned,
     } });
 
     switch (result) {
@@ -387,7 +387,7 @@ test "internResolvedModule: .file owns_path=true 시 원본 free + intern" {
             try testing.expect(f.path.ptr != dup_path.ptr);
             try testing.expect(f.resolve_dir != null);
             try testing.expect(f.resolve_dir.?.ptr != dup_rd.ptr);
-            try testing.expect(!f.owns_path);
+            try testing.expect(f.owner == .borrowed);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -405,14 +405,14 @@ test "internResolvedModule: .file owns_path=false 시 borrow 유지" {
     const result = try cache.internResolvedModule(.{ .file = .{
         .path = static_path,
         .module_type = .js,
-        .owns_path = false,
+        .owner = .borrowed,
     } });
 
     switch (result) {
         .file => |f| {
             try testing.expectEqualStrings("/abs/borrowed.ts", f.path);
             try testing.expect(f.path.ptr != static_path.ptr); // intern 됐음
-            try testing.expect(!f.owns_path);
+            try testing.expect(f.owner == .borrowed);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -429,7 +429,7 @@ test "internResolvedModule: .disabled owns_path=true / false" {
     const r1 = try cache.internResolvedModule(.{ .disabled = .{
         .path = dup_path,
         .module_type = .js,
-        .owns_path = true,
+        .owner = .owned,
     } });
     switch (r1) {
         .disabled => |d| try testing.expect(d.path.ptr != dup_path.ptr),
@@ -441,12 +441,12 @@ test "internResolvedModule: .disabled owns_path=true / false" {
     const r2 = try cache.internResolvedModule(.{ .disabled = .{
         .path = static_path,
         .module_type = .js,
-        .owns_path = false,
+        .owner = .borrowed,
     } });
     switch (r2) {
         .disabled => |d| {
             try testing.expectEqualStrings("/disabled/static", d.path);
-            try testing.expect(!d.owns_path);
+            try testing.expect(d.owner == .borrowed);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -462,13 +462,13 @@ test "internResolvedModule: .external owns_path=true / false" {
     const dup_path = try testing.allocator.dupe(u8, "react");
     const r1 = try cache.internResolvedModule(.{ .external = .{
         .path = dup_path,
-        .owns_path = true,
+        .owner = .owned,
     } });
     switch (r1) {
         .external => |e| {
             try testing.expectEqualStrings("react", e.path);
             try testing.expect(e.path.ptr != dup_path.ptr);
-            try testing.expect(!e.owns_path);
+            try testing.expect(e.owner == .borrowed);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -477,12 +477,12 @@ test "internResolvedModule: .external owns_path=true / false" {
     const static_path: []const u8 = "node:fs";
     const r2 = try cache.internResolvedModule(.{ .external = .{
         .path = static_path,
-        .owns_path = false,
+        .owner = .borrowed,
     } });
     switch (r2) {
         .external => |e| {
             try testing.expectEqualStrings("node:fs", e.path);
-            try testing.expect(!e.owns_path);
+            try testing.expect(e.owner == .borrowed);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -499,7 +499,7 @@ test "internResolvedModule: .custom owns_path=true / false (name + path)" {
     const r1 = try cache.internResolvedModule(.{ .custom = .{
         .name = dup_name,
         .path = dup_path,
-        .owns_path = true,
+        .owner = .owned,
     } });
     switch (r1) {
         .custom => |c| {
@@ -507,7 +507,7 @@ test "internResolvedModule: .custom owns_path=true / false (name + path)" {
             try testing.expectEqualStrings("/abs/custom", c.path);
             try testing.expect(c.name.ptr != dup_name.ptr);
             try testing.expect(c.path.ptr != dup_path.ptr);
-            try testing.expect(!c.owns_path);
+            try testing.expect(c.owner == .borrowed);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -516,13 +516,13 @@ test "internResolvedModule: .custom owns_path=true / false (name + path)" {
     const r2 = try cache.internResolvedModule(.{ .custom = .{
         .name = "static-ns",
         .path = "/abs/static",
-        .owns_path = false,
+        .owner = .borrowed,
     } });
     switch (r2) {
         .custom => |c| {
             try testing.expectEqualStrings("static-ns", c.name);
             try testing.expectEqualStrings("/abs/static", c.path);
-            try testing.expect(!c.owns_path);
+            try testing.expect(c.owner == .borrowed);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -540,13 +540,13 @@ test "internResolvedModule: .dataurl owns_payload=true / false" {
     const r1 = try cache.internResolvedModule(.{ .dataurl = .{
         .mime = dup_mime,
         .data = dup_data,
-        .owns_payload = true,
+        .owner = .owned,
     } });
     switch (r1) {
         .dataurl => |du| {
             try testing.expectEqualStrings("image/png", du.mime);
             try testing.expect(du.mime.ptr != dup_mime.ptr); // mime intern
-            try testing.expect(!du.owns_payload);
+            try testing.expect(du.owner == .borrowed);
             // data 는 free 됐으므로 "" 반환 (future RFC 까지 안전 placeholder).
             try testing.expectEqualStrings("", du.data);
         },
@@ -557,13 +557,13 @@ test "internResolvedModule: .dataurl owns_payload=true / false" {
     const r2 = try cache.internResolvedModule(.{ .dataurl = .{
         .mime = "text/plain",
         .data = "literal-data",
-        .owns_payload = false,
+        .owner = .borrowed,
     } });
     switch (r2) {
         .dataurl => |du| {
             try testing.expectEqualStrings("text/plain", du.mime);
             try testing.expectEqualStrings("literal-data", du.data);
-            try testing.expect(!du.owns_payload);
+            try testing.expect(du.owner == .borrowed);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -575,7 +575,7 @@ test "internResolvedModule: .dataurl owns_payload=true / false" {
     const r3 = try cache.internResolvedModule(.{ .dataurl = .{
         .mime = "application/octet-stream",
         .data = borrow_data,
-        .owns_payload = false,
+        .owner = .borrowed,
     } });
     switch (r3) {
         .dataurl => |du| {

--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -398,7 +398,7 @@ fn resolveIdHook(
     if (findModule(short) == null) return null;
     // specifier 는 Module.import_records[i].specifier slice 의 borrow — parse_arena 소유.
     // owns_path=false: bundler 가 free 시도 금지.
-    return .{ .virtual = .{ .path = specifier, .owns_path = false } };
+    return .{ .virtual = .{ .path = specifier, .owner = .borrowed } };
 }
 
 fn loadHook(


### PR DESCRIPTION
## 요약
PR #3766/#3767 deferred 3 — `bool` trap 해소. `.owned/.borrowed` 가 `true/false`
보다 self-documenting.

## 변경
- `plugin.zig` 에 `Owner enum { owned, borrowed }` 신설 + `isOwned()` / `isBorrowed()` helper
- 모든 `owns_path: bool`, `owns_payload: bool` → `owner: Owner`
- 모든 caller (NAPI bridge, runtime_helper, test fixture, internResolvedModule
  내부, internDisabled helper signature) `.owned/.borrowed` 명시
- 6 path-bearing variants (.file/.virtual/.dataurl/.external/.disabled/.custom) 일관

## /code-review max
5-angle 통합 review. P1/P2 5 finding 중 4건 commit 2 에 적용:
- 코멘트 일괄 갱신 (옛 owns_path/owns_payload → Owner)
- `owner == .owned` → `owner.isOwned()` (intent 직접 표현)
- Owner enum doc 위치 분리 (ResolvedModule 사이에서 위로)

Deferred (ROI 낮음):
- `internDisabledOwned` wrapper (3 caller 모두 `.owned` 라 literal noise)

## 효과
- Call site 가독성: `.owns_path = true` (의미 확인 필요) → `.owner = .owned` (직접 읽힘)
- `bool` trap 차단: future `owns_path = !is_borrowed` 같은 의미 역전 실수 불가
- type-level: exhaustive enum — invalid value 불가능
- helper method: `owner.isOwned()` 가 `== .owned` 비교보다 의도 표현

## Test plan
- [x] `zig build test` 전체 통과
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)