### PR TITLE
fix(bundler): resolve_imports unreachable → explicit panic (deferred 6)

### DIFF
--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -179,7 +179,14 @@ pub fn applyContextDepResults(self: *ModuleGraph, mod_idx: usize) !void {
             },
             // require.context 의 disabled / virtual 등 variant — path_pool borrow only.
             .disabled => {},
-            .virtual, .dataurl, .external, .custom => unreachable,
+            // (deferred 6) future plugin layer 가 이들 variant 를 require.context 결과로
+            // 반환할 가능성은 현재 없음 (resolver 는 .file/.disabled 만 emit). 그러나
+            // unreachable 는 release build 에서 UB → explicit panic 으로 의미 있는
+            // diagnostic 제공. 활성화 시 별도 RFC 필요.
+            .virtual, .dataurl, .external, .custom => std.debug.panic(
+                "require.context resolver returned unsupported variant — only .file/.disabled supported here (got {s})",
+                .{@tagName(m)},
+            ),
         };
     }
 }
@@ -347,7 +354,14 @@ pub fn applyResolveResult(
                 try recordResolvedDep(self, mod_index, mod_idx, rec_i, dep_idx, record.kind);
                 if (request_changed) try resolveDeferredRequestedImportsIfReady(self, dep_idx);
             },
-            .dataurl, .external, .custom => unreachable,
+            // (deferred 6) `.external` 은 phantom external 경로 (line 354 의 else 분기) 가
+            // 별도로 처리하지만, plugin 이 resolveId 에서 직접 `.external` 반환하는 경로는
+            // 아직 미설계. `.dataurl` / `.custom` 도 동일 — production 도달 시 별도 RFC 후
+            // 명시적 활성화. 그 전까지 release build 의 silent UB 방지 위해 explicit panic.
+            .dataurl, .external, .custom => std.debug.panic(
+                "resolved variant not yet wired into resolve_imports — plugin returned unsupported variant for specifier '{s}' (got {s})",
+                .{ record.specifier, @tagName(m) },
+            ),
         }
     } else {
         // external — phantom Module 로 graph 에 등록 + 양방향 link.

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -183,6 +183,8 @@ pub fn applyContextDepResults(self: *ModuleGraph, mod_idx: usize) !void {
             // 반환할 가능성은 현재 없음 (resolver 는 .file/.disabled 만 emit). 그러나
             // unreachable 는 release build 에서 UB → explicit panic 으로 의미 있는
             // diagnostic 제공. 활성화 시 별도 RFC 필요.
+            // (review note) site 2 (line ~357) 와 달리 require.context 는 `.virtual` 도
+            // 미지원 — `.virtual` 까지 panic arm 에 포함.
             .virtual, .dataurl, .external, .custom => std.debug.panic(
                 "require.context resolver returned unsupported variant — only .file/.disabled supported here (got {s})",
                 .{@tagName(m)},


### PR DESCRIPTION
## 요약
PR #3770 deferred 6 — `resolve_imports.zig` 의 두 곳에서 `.dataurl/.external/.custom => unreachable` 가 release build 에서 silent UB (SIGILL).

## Fix
`std.debug.panic` 으로 변경 — variant name + (가능한 경우) specifier 까지 message 포함:
- site 1 (require.context 결과): `.virtual` 도 panic 포함 (require.context 는 .file/.disabled 만)
- site 2 (일반 plugin resolveId 결과): `.virtual` 은 별도 처리, `.dataurl/.external/.custom` 만 panic

## 효과
- release build 의 silent UB → meaningful panic message
- future plugin layer 가 새 variant 반환 시 stack trace + variant 명 + specifier 즉시 확인
- 실제 활성화는 별도 RFC

## /code-review max
3 finding 모두 low/info (release UB 차단 목표 자체엔 결함 없음):
- panic message 의 specifier 가 user-controlled (CI log only 단계라 risk 낮음)
- 두 site message 차이는 의도 (가용 context 다름)
- variant set 차이는 의도 — commit 2 에 코멘트 명시

## Test plan
- [x] `zig build test` 전체 통과 (production 도달 없음)
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)