### PR TITLE
refactor(napi): plugin_bridge owned ResolvedModule builder 헬퍼 (deferred 4)

### DIFF
--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -687,6 +687,32 @@ fn NapiPluginAdapter(comptime Self: type) type {
             return null;
         }
 
+        /// (deferred 4) plugin response → owned ResolvedModule builder. dupe + `.owned`
+        /// 패턴 한 곳에 모아 drift 방지 — 한 site 만 dupe 빠뜨려도 owner 와 mismatch 면
+        /// bundler 가 borrowed slice 를 free 시도 → panic.
+        fn buildOwnedFile(alloc: std.mem.Allocator, path: []const u8) PluginError!plugin_mod.ResolvedModule {
+            return .{ .file = .{
+                .path = alloc.dupe(u8, path) catch return error.OutOfMemory,
+                .module_type = .js,
+                .owner = .owned,
+            } };
+        }
+
+        fn buildOwnedVirtual(alloc: std.mem.Allocator, path: []const u8) PluginError!plugin_mod.ResolvedModule {
+            return .{ .virtual = .{
+                .path = alloc.dupe(u8, path) catch return error.OutOfMemory,
+                .owner = .owned,
+            } };
+        }
+
+        fn buildOwnedDisabled(alloc: std.mem.Allocator, path: []const u8) PluginError!plugin_mod.ResolvedModule {
+            return .{ .disabled = .{
+                .path = alloc.dupe(u8, path) catch return error.OutOfMemory,
+                .module_type = .js,
+                .owner = .owned,
+            } };
+        }
+
         fn pluginResolveId(
             ctx: ?*anyopaque,
             specifier: []const u8,
@@ -703,12 +729,7 @@ fn NapiPluginAdapter(comptime Self: type) type {
             // disabled: 빈 모듈로 처리. path는 식별용 — resolved_path 또는 specifier 그대로.
             // Metro `{ type: 'empty' }` 매핑, webpack `resolve.fallback: false`와 동등.
             if (resp.is_disabled) {
-                const id_path = resp.resolved_path orelse specifier;
-                return .{ .disabled = .{
-                    .path = alloc.dupe(u8, id_path) catch return error.OutOfMemory,
-                    .module_type = .js,
-                    .owner = .owned, // (retro review) default 와 동일하지만 명시 — default flip 방지.
-                } };
+                return try buildOwnedDisabled(alloc, resp.resolved_path orelse specifier);
             }
 
             if (resp.resolved_path) |path| {
@@ -719,16 +740,9 @@ fn NapiPluginAdapter(comptime Self: type) type {
                 // (#3022 — vue/svelte SFC 의 `\0plugin-vue:...` 및 `?vue&type=style&lang.css`)
                 // 술어는 graph/plugins.zig 와 동일 — 한 곳에서만 정의 (drift 방지).
                 if (graph_plugins_mod.isPluginVirtualId(path)) {
-                    return .{ .virtual = .{
-                        .path = alloc.dupe(u8, path) catch return error.OutOfMemory,
-                        .owner = .owned, // (#3759) bundler 가 intern 후 원본 free.
-                    } };
+                    return try buildOwnedVirtual(alloc, path);
                 }
-                return .{ .file = .{
-                    .path = alloc.dupe(u8, path) catch return error.OutOfMemory,
-                    .module_type = .js,
-                    .owner = .owned, // (retro review) default 와 동일하지만 명시 — default flip 방지.
-                } };
+                return try buildOwnedFile(alloc, path);
             }
             return null;
         }

--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -690,6 +690,15 @@ fn NapiPluginAdapter(comptime Self: type) type {
         /// (deferred 4) plugin response → owned ResolvedModule builder. dupe + `.owned`
         /// 패턴 한 곳에 모아 drift 방지 — 한 site 만 dupe 빠뜨려도 owner 와 mismatch 면
         /// bundler 가 borrowed slice 를 free 시도 → panic.
+        ///
+        /// **Invariants** (review finding):
+        /// - `module_type = .js`: 현재 module_registry.zig:100 `fromExtension(ext)` 가
+        ///   덮어쓰므로 dead — 향후 plugin 제공 module_type 을 trust 하면 caller 명시
+        ///   파라미터로 확장 필요.
+        /// - `.virtual.plugin_data`: null 고정 — Rollup pluginContext meta thread 도입 시
+        ///   시그니처 확장 필요.
+        /// - NAPI 가 향후 `.external/.custom/.dataurl` 변환을 노출하면 동일한 buildOwnedX
+        ///   helper 추가 (inline alloc.dupe + .owner=.owned 패턴 회귀 차단).
         fn buildOwnedFile(alloc: std.mem.Allocator, path: []const u8) PluginError!plugin_mod.ResolvedModule {
             return .{ .file = .{
                 .path = alloc.dupe(u8, path) catch return error.OutOfMemory,


### PR DESCRIPTION
## 요약
PR #3768 deferred 4 — NAPI bridge `pluginResolveId` 가 3개 site (.disabled, .virtual, .file)
모두 `alloc.dupe + .owner = .owned` 패턴 반복. 헬퍼 함수로 묶어 drift 방지.

## Risk 차단
한 site 만 dupe 빠뜨려도 (예: 향후 `.path = path` 만 적고 dupe 누락):
- owner=.owned + non-duped slice → bundler 가 borrowed slice 를 free 시도 → panic
- 또는 dupe 후 owner=.borrowed 잊으면 → leak

헬퍼는 dupe 와 .owner=.owned 를 *atomically* 묶어 partial 변경 불가.

## 변경
- `buildOwnedFile/Virtual/Disabled(alloc, path)` 헬퍼 3개 추가
- `pluginResolveId` 의 3개 inline literal 모두 헬퍼 호출로 치환

## /code-review max
5-angle 통합. P2 minor 3 finding 모두 doc 명시로 cover:
- module_type=.js hardcode 가 dead — 향후 trust 변경 시 caller 명시 파라미터로 확장
- .virtual.plugin_data null 고정 — Rollup meta 도입 시 시그니처 확장 필요
- future .external/.custom/.dataurl 추가 시 buildOwnedX 도 동시 추가 (drift 회귀 차단)

## Test plan
- [x] `zig build test` 전체 통과
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)