### PR TITLE
fix(dev-server): drain else 분기 3분기 fix — HTML/JSON FullReload + JS noop + CSS-only full pipeline (#3797)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -2031,22 +2031,37 @@ async function runServe(opts, config, { appDev = null } = {}) {
               if (opts.logLevel !== 'silent') console.error('[serve] css updated');
             }
           } else {
-            // #3779 — paths 의 CSS-derived 변경 (CSS Module / Sass Module / 그 외 CSS-like)
-            // 은 native watch 의 module graph 밖이라 incremental update 가 트리거되지 않는다.
-            // class 이름 매핑이나 JS proxy 가 재생성돼야 하므로 full pipeline rebuild + FullReload.
-            // 순수 JS/TS 변경은 native watch handle 이 incremental Update / FullReload 단독 처리
-            // — drain 은 noop (중복 컴파일/output race 회피).
-            const cssDerived = paths.some(
-              (p) =>
-                p.endsWith('.css') ||
-                p.endsWith('.scss') ||
-                p.endsWith('.sass') ||
-                p.endsWith('.less') ||
-                appDev.isPostcssConfig(p),
-            );
-            if (cssDerived) {
+            // #3797 — paths 의 종류에 따라 3분기:
+            // - 전부 CSS-derived (CSS Module / Sass Module / postcss): native watch 의 module
+            //   graph 밖이라 incremental update 트리거 안 됨 → full pipeline + FullReload.
+            // - JS module (.ts/.tsx/.js 등) 섞임: native watch 가 단독 처리. drain noop
+            //   (중복 컴파일/output race 회피).
+            // - 그 외 (HTML / JSON / static asset 등 native watch graph 밖 + non-CSS): fallback
+            //   FullReload broadcast. pre-#3779 의 unconditional rebuildAppDevFull 회귀 가드.
+            const isCssDerived = (p) =>
+              p.endsWith('.css') ||
+              p.endsWith('.scss') ||
+              p.endsWith('.sass') ||
+              p.endsWith('.less') ||
+              appDev.isPostcssConfig(p);
+            const isJsModule = (p) =>
+              p.endsWith('.ts') ||
+              p.endsWith('.tsx') ||
+              p.endsWith('.js') ||
+              p.endsWith('.jsx') ||
+              p.endsWith('.mjs') ||
+              p.endsWith('.cjs');
+            const allCssDerived = paths.every(isCssDerived);
+            const hasJs = paths.some(isJsModule);
+            if (allCssDerived) {
               await rebuildAppDevFull(paths);
+            } else if (!hasJs) {
+              // HTML/JSON/asset 변경 — native watch 가 안 보는 변경에 대한 reload 신호.
+              hmr?.clearError();
+              hmr?.broadcast({ type: HMR_MSG.FullReload, timestamp: Date.now() });
+              if (opts.logLevel !== 'silent') console.error('[serve] file changed, full reload');
             }
+            // hasJs=true: native watch handle 의 onRebuild 가 단독 broadcast. drain noop.
           }
         }
       } catch (err) {

--- a/packages/core/test/cli/app-builder/dev-hmr.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr.ts
@@ -4,3 +4,4 @@ import './dev-hmr/postcss';
 import './dev-hmr/bun-runtime';
 import './dev-hmr/dev-runtime-injected';
 import './dev-hmr/outdir-custom';
+import './dev-hmr/non-graph-reload';

--- a/packages/core/test/cli/app-builder/dev-hmr/non-graph-reload.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/non-graph-reload.ts
@@ -1,0 +1,63 @@
+// #3797 회귀 가드 — index.html 처럼 native watch 의 module graph 밖이면서 CSS 도 아닌
+// 파일 변경은 drain else 분기에서 fallback FullReload broadcast 받아야 함.
+// 가드 전 (pre-#3797): drain 의 cssDerived 분기만 broadcast → HTML/JSON 변경은 silent drop.
+// pre-#3779 회귀 — 사용자가 reload 받지 못해 화면 stale.
+
+import {
+  CLI,
+  RUNTIME,
+  describe,
+  expect,
+  findFreePort,
+  join,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  spawn,
+  test,
+  tmpdir,
+  waitForServer,
+  writeFileSync,
+} from '../helpers';
+
+describe('CLI: Vite-style app builder > dev HMR > non-graph file reload', () => {
+  test('index.html 변경 → FullReload broadcast 수신 (#3797)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-html-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<!doctype html><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, 'src', 'main.ts'), 'console.log("v1");');
+
+    const port = await findFreePort();
+    const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      const messagePromise = new Promise<{ type: string }>((resolve) => {
+        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
+        ws.onmessage = (event) => {
+          const msg = JSON.parse(String(event.data));
+          // connected 무시, full-reload 받으면 종료
+          if (msg.type === 'full-reload') {
+            ws.close();
+            resolve(msg);
+          }
+        };
+        ws.onerror = () => resolve({ type: 'error' });
+        setTimeout(() => resolve({ type: 'timeout' }), 5000);
+      });
+      await new Promise((r) => setTimeout(r, 300));
+      // HTML 변경 — module graph 밖, CSS 도 아님 → drain 의 fallback FullReload 가 처리해야.
+      writeFileSync(
+        join(dir, 'index.html'),
+        '<!doctype html><meta name="v" content="2"><script type="module" src="/src/main.ts"></script>',
+      );
+      const msg = await messagePromise;
+      expect(msg.type).toBe('full-reload');
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- PR #3783 의 `/code-review max` 가 발견한 회귀 3개 중 **회귀 1/2 부분 fix** (회귀 3은 별도 follow-up 으로 분리)
- drain 의 else 분기를 paths 종류에 따라 3분기로 명시화 — CSS-only / JS-mixed / 그 외

## Refs

- #3797 (본 epic — 3가지 회귀 묶음 issue)

## 변경

- `packages/core/bin/zntc.mjs` drain else 분기:
  - **allCssDerived=true** (전부 CSS Module / Sass Module / postcss): `rebuildAppDevFull` + FullReload
  - **hasJs=true** (JS module .ts/.tsx/.js/.jsx/.mjs/.cjs 섞임): noop (native watch 가 단독 broadcast)
  - **그 외** (HTML/JSON/static asset): fallback `FullReload` broadcast (pre-#3779 회귀 가드)
- `packages/core/test/cli/app-builder/dev-hmr/non-graph-reload.ts` (신규) — index.html 변경 시 `full-reload` 수신 가드

## 분리된 follow-up

- 회귀 3 (JS-only 변경이 새 CSS import 추가 → HTML `<link>` stale): native watch onRebuild 에서 outdir 스캔 기반 `injectBundleCssLinks` 호출 필요. #3797 본문에 별도 작업으로 분리.

## Test plan

- [x] `zig build test`: 0 fail
- [x] `bin/zntc.test.ts -t "dev HMR"`: 10 pass / 0 fail
- [x] `bin/zntc.test.ts` 전체: 295 pass / 2 skip / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)