### PR TITLE
chore(deps): bump mimalloc v3.2.8 → v3.3.2

### DIFF
--- a/src/mimalloc.zig
+++ b/src/mimalloc.zig
@@ -1,6 +1,6 @@
 //! mimalloc Zig Allocator 래퍼
 //!
-//! Microsoft mimalloc (v3.2.8)을 Zig의 std.mem.Allocator 인터페이스로 래핑한다.
+//! Microsoft mimalloc (v3.3.2)을 Zig의 std.mem.Allocator 인터페이스로 래핑한다.
 //! ReleaseFast/ReleaseSafe에서 GPA/c_allocator 대신 사용하여
 //! 스레드별 힙 격리, 페이지 캐싱, 슬랩 할당의 이점을 얻는다.
 


### PR DESCRIPTION
## Summary

- `vendor/mimalloc` submodule 을 microsoft/mimalloc **v3.2.8 → v3.3.2** (2026-04-29) 로 갱신
- `src/mimalloc.zig` doc 코멘트 버전 표기 한 줄 동기화
- 우리 사용 면적(API 5개 + static.c entry + CommonCrypto include)에 영향 없음

## v3.3 시리즈 주요 변경

- TLS/arena 안정성 버그픽스 (TLS re-init macOS, win32 TLS detach, slice_index check, heap allocation 실패 경로 leak fix)
- macOS i386 빌드 fix
- arenas 의 numa node 로컬 할당 옵션 추가 (default off, opt-in)
- emscripten 빌드 호환 개선 (`sched_yield` 로 대체)
- `MI_MALLOC_VERSION` 매크로 포맷 변경 `3208 → 30302` (major+2digit minor+2digit patch). 우리는 이 매크로를 직접 참조하지 않으므로 무영향

## 영향 면적 점검

| 항목 | 결과 |
|---|---|
| `src/static.c` (build entry) | 변경 0 — `build.zig:71` 의 single source compile 분기 그대로 |
| 우리가 쓰는 API 5개 (`mi_malloc` / `mi_malloc_aligned` / `mi_realloc` / `mi_free` / `mi_usable_size`) | 시그니처 동일 — `src/mimalloc.zig` 래퍼 무수정 |
| macOS `CommonCrypto` include | `src/prim/unix/prim.c:869-870` 잔존 → `build.zig:80-87` SDKROOT 보강 분기 (PR #3632 fix) 유효 |
| 빌드 플래그 | `MI_OVERRIDE=0` / `MI_SKIP_COLLECT_ON_EXIT=1` / `NDEBUG` 3.x 내내 안정, 그대로 유지 |
| Debug/Release 분기 | `src/main.zig:273-279` 의 `is_debug ? GPA : mimalloc` 분기 무영향 |

## Test plan

- [x] `zig build` (Debug, GPA 경로) 통과
- [x] `zig build -Doptimize=ReleaseFast` (mimalloc 활성 경로) 통과
- [x] 스모크: `zntc <file.ts>` transpile + `zntc --bundle` 정상 동작
- [ ] CI 9-플랫폼 크로스 빌드 매트릭스 (Linux/macOS/Windows × x64/arm64 등) 통과 확인 — PR 후 GH Actions 결과 대기
- [ ] (선택) `bench --phase=all` 로 warm run A/B (v3.3 의 TLS/arena 개선이 워크로드에 어떤 영향 주는지). 필요 시 별도 측정 코멘트로

## Notes

- Debug 빌드는 여전히 Zig `GeneralPurposeAllocator` 사용 (leak/double-free 감지 유지). 이 PR 은 ReleaseFast/ReleaseSafe 경로의 mimalloc 만 갱신
- v3.2.8 자체가 readme 상 *"rc3, please report any issues"* 였고, v3.3.2 가 현 stable. RC → stable 승격으로 보면 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)