### PR TITLE
fix(napi): watch worker 가 outdir 받아 output path 결합 (#3795)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -3355,6 +3355,11 @@ export function watch(options: BuildOptions): WatchHandle {
   const n = ensureNative();
 
   const { napiOptions: nativeOpts, cleanup } = prepareNapiOptions(options);
+  // #3795 — `prepareNapiOptions` 가 `outdir` 를 delete 함 (build/buildSync 케이스는 JS-side
+  // writeOutputFiles 가 outdir 처리). 그러나 watch worker thread 는 NAPI 안에서 직접
+  // `o.path` (bundler 가 outdir-relative 로 생성) 로 createFile/writeAll 수행하므로 outdir
+  // 정보가 필요. 사용자가 명시한 outdir 를 watch path 에 한해 다시 주입.
+  if (options.outdir !== undefined) nativeOpts.outdir = options.outdir;
   const dispatcher = resolveDispatcher(options);
 
   if (dispatcher) {

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -553,6 +553,9 @@ pub fn parseBuildOptions(
         .{};
 
     const outfile = ownStr(env, opts_obj, "outfile", owned_strings);
+    // #3795 — `watch()` 경로에서 worker thread 가 outdir-relative output path 를 결합할 때 사용.
+    // build/buildSync 는 JS 측 writeOutputFiles 가 처리하므로 bundler/emitter 는 이 필드를 보지 않음.
+    const outdir = ownStr(env, opts_obj, "outdir", owned_strings);
     const outbase = ownStr(env, opts_obj, "outbase", owned_strings);
     const tsconfig_raw = ownStr(env, opts_obj, "tsconfigRaw", owned_strings);
     const tsconfig_path_js = ownStr(env, opts_obj, "tsconfigPath", owned_strings);
@@ -818,6 +821,8 @@ pub fn parseBuildOptions(
         .main_fields = main_fields orelse &.{},
         .unsupported = unsupported,
         .output_filename = outfile orelse "bundle.js",
+        // #3795 — watch worker thread 가 outputs[].path 를 outdir 와 결합하기 위해 사용.
+        .outdir = outdir orelse "",
         .outbase = outbase,
         .packages_external = getObjectBool(env, opts_obj, "packagesExternal", false),
         .preserve_symlinks = getObjectBool(env, opts_obj, "preserveSymlinks", false),

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -520,6 +520,32 @@ fn writeSourcemapFile(
     sm_file.writeAll(sm) catch {};
 }
 
+/// #3795 — `o.path` 를 outdir 와 결합해 최종 path 를 반환. outdir 가 빈 문자열이면 o_path
+/// 그대로 (caller-allocated). o_path 가 이미 absolute 면 outdir 무시 (esbuild 동일). caller
+/// 가 alloc 된 결과를 free 해야 함.
+fn resolveOutdirPath(allocator: std.mem.Allocator, outdir: []const u8, o_path: []const u8) ![]u8 {
+    if (outdir.len == 0) return try allocator.dupe(u8, o_path);
+    if (std.fs.path.isAbsolute(o_path)) return try allocator.dupe(u8, o_path);
+    return try std.fs.path.join(allocator, &.{ outdir, o_path });
+}
+
+/// #3795 — output 한 개를 outdir+path 로 결합해 write. dirname makePath + createFile +
+/// writeAll. 실패는 swallow (worker thread 가 다음 output 으로 계속 진행). bundler/emitter 가
+/// outdir 를 모르므로 path 가 entry-relative 라도 outdir 명시 시 정확한 디스크 위치로 결합.
+fn writeOutputToOutdir(
+    allocator: std.mem.Allocator,
+    outdir: []const u8,
+    o_path: []const u8,
+    contents: []const u8,
+) void {
+    const full_path = resolveOutdirPath(allocator, outdir, o_path) catch return;
+    defer allocator.free(full_path);
+    if (std.fs.path.dirname(full_path)) |dir| std.fs.cwd().makePath(dir) catch {};
+    const file = std.fs.cwd().createFile(full_path, .{}) catch return;
+    defer file.close();
+    file.writeAll(contents) catch {};
+}
+
 fn watchWorkerThread(async_data: *WatchAsyncData) void {
     const allocator = native_alloc;
     const bundle_opts = async_data.options;
@@ -663,24 +689,23 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     if (result.outputs) |outputs| {
         for (outputs) |o| initial_bytes += o.contents.len;
         if (write_initial) {
-            // code splitting: 각 output의 path로 직접 쓰기
+            // code splitting: 각 output의 path 로 직접 쓰기 (#3795 — outdir 가 명시되면 결합).
             for (outputs) |o| {
-                if (std.fs.path.dirname(o.path)) |dir| std.fs.cwd().makePath(dir) catch {};
-                const file = std.fs.cwd().createFile(o.path, .{}) catch continue;
-                defer file.close();
-                file.writeAll(o.contents) catch continue;
+                writeOutputToOutdir(allocator, bundle_opts.outdir, o.path, o.contents);
             }
         }
     } else {
         initial_bytes = result.output.len;
-        // 단일 파일: output_filename으로 쓰기 (skip_initial_output 활성 시 skip)
+        // 단일 파일: output_filename으로 쓰기 (skip_initial_output 활성 시 skip).
+        // #3795 — outdir 명시 시 output_filename 도 outdir-relative 로 처리.
         if (write_initial and bundle_opts.output_filename.len > 0) {
-            if (std.fs.path.dirname(bundle_opts.output_filename)) |dir| std.fs.cwd().makePath(dir) catch {};
-            if (std.fs.cwd().createFile(bundle_opts.output_filename, .{})) |file| {
-                defer file.close();
-                file.writeAll(result.output) catch {};
-                writeSourcemapFile(allocator, bundle_opts.output_filename, result.sourcemap, async_data.emit_disk_sourcemap);
-            } else |_| {}
+            writeOutputToOutdir(allocator, bundle_opts.outdir, bundle_opts.output_filename, result.output);
+            const final_path = resolveOutdirPath(allocator, bundle_opts.outdir, bundle_opts.output_filename) catch null;
+            if (final_path) |p| {
+                defer allocator.free(p);
+                writeSourcemapFile(allocator, p, result.sourcemap, async_data.emit_disk_sourcemap);
+            }
+            // 빈 placeholder if 분기 — 기존 else 패턴 호환 (sourcemap helper 호출 후).
         }
     }
 
@@ -781,28 +806,27 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
 
         async_data.compiled_cache.logStats("");
 
-        // 출력 파일 쓰기 + 바이트 수 계산
+        // 출력 파일 쓰기 + 바이트 수 계산 (#3795 — outdir 명시 시 결합).
         var output_bytes: usize = 0;
         if (rebuild_result.outputs) |outputs| {
             for (outputs) |o| output_bytes += o.contents.len;
             for (outputs) |o| {
-                if (std.fs.path.dirname(o.path)) |dir| std.fs.cwd().makePath(dir) catch {};
-                const file = std.fs.cwd().createFile(o.path, .{}) catch continue;
-                defer file.close();
-                file.writeAll(o.contents) catch continue;
+                writeOutputToOutdir(allocator, bundle_opts.outdir, o.path, o.contents);
             }
         } else {
             output_bytes = rebuild_result.output.len;
             if (bundle_opts.output_filename.len > 0) {
-                if (std.fs.path.dirname(bundle_opts.output_filename)) |dir| std.fs.cwd().makePath(dir) catch {};
-                if (std.fs.cwd().createFile(bundle_opts.output_filename, .{})) |file| {
-                    defer file.close();
-                    file.writeAll(rebuild_result.output) catch {};
+                writeOutputToOutdir(allocator, bundle_opts.outdir, bundle_opts.output_filename, rebuild_result.output);
+                const sm_path = resolveOutdirPath(allocator, bundle_opts.outdir, bundle_opts.output_filename) catch null;
+                if (sm_path) |p| {
+                    defer allocator.free(p);
                     // lazy 는 `rebuild_result.sourcemap == null` 이라 helper 안에서 자동 skip.
                     // eager + `emit_disk_sourcemap=false` 도 skip — bungae 처럼 dev server 가
                     // 직접 lazy 라우트를 제공하는 경우.
-                    writeSourcemapFile(allocator, bundle_opts.output_filename, rebuild_result.sourcemap, async_data.emit_disk_sourcemap);
-                } else |_| {}
+                    writeSourcemapFile(allocator, p, rebuild_result.sourcemap, async_data.emit_disk_sourcemap);
+                }
+                // sourcemap helper 호출 후 — 빈 placeholder if 분기 (기존 else 패턴 호환).
+                if (false) {}
             }
         }
 

--- a/packages/core/test/cli/app-builder/dev-hmr.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr.ts
@@ -3,3 +3,4 @@ import './dev-hmr/css-updates';
 import './dev-hmr/postcss';
 import './dev-hmr/bun-runtime';
 import './dev-hmr/dev-runtime-injected';
+import './dev-hmr/outdir-custom';

--- a/packages/core/test/cli/app-builder/dev-hmr/outdir-custom.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/outdir-custom.ts
@@ -1,0 +1,52 @@
+// #3795 회귀 가드 — native watch worker 의 출력이 지정된 outdir 외 다른 위치 (cwd 등) 로
+// 누출되지 않음. 가드 전: prepareNapiOptions 가 outdir 를 NAPI 로 보내기 전 delete →
+// bundler/watch.zig 가 outdir 를 모르고 `o.path` 그대로 (entry-relative or cwd) 출력 →
+// 결과적으로 dev server 의 serveDir 와 mis-match.
+// 본 PR 가 NAPI outdir parsing + watch.zig 의 writeOutputToOutdir helper 로 결합 보장.
+
+import {
+  CLI,
+  RUNTIME,
+  describe,
+  existsSync,
+  expect,
+  findFreePort,
+  join,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  spawn,
+  test,
+  tmpdir,
+  waitForServer,
+  writeFileSync,
+} from '../helpers';
+
+describe('CLI: Vite-style app builder > dev HMR > outdir 누출 가드', () => {
+  test('zntc dev → outdir 외 cwd 등 다른 위치에 bundle.js 누출 없음 (#3795)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-outdir-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'index.html'), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(join(dir, 'src', 'main.ts'), 'console.log("ok");');
+
+    const port = await findFreePort();
+    // cwd 를 별도 staging dir 로 두고 dev 의 root 는 source dir — 만약 watch worker 가
+    // entry-relative 또는 cwd 기준 fallback 한다면 staging 또는 dir 의 root 에 bundle.js
+    // 가 leak 된다 (정상 동작은 dir/.zntc-dev/ 안에만 생성).
+    const stagingCwd = mkdtempSync(join(tmpdir(), 'zntc-app-dev-cwd-'));
+    const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: stagingCwd });
+    await waitForServer(port);
+    try {
+      // 정상 — dev default outdir `.zntc-dev` 에 bundle.js 생성
+      expect(existsSync(join(dir, '.zntc-dev', 'bundle.js'))).toBe(true);
+      // 회귀 가드 — staging cwd 에는 bundle.js 가 leak 되면 안 됨
+      expect(existsSync(join(stagingCwd, 'bundle.js'))).toBe(false);
+      // 회귀 가드 — source root 직속 (dir/bundle.js) 에도 leak 없음
+      expect(existsSync(join(dir, 'bundle.js'))).toBe(false);
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(stagingCwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -252,6 +252,12 @@ pub const BundleOptions = struct {
     sourcemap: @import("../codegen/sourcemap.zig").SourceMapOptions = .{},
     /// 출력 파일명 (소스맵 참조용)
     output_filename: []const u8 = "bundle.js",
+    /// 출력 디렉터리 (#3795). `watch()` worker 가 outputs[].path 를 outdir-relative 로
+    /// 받아도 outdir 정보가 없으면 cwd 기준 fallback — JS 측 caller 가 명시한 outdir 와
+    /// 어긋날 위험. 기본 빈 문자열 = "디렉터리 명시 없음". bundler 자체는 path 생성 시
+    /// 이 필드를 보지 않고 (entry-relative 그대로), `watch.zig` 의 createFile 호출에서
+    /// outdir 와 join 한다.
+    outdir: []const u8 = "",
     /// UTF-8 문자를 이스케이프하지 않고 그대로 출력 (--charset=utf8)
     charset_utf8: bool = false,
     /// 엔트리 청크 파일명 패턴 (--entry-names, 기본: "[dir]/[name]")


### PR DESCRIPTION
## Summary

- PR #3783 의 `/code-review max` finding — `prepareNapiOptions` 가 `napiOptions.outdir` 를 delete. NAPI 가 outdir 모름 → watch worker thread 의 `createFile(o.path)` 가 mis-routing 가능성
- index.ts watch() 가 outdir restore + NAPI options.zig parsing + bundler.zig BundleOptions field + watch.zig 의 `writeOutputToOutdir` helper 로 결합

## Closes

- #3795

## 변경

- `packages/core/index.ts:3357` — watch() 가 `nativeOpts.outdir` restore
- `packages/core/src/napi/options.zig` — `outdir` NAPI parsing → `BundleOptions.outdir`
- `src/bundler/bundler.zig` — `BundleOptions.outdir: []const u8 = ""` 신설. bundler 자체는 사용 안 함 (entry-relative path 유지)
- `packages/core/src/napi/watch.zig`:
  - `resolveOutdirPath` / `writeOutputToOutdir` helper 추가 (esbuild 호환 — absolute path 면 outdir 무시)
  - initial + rebuild output write 모두 새 helper 통과
- `packages/core/test/cli/app-builder/dev-hmr/outdir-custom.ts` (신규) — outdir 누출 회귀 가드

## Test plan

- [x] `zig build test`: 0 fail
- [x] `bin/zntc.test.ts -t "dev HMR"`: 9 pass / 0 fail
- [ ] `--outdir=/custom` 으로 RN dev 등 다른 watch 사용자 회귀 없음 (default empty outdir = 기존 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)