### PR TITLE
fix(dev-server): graphChanged 시 outdir 재출력 + CSS link 재주입 (#3813 partial)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -1944,11 +1944,25 @@ async function runServe(opts, config, { appDev = null } = {}) {
       // #3779 follow-up — runBundle 이 outdir 를 이미 채웠으므로 watch initial 출력은 skip.
       watchBuildOpts.skipInitialOutput = true;
       watchBuildOpts.onRebuild = (event) => {
-        try {
-          web.broadcastRebuildEvent(hmr, event);
-        } catch (err) {
-          console.error('[serve] hmr broadcast error:', err);
-        }
+        // #3813 — graphChanged 시 outdir 새 chunk/CSS 갱신이 필요한데, skipInitialOutput=true
+        // + #3802 의 incremental skip_bundle_output 강제로 native watch 가 outdir 안 씀.
+        // workaround: graphChanged 면 추가 runBundle 호출로 outdir 채운 후 HTML `<link>`
+        // 재주입. (architectural cleanup 은 #3796/#3798 epic 에서 watch 단독화로 풀 예정.)
+        void (async () => {
+          try {
+            if (event && event.success && event.graphChanged) {
+              try {
+                const r = await runBundle(opts, config);
+                if (r.errors.length === 0) appDev.injectBundleCssLinks(r);
+              } catch (cssErr) {
+                console.error('[serve] graph 변경 outdir 재출력 실패:', cssErr);
+              }
+            }
+            web.broadcastRebuildEvent(hmr, event);
+          } catch (err) {
+            console.error('[serve] hmr broadcast error:', err);
+          }
+        })();
       };
       try {
         nativeWatchHandle = watch(watchBuildOpts);

--- a/packages/core/test/cli/app-builder/dev-hmr.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr.ts
@@ -5,3 +5,4 @@ import './dev-hmr/bun-runtime';
 import './dev-hmr/dev-runtime-injected';
 import './dev-hmr/outdir-custom';
 import './dev-hmr/non-graph-reload';
+import './dev-hmr/new-css-import';

--- a/packages/core/test/cli/app-builder/dev-hmr/new-css-import.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/new-css-import.ts
@@ -1,0 +1,65 @@
+// #3813 가드 (partial) — JS-only 변경이 새 CSS import 추가 시 broadcast 수신 검증.
+//
+// Limitation: native incremental bundler 가 새 module path 추가를 항상 `graphChanged=true`
+// 로 trigger 하지 않음 (changed_files 만 partial rebuild 가능). 그래서 본 PR 의 outdir-scan
+// CSS inject 가 `graphChanged=true` 케이스만 활성화. 새 import 가 update-done 시퀀스로
+// broadcast 되면 inject 가 호출 안 됨. 완전 fix 는 native bundler 의 graphChanged 정책 변경
+// (#3784 / 향후 epic) 와 함께.
+//
+// 본 가드는 broadcast 자체가 (FullReload 또는 Update sequence) 정상 도착하는지만 검증 —
+// inject helper 가 plumbing 상태로 잘 동작하는지는 별도 unit test 로 검증.
+
+import {
+  CLI,
+  RUNTIME,
+  describe,
+  expect,
+  findFreePort,
+  join,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  spawn,
+  test,
+  tmpdir,
+  waitForServer,
+  writeFileSync,
+} from '../helpers';
+
+describe('CLI: Vite-style app builder > dev HMR > new CSS import (#3813)', () => {
+  test('JS-only 변경이 새 CSS import 추가 → broadcast 수신 (FullReload 또는 Update)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-new-css-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'index.html'), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(join(dir, 'src', 'main.ts'), 'console.log("v1");');
+
+    const port = await findFreePort();
+    const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      const reloadOrUpdate = new Promise<{ type: string }>((resolve) => {
+        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
+        const timeout = setTimeout(() => resolve({ type: 'timeout' }), 8000);
+        ws.onopen = async () => {
+          await new Promise((r) => setTimeout(r, 300));
+          writeFileSync(join(dir, 'src', 'styles.css'), 'body { background: lime; }');
+          writeFileSync(join(dir, 'src', 'main.ts'), 'import "./styles.css"; console.log("v2");');
+        };
+        ws.onmessage = (event) => {
+          const msg = JSON.parse(String(event.data));
+          if (msg.type === 'full-reload' || msg.type === 'update-done') {
+            clearTimeout(timeout);
+            ws.close();
+            resolve(msg);
+          }
+        };
+      });
+      const msg = await reloadOrUpdate;
+      // broadcast 자체 수신 가드 — pre-#3779 회귀 (silent drop) 방지
+      expect(['full-reload', 'update-done']).toContain(msg.type);
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -18,6 +18,7 @@ import { applyHtmlEnvTokens } from './html-env.ts';
 import {
   type BundleResult,
   injectAppDevBundleCssLinks,
+  injectAppDevBundleCssLinksFromOutdir,
   injectAppDevHmrClient,
   injectAppDevPipelineCssLinks,
 } from './inject.ts';
@@ -420,6 +421,13 @@ export interface AppDevController {
     processed: number;
   }>;
   injectBundleCssLinks(bundleResult: BundleResult): void;
+  /**
+   * #3813 — outdir 의 `.css` 파일을 file system 스캔해 HTML `<link>` 주입.
+   * `injectBundleCssLinks` 가 bundleResult 를 받는 것과 달리 native watch onRebuild 의
+   * graphChanged 분기처럼 bundleResult 가 없는 경로용. JS 변경이 새 CSS import 추가했을 때
+   * stale `<link>` 회귀 가드.
+   */
+  injectBundleCssLinksFromOutdir(): void;
   isPostcssConfig(absPath: string): boolean;
   isCssOnlyChange(absPath: string): boolean;
   isSassOnlyChange(absPath: string): boolean;
@@ -576,6 +584,12 @@ export function createAppDevController(
       // 하도록 확장하거나 metafile inputs 기반 정밀 dedup 으로 follow-up.
       if (hasPipelineCss) return;
       injectAppDevBundleCssLinks(outdir, base, bundleResult);
+    },
+    injectBundleCssLinksFromOutdir() {
+      // #3813 — native watch onRebuild 의 graphChanged 분기처럼 bundleResult 가 없는 경로용.
+      // pipeline CSS 우선 정책은 동일 — pipeline 이 inject 했으면 outdir scan skip.
+      if (hasPipelineCss) return;
+      injectAppDevBundleCssLinksFromOutdir(outdir, base);
     },
     isPostcssConfig(absPath) {
       return isPostcssConfigFile(absPath);

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -36,6 +36,7 @@ export {
 export {
   type BundleResult,
   injectAppDevBundleCssLinks,
+  injectAppDevBundleCssLinksFromOutdir,
   injectAppDevHmrClient,
   injectAppDevPipelineCssLinks,
   injectIntoDevHtml,

--- a/packages/web/src/inject.test.ts
+++ b/packages/web/src/inject.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 
 import {
   injectAppDevBundleCssLinks,
+  injectAppDevBundleCssLinksFromOutdir,
   injectAppDevHmrClient,
   injectAppDevPipelineCssLinks,
   injectIntoDevHtml,
@@ -181,6 +182,35 @@ describe('injectAppDevPipelineCssLinks', () => {
     writeHtml(original);
     injectAppDevPipelineCssLinks(outdir, '/', []);
     expect(readHtml()).toBe(original);
+  });
+
+  test('injectAppDevBundleCssLinksFromOutdir — outdir 의 .css 파일 스캔해 link 주입 (#3813)', () => {
+    writeHtml('<html><head></head></html>');
+    writeFileSync(join(outdir, 'bundle.js'), '// js, ignored');
+    writeFileSync(join(outdir, 'style-a.css'), 'a {}');
+    writeFileSync(join(outdir, 'style-b.css'), 'b {}');
+    injectAppDevBundleCssLinksFromOutdir(outdir, '/');
+    const html = readHtml();
+    expect(html).toMatch(/<link[^>]+rel="stylesheet"[^>]+href="\/style-a\.css"/);
+    expect(html).toMatch(/<link[^>]+rel="stylesheet"[^>]+href="\/style-b\.css"/);
+    // .js 는 무시
+    expect(html).not.toMatch(/href="\/bundle\.js"/);
+  });
+
+  test('injectAppDevBundleCssLinksFromOutdir — 이미 있는 link 는 중복 추가 안 함', () => {
+    writeHtml('<html><head><link rel="stylesheet" href="/a.css"></head></html>');
+    writeFileSync(join(outdir, 'a.css'), 'a {}');
+    injectAppDevBundleCssLinksFromOutdir(outdir, '/');
+    const html = readHtml();
+    expect(html.match(/href="\/a\.css"/g)?.length).toBe(1);
+  });
+
+  test('injectAppDevBundleCssLinksFromOutdir — outdir 미존재 시 silent skip', () => {
+    writeHtml('<html><head></head></html>');
+    // outdir 안 만든 nested 경로
+    injectAppDevBundleCssLinksFromOutdir(join(outdir, 'no-such-subdir'), '/');
+    // HTML 그대로
+    expect(readHtml()).toBe('<html><head></head></html>');
   });
 
   test('Windows path separator 를 forward slash 로 변환', () => {

--- a/packages/web/src/inject.ts
+++ b/packages/web/src/inject.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { basename, join, sep } from 'node:path';
 
 import { APP_DEV_HMR_CLIENT_PATH } from '@zntc/server';
@@ -54,6 +54,32 @@ export function injectAppDevBundleCssLinks(
     for (const file of bundleResult?.outputFiles ?? []) {
       if (!file?.path || !isCssFile(file.path)) continue;
       const href = joinUrl(base, basename(file.path));
+      if (!html.includes(`href="${href}"`) && !html.includes(`href='${href}'`)) cssHrefs.push(href);
+    }
+    if (cssHrefs.length === 0) return null;
+    return cssHrefs.map((href) => `<link rel="stylesheet" href="${href}">`).join('\n');
+  });
+}
+
+/**
+ * #3813 — outdir 의 `.css` 파일을 file system 스캔해 HTML `<link>` 주입. `injectAppDevBundleCssLinks`
+ * 가 `bundleResult.outputFiles` 를 받는 것과 달리 file system 기반. caller (`runServe`) 가
+ * native watch onRebuild 에서 호출 — bundleResult 가 없는 graphChanged 경로의 stale link 회귀
+ * 가드. outdir 의 first-level `*.css` 만 스캔 (chunk subdirectory 미포함 — bundler 의 entry_names
+ * `[dir]/[name]` default 가 emit 한 결과 위치 기준).
+ */
+export function injectAppDevBundleCssLinksFromOutdir(outdir: string, base: string | undefined): void {
+  injectIntoDevHtml(outdir, (html) => {
+    let entries: string[];
+    try {
+      entries = readdirSync(outdir);
+    } catch {
+      return null;
+    }
+    const cssHrefs: string[] = [];
+    for (const name of entries) {
+      if (!isCssFile(name)) continue;
+      const href = joinUrl(base, name);
       if (!html.includes(`href="${href}"`) && !html.includes(`href='${href}'`)) cssHrefs.push(href);
     }
     if (cssHrefs.length === 0) return null;

--- a/packages/web/src/inject.ts
+++ b/packages/web/src/inject.ts
@@ -68,7 +68,10 @@ export function injectAppDevBundleCssLinks(
  * 가드. outdir 의 first-level `*.css` 만 스캔 (chunk subdirectory 미포함 — bundler 의 entry_names
  * `[dir]/[name]` default 가 emit 한 결과 위치 기준).
  */
-export function injectAppDevBundleCssLinksFromOutdir(outdir: string, base: string | undefined): void {
+export function injectAppDevBundleCssLinksFromOutdir(
+  outdir: string,
+  base: string | undefined,
+): void {
   injectIntoDevHtml(outdir, (html) => {
     let entries: string[];
     try {


### PR DESCRIPTION
## Summary

- PR #3810 가 남긴 회귀 3 — JS-only 변경이 새 CSS import 추가 시 HTML link stale
- `injectAppDevBundleCssLinksFromOutdir` 신설 + `AppDevController.injectBundleCssLinksFromOutdir` + runServe onRebuild 가 graphChanged 시 runBundle + inject 호출

## Limitation (별도 epic)

- Native incremental bundler 가 새 import 를 항상 `graphChanged=true` 로 trigger 하지 않음 (changed_files 기반 partial rebuild → update sequence 로 처리될 수도). 그 케이스에서는 본 fix 가 미활성. 완전 fix 는 #3796/#3798 epic (runServe 의 watch 단독화) 와 함께.

## Closes (partial)

- #3813 — graphChanged=true case 만 cover

## Test plan

- [x] web inject.test.ts -t "injectAppDevBundleCssLinksFromOutdir": 3 pass / 5 expect (정상 inject / 중복 회피 / outdir 미존재 silent skip)
- [x] bin/zntc.test.ts -t "dev HMR": 11 pass / 0 fail (기존 10 + 신규 broadcast 가드 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)