### PR TITLE
feat(web): @zntc/web/css sub-export 신설 — ZntcPlugin factory + .css PostCSS pass (#2538 4-4 PR-2)

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,10 +35,14 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./css": {
+      "types": "./dist/css/index.d.ts",
+      "import": "./dist/css/index.js"
     }
   },
   "scripts": {
-    "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external postcss --external postcss-load-config --external sass && node -e \"require('node:fs').copyFileSync('runtime/dev-overlay-client.raw.js','dist/dev-overlay-client.raw.js')\"",
+    "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external postcss --external postcss-load-config --external sass && node ../core/bin/zntc.mjs --bundle src/css/index.ts --outfile dist/css/index.js --format=esm --target=node --conditions=source --external @zntc/core --external postcss --external postcss-load-config --external sass && node -e \"require('node:fs').copyFileSync('runtime/dev-overlay-client.raw.js','dist/dev-overlay-client.raw.js')\"",
     "build:dts": "bun x tsc -b",
     "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test --timeout 10000",

--- a/packages/web/src/css/css.test.ts
+++ b/packages/web/src/css/css.test.ts
@@ -1,0 +1,128 @@
+/**
+ * `css()` plugin factory 단위 test (#2538 4-4 PR-2).
+ *
+ * setup() 안 onLoad hook 등록 검증 + disabled 옵션 + ZntcPlugin shape. 실 PostCSS
+ * 호출은 integration test (PR-3) 에서.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { PluginBuild } from '@zntc/core';
+
+import { css } from './index.ts';
+
+interface MockBuild {
+  loadHooks: Array<{ filter: RegExp; cb: (args: { path: string }) => unknown }>;
+  resolveHooks: Array<{ filter: RegExp; cb: unknown }>;
+  transformHooks: Array<{ filter: RegExp; cb: unknown }>;
+}
+
+function makeMockBuild(): { build: PluginBuild; tracked: MockBuild } {
+  const tracked: MockBuild = { loadHooks: [], resolveHooks: [], transformHooks: [] };
+  const build = {
+    onLoad: (opts: { filter: RegExp }, cb: (args: { path: string }) => unknown) => {
+      tracked.loadHooks.push({ filter: opts.filter, cb });
+    },
+    onResolve: (opts: { filter: RegExp }, cb: unknown) => {
+      tracked.resolveHooks.push({ filter: opts.filter, cb });
+    },
+    onTransform: (opts: { filter: RegExp }, cb: unknown) => {
+      tracked.transformHooks.push({ filter: opts.filter, cb });
+    },
+  } as unknown as PluginBuild;
+  return { build, tracked };
+}
+
+describe('css() plugin factory', () => {
+  test('ZntcPlugin shape — name + setup(build)', () => {
+    const plugin = css();
+    expect(plugin.name).toBe('@zntc/web/css');
+    expect(typeof plugin.setup).toBe('function');
+  });
+
+  test('zero-config 호출 — onLoad hook 1개 등록 (.css filter)', () => {
+    const plugin = css();
+    const { build, tracked } = makeMockBuild();
+    plugin.setup(build);
+
+    expect(tracked.loadHooks.length).toBe(1);
+    // filter 는 .module.css 제외 — negative lookbehind 적용된 정규식.
+    expect(tracked.loadHooks[0]!.filter.test('foo.css')).toBe(true);
+    expect(tracked.loadHooks[0]!.filter.test('foo.module.css')).toBe(false);
+    expect(tracked.resolveHooks.length).toBe(0);
+    expect(tracked.transformHooks.length).toBe(0);
+  });
+
+  test('disabled: true — setup 이 hook 미등록', () => {
+    const plugin = css({ disabled: true });
+    const { build, tracked } = makeMockBuild();
+    plugin.setup(build);
+
+    expect(tracked.loadHooks.length).toBe(0);
+    expect(tracked.resolveHooks.length).toBe(0);
+    expect(tracked.transformHooks.length).toBe(0);
+  });
+
+  test('postcss override — postcss.plugins 명시 시에도 정상 setup', () => {
+    const plugin = css({ postcss: { plugins: [], options: { map: false } } });
+    const { build, tracked } = makeMockBuild();
+    plugin.setup(build);
+
+    // override 케이스에도 onLoad hook 은 동일하게 1개 — 차이는 hook 안의 분기.
+    expect(tracked.loadHooks.length).toBe(1);
+  });
+
+  test('onLoad — postcss.config 없을 때 입력 그대로 pass-through', async () => {
+    const plugin = css({ root: '/nonexistent-dir-no-config' });
+    const { build, tracked } = makeMockBuild();
+    plugin.setup(build);
+
+    const hook = tracked.loadHooks[0]!.cb;
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zntc-css-test-'));
+    const file = path.join(dir, 'sample.css');
+    fs.writeFileSync(file, 'body { color: red; }');
+
+    try {
+      const result = (await hook({ path: file })) as { contents: string };
+      // postcss.config 없으므로 pass-through — 입력 그대로
+      expect(result.contents).toBe('body { color: red; }');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('filter regex 는 .module.css 미매치', () => {
+    const plugin = css();
+    const { build, tracked } = makeMockBuild();
+    plugin.setup(build);
+
+    const filter = tracked.loadHooks[0]!.filter;
+    expect(filter.test('/foo/app.css')).toBe(true);
+    expect(filter.test('/foo/a.module.css')).toBe(false);
+    expect(filter.test('/foo/styles.module.css')).toBe(false);
+  });
+
+  test('override path 의 plugins=[] (empty) → onLoad 가 pass-through', async () => {
+    const plugin = css({ postcss: { plugins: [] } }); // empty 명시
+    const { build, tracked } = makeMockBuild();
+    plugin.setup(build);
+
+    const hook = tracked.loadHooks[0]!.cb;
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zntc-css-test-'));
+    const file = path.join(dir, 'empty.css');
+    fs.writeFileSync(file, 'a { b: c; }');
+
+    try {
+      const result = (await hook({ path: file })) as { contents: string };
+      // empty plugins → round-trip 회피 (zero-config path 진입). config 없으면 pass-through.
+      expect(result.contents).toBe('a { b: c; }');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/web/src/css/index.ts
+++ b/packages/web/src/css/index.ts
@@ -1,0 +1,132 @@
+/**
+ * `@zntc/web/css` — ZTS dev/build 의 CSS pipeline plugin (#2538 4-4 PR-2).
+ *
+ * 사용자가 명시 안 해도 controller 가 default 로 등록 (#2538 4-4 PR-3 에서 wiring).
+ * 명시적으로 끄거나 옵션 override 하려면 zntc.config 에 `plugins: [css(...)]` 추가.
+ *
+ * Vite 의 `vite:css` plugin 과 같은 역할 — postcss.config.js 자동 발견 (Vite 정확
+ * 패턴) + `css({ postcss: { plugins } })` 명시 override. 둘 다 지원.
+ *
+ * 현 PR-2 의 scope = factory + ZntcPlugin shape + .css 파일 onLoad PostCSS 통과
+ * (minimal). Sass / CSS Modules 는 follow-up commit.
+ */
+
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+import type { ZntcPlugin } from '@zntc/core';
+
+import { loadPostcssConfig } from '../style/postcss.ts';
+
+export interface CssPluginOptions {
+  /** plugin 전체 비활성. `ZNTC_NO_CSS_DEFAULTS=1` env 대신 명시적 disable. */
+  disabled?: boolean;
+  /**
+   * PostCSS override. 미지정 시 ZTS 가 postcss.config.js 자동 발견 (Vite 패턴).
+   * 명시 시 자동 발견 무시하고 해당 plugins 사용.
+   */
+  postcss?: {
+    plugins?: unknown[];
+    options?: Record<string, unknown>;
+  };
+  /**
+   * postcss.config 검색의 root. 미지정 시 process.cwd().
+   * Vite 의 `css.postcss` 또는 `process.cwd()` 와 동일 의미.
+   */
+  root?: string;
+  /**
+   * postcss-load-config 의 `env` 로 전달 — postcss.config.js 가 factory 형식
+   * `({ mode }) => ({...})` 일 때 사용. 미지정 시 `process.env.NODE_ENV` 또는
+   * `'development'` (dev safer). Vite 의 `css.postcss` env parity.
+   */
+  mode?: 'development' | 'production';
+}
+
+/**
+ * CSS pipeline plugin factory. ZTS dev / build pipeline 의 `.css` 파일 onLoad 시
+ * PostCSS pass 적용 (autoprefixer / preset-env 등 postcss.config 의 plugin들).
+ *
+ * @example
+ * ```ts
+ * // zero-config — postcss.config.js 자동 발견
+ * export default defineConfig({ plugins: [css()] });
+ *
+ * // override
+ * export default defineConfig({
+ *   plugins: [css({ postcss: { plugins: [autoprefixer()] } })],
+ * });
+ *
+ * // disable
+ * export default defineConfig({ plugins: [css({ disabled: true })] });
+ * ```
+ */
+export function css(options: CssPluginOptions = {}): ZntcPlugin {
+  return {
+    name: '@zntc/web/css',
+    setup(build) {
+      if (options.disabled) return;
+
+      // `.module.css` 는 CSS Modules 처리 path 라 본 plugin 의 raw PostCSS 통과
+      // 대상에서 제외. negative-lookbehind 로 `.module.css` 매치 방지.
+      build.onLoad({ filter: /(?<!\.module)\.css$/ }, async (args) => {
+        // 파일 read — onLoad 의 caller 가 contents 직접 안 줌. 우리가 fs 호출.
+        const input = readFileSync(args.path, 'utf8');
+
+        // override 가 있으면 그 plugins 사용. 미지정 시 postcss.config 자동 발견.
+        const root = options.root ?? process.cwd();
+        const fallbackRequire = createRequire(import.meta.url);
+        const mode = options.mode ?? ((process.env.NODE_ENV === 'production' ? 'production' : 'development') as 'development' | 'production');
+
+        let plugins: unknown[];
+        let postcssOptions: Record<string, unknown>;
+        let postcssModule: { (plugins?: unknown[]): { process: PostcssProcess } };
+
+        const overridePlugins = options.postcss?.plugins;
+        if (overridePlugins && overridePlugins.length > 0) {
+          // override path — 사용자가 명시한 plugins 사용. 빈 배열 (`.length === 0`)
+          // 은 round-trip 만 발생시킬 무의미 호출이라 pass-through.
+          try {
+            postcssModule = (await import('postcss')).default as typeof postcssModule;
+          } catch {
+            return { contents: input }; // postcss 미설치 시 pass-through
+          }
+          plugins = overridePlugins;
+          postcssOptions = options.postcss?.options ?? {};
+        } else {
+          // zero-config path — postcss.config 자동 발견 (Vite 패턴). postcss /
+          // postcss-load-config 미설치 시 silent pass-through (optionalDependencies
+          // 정합 — packages/web/package.json 의 optional 선언과 일치).
+          let loaded;
+          try {
+            loaded = await loadPostcssConfig(root, { mode }, fallbackRequire);
+          } catch {
+            return { contents: input };
+          }
+          if (!loaded) return { contents: input };
+          plugins = loaded.plugins;
+          postcssOptions = loaded.options ?? {};
+          postcssModule = loaded.postcss as typeof postcssModule;
+        }
+
+        const result = await postcssModule(plugins).process(input, {
+          ...postcssOptions,
+          from: args.path,
+          to: args.path,
+        });
+
+        return {
+          contents: result.css,
+          map: result.map?.toString(),
+          loader: 'css',
+        };
+      });
+    },
+  };
+}
+
+interface PostcssProcess {
+  (
+    input: string,
+    options: { from: string; to: string; [k: string]: unknown },
+  ): Promise<{ css: string; map?: { toString(): string } }>;
+}

--- a/packages/web/src/css/index.ts
+++ b/packages/web/src/css/index.ts
@@ -75,7 +75,11 @@ export function css(options: CssPluginOptions = {}): ZntcPlugin {
         // override 가 있으면 그 plugins 사용. 미지정 시 postcss.config 자동 발견.
         const root = options.root ?? process.cwd();
         const fallbackRequire = createRequire(import.meta.url);
-        const mode = options.mode ?? ((process.env.NODE_ENV === 'production' ? 'production' : 'development') as 'development' | 'production');
+        const mode =
+          options.mode ??
+          ((process.env.NODE_ENV === 'production' ? 'production' : 'development') as
+            | 'development'
+            | 'production');
 
         let plugins: unknown[];
         let postcssOptions: Record<string, unknown>;


### PR DESCRIPTION
## 요약

epic #2538 4-4 의 **PR-2** — `@zntc/web/css` sub-export 신설. PR-1 (#3827) 의 app pipeline plugin dispatcher 가 호출할 첫 default plugin.

### scope (minimal)

| | |
|---|---|
| ✅ | `css()` factory + `CssPluginOptions` interface |
| ✅ | ZntcPlugin shape (`name`/`setup(build)`) — esbuild-style |
| ✅ | `.css` 파일 onLoad — PostCSS 통과 (자동 발견 + override) |
| ❌ → follow-up | Sass (`.scss/.sass`), CSS Modules, source map outdir-relative |
| ❌ → PR-3 | dev-controller 의 plugin chain wiring |

## Vite parity 설계

- **자동 발견** — postcss.config 자동 load (Vite `vite:css` 패턴)
- **override** — `css({ postcss: { plugins: [autoprefixer()] } })` 명시 가능
- **disable** — `css({ disabled: true })` 또는 (PR-3 후) `ZNTC_NO_CSS_DEFAULTS=1` env
- **mode** — `CssPluginOptions.mode` (default = `process.env.NODE_ENV` or `'development'`) — Vite `mode` env parity

## /code-review max — HIGH 1 + MEDIUM 4 fix

| | finding | fix |
|---|---|---|
| **HIGH** | zero-config path 의 postcss/postcss-load-config 미설치 시 throw → build fail | try/catch swallow (optionalDependencies 정합) |
| **MEDIUM** | `mode: 'production'` 하드코딩 → dev 시 prod plugin 활성 | `CssPluginOptions.mode` + `process.env.NODE_ENV` default |
| **MEDIUM** | filter `/\.css$/` 가 `.module.css` 매치 | negative lookbehind `/(?<!\.module)\.css$/` |
| **MEDIUM** | override `plugins=[]` empty 가 truthy → 무의미 round-trip | `.length > 0` 가드 + zero-config fallback |
| **MEDIUM** | test 의 Bun.write 잔재 (path 오해 + cleanup 없음) | 제거 + `mkdtempSync` 만 |

## 변경 (3 파일 +265)

| 파일 | 변경 |
|---|---|
| `packages/web/src/css/index.ts` (신규) | `css()` factory, `CssPluginOptions`, onLoad hook |
| `packages/web/src/css/css.test.ts` (신규) | 7 test (shape, zero-config, disabled, override, pass-through, .module.css 제외, empty plugins round-trip 회피) |
| `packages/web/package.json` | `./css` sub-export + `build:bundle` 에 css entry 추가 |

## 검증

| | 결과 |
|---|---|
| `bun test` packages/web | ✅ 176 pass / 0 fail (7 신규) |
| `bun run build` packages/web | ✅ dist/css/index.js + .d.ts 산출 |

## 미반영 (별도 PR)

| | scope |
|---|---|
| MEDIUM (PR-3) | `PluginBuild` 가 mode/initialOptions 미노출 — controller wire 시 mode 전달 경로 결정 |
| LOW (PR-3) | source map sources 절대경로 → outdir relative |
| follow-up | Sass / CSS Modules 처리 추가 |

## 후속

- **PR-3** — `runAppDev`/`runAppBuild` 의 plugin chain — `afterBundle` PostCSS pass 를 plugin chain 으로 이행 + default `css()` 자동 등록 + `ZNTC_NO_CSS_DEFAULTS` kill-switch
- **PR-4** — Vite/Rollup adapter (`vitePlugin()`) app pipeline 활성 + `@vitejs/plugin-react` smoke

Refs: #2538 (4-4 PR-2/N), follows #3827

🤖 Generated with [Claude Code](https://claude.com/claude-code)