### PR TITLE
refactor(cli) + test: dropCallerPreWarmedCssPlugin helper + dev sass/css-modules/single-pass 통합 test (RFC #3833)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -708,13 +708,21 @@ function extractCssPostcssOverride(plugins) {
 
 /**
  * RFC #3833 v3 D1a'' — caller-pre-warm sentinel (`__cssOptions !== undefined`)
- * 가진 css plugin 을 dispatcher plugin chain 에서 제거. caller (runAppBuild /
- * runAppDev) 가 옵션 추출해 prepare 의 PostCSS 단계에서 이미 처리한 plugin —
- * dispatcher 에 또 보내면:
- *   - build (sync dispatcher): async onLoad → syncPluginPromiseFailure → BundleFailed
- *   - dev (async dispatcher): 같은 PostCSS 두 번 실행 → double-pass
- * 양쪽 모두 본 helper 의 filter 로 해소. extractCssPostcssOverride 와 같은
- * sentinel match 조건 (predicate 일관) — drift 위험 차단.
+ * 가진 css plugin 을 native dispatcher plugin chain 에서 제거.
+ *
+ * Caller paths:
+ *   - **runAppBuild**: buildAppSync 의 sync dispatcher 가 async onLoad 받으면
+ *     syncPluginPromiseFailure → BundleFailed. 본 helper 로 dispatch 차단.
+ *   - **buildBundleOptions** (runBundle/watch/runServe): native async dispatcher
+ *     가 onLoad 호출 → prepare 와 같은 PostCSS 두 번 실행 (double-pass). 본
+ *     helper 로 dispatch 차단.
+ *
+ * **runAppDev 는 본 helper 미경유** — controller (createAppDevController) 에
+ * postcssOverride 만 전달, plugin chain 자체는 runServe → buildBundleOptions
+ * 경로에서 처리. 따라서 dev path 의 filter 는 buildBundleOptions 가 cover.
+ *
+ * extractCssPostcssOverride 와 동일 sentinel match 조건 (predicate 일관) —
+ * drift 위험 차단.
  *
  * @param {Array<{name?:string,__cssOptions?:object}>} plugins
  * @returns {Array<unknown>} caller-pre-warm 활성 css plugin 제거된 새 array
@@ -745,9 +753,12 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   if (opts.clean) rmSync(outdir, { recursive: true, force: true });
   // RFC #3833 v3 D1a'' caller-side pre-warm — extractCssPostcssOverride helper 참조.
   const postcssOverride = extractCssPostcssOverride(appPlugins);
-  // dropCallerPreWarmedCssPlugin: caller-pre-warm 활성화 시 그 css plugin 을
-  // dispatcher 에서 제거. buildBundleOptions 와 동일 logic 공유 (drift 방지).
-  const dispatchPlugins = postcssOverride ? dropCallerPreWarmedCssPlugin(appPlugins) : appPlugins;
+  // dropCallerPreWarmedCssPlugin: sentinel 가진 css plugin 을 항상 dispatcher 에서
+  // 제거 (buildBundleOptions 와 동일 무조건 적용). /code-review max #5: 조건부
+  // (postcssOverride truthy 시만) 분기는 비대칭 — 사용자가 sentinel 만 가진
+  // plugin (예: `__cssOptions:{someFutureKey}` — extract null) 등록 시
+  // BundleFailed 회귀 가능. 무조건 drop 으로 future-key 안전 + 양쪽 path 일관.
+  const dispatchPlugins = dropCallerPreWarmedCssPlugin(appPlugins);
   let pipelineRoot = null;
   try {
     const pipeline = await web.prepareAppCssPipelineRoot(

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -706,6 +706,25 @@ function extractCssPostcssOverride(plugins) {
   return null;
 }
 
+/**
+ * RFC #3833 v3 D1a'' — caller-pre-warm sentinel (`__cssOptions !== undefined`)
+ * 가진 css plugin 을 dispatcher plugin chain 에서 제거. caller (runAppBuild /
+ * runAppDev) 가 옵션 추출해 prepare 의 PostCSS 단계에서 이미 처리한 plugin —
+ * dispatcher 에 또 보내면:
+ *   - build (sync dispatcher): async onLoad → syncPluginPromiseFailure → BundleFailed
+ *   - dev (async dispatcher): 같은 PostCSS 두 번 실행 → double-pass
+ * 양쪽 모두 본 helper 의 filter 로 해소. extractCssPostcssOverride 와 같은
+ * sentinel match 조건 (predicate 일관) — drift 위험 차단.
+ *
+ * @param {Array<{name?:string,__cssOptions?:object}>} plugins
+ * @returns {Array<unknown>} caller-pre-warm 활성 css plugin 제거된 새 array
+ */
+function dropCallerPreWarmedCssPlugin(plugins) {
+  return plugins.filter(
+    (p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined),
+  );
+}
+
 async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   // JS plugin 로드 — bundle pipeline 의 buildBundleOptions 와 동일 패턴. app
   // pipeline 도 plugin dispatcher 통과 (#2538 4-4 PR-1).
@@ -728,13 +747,10 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   if (opts.clean) rmSync(outdir, { recursive: true, force: true });
   // RFC #3833 v3 D1a'' caller-side pre-warm — extractCssPostcssOverride helper 참조.
   const postcssOverride = extractCssPostcssOverride(appPlugins);
-  // **caller-pre-warm 활성화 시 그 css plugin 을 dispatcher 에 보내지 않음**:
-  // buildAppSync 의 sync dispatcher 가 css() 의 async onLoad 받으면 즉시
-  // `syncPluginPromiseFailure` → BundleFailed. caller 가 옵션 추출 후 그
-  // plugin 자체를 dispatcher 에서 제거 — onLoad 가 dispatch 안 됨. 다른
-  // user plugin (non-css) 은 그대로.
+  // dropCallerPreWarmedCssPlugin: caller-pre-warm 활성화 시 그 css plugin 을
+  // dispatcher 에서 제거. buildBundleOptions 와 동일 logic 공유 (drift 방지).
   const dispatchPlugins = postcssOverride
-    ? appPlugins.filter((p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined))
+    ? dropCallerPreWarmedCssPlugin(appPlugins)
     : appPlugins;
   let pipelineRoot = null;
   try {
@@ -1409,15 +1425,10 @@ async function buildBundleOptions(opts, config) {
       plugins.push(cfg);
     }
   }
-  // RFC #3833 v3 D1a'' caller-side pre-warm — `__cssOptions` sentinel 가진
-  // css plugin 은 caller (runAppBuild/runAppDev) 가 옵션 추출해 prepare 의
-  // PostCSS 단계에서 이미 처리. dispatcher 에 또 보내면:
-  //  - build (sync dispatcher): async onLoad 가 syncPluginPromiseFailure → BundleFailed
-  //  - dev (async dispatcher): onLoad 가 같은 PostCSS 한 번 더 실행 → double-pass
-  // 양쪽 모두 caller-pre-warm 활성 plugin filter 로 해소 (issue #3847 root cause).
-  const dispatchPlugins = plugins.filter(
-    (p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined),
-  );
+  // RFC #3833 v3 D1a'' caller-side pre-warm — dropCallerPreWarmedCssPlugin helper
+  // 로 sentinel 가진 css plugin 을 dispatcher chain 에서 제거. runAppBuild 와
+  // 동일 logic 공유 (drift 방지).
+  const dispatchPlugins = dropCallerPreWarmedCssPlugin(plugins);
 
   applySingleFileDynamicImportDefault(opts);
 

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -720,9 +720,7 @@ function extractCssPostcssOverride(plugins) {
  * @returns {Array<unknown>} caller-pre-warm 활성 css plugin 제거된 새 array
  */
 function dropCallerPreWarmedCssPlugin(plugins) {
-  return plugins.filter(
-    (p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined),
-  );
+  return plugins.filter((p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined));
 }
 
 async function runAppBuild(opts, config, configEnv, _dotenvVars) {
@@ -749,9 +747,7 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   const postcssOverride = extractCssPostcssOverride(appPlugins);
   // dropCallerPreWarmedCssPlugin: caller-pre-warm 활성화 시 그 css plugin 을
   // dispatcher 에서 제거. buildBundleOptions 와 동일 logic 공유 (drift 방지).
-  const dispatchPlugins = postcssOverride
-    ? dropCallerPreWarmedCssPlugin(appPlugins)
-    : appPlugins;
+  const dispatchPlugins = postcssOverride ? dropCallerPreWarmedCssPlugin(appPlugins) : appPlugins;
   let pipelineRoot = null;
   try {
     const pipeline = await web.prepareAppCssPipelineRoot(

--- a/packages/core/test/cli/app-builder/styles/dev.ts
+++ b/packages/core/test/cli/app-builder/styles/dev.ts
@@ -141,4 +141,105 @@ describe('CLI: Vite-style app builder > styles > dev', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // issue #3847 fix 회귀 가드 — dev 의 zero-config PostCSS 가 **한 번만** 적용
+  // (이전엔 prepare + afterBundle 둘 다 호출되어 마지막 emit 된 css 에 marker
+  // 2번 emit). controller 의 preparePostcssApplied flag + runPostcssForAppDev
+  // 의 skipPostcssRun 분기로 mirror 만 — emit 결과 marker 1번 보장. stderr
+  // capture 가 timing-flaky 이므로 HTTP 응답 의 marker count 만 단언.
+  test('dev zero-config PostCSS 1번만 적용 (#3847 double-pass 해소)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-singlepass-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<link rel="stylesheet" href="/src/style.css"><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, 'src', 'main.ts'), 'console.log("ok");');
+    writeFileSync(join(dir, 'src', 'style.css'), '.x{color:red}');
+    writeFileSync(
+      join(dir, 'postcss.config.mjs'),
+      [
+        'export default {',
+        '  plugins: [',
+        "    { postcssPlugin: 'single-marker', Once(root) { root.append({ selector: '.single-pass', nodes: [] }); } },",
+        '  ],',
+        '};',
+      ].join('\n'),
+    );
+
+    const port = await findFreePort();
+    const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      const css = await fetch(`http://localhost:${port}/src/style.css`).then((r) => r.text());
+      // marker 가 **정확히 1번** — double-pass 이전엔 2번 emit
+      const markerMatches = css.match(/\.single-pass/g) ?? [];
+      expect(markerMatches.length).toBe(1);
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // dev + Sass 시나리오 — D1a'' Phase 2 + #3847 fix 후에도 Sass 컴파일 정상.
+  // prepare 의 transformCssPreprocessors 가 sass 처리 → mirror 가 결과 .css 응답.
+  test('dev Sass — $variable + nested 컴파일 결과 응답', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-sass-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<link rel="stylesheet" href="/src/style.css"><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, 'src', 'main.ts'), 'console.log("sass");');
+    writeFileSync(
+      join(dir, 'src', 'style.scss'),
+      '$primary: red;\n.card { color: $primary; .inner { padding: 4px; } }',
+    );
+
+    const port = await findFreePort();
+    const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      // sass 컴파일 결과 .css 가 mirror 에 — HTML 의 link 가 .css 가리켜야
+      const css = await fetch(`http://localhost:${port}/src/style.css`).then((r) => r.text());
+      expect(css).toContain('color: red'); // $primary 변수 expanded
+      expect(css).toMatch(/\.card\s+\.inner/); // nested rule expanded
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // dev + CSS Modules 시나리오 — D1a'' Phase 2 + #3847 fix 후 scoped class
+  // names 가 bundle.js 안에 inline. proxy.js 자체는 bundler 가 처리 → bundle.js
+  // 응답에 mapping 포함.
+  test('dev CSS Modules — bundle.js 안 scoped class names mapping', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-cssmod-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'index.html'), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(
+      join(dir, 'src', 'main.ts'),
+      'import styles from "./Button.module.css"; globalThis.__styles = styles;',
+    );
+    writeFileSync(
+      join(dir, 'src', 'Button.module.css'),
+      '.primary { color: red; }\n.danger { color: darkred; }',
+    );
+
+    const port = await findFreePort();
+    const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      // bundle.js 안에 CSS Modules mapping inline (bundler 가 proxy 처리)
+      const bundle = await fetch(`http://localhost:${port}/bundle.js`).then((r) => r.text());
+      // scoped class names + mapping key 양쪽 검증
+      expect(bundle).toMatch(/Button_primary__[A-Za-z0-9_-]{8}/);
+      expect(bundle).toMatch(/Button_danger__[A-Za-z0-9_-]{8}/);
+      expect(bundle).toContain('primary');
+      expect(bundle).toContain('danger');
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/core/test/cli/app-builder/styles/dev.ts
+++ b/packages/core/test/cli/app-builder/styles/dev.ts
@@ -232,11 +232,19 @@ describe('CLI: Vite-style app builder > styles > dev', () => {
     try {
       // bundle.js 안에 CSS Modules mapping inline (bundler 가 proxy 처리)
       const bundle = await fetch(`http://localhost:${port}/bundle.js`).then((r) => r.text());
-      // scoped class names + mapping key 양쪽 검증
+      // 404/HTML fallback 회피 가드 (review #2)
+      expect(bundle).not.toContain('<html');
+      expect(bundle).not.toMatch(/Not\s*Found/i);
+      // scoped class names — generated CSS Modules 결과
       expect(bundle).toMatch(/Button_primary__[A-Za-z0-9_-]{8}/);
       expect(bundle).toMatch(/Button_danger__[A-Za-z0-9_-]{8}/);
-      expect(bundle).toContain('primary');
-      expect(bundle).toContain('danger');
+      // mapping shape — proxy module 의 default mapping 이 JSON-literal 로
+      // `{ "primary": "Button_primary__<hash>", "danger": "..." }` 형태 inline
+      // (bundler 가 whitespace 보존). 단순 substring `primary`/`danger` 는
+      // scoped 이름 안에 포함되어 false-green — JSON key 패턴 (`:\s*` 허용) 명시
+      // 검증 (review #1).
+      expect(bundle).toMatch(/"primary":\s*"Button_primary__[A-Za-z0-9_-]{8}"/);
+      expect(bundle).toMatch(/"danger":\s*"Button_danger__[A-Za-z0-9_-]{8}"/);
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

사용자 검증 요청 후 "잠재적 위험 해결 + 테스트 추가":
- **filter helper 추출** — runAppBuild + buildBundleOptions 의 동일 filter logic 2 곳 (drift 위험 LOW) → \`dropCallerPreWarmedCssPlugin\` 단일 helper
- **dev path 통합 test 3개** — sass / CSS Modules / single-pass (#3847 회귀 가드)

> ⚠️ Stacked on PR #3848 (zero-config double-pass fix)

## 변경

| 영역 | scope |
|---|---|
| \`packages/core/bin/zntc.mjs\` | 새 helper \`dropCallerPreWarmedCssPlugin(plugins)\` + runAppBuild 무조건 drop + buildBundleOptions 무조건 drop (양쪽 sentinel 정확 match) |
| \`packages/core/test/cli/app-builder/styles/dev.ts\` | 신규 3 integration test (single-pass / sass dev / cssMod dev — JSON-literal mapping regex) |

## /code-review max 5 finding 중 3 fix

| # | severity | fix |
|---|---|---|
| 5 | MEDIUM | runAppBuild 의 조건부 drop → **무조건 drop** (buildBundleOptions 와 일관). future sentinel 확장 시 BundleFailed 회귀 차단 |
| 3 | LOW | helper docstring 의 runAppDev 부정확 → Caller paths 명시 (runAppBuild + buildBundleOptions 만, runAppDev 는 buildBundleOptions 가 cover) |
| 1 | LOW | cssMod test 의 substring 매치 false-green → JSON-literal regex (\`"primary":\s*"Button_primary__<hash>"\`) + HTML fallback 가드 |
| 2 | LOW | dev server \`/bundle.js\` served path | local + 추가 \`<html\`/\`Not Found\` 가드로 sufficient |
| 4 | LOW | single-pass test 단방향 가드 | follow-up — preparePostcssApplied flag 가 pipeline 결과 직접 binding, silent skip 경로 부재 |

## 검증

- [x] core build:js pass
- [x] web 단위 test 74 pass / 0 fail (회귀 0)
- [x] core integration: 297 pass / 9 fail (이전 294 + 신규 3 모두 pass, baseline 9 fail 그대로)
- [ ] (merge 후) CI Integration 회귀 0 기대

## 회차 종합

PR #3838 revert → #3842 CI mitigation → #3843 Windows TLS root-cause → #3844 D1a'' Phase 1 → #3845 D1a'' Phase 2 → #3846 helper refactor + filter root-cause fix → #3848 zero-config double-pass fix → 본 PR (helper 통일 + 통합 test).

issue 5개 (#3834/#3835/#3836/#3841/#3847) 모두 close. 신규 architectural issue 0. **D1a'' 모델로 build/dev 양쪽 PostCSS 단일 적용 + sass/css-modules 회귀 0 보장**.

Refs: PR #3846 (caller-pre-warm root-cause filter) / #3848 (double-pass fix), issue #3847 (closed), RFC #3833 v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)