### PR TITLE
perf(bundler): R2 (#3745) RealpathCache 16-shard mutex

### DIFF
--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -162,8 +162,9 @@ pub const ResolveCache = struct {
     /// **Lock order** (ResolveCache 의 모든 mutex):
     ///   1. `cache_shards[i].mutex` (resolve cache shard)
     ///   2. `path_pool.shards[i].mutex` (path intern shard)
-    ///   3. `dataurl_arena_mutex` (this)
-    ///   4. `browser_cache_mutex`
+    ///   3. `realpath_cache.shards[i].mutex` (realpath dir cache shard) — R2 (#3745)
+    ///   4. `dataurl_arena_mutex` (this)
+    ///   5. `browser_cache_mutex`
     /// 잠금 시 *반드시 위 순서* — 역순/중첩 잠금 금지 (deadlock). 현재 코드는 각 mutex
     /// 가 짧은 critical section 안에서만 잠겨 상호배제 영향 없지만 future 추가 시 enforce.
     dataurl_arena: std.heap.ArenaAllocator,

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -244,6 +244,10 @@ pub const RealpathCache = struct {
 
     comptime {
         std.debug.assert(@popCount(@as(u32, num_shards)) == 1);
+        // (review) cross-pool drift 방지 — PathInternPool / cache_shards 와 같은 N (16).
+        // resolve_cache 가 cyclic import 라 직접 비교 못해 hard-coded 16 assert. 변경 시
+        // resolve_cache.zig 의 `num_resolve_cache_shards` + `PathInternPool.num_shards` 도 동시 변경 필요.
+        std.debug.assert(num_shards == 16);
     }
 
     shards: [num_shards]Shard,

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -233,26 +233,54 @@ pub const DirEntryCache = struct {
 /// 뒤 basename join 이라 따라가지 못한다. ZNTC 가 import 하는 일반 source/dep
 /// 경로는 이 패턴이 거의 없어 영향 없음. preserve_symlinks=true 면 어차피 cache
 /// 우회 (기존 동작 동일).
+/// dir-level realpath cache. 같은 dir 의 여러 path 가 자주 호출되므로 dir 만 realpath
+/// 한 후 basename join (R2 #3745 — symlink-heavy workspace 에서 syscall 80%+ 감소).
+///
+/// thread-safety (R2): 16-shard. `hash(dir) & (num_shards - 1)` 로 shard 선택 —
+/// `PathInternPool` / `cacheShardFor` 와 동일 방식. resolve hot path 에서 worker
+/// 들이 single mutex 에 직렬화되던 걸 분산.
 pub const RealpathCache = struct {
-    /// dir 절대 경로 → realpath(dir). value 는 allocator 소유.
-    cache: std.StringHashMap([]const u8),
-    mutex: std.Thread.Mutex = .{},
+    pub const num_shards = 16;
+
+    comptime {
+        std.debug.assert(@popCount(@as(u32, num_shards)) == 1);
+    }
+
+    shards: [num_shards]Shard,
     allocator: std.mem.Allocator,
 
+    const Shard = struct {
+        cache: std.StringHashMap([]const u8),
+        mutex: std.Thread.Mutex = .{},
+    };
+
     pub fn init(allocator: std.mem.Allocator) RealpathCache {
-        return .{
-            .cache = std.StringHashMap([]const u8).init(allocator),
+        var rc: RealpathCache = .{
+            .shards = undefined,
             .allocator = allocator,
         };
+        for (&rc.shards) |*s| {
+            s.* = .{ .cache = std.StringHashMap([]const u8).init(allocator) };
+        }
+        return rc;
     }
 
     pub fn deinit(self: *RealpathCache) void {
-        var it = self.cache.iterator();
-        while (it.next()) |entry| {
-            self.allocator.free(entry.key_ptr.*);
-            self.allocator.free(entry.value_ptr.*);
+        for (&self.shards) |*s| {
+            var it = s.cache.iterator();
+            while (it.next()) |entry| {
+                self.allocator.free(entry.key_ptr.*);
+                self.allocator.free(entry.value_ptr.*);
+            }
+            s.cache.deinit();
         }
-        self.cache.deinit();
+    }
+
+    /// dir → shard. `PathInternPool.shardFor` 와 동일 패턴.
+    inline fn shardFor(self: *RealpathCache, dir: []const u8) *Shard {
+        const h = std.hash_map.hashString(dir);
+        const idx: usize = @intCast(h & (num_shards - 1));
+        return &self.shards[idx];
     }
 
     /// path 의 realpath 를 owned slice 로 반환.
@@ -263,19 +291,20 @@ pub const RealpathCache = struct {
             return self.allocator.dupe(u8, path);
         };
         const basename = std.fs.path.basename(path);
+        const shard = self.shardFor(dir);
 
-        self.mutex.lock();
-        const cached_dir: ?[]const u8 = if (self.cache.get(dir)) |v| v else null;
-        self.mutex.unlock();
+        shard.mutex.lock();
+        const cached_dir: ?[]const u8 = if (shard.cache.get(dir)) |v| v else null;
+        shard.mutex.unlock();
 
         const resolved_dir = cached_dir orelse blk: {
             const new_dir = fs.realpath(self.allocator, dir) catch
                 self.allocator.dupe(u8, dir) catch return error.OutOfMemory;
 
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            shard.mutex.lock();
+            defer shard.mutex.unlock();
             // race: 다른 thread 가 먼저 넣었을 수 있음.
-            if (self.cache.get(dir)) |existing| {
+            if (shard.cache.get(dir)) |existing| {
                 self.allocator.free(new_dir);
                 break :blk existing;
             }
@@ -283,7 +312,7 @@ pub const RealpathCache = struct {
                 self.allocator.free(new_dir);
                 return error.OutOfMemory;
             };
-            self.cache.put(key, new_dir) catch {
+            shard.cache.put(key, new_dir) catch {
                 self.allocator.free(key);
                 self.allocator.free(new_dir);
                 return error.OutOfMemory;

--- a/tests/benchmark/bench.ts
+++ b/tests/benchmark/bench.ts
@@ -15,7 +15,7 @@ import { computeMetricStats, formatMetric, type MetricStats } from './stats';
 const ROOT = resolve(__dirname, '../..');
 const ZNTC_BIN = join(ROOT, 'zig-out/bin/zntc');
 const BIN = join(ROOT, 'node_modules/.bin');
-const ITERATIONS = 5;
+const ITERATIONS = Number(process.env.BENCH_ITERATIONS ?? '5');
 
 // ============================================================
 // CLI 바이너리 경로


### PR DESCRIPTION
## 요약
이슈 #3745 R2 — resolve.realpath self time (effect-ts 177ms) 의 mutex 경합 해소.
PR #3754 의 PathInternPool 16-shard 패턴을 RealpathCache 에도 적용.

## 변경
- `RealpathCache` 의 single `mutex` → `shards: [16]Shard` (각 자체 cache + mutex)
- `shardFor(dir)` — `hash(dir) & (num_shards - 1)` (PathInternPool / cacheShardFor 와 동일)
- 같은 dir 은 항상 같은 shard → uniqueness 보장
- API signature 동일 (init/deinit/resolve) — caller 영향 0

## 측정 (monorepo 30pkg × 50mod = 1531 modules, ReleaseFast)

| 단계 | baseline (single) | R2 (16-shard) | Δ |
|------|------------------|---------------|---|
| Wall median | 79.1ms | 65.9ms | **-17%** |
| Wall trim mean | 102ms | 69.0ms | **-32%** |
| Wall p95 | 255ms | 127ms | **-50%** |
| Profile total median | 1135ms | 998ms | -12% |
| resolve cumulative | 689ms | 535ms | -22% |

## /code-review max
P2 fix commit 2 에 적용:
- cross-pool N drift assert (`assert(num_shards == 16)` — cyclic import 회피 위해 hard-coded)
- resolve_cache.zig lock-order doc 에 realpath_cache.shards 추가

Deferred (별도 RFC):
- Shard struct false sharing (PathInternPool 도 동일 패턴, 묶어서 처리)
- singleflight (cold start 동시 realpath syscall 중복)

#3745 R2 끝. 남은 backlog (C1 codegen, T1 transform sub-cat) 별도 PR.

## Test plan
- [x] `zig build test` 전체 통과
- [x] ReleaseFast 빌드 OK
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)