### PR TITLE
fix(web): css-modules prototype shadowing — Object.create(null) + Object.hasOwn 이중 가드 (RFC #3833 a1-#2)

### DIFF
--- a/packages/web/src/style/css-modules.test.ts
+++ b/packages/web/src/style/css-modules.test.ts
@@ -293,7 +293,8 @@ describe('transformCssModules — prototype-shadowing class name (a1-#2 가드)'
   // public `rewriteCssModuleClasses` (line 99 export) 가 외부 caller-supplied
   // plain `{}` mapping 받아도 안전 — Object.hasOwn 가드로 prototype lookup 무력화.
   test('public rewriteCssModuleClasses + plain {} mapping → prototype lookup 무력화', () => {
-    const css = '.constructor { color: red; }\n.toString { color: blue; }\n.regular { color: green; }';
+    const css =
+      '.constructor { color: red; }\n.toString { color: blue; }\n.regular { color: green; }';
     const mapping: Record<string, string> = { regular: 'scoped-regular' };
     // 의도적으로 plain {} (Object.prototype 상속) 사용. caller 가 잘못 만들어도 안전.
     const out = rewriteCssModuleClasses(css, mapping);

--- a/packages/web/src/style/css-modules.test.ts
+++ b/packages/web/src/style/css-modules.test.ts
@@ -14,6 +14,7 @@ import {
   rewriteCssModuleClasses,
   rewriteCssModuleReferences,
   scanCssModuleClassTokens,
+  transformCssModules,
 } from './css-modules.ts';
 
 let dir: string;
@@ -224,5 +225,84 @@ describe('rewriteCssModuleReferences', () => {
     const path = touch('entry.ts', `import './x.module.css';`);
     rewriteCssModuleReferences([path]);
     expect(readFileSync(path, 'utf8')).toBe(`import './x.module.css.js';`);
+  });
+});
+
+// a1-#2 (RFC #3833): plain `{}` 의 prototype shadowing 가드.
+// `.constructor` / `.toString` / `.__proto__` / `.hasOwnProperty` 같은
+// Object.prototype 메서드 이름이 CSS class 로 쓰일 시, mapping = {} 의 lookup
+// 이 native function 반환 → `if (!mapping[token.local])` truthy → 매핑 누락 +
+// rewrite 가 native fn 을 stringify 해 CSS 에 garbage 삽입.
+// fix: `Object.create(null)` 로 prototype-less mapping. lookup 안전.
+describe('transformCssModules — prototype-shadowing class name (a1-#2 가드)', () => {
+  function makeFixture(filename: string, css: string): { root: string; file: string } {
+    const file = join(dir, filename);
+    writeFileSync(file, css);
+    return { root: dir, file };
+  }
+
+  test('class name `.constructor` 도 정상 scoping (prototype shadowing 회귀 가드)', () => {
+    const { root, file } = makeFixture(
+      'a.module.css',
+      '.constructor { color: red; }\n.toString { color: blue; }\n.regular { color: green; }',
+    );
+    transformCssModules(root, [file], [], 'silent');
+
+    // generated .module.zntc.css 에 scoped 클래스가 모두 있어야 (native fn stringify 가 아니라)
+    const generated = readFileSync(file.replace(/\.module\.css$/, '.module.zntc.css'), 'utf8');
+    expect(generated).toMatch(/\.a_constructor__[A-Za-z0-9_-]{8}/);
+    expect(generated).toMatch(/\.a_toString__[A-Za-z0-9_-]{8}/);
+    expect(generated).toMatch(/\.a_regular__[A-Za-z0-9_-]{8}/);
+    // native fn stringify garbage 없음
+    expect(generated).not.toMatch(/native code|function Object|function toString/);
+
+    // proxy module 의 default mapping 에 prototype-shadowing 키도 own property 로 포함
+    const proxy = readFileSync(`${file}.js`, 'utf8');
+    expect(proxy).toContain('"constructor"');
+    expect(proxy).toContain('"toString"');
+    expect(proxy).toContain('"regular"');
+  });
+
+  test('class name `.__proto__` / `.hasOwnProperty` 도 정상 (다른 prototype-shadowing 케이스)', () => {
+    const { root, file } = makeFixture(
+      'b.module.css',
+      '.__proto__ { color: red; }\n.hasOwnProperty { color: blue; }',
+    );
+    transformCssModules(root, [file], [], 'silent');
+
+    const generated = readFileSync(file.replace(/\.module\.css$/, '.module.zntc.css'), 'utf8');
+    // __proto__ 는 sha hash 가 다른 형식. SAFE_LOCAL_RE 가 _ 로 치환하지 않음 (alnum + _ 라).
+    // 따라서 fileName_local__hash 가 fileName___proto____hash 가 됨 (4 underscores).
+    expect(generated).toMatch(/\.b___proto____[A-Za-z0-9_-]{8}/);
+    expect(generated).toMatch(/\.b_hasOwnProperty__[A-Za-z0-9_-]{8}/);
+    expect(generated).not.toMatch(/native code|\[object/);
+  });
+
+  test('regular class 만 있는 케이스도 회귀 없음 (사전 존재 동작 보존)', () => {
+    const { root, file } = makeFixture(
+      'c.module.css',
+      '.primary { color: red; }\n.danger { color: darkred; }',
+    );
+    transformCssModules(root, [file], [], 'silent');
+
+    const generated = readFileSync(file.replace(/\.module\.css$/, '.module.zntc.css'), 'utf8');
+    expect(generated).toMatch(/\.c_primary__[A-Za-z0-9_-]{8}/);
+    expect(generated).toMatch(/\.c_danger__[A-Za-z0-9_-]{8}/);
+  });
+
+  // public `rewriteCssModuleClasses` (line 99 export) 가 외부 caller-supplied
+  // plain `{}` mapping 받아도 안전 — Object.hasOwn 가드로 prototype lookup 무력화.
+  test('public rewriteCssModuleClasses + plain {} mapping → prototype lookup 무력화', () => {
+    const css = '.constructor { color: red; }\n.toString { color: blue; }\n.regular { color: green; }';
+    const mapping: Record<string, string> = { regular: 'scoped-regular' };
+    // 의도적으로 plain {} (Object.prototype 상속) 사용. caller 가 잘못 만들어도 안전.
+    const out = rewriteCssModuleClasses(css, mapping);
+    // .regular 만 scope 적용 (mapping 의 own property)
+    expect(out).toContain('.scoped-regular { color: green; }');
+    // .constructor / .toString 은 mapping own property 아님 → 원본 그대로 (skip, 변경 X)
+    expect(out).toContain('.constructor { color: red; }');
+    expect(out).toContain('.toString { color: blue; }');
+    // native fn stringify garbage 없음
+    expect(out).not.toMatch(/native code|function Object|function toString|\[object/);
   });
 });

--- a/packages/web/src/style/css-modules.ts
+++ b/packages/web/src/style/css-modules.ts
@@ -233,7 +233,11 @@ export function transformCssModules(
     const tokens = scanCssModuleClassTokens(css);
     const rel = relative(root, file).replaceAll(sep, '/');
     const fileName = basename(file, '.module.css').replace(SAFE_LOCAL_RE, '_');
-    const mapping: Record<string, string> = {};
+    // a1-#2 (RFC #3833): plain `{}` 은 Object.prototype 상속 → `.constructor`/
+    // `.toString`/`.__proto__` 같은 class name 시 `!mapping[token.local]` 가 truthy
+    // (native function lookup) → 매핑 누락 + rewrite 가 native fn 을 stringify 해
+    // CSS 에 garbage 삽입. `Object.create(null)` 은 prototype-less 라 안전.
+    const mapping: Record<string, string> = Object.create(null) as Record<string, string>;
     for (const token of tokens) {
       if (!mapping[token.local]) {
         mapping[token.local] = cssModuleLocalNameWithCachedFile(rel, fileName, token.local);
@@ -265,6 +269,13 @@ function rewriteCssModuleClassesWithTokens(
   let out = '';
   let offset = 0;
   for (const token of tokens) {
+    // a1-#2 (RFC #3833): public `rewriteCssModuleClasses` (line 99) 가 caller-
+    // supplied mapping 받음. caller 가 plain `{}` 전달 시 `mapping[token.local]`
+    // 의 prototype lookup 으로 `.constructor`/`.toString` 같은 native fn 이 truthy
+    // 반환 → `if (!scoped)` 통과 → CSS 에 garbage 삽입. `Object.hasOwn` 가드로
+    // mapping shape 무관 안전 (transformCssModules 의 Object.create(null) 와
+    // 이중 가드).
+    if (!Object.hasOwn(mapping, token.local)) continue;
     const scoped = mapping[token.local];
     if (!scoped) continue;
     out += css.slice(offset, token.start);


### PR DESCRIPTION
## Summary

PR #3839 (close) 의 A-1 attempt 시 \`/code-review max\` Phase 2 verify 가 발견한 **사전 존재 버그** (RFC #3833 의 a1-#2). PR-3a 부터 무관 — RFC 와 별개 **standalone hot-fix**.

## 문제

\`transformCssModules\` 와 \`rewriteCssModuleClasses\` 의 mapping 으로 \`Record<string, string> = {}\` (plain object, Object.prototype 상속) 사용. CSS class name 이 \`.constructor\`/\`.toString\`/\`.__proto__\`/\`.hasOwnProperty\` 같은 prototype 메서드 이름과 일치 시:

1. \`if (!mapping[token.local])\` → native fn lookup truthy → 매핑 미생성
2. \`rewriteCssModuleClassesWithTokens\` 의 \`mapping[token.local]\` → 같은 prototype lookup → native fn → CSS 에 \`.function Object() { [native code] }\` 같은 garbage 삽입
3. proxy module 의 default mapping (JSON.stringify) 에는 own property 만 → \`styles.constructor\` 가 native Object constructor 반환 (런타임 surprise)

## fix (이중 가드)

- **A**: \`transformCssModules\` 내 \`mapping = Object.create(null) as Record<...>\` — prototype-less object, 내부 lookup 안전
- **B**: \`rewriteCssModuleClassesWithTokens\` 내 \`if (!Object.hasOwn(mapping, token.local)) continue\` 가드 — 외부 caller (public \`rewriteCssModuleClasses\` export) 가 plain \`{}\` mapping 전달해도 API 자체 bug-class-proof

\`/code-review max\` 가 잡은 latent gap (public API caller 보호) 도 fix B 로 함께 cover.

## TDD test (4개)

1. \`.constructor\` / \`.toString\` / \`.regular\` mixed — scoping + native fn garbage 0
2. \`.__proto__\` / \`.hasOwnProperty\` — 다른 prototype-shadowing 케이스
3. regular class 회귀 가드
4. **public \`rewriteCssModuleClasses\` + plain \`{}\` mapping** — \`Object.hasOwn\` 가드 검증

## Test plan

- [x] \`bun test packages/web/src/style/css-modules.test.ts\` → 33 pass / 0 fail
- [x] \`bun --cwd packages/web run build\` (bundle + dts) pass
- [x] \`bun run fmt\` (oxfmt)
- [ ] (merge 후) integration test — 회귀 0 기대 (기존 CSS Modules 동작 보존)

## 의존성

- RFC #3833 옵션 채택과 무관 — pre-existing bug 단순 fix
- A-1 attempt (PR #3839 close) 가 발견한 finding, 본 fix 가 standalone 진행

Refs: RFC #3833 (§1.5 a1-#2), PR #3839 close, \`/code-review max\` finding (1 latent gap fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)