### PR TITLE
feat(build): BoringSSL 정적 lib 통합 (OPENSSL_NO_ASM=1) (#2538 4-1 PR-2/N)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const boringssl_build = @import("build/boringssl.zig");
 
 // Although this function looks imperative, note that its job is to
 // declaratively construct a build graph that will be executed by an external
@@ -88,6 +89,18 @@ pub fn build(b: *std.Build) void {
         }
     }
 
+    // BoringSSL: 정적 lib (vendor/boringssl, asm 제외 OPENSSL_NO_ASM=1).
+    // dev server TLS 의 토대 — handshake/cert/SSL_CTX 등은 후속 PR (#2538 4-2).
+    // lib 1개 build + caller 별 linkLibrary — exe / lib_unit_tests / exe_unit_tests 가
+    // 같은 .a 를 공유 (중복 컴파일 회피).
+    const boringssl_lib = boringssl_build.build(b, target, optimize) catch |err| {
+        std.debug.panic(
+            "boringssl.build failed ({}): vendor/boringssl/gen/sources.json 형식 변경 또는 OOM 의심",
+            .{err},
+        );
+    };
+    boringssl_build.attach(exe, boringssl_lib, b);
+
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default
     // step when running `zig build`).
@@ -124,6 +137,7 @@ pub fn build(b: *std.Build) void {
         .root_module = lib_mod,
         .filters = test_filters,
     });
+    boringssl_build.attach(lib_unit_tests, boringssl_lib, b);
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
@@ -131,6 +145,7 @@ pub fn build(b: *std.Build) void {
         .root_module = exe_mod,
         .filters = test_filters,
     });
+    boringssl_build.attach(exe_unit_tests, boringssl_lib, b);
 
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
 

--- a/build/boringssl.zig
+++ b/build/boringssl.zig
@@ -1,0 +1,129 @@
+// BoringSSL static-lib build (epic #2538 4-1 PR-2).
+//
+// vendor/boringssl/gen/sources.json 의 `bcm` + `crypto` + `ssl` 의 srcs 만 골라
+// libboringssl 정적 라이브러리로 컴파일한다. asm 은 전부 제외 (`OPENSSL_NO_ASM=1`)
+// — arch 분기/NASM 의존성 회피. asm 활성화는 별도 작업 (#3788).
+//
+// 호출자 (build.zig) 는 `link(b, exe, target, optimize)` 로 lib 을 빌드 + exe 에
+// linkLibrary + include path 추가. BoringSSL 자체는 system C/C++ stdlib (libc/libc++)
+// 에 의존하므로 exe 가 linkLibC / linkLibCpp 도 이미 호출돼 있어야 한다.
+
+const std = @import("std");
+
+const SrcsList = struct { srcs: []const []const u8 };
+const SourcesJson = struct {
+    bcm: SrcsList,
+    crypto: SrcsList,
+    ssl: SrcsList,
+};
+
+/// BoringSSL 정적 lib 을 1회 컴파일해 반환. `attach()` 로 caller (exe / test) 에
+/// linkLibrary + include path 를 부착하는 두 단계 분리 — exe / lib_unit_tests /
+/// exe_unit_tests 가 같은 .a 를 공유 (중복 컴파일 회피).
+pub fn build(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+) !*std.Build.Step.Compile {
+    const lib = b.addLibrary(.{
+        .name = "boringssl",
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    lib.linkLibC();
+    lib.linkLibCpp();
+
+    const sources_text = @embedFile("../vendor/boringssl/gen/sources.json");
+    // Leaky variant — b.allocator 가 build graph lifetime arena 라 별도 ArenaAllocator
+    // 가 필요 없음. std.json doc 의 ArenaAllocator caller 권장 패턴.
+    const parsed = try std.json.parseFromSliceLeaky(
+        SourcesJson,
+        b.allocator,
+        sources_text,
+        .{ .ignore_unknown_fields = true },
+    );
+
+    const cflags_common = [_][]const u8{
+        "-DOPENSSL_NO_ASM=1",
+        "-DOPENSSL_SMALL", // dev server scope — table 작게
+        "-fno-strict-aliasing",
+        "-Wno-unused-parameter",
+        "-Wno-unused-function",
+        "-Wno-missing-field-initializers",
+    };
+
+    const cxxflags = cflags_common ++ [_][]const u8{
+        "-std=c++17",
+        "-fno-exceptions",
+        "-fno-rtti",
+    };
+
+    const cflags = cflags_common ++ [_][]const u8{
+        "-std=c11",
+    };
+
+    const linux_extra = [_][]const u8{"-D_XOPEN_SOURCE=700"};
+    const win_extra = [_][]const u8{
+        "-D_HAS_EXCEPTIONS=0",
+        "-DWIN32_LEAN_AND_MEAN",
+        "-DNOMINMAX",
+        "-D_CRT_SECURE_NO_WARNINGS",
+    };
+
+    const cxx_linux = cxxflags ++ linux_extra;
+    const cxx_win = cxxflags ++ win_extra;
+    const c_linux = cflags ++ linux_extra;
+    const c_win = cflags ++ win_extra;
+    const cxx_full: []const []const u8 = switch (target.result.os.tag) {
+        .linux => &cxx_linux,
+        .windows => &cxx_win,
+        else => &cxxflags,
+    };
+    const c_full: []const []const u8 = switch (target.result.os.tag) {
+        .linux => &c_linux,
+        .windows => &c_win,
+        else => &cflags,
+    };
+
+    inline for (.{ "bcm", "crypto", "ssl" }) |group| {
+        const srcs = @field(parsed, group).srcs;
+        for (srcs) |rel| {
+            const full = try std.fs.path.join(b.allocator, &.{ "vendor/boringssl", rel });
+            const is_cpp = std.mem.endsWith(u8, rel, ".cc") or std.mem.endsWith(u8, rel, ".cpp");
+            lib.addCSourceFile(.{
+                .file = b.path(full),
+                .flags = if (is_cpp) cxx_full else c_full,
+            });
+        }
+    }
+
+    // angle-bracket `<openssl/...>` 가 BoringSSL 의 public header 를 resolve.
+    lib.addIncludePath(b.path("vendor/boringssl/include"));
+
+    // Windows target — crypto/bio/socket.cc / connect.cc 가 `<winsock2.h>` 무조건
+    // include 하고 Win32 socket API (socket/recv/WSAGetLastError) 호출. 시스템
+    // ws2_32 link 가 없으면 cross-Windows build 가 undefined symbol.
+    if (target.result.os.tag == .windows) {
+        lib.linkSystemLibrary("ws2_32");
+    }
+
+    return lib;
+}
+
+/// `build()` 가 만든 lib 을 caller (exe / test step) 에 부착. linkLibrary +
+/// BoringSSL header 의 include path. include path 는 pure-Zig caller (extern fn
+/// declaration 만) 에는 dead 지만, 추후 caller 가 `addCSourceFile` 로 inline C
+/// bridge 를 추가하거나 `@cImport` 를 쓰면 필요해진다. 또 lib 의 linkLibCpp 가
+/// transitive 로 caller 의 is_linking_libcpp 를 true 로 만든다 (Zig 0.15.2
+/// std.Build.Step.Compile L1147-1152).
+pub fn attach(
+    target_step: *std.Build.Step.Compile,
+    lib: *std.Build.Step.Compile,
+    b: *std.Build,
+) void {
+    target_step.linkLibrary(lib);
+    target_step.addIncludePath(b.path("vendor/boringssl/include"));
+}

--- a/src/server/boringssl.zig
+++ b/src/server/boringssl.zig
@@ -1,0 +1,28 @@
+//! BoringSSL thin Zig binding (epic #2538 4-1 PR-2 — build link 검증 + 최소 노출).
+//!
+//! 본 파일은 dev_server.zig 의 TLS wrapper (PR-3) 가 의존할 최소 extern fn 들의
+//! 거점. 현 단계에선 `init()` 한 함수만 노출 — `zig build test` 가 link 무결성
+//! (libboringssl.a 가 실제 exe 에 묶이는지) 을 단위 test 로 검증한다.
+//!
+//! 본격 wrapper (SSL_CTX_new/SSL_accept/SSL_read/SSL_write 등) 는 PR-3 에 추가.
+
+const std = @import("std");
+
+// BoringSSL 의 옛 OpenSSL 호환 entry. 1.1.0+ 부터는 internal 이 자동 init 처리하므로
+// 대부분 no-op 이지만, return 값 0 (이미 init 됨) 또는 1 (성공) 만 보장 — link 검증의
+// 가장 가벼운 호출.
+pub extern "c" fn SSL_library_init() c_int;
+
+/// 후속 PR-3 의 TLS wrapper 가 의존할 거점 (forward declaration). 본 PR-2 의 link
+/// 무결성은 아래 단위 test 가 검증.
+pub fn init() c_int {
+    return SSL_library_init();
+}
+
+test "BoringSSL: SSL_library_init link smoke" {
+    // 0 (already initialized) 또는 1 (initialized now) — 둘 다 link 검증의 PASS.
+    // 실제 값 검증 대신 호출 가능 여부만 — linker 가 libboringssl.a 의 symbol 을
+    // exe 에 묶지 않으면 build/test 가 link error 로 실패.
+    const rc = SSL_library_init();
+    try std.testing.expect(rc == 0 or rc == 1);
+}

--- a/src/server/mod.zig
+++ b/src/server/mod.zig
@@ -6,6 +6,7 @@ pub const TrackedFileSet = @import("tracked_file_set.zig").TrackedFileSet;
 pub const mime = @import("mime.zig");
 pub const watch_scan = @import("watch_scan.zig");
 pub const events = @import("events.zig");
+pub const boringssl = @import("boringssl.zig");
 
 test {
     _ = @import("dev_server.zig");
@@ -14,6 +15,7 @@ test {
     _ = @import("mime.zig");
     _ = @import("watch_scan.zig");
     _ = @import("events.zig");
+    _ = @import("boringssl.zig");
 
     // test files
     _ = @import("dev_server_test.zig");


### PR DESCRIPTION
## 요약

epic #2538 4-1 (BoringSSL vendoring) 의 **PR-2/N**. PR-1 (#3786) 의 dead vendor 가 이제 `libboringssl.a` 산출물로 살아나 `zig build` 가 정적 link. 후속 PR-3 의 dev_server.zig TLS wrapper 가 의존할 토대.

ASM 활성화는 **#3788 분리** — 현재는 `OPENSSL_NO_ASM=1` 정의로 arch 분기 / NASM 의존성 회피.

## 변경 (4 파일 +174)

| | |
|---|---|
| `build/boringssl.zig` (신규) | `@embedFile + std.json.parseFromSliceLeaky` 로 `vendor/boringssl/gen/sources.json` 파싱. `bcm` + `crypto` + `ssl` srcs (~282 file) 만 `addCSourceFile`. `build()` (lib 1회 컴파일) + `attach()` (caller 별 linkLibrary) 분리 — exe / lib_unit_tests / exe_unit_tests 가 같은 .a 공유 |
| `build.zig` | BoringSSL helper import + exe/test step 에 attach |
| `src/server/boringssl.zig` (신규) | `extern fn SSL_library_init` 거점 + 단위 test "link smoke" — .a 가 실제 exe/test 에 묶이는지 검증 |
| `src/server/mod.zig` | boringssl module export + test runner pickup |

## 컴파일 flag

| flag | scope |
|---|---|
| `-DOPENSSL_NO_ASM=1` | 모든 target — asm 제외 (arch 분기 회피) |
| `-DOPENSSL_SMALL` | 모든 — table 작게 (dev scope) |
| `-fno-strict-aliasing` `-Wno-unused-parameter` `-Wno-unused-function` | 모든 |
| `-std=c++17` `-fno-exceptions` `-fno-rtti` | C++ |
| `-D_XOPEN_SOURCE=700` | Linux — `pthread_rwlock` |
| `-D_HAS_EXCEPTIONS=0` `-DWIN32_LEAN_AND_MEAN` `-DNOMINMAX` `-D_CRT_SECURE_NO_WARNINGS` | Windows |
| `linkSystemLibrary("ws2_32")` | Windows — `crypto/bio/socket.cc` winsock2 API |

## 검증

| | 결과 |
|---|---|
| `zig build` (Debug) | ✅ pass |
| `zig build -Doptimize=ReleaseFast` | ✅ pass |
| `zig build test` (BoringSSL smoke 포함) | ✅ pass |
| `libboringssl.a` (build cache) | 46MB |
| `zntc` binary (Debug) | 16.5MB |
| `zntc` binary (ReleaseFast) | 5.7MB |

## `/code-review max` 결과

8 finding 중 **HIGH 1 + MEDIUM 3** 본 PR 에 반영:

- ✅ **HIGH** — Windows target `ws2_32` systemLibrary link 추가 (cross-Windows build undefined symbol 회피)
- ✅ **MEDIUM** — `parseFromSlice` → `parseFromSliceLeaky` (std.json doc 권장 패턴, b.allocator 가 build graph arena 라 inner arena 불요)
- ✅ **MEDIUM** — `attach()` 의 include path + linkLibCpp transitive 동작 doc 보강 (pure-Zig caller 에는 dead 지만 PR-3 의 inline C bridge 추가 시 필요)
- ✅ **MEDIUM** — `vendor/boringssl` include path 의 부정확 rationale 정정 (실 quoted include 는 source-dir 상대로 resolve, angle-bracket 만 path 필요)
- ✅ **LOW** — `init()` doc 의 "noinline" 오기 정정 + panic 메시지 보강 (sources.json 형식 변경 / OOM 식별 가능)

미반영 LOW (cosmetic / 본 PR 무영향):
- `.cc/.cpp` is_cpp 분기의 `.c` branch dead — sources.json 의 모든 src 가 `.cc` 라 미사용 (defensive 유지)
- `OPENSSL_SMALL` trade-off — P-256 ECDHE -2x 가능, dev scope 무영향 (production grade 시 #3788 와 함께 재평가)

## 후속

| | |
|---|---|
| **PR-3** | `src/server/dev_server.zig` 의 `handleConnection` TLS wrapper + `--certfile`/`--keyfile` CLI + WSS HMR |
| **PR-4** | e2e (Playwright wss + HMR overlay) + CI macOS/Linux 매트릭스 확장 |
| **#3788** | asm 활성화 (production grade, arch 분기 + NASM 의존) |

Refs: #2538 (4-1 PR-2/N), follows #3786 / #3789

🤖 Generated with [Claude Code](https://claude.com/claude-code)