### PR TITLE
fix(dev-server): cssDerived predicate 를 appDev.isCssLikeChange 헬퍼로 통일 (#3801)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -2038,12 +2038,8 @@ async function runServe(opts, config, { appDev = null } = {}) {
             //   (중복 컴파일/output race 회피).
             // - 그 외 (HTML / JSON / static asset 등 native watch graph 밖 + non-CSS): fallback
             //   FullReload broadcast. pre-#3779 의 unconditional rebuildAppDevFull 회귀 가드.
-            const isCssDerived = (p) =>
-              p.endsWith('.css') ||
-              p.endsWith('.scss') ||
-              p.endsWith('.sass') ||
-              p.endsWith('.less') ||
-              appDev.isPostcssConfig(p);
+            // #3801 — appDev 의 isCssLikeChange 가 단일 진실 소스. inline literal endsWith
+            // 가 `.less` (미지원) 포함하거나 `.styl/.pcss` 누락하던 drift 회귀 방지.
             const isJsModule = (p) =>
               p.endsWith('.ts') ||
               p.endsWith('.tsx') ||
@@ -2051,7 +2047,7 @@ async function runServe(opts, config, { appDev = null } = {}) {
               p.endsWith('.jsx') ||
               p.endsWith('.mjs') ||
               p.endsWith('.cjs');
-            const allCssDerived = paths.every(isCssDerived);
+            const allCssDerived = paths.every((p) => appDev.isCssLikeChange(p));
             const hasJs = paths.some(isJsModule);
             if (allCssDerived) {
               await rebuildAppDevFull(paths);

--- a/packages/web/src/dev-controller.test.ts
+++ b/packages/web/src/dev-controller.test.ts
@@ -142,6 +142,27 @@ describe('createAppDevController', () => {
     expect(c.isCssOnlyChange('/x/main.ts')).toBe(false);
   });
 
+  test('isCssLikeChange — CSS / Sass / postcss / CSS Module 전부 true, JS/HTML false (#3801)', () => {
+    const c = controller();
+    // 일반 CSS / Sass
+    expect(c.isCssLikeChange('/x/style.css')).toBe(true);
+    expect(c.isCssLikeChange('/x/style.scss')).toBe(true);
+    expect(c.isCssLikeChange('/x/style.sass')).toBe(true);
+    // CSS Modules / Sass Modules — drain 에서 full pipeline rebuild 가 필요한 케이스
+    expect(c.isCssLikeChange('/x/style.module.css')).toBe(true);
+    expect(c.isCssLikeChange('/x/style.module.scss')).toBe(true);
+    // postcss config
+    expect(c.isCssLikeChange('/x/postcss.config.js')).toBe(true);
+    // 미지원 확장자 (.less / .styl / .pcss): 코드베이스에 pipeline 없음 → false. drift 가드.
+    expect(c.isCssLikeChange('/x/style.less')).toBe(false);
+    expect(c.isCssLikeChange('/x/style.styl')).toBe(false);
+    expect(c.isCssLikeChange('/x/style.pcss')).toBe(false);
+    // JS / HTML / asset — 명확히 false
+    expect(c.isCssLikeChange('/x/main.ts')).toBe(false);
+    expect(c.isCssLikeChange('/x/index.html')).toBe(false);
+    expect(c.isCssLikeChange('/x/data.json')).toBe(false);
+  });
+
   test('isSassOnlyChange — non-module .scss/.sass 만 true', () => {
     const c = controller();
     expect(c.isSassOnlyChange('/x/style.scss')).toBe(true);

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -423,6 +423,13 @@ export interface AppDevController {
   isPostcssConfig(absPath: string): boolean;
   isCssOnlyChange(absPath: string): boolean;
   isSassOnlyChange(absPath: string): boolean;
+  /**
+   * #3801 — drain else 분기의 CSS-derived 판정 단일 소스. inline literal endsWith 가
+   * `.less` 같은 미지원 확장자나 `.styl/.pcss` 누락으로 drift 하던 회귀 방지. CSS / Sass /
+   * postcss config / CSS Module / Sass Module 등 native watch graph 밖이라 incremental
+   * update 가 트리거되지 않는 변경을 cover.
+   */
+  isCssLikeChange(absPath: string): boolean;
   rebuildScssIncremental(absPath: string): Promise<string | null>;
   hrefFor(absPath: string): string;
 }
@@ -572,6 +579,17 @@ export function createAppDevController(
     },
     isPostcssConfig(absPath) {
       return isPostcssConfigFile(absPath);
+    },
+    isCssLikeChange(absPath) {
+      // #3801 — 단일 진실 소스. isCssFile (.css 만) / isCssPreprocessorFile (.scss/.sass)
+      // / isCssModuleFile (*.module.css) / isCssModulePreprocessorFile (*.module.scss/.sass)
+      // / postcss config 모두 cover. .less / .styl / .pcss 같이 코드베이스 미지원 확장자는
+      // 명시적으로 false — 사용자가 third-party plugin 으로 처리해도 native watch 의 graph
+      // 안에 있으면 자동 trigger 됨, graph 밖이면 별도 issue.
+      if (isPostcssConfigFile(absPath)) return true;
+      if (isCssFile(absPath) || isCssPreprocessorFile(absPath)) return true;
+      if (isCssModuleFile(absPath) || isCssModulePreprocessorFile(absPath)) return true;
+      return false;
     },
     isCssOnlyChange(absPath) {
       // CSS Modules 는 class 이름 매핑이 변할 수 있어 JS proxy 도 같이 재생성 필요 →


### PR DESCRIPTION
## Summary

- PR #3810 의 inline literal endsWith 가 `.less` 포함 (코드베이스 미지원) + `.styl/.pcss` 누락 등 drift. `appDev.isCssOnlyChange` 처럼 헬퍼 기반 truth source 와 어긋남
- `AppDevController.isCssLikeChange` 헬퍼 신설 (기존 helper 5개 재사용) + zntc.mjs inline 제거

## Closes

- #3801

## 변경

- `packages/web/src/dev-controller.ts` — interface 와 구현 추가
- `packages/core/bin/zntc.mjs` — inline literal → `appDev.isCssLikeChange`
- `packages/web/src/dev-controller.test.ts` — drift 가드 (12 expect)

## Test plan

- [x] `bun test src/dev-controller.test.ts -t "isCssLikeChange"`: 1 pass
- [x] packages/web 전체: 166 pass / 0 fail
- [x] bin/zntc.test.ts -t "dev HMR": 10 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)