### PR TITLE
fix(cli,web): css({root}) caller-pre-warm 에서 silent ignore 회귀 (Closes #3851)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -701,7 +701,16 @@ function extractCssPostcssOverride(plugins) {
   const opts = cssPlugin.__cssOptions;
   if (opts.disabled === true) return { plugins: [], options: undefined };
   if (opts.postcss) {
-    return { plugins: opts.postcss.plugins ?? [], options: opts.postcss.options };
+    return {
+      plugins: opts.postcss.plugins ?? [],
+      options: opts.postcss.options,
+      // issue #3851 — css({root}) 의 root 가 caller-pre-warm path 에서 silent
+      // ignore 였던 회귀 fix. override path 의 postcss require base 로 routing.
+      // mode 는 override.plugins 명시 시 loadPostcssConfig 미호출이라 무의미 —
+      // routing 안 함 (사용자가 root 와 mode 둘 다 명시한 경우 mode 는 onLoad
+      // 의 dispatcher path 에서만 의미 있었음, caller-pre-warm 에선 dead).
+      root: opts.root,
+    };
   }
   return null;
 }

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -152,7 +152,13 @@ export async function runPostcssIfConfigured(
   configEnv: ConfigEnv,
   logLevel: string | undefined,
   fallbackRequire: NodeRequire,
-  override?: { plugins: unknown[]; options?: Record<string, unknown> } | null,
+  override?: {
+    plugins: unknown[];
+    options?: Record<string, unknown>;
+    /** issue #3851 — css({root}) 의 root override. postcss module require 의
+     *  base. 미지정 시 root 인자 사용. */
+    root?: string;
+  } | null,
 ): Promise<void> {
   let loaded: LoadedPostcss | null;
   if (override) {
@@ -160,9 +166,15 @@ export async function runPostcssIfConfigured(
     // (Vite 식 'explicit no-op' — auto-discover 로 fallback 안 함).
     if (override.plugins.length === 0) return;
     // postcss 자체만 require (app-first / fallback-second).
+    // issue #3851 — override.root 가 있으면 그것 use, 아니면 root.
+    const requireBase = override.root ?? root;
     let postcssModule: { default?: LoadedPostcss['postcss'] } & LoadedPostcss['postcss'];
     try {
-      postcssModule = requireFromAppRoot(root, fallbackRequire, 'postcss') as typeof postcssModule;
+      postcssModule = requireFromAppRoot(
+        requireBase,
+        fallbackRequire,
+        'postcss',
+      ) as typeof postcssModule;
     } catch {
       // postcss 미설치. 자동 발견 path 는 silent skip 인데 override path 는
       // 사용자 explicit intent 라 silent 가 silent-bug 가능 — warn 후 skip.
@@ -208,8 +220,13 @@ export interface AppDevPostcssOptions {
   fallbackRequire: NodeRequire;
   /** caller-side pre-warm 으로 전달되는 PostCSS override (RFC #3833 v3 D1a''
    *  Phase 2). build path 의 `runPostcssIfConfigured` 와 동일 시맨틱 — truthy
-   *  면 자동발견 skip, plugins.length === 0 면 explicit no-op. */
-  postcssOverride?: { plugins: unknown[]; options?: Record<string, unknown> } | null;
+   *  면 자동발견 skip, plugins.length === 0 면 explicit no-op. issue #3851:
+   *  root override 도 routing (postcss require base). */
+  postcssOverride?: {
+    plugins: unknown[];
+    options?: Record<string, unknown>;
+    root?: string;
+  } | null;
   /** dev path zero-config double-pass 회피 (issue #3847). controller 의
    *  prepare 가 PostCSS 처리 (auto-discover 또는 override) 했음을 caller 가
    *  알린 경우 true — runPostcssForAppDev 가 PostCSS 호출 skip + sourceRoot
@@ -305,9 +322,15 @@ export async function runPostcssForAppDev(
       if (allCssFiles[0]) primaryHref = joinUrl(base, relative(root, allCssFiles[0]));
       return { deps, dirDeps, primaryHref, processed: 0 };
     }
+    // issue #3851 — override.root 가 있으면 그것 use, 아니면 root.
+    const requireBase = postcssOverride.root ?? root;
     let postcssModule: { default?: LoadedPostcss['postcss'] } & LoadedPostcss['postcss'];
     try {
-      postcssModule = requireFromAppRoot(root, fallbackRequire, 'postcss') as typeof postcssModule;
+      postcssModule = requireFromAppRoot(
+        requireBase,
+        fallbackRequire,
+        'postcss',
+      ) as typeof postcssModule;
     } catch {
       if (logLevel !== 'silent') {
         console.error('[postcss] override path (dev): postcss require 실패 — skip');


### PR DESCRIPTION
## Summary

issue #3851 fix — \`css({root})\` 의 root 옵션이 caller-pre-warm path 에서 silent ignore 되던 회귀.

> ⚠️ Stacked on PR #3849 (helper + test)

## 변경

- \`extractCssPostcssOverride\` 가 \`{plugins, options, root?}\` 반환 (root 추출)
- \`runPostcssIfConfigured\` / \`runPostcssForAppDev\` 의 override path 에서 \`requireBase = override.root ?? root\` 로 postcss require base 결정

## mode 는 별도

\`css({mode})\` 의 mode 는 caller-pre-warm path 에서 미사용 — \`postcss-load-config\` 의 env 파라미터로 자동발견 시점 (\`loadPostcssConfig\`) 에서만 의미, override.plugins 명시 시 \`loadPostcssConfig\` 미호출 → mode 무관. **자가 모순 아닌 의도** (Vite parity — inline override 시 file config skip).

## 검증

- [x] web build (bundle + dts) pass
- [x] core build:js pass  
- [x] web 단위 test 74 pass / 0 fail (회귀 0)

Closes #3851
Refs: RFC #3833 v3 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)