### PR TITLE
feat(core,web): RFC #3833 v3 D1a'' Phase 1 — caller-side pre-warm 으로 사용자 explicit css({postcss}) 적용

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -692,13 +692,18 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   // RFC #3833 v3 D1a'' (caller-side pre-warm): 사용자 explicit `plugins: [css({...})]`
   // 의 옵션을 prepare 에 전달. buildAppSync 의 sync dispatcher × async onLoad 충돌
   // 우회 — `css()` factory 가 `__cssOptions` sentinel 로 노출 (web/css/index.ts).
-  // name 매치 + sentinel 존재 둘 다 검사 (third-party 가장 plugin 방어).
-  const cssPlugin = appPlugins.find(
+  // **findLast**: 미래 default `css()` prepend (PR-3b 후속) 와 user override `css()` 가
+  // 같이 있을 때 user 가 winner (Vite 의 plugins 순서 의미와 일관). sentinel 은
+  // unique property 가 아닌 단순 string field — 의도 위장 방어보다 의도 매치용.
+  const cssPlugin = appPlugins.findLast(
     (p) => p?.name === '@zntc/web/css' && p.__cssOptions !== undefined,
   );
-  const postcssOverride = cssPlugin?.__cssOptions?.postcss?.plugins?.length
+  // **presence check**: `postcss !== undefined` — 사용자가 의도적으로 `plugins:[]`
+  // 명시한 경우 (postcss 명시 disable) 도 override path 진입. plugins.length 로
+  // 분기하면 빈 배열이 silently auto-discover 로 fallback 되어 Vite 비호환.
+  const postcssOverride = cssPlugin?.__cssOptions?.postcss
     ? {
-        plugins: cssPlugin.__cssOptions.postcss.plugins,
+        plugins: cssPlugin.__cssOptions.postcss.plugins ?? [],
         options: cssPlugin.__cssOptions.postcss.options,
       }
     : null;

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -689,6 +689,19 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   const root = resolve(opts.appRoot ?? '.');
   const outdir = resolve(opts.outdir ?? join(root, 'dist'));
   if (opts.clean) rmSync(outdir, { recursive: true, force: true });
+  // RFC #3833 v3 D1a'' (caller-side pre-warm): 사용자 explicit `plugins: [css({...})]`
+  // 의 옵션을 prepare 에 전달. buildAppSync 의 sync dispatcher × async onLoad 충돌
+  // 우회 — `css()` factory 가 `__cssOptions` sentinel 로 노출 (web/css/index.ts).
+  // name 매치 + sentinel 존재 둘 다 검사 (third-party 가장 plugin 방어).
+  const cssPlugin = appPlugins.find(
+    (p) => p?.name === '@zntc/web/css' && p.__cssOptions !== undefined,
+  );
+  const postcssOverride = cssPlugin?.__cssOptions?.postcss?.plugins?.length
+    ? {
+        plugins: cssPlugin.__cssOptions.postcss.plugins,
+        options: cssPlugin.__cssOptions.postcss.options,
+      }
+    : null;
   let pipelineRoot = null;
   try {
     const pipeline = await web.prepareAppCssPipelineRoot(
@@ -698,6 +711,7 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
       opts.logLevel,
       'build',
       { fallbackRequire: requireFromCli, cliNodeModules },
+      { postcssOverride },
     );
     pipelineRoot = pipeline?.tempRoot ?? null;
     const result = buildAppSync({

--- a/packages/core/test/cli/app-builder/styles/postcss.ts
+++ b/packages/core/test/cli/app-builder/styles/postcss.ts
@@ -48,6 +48,54 @@ describe('CLI: Vite-style app builder > styles > PostCSS', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  // RFC #3833 v3 D1a'' (caller-side pre-warm): 사용자 explicit `plugins: [css({
+  // postcss: { plugins: [...override] } })]` 가 buildAppSync 의 sync dispatcher 와
+  // 호환 안 되지만, runAppBuild 가 caller-side 에서 옵션 extract 해
+  // prepareAppCssPipelineRoot 의 PostCSS 단계에 override 직접 전달 → main thread
+  // async pre-warm → tempRoot commit → sync build 가 결과 read. 회귀 가드.
+  test('explicit css({postcss}) override via caller-side pre-warm (D1a)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-postcss-override-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<div class="card">override</div><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, 'src', 'main.ts'), 'import "./style.css";');
+    writeFileSync(join(dir, 'src', 'style.css'), '.card { color: red; }\n');
+    // postcss.config 부재 — 자동 발견 path 가 null 이어야 override path 가 활성화됨.
+    // fixture 가 @zntc/web 미설치 → css() 반환과 동등 plain object 직접 정의.
+    // caller (runAppBuild) 가 name + __cssOptions sentinel 만 검사 (D1a'' design).
+    writeFileSync(
+      join(dir, 'zntc.config.mjs'),
+      [
+        'export default {',
+        '  plugins: [',
+        '    {',
+        "      name: '@zntc/web/css',",
+        '      __cssOptions: {',
+        '        postcss: {',
+        '          plugins: [',
+        "            { postcssPlugin: 'override-marker', Once(root) { root.append({ selector: '.override-applied', nodes: [] }); } },",
+        '          ],',
+        '        },',
+        '      },',
+        '      setup() {},',
+        '    },',
+        '  ],',
+        '};',
+      ].join('\n'),
+    );
+
+    const outdir = join(dir, 'dist');
+    const { exitCode, stderr } = runCli(['build', dir, '--outdir', outdir], { cwd: dir });
+    expect(exitCode).toBe(0);
+    // caller-side pre-warm path 도 동일 메시지 출력 (postcss.ts:logPostcssProcessed)
+    expect(stderr).toContain('[postcss] processed 1 CSS file');
+    const css = readFileSync(join(outdir, 'main.css'), 'utf8');
+    expect(css).toContain('.override-applied');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test('Tailwind v4 @tailwindcss/postcss app fixture', () => {
     const dir = mkdtempSync(join(tmpdir(), 'zntc-app-tailwind-'));
     mkdirSync(join(dir, 'src'), { recursive: true });

--- a/packages/web/src/css/index.ts
+++ b/packages/web/src/css/index.ts
@@ -60,9 +60,18 @@ export interface CssPluginOptions {
  * export default defineConfig({ plugins: [css({ disabled: true })] });
  * ```
  */
-export function css(options: CssPluginOptions = {}): ZntcPlugin {
+/** ZntcPlugin + caller-side pre-warm sentinel (RFC #3833 v3 D1a'', @internal). */
+export type CssZntcPlugin = ZntcPlugin & { readonly __cssOptions: CssPluginOptions };
+
+export function css(options: CssPluginOptions = {}): CssZntcPlugin {
+  // RFC #3833 v3 D1a'' (caller-side pre-warm): `__cssOptions` sentinel 로 caller
+  // (runAppBuild) 가 사용자 explicit `css({...override})` 의 옵션을 extract 해서
+  // `prepareAppCssPipelineRoot` 의 PostCSS 단계로 전달. sync dispatcher × async
+  // onLoad 충돌 회피 — Vite/esbuild 의 main thread pre-process → sync bundle 패턴.
+  // dispatcher 는 name/setup 만 사용 — `__cssOptions` 무영향.
   return {
     name: '@zntc/web/css',
+    __cssOptions: options,
     setup(build) {
       if (options.disabled) return;
 

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -93,6 +93,11 @@ export interface PrepareAppCssPipelineRootOptions {
    *  소유하고 prep 마다 갱신/조회한다. dirty 한 sass 가 다른 root scss 의 dep 이면 그 root 도 재컴파일
    *  대상에 transitive 추가 — partial(`_x.scss`) 변경 시 stale CSS 방지 (#71). */
   sassReverseDep?: Map<string, Set<string>> | null;
+  /** caller-side pre-warm 으로 전달되는 PostCSS override (RFC #3833 v3 D1a''). 사용자
+   *  explicit `plugins: [css({ postcss: {...override} })]` 의 옵션을 runAppBuild 가
+   *  추출해 prepareAppCssPipelineRoot 로 전달. truthy + plugins.length>0 면 자동 발견
+   *  skip 후 override 직접 사용. sync dispatcher × async onLoad 충돌 회피용 path. */
+  postcssOverride?: { plugins: unknown[]; options?: Record<string, unknown> } | null;
 }
 
 export interface AppCssPipelineResult {
@@ -278,9 +283,11 @@ export async function prepareAppCssPipelineRoot(
     dirtyPaths = null,
     cache = null,
     sassReverseDep = null,
+    postcssOverride = null,
   } = options;
   const { fallbackRequire, cliNodeModules } = deps;
-  const configPath = findPostcssConfig(root);
+  // configPath 자동 발견은 override 없을 때만 필요. override 가 있으면 자동 발견 skip.
+  const configPath = postcssOverride ? null : findPostcssConfig(root);
   // F1 cache: 이전 prep 의 stylePipelineFiles 를 재사용. 호출자가 구조 변화 (.scss/.module.css
   // 추가/삭제) 시 cache=null 로 무효화한다. 재사용이면 full tree walk 를 통째 회피.
   const stylePipelineFiles =
@@ -293,7 +300,9 @@ export async function prepareAppCssPipelineRoot(
   const moduleFiles = stylePipelineFiles.filter(isCssModuleFile);
   const needsSource = preprocessorFiles.length > 0 || moduleFiles.length > 0;
 
-  if (!configPath && !needsSource) return null;
+  // configPath 자동 발견 결과 + needsSource(sass/css-modules) + override 셋 중 하나라도
+  // 있어야 prepare 진행. override 가 있으면 configPath 가 null 이어도 prepare 필요.
+  if (!configPath && !needsSource && !postcssOverride) return null;
   // Incremental: existing tempRoot 가 있으면 dirty 파일만 sync (BACKLOG #70). 초기 빌드는
   // 전체 cpSync. dirtyPaths 가 null 이면 안전쪽 fallback 으로 간주해 full sync.
   const tempRoot = existingTempRoot ?? copyAppRootForPostcss(root, outdir, phase, cliNodeModules);
@@ -372,7 +381,15 @@ export async function prepareAppCssPipelineRoot(
     (dirtyPaths !== null &&
       dirtyPaths.some((p) => isCssFile(p) || isCssPreprocessorFile(p) || isPostcssConfigFile(p)));
   if (postcssRelevant) {
-    await runPostcssIfConfigured(tempRoot, tempRoot, null, configEnv, logLevel, fallbackRequire);
+    await runPostcssIfConfigured(
+      tempRoot,
+      tempRoot,
+      null,
+      configEnv,
+      logLevel,
+      fallbackRequire,
+      postcssOverride,
+    );
   }
   // `*.module.scss` 는 위 sass 단계에서 `*.module.css` 가 새로 만들어지므로, 사전 walk
   // 가 본 모듈 리스트엔 빠져 있다. preprocessor 출력 경로를 재계산해 보강.

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -137,6 +137,11 @@ export async function loadPostcssConfig(
 /**
  * `cssDir` 의 모든 CSS 파일 (skipDir 제외) 에 postcss 실행 → in-place 덮어쓰기.
  * postcss config 가 없으면 no-op. `runPostcssForAppDev` 와 달리 outdir 분리 안 함.
+ *
+ * `override` 가 truthy + `plugins.length > 0` 면 자동 발견 skip 후 직접 사용 —
+ * 사용자 explicit `plugins: [css({ postcss: {...override} })]` 의 caller-side
+ * pre-warm path (RFC #3833 v3 D1a''). `postcss` 자체는 동일 fallback chain 으로
+ * require. 미설치 시 silent skip (overide path 도 동일).
  */
 export async function runPostcssIfConfigured(
   root: string,
@@ -145,8 +150,28 @@ export async function runPostcssIfConfigured(
   configEnv: ConfigEnv,
   logLevel: string | undefined,
   fallbackRequire: NodeRequire,
+  override?: { plugins: unknown[]; options?: Record<string, unknown> } | null,
 ): Promise<void> {
-  const loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
+  let loaded: LoadedPostcss | null;
+  if (override && override.plugins.length > 0) {
+    // caller 가 explicit override 전달 — postcss-load-config 자동 발견 skip.
+    // postcss 자체만 require (app-first / fallback-second).
+    let postcssModule: { default?: LoadedPostcss['postcss'] } & LoadedPostcss['postcss'];
+    try {
+      postcssModule = requireFromAppRoot(root, fallbackRequire, 'postcss') as typeof postcssModule;
+    } catch {
+      return; // postcss 미설치 시 silent pass-through (자동 발견 path 와 동일)
+    }
+    const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss['postcss'];
+    loaded = {
+      postcss,
+      plugins: override.plugins,
+      options: override.options ?? {},
+      configFile: null,
+    };
+  } else {
+    loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
+  }
   if (!loaded) return;
   const cssFiles = collectAppFiles(cssDir, { skipDir, predicate: isCssFile });
   await Promise.all(

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -138,10 +138,12 @@ export async function loadPostcssConfig(
  * `cssDir` 의 모든 CSS 파일 (skipDir 제외) 에 postcss 실행 → in-place 덮어쓰기.
  * postcss config 가 없으면 no-op. `runPostcssForAppDev` 와 달리 outdir 분리 안 함.
  *
- * `override` 가 truthy + `plugins.length > 0` 면 자동 발견 skip 후 직접 사용 —
- * 사용자 explicit `plugins: [css({ postcss: {...override} })]` 의 caller-side
- * pre-warm path (RFC #3833 v3 D1a''). `postcss` 자체는 동일 fallback chain 으로
- * require. 미설치 시 silent skip (overide path 도 동일).
+ * `override` 가 truthy 면 자동 발견 skip — 사용자 explicit `plugins: [css({
+ * postcss: {...override} })]` 의 caller-side pre-warm path (RFC #3833 v3 D1a'').
+ * Vite parity: `override.plugins` 가 빈 배열이어도 explicit no-op 으로 처리
+ * (auto-discover 로 fallback 안 함). `postcss` 자체는 동일 fallback chain 으로
+ * require — 미설치 시 logLevel != silent 면 warn 출력 후 skip (override path
+ * 가 silently no-op 안 되도록 가시성 확보).
  */
 export async function runPostcssIfConfigured(
   root: string,
@@ -153,14 +155,21 @@ export async function runPostcssIfConfigured(
   override?: { plugins: unknown[]; options?: Record<string, unknown> } | null,
 ): Promise<void> {
   let loaded: LoadedPostcss | null;
-  if (override && override.plugins.length > 0) {
-    // caller 가 explicit override 전달 — postcss-load-config 자동 발견 skip.
+  if (override) {
+    // explicit override path. plugins 가 빈 배열이면 PostCSS process 자체 skip
+    // (Vite 식 'explicit no-op' — auto-discover 로 fallback 안 함).
+    if (override.plugins.length === 0) return;
     // postcss 자체만 require (app-first / fallback-second).
     let postcssModule: { default?: LoadedPostcss['postcss'] } & LoadedPostcss['postcss'];
     try {
       postcssModule = requireFromAppRoot(root, fallbackRequire, 'postcss') as typeof postcssModule;
     } catch {
-      return; // postcss 미설치 시 silent pass-through (자동 발견 path 와 동일)
+      // postcss 미설치. 자동 발견 path 는 silent skip 인데 override path 는
+      // 사용자 explicit intent 라 silent 가 silent-bug 가능 — warn 후 skip.
+      if (logLevel !== 'silent') {
+        console.error('[postcss] override path: postcss require 실패 — skip');
+      }
+      return;
     }
     const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss['postcss'];
     loaded = {


### PR DESCRIPTION
## Summary

PR-3a (revert #3838) 의 dead code 근본 원인 (`buildAppSync` sync dispatcher × async \`cssOnLoad\`) 를 사용자 explicit \`plugins: [css({ postcss: {...override} })]\` 에 대해 해결. v2-A (D1a, PR #3839 closed) 가 worker thread 접근으로 PostCSS pipeline 결과 미반영 회귀했던 것과 달리, **RFC v3 권장 D1a'' = caller-side pre-warm** (Vite/esbuild reference 정합):

\`runAppBuild\` 가 prepare 단계에서 사용자 \`css({postcss})\` 옵션을 extract → main thread async PostCSS 실행 → tempRoot commit → sync \`buildAppSync\` 가 결과 read.

## 변경 (5 파일, ~135 LOC)

| 파일 | scope |
|---|---|
| \`packages/web/src/css/index.ts\` | \`css()\` 반환 객체에 \`__cssOptions\` sentinel + 새 type \`CssZntcPlugin\` |
| \`packages/web/src/dev-controller.ts\` | \`PrepareAppCssPipelineRootOptions.postcssOverride\` 추가 + prepare 가 override 전달 + 자동 발견 skip |
| \`packages/web/src/style/postcss.ts\` | \`runPostcssIfConfigured\` 의 마지막 optional \`override\` 인자 + 분기 (auto-discover skip, postcss require + LoadedPostcss 합성) |
| \`packages/core/bin/zntc.mjs\` | \`runAppBuild\` 가 css plugin findLast + presence check 로 postcssOverride 추출 → prepare 전달 |
| \`packages/core/test/cli/app-builder/styles/postcss.ts\` | 신규 test — fixture 가 css() 와 동등 plain object (sentinel pattern) 정의 → build 결과 \`main.css\` 에 override marker 적용 확인 |

## /code-review max 8 finding (commit 8344f15a 에서 fix)

### HIGH 즉시 fix
- **#1**: \`plugins:[]\` 명시 silent fallback (Vite parity) — presence check (\`postcss !== undefined\`) + postcss.ts 가 explicit no-op 처리
- **#5**: default + user css() 중복 시 first-match 묵살 — \`find\` → \`findLast\` (Vite plugins 순서 의미)

### LOW fix
- **#4**: override 분기의 postcss require 실패 silent → warn 출력
- **#6**: sentinel 위장 방어 주석 정확화
- **#8**: JSDoc 오타 'overide' → 'override'

### Follow-up (PR scope 외)
- **#2**: dev/build divergence — D1a'' Phase 2 (dev path 별도 PR)
- **#3**: tempRoot 가 require base — \`loadPostcssConfig\` 와 동일 broken (사전 존재), 별도 issue
- **#7**: pipeline 0 css + override 진단 메시지 부재

## 검증

- [x] web build (bundle + dts) pass
- [x] core dts + build:js pass
- [x] web 단위 test 60 pass / 0 fail (회귀 0)
- [x] core integration: 291 pass / 9 fail. baseline main 11 fail 대비 **2 감소**. 신규 D1a'' test pass — fail 목록 부재 확인. 잔여 9 fail = dev path styles/dev-hmr + 사전 존재 pattern (본 PR 무관)
- [ ] (merge 후) CI 의 Integration Tests 확인

## D1a'' Phase 2 (별도 PR)

- dev path (\`runAppDev\` / \`runPostcssForAppDev\`) 도 동일 caller-pre-warm
- 다른 plugin hook (\`onLoad\` transform 등) pre-warm protocol — 본 PR 은 css() 의 postcss 옵션만 cover

Refs: RFC #3833 v3 axis 1 D1a'' (Phase 1), PR #3839 (D1a 시도 close), PR #3838 (PR-3a revert 머지), #2538 4-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)