### PR TITLE
refactor(bundler): .dataurl.data 별도 arena intern (deferred 5)

### DIFF
--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -218,16 +218,15 @@ pub const ResolvedModule = union(fs.Namespace) {
         owner: Owner,
     },
     /// data: URL — 인라인 base64 asset.
-    /// `owner` (default 없음): mime + data 둘 다 동일 owner 가정. data 가 base64
-    /// 큰 메모리라 path_pool intern 부적합 — `internResolvedModule` 가 mime 만 intern,
-    /// data 는 그대로. `.owned` 면 mime + data 원본 free.
-    /// **invariant** (review finding): `.owned` 시 `mime.ptr != data.ptr` —
-    /// 같은 slice aliasing 시 double-free (debug assert 차단).
-    /// **caller contract** (`.borrowed`): data 의 lifetime 이 *ResolveCache lifetime
-    /// 이상* 이어야 함 — internResolvedModule 후 반환 ResolvedModule 의 data 가 caller
-    /// borrow 그대로 (mime 만 pool 소유). 다른 variant 와 비대칭이라 caller 가 주의 필요.
-    /// 현재 `resolve_imports.zig:349` 가 unreachable 라 production 도달 안 함 — future
-    /// plugin layer 활성화 시 별도 RFC (data 도 별도 arena intern 또는 emitter 즉시 consume).
+    /// `owner` (default 없음): mime + data 둘 다 동일 owner.
+    /// - `.owned`: caller alloc → `internResolvedModule` 가 mime 은 path_pool intern,
+    ///   data 는 별도 `dataurl_arena` 에 dupe + 원본 free
+    /// - `.borrowed`: caller borrow → mime intern, data 도 `dataurl_arena` dupe (lifetime
+    ///   독립, deferred 5 fix). caller 가 mid-build free 해도 cache 반환값 안전.
+    /// **invariant**: `.owned` 시 `mime.ptr != data.ptr` — aliasing 시 double-free (debug
+    /// assert 차단).
+    /// **반환**: 항상 cache-owned (mime 은 path_pool, data 는 dataurl_arena) → caller 는
+    /// borrow only. 다른 variant 와 lifetime 일관.
     dataurl: struct {
         mime: []const u8,
         data: []const u8,

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -225,8 +225,9 @@ pub const ResolvedModule = union(fs.Namespace) {
     ///   독립, deferred 5 fix). caller 가 mid-build free 해도 cache 반환값 안전.
     /// **invariant**: `.owned` 시 `mime.ptr != data.ptr` — aliasing 시 double-free (debug
     /// assert 차단).
-    /// **반환**: 항상 cache-owned (mime 은 path_pool, data 는 dataurl_arena) → caller 는
-    /// borrow only. 다른 variant 와 lifetime 일관.
+    /// **반환 lifetime**: 모두 cache-owned — caller borrow only. valid 까지:
+    /// `ResolveCache.deinit()` 또는 (future) dataurl_arena 자체 reset. caller 가 build
+    /// session 너머 보유하려면 자체 clone 필수.
     dataurl: struct {
         mime: []const u8,
         data: []const u8,

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -155,6 +155,17 @@ pub const ResolveCache = struct {
     /// (deferred 5) `.dataurl.data` 전용 arena. data 가 base64 큰 메모리라 path_pool
     /// (StringHashMap dedup) 부적합 — 별도 arena 로 caller-borrow 일관성 확보 + ""
     /// placeholder 위험 제거. dedup 없음 (data 가 모듈마다 다르고 hash 매칭 거의 없음).
+    ///
+    /// **Memory bound**: monotonic 증가. `IncrementalBundler` 의 N rebuild 마다 ResolveCache
+    /// 재생성 (PR #3756) 으로 자동 reclaim — watch mode 무한 누적 방지.
+    ///
+    /// **Lock order** (ResolveCache 의 모든 mutex):
+    ///   1. `cache_shards[i].mutex` (resolve cache shard)
+    ///   2. `path_pool.shards[i].mutex` (path intern shard)
+    ///   3. `dataurl_arena_mutex` (this)
+    ///   4. `browser_cache_mutex`
+    /// 잠금 시 *반드시 위 순서* — 역순/중첩 잠금 금지 (deadlock). 현재 코드는 각 mutex
+    /// 가 짧은 critical section 안에서만 잠겨 상호배제 영향 없지만 future 추가 시 enforce.
     dataurl_arena: std.heap.ArenaAllocator,
     dataurl_arena_mutex: std.Thread.Mutex = .{},
     external_patterns: []const []const u8,
@@ -866,9 +877,9 @@ pub const ResolveCache = struct {
     /// 원본 path / resolve_dir 는 free, pool 의 interned slice 가리키는 ResolvedModule 반환.
     /// plugin runner 가 alloc 한 결과를 caller-borrow invariant 에 맞춤.
     ///
-    /// **interning 적용 variant**: 모든 variant — Owner discriminator
-    /// 로 borrow vs owned 분기.
-    /// `.dataurl` 는 mime 만 intern (data 는 base64 큰 메모리, pool 부적합).
+    /// **interning 적용 variant**: 모든 variant — Owner discriminator 로 borrow vs owned 분기.
+    /// `.dataurl` 는 mime 은 path_pool, data 는 별도 `dataurl_arena` 에 dupe (deferred 5) —
+    /// data 가 base64 큰 메모리라 dedup 부적합이지만 cache lifetime 동안 valid 보장.
     ///
     /// owner ambiguity 해소 — Owner enum discriminator:
     /// - `.file/.disabled/.external/.custom` default true (native resolver / NAPI bridge dupe)

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -152,6 +152,11 @@ pub const ResolveCache = struct {
     /// PR resolve interning: 모든 resolved path 의 single-source-of-truth pool.
     /// caller 는 *borrow only*, free 안 함. `deinit` 시 일괄 reclaim.
     path_pool: PathInternPool,
+    /// (deferred 5) `.dataurl.data` 전용 arena. data 가 base64 큰 메모리라 path_pool
+    /// (StringHashMap dedup) 부적합 — 별도 arena 로 caller-borrow 일관성 확보 + ""
+    /// placeholder 위험 제거. dedup 없음 (data 가 모듈마다 다르고 hash 매칭 거의 없음).
+    dataurl_arena: std.heap.ArenaAllocator,
+    dataurl_arena_mutex: std.Thread.Mutex = .{},
     external_patterns: []const []const u8,
     platform: Platform,
     packages_external: bool = false,
@@ -361,6 +366,7 @@ pub const ResolveCache = struct {
             .resolver = r,
             .cache_shards = cache_shards,
             .path_pool = PathInternPool.init(allocator),
+            .dataurl_arena = std.heap.ArenaAllocator.init(allocator),
             .external_patterns = external_patterns,
             .platform = platform,
             .packages_external = options.packages_external,
@@ -391,6 +397,8 @@ pub const ResolveCache = struct {
 
         // PR resolve interning: path pool 일괄 reclaim.
         self.path_pool.deinit();
+        // (deferred 5) dataurl.data arena 일괄 reclaim.
+        self.dataurl_arena.deinit();
 
         // browser overrides 캐시 해제
         var bd_it = self.browser_overrides_cache.iterator();
@@ -945,13 +953,18 @@ pub const ResolveCache = struct {
                     .owner = .borrowed,
                 } };
             },
-            // (deferred 2) .dataurl mime 만 intern (짧고 재사용 가능), data 는 그대로 (base64
-            // 큰 메모리, pool 부적합). `.owned` 면 둘 다 free.
-            // 현 resolve_imports.zig:349 unreachable — production 도달 안 함이지만
-            // future plugin layer 활성화 시 owner discipline 보장.
+            // (deferred 2 + 5) .dataurl: mime 은 path_pool intern (짧고 재사용 가능),
+            // data 는 별도 `dataurl_arena` 에 dupe (base64 큰 메모리라 path_pool dedup
+            // 부적합, 그러나 cache lifetime 유지 위해 자체 arena 필요).
+            // - `.owned`: mime + data 원본 free (intern/dupe 후 store 가 owner)
+            // - `.borrowed`: caller-borrow 유지하되, dataurl_arena 에 dupe 해 cache lifetime
+            //   동안 valid 보장 (caller 가 그 사이 free 해도 안전).
+            //
+            // ★ 일관성: 모든 variant 가 반환 시 cache-owned slice → caller 가 borrow
+            //   하기만 하면 됨. 이전 PR (#3767) 의 "" placeholder 위험 제거.
             //
             // (review finding) `.custom` 처럼 mime.ptr == data.ptr aliasing 시 double-free
-            // → debug assert 로 차단. errdefer 도 같은 두 free 라 동일 위험.
+            // → debug assert 로 차단.
             .dataurl => |du| blk: {
                 if (du.owner.isOwned()) std.debug.assert(du.mime.ptr != du.data.ptr);
                 const interned_mime = pool: {
@@ -961,19 +974,23 @@ pub const ResolveCache = struct {
                     };
                     break :pool try self.path_pool.intern(du.mime);
                 };
+                const interned_data = data_blk: {
+                    errdefer if (du.owner.isOwned()) {
+                        self.allocator.free(du.mime);
+                        self.allocator.free(du.data);
+                    };
+                    self.dataurl_arena_mutex.lock();
+                    defer self.dataurl_arena_mutex.unlock();
+                    break :data_blk try self.dataurl_arena.allocator().dupe(u8, du.data);
+                };
                 if (du.owner.isOwned()) {
                     self.allocator.free(du.mime);
-                    // data 는 caller 가 borrow 시점 결정 — 본 PR 은 intern 안 함. `.owned`
-                    // 면 원본도 free (caller 가 임시 alloc 했다는 의미).
                     self.allocator.free(du.data);
                 }
                 break :blk .{
                     .dataurl = .{
                         .mime = interned_mime,
-                        // data 는 caller 가 free 했으므로 dangling 슬라이스 반환 안 됨 —
-                        // future RFC: data 도 path_pool 외 별도 arena 로 intern 또는 emitter
-                        // 가 즉시 consume. 현재 unreachable 이라 안전.
-                        .data = if (du.owner.isOwned()) "" else du.data,
+                        .data = interned_data, // cache-owned (dataurl_arena, dedup 없음)
                         .owner = .borrowed,
                     },
                 };

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -572,13 +572,17 @@ test "internResolvedModule: .dataurl .owned / .borrowed 모두 cache-owned data 
 
     // .borrowed + heap-alloc — caller borrow 라도 data 는 *cache 가 dupe* 해 lifetime
     // 독립. caller 가 그 사이 free 해도 cache 반환값 안전 (이전 PR #3767 보다 더 강화).
+    //
+    // (review finding) 실제 lifetime 독립을 증명: dupe 직후 borrow_data 를 *즉시* free
+    // 한 다음 du.data 를 사용. dupe 누락 회귀 시 testing.allocator 가 freed read 잡아냄
+    // (이전엔 defer 라 test 종료 시점에만 free → false-positive).
     const borrow_data = try testing.allocator.dupe(u8, "heap-borrow-data");
-    defer testing.allocator.free(borrow_data);
     const r3 = try cache.internResolvedModule(.{ .dataurl = .{
         .mime = "application/octet-stream",
         .data = borrow_data,
         .owner = .borrowed,
     } });
+    testing.allocator.free(borrow_data); // 즉시 free — du.data 가 진짜 독립인지 확인
     switch (r3) {
         .dataurl => |du| {
             try testing.expect(du.data.ptr != borrow_data.ptr); // arena dupe (lifetime 독립)

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -528,13 +528,13 @@ test "internResolvedModule: .custom owns_path=true / false (name + path)" {
     }
 }
 
-// .dataurl owns_payload — mime 만 intern, data 는 caller lifecycle (deferred 2).
-test "internResolvedModule: .dataurl owns_payload=true / false" {
+// .dataurl Owner — mime 은 path_pool intern, data 는 dataurl_arena dupe (deferred 5).
+test "internResolvedModule: .dataurl .owned / .borrowed 모두 cache-owned data 반환" {
     const testing = std.testing;
     var cache = ResolveCache.init(testing.allocator, .{});
     defer cache.deinit();
 
-    // owns_payload=true: caller alloc 한 mime + data 둘 다 free, mime 만 intern.
+    // .owned: caller alloc → 원본 free, mime/data 모두 cache 가 자체 owner.
     const dup_mime = try testing.allocator.dupe(u8, "image/png");
     const dup_data = try testing.allocator.dupe(u8, "BASE64DATA");
     const r1 = try cache.internResolvedModule(.{ .dataurl = .{
@@ -545,15 +545,17 @@ test "internResolvedModule: .dataurl owns_payload=true / false" {
     switch (r1) {
         .dataurl => |du| {
             try testing.expectEqualStrings("image/png", du.mime);
-            try testing.expect(du.mime.ptr != dup_mime.ptr); // mime intern
-            try testing.expect(du.owner == .borrowed);
-            // data 는 free 됐으므로 "" 반환 (future RFC 까지 안전 placeholder).
-            try testing.expectEqualStrings("", du.data);
+            try testing.expect(du.mime.ptr != dup_mime.ptr); // mime intern (path_pool)
+            try testing.expect(du.owner == .borrowed); // 반환은 항상 cache-borrow
+            // (deferred 5 fix) data 는 더 이상 "" placeholder 가 아닌 *실제* data — cache
+            // 의 dataurl_arena 에 dupe 됨.
+            try testing.expectEqualStrings("BASE64DATA", du.data);
+            try testing.expect(du.data.ptr != dup_data.ptr); // 별도 arena dupe
         },
         else => return error.TestUnexpectedResult,
     }
 
-    // owns_payload=false: static literal — bundler 가 free 안 함.
+    // .borrowed: static literal — 원본 free 안 함. data 는 dataurl_arena dupe.
     const r2 = try cache.internResolvedModule(.{ .dataurl = .{
         .mime = "text/plain",
         .data = "literal-data",
@@ -568,8 +570,8 @@ test "internResolvedModule: .dataurl owns_payload=true / false" {
         else => return error.TestUnexpectedResult,
     }
 
-    // owns_payload=false + heap-alloc borrow case (review finding) — caller 가 alloc
-    // 한 data 슬라이스의 ptr identity 가 보존되어야 함 (intern 회귀 검출).
+    // .borrowed + heap-alloc — caller borrow 라도 data 는 *cache 가 dupe* 해 lifetime
+    // 독립. caller 가 그 사이 free 해도 cache 반환값 안전 (이전 PR #3767 보다 더 강화).
     const borrow_data = try testing.allocator.dupe(u8, "heap-borrow-data");
     defer testing.allocator.free(borrow_data);
     const r3 = try cache.internResolvedModule(.{ .dataurl = .{
@@ -579,7 +581,8 @@ test "internResolvedModule: .dataurl owns_payload=true / false" {
     } });
     switch (r3) {
         .dataurl => |du| {
-            try testing.expect(du.data.ptr == borrow_data.ptr); // borrow 무손상
+            try testing.expect(du.data.ptr != borrow_data.ptr); // arena dupe (lifetime 독립)
+            try testing.expectEqualStrings("heap-borrow-data", du.data);
         },
         else => return error.TestUnexpectedResult,
     }


### PR DESCRIPTION
## 요약
PR #3768/#3769 deferred 5 — `.dataurl.data` placeholder `\"\"` 위험 해소.

## Root cause
PR #3767 에서 `.owned` 시 data 원본 free 후 placeholder `\"\"` 반환. future emit
caller 활성화 시 silent corruption 위험.

## Fix (옵션 A)
ResolveCache 에 별도 `dataurl_arena: ArenaAllocator` + mutex 추가:
- `.owned`: mime path_pool intern + data dataurl_arena dupe + 원본 mime/data free
- `.borrowed`: mime intern + data 도 arena dupe (lifetime 독립 — caller mid-build free 안전)
- 반환: 항상 cache-owned (mime=path_pool, data=dataurl_arena)
- dedup 없음 (data 모듈마다 다르고 hash 매칭 거의 없음)

## 효과
- placeholder `\"\"` 제거 — silent corruption 위험 해소
- 모든 variant 의 반환값이 cache-owned 로 일관
- caller mid-build free 안전성 강화

## /code-review max
5 finding 모두 commit 2 에 적용:
- internResolvedModule header doc 갱신 (stale `\"data 는 ... pool 부적합\"`)
- r3 test false-positive 수정 (defer → 즉시 free 로 lifetime 독립 실제 검증)
- dataurl_arena monotonic growth — watch reset (#3756) 으로 자동 bound 명시
- ResolveCache 의 4종 mutex lock-order 명시
- caller-contract: valid 시점 + build session 너머 보관 시 self-clone 필요 명시

## Memory bound
dataurl_arena 는 monotonic 이지만 IncrementalBundler 의 N rebuild 마다 ResolveCache
재생성 (PR #3756) 으로 자동 reclaim — watch mode 무한 누적 방지.

## Test plan
- [x] `zig build test` 전체 통과
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)