### PR TITLE
fix(web): prepare 의 postcssDirDeps 보존 + afterBundle skipPostcssRun 머지 (Closes #3850)

### DIFF
--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -110,6 +110,10 @@ export interface AppCssPipelineResult {
   tempRoot: string;
   generatedCssAbsPaths: string[];
   cache: PipelineCache;
+  /** issue #3850 — PostCSS message 의 deps/dirDeps 보존. afterBundle skipPostcssRun
+   *  path 가 watch trigger 정합 위해 사용 (tailwind `@source` 같은 dir-dep). */
+  postcssDeps?: Set<string>;
+  postcssDirDeps?: Set<string>;
 }
 
 function normalizeBase(base: string | undefined): string {
@@ -386,8 +390,13 @@ export async function prepareAppCssPipelineRoot(
     !isIncremental ||
     (dirtyPaths !== null &&
       dirtyPaths.some((p) => isCssFile(p) || isCssPreprocessorFile(p) || isPostcssConfigFile(p)));
+  // issue #3850 — runPostcssIfConfigured 의 deps/dirDeps 결과 보존. afterBundle
+  // 의 skipPostcssRun path 가 tailwind @source 같은 dir-dep watch trigger 정합
+  // 위해 사용. postcssRelevant 가 false 면 빈 set (이전 prep 결과 재사용 가정).
+  let postcssDeps = new Set<string>();
+  let postcssDirDeps = new Set<string>();
   if (postcssRelevant) {
-    await runPostcssIfConfigured(
+    const postcssResult = await runPostcssIfConfigured(
       tempRoot,
       tempRoot,
       null,
@@ -396,6 +405,8 @@ export async function prepareAppCssPipelineRoot(
       fallbackRequire,
       postcssOverride,
     );
+    postcssDeps = postcssResult.deps;
+    postcssDirDeps = postcssResult.dirDeps;
   }
   // `*.module.scss` 는 위 sass 단계에서 `*.module.css` 가 새로 만들어지므로, 사전 walk
   // 가 본 모듈 리스트엔 빠져 있다. preprocessor 출력 경로를 재계산해 보강.
@@ -425,6 +436,8 @@ export async function prepareAppCssPipelineRoot(
     tempRoot,
     generatedCssAbsPaths,
     cache: { stylePipelineFiles, styleSourceFiles },
+    postcssDeps,
+    postcssDirDeps,
   };
 }
 
@@ -485,6 +498,10 @@ export function createAppDevController(
   // true. afterBundle 가 그 flag 보고 runPostcssForAppDev 의 redundant PostCSS
   // pass 차단 (zero-config double-pass 해소). prepare 의 pipeline 결과로 결정.
   let preparePostcssApplied = false;
+  // issue #3850 — prepare 의 postcssDeps/postcssDirDeps 보존. afterBundle 가
+  // skipPostcssRun path 에서 머지 (tailwind @source 같은 dir-dep watch trigger).
+  let preparePostcssDeps = new Set<string>();
+  let preparePostcssDirDeps = new Set<string>();
   // #71: sass @import reverse-dep 맵(tempRoot 기준 path). prepare(full pipeline) 와 fast-path
   // (rebuildScssIncremental) 가 갱신하고, isSassOnlyChange 가 조회해 dep 있는 파일은 fast-path
   // 박탈 → full pipeline 의 transitive 재컴파일로 dependents 까지 갱신. 세션 내내 누적.
@@ -556,6 +573,10 @@ export function createAppDevController(
       // runPostcssIfConfigured 호출됨 (override 또는 자동발견 어느 path 든 PostCSS
       // 처리 가능). afterBundle 가 redundant pass 차단할 수 있도록 flag set.
       preparePostcssApplied = !!pipeline;
+      // issue #3850 — prepare result 의 postcssDeps/postcssDirDeps 보존.
+      // afterBundle skipPostcssRun path 가 watch trigger 정합 위해 사용.
+      preparePostcssDeps = pipeline?.postcssDeps ?? new Set();
+      preparePostcssDirDeps = pipeline?.postcssDirDeps ?? new Set();
       const prepareRoot = pipelineRoot ?? root;
       const envDir = opts.envDir ? resolve(opts.envDir) : prepareRoot;
       const prepared = prepareAppDevSync({
@@ -620,8 +641,16 @@ export function createAppDevController(
       });
       cssDeps = result.deps;
       cssDirDeps = result.dirDeps;
+      // issue #3850 — skipPostcssRun path 의 result.dirDeps 가 빈 set 라
+      // tailwind @source 같은 dir-dep watch trigger 누락. prepare 의 결과를
+      // 머지 (preparePostcssDeps/Dirs) — controller 의 cssDeps/cssDirDeps 가
+      // 양쪽 source 의 union 으로 watch 정합.
+      if (preparePostcssApplied) {
+        for (const d of preparePostcssDeps) cssDeps.add(d);
+        for (const d of preparePostcssDirDeps) cssDirDeps.add(d);
+      }
       primaryHref = result.primaryHref;
-      return result;
+      return { ...result, deps: cssDeps, dirDeps: cssDirDeps };
     },
     injectBundleCssLinks(bundleResult: BundleResult) {
       // pipeline 이 SCSS / CSS Modules generated CSS 를 inject 한 상태면 bundler 의

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -145,6 +145,16 @@ export async function loadPostcssConfig(
  * require — 미설치 시 logLevel != silent 면 warn 출력 후 skip (override path
  * 가 silently no-op 안 되도록 가시성 확보).
  */
+export interface RunPostcssIfConfiguredResult {
+  /** issue #3850 — PostCSS message 의 dep tracking. tailwind @source 등의
+   *  file dependency. caller (prepareAppCssPipelineRoot) 가 보존 후 dev path
+   *  의 skipPostcssRun 가 watch trigger 정합 위해 사용. */
+  deps: Set<string>;
+  /** issue #3850 — PostCSS message 의 dir-dep tracking. tailwind v4 의
+   *  @source "../html" 같은 directory watch. */
+  dirDeps: Set<string>;
+}
+
 export async function runPostcssIfConfigured(
   root: string,
   cssDir: string,
@@ -159,12 +169,14 @@ export async function runPostcssIfConfigured(
      *  base. 미지정 시 root 인자 사용. */
     root?: string;
   } | null,
-): Promise<void> {
+): Promise<RunPostcssIfConfiguredResult> {
+  const deps = new Set<string>();
+  const dirDeps = new Set<string>();
   let loaded: LoadedPostcss | null;
   if (override) {
     // explicit override path. plugins 가 빈 배열이면 PostCSS process 자체 skip
     // (Vite 식 'explicit no-op' — auto-discover 로 fallback 안 함).
-    if (override.plugins.length === 0) return;
+    if (override.plugins.length === 0) return { deps, dirDeps };
     // postcss 자체만 require (app-first / fallback-second).
     // issue #3851 — override.root 가 있으면 그것 use, 아니면 root.
     const requireBase = override.root ?? root;
@@ -181,7 +193,7 @@ export async function runPostcssIfConfigured(
       if (logLevel !== 'silent') {
         console.error('[postcss] override path: postcss require 실패 — skip');
       }
-      return;
+      return { deps, dirDeps };
     }
     const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss['postcss'];
     loaded = {
@@ -193,7 +205,7 @@ export async function runPostcssIfConfigured(
   } else {
     loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
   }
-  if (!loaded) return;
+  if (!loaded) return { deps, dirDeps };
   const cssFiles = collectAppFiles(cssDir, { skipDir, predicate: isCssFile });
   await Promise.all(
     cssFiles.map(async (file) => {
@@ -205,9 +217,13 @@ export async function runPostcssIfConfigured(
       });
       writeFileSync(file, result.css);
       if (result.map) writeFileSync(`${file}.map`, result.map.toString());
+      // issue #3850 — PostCSS message 의 deps/dirDeps 수집. tailwind @source
+      // 등 dir-dep watch trigger 정합.
+      collectPostcssMessages(result.messages, deps, dirDeps);
     }),
   );
   logPostcssProcessed(logLevel, cssFiles.length, loaded.configFile);
+  return { deps, dirDeps };
 }
 
 export interface AppDevPostcssOptions {


### PR DESCRIPTION
## Summary

issue #3850 — D1a'' Phase 2 + #3848 의 \`skipPostcssRun\` fix 가 PostCSS dir-dependency message (tailwind \`@source\` 등) watch trigger 누락한 회귀.

> ⚠️ Stacked on PR #3854 (#3851 root routing)

## 변경

| 영역 | scope |
|---|---|
| \`packages/web/src/style/postcss.ts\` | \`RunPostcssIfConfiguredResult { deps, dirDeps }\` 신설. \`runPostcssIfConfigured\` 가 result 반환 (이전 void). PostCSS message 의 deps/dirDeps 수집 (collectPostcssMessages) |
| \`packages/web/src/dev-controller.ts\` | \`AppCssPipelineResult.postcssDeps/postcssDirDeps\` 보존. controller state 가 prepare result 보유. \`afterBundle\` 가 skipPostcssRun path 의 cssDeps/cssDirDeps 에 prepare 결과 머지 |

## 영향

zero-config + tailwind v4 + \`@source "../html"\` 환경에서 dev mode 시 watched dir 의 html 변경 → cssDirDeps 가 prepare 의 dir-dep 포함 → \`isCssOnlyChange\` true → CSS update HMR 정상 trigger (이전엔 빈 set 으로 누락).

## 검증

- [x] web build (bundle + dts) pass
- [x] core build:js pass
- [x] web 단위 test 74 pass / 0 fail (회귀 0)

Closes #3850
Refs: PR #3848 (skipPostcssRun fix), RFC #3833 v3 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)