### PR TITLE
fix(server): Windows TLS root-cause — TlsConnection comptime 분기 + #3842 mitigation revert (Closes #3841)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,15 +64,8 @@ jobs:
       # Windows GitHub runner (7GB RAM) 는 Debug LLVM 메모리 상한에 걸림
       # ("LLVM ERROR: out of memory"). Debug 빌드·테스트 커버리지는 Linux/macOS
       # 에서 유지하고, Windows 에서는 Release 빌드만 검증한다.
-      #
-      # Windows 한정 continue-on-error: src/server/tls.zig 의 `@compileError`
-      # ("Windows dev server TLS 는 별도 epic 진행 필요 — winsock SOCKET 어댑터")
-      # 가 사전 의도된 차단 (project_2538_4_2_https_tls_complete 메모리). winsock
-      # 어댑터 구현은 별도 epic — 본 step 의 windows fail 은 known 상태로 다른
-      # check 들의 가시성을 흐리지 않게 회피. 진짜 fix 는 follow-up issue 추적.
       - name: Build (${{ matrix.optimize }})
         run: zig build -Doptimize=${{ matrix.optimize }}
-        continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
   lint:
     name: Lint

--- a/src/server/tls.zig
+++ b/src/server/tls.zig
@@ -39,6 +39,9 @@ pub const Error = error{
     HandshakeFailed,
     TlsRead,
     TlsWrite,
+    /// Windows 의 std.posix.fd_t = HANDLE (*anyopaque) 라 boringssl 의
+    /// `SSL_set_fd(c_int)` 어댑터 부재. winsock SOCKET 어댑터는 별도 epic (#3841).
+    WindowsTlsUnsupported,
 };
 
 /// SSL_CTX wrapper — 1개 dev server 가 1개 context 공유. cert/key 로드는 init 시 1회.
@@ -85,17 +88,41 @@ pub const TlsContext = struct {
 };
 
 /// per-connection SSL wrapper. accept 후 1회 생성 — handshake 완료 후 reader/writer.
-pub const TlsConnection = struct {
+///
+/// Platform 분기 (RFC #3833 root-cause fix, issue #3841 winsock SOCKET 어댑터):
+/// Windows 의 std.posix.fd_t = HANDLE (*anyopaque) → boringssl 의 `SSL_set_fd(c_int)`
+/// 에 직접 cast 불가. 사전에는 `@compileError` 로 Windows 빌드 자체 차단했으나 (PR #3842
+/// 의 mitigation 까지 누적), 본 fix 는 struct 자체를 comptime 분기해 Windows 빌드
+/// 통과 + runtime 시 `WindowsTlsUnsupported` error 반환. `dev_server.zig:158/434` 의
+/// catch handler 가 이미 처리. winsock 어댑터 (#3841 Phase 2) 머지 시 분기 제거.
+pub const TlsConnection = if (builtin.os.tag == .windows) WindowsTlsConnectionStub else PosixTlsConnection;
+
+/// Windows 한정 stub — init 가 즉시 error 반환. reader/writer 는 init error 가드 후
+/// 호출 안 되지만 type signature 만족 위해 undefined-backed stub 제공.
+const WindowsTlsConnectionStub = struct {
     ssl: *boringssl.SSL,
 
-    pub fn init(ctx: *TlsContext, fd: std.posix.fd_t) Error!TlsConnection {
-        // Windows 에서 std.posix.fd_t = HANDLE (*anyopaque) 라 c_int cast 불가.
-        // BoringSSL on Windows 는 winsock SOCKET (ULONG_PTR) 을 c_int truncate
-        // 하는 별도 footgun + ZTS 의 dev_server Windows 지원은 별도 phase. 명시
-        // 차단 — 향후 windows TLS 지원 시 winsock 어댑터 추가.
-        if (@import("builtin").os.tag == .windows) {
-            @compileError("TLS adapter: Windows dev server TLS 는 별도 epic 진행 필요 (winsock SOCKET 어댑터)");
-        }
+    pub fn init(_: *TlsContext, _: std.posix.fd_t) Error!WindowsTlsConnectionStub {
+        log.err("TLS adapter: Windows dev server TLS 미지원 (winsock SOCKET 어댑터 별도 epic — issue #3841).", .{});
+        return Error.WindowsTlsUnsupported;
+    }
+
+    pub fn deinit(_: *WindowsTlsConnectionStub) void {}
+
+    pub fn reader(_: *WindowsTlsConnectionStub, buffer: []u8) TlsReader {
+        // init Error 후 reader 호출 unreachable — type 만족용.
+        return .init(undefined, buffer);
+    }
+
+    pub fn writer(_: *WindowsTlsConnectionStub, buffer: []u8) TlsWriter {
+        return .init(undefined, buffer);
+    }
+};
+
+const PosixTlsConnection = struct {
+    ssl: *boringssl.SSL,
+
+    pub fn init(ctx: *TlsContext, fd: std.posix.fd_t) Error!PosixTlsConnection {
         const ssl = boringssl.SSL_new(ctx.ctx) orelse return Error.SslNewFailed;
         errdefer boringssl.SSL_free(ssl);
         if (boringssl.SSL_set_fd(ssl, @intCast(fd)) != 1) return Error.SslSetFdFailed;
@@ -108,17 +135,17 @@ pub const TlsConnection = struct {
         return .{ .ssl = ssl };
     }
 
-    pub fn deinit(self: *TlsConnection) void {
+    pub fn deinit(self: *PosixTlsConnection) void {
         // graceful shutdown — 0 (진행 중) / 1 (완료) / <0 (error) 모두 cleanup 진행.
         _ = boringssl.SSL_shutdown(self.ssl);
         boringssl.SSL_free(self.ssl);
     }
 
-    pub fn reader(self: *TlsConnection, buffer: []u8) TlsReader {
+    pub fn reader(self: *PosixTlsConnection, buffer: []u8) TlsReader {
         return .init(self.ssl, buffer);
     }
 
-    pub fn writer(self: *TlsConnection, buffer: []u8) TlsWriter {
+    pub fn writer(self: *PosixTlsConnection, buffer: []u8) TlsWriter {
         return .init(self.ssl, buffer);
     }
 };


### PR DESCRIPTION
## Summary

PR #3842 의 \`continue-on-error\` mitigation 대신 **root-cause fix**. 사용자 요청: "이것도 루트커즈 고쳐주세요".

## 원인

\`src/server/tls.zig:97\` 의 \`@compileError\` 가 Windows Release Build 3 카테고리를 모든 main CI run 에서 fail. Windows 의 \`std.posix.fd_t = HANDLE (*anyopaque)\` → boringssl 의 \`SSL_set_fd(c_int)\` 에 직접 cast 불가.

## fix

\`TlsConnection\` struct 자체를 comptime 분기:

\`\`\`zig
pub const TlsConnection = if (builtin.os.tag == .windows)
    WindowsTlsConnectionStub
else
    PosixTlsConnection;
\`\`\`

- **WindowsTlsConnectionStub** — \`init\` 가 즉시 \`Error.WindowsTlsUnsupported\` 반환. reader/writer 는 undefined-backed type-만족 stub. \`dev_server.zig:158/434\` 의 catch handler 가 이미 처리
- **PosixTlsConnection** — 기존 real impl 그대로. Windows 빌드 시 body 가 미참조라 Zig 의 lazy semantic analysis 가 \`@intCast(fd)\` typecheck skip
- **Error.WindowsTlsUnsupported** variant 추가 (internal-only)

## ci.yml revert

PR #3842 의 \`continue-on-error: \${{ matrix.os == 'windows-latest' }}\` 제거. root-cause fix 후 mitigation 불필요.

## 검증

- [x] \`zig build\` (native macos) silent success
- [x] \`zig build -Doptimize=ReleaseSmall -Dtarget=x86_64-windows-gnu\` silent success
- [x] \`/code-review max\` 6 finding — 5 SAFE / 1 운영 위험 (MSVC ABI):
  - **위험**: Windows CI = MSVC ABI 이고 로컬 cross-compile = gnu ABI. MSVC ABI 에서 추가 system lib (crypt32 / ncrypt) 누락 가능성. **PR 머지 전 CI 실행 결과 확인 필수**. 추가 fail 시 \`build/boringssl.zig\` 에 MSVC link 추가
- [ ] (merge 후) main CI 의 Windows Release Build 통과 — continue-on-error 없이

## Closes #3841 Phase 1

본 fix 가 issue #3841 (Windows winsock SOCKET 어댑터 epic) 의 Phase 1 명세 완전 충족 — TlsConnection 분기 + Windows 빌드 통과 + WindowsTlsUnsupported runtime error. Phase 2 (진짜 Windows TLS 지원) 는 demand 발생 시 별도 진행.

Refs: PR #3842 (mitigation, 본 PR 머지 시 revert 완료), #2538 4-2 (TLS 통합), memory \`project_2538_4_2_https_tls_complete\`

Closes #3841

🤖 Generated with [Claude Code](https://claude.com/claude-code)