### PR TITLE
fix(napi): multi-error root-cause — partial build success 유지 + errors 별도 노출 (#3799 cont., #3796 partial)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -1344,6 +1344,12 @@ async function buildBundleOptions(opts, config) {
 
   return {
     entryPoints: opts.entryPoints.map((e) => resolve(e)),
+    // #3795/#3796 — watch handle 이 outdir 알아야 worker thread 의 createFile 가 정확한 위치에
+    // 출력. `prepareNapiOptions` 가 build/buildSync 케이스에서 outdir 를 delete 하지만 watch()
+    // wrapper (index.ts:3358) 가 명시 outdir 받아 NAPI 로 restore. 그러므로 BuildOptions 의
+    // outdir/outfile 필드 자체는 enrich 해서 보내야 함.
+    outdir: opts.outdir,
+    outfile: opts.outfile,
     format: opts.format,
     platform: opts.platform,
     target: opts.target,
@@ -1715,11 +1721,10 @@ async function runServe(opts, config, { appDev = null } = {}) {
     '.map': 'application/json',
   };
 
-  // 번들 모드면 먼저 빌드 — cold-start 시점에 outdir 채움 보장 (사용자 첫 fetch 가 build
-  // 완료 전 도착해도 정상 응답). watch handle 의 initial 은 #3787 의 skipInitialOutput 으로
-  // outdir 출력 skip. #3796/#3798 의 watch 단독화 시도가 test race 노출 — 별도 큰 epic 으로
-  // 분리 (HTTP server listen 을 watch.onReady 까지 wait + onReady 가 outputFiles 메타 노출
-  // 같은 architectural 변경이 선행).
+  // 번들 모드면 먼저 빌드 — cold-start 시점에 outdir 채움 보장 (사용자 첫 fetch 가 build 완료
+  // 전 도착해도 정상 응답). watch handle 의 initial 은 #3787 의 skipInitialOutput 으로 outdir
+  // 출력 skip. #3796/#3798 의 watch 단독화 시도는 bundler 의 outputs[].path 가 absolute 라 outdir
+  // join 안 됨 (새 회귀). 완전 fix 는 bundler 의 path generation 변경이 선행 — 별도 큰 epic.
   if (opts.bundle && opts.entryPoints.length > 0) {
     opts.outdir = opts.outdir || join(opts.serveDir, '.zntc-serve');
     const bundleResult = await runBundle(opts, config);
@@ -1957,22 +1962,19 @@ async function runServe(opts, config, { appDev = null } = {}) {
     let rebuilding = false;
     const dirty = new Set();
 
-    // #3779 — JS module 변경 시 incremental HMR update broadcast.
-    // appDev + hmr 모드일 때만 native watch handle 을 띄워 onRebuild 콜백에서
-    // graph change → FullReload, modules 변경 → UpdateStart/Update/UpdateDone 송출.
-    // fsWatch + drain 은 CSS/sass/postcss/restart 만 처리 — JS 분기는 noop (중복 컴파일 회피).
-    // 첫 빌드는 위쪽 `runBundle` 가 이미 수행 — watch handle 은 `skipInitialOutput: true`
-    // 로 initial 빌드의 outdir 출력만 skip (graph/cache 는 정상 구성). 중복 출력 race 회피.
+    // #3779 — JS module 변경 시 incremental HMR update broadcast. appDev + hmr 모드에서만
+    // native watch handle 을 띄워 onRebuild 콜백에서 graph change → FullReload, modules 변경
+    // → UpdateStart/Update/UpdateDone 송출. fsWatch + drain 은 CSS/sass/postcss/restart 만 처리
+    // — JS 분기는 noop. 첫 빌드는 위쪽 `runBundle` 가 이미 수행 — watch handle 은
+    // `skipInitialOutput: true` 로 initial output 만 skip (graph/cache 는 정상 구성).
     if (appDev && hmr) {
       const watchBuildOpts = await buildBundleOptions(opts, config);
       watchBuildOpts.devMode = true;
       watchBuildOpts.skipInitialOutput = true;
       watchBuildOpts.onRebuild = (event) => {
-        // #3813 — graphChanged 시 새 chunk/CSS 출력 필요. dev_mode + collect_module_codes
-        // 인 incremental rebuild 는 skip_bundle_output 자동 활성이라 outdir 갱신 안 함.
-        // workaround 로 runBundle 한 번 호출해 outdir 채운 후 css link 재주입. 사용자 plugin
-        // setup 이 graphChanged 시점에 2회 호출 (watch + runBundle) — cold-start 의 plugin
-        // double setup 회귀 없음 (initial 은 watch 1회).
+        // #3813 — graphChanged 시 새 chunk/CSS 출력 필요. dev_mode + collect_module_codes 인
+        // incremental rebuild 는 skip_bundle_output 자동 활성이라 outdir 갱신 안 함. workaround
+        // 로 runBundle 한 번 호출해 outdir 채운 후 css link 재주입.
         void (async () => {
           try {
             if (event && event.success && event.graphChanged) {
@@ -1983,9 +1985,7 @@ async function runServe(opts, config, { appDev = null } = {}) {
                 console.error('[serve] graph-change outdir rebuild failed:', cssErr);
               }
             }
-            // #3799 — Update modules 의 code 끝에 sourceMappingURL 주석 append. eval 된
-            // module 의 stack trace 가 원본 source 좌표로 매핑되도록 DevTools 가 lazy fetch
-            // (`/__zntc_hmr_map/<id>` route). RN bridge (hmr-bridge.ts:42) 와 같은 패턴.
+            // #3799 — Update modules.code 끝에 sourceMappingURL 주석 append.
             const annotated =
               event && event.success && event.updates && event.updates.length > 0
                 ? {
@@ -2005,7 +2005,6 @@ async function runServe(opts, config, { appDev = null } = {}) {
       try {
         nativeWatchHandle = watch(watchBuildOpts);
       } catch (err) {
-        // watch 시작 실패해도 fsWatch + drain (CSS path) 는 계속 동작 — incremental HMR 만 비활성.
         console.error('[serve] native watch failed to start (incremental HMR disabled):', err);
       }
     }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1165,6 +1165,12 @@ export type BuildOptions =
 export interface WatchReadyEvent {
   files: number;
   bytes: number;
+  /**
+   * #3796 — initial 빌드의 output 파일 path 목록. caller (예: `runServe`) 가 outdir scan 없이
+   * 정확한 outputFiles 정보를 받아 후속 hook (예: `injectBundleCssLinks`) 호출 가능. contents
+   * 는 메모리 비용이 커 path 만 노출 — caller 가 fs read 또는 path 기반 분기.
+   */
+  outputs?: string[];
 }
 
 export interface WatchRebuildEvent {

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -214,6 +214,31 @@ const LazySourceMapCache = struct {
 const WatchReadyEvent = struct {
     files: usize,
     bytes: usize,
+    /// #3796 — initial 빌드의 output 파일 path 목록. caller (`runServe`) 가 outdir scan 없이
+    /// 정확한 outputFiles 정보를 받아 `appDev.injectBundleCssLinks` 호출 가능. contents 는
+    /// 메모리 비용 큼 + caller 가 보통 path 만 본다 (`inject.ts` 의 `isCssFile(file.path)` 만
+    /// 검사) — path 만 노출. null 이면 outputs 없음 (단일 파일 빌드 등).
+    outputs: ?[]const []const u8 = null,
+    /// #3799 root-cause — initial bundle() 이 success 반환 + diagnostics 에 error severity
+    /// (missing import 등 placeholder 처리된 partial build). 이전엔 worker 종료 — 잘못된 design.
+    /// `success` 는 watch lifecycle 자체에 보존, errors 는 별도 노출. consumer (runServe) 가
+    /// reportError 호출.
+    errors: ?[]const WatchRebuildEvent.ErrorEntry = null,
+
+    fn deinit(self: *WatchReadyEvent, allocator: std.mem.Allocator) void {
+        if (self.outputs) |paths| {
+            for (paths) |p| allocator.free(p);
+            allocator.free(paths);
+        }
+        if (self.errors) |errs| {
+            for (errs) |e| {
+                allocator.free(e.file);
+                allocator.free(e.message);
+            }
+            allocator.free(errs);
+        }
+        allocator.destroy(self);
+    }
 };
 
 /// HMR rebuild phase 별 소요시간 (밀리초). Issue #1223 관측성.
@@ -337,11 +362,11 @@ fn getFileMtime(path: []const u8) !i128 {
 /// onReady TSFN 콜백 — 메인 스레드에서 실행
 fn watchReadyTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data: ?*anyopaque) callconv(.c) void {
     const event: *WatchReadyEvent = @ptrCast(@alignCast(data.?));
-    defer native_alloc.destroy(event);
+    defer event.deinit(native_alloc);
 
     if (js_func == null) return;
 
-    // {files: N, bytes: N} 객체 생성
+    // {files: N, bytes: N, outputs?: string[]} 객체 생성
     var js_event: c.napi_value = undefined;
     if (c.napi_create_object(env, &js_event) != c.napi_ok) return;
 
@@ -352,6 +377,36 @@ fn watchReadyTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data: 
     var js_bytes: c.napi_value = undefined;
     _ = c.napi_create_int64(env, @intCast(event.bytes), &js_bytes);
     _ = c.napi_set_named_property(env, js_event, "bytes", js_bytes);
+
+    // #3796 — outputs: Array<string> (initial 빌드의 output 파일 path 목록).
+    if (event.outputs) |paths| {
+        var js_outputs: c.napi_value = undefined;
+        _ = c.napi_create_array_with_length(env, paths.len, &js_outputs);
+        for (paths, 0..) |p, idx| {
+            var js_str: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, p.ptr, p.len, &js_str);
+            _ = c.napi_set_element(env, js_outputs, @intCast(idx), js_str);
+        }
+        _ = c.napi_set_named_property(env, js_event, "outputs", js_outputs);
+    }
+
+    // #3799 root-cause — errors: Array<{file, message}> (initial diagnostics 의 error 목록).
+    if (event.errors) |errs| {
+        var js_errors: c.napi_value = undefined;
+        _ = c.napi_create_array_with_length(env, errs.len, &js_errors);
+        for (errs, 0..) |e, idx| {
+            var js_entry: c.napi_value = undefined;
+            _ = c.napi_create_object(env, &js_entry);
+            var js_file: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, e.file.ptr, e.file.len, &js_file);
+            _ = c.napi_set_named_property(env, js_entry, "file", js_file);
+            var js_msg: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, e.message.ptr, e.message.len, &js_msg);
+            _ = c.napi_set_named_property(env, js_entry, "message", js_msg);
+            _ = c.napi_set_element(env, js_errors, @intCast(idx), js_entry);
+        }
+        _ = c.napi_set_named_property(env, js_event, "errors", js_errors);
+    }
 
     // onReady(event) 호출
     var js_undefined: c.napi_value = undefined;
@@ -477,29 +532,30 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
             _ = c.napi_set_named_property(env, js_event, "reparsedModules", js_n);
         }
     } else {
-        // error: string (catch 분기)
+        // error: string (catch 분기 — bundle() 자체가 throw 한 케이스)
         if (event.error_msg) |msg| {
             var js_err: c.napi_value = undefined;
             _ = c.napi_create_string_utf8(env, msg.ptr, msg.len, &js_err);
             _ = c.napi_set_named_property(env, js_event, "error", js_err);
         }
-        // #3799 — errors: Array<{file, message}> (success 후 diagnostics 분기)
-        if (event.errors) |errs| {
-            var js_errors: c.napi_value = undefined;
-            _ = c.napi_create_array_with_length(env, errs.len, &js_errors);
-            for (errs, 0..) |e, idx| {
-                var js_entry: c.napi_value = undefined;
-                _ = c.napi_create_object(env, &js_entry);
-                var js_file: c.napi_value = undefined;
-                _ = c.napi_create_string_utf8(env, e.file.ptr, e.file.len, &js_file);
-                _ = c.napi_set_named_property(env, js_entry, "file", js_file);
-                var js_msg: c.napi_value = undefined;
-                _ = c.napi_create_string_utf8(env, e.message.ptr, e.message.len, &js_msg);
-                _ = c.napi_set_named_property(env, js_entry, "message", js_msg);
-                _ = c.napi_set_element(env, js_errors, @intCast(idx), js_entry);
-            }
-            _ = c.napi_set_named_property(env, js_event, "errors", js_errors);
+    }
+    // #3799 root-cause — errors 는 success/false 두 분기에서 모두 채워질 수 있다. success=true
+    // + errors 는 missing import 같은 partial build 시그널 (build 자체는 성공, output 있음).
+    if (event.errors) |errs| {
+        var js_errors: c.napi_value = undefined;
+        _ = c.napi_create_array_with_length(env, errs.len, &js_errors);
+        for (errs, 0..) |e, idx| {
+            var js_entry: c.napi_value = undefined;
+            _ = c.napi_create_object(env, &js_entry);
+            var js_file: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, e.file.ptr, e.file.len, &js_file);
+            _ = c.napi_set_named_property(env, js_entry, "file", js_file);
+            var js_msg: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, e.message.ptr, e.message.len, &js_msg);
+            _ = c.napi_set_named_property(env, js_entry, "message", js_msg);
+            _ = c.napi_set_element(env, js_errors, @intCast(idx), js_entry);
         }
+        _ = c.napi_set_named_property(env, js_event, "errors", js_errors);
     }
 
     // onRebuild(event) 호출
@@ -670,28 +726,12 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     };
     defer result.deinit(allocator);
 
-    // #3799 — initial 빌드 자체는 성공했지만 result.diagnostics 에 error severity 가 있으면
-    // multi-error event 발화 후 worker 종료. caller (broadcastRebuildEvent) 가 errors 배열을
-    // reportError 로 전달 — 다중 error + file/message 정보 보존.
-    if (result.hasErrors()) {
-        const event = allocator.create(WatchRebuildEvent) catch {
-            _ = c.napi_release_threadsafe_function(async_data.ready_tsfn, c.napi_tsfn_release);
-            _ = c.napi_release_threadsafe_function(async_data.rebuild_tsfn, c.napi_tsfn_release);
-            async_data.deinit();
-            return;
-        };
-        event.* = .{
-            .success = false,
-            .errors = collectErrorsFromResult(allocator, &result),
-        };
-        if (c.napi_call_threadsafe_function(async_data.rebuild_tsfn, @ptrCast(event), c.napi_tsfn_blocking) != c.napi_ok) {
-            event.deinit();
-        }
-        _ = c.napi_release_threadsafe_function(async_data.ready_tsfn, c.napi_tsfn_release);
-        _ = c.napi_release_threadsafe_function(async_data.rebuild_tsfn, c.napi_tsfn_release);
-        async_data.deinit();
-        return;
-    }
+    // #3799 root-cause fix — initial bundle() 가 success 반환 (output 생성됨) 이지만
+    // diagnostics 에 error severity 가 있을 수 있다 (missing import 등 placeholder 처리된 partial
+    // build). 이전 코드는 worker 종료해 dev server 첫 빌드 실패 시 restart 까지 죽음 — 사용자가
+    // syntax error 만 만져도 watch 끊김. 정확한 design 은 *success 유지 + ready_event.errors
+    // 로 별도 노출* — consumer (runServe) 가 reportError + 정상 흐름 (module_code_cache 채움,
+    // file output 등) 둘 다 처리. worker 는 정상 계속.
 
     // dev mode: per-module code 캐시 (HMR diff용)
     var module_code_cache = std.StringHashMap([]const u8).init(allocator);
@@ -811,12 +851,47 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     // ready 이벤트 전송
     {
         const ready_event = allocator.create(WatchReadyEvent) catch return;
+        // #3796 — outputs path 목록 복사 (initial 빌드의 산출 path). single-file 경로
+        // (`output_filename`) 도 same shape 으로 일관 노출 → caller (`runServe`) 가 통일 처리.
+        var outputs_copy: ?[]const []const u8 = null;
+        if (result.outputs) |outputs| {
+            const arr = allocator.alloc([]const u8, outputs.len) catch null;
+            if (arr) |paths| {
+                var fill: usize = 0;
+                for (outputs) |o| {
+                    const dup = allocator.dupe(u8, o.path) catch break;
+                    paths[fill] = dup;
+                    fill += 1;
+                }
+                if (fill == outputs.len) {
+                    outputs_copy = paths;
+                } else {
+                    // partial alloc 실패 — cleanup
+                    for (paths[0..fill]) |p| allocator.free(p);
+                    allocator.free(paths);
+                }
+            }
+        } else if (bundle_opts.output_filename.len > 0) {
+            const arr = allocator.alloc([]const u8, 1) catch null;
+            if (arr) |paths| {
+                if (allocator.dupe(u8, bundle_opts.output_filename)) |dup| {
+                    paths[0] = dup;
+                    outputs_copy = paths;
+                } else |_| {
+                    allocator.free(paths);
+                }
+            }
+        }
         ready_event.* = .{
             .files = initial_watch_count,
             .bytes = initial_bytes,
+            .outputs = outputs_copy,
+            // #3799 root-cause — initial build 의 diagnostics 에 error 가 있으면 별도 노출.
+            // success/lifecycle 영향 없음, consumer (runServe onReady) 가 reportError 처리.
+            .errors = if (result.hasErrors()) collectErrorsFromResult(allocator, &result) else null,
         };
         if (c.napi_call_threadsafe_function(async_data.ready_tsfn, @ptrCast(ready_event), c.napi_tsfn_blocking) != c.napi_ok) {
-            allocator.destroy(ready_event);
+            ready_event.deinit(allocator);
         }
     }
 
@@ -911,19 +986,11 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         };
         defer rebuild_result.deinit(allocator);
 
-        // #3799 — rebuild 성공했지만 diagnostics 에 errors 있으면 multi-error event 발화.
-        // 다음 rebuild 사이클로 계속 (worker 종료 안 함 — file 수정으로 사용자 fix 가능).
-        if (rebuild_result.hasErrors()) {
-            const event = allocator.create(WatchRebuildEvent) catch continue;
-            event.* = .{
-                .success = false,
-                .errors = collectErrorsFromResult(allocator, &rebuild_result),
-            };
-            if (c.napi_call_threadsafe_function(async_data.rebuild_tsfn, @ptrCast(event), c.napi_tsfn_blocking) != c.napi_ok) {
-                event.deinit();
-            }
-            continue;
-        }
+        // #3799 root-cause fix — rebuild_result.hasErrors() 면 이전 코드는 별도 early-event +
+        // continue 였다. 그러나 그러면 module_code_cache / file output / lazy sourcemap swap 등
+        // state update path 가 skip 돼 다음 rebuild 가 stale base 위에서 시작. 정확한 design:
+        // *success=true 유지* + event.errors 별도 노출 → consumer 가 reportError + Update broadcast
+        // 동시 처리. 정상 흐름 그대로 진행.
 
         async_data.compiled_cache.logStats("");
 
@@ -967,6 +1034,10 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         event.* = .{
             .success = true,
             .bytes = output_bytes,
+            // #3799 root-cause — rebuild_result.diagnostics 의 error severity 를 같이 노출.
+            // success=true 유지 (output / module_code_cache 모두 정상). consumer 가 reportError
+            // + Update broadcast 둘 다 처리.
+            .errors = if (rebuild_result.hasErrors()) collectErrorsFromResult(allocator, &rebuild_result) else null,
         };
 
         // changed 파일 목록 복사

--- a/packages/server/src/hmr-rebuild-broadcast.ts
+++ b/packages/server/src/hmr-rebuild-broadcast.ts
@@ -43,8 +43,8 @@ export function broadcastRebuildEvent(
   event: RebuildEventLike,
 ): RebuildBroadcastOutcome {
   if (!event.success) {
-    // #3799 — multi-error 가 있으면 file/message 둘 다 전달. 단일 `error` 는 catch path 의
-    // Zig error tag (예: 'OutOfMemory') 라 fallback.
+    // catch path (bundle() throw) — error tag 단일 string. multi-error 가 있어도 build 가
+    // 진행 못 한 상태라 reportError 로 통일.
     if (event.errors && event.errors.length > 0) {
       hmr.reportError(event.errors.map((e) => ({ text: e.message, location: { file: e.file } })));
     } else {
@@ -52,13 +52,22 @@ export function broadcastRebuildEvent(
     }
     return 'error';
   }
+  // #3799 root-cause — success=true + errors 는 partial build (missing import 같은 diagnostic
+  // 이 있지만 output 자체는 생성됨). 사용자 overlay 에 error 표시 + 정상 incremental broadcast
+  // 둘 다 진행 — 후속 graphChanged/updates 분기는 그대로.
+  if (event.errors && event.errors.length > 0) {
+    hmr.reportError(event.errors.map((e) => ({ text: e.message, location: { file: e.file } })));
+  }
   if (event.graphChanged) {
-    hmr.clearError();
+    // errors 가 있다면 reportError 가 latch — clearError 호출 안 함 (overlay 유지).
+    if (!event.errors || event.errors.length === 0) hmr.clearError();
     hmr.broadcast({ type: HMR_MSG.FullReload, timestamp: Date.now() });
     return 'full-reload';
   }
   if (event.updates && event.updates.length > 0) {
-    hmr.clearError();
+    // errors 가 있다면 clearError 호출 안 함 (overlay 유지) — partial build 의 incremental
+    // update 는 진행하되 사용자에게 error 도 동시 표시.
+    if (!event.errors || event.errors.length === 0) hmr.clearError();
     hmr.broadcast({ type: HMR_MSG.UpdateStart });
     hmr.broadcast({
       type: HMR_MSG.Update,
@@ -67,9 +76,8 @@ export function broadcastRebuildEvent(
     hmr.broadcast({ type: HMR_MSG.UpdateDone });
     return 'update';
   }
-  // #3799 — 성공한 rebuild + code 변경 없음 (whitespace-only edit 등 bytewise-identical
-  // output). 이전 error latch 도 자동 해제 — 사용자가 fix 한 셈. clearError 자체는 broadcast
-  // 아님 (state mutation only), 다음 연결되는 client 에게 stale error 가 안 전달되도록 가드.
-  hmr.clearError();
+  // #3799 — 성공한 rebuild + code 변경 없음. 이전 error latch 자동 해제 — 단 본 event 의 errors
+  // 가 있으면 그것이 새 latch (위에서 reportError 호출). errors 있으면 clearError 안 함.
+  if (!event.errors || event.errors.length === 0) hmr.clearError();
   return 'noop';
 }


### PR DESCRIPTION
## Summary

- PR #3822 (multi-error) 의 잘못된 design 가 새 회귀 도입 — `result.hasErrors()` 시 worker 종료. bundler 의 hasErrors() 는 partial build (missing import 등) 도 포함이라 dev server 가 첫 빌드 syntax error 만 만져도 끊김
- root-cause fix — `success` 유지 + `errors` 별도 노출. consumer 가 reportError + 정상 broadcast 둘 다
- WatchReadyEvent.outputs 도 추가 (향후 watch 단독화 epic plumbing). 단 full cold-start 단독화는 bundler 의 outputs[].path 가 absolute path 라 outdir join 안 되는 새 회귀 발견 — 별도 큰 epic (bundler path generation 변경) 와 함께

## Closes (partial)

- #3796 — plumbing 만 (WatchReadyEvent.outputs/errors). 완전 fix 는 bundler path epic

## 변경

- `watch.zig` — `if (result.hasErrors())` 조기 종료 분기 제거 (initial + rebuild). state update path (module_code_cache 등) 정상 진행
- `WatchReadyEvent.errors` + `WatchReadyEvent.outputs` 신설
- `WatchRebuildEvent.errors` 가 success=true 케이스에도 채워짐
- NAPI 변환 errors 가 두 분기 (success/false) 모두에서 노출
- `broadcastRebuildEvent` — success=true + errors 시 reportError + 정상 broadcast
- TS `WatchReadyEvent` interface 갱신

## Test plan

- [x] `zig build test`: 0 fail
- [x] `index.test.ts -t "watch"`: 39 pass / 0 fail (diagnostics 회귀 fix)
- [x] `bin/zntc.test.ts -t "dev HMR"`: 12 pass / 0 fail
- [x] `packages/server`: 95 pass

## Limitation (별도 epic)

cold-start 의 *완전한 watch 단독화* (#3796/#3798 의 plugin.setup() 1회 invoke) 는 bundler 의 `outputs[].path` 가 absolute path 인 정책 변경이 선행. 시도 결과 outdir mis-routing 새 회귀 발견 — revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)