### PR TITLE
perf(profile): transform sub-phase 측정 hook (#3745 T1 — 도구 보강)

### DIFF
--- a/src/profile.zig
+++ b/src/profile.zig
@@ -290,11 +290,14 @@ pub const Category = enum {
 
     // ── Transform ──
     transform,
-    transform_ts_strip,
-    transform_jsx,
-    transform_class_field,
-    transform_decorator,
-    transform_pass2,
+    transform_ts_strip, // (placeholder — visitor 내부 분리는 별도 작업)
+    transform_jsx, // (placeholder — visitor 내부 분리는 별도 작업)
+    transform_class_field, // (placeholder — visitor 내부 분리는 별도 작업)
+    transform_decorator, // (placeholder — visitor 내부 분리는 별도 작업)
+    transform_pass2, // ES2015 params lowering (lowerAllFunctionParams)
+    // (T1 도구 보강) sub-phase 측정
+    transform_visit, // visitNode (program 전체) — visitor 안의 ts_strip/jsx/class_field/decorator 합산
+    transform_finalize, // hoistTempVars + tagged_template_fns + helper imports + jsx imports + refresh
 
     // ── Codegen ──
     codegen,

--- a/src/transformer/transformer/driver.zig
+++ b/src/transformer/transformer/driver.zig
@@ -6,7 +6,8 @@ const NodeIndex = ast_mod.NodeIndex;
 const Error = std.mem.Allocator.Error;
 
 pub fn transform(self: anytype) Error!NodeIndex {
-    var scope = @import("../../profile.zig").begin(.transform);
+    const profile = @import("../../profile.zig");
+    var scope = profile.begin(.transform);
     defer scope.end();
 
     // #1961: graph parse 단계의 pre-pass 가 이미 transform 한 ast 면 cached root 반환.
@@ -30,12 +31,25 @@ pub fn transform(self: anytype) Error!NodeIndex {
     const saved_temp_counter = self.temp_var_counter;
     // worklet anonymous naming counter — Transformer 인스턴스 재사용 시 매 transform당 0부터 시작.
     self.plugins.worklet.anonymous_counter = 0;
-    var root = try self.visitNode(root_idx);
+
+    // (T1 도구 보강) sub-phase 측정: visit pass + pass2 + finalize. visitor 내부의
+    // ts_strip / jsx / class_field / decorator 분리는 별도 작업 (visitor 코드 수정 필요).
+    var root: NodeIndex = undefined;
+    {
+        var visit_scope = profile.begin(.transform_visit);
+        defer visit_scope.end();
+        root = try self.visitNode(root_idx);
+    }
 
     // Pass 2: ES2015 params lowering 일괄 적용
     if (self.options.unsupported.default_params) {
+        var pass2_scope = profile.begin(.transform_pass2);
+        defer pass2_scope.end();
         try lowerAllFunctionParams(self);
     }
+
+    var finalize_scope = profile.begin(.transform_finalize);
+    defer finalize_scope.end();
 
     // top-level 임시 변수 호이스팅: var _a, _b, ... 선언을 program 앞에 삽입
     if (self.temp_var_counter > saved_temp_counter and !root.isNone()) {


### PR DESCRIPTION
## 요약
#3745 T1 (transform sub-category profile) — C1 (#3776) 와 동일 패턴.

## ROI 측정 결과 — 0%
3000-module monorepo profile:
| 단계 | total | self |
|------|-------|------|
| transform | 0.30ms | 0.02ms |
| transform.visit | 0.27ms | 0.27ms |
| transform.finalize | 0.00ms | 0.00ms |

wall 의 <0.1% — 본격 fix skip 결정.

## 도구 보강
- `profile.zig` 에 2 sub-category:
  - `transform_visit` — visitNode (program 전체)
  - `transform_finalize` — hoistTempVars + tagged_template + helper/jsx imports + refresh
- 기존 placeholder (`transform_ts_strip/jsx/class_field/decorator`) 는 visitor 내부
  분리 별도 작업 명시 (큰 refactor 필요)
- `driver.zig:transform()` 의 3 sub-phase begin/end + defer (C1 pattern)

향후 transform-heavy fixture (TS-heavy / JSX-heavy / decorator-heavy) 에서 sub-phase
분포 확인 후 visitor 내부 분리 ROI 결정.

## /code-review max
직접 review (agent API 529) — finding 없음:
- C1 의 setup_scope OOM leak → 본 PR 은 try 영역 안전 (worklet allocPrint 만 try, 조건부)
- sm_add measure cost → 매 노드 hook 없음 (high-level 3-phase 만)
- dark time (assertInvariants + worklet setup) 매우 작음

## Test plan
- [x] `zig build test` 통과
- [x] ReleaseFast 빌드 OK
- [x] `--profile=all --profile-level=detailed` 로 sub-category 표시 확인

#3745 R2/C1/T1 backlog 끝. 본 이슈는 visitor 내부 분리 (별도 작업) 후 close 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)