### PR TITLE
fix(core): #3803 minor 묶음 — skipInitialOutput build warn + stop throw retry 가능

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -1895,13 +1895,16 @@ async function runServe(opts, config, { appDev = null } = {}) {
     // #3779 follow-up — native watch worker thread 가 child process spawn 후에도 살아남으면
     // outdir 출력이 부모/자식 두 곳에서 일어나 race. emitRestartAfter 의 child spawn 전에 stop.
     // stop 자체가 throw 해도 server.close 는 시도 (HTTP 포트 해제 우선).
+    // #3803 — stop() throw 시 nativeWatchHandle 을 null 하지 않고 유지 → 다음 호출에서 retry
+    // 가능. 정상 path 에서만 null 로 갱신. idempotent stop (#3794 의 napi_remove_wrap) 라
+    // 다음 시도도 안전.
     if (nativeWatchHandle) {
       try {
         nativeWatchHandle.stop();
+        nativeWatchHandle = null;
       } catch (err) {
-        console.error('[serve] native watch stop 실패:', err);
+        console.error('[serve] native watch stop 실패 (다음 호출에서 재시도):', err);
       }
-      nativeWatchHandle = null;
     }
     if (!serverHandle) return;
     if (typeof serverHandle.stop === 'function') {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -2315,6 +2315,18 @@ function withDefaultBuildDefines(options: BuildOptions): Record<string, string> 
   return Object.keys(define).length > 0 ? define : undefined;
 }
 
+/**
+ * #3803 — `BuildOptionsCommon` 의 watch-only 옵션이 build()/buildSync() 에 silent 무시되는
+ * 위험을 stderr warn 으로 surface. 사용자가 잘못 호출했을 때 디버깅 도움.
+ */
+function warnIfWatchOnlyOption(options: BuildOptions, fnName: string): void {
+  if (options.skipInitialOutput) {
+    console.warn(
+      `@zntc/core: ${fnName}() does not honor skipInitialOutput (watch()-only option). It is silently ignored. If you meant to use this with a separate build, call watch() instead.`,
+    );
+  }
+}
+
 function withDefaultAppBuildDefines(options: AppBuildOptions): Record<string, string> | undefined {
   const define = { ...options.define };
   if (define['process.env.NODE_ENV'] === undefined) {
@@ -2564,6 +2576,7 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
   const n = ensureNative();
   if (!options.entryPoints?.length) throw new Error('@zntc/core: entryPoints is required');
   validateTsConfigRaw(options.tsconfigRaw);
+  warnIfWatchOnlyOption(options, 'build');
 
   if (options.output && options.output.length >= 2) {
     return buildMultiFormat(options);
@@ -2615,6 +2628,7 @@ export function buildSync(options: BuildOptions): BuildResult {
   const n = ensureNative();
   if (!options.entryPoints?.length) throw new Error('@zntc/core: entryPoints is required');
   validateTsConfigRaw(options.tsconfigRaw);
+  warnIfWatchOnlyOption(options, 'buildSync');
 
   const { napiOptions, cleanup } = prepareNapiOptions(options);
   const dispatcher = resolveDispatcher(options, 'sync');

--- a/packages/core/test/core/build-sync.ts
+++ b/packages/core/test/core/build-sync.ts
@@ -3,3 +3,4 @@ import './build-sync/drop-options';
 import './build-sync/graph-prepass';
 import './build-sync/ts-export-equals-basic';
 import './build-sync/ts-export-equals-minify-targets';
+import './build-sync/skip-initial-output-warn';

--- a/packages/core/test/core/build-sync/skip-initial-output-warn.ts
+++ b/packages/core/test/core/build-sync/skip-initial-output-warn.ts
@@ -1,0 +1,54 @@
+// #3803 — `BuildOptionsCommon.skipInitialOutput` 은 watch()-only. build()/buildSync()
+// 가 무시하지만 사용자가 잘못 전달하면 silent. console.warn 으로 surface.
+
+import { describe, expect, test, mkdtempSync, writeFileSync, rmSync, join, tmpdir } from './helpers';
+import { build, buildSync } from '../../../index';
+
+describe('build*/skipInitialOutput silent ignore warn (#3803)', () => {
+  test('buildSync({skipInitialOutput:true}) → stderr warn 출력', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-skip-warn-'));
+    writeFileSync(join(dir, 'entry.ts'), 'export const x = 1;');
+    const origWarn = console.warn;
+    const captured: string[] = [];
+    console.warn = (msg: string) => captured.push(String(msg));
+    try {
+      buildSync({ entryPoints: [join(dir, 'entry.ts')], skipInitialOutput: true });
+      expect(captured.some((m) => m.includes('skipInitialOutput'))).toBe(true);
+      expect(captured.some((m) => m.includes('buildSync'))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  test('build({skipInitialOutput:true}) → stderr warn 출력', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-skip-warn-'));
+    writeFileSync(join(dir, 'entry.ts'), 'export const x = 1;');
+    const origWarn = console.warn;
+    const captured: string[] = [];
+    console.warn = (msg: string) => captured.push(String(msg));
+    try {
+      await build({ entryPoints: [join(dir, 'entry.ts')], skipInitialOutput: true });
+      expect(captured.some((m) => m.includes('skipInitialOutput'))).toBe(true);
+      expect(captured.some((m) => m.includes('build()'))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  test('skipInitialOutput 미지정 → warn 없음', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-skip-warn-'));
+    writeFileSync(join(dir, 'entry.ts'), 'export const x = 1;');
+    const origWarn = console.warn;
+    const captured: string[] = [];
+    console.warn = (msg: string) => captured.push(String(msg));
+    try {
+      buildSync({ entryPoints: [join(dir, 'entry.ts')] });
+      expect(captured.some((m) => m.includes('skipInitialOutput'))).toBe(false);
+    } finally {
+      console.warn = origWarn;
+      rmSync(dir, { recursive: true });
+    }
+  });
+});

--- a/packages/core/test/core/build-sync/skip-initial-output-warn.ts
+++ b/packages/core/test/core/build-sync/skip-initial-output-warn.ts
@@ -1,7 +1,16 @@
 // #3803 — `BuildOptionsCommon.skipInitialOutput` 은 watch()-only. build()/buildSync()
 // 가 무시하지만 사용자가 잘못 전달하면 silent. console.warn 으로 surface.
 
-import { describe, expect, test, mkdtempSync, writeFileSync, rmSync, join, tmpdir } from './helpers';
+import {
+  describe,
+  expect,
+  test,
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  join,
+  tmpdir,
+} from './helpers';
 import { build, buildSync } from '../../../index';
 
 describe('build*/skipInitialOutput silent ignore warn (#3803)', () => {


### PR DESCRIPTION
## Summary

- #3803 의 minor 6개 중 priority 높은 2개 fix:
  1. `BuildOptionsCommon.skipInitialOutput` 가 build()/buildSync() 에서 silent 무시 → `console.warn` 으로 surface
  2. `closeServerForRestart` 의 stop() throw 시 nativeWatchHandle 을 null 안 함 → 다음 호출에서 retry 가능

## Refs

- #3803

## 남은 #3803 항목 (별도)

- initial_bytes metric misleading — PR #3787 코멘트가 의도된 동작이라 docs only
- outdir 미준비 explicit guard — JSDoc 만으로 충분
- NAPI options unit test — schema-allowlists 가 키 가드, timing 측정 비용 > 가치
- Stale native watch entry after opts.entryPoints mutation — appDev.prepare 의 entryPath stable invariant

## Test plan

- [x] `index.test.ts -t "skipInitialOutput silent ignore warn"`: 3 pass
- [x] `bin/zntc.test.ts -t "dev HMR"`: 10 pass / 0 fail
- [x] `index.test.ts -t "watch"`: 39 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)