### PR TITLE
chore(dev-server): #2538 4-3 review follow-ups (EOL/leak/sentinel/invariant)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 references/** linguist-vendored=true
 tests/codegen-snapshots/**/golden/** linguist-generated=true
+
+# dev overlay client 정본 + JS publish 미러 — Windows autocrlf 등으로 EOL 이 변환
+# 되면 둘이 byte-equal 가드는 통과해도 Zig @embedFile 결과와 mismatch 가 잠재.
+# LF 로 고정 (#2538 4-3 follow-up).
+src/server/dev_overlay_client.js text eol=lf
+packages/web/runtime/dev-overlay-client.raw.js text eol=lf

--- a/packages/web/runtime/dev-overlay-client.test.ts
+++ b/packages/web/runtime/dev-overlay-client.test.ts
@@ -39,10 +39,11 @@ describe('dev overlay client mirror', () => {
   });
 });
 
-// 본문 (comment 제외) 만 추출 — comment 안의 sentinel 설명 문구가 검증에 끼지
-// 않도록 한다.
+// 본문 (line + block comment 제외) 만 추출 — comment 안의 sentinel 설명 문구가
+// not.toContain 가드에 false-positive 로 잡히지 않도록 한다.
 function codeOnly(source: string): string {
   return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
     .split('\n')
     .filter((line) => !line.trim().startsWith('//'))
     .join('\n');

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -64,7 +64,9 @@ pub const DevServer = struct {
     /// dev overlay client — raw template (overlay_client_template) 의 `__ZNTC_HMR_*__`
     /// sentinel 을 protocol 상수로 치환한 결과. init 에서 1회 생성, deinit 에서 free.
     /// JS 측 packages/web/runtime/dev-overlay-client.mjs 와 같은 source/치환표 사용 (#2538 4-3).
-    overlay_client: []u8 = &.{},
+    /// default 미제공 — partial-init 인스턴스가 serveAppDevClient 로 빈 body 응답하는
+    /// silent regression 차단 (event_ring 과 같은 invariant).
+    overlay_client: []u8,
 
     pub const ProxyRule = struct {
         /// 매칭할 경로 prefix (예: "/api")
@@ -118,13 +120,18 @@ pub const DevServer = struct {
             getLog().print("zntc: cannot open directory '{s}': {}\n", .{ options.root_dir, err }) catch {};
             return err;
         };
+        // 이후 ! 반환은 모두 root_dir 을 닫아야 함 (open 직후 ownership 이 init 에
+        // 있어 호출자가 deinit 못 호출). errdefer 한 줄로 통일해 향후 init 후반에
+        // 추가될 fallible 자원이 leak 을 발생시키지 않도록 가드 (#2538 4-3 review).
+        errdefer {
+            var dir_copy = root_dir;
+            dir_copy.close();
+        }
 
         var abs_entry: ?[]const u8 = null;
         if (options.entry_point) |ep| {
             abs_entry = std.fs.cwd().realpathAlloc(allocator, ep) catch |err| {
                 getLog().print("zntc: cannot resolve entry '{s}': {}\n", .{ ep, err }) catch {};
-                var dir_copy = root_dir;
-                dir_copy.close();
                 return err;
             };
         }
@@ -132,8 +139,6 @@ pub const DevServer = struct {
 
         const overlay_client = substituteOverlayPlaceholders(allocator) catch |err| {
             getLog().print("zntc: failed to prepare dev overlay client: {}\n", .{err}) catch {};
-            var dir_copy = root_dir;
-            dir_copy.close();
             return err;
         };
 
@@ -163,7 +168,8 @@ pub const DevServer = struct {
     pub fn deinit(self: *DevServer) void {
         if (self.tcp_server) |*s| s.deinit();
         if (self.abs_entry) |ae| self.allocator.free(ae);
-        if (self.overlay_client.len > 0) self.allocator.free(self.overlay_client);
+        // overlay_client 는 init 에서 반드시 알록된 owned slice (default 미제공).
+        self.allocator.free(self.overlay_client);
         self.root_dir.close();
         self.event_ring.deinit();
         self.error_state.deinit(self.allocator);
@@ -191,7 +197,18 @@ pub const DevServer = struct {
         for (subs) |s| {
             const next_size = std.mem.replacementSize(u8, current, s.token, s.value);
             const next = try allocator.alloc(u8, next_size);
-            _ = std.mem.replace(u8, current, s.token, s.value, next);
+            const count = std.mem.replace(u8, current, s.token, s.value, next);
+            // sentinel 이 정본에 없다 = subs 의 token 이 정본과 어긋남 (정본은
+            // src/server/dev_overlay_client.js). 단위 test 가 결과를 검증하지만
+            // 빌드/init 시점에 즉시 잡히면 디버깅이 명확.
+            if (count == 0) {
+                allocator.free(next);
+                getLog().print(
+                    "zntc: dev overlay client sentinel '{s}' 가 정본에 없음 — subs 표와 src/server/dev_overlay_client.js 동기 확인 필요\n",
+                    .{s.token},
+                ) catch {};
+                return error.OverlaySentinelMissing;
+            }
             allocator.free(current);
             current = next;
         }


### PR DESCRIPTION
## 요약

#3780 (epic #2538 4-3 정본 통일) 의 `/code-review max` 14 finding 중 **low/info 5건** 정리. high+medium 5건은 #3780 본 PR 에 이미 반영됨. (이전 stacked PR #3781 은 base branch 삭제로 closed — 본 PR 이 main 기준 재오픈.)

## 변경 내역

| # | 영역 | 파일 |
|---|---|---|
| **A8** | `.gitattributes` 에 정본/미러 `text eol=lf` 강제 | `.gitattributes` |
| **P6** | DevServer.init 의 root_dir 에 errdefer 통일 | `src/server/dev_server.zig` |
| **P12** | substituteOverlayPlaceholders 가 std.mem.replace count 확인 → 0 이면 `error.OverlaySentinelMissing` | `src/server/dev_server.zig` |
| **C4** | DevServer.overlay_client field 의 default `&.{}` 제거 — partial-init invariant 강화 | `src/server/dev_server.zig` |
| **C6** | dev-overlay-client.test.ts 의 codeOnly 가 block comment 도 필터 | `packages/web/runtime/dev-overlay-client.test.ts` |

## 상세

### A8 — EOL 가드
Windows autocrlf 환경에서 정본 + 미러가 같이 CRLF 로 변환되면 byte-equal 가드는 통과해도 Zig `@embedFile` 결과 (LF) 와 잠재 mismatch. `.gitattributes` 에 두 파일 모두 LF 강제.

### P6 — errdefer 통일
이전엔 catch arm 두 곳 (`realpathAlloc`, `substituteOverlayPlaceholders` 실패) 에서 수동으로 `dir_copy.close()` 호출. `errdefer { var c = root_dir; c.close(); }` 한 줄로 통일하면 향후 init 후반에 fallible 자원 (event_ring 등) 추가 시 leak 함정 자동 차단.

### P12 — sentinel typo 즉시 검출
`std.mem.replace` 의 반환값 (실제 치환 횟수) 을 `_ =` 로 drop 하던 코드를 `count` 로 받아 0 이면 즉시 fail. subs 표의 token 과 정본 (`src/server/dev_overlay_client.js`) 이 drift 한 경우 (typo / rename) 단위 test 가 잡지만, 빌드/init 시점에 명확한 메시지로 catch.

### C4 — partial-init invariant
`overlay_client: []u8 = &.{}` default 가 있으면 partial-init 인스턴스가 serveAppDevClient 호출 시 200 OK + 빈 body 응답. event_ring 처럼 default 미제공으로 명시 init 강제.

### C6 — block comment 필터
codeOnly 가 line-leading `//` 만 필터하던 코드를 block comment `/* ... */` 도 필터하도록 확장. 정본에 향후 block comment 추가 시 `not.toContain('__ZNTC_HMR_')` 가드의 false-positive 방지.

## 미반영 finding

- **A7** Update 메시지 XSS / LAN trust boundary — security 별도 issue 권장. dev-only.
- **B8** HmrMessage union 확장 SemVer — 코드 변경 없음, release-notes 명시.
- **E4** raw mirror auto sync (pre-commit hook) — 운영 개선, 별도 PR.
- **C5 / V2** JS runServe Update broadcast — #3779 으로 분리.

## 검증

| | 결과 |
|---|---|
| `zig build test` | ✅ pass |
| `bun test` @ packages/web | ✅ 165 pass |
| `bun test` @ packages/server | ✅ 85 pass |

Refs: #2538, follows #3780

🤖 Generated with [Claude Code](https://claude.com/claude-code)