### PR TITLE
fix(web): dev path zero-config PostCSS double-pass 해소 (Closes #3847)

### DIFF
--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -481,6 +481,10 @@ export function createAppDevController(
   const base = normalizeBase(opts.base ?? opts.publicPath ?? '/');
   let cssDeps = new Set<string>();
   let cssDirDeps = new Set<string>();
+  // issue #3847 — prepare 가 PostCSS 처리 (auto-discover 또는 override) 한 경우
+  // true. afterBundle 가 그 flag 보고 runPostcssForAppDev 의 redundant PostCSS
+  // pass 차단 (zero-config double-pass 해소). prepare 의 pipeline 결과로 결정.
+  let preparePostcssApplied = false;
   // #71: sass @import reverse-dep 맵(tempRoot 기준 path). prepare(full pipeline) 와 fast-path
   // (rebuildScssIncremental) 가 갱신하고, isSassOnlyChange 가 조회해 dep 있는 파일은 fast-path
   // 박탈 → full pipeline 의 transitive 재컴파일로 dependents 까지 갱신. 세션 내내 누적.
@@ -548,6 +552,10 @@ export function createAppDevController(
       pipelineRoot = pipeline?.tempRoot ?? null;
       pipelineCache = pipeline?.cache ?? null;
       hasPipelineCss = (pipeline?.generatedCssAbsPaths.length ?? 0) > 0;
+      // issue #3847 — pipeline truthy = prepareAppCssPipelineRoot 진입 →
+      // runPostcssIfConfigured 호출됨 (override 또는 자동발견 어느 path 든 PostCSS
+      // 처리 가능). afterBundle 가 redundant pass 차단할 수 있도록 flag set.
+      preparePostcssApplied = !!pipeline;
       const prepareRoot = pipelineRoot ?? root;
       const envDir = opts.envDir ? resolve(opts.envDir) : prepareRoot;
       const prepared = prepareAppDevSync({
@@ -595,7 +603,8 @@ export function createAppDevController(
     },
     async afterBundle({ changedPath = null } = {}) {
       // RFC #3833 v3 D1a'' Phase 2: prepare 와 동일 override 를 afterBundle 에도
-      // 전달 — 일관된 PostCSS plugin set (build path 와 시맨틱 일치).
+      // 전달. issue #3847: prepare 가 PostCSS 처리한 경우 skipPostcssRun=true 로
+      // redundant pass 차단 (zero-config double-pass + caller-pre-warm 모두).
       const result = await runPostcssForAppDev({
         root,
         outdir,
@@ -605,6 +614,9 @@ export function createAppDevController(
         changedPath,
         fallbackRequire,
         postcssOverride: opts.postcssOverride ?? null,
+        skipPostcssRun: preparePostcssApplied,
+        // issue #3847 — mirror 의 source 가 prepare 의 tempRoot (PostCSS 처리됨)
+        sourceRoot: pipelineRoot ?? root,
       });
       cssDeps = result.deps;
       cssDirDeps = result.dirDeps;

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -210,6 +210,15 @@ export interface AppDevPostcssOptions {
    *  Phase 2). build path 의 `runPostcssIfConfigured` 와 동일 시맨틱 — truthy
    *  면 자동발견 skip, plugins.length === 0 면 explicit no-op. */
   postcssOverride?: { plugins: unknown[]; options?: Record<string, unknown> } | null;
+  /** dev path zero-config double-pass 회피 (issue #3847). controller 의
+   *  prepare 가 PostCSS 처리 (auto-discover 또는 override) 했음을 caller 가
+   *  알린 경우 true — runPostcssForAppDev 가 PostCSS 호출 skip + sourceRoot
+   *  의 .css 를 outdir 로 mirror (PostCSS 미적용, 이미 처리된 결과 그대로).
+   *  cssDeps 는 raw root path 로 유지 (watch trigger 정합). */
+  skipPostcssRun?: boolean;
+  /** skipPostcssRun=true 시 mirror 의 source root (prepare 의 tempRoot 또는
+   *  raw root). 미지정 시 root 사용. controller 가 pipelineRoot 전달. */
+  sourceRoot?: string;
 }
 
 export interface AppDevPostcssResult {
@@ -236,10 +245,36 @@ export async function runPostcssForAppDev(
     changedPath = null,
     fallbackRequire,
     postcssOverride = null,
+    skipPostcssRun = false,
+    sourceRoot,
   } = options;
+  const mirrorRoot = sourceRoot ?? root;
   const deps = new Set<string>();
   const dirDeps = new Set<string>();
   let primaryHref: string | null = null;
+  // issue #3847 — controller 의 prepare 가 이미 PostCSS 처리 (auto-discover
+  // 또는 override) 했음을 caller 가 알린 경우 redundant PostCSS pass 차단.
+  // 단 file mirror 는 유지 — 기존 runPostcssForAppDev 가 outdir 에 emit 하는
+  // 역할 (dev server 가 outdir 에서 서빙). PostCSS 미적용 file copy 만.
+  if (skipPostcssRun) {
+    // mirror: mirrorRoot (= prepare 의 tempRoot) 의 .css → outdir. PostCSS
+    // 미적용 (이미 prepare 가 처리한 결과). raw root 와 path 다른 경우 (caller
+    // 가 pipelineRoot 명시) tempRoot 의 처리된 결과를 outdir 로 copy.
+    const mirrorCssFiles = collectAppFiles(mirrorRoot, { skipDir: outdir, predicate: isCssFile });
+    mkdirSync(outdir, { recursive: true });
+    for (const f of mirrorCssFiles) {
+      const outputRel = relative(mirrorRoot, f);
+      const outputPath = join(outdir, outputRel);
+      mkdirSync(dirname(outputPath), { recursive: true });
+      const input = readFileSync(f, 'utf8');
+      writeFileSync(outputPath, input);
+    }
+    // cssDeps: raw root 의 .css path — watch trigger 정합 (사용자 file edit 감지).
+    const watchCssFiles = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile });
+    for (const f of watchCssFiles) deps.add(resolve(f));
+    if (watchCssFiles[0]) primaryHref = joinUrl(base, relative(root, watchCssFiles[0]));
+    return { deps, dirDeps, primaryHref, processed: 0 };
+  }
   // override 가 있으면 자동발견 skip. plugins.length === 0 면 explicit no-op
   // (build path 의 runPostcssIfConfigured 와 동일 시맨틱).
   const configPath = postcssOverride ? null : findPostcssConfig(root);


### PR DESCRIPTION
## Summary

issue #3847 의 dev path zero-config double-pass fix. PR #3846 (caller-pre-warm filter) 가 explicit \`css()\` 활성 시의 double-pass 해소 → 본 PR 은 zero-config (사용자 css() 미명시, postcss.config 만) 의 사전 존재 double-pass 추가 해소.

> ⚠️ Stacked on PR #3846 (refactor + caller-pre-warm filter)

## 증상

zero-config dev:
- 이전: \`[postcss] processed\` 2번 + outdir CSS 에 marker 2번
- 현재: \`[postcss] processed\` 1번 + outdir CSS 에 marker 1번

## Root cause

\`runPostcssForAppDev\` (afterBundle) 가 항상 자동발견 path 호출 → raw root 의 .css 를 다시 PostCSS. prepare 가 이미 tempRoot 에 같은 PostCSS pipeline 처리 → redundant pass.

## Fix

controller state \`preparePostcssApplied\` flag — prepare 의 pipeline 결과로 set. afterBundle 가 그 flag 보고 runPostcssForAppDev 에 \`skipPostcssRun: true\` + \`sourceRoot: pipelineRoot ?? root\` 전달. skip 분기:
- PostCSS 호출 skip
- mirror: sourceRoot (= tempRoot, PostCSS 처리됨) → outdir
- cssDeps: raw root .css path (watch trigger 정합)

## 검증

- [x] web build (bundle + dts) pass
- [x] web 단위 test 74 pass / 0 fail (회귀 0)
- [x] local dev 실측: \`[postcss] processed\` 1번 + marker 1번 (double-pass 해소)
- [x] caller-pre-warm 활성 (PR #3846) 시도 정합 작동
- [ ] (merge 후) CI Integration 회귀 0 기대

## Closes #3847

본 PR 머지 후 dev path 의 zero-config + caller-pre-warm PostCSS 모두 1번 적용.

Refs: PR #3846 (caller-pre-warm filter), issue #3847, RFC #3833 v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)