### PR TITLE
feat(cli): runAppBuild 의 default css() plugin 자동 prepend + opt-out (#2538 4-4 PR-3a)

### DIFF
--- a/packages/core/bin/app-default-plugins.mjs
+++ b/packages/core/bin/app-default-plugins.mjs
@@ -1,0 +1,41 @@
+/**
+ * `runAppBuild` 가 호출하는 default plugin 주입 helper. (#2538 4-4 PR-3a)
+ *
+ * Vite 의 `vite:css` 패턴과 동등 — 사용자가 명시 안 해도 `@zntc/web/css` plugin
+ * 자동 적용. 사용자 plugins 앞에 prepend (resolveId/load/transform 우선순위).
+ *
+ * Opt-out:
+ *   - `ZNTC_NO_CSS_DEFAULTS=1` 환경변수 (caller 가 `disableDefaults` 로 전달)
+ *   - `zntc.config.appPlugins.disableDefaults: true` (caller 가 옵션 전달)
+ *
+ * runAppDev (dev mode) 의 default css 주입은 PR-3b (dev-controller wiring) 에서.
+ * 현 PR-3a 는 runAppBuild (production build) 만 적용.
+ *
+ * @param {object} args
+ * @param {Array<{ name: string, setup: Function }>} args.userPlugins — user
+ *   plugins (config.plugins + pluginPaths). 순서 보존. 반환값은 항상 새 array
+ *   (caller mutate 가 외부 영향 X).
+ * @param {boolean} args.disableDefaults — true 면 default 미주입.
+ * @param {{ name: string, setup: Function } | null} args.cssPlugin — `css()`
+ *   factory 결과 또는 null (web module 미로드 등 — defensive).
+ * @returns {Array<{ name: string, setup: Function }>} 새 array (ownership 분리)
+ */
+export function resolveAppPlugins({ userPlugins, disableDefaults, cssPlugin }) {
+  if (disableDefaults) return [...userPlugins];
+  if (!cssPlugin) return [...userPlugins];
+  return [cssPlugin, ...userPlugins];
+}
+
+/**
+ * `process.env.ZNTC_NO_CSS_DEFAULTS` 같은 boolean 환경변수의 truthy 정규화.
+ * '1' / 'true' / 'TRUE' / 'yes' / 'YES' / 'on' / 'ON' 을 truthy. 미지정 / '0' /
+ * 'false' / 'no' / 'off' / '' 는 falsy. Vite/Rollup 의 흔한 env 관용 따름.
+ *
+ * @param {string | undefined | null} value
+ * @returns {boolean}
+ */
+export function isEnvTruthy(value) {
+  if (value == null || value === '') return false;
+  const v = value.toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}

--- a/packages/core/bin/app-default-plugins.test.ts
+++ b/packages/core/bin/app-default-plugins.test.ts
@@ -1,0 +1,112 @@
+/**
+ * `resolveAppPlugins` + `isEnvTruthy` 유닛 test — `runAppBuild` 의 default
+ * plugin 주입 helper. (#2538 4-4 PR-3a)
+ *
+ * TDD: helper 미존재 상태에서 test 먼저 작성 → 구현 → green 확인.
+ *
+ * Vite parity: 사용자 config.plugins 외에 default css() 가 prepend (resolveId/
+ * load/transform 순서상 우선). `ZNTC_NO_CSS_DEFAULTS=1` env 또는 명시
+ * `disableDefaults: true` 옵션 (zntc.config 의 `appPlugins.disableDefaults`)
+ * 으로 opt-out.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { isEnvTruthy, resolveAppPlugins } from './app-default-plugins.mjs';
+
+const cssDefault = { name: '@zntc/web/css', setup: () => {} };
+const userPluginA = { name: 'user:a', setup: () => {} };
+const userPluginB = { name: 'user:b', setup: () => {} };
+
+describe('resolveAppPlugins', () => {
+  test('user plugins 빈 배열 + default 활성 → [css()] 1개', () => {
+    const result = resolveAppPlugins({
+      userPlugins: [],
+      disableDefaults: false,
+      cssPlugin: cssDefault,
+    });
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('@zntc/web/css');
+  });
+
+  test('user plugins + default 활성 → [css(), ...user]', () => {
+    const result = resolveAppPlugins({
+      userPlugins: [userPluginA, userPluginB],
+      disableDefaults: false,
+      cssPlugin: cssDefault,
+    });
+    expect(result.length).toBe(3);
+    expect(result[0]!.name).toBe('@zntc/web/css');
+    expect(result[1]!.name).toBe('user:a');
+    expect(result[2]!.name).toBe('user:b');
+  });
+
+  test('disableDefaults=true → user plugins 만 (default 미주입)', () => {
+    const result = resolveAppPlugins({
+      userPlugins: [userPluginA],
+      disableDefaults: true,
+      cssPlugin: cssDefault,
+    });
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('user:a');
+  });
+
+  test('disableDefaults=true + user plugins 빈 배열 → 빈 배열', () => {
+    const result = resolveAppPlugins({
+      userPlugins: [],
+      disableDefaults: true,
+      cssPlugin: cssDefault,
+    });
+    expect(result.length).toBe(0);
+  });
+
+  test('cssPlugin 인자가 null 일 때도 안전 — default 미주입', () => {
+    const result = resolveAppPlugins({
+      userPlugins: [userPluginA],
+      disableDefaults: false,
+      cssPlugin: null,
+    });
+    expect(result.length).toBe(1);
+    expect(result[0]!.name).toBe('user:a');
+  });
+
+  test('user plugins 의 순서 보존 (a → b → c)', () => {
+    const userPluginC = { name: 'user:c', setup: () => {} };
+    const result = resolveAppPlugins({
+      userPlugins: [userPluginA, userPluginB, userPluginC],
+      disableDefaults: true,
+      cssPlugin: cssDefault,
+    });
+    expect(result.map((p) => p.name)).toEqual(['user:a', 'user:b', 'user:c']);
+  });
+
+  test('ownership: 반환 array 가 userPlugins 와 다른 reference (caller mutate 안전)', () => {
+    const userPlugins = [userPluginA];
+    const result = resolveAppPlugins({ userPlugins, disableDefaults: true, cssPlugin: null });
+    expect(result).not.toBe(userPlugins); // 새 array
+    expect(result).toEqual(userPlugins); // content 동등
+  });
+});
+
+describe('isEnvTruthy', () => {
+  test('truthy values', () => {
+    expect(isEnvTruthy('1')).toBe(true);
+    expect(isEnvTruthy('true')).toBe(true);
+    expect(isEnvTruthy('TRUE')).toBe(true);
+    expect(isEnvTruthy('yes')).toBe(true);
+    expect(isEnvTruthy('YES')).toBe(true);
+    expect(isEnvTruthy('on')).toBe(true);
+    expect(isEnvTruthy('ON')).toBe(true);
+  });
+
+  test('falsy values', () => {
+    expect(isEnvTruthy('0')).toBe(false);
+    expect(isEnvTruthy('false')).toBe(false);
+    expect(isEnvTruthy('FALSE')).toBe(false);
+    expect(isEnvTruthy('no')).toBe(false);
+    expect(isEnvTruthy('off')).toBe(false);
+    expect(isEnvTruthy('')).toBe(false);
+    expect(isEnvTruthy(undefined)).toBe(false);
+    expect(isEnvTruthy(null)).toBe(false);
+  });
+});

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -27,6 +27,7 @@ import {
   buildRnDevServerInput,
 } from './rn-dev-input.mjs';
 import { applyColorPreference, printZntcBanner } from './banner.mjs';
+import { isEnvTruthy, resolveAppPlugins } from './app-default-plugins.mjs';
 
 function isMissingBuiltCore(error) {
   if (!error || error.code !== 'ERR_MODULE_NOT_FOUND') return false;
@@ -672,19 +673,40 @@ function getAutoConfigSearchDir(opts) {
 async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   // JS plugin 로드 — bundle pipeline 의 buildBundleOptions 와 동일 패턴. app
   // pipeline 도 plugin dispatcher 통과 (#2538 4-4 PR-1).
-  const appPlugins = [];
+  const userPlugins = [];
   if (config && Array.isArray(config.plugins)) {
-    appPlugins.push(...config.plugins);
+    userPlugins.push(...config.plugins);
   }
   for (const pluginPath of opts.pluginPaths) {
     const absPath = resolve(pluginPath);
     const cfg = await importAndResolveDefault(absPath);
     if (Array.isArray(cfg.plugins)) {
-      appPlugins.push(...cfg.plugins);
+      userPlugins.push(...cfg.plugins);
     } else if (typeof cfg.setup === 'function') {
-      appPlugins.push(cfg);
+      userPlugins.push(cfg);
     }
   }
+  // default css() plugin 자동 prepend — Vite `vite:css` 패턴 (#2538 4-4 PR-3a).
+  // ZNTC_NO_CSS_DEFAULTS (1/true/yes/on) 또는 config.appPlugins?.disableDefaults
+  // 로 opt-out. dev 모드 (runAppDev) 의 default css 는 PR-3b.
+  const disableCssDefaults =
+    isEnvTruthy(process.env.ZNTC_NO_CSS_DEFAULTS) || config?.appPlugins?.disableDefaults === true;
+  const webCss = disableCssDefaults ? null : await loadWebCssModule();
+  // css() factory throw 방어 — postcss/postcss-load-config 미설치 같은 init 실패
+  // 케이스에서 build 전체 죽지 않게. loadWebCssModule 의 friendly handler 와 동등.
+  let cssPlugin = null;
+  if (webCss?.css) {
+    try {
+      cssPlugin = webCss.css() ?? null;
+    } catch (err) {
+      console.error(`warning: @zntc/web/css 의 default plugin 초기화 실패 — pass-through. ${err}`);
+    }
+  }
+  const appPlugins = resolveAppPlugins({
+    userPlugins,
+    disableDefaults: disableCssDefaults,
+    cssPlugin,
+  });
   const web = await loadWebModule();
   const root = resolve(opts.appRoot ?? '.');
   const outdir = resolve(opts.outdir ?? join(root, 'dist'));
@@ -795,6 +817,37 @@ async function loadWebModule() {
     }
   })();
   return webModulePromise;
+}
+
+// `@zntc/web/css` sub-export — runAppBuild/runAppDev 의 default css() plugin.
+// loadWebModule 과 분리: main `@zntc/web` 은 dev-controller / HMR 정도라 항상
+// 로드되지만, css sub-export 는 plugin chain 진입할 때만. lazy.
+let webCssModulePromise = null;
+async function loadWebCssModule() {
+  if (webCssModulePromise) return webCssModulePromise;
+  webCssModulePromise = (async () => {
+    try {
+      return await import('@zntc/web/css');
+    } catch (err) {
+      // sub-export 누락 시도 친절 메시지 — main `@zntc/web` 은 있는데 ./css 가
+      // dist 에 없는 경우 (build:bundle 의 css entry 누락 등).
+      const code = err?.code;
+      const message = String(err?.message ?? '');
+      // 정확 매칭 — Node 의 ERR_PACKAGE_PATH_NOT_EXPORTED (구버전 @zntc/web 에 ./css
+      // sub-export 부재) 또는 ERR_MODULE_NOT_FOUND (build:bundle 의 css entry 누락)
+      // 만 friendly. 그 외 (sub-dependency 등) 는 throw — 진짜 에러 silent 방지.
+      if (
+        code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' ||
+        (code === 'ERR_MODULE_NOT_FOUND' && /@zntc\/web\/css/.test(message))
+      ) {
+        console.error('warning: @zntc/web/css sub-export 미발견 — default CSS plugin 미적용.');
+        console.error('help: @zntc/web 을 최신 버전으로 업그레이드 (>= 0.x sub-export 도입).');
+        return null;
+      }
+      throw err;
+    }
+  })();
+  return webCssModulePromise;
 }
 
 // RN 모드 (`zntc bundle --platform=react-native`) — @zntc/react-native 을 lazy

--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -25,6 +25,14 @@ import { init, isPlainObject, transpile } from '../index';
  */
 export type UserConfig = Partial<BuildOptions> & {
   extends?: string | string[];
+  /**
+   * `zntc build/dev --app` (Vite-style app pipeline) 의 default plugin 제어
+   * (#2538 4-4). 현재는 `disableDefaults` 만 — 모든 default plugin (현 시점
+   * `@zntc/web/css`) 자동 주입 끄기. `ZNTC_NO_CSS_DEFAULTS=1` env 와 동등.
+   */
+  appPlugins?: {
+    disableDefaults?: boolean;
+  };
 };
 
 /**


### PR DESCRIPTION
## 요약

epic #2538 4-4 의 **PR-3a** — `zntc build --app` 가 사용자 explicit plugin 없어도 `@zntc/web/css` (PR-2 #3829) 를 자동 적용. **Vite `vite:css` 패턴 정확 모방**.

## TDD 진행

1. test 먼저 (`bin/app-default-plugins.test.ts`) — helper 미존재 상태 red
2. helper 구현 (`bin/app-default-plugins.mjs`) → green
3. zntc.mjs wiring (loadWebCssModule + resolveAppPlugins)
4. `/code-review max` → MEDIUM 3 + LOW 4 fix

## 변경 (4 파일 +218 -4)

| 파일 | 변경 |
|---|---|
| `bin/app-default-plugins.mjs` (신규) | `resolveAppPlugins` + `isEnvTruthy` helpers |
| `bin/app-default-plugins.test.ts` (신규) | **9 test** (resolveAppPlugins 7 + isEnvTruthy 2 describe) |
| `bin/zntc.mjs` | `loadWebCssModule` lazy import + `runAppBuild` 의 plugin chain |
| `src/config-loader.ts` | `UserConfig.appPlugins?.disableDefaults` type |

## opt-out

```bash
# 1. env
ZNTC_NO_CSS_DEFAULTS=1 zntc build --app   # 또는 'true' / 'yes' / 'on'

# 2. config
defineConfig({ appPlugins: { disableDefaults: true } })
```

## /code-review max 결과 — 진짜 bug 0건. MEDIUM 3 + LOW 4 fix

| | finding | fix |
|---|---|---|
| MEDIUM | jsdoc `runAppDev` 언급 — dev mode 미적용 | jsdoc 정정 + PR-3b 명시 |
| MEDIUM | test 주석 옵션명 불일치 (`disableDefaultPlugins`) | `disableDefaults` 로 정정 |
| MEDIUM | `loadWebCssModule` regex 광범위 — 진짜 에러 마스킹 | `ERR_PACKAGE_PATH_NOT_EXPORTED` + scoped message regex |
| LOW | `css()` factory throw 무방어 | try/catch + warning |
| LOW | disable 분기 reference 누출 | `[...userPlugins]` 양 분기 |
| LOW | env value 정규화 미흡 (`'1'` literal 만) | `isEnvTruthy` (1/true/yes/on 다 truthy) |
| LOW | `ZntcConfig.appPlugins` type 미정의 | `UserConfig.appPlugins.disableDefaults` 추가 |

## 미반영 (PR-3b)

- **runAppDev (dev mode) 의 default css 주입** — dev-controller 의 plugin chain wiring 과 함께. PR-3b 의 scope. 본 PR-3a 는 build mode 만이라 dev/build 비대칭이지만 PR-3b 가 즉시 해소

## 검증

| | 결과 |
|---|---|
| `bun test bin/app-default-plugins.test.ts` | ✅ 9 pass / 0 fail / 29 expect |
| `bun run build:dts` (packages/core) | ✅ tsc -b pass |

Refs: #2538 (4-4 PR-3a/N), follows #3829

🤖 Generated with [Claude Code](https://claude.com/claude-code)