### PR TITLE
fix(server): broadcastRebuildEvent noop branch 도 clearError — stale overlay 해제 (#3799 부분)

### DIFF
--- a/packages/server/src/hmr-rebuild-broadcast.test.ts
+++ b/packages/server/src/hmr-rebuild-broadcast.test.ts
@@ -115,6 +115,23 @@ describe('broadcastRebuildEvent', () => {
     expect(client.received).toHaveLength(0);
   });
 
+  test('noop branch 도 clearError 호출 — 이전 error latch 자동 해제 (#3799)', () => {
+    const { ch, client } = attach();
+    // 1) 이전 빌드 error 가 latched
+    ch.reportError([{ text: 'syntax error before' }]);
+    client.received.length = 0;
+    // 2) 성공 + code 변경 없는 noop rebuild (사용자가 whitespace-only edit 으로 fix)
+    const outcome = broadcastRebuildEvent(ch, { success: true });
+    expect(outcome).toBe('noop');
+    // broadcast 자체는 0건 (clearError 가 메시지 송출 안 함 — state mutation only)
+    expect(client.received).toHaveLength(0);
+    // 그러나 latch 는 해제됐어야 — 새 client 연결 시 connected 만 받음 (error 메시지 안 전달)
+    const fresh = makeClient();
+    ch.addBunClient(fresh);
+    const freshTypes = fresh.received.map((t) => JSON.parse(t).type);
+    expect(freshTypes).toEqual([HMR_MSG.Connected]);
+  });
+
   test('graphChanged=true 이면 updates 있어도 FullReload 만 (분기 mutually exclusive)', () => {
     const { ch, client } = attach();
     const event: RebuildEventLike = {

--- a/packages/server/src/hmr-rebuild-broadcast.ts
+++ b/packages/server/src/hmr-rebuild-broadcast.ts
@@ -24,7 +24,9 @@ export interface RebuildEventLike {
  * - `success=false` → `reportError`
  * - `graphChanged=true` → `clearError` + `FullReload`
  * - `updates` 있음 → `clearError` + `UpdateStart` → `Update(modules)` → `UpdateDone`
- * - 그 외 (code 변경 없음) → no-op (`clearError` 도 호출 안 함 — 이전 error latch 보존)
+ * - 그 외 (code 변경 없음) → `clearError` 만 호출 (#3799 — success 한 rebuild 라 이전 error
+ *   latch 도 자동 해제. 사용자가 syntax error 를 whitespace-only edit 등으로 fix 했을 때
+ *   overlay 가 stuck 안 되도록.)
  *
  * Return: 어떤 분기로 갔는지 — 호출자가 로그/메트릭에 사용. Test 에서 분기 검증.
  */
@@ -53,5 +55,9 @@ export function broadcastRebuildEvent(
     hmr.broadcast({ type: HMR_MSG.UpdateDone });
     return 'update';
   }
+  // #3799 — 성공한 rebuild + code 변경 없음 (whitespace-only edit 등 bytewise-identical
+  // output). 이전 error latch 도 자동 해제 — 사용자가 fix 한 셈. clearError 자체는 broadcast
+  // 아님 (state mutation only), 다음 연결되는 client 에게 stale error 가 안 전달되도록 가드.
+  hmr.clearError();
   return 'noop';
 }


### PR DESCRIPTION
## Summary

- #3799 의 3가지 중 noop branch clearError 만 fix (나머지 multi-error + sourcemap endpoint 별도 PR)
- success=true + graphChanged=false + updates 비어있을 때 (whitespace-only edit) 이전 error latch 가 해제되지 않아 overlay 가 stuck — clearError 추가로 해제

## Refs

- #3799 (epic)

## 변경

- `hmr-rebuild-broadcast.ts` — noop branch 에 `hmr.clearError()` 호출
- `hmr-rebuild-broadcast.test.ts` — 회귀 가드 (reportError → noop → 새 client connected only)

## Test plan

- [x] `bun test src/hmr-rebuild-broadcast.test.ts`: 9 pass / 0 fail
- [x] bin/zntc.test.ts -t "dev HMR": 10 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)