### PR TITLE
feat(web,core): D1a'' Phase 2 — dev path 도 caller-side pre-warm (RFC #3833)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -776,10 +776,35 @@ async function runAppDev(opts, config, configEnv, _dotenvVars) {
   const web = await loadWebModule();
   const root = resolve(opts.appRoot ?? '.');
   opts.outdir = opts.outdir || join(root, '.zntc-dev');
-  const appDev = web.createAppDevController(opts, root, configEnv, {
-    fallbackRequire: requireFromCli,
-    cliNodeModules,
-  });
+  // RFC #3833 v3 D1a'' Phase 2: dev path 도 build path (runAppBuild) 와 동일하게
+  // 사용자 explicit `plugins: [css({postcss:{...}})]` 를 caller-side pre-warm 으로
+  // controller 에 전달. dev/build divergence 해소.
+  const devUserPlugins = [];
+  if (config && Array.isArray(config.plugins)) devUserPlugins.push(...config.plugins);
+  for (const pluginPath of opts.pluginPaths) {
+    const absPath = resolve(pluginPath);
+    const cfg = await importAndResolveDefault(absPath);
+    if (Array.isArray(cfg.plugins)) devUserPlugins.push(...cfg.plugins);
+    else if (typeof cfg.setup === 'function') devUserPlugins.push(cfg);
+  }
+  const devCssPlugin = devUserPlugins.findLast(
+    (p) => p?.name === '@zntc/web/css' && p.__cssOptions !== undefined,
+  );
+  let devPostcssOverride = null;
+  if (devCssPlugin?.__cssOptions) {
+    const o = devCssPlugin.__cssOptions;
+    if (o.disabled === true) {
+      devPostcssOverride = { plugins: [], options: undefined };
+    } else if (o.postcss) {
+      devPostcssOverride = { plugins: o.postcss.plugins ?? [], options: o.postcss.options };
+    }
+  }
+  const appDev = web.createAppDevController(
+    { ...opts, postcssOverride: devPostcssOverride },
+    root,
+    configEnv,
+    { fallbackRequire: requireFromCli, cliNodeModules },
+  );
   const prepared = await appDev.prepare();
 
   opts.entryPoints = [prepared.entryPath];

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -68,6 +68,12 @@ export interface AppDevControllerOptions {
   envDir?: string | undefined;
   envPrefixes?: readonly string[] | undefined;
   logLevel?: string | undefined;
+  /** caller-side pre-warm PostCSS override (RFC #3833 v3 D1a'' Phase 2). 사용자
+   *  explicit `plugins: [css({postcss:{...override}})]` 의 옵션을 runAppDev 가
+   *  추출해 controller 에 전달. prepare 의 `postcssOverride` + afterBundle 의
+   *  `runPostcssForAppDev` override 둘 다에 동일 값. build path 와 dev path 의
+   *  PostCSS plugin set 일치 (dev/build divergence 해소). */
+  postcssOverride?: { plugins: unknown[]; options?: Record<string, unknown> } | null;
 }
 
 export interface AppDevControllerDeps {
@@ -518,6 +524,10 @@ export function createAppDevController(
       ) {
         pipelineCache = null;
       }
+      // RFC #3833 v3 D1a'' Phase 2: build path (runAppBuild) 와 동일하게 caller
+      // (runAppDev) 의 explicit `css({postcss:{...override}})` 를 prepare 의
+      // PostCSS 단계에 전달. dev/build divergence 해소.
+      const postcssOverride = opts.postcssOverride ?? null;
       const pipeline = await prepareAppCssPipelineRoot(
         root,
         outdir,
@@ -526,8 +536,14 @@ export function createAppDevController(
         'dev',
         deps,
         reuseRoot
-          ? { existingTempRoot: pipelineRoot, dirtyPaths, cache: pipelineCache, sassReverseDep }
-          : { sassReverseDep },
+          ? {
+              existingTempRoot: pipelineRoot,
+              dirtyPaths,
+              cache: pipelineCache,
+              sassReverseDep,
+              postcssOverride,
+            }
+          : { sassReverseDep, postcssOverride },
       );
       pipelineRoot = pipeline?.tempRoot ?? null;
       pipelineCache = pipeline?.cache ?? null;
@@ -578,6 +594,8 @@ export function createAppDevController(
       return prepared;
     },
     async afterBundle({ changedPath = null } = {}) {
+      // RFC #3833 v3 D1a'' Phase 2: prepare 와 동일 override 를 afterBundle 에도
+      // 전달 — 일관된 PostCSS plugin set (build path 와 시맨틱 일치).
       const result = await runPostcssForAppDev({
         root,
         outdir,
@@ -586,6 +604,7 @@ export function createAppDevController(
         base,
         changedPath,
         fallbackRequire,
+        postcssOverride: opts.postcssOverride ?? null,
       });
       cssDeps = result.deps;
       cssDirDeps = result.dirDeps;

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -267,7 +267,12 @@ export async function runPostcssForAppDev(
       return { deps, dirDeps, primaryHref, processed: 0 };
     }
     const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss['postcss'];
-    loaded = { postcss, plugins: postcssOverride.plugins, options: postcssOverride.options ?? {}, configFile: null };
+    loaded = {
+      postcss,
+      plugins: postcssOverride.plugins,
+      options: postcssOverride.options ?? {},
+      configFile: null,
+    };
   } else {
     loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
   }

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -206,6 +206,10 @@ export interface AppDevPostcssOptions {
   base: string | undefined;
   changedPath?: string | null;
   fallbackRequire: NodeRequire;
+  /** caller-side pre-warm 으로 전달되는 PostCSS override (RFC #3833 v3 D1a''
+   *  Phase 2). build path 의 `runPostcssIfConfigured` 와 동일 시맨틱 — truthy
+   *  면 자동발견 skip, plugins.length === 0 면 explicit no-op. */
+  postcssOverride?: { plugins: unknown[]; options?: Record<string, unknown> } | null;
 }
 
 export interface AppDevPostcssResult {
@@ -223,20 +227,53 @@ export interface AppDevPostcssResult {
 export async function runPostcssForAppDev(
   options: AppDevPostcssOptions,
 ): Promise<AppDevPostcssResult> {
-  const { root, outdir, configEnv, logLevel, base, changedPath = null, fallbackRequire } = options;
+  const {
+    root,
+    outdir,
+    configEnv,
+    logLevel,
+    base,
+    changedPath = null,
+    fallbackRequire,
+    postcssOverride = null,
+  } = options;
   const deps = new Set<string>();
   const dirDeps = new Set<string>();
   let primaryHref: string | null = null;
-  const configPath = findPostcssConfig(root);
-  if (!configPath) {
+  // override 가 있으면 자동발견 skip. plugins.length === 0 면 explicit no-op
+  // (build path 의 runPostcssIfConfigured 와 동일 시맨틱).
+  const configPath = postcssOverride ? null : findPostcssConfig(root);
+  if (!configPath && !postcssOverride) {
     const first = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile })[0];
     if (first) primaryHref = joinUrl(base, relative(root, first));
     return { deps, dirDeps, primaryHref, processed: 0 };
   }
 
-  const loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
+  let loaded: LoadedPostcss | null;
+  if (postcssOverride) {
+    if (postcssOverride.plugins.length === 0) {
+      // explicit no-op — primaryHref 만 첫 CSS 로 채워 link 유지.
+      const first = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile })[0];
+      if (first) primaryHref = joinUrl(base, relative(root, first));
+      return { deps, dirDeps, primaryHref, processed: 0 };
+    }
+    let postcssModule: { default?: LoadedPostcss['postcss'] } & LoadedPostcss['postcss'];
+    try {
+      postcssModule = requireFromAppRoot(root, fallbackRequire, 'postcss') as typeof postcssModule;
+    } catch {
+      if (logLevel !== 'silent') {
+        console.error('[postcss] override path (dev): postcss require 실패 — skip');
+      }
+      return { deps, dirDeps, primaryHref, processed: 0 };
+    }
+    const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss['postcss'];
+    loaded = { postcss, plugins: postcssOverride.plugins, options: postcssOverride.options ?? {}, configFile: null };
+  } else {
+    loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
+  }
   if (!loaded) return { deps, dirDeps, primaryHref, processed: 0 };
-  deps.add(resolve(loaded.configFile ?? configPath));
+  if (loaded.configFile) deps.add(resolve(loaded.configFile));
+  else if (configPath) deps.add(resolve(configPath));
 
   mkdirSync(outdir, { recursive: true });
   const allCssFiles = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile });

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -252,9 +252,13 @@ export async function runPostcssForAppDev(
   let loaded: LoadedPostcss | null;
   if (postcssOverride) {
     if (postcssOverride.plugins.length === 0) {
-      // explicit no-op — primaryHref 만 첫 CSS 로 채워 link 유지.
-      const first = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile })[0];
-      if (first) primaryHref = joinUrl(base, relative(root, first));
+      // explicit no-op — primaryHref 만 첫 CSS 로 채워 link 유지. 단 watch deps
+      // 는 모든 .css 파일 추가 — controller 의 isCssOnlyChange / cssDeps 가 변경
+      // 감지에 사용. 빈 deps 반환 시 watch 가 reload trigger 누락 가능 (/code-review
+      // max #3).
+      const allCssFiles = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile });
+      for (const f of allCssFiles) deps.add(resolve(f));
+      if (allCssFiles[0]) primaryHref = joinUrl(base, relative(root, allCssFiles[0]));
       return { deps, dirDeps, primaryHref, processed: 0 };
     }
     let postcssModule: { default?: LoadedPostcss['postcss'] } & LoadedPostcss['postcss'];


### PR DESCRIPTION
## Summary

Phase 1 (PR #3844, base) 의 build path caller-side pre-warm 을 dev path 로 확장. RFC v3 §5 finding **#2 dev/build divergence 해소**.

> ⚠️ Stacked on PR #3844 (Phase 1). #3844 머지 후 본 PR 의 base 가 main 으로 갱신됨.

## 변경 (~95 LOC)

| 파일 | scope |
|---|---|
| \`packages/web/src/style/postcss.ts\` | \`AppDevPostcssOptions.postcssOverride\` + \`runPostcssForAppDev\` override 분기 (build path 와 동일 시맨틱) |
| \`packages/web/src/dev-controller.ts\` | \`AppDevControllerOptions.postcssOverride\` + prepare + afterBundle 양쪽에 동일 override 전달 |
| \`packages/core/bin/zntc.mjs\` | runAppDev 가 build path 와 동일 패턴 (user plugins walk + findLast css + __cssOptions extract) → \`createAppDevController({...opts, postcssOverride: devPostcssOverride}, ...)\` |

## /code-review max 3 finding

| # | 결정 | fix |
|---|---|---|
| 3 (LOW, real) | explicit no-op 시 watch deps 누락 → reload trigger 미발생 가능 | **fix in commit c808c6ff** — early-return 전에 모든 .css 파일을 deps 에 add (PostCSS process 는 여전히 skip) |
| 1 (LOW) | build/dev plugin extract 코드 중복 — divergence 위험 | **follow-up** — helper 추출 별도 PR |
| 2 (LOW) | runAppBuild 의 inner opts shadowing | **follow-up** — helper 추출 시 동시 해소 |

## 검증

- [x] web build (bundle + dts) pass
- [x] core dts + build:js pass
- [x] web 단위 test 73 pass / 0 fail (회귀 0)
- [ ] (merge 후) CI Integration Tests 확인

## RFC §5 finding 갱신

- **#2 dev/build divergence** ✅ Phase 2 로 해소
- **#1 runBundle cssPlugin forward** (이슈 #3834) — runServe 의 graphChanged rebuild path 도 postcssOverride 흐름 통일, 별도 PR
- **#3 NODE_ENV vs configEnv.mode** — caller 가 root/mode 명시 의무화 별도 PR

Refs: RFC #3833 v3 axis 1 D1a'' Phase 2, PR #3844 (Phase 1, stacked base), #2538 4-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)