### PR TITLE
perf(profile): codegen sub-phase 측정 hook (#3745 C1 — 도구 보강)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -153,22 +153,33 @@ pub const Codegen = struct {
 
     /// AST를 JS 문자열로 출력한다.
     pub fn generate(self: *Codegen, root: NodeIndex) ![]const u8 {
-        var scope = @import("../profile.zig").begin(.codegen);
+        const profile = @import("../profile.zig");
+        var scope = profile.begin(.codegen);
         defer scope.end();
 
         if (self.options.assert_no_raw_private_syntax) {
             std.debug.assert(!hasRawPrivateSyntax(self.ast, root));
         }
 
+        // (C1 도구 보강) sub-phase 측정 — generate() 의 어느 단계가 hot 한지 분리.
+        var setup_scope = profile.begin(.codegen_setup);
         // 출력 크기는 보통 소스 크기와 비슷 → 사전 할당
         try self.buf.ensureTotalCapacity(self.allocator, self.ast.source.len);
 
         // namespace var 중복 제거: top-level 선언 이름 사전 수집
         self.collectTopLevelDeclNames(root);
+        setup_scope.end();
         // function map: program 진입 시 <global> frame
         if (self.fn_map_builder != null) try self.fnMapEnter("<global>");
-        try self.emitNode(root);
+        {
+            var emit_scope = profile.begin(.codegen_emit);
+            defer emit_scope.end();
+            try self.emitNode(root);
+        }
         if (self.fn_map_builder != null) try self.fnMapExit();
+
+        var finalize_scope = profile.begin(.codegen_finalize);
+        defer finalize_scope.end();
 
         // keepNames: 수집된 entries를 코드 끝에 __name() 호출로 append (복사 없음)
         // #1621: minify 시 __name → $nm 축약.

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -161,22 +161,25 @@ pub const Codegen = struct {
             std.debug.assert(!hasRawPrivateSyntax(self.ast, root));
         }
 
-        // (C1 도구 보강) sub-phase 측정 — generate() 의 어느 단계가 hot 한지 분리.
-        var setup_scope = profile.begin(.codegen_setup);
-        // 출력 크기는 보통 소스 크기와 비슷 → 사전 할당
-        try self.buf.ensureTotalCapacity(self.allocator, self.ast.source.len);
-
-        // namespace var 중복 제거: top-level 선언 이름 사전 수집
-        self.collectTopLevelDeclNames(root);
-        setup_scope.end();
-        // function map: program 진입 시 <global> frame
-        if (self.fn_map_builder != null) try self.fnMapEnter("<global>");
+        // (C1 도구 보강 + review fix) sub-phase 측정 — review P1: defer 패턴으로 OOM 시
+        // scope leak 방지. fnMap enter/exit 는 emit_scope 안으로 옮겨 sub-phase 합 정확화.
+        {
+            var setup_scope = profile.begin(.codegen_setup);
+            defer setup_scope.end();
+            // 출력 크기는 보통 소스 크기와 비슷 → 사전 할당
+            try self.buf.ensureTotalCapacity(self.allocator, self.ast.source.len);
+            // namespace var 중복 제거: top-level 선언 이름 사전 수집
+            self.collectTopLevelDeclNames(root);
+        }
         {
             var emit_scope = profile.begin(.codegen_emit);
             defer emit_scope.end();
+            // function map: program 진입 시 <global> frame — sub-phase 합 정확성 위해
+            // emit_scope 안에 포함 (review P2).
+            if (self.fn_map_builder != null) try self.fnMapEnter("<global>");
             try self.emitNode(root);
+            if (self.fn_map_builder != null) try self.fnMapExit();
         }
-        if (self.fn_map_builder != null) try self.fnMapExit();
 
         var finalize_scope = profile.begin(.codegen_finalize);
         defer finalize_scope.end();

--- a/src/codegen/debug_metadata.zig
+++ b/src/codegen/debug_metadata.zig
@@ -32,6 +32,10 @@ pub fn generateSourceMapWithFunctionMap(self: anytype, output_file: []const u8) 
 
 pub fn addSourceMapping(self: anytype, span: Span) !void {
     if (self.sm_builder) |*sm| {
+        // (C1 도구 보강) sourcemap mapping 누적 측정. sm_builder 가 있을 때만 측정 —
+        // sourcemap 비활성 빌드는 overhead 0.
+        var scope = @import("../profile.zig").begin(.codegen_sm_add);
+        defer scope.end();
         // 합성 노드 (string_table 참조) 와 zero-width span 은 발행 안 함 (zero span 도 포함).
         // 호출자가 emitter 첫 줄에서 부담 없이 호출하도록 가드 일원화.
         if (span.start & Ast.STRING_TABLE_BIT != 0) return;

--- a/src/codegen/debug_metadata.zig
+++ b/src/codegen/debug_metadata.zig
@@ -32,14 +32,15 @@ pub fn generateSourceMapWithFunctionMap(self: anytype, output_file: []const u8) 
 
 pub fn addSourceMapping(self: anytype, span: Span) !void {
     if (self.sm_builder) |*sm| {
-        // (C1 도구 보강) sourcemap mapping 누적 측정. sm_builder 가 있을 때만 측정 —
-        // sourcemap 비활성 빌드는 overhead 0.
-        var scope = @import("../profile.zig").begin(.codegen_sm_add);
-        defer scope.end();
         // 합성 노드 (string_table 참조) 와 zero-width span 은 발행 안 함 (zero span 도 포함).
         // 호출자가 emitter 첫 줄에서 부담 없이 호출하도록 가드 일원화.
         if (span.start & Ast.STRING_TABLE_BIT != 0) return;
         if (span.start == span.end) return;
+        // (C1 도구 보강 + review P1) 가드 통과 후에 측정 시작 — 발행 안 할 mapping 호출도
+        // Timer.start + atomicAdd cost 지불하던 회귀 차단. JSX/TS 합성 span 비율 높은 입력
+        // 에서 noise 큰 폭 감소.
+        var scope = @import("../profile.zig").begin(.codegen_sm_add);
+        defer scope.end();
         const lc = getOriginalLineColumn(self, span.start);
         try sm.addMapping(.{
             .generated_line = self.gen_line,

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -300,6 +300,11 @@ pub const Category = enum {
     codegen,
     codegen_walk,
     codegen_sourcemap,
+    // (C1 도구 보강) sub-phase 측정
+    codegen_setup, // collectTopLevelDeclNames + ensureTotalCapacity
+    codegen_emit, // emitNode (program 전체)
+    codegen_finalize, // keep_names + finalize
+    codegen_sm_add, // addSourceMapping 누적 (매 노드)
 
     // ── Top-level emit ──
     emit,

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -298,13 +298,13 @@ pub const Category = enum {
 
     // ── Codegen ──
     codegen,
-    codegen_walk,
-    codegen_sourcemap,
+    codegen_walk, // (legacy placeholder — no callsite, kept for ABI)
+    codegen_sourcemap, // (legacy placeholder — no callsite, kept for ABI)
     // (C1 도구 보강) sub-phase 측정
     codegen_setup, // collectTopLevelDeclNames + ensureTotalCapacity
-    codegen_emit, // emitNode (program 전체)
+    codegen_emit, // emitNode (program 전체) + fn_map enter/exit
     codegen_finalize, // keep_names + finalize
-    codegen_sm_add, // addSourceMapping 누적 (매 노드)
+    codegen_sm_add, // addSourceMapping 누적 (가드 통과 후만)
 
     // ── Top-level emit ──
     emit,


### PR DESCRIPTION
## 요약
#3745 C1 (codegen AST walk inline 최적화) 의 **사전 조사 도구 보강**.

## C1 ROI 측정 결과 — 0%
3000-module bundle profile:
| 단계 | total | self | % wall |
|------|-------|------|--------|
| resolve | 348ms | 52ms | 5.8% |
| graph | 68ms | - | - |
| emit | 6.81ms | 0.22ms | - |
| transform | 0.03ms | - | - |
| **codegen** | **0.02ms** | **0.01ms** | **<0.01%** |

codegen self time 0.01ms (31 calls) — wall 의 0%. **C1 본격 fix skip 결정** (AST walk inline 영향 없음).

## 도구 보강 (이번 PR scope)
향후 codegen 영역 회귀 감지용 — sub-phase 측정 가능.

- `profile.zig` 에 4 sub-category:
  - `codegen_setup` (collectTopLevelDeclNames + ensureTotalCapacity)
  - `codegen_emit` (emitNode + fn_map enter/exit)
  - `codegen_finalize` (keep_names + 후처리)
  - `codegen_sm_add` (addSourceMapping 누적, 가드 통과 후만)
- `codegen.zig:generate()` 의 3 sub-phase begin/end + defer
- `debug_metadata.zig:addSourceMapping` 의 가드-아래 측정 (review P1 fix)

## /code-review max
5 finding 중 P1 2건 + P2 1건 commit 2 에 적용:
- setup_scope OOM leak → defer 패턴
- sm_add measure cost → 가드 아래로 이동
- fnMap enter/exit → emit_scope 안으로 (sub-phase 합 정확화)

Deferred:
- codegen_walk / codegen_sourcemap legacy 정리 (주석만)
- finalize_scope HMR noise — counts u32 overflow risk 별도 RFC

## Test plan
- [x] `zig build test` 본 PR 변경 회귀 없음 (RN snapshot 25 fail 은 main 에서도 동일 — 별도 환경 issue)
- [x] ReleaseFast 빌드 OK
- [x] `--profile=all --profile-level=detailed` 로 sub-category 표시 확인
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)