### PR TITLE
feat(app): app pipeline plugin dispatcher 노출 — buildApp 이 JS plugin 통과 (#2538 4-4 PR-1)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -670,10 +670,20 @@ function getAutoConfigSearchDir(opts) {
 }
 
 async function runAppBuild(opts, config, configEnv, _dotenvVars) {
-  if (config?.plugins?.length || opts.pluginPaths.length > 0) {
-    throw new Error(
-      'zntc build app mode does not support JS plugins yet; use --bundle for plugin builds',
-    );
+  // JS plugin 로드 — bundle pipeline 의 buildBundleOptions 와 동일 패턴. app
+  // pipeline 도 plugin dispatcher 통과 (#2538 4-4 PR-1).
+  const appPlugins = [];
+  if (config && Array.isArray(config.plugins)) {
+    appPlugins.push(...config.plugins);
+  }
+  for (const pluginPath of opts.pluginPaths) {
+    const absPath = resolve(pluginPath);
+    const cfg = await importAndResolveDefault(absPath);
+    if (Array.isArray(cfg.plugins)) {
+      appPlugins.push(...cfg.plugins);
+    } else if (typeof cfg.setup === 'function') {
+      appPlugins.push(cfg);
+    }
   }
   const web = await loadWebModule();
   const root = resolve(opts.appRoot ?? '.');
@@ -708,6 +718,7 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
       jsxFactory: opts.jsxFactory,
       jsxFragment: opts.jsxFragment,
       compiler: config?.compiler,
+      plugins: appPlugins.length > 0 ? appPlugins : undefined,
     });
     const htmlEnv = loadEnv(
       configEnv.mode,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1494,6 +1494,12 @@ export interface AppBuildOptions {
    * the same option representation.
    */
   compiler?: CompilerOptions;
+  /**
+   * Rollup-compatible JS plugins. Same `resolveId`/`load`/`transform` hooks as
+   * `BuildOptions.plugins` — app build pipeline 도 같은 dispatcher 를 받는다
+   * (#2538 4-4 PR-1).
+   */
+  plugins?: ZntcPlugin[];
 }
 
 /**
@@ -2764,20 +2770,47 @@ async function buildMultiFormat(options: BuildOptions): Promise<BuildResult> {
 
 export function buildAppSync(options: AppBuildOptions = {}): BuildResult {
   const n = ensureNative();
-  const { publicDir, compiler, ...rest } = options;
-  return wrapOutputFiles(
-    n.buildAppSync({
-      ...rest,
-      define: withDefaultAppBuildDefines(options),
-      ...(publicDir === false
-        ? { disablePublicDir: true }
-        : publicDir !== undefined
-          ? { publicDir }
-          : {}),
-      // compiler.* → flat NAPI fields. `prepareNapiOptions` 와 동일 변환을 한 곳에서.
-      ...buildCompilerNapiFields(compiler),
-    }),
-  );
+  // plugins 는 JS-only — napi 로 spread 시 closure marshalling 비용/타입 mismatch
+  // 잠재. 명시 strip (prepareNapiOptions 와 동일 정책).
+  const { publicDir, compiler, plugins: _plugins, ...rest } = options;
+  void _plugins;
+  // JS plugin dispatcher — bundle pipeline 의 `buildSync` 와 동일 패턴.
+  // resolveDispatcher 가 옵션의 plugins 를 native 가 호출할 sync dispatcher 로
+  // wrap. 미지정 시 plugin 없는 build (#2538 4-4 PR-1).
+  const dispatcher = resolveDispatcher(options as unknown as BuildOptions, 'sync');
+  const napiOptions: Record<string, unknown> = {
+    ...rest,
+    define: withDefaultAppBuildDefines(options),
+    ...(publicDir === false
+      ? { disablePublicDir: true }
+      : publicDir !== undefined
+        ? { publicDir }
+        : {}),
+    // compiler.* → flat NAPI fields. `prepareNapiOptions` 와 동일 변환을 한 곳에서.
+    ...buildCompilerNapiFields(compiler),
+  };
+  if (dispatcher) napiOptions._pluginDispatcherSync = dispatcher;
+  // buildSync 와 동일한 lifecycle 후처리: native 호출 후 takeLifecycleFailures /
+  // takePluginWarnings 동기화 + closeBundle 발화 (NapiPluginAdapter.closeBundle 는
+  // null 이라 native 가 자체 호출 X — JS dispatcher 가 직접 발화해야 user plugin
+  // 의 closeBundle hook 이 동작).
+  const result: BuildResult = wrapOutputFiles(n.buildAppSync(napiOptions));
+  if (dispatcher) {
+    for (const failure of dispatcher.takeLifecycleFailures()) {
+      result.errors.push(pluginFailureToDiagnostic(failure));
+    }
+    for (const warning of dispatcher.takePluginWarnings()) {
+      result.warnings.push(warning);
+    }
+    dispatcher('closeBundle', undefined, null);
+    for (const failure of dispatcher.takeLifecycleFailures()) {
+      result.errors.push(pluginFailureToDiagnostic(failure));
+    }
+    for (const warning of dispatcher.takePluginWarnings()) {
+      result.warnings.push(warning);
+    }
+  }
+  return result;
 }
 
 /// `compiler.styledComponents` / `compiler.emotion` (boolean / 객체 form) 를 평면 NAPI

--- a/packages/core/src/napi/build_sync_entry.zig
+++ b/packages/core/src/napi/build_sync_entry.zig
@@ -185,6 +185,33 @@ pub fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c
     if (ownStr(env, opts_obj, "jsxFactory", &owned_strings)) |s| jsx_cfg.factory = s;
     if (ownStr(env, opts_obj, "jsxFragment", &owned_strings)) |s| jsx_cfg.fragment = s;
 
+    // JS plugin dispatcher — `napiBuildSync` 의 동일 패턴. `_pluginDispatcherSync`
+    // 미지정 시 plugin 없는 build. AppBuildOptions.plugins 로 전달돼 buildApp 의
+    // Bundler.init 이 받는다 (#2538 4-4 PR-1).
+    var sync_plugin: ?*NapiSyncPlugin = null;
+    defer if (sync_plugin) |sp| sp.deinit();
+    var sync_plugin_storage: [1]Plugin = undefined;
+    var plugins_slice: []const Plugin = &.{};
+    if (getNamedProperty(env, opts_obj, "_pluginDispatcherSync")) |dispatcher_fn| {
+        const sp = native_alloc.create(NapiSyncPlugin) catch return throwError(env, "OutOfMemory");
+        sp.* = .{
+            .name = native_alloc.dupe(u8, "js-plugin") catch {
+                native_alloc.destroy(sp);
+                return throwError(env, "OutOfMemory");
+            },
+            .env = env,
+            .callback_ref = undefined,
+        };
+        if (c.napi_create_reference(env, dispatcher_fn, 1, &sp.callback_ref) != c.napi_ok) {
+            native_alloc.free(sp.name);
+            native_alloc.destroy(sp);
+            return throwError(env, "failed to create plugin reference");
+        }
+        sync_plugin = sp;
+        sync_plugin_storage[0] = sp.toPlugin();
+        plugins_slice = sync_plugin_storage[0..1];
+    }
+
     const output_count = zntc_lib.app.build.buildApp(native_alloc, .{
         .root = root,
         .outdir = outdir,
@@ -214,6 +241,7 @@ pub fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c
         .emotion_extra_css_sources = emotion_extra_css orelse &.{},
         .emotion_extra_styled_sources = emotion_extra_styled orelse &.{},
         .jsx = jsx_cfg,
+        .plugins = plugins_slice,
     }) catch |err| {
         return throwError(env, @errorName(err));
     };

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -5,6 +5,7 @@ const transformer_mod = @import("../transformer/transformer.zig");
 
 const Bundler = bundler_mod.Bundler;
 const BundleOptions = bundler_mod.BundleOptions;
+const Plugin = bundler_mod.plugin.Plugin;
 const DefineEntry = transformer_mod.DefineEntry;
 const JsxRuntime = @import("../codegen/codegen.zig").JsxRuntime;
 
@@ -62,6 +63,10 @@ pub const AppBuildOptions = struct {
     emotion_extra_css_sources: []const []const u8 = &.{},
     /// emotion.importMap re-export 케이스 단순화 — vendored emotion styled source.
     emotion_extra_styled_sources: []const []const u8 = &.{},
+    /// JS plugin dispatcher 들 — `napiBuildAppSync` 의 `_pluginDispatcherSync` 를
+    /// 통해 전달. 비어 있으면 plugin 없는 build. bundle pipeline 의 Bundler.init 에
+    /// 그대로 전달 (#2538 4-4 PR-1).
+    plugins: []const Plugin = &.{},
 };
 
 pub const AppDevPrepareOptions = struct {
@@ -177,6 +182,7 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
         .emotion_label_format = opts.emotion_label_format,
         .emotion_extra_css_sources = opts.emotion_extra_css_sources,
         .emotion_extra_styled_sources = opts.emotion_extra_styled_sources,
+        .plugins = opts.plugins,
     });
     defer bundler.deinit();
 


### PR DESCRIPTION
## 요약

epic #2538 4-4 (`appDev` plugin API 추상화) 의 **PR-1**. bundle pipeline 만 plugin host 통과하던 제약 해제 — app build 도 `buildSync` 와 같은 sync dispatcher 패턴으로 JS plugin (resolveId/load/transform/...) 호출.

이전: `zntc build --app` + `config.plugins` 시 `throw 'app mode does not support JS plugins yet; use --bundle'`. 이번 PR 로 풀림.

## 변경 (4 파일 +96 -18)

| 파일 | 변경 |
|---|---|
| `src/app/build.zig` | `AppBuildOptions.plugins: []const Plugin = &.{}` + Plugin import + Bundler.init 전달 |
| `packages/core/src/napi/build_sync_entry.zig` | napiBuildAppSync 가 `_pluginDispatcherSync` 수용 — napiBuildSync 동일 패턴 |
| `packages/core/index.ts` | AppBuildOptions.plugins TS 타입 + buildAppSync 의 dispatcher 호출 + lifecycle 후처리 |
| `packages/core/bin/zntc.mjs` | runAppBuild 의 throw 제거 + plugin 로드 + buildAppSync 호출에 plugins 전달 |

## /code-review max — HIGH 1 + MEDIUM 2 fix

| | finding | fix |
|---|---|---|
| **HIGH** | buildAppSync 가 dispatcher.takeLifecycleFailures/takePluginWarnings/closeBundle 미호출 → user plugin 의 closeBundle hook silent + plugin error result.errors 누락 | buildSync 의 후처리 블록 미러링 (try 후 7줄) |
| **MEDIUM** | plugins/alias key 가 napi spread 로 leak | destructure 명시 `{ plugins: _plugins, ...rest }` |
| **MEDIUM** | throw 제거 후 async-only plugin silent failure | HIGH fix 로 자동 해결 (failures sink 만들어짐) |

## 미반영 LOW (별도 PR)

- **integration test 부재** — app pipeline 의 resolveId/transform 실 발화 검증 fixture 필요 (PR-2 또는 별도)
- **runAppBuild 의 result.errors 미 surface** — stderr/exit-code 처리 필요 (plugin 활성화 후 user visibility)

## 후속

| PR | scope |
|---|---|
| **PR-2** | `@zntc/web/css` sub-export 신설 — `style/*.ts` (PostCSS/Sass/CSSModules) 를 ZntcPlugin hook 으로 wrap |
| **PR-3** | `runAppDev` (dev mode) 의 plugin chain — IncrementalBundler 통과 |
| **PR-4** | Vite/Rollup adapter (`vitePlugin()`) app pipeline 활성 + smoke |

## 검증

| | 결과 |
|---|---|
| `zig build` debug | ✅ |
| `zig build test` 전체 | ✅ |
| `bun x tsc -b` packages/core dts | ✅ |

Refs: #2538 (4-4 PR-1/N), follows #3824

🤖 Generated with [Claude Code](https://claude.com/claude-code)