### PR TITLE
fix(build): mimalloc 을 C++ 컴파일로 처리 — MSVC ARM64 ldar64/stlr64 intrinsic 회피 (CI hotfix)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -67,9 +67,14 @@ pub fn build(b: *std.Build) void {
     });
     exe.linkLibC();
 
-    // mimalloc: 고성능 메모리 할당자 (vendor/mimalloc, static.c 단일 컴파일)
+    // mimalloc: 고성능 메모리 할당자 (vendor/mimalloc, static.c 단일 컴파일).
+    // CI #3795 — MSVC ARM64 target 에서 mimalloc atomic.h 가 C 로 컴파일되면 `__ldar64` /
+    // `__stlr64` 같은 ARM64 MSVC intrinsic 호출 → Zig libc 헤더에 미선언 → 빌드 fail.
+    // mimalloc 권장대로 (`atomic.h:161`) MSVC target 은 C++ 컴파일 — `__cplusplus` 분기가
+    // std::atomic 사용해 intrinsic 회피. shim 파일이 `extern "C" { #include static.c }` 로
+    // mimalloc unity build 를 C++ 컴파일러로 처리.
     exe.addCSourceFile(.{
-        .file = b.path("vendor/mimalloc/src/static.c"),
+        .file = b.path("vendor/mimalloc-shim.cpp"),
         .flags = &.{
             "-DMI_SKIP_COLLECT_ON_EXIT=1",
             "-DMI_OVERRIDE=0",
@@ -78,6 +83,7 @@ pub fn build(b: *std.Build) void {
         },
     });
     exe.addIncludePath(b.path("vendor/mimalloc/include"));
+    exe.addIncludePath(b.path("vendor")); // shim 의 "mimalloc/src/static.c" include path
 
     // macOS 를 -Dtarget 으로 cross 빌드하면 zig 가 SDK 의 usr/include 를 자동 포함하지
     // 않아 mimalloc(prim.c)의 <CommonCrypto/CommonCryptoError.h> 를 못 찾는다.

--- a/vendor/mimalloc-shim.cpp
+++ b/vendor/mimalloc-shim.cpp
@@ -1,0 +1,18 @@
+// mimalloc C++ shim — `src/static.c` 의 단일 컴파일 unit 을 C++ 로 강제.
+//
+// 배경: mimalloc 의 `include/mimalloc/atomic.h` 가 `_MSC_VER` 정의된 환경에서 C 로
+// 컴파일될 때 ARM64 Windows MSVC intrinsic (`__ldar64` / `__stlr64` 등) 호출하는데,
+// Zig 의 libc 헤더에 그 intrinsic 미선언 → MSVC ARM64 target 빌드 fail.
+// 같은 atomic.h:161 가 "It is recommended to always compile as C++ when using MSVC"
+// 라고 명시. C++ 분기 (`__cplusplus`) 는 std::atomic 사용해 MSVC intrinsic 우회.
+//
+// 본 shim 은 `src/static.c` 를 그대로 include — mimalloc 의 unity build 단위. C 코드도
+// C++ 컴파일러로 처리되며 atomic.h 의 `__cplusplus` 분기로 들어가 ARM64 Windows MSVC
+// 빌드 회귀 (#3779 이후 GH Actions run 26399900801) 해결.
+//
+// Linux/macOS 빌드는 `_MSC_VER` 미정의라 C11 stdatomic 또는 C++ std::atomic 어느 쪽이든
+// 동일 동작 — cross-platform 안전.
+
+// mimalloc 의 unity build 파일을 그대로 C++ 으로 컴파일. atomic.h 가 `__cplusplus`
+// 분기로 std::atomic 사용 → MSVC ARM64 intrinsic 회피.
+#include "mimalloc/src/static.c"


### PR DESCRIPTION
## Summary

- 머지된 PR #fd713c68 (mimalloc v3.2.8 → v3.3.2) 이후 GH Actions run 26399900801 의 Windows MSVC CLI 빌드 3종 (x86_64 / x86 / aarch64) 이 모두 mimalloc atomic.h 의 ARM64 MSVC intrinsic (`__ldar64`/`__stlr64`) 미선언 으로 실패
- mimalloc 권장대로 (`atomic.h:161` "It is recommended to always compile as C++ when using MSVC") `static.c` 를 C++ 컴파일러로 처리 — `__cplusplus` 분기가 std::atomic 사용해 intrinsic 회피
- `vendor/mimalloc-shim.cpp` 신설 (`#include "mimalloc/src/static.c"`) + `build.zig` 가 shim 을 mimalloc unit 으로 등록

## 변경

- `vendor/mimalloc-shim.cpp` (신규) — mimalloc 의 unity build 파일을 C++ 으로 컴파일하는 wrapper
- `build.zig` — mimalloc 소스를 shim.cpp 로 변경 + `addIncludePath("vendor")` 로 include path resolve

## 영향 범위

- **Windows MSVC** (x86_64 / x86 / aarch64): mimalloc 컴파일 통과 → CLI 빌드 회복
- **Linux / macOS**: `_MSC_VER` 미정의라 C/C++ 어느 쪽이든 동일 결과 (C11 stdatomic vs std::atomic). cross-platform 안전

## Refs

- mimalloc v3.2.8 → v3.3.2 (#fd713c68)
- GH Actions run 26399900801 (Windows CLI 3종 실패)
- mimalloc atomic.h:161 의 권장 ("compile as C++ when using MSVC")

## Test plan

- [x] 로컬 native (macOS arm64) `zig build install`: 성공
- [x] 로컬 cross `-Dtarget=aarch64-windows-msvc`: mimalloc 단계 통과 (이전 fail 지점). boringssl ws2_32 누락은 로컬 cross-build 환경 한계라 CI 와 무관
- [x] `zig build test`: 0 fail
- [x] `bin/zntc.test.ts`: 295 pass / 2 skip / 0 fail
- [ ] GH Actions Windows CLI 빌드 통과 확인 (PR CI 결과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)