### PR TITLE
fix(dev-server): closeServerForRestart 시 native watch handle stop (#3779 follow-up)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -1692,6 +1692,8 @@ async function runServe(opts, config, { appDev = null } = {}) {
   const APP_DEV_HMR_CLIENT_PATH = web?.APP_DEV_HMR_CLIENT_PATH;
   const APP_DEV_HMR_WS_PATH = web?.APP_DEV_HMR_WS_PATH;
   let serverHandle = null;
+  // #3779 follow-up — restart 시 stop 호출용. opts.bundle+watch+appDev+hmr 분기 안에서만 할당.
+  let nativeWatchHandle = null;
   const mimeTypes = {
     '.html': 'text/html',
     '.js': 'application/javascript',
@@ -1885,6 +1887,17 @@ async function runServe(opts, config, { appDev = null } = {}) {
   }
 
   async function closeServerForRestart() {
+    // #3779 follow-up — native watch worker thread 가 child process spawn 후에도 살아남으면
+    // outdir 출력이 부모/자식 두 곳에서 일어나 race. emitRestartAfter 의 child spawn 전에 stop.
+    // stop 자체가 throw 해도 server.close 는 시도 (HTTP 포트 해제 우선).
+    if (nativeWatchHandle) {
+      try {
+        nativeWatchHandle.stop();
+      } catch (err) {
+        console.error('[serve] native watch stop 실패:', err);
+      }
+      nativeWatchHandle = null;
+    }
     if (!serverHandle) return;
     if (typeof serverHandle.stop === 'function') {
       await serverHandle.stop();
@@ -1928,7 +1941,7 @@ async function runServe(opts, config, { appDev = null } = {}) {
         }
       };
       try {
-        watch(watchBuildOpts);
+        nativeWatchHandle = watch(watchBuildOpts);
       } catch (err) {
         // watch 시작 실패해도 fsWatch + drain (CSS path) 는 계속 동작 — incremental HMR 만 비활성.
         console.error('[serve] native watch 시작 실패 (incremental HMR 비활성):', err);


### PR DESCRIPTION
## Summary

- PR #3783 에서 도입한 `runServe` 의 native `watch()` handle 이 `closeServerForRestart` 경로에서 stop 처리되지 않아, config/.env 변경 restart 시 부모 process 의 NAPI worker thread 가 child spawn 후에도 살아남음 (outdir 동시 출력 + worker leak)
- `nativeWatchHandle` 변수로 watch handle 을 보존, `closeServerForRestart` 가 server stop 직전에 stop 호출

## Refs

- #3779 (상위 epic)
- #3783 (incremental HMR 1차 fix — 본 PR 의 회귀 대상)

## 주요 변경

- `packages/core/bin/zntc.mjs`:
  - `runServe` scope 에 `let nativeWatchHandle = null;` 추가
  - `closeServerForRestart` 가 stop 먼저 (try/catch swallow), 그 후 server.close
  - SIGINT 직접 종료 경로는 process exit 시 OS 가 worker thread 도 정리 → 별도 hook 불필요

## Test plan

- [x] `bun test bin/zntc.test.ts -t "dev HMR"`: 7 pass, 0 fail
- [x] `bun x tsc -b --force`: pass
- [ ] 실제 dev 환경에서 `.env` 또는 `zntc.config.ts` 변경 → restart 시 outdir race / orphan worker 없는지 확인 (사용자 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)