### PR TITLE
fix(dev-server): zntc dev 가 opts.devMode 자동 set — incremental HMR runtime 주입 (#3793)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -395,6 +395,11 @@ function parseArgs(argv) {
     opts.serve = true;
     opts.bundle = true;
     opts.watch = true;
+    // #3793 — `zntc dev` 는 incremental HMR 활성 (__zntc_apply_update / __esm register
+    // 주입) 이 필수. 명시 안 set 시 initial bundle 이 production 모드로 빌드돼 HMR
+    // 런타임 누락 → broadcast 된 Update 가 client 에서 fallback reload. user 가
+    // 명시적으로 `--dev=false` 줘서 override 하기 전엔 dev 모드 default 보장.
+    opts.devMode = true;
   } else if (appCommand === 'build') {
     opts.bundle = true;
   } else if (appCommand === 'preview') {

--- a/packages/core/test/cli/app-builder/dev-hmr.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr.ts
@@ -2,3 +2,4 @@ import './dev-hmr/overlay';
 import './dev-hmr/css-updates';
 import './dev-hmr/postcss';
 import './dev-hmr/bun-runtime';
+import './dev-hmr/dev-runtime-injected';

--- a/packages/core/test/cli/app-builder/dev-hmr/dev-runtime-injected.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/dev-runtime-injected.ts
@@ -1,0 +1,50 @@
+// #3793 회귀 가드 — `zntc dev` 가 dev mode 로 빌드해 HMR 런타임을 inject.
+// 가드 전: `appCommand === 'dev'` 가 opts.devMode 를 set 안 함 → initial bundle 이 production
+// 모드 (no __zntc_apply_update / no __esm register) → broadcast 된 Update 가 client 에서
+// undefined 분기로 location.reload() fallback. 모든 incremental HMR 이 무효화.
+// 회귀 시 broadcast WS 시퀀스 자체는 정상이라 broadcast 단위 테스트 (hmr-rebuild-broadcast.test.ts)
+// 로는 잡히지 않음 — bundle 내용 자체를 검증.
+
+import {
+  CLI,
+  RUNTIME,
+  describe,
+  expect,
+  findFreePort,
+  join,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  spawn,
+  test,
+  tmpdir,
+  waitForServer,
+  writeFileSync,
+} from '../helpers';
+
+describe('CLI: Vite-style app builder > dev HMR > dev runtime injected', () => {
+  test('zntc dev 빌드 결과는 dev runtime token 을 포함 (#3793)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-runtime-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'index.html'), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(join(dir, 'src', 'main.ts'), 'console.log("hello");');
+
+    const port = await findFreePort();
+    const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      // dev server 의 outdir 인 .zntc-dev/ 의 bundle.js 가 dev runtime literal 을 포함해야 함.
+      // - __esm: ES module factory wrapper (dev mode 에서 모듈 register 용)
+      // - __zntc_register 또는 globalThis.__zntc_g: dev runtime global registry
+      // pre-fix (production mode default) 에서는 이 토큰들이 누락돼 incremental HMR client 의
+      // __zntc_apply_update 가 평가할 모듈 factory 를 찾지 못함.
+      const bundle = readFileSync(join(dir, '.zntc-dev', 'bundle.js'), 'utf8');
+      expect(bundle).toContain('__esm');
+      expect(bundle).toMatch(/__zntc_register|__zntc_g/);
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- PR #3783 의 `/code-review max` 가 발견한 **가장 critical 한 회귀** (issue #3793)
- `appCommand === 'dev'` 가 `opts.devMode` 를 set 안 해 initial bundle 이 production mode → HMR 런타임 (`__zntc_apply_update` / `__esm`) 누락 → 모든 incremental update 가 `location.reload()` fallback → PR #3779 의 목적 자체 무효
- `appCommand === 'dev'` 분기에 `opts.devMode = true;` 추가 + 회귀 가드 통합 테스트 신설

## Closes

- #3793

## 변경

- `packages/core/bin/zntc.mjs`: appCommand==='dev' 분기에 `opts.devMode = true`. 사용자 `--dev=false` override 가능
- `packages/core/test/cli/app-builder/dev-hmr/dev-runtime-injected.ts` (신규): outdir/bundle.js 가 `__esm` + `__zntc_register|__zntc_g` token 포함 가드
- `packages/core/test/cli/app-builder/dev-hmr.ts`: 신규 테스트 import

## Test plan

- [x] `bun test bin/zntc.test.ts -t "dev HMR"`: 8 pass / 0 fail
- [x] `bun test bin/zntc.test.ts` 전체: 294 pass / 2 skip / 0 fail
- [ ] 실제 브라우저에서 `.ts` 수정 시 React state 보존 여부 확인 (사용자 검증 필요)

## 참고

- `runServe` 의 `watchBuildOpts.devMode = true` 하드코드 (PR #3783) 는 이제 redundant 지만 defense-in-depth 로 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)