### PR TITLE
docs: ResolveCache + Owner discipline 시리즈 반영 (D104)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -883,5 +883,24 @@
   - `parseFunctionTypeParamList` 호출자 (Flow function type 4 path) — 동일.
 - **codegen plugin (#2462) 효과**: `extractCommandParams` 의 source-text 기반 depth-aware paren split fallback 제거 가능 → AST 기반으로 단순화.
 
+### D104: ResolveCache + ResolvedModule owner discipline (2026-05-25)
+- **결정**: `ResolvedModule` 의 모든 path-bearing variant 가 `owner: Owner { owned, borrowed }` discriminator 보유 — default 없음, caller 명시 강제. `PathRef` 3-variant (`.interned`/`.specifier`/`.owned`) 로 slice lifetime 을 type system 으로 표명. `internResolvedModule` 가 모든 plugin 결과 path 를 `path_pool` (mime) / `dataurl_arena` (data) 로 cache-owned slice 변환 — 반환값은 항상 caller borrow only.
+- **이유**:
+  1. **silent leak / panic 차단**: bool 또는 default 가 있으면 caller 가 owner 명시 누락 시 silent leak (free 안 함) 또는 panic (static literal free). enum + no-default 로 compile-time 강제.
+  2. **NAPI plugin path leak 해소**: `internResolvedModule` 의 `.virtual` 등 pass-through 가 plugin alloc 한 path 를 free 하지 않아 매 build 마다 leak. owner discriminator + intern 으로 일관 해소.
+  3. **OOM rollback 안전성**: `putModule` 의 partial-clone rollback 이 shared backing 의 `.owned` slice 를 double-free 하던 버그를 `rollbackOomCloned` 의 `.specifier=""` sanitize 로 차단. 모든 path-bearing variant 에 OOM injection 회귀 가드 추가.
+  4. **PathInternPool 16-shard**: resolve hot path 의 mutex 경합 해소 — 5051 module monorepo 에서 resolve 단계 -31% (969→671ms). `cache_shards` 와 동일 N, hash low-bit mask 로 shard 선택.
+  5. **Watch mode RSS bound**: `IncrementalBundler` 가 N-rebuild 마다 ResolveCache 재생성 — `path_pool.arena` / `dataurl_arena` 의 monotonic growth 차단.
+- **trade-off**:
+  - default 없음 = caller 추가 명시 부담 (모든 ResolvedModule literal 에 `.owner = .owned/.borrowed`). 비용보다 안전성 이득 큼 (silent UB > verbose 명시).
+  - `dataurl_arena` 가 dedup 없음 (base64 큰 데이터 hash 매칭 거의 없음) — IncrementalBundler reset 으로 bound 보장.
+  - 모든 mutex (cache_shard / path_pool shard / dataurl_arena / browser_cache) 의 lock order 명시 (deadlock 방지).
+- **영향 범위**:
+  - `internResolvedModule` (resolve_cache.zig:873) — 모든 variant 분기 추가
+  - NAPI bridge `pluginResolveId` (packages/core/src/napi/plugin_bridge.zig) — `buildOwnedFile/Virtual/Disabled` 헬퍼로 dupe+owner atomic 보장
+  - `runtime_helper_modules.resolveIdHook` — borrow specifier → `.owner = .borrowed`
+  - `clonePathRefIfNeeded` (module_store.zig) — `.interned` 만 store-owned 로 clone (others pass-through)
+  - resolve_imports.zig:182/350 `unreachable` → `std.debug.panic` (release UB → meaningful diagnostic)
+
 ### Phase 6 (Advanced) 미결정 사항
 - 개발 서버 고급 기능 (증분 재빌드, 프레임워크 통합)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -143,6 +143,27 @@
 - **Plugin API 확장** — `onResolve` 훅이 `{ disabled: true }` 반환 허용 (49955634)
 - **BuildOptions 보완** — `strictExecutionOrder`, `scopeHoist`, `workletTransform` 추가 (eb909fcc)
 
+## ✅ 최근 추가 (2026-05 resolve safety + perf)
+
+ResolveCache + plugin resolve 경로 전반의 type-safety 강화 + perf 개선 시리즈.
+
+**성능** (5051-module monorepo, ReleaseFast 실측):
+- resolve 단계 -31% (969ms → 671ms) — PathInternPool 16-shard 로 mutex 경합 해소
+- wall p95 -4%
+- watch mode 무한 RSS 누적 방지 (N-rebuild 마다 ResolveCache 자동 reclaim)
+
+**Correctness**:
+- `putModule` OOM rollback 시 shared backing 더블 free 차단
+- plugin 이 alloc 한 path 의 leak 차단 (NAPI bridge 등 모든 진입점)
+- `had_existing` 분기 + OOM 조합의 dangling map entry 차단
+
+**Type 안전성** (compile-time):
+- `Owner enum { owned, borrowed }` — 모든 path-bearing variant 가 명시 강제 (default 없음). bool trap 차단.
+- `PathRef` 3-variant (`.interned`/`.specifier`/`.owned`) — slice lifetime invariant 를 type system 으로 표명.
+- `.custom` name+path aliasing → debug assert.
+- `.dataurl.data` 도 cache-owned (별도 arena, base64 큰 메모리 대응).
+- 모든 path-bearing variant 의 OOM errdefer 경로 회귀 가드 (FailingAllocator 주입).
+
 ## ✅ 최근 추가 (2026-04 transformer / bundler)
 
 - **Runtime helper virtual module** (#1961, PR 1a~1h, 2026-04-26) — splitting + single-bundle 양쪽에서 helper 를 가상 모듈로 모델링 (`__esm`, `__commonJS` 등). HelperBit enum 화 (#1982) 등 후속 정리 5건.


### PR DESCRIPTION
## 요약
PR #3754~#3772 (18 PR) 결과를 docs/ROADMAP.md + docs/DECISIONS.md 에 반영.

## 변경
- **ROADMAP**: '2026-05 resolve safety + perf' 섹션 신설 — 성능 측정값, correctness fix, type 안전성 강화 요약
- **DECISIONS D104**: ResolveCache + ResolvedModule owner discipline — 결정 배경, 이유 (5가지), trade-off, 영향 범위

## 효과
- 18 PR 시리즈의 결과가 향후 contributor 가 한눈에 확인 가능
- D104 가 owner discriminator + PathInternPool 16-shard + watch RSS bound 등 모든 결정 cluster

## Test plan
- [x] doc-only 변경 (코드 영향 없음)
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)