### PR TITLE
chore(vendor): add google/boringssl submodule pinned to Chromium 148 stable (#2538 4-1 PR-1/N)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "vendor/mimalloc"]
 	path = vendor/mimalloc
 	url = https://github.com/microsoft/mimalloc.git
+[submodule "vendor/boringssl"]
+	path = vendor/boringssl
+	url = https://github.com/google/boringssl


### PR DESCRIPTION
## 요약

epic #2538 4-1 (dev server HTTPS / BoringSSL vendoring) 의 **첫 step** — vendor submodule 도입만. build.zig 통합 + Zig 바인딩 + dev_server.zig TLS wrapper + CLI flag 는 후속 PR.

## 변경

- `vendor/boringssl/` = `google/boringssl` 직접 git submodule (자체 fork X)
- commit pin = `d8be2b4a71155bf82da092ef543176351eeb59ff`
  - **Chromium 148 stable** (branch-heads/7778), 2026-01-23 UTC
  - Linux stable channel — 가장 widely deployed validate
  - sentinel tag `0.20260327.0-21-gd8be2b4a7`
- `.gitmodules` 에 entry 추가

## 채택 근거 (이슈 본문 + 사전조사)

| | |
|---|---|
| Zig stdlib TLS server | `std.crypto.tls.Server` **부재**. ziglang #14171 OPEN, milestone `upcoming` — 0.16 / 0.17 모두 미할당 (사실상 무한 대기) |
| BoringSSL 공식 정책 | "live at head" — vendoring + 주기적 head bump 권장, tagged release 비권장 |
| google upstream vs Bun fork | Bun fork (oven-sh/boringssl) 의 추가 patches (SHA3/RIPEMD160/HMAC-SHA3 등) 는 Node `crypto` API surface 호환 목적 — ZTS dev server scope 와 무관 → fork 채택 X, upstream 직접 |
| Chromium stable pin | Envoy 등 다른 consumer 공통 패턴 — production validate 의 사실상 표준 |

## 후속 PR 분할 (계획)

- **PR-2**: `build.zig` 통합 — `gen/sources.json` 파싱, `libboringssl.a` static lib, target arch asm 분기 (`x86_64.linux.S` / `x86_64.macos.S` / `aarch64.*.S`)
- **PR-3**: `src/server/dev_server.zig` 의 `handleConnection` 에 TLS wrapper + `--certfile`/`--keyfile` CLI + WSS HMR
- **PR-4**: e2e (Playwright wss + HMR overlay) + CI macOS/Linux 매트릭스
- **trailing**: self-signed cert 자동 생성 (vite-plugin-basic-ssl 류) — 별도 issue

## 검증

- `git submodule status` ✅ `vendor/boringssl` `0.20260327.0-21-gd8be2b4a7` (d8be2b4a7) detached
- 빌드/test 영향 없음 — submodule pointer 만 추가, build.zig 미연결 (dead vendor)

본 PR 단독으로는 dead code 상태. 후속 PR-2 까지 묶어 평가 권장. 검토자 부담 줄이려고 분할.

Refs: #2538 (4-1 PR-1/N)

🤖 Generated with [Claude Code](https://claude.com/claude-code)