### PR TITLE
fix(web,cli): RFC #3833 v3 D1a'' follow-up 5 issue 통합 fix

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -693,7 +693,9 @@ function getAutoConfigSearchDir(opts) {
  */
 function extractCssPostcssOverride(plugins) {
   const cssPlugin = plugins.findLast(
-    (p) => p?.name === '@zntc/web/css' && p.__cssOptions !== undefined,
+    // 두 항 모두 optional chain — predicate 순서 변경 시 null/undefined deref 회귀
+    // 차단 (/code-review max #1 latent finding).
+    (p) => p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined,
   );
   if (!cssPlugin?.__cssOptions) return null;
   const opts = cssPlugin.__cssOptions;

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -708,13 +708,21 @@ function extractCssPostcssOverride(plugins) {
 
 /**
  * RFC #3833 v3 D1a'' — caller-pre-warm sentinel (`__cssOptions !== undefined`)
- * 가진 css plugin 을 dispatcher plugin chain 에서 제거. caller (runAppBuild /
- * runAppDev) 가 옵션 추출해 prepare 의 PostCSS 단계에서 이미 처리한 plugin —
- * dispatcher 에 또 보내면:
- *   - build (sync dispatcher): async onLoad → syncPluginPromiseFailure → BundleFailed
- *   - dev (async dispatcher): 같은 PostCSS 두 번 실행 → double-pass
- * 양쪽 모두 본 helper 의 filter 로 해소. extractCssPostcssOverride 와 같은
- * sentinel match 조건 (predicate 일관) — drift 위험 차단.
+ * 가진 css plugin 을 native dispatcher plugin chain 에서 제거.
+ *
+ * Caller paths:
+ *   - **runAppBuild**: buildAppSync 의 sync dispatcher 가 async onLoad 받으면
+ *     syncPluginPromiseFailure → BundleFailed. 본 helper 로 dispatch 차단.
+ *   - **buildBundleOptions** (runBundle/watch/runServe): native async dispatcher
+ *     가 onLoad 호출 → prepare 와 같은 PostCSS 두 번 실행 (double-pass). 본
+ *     helper 로 dispatch 차단.
+ *
+ * **runAppDev 는 본 helper 미경유** — controller (createAppDevController) 에
+ * postcssOverride 만 전달, plugin chain 자체는 runServe → buildBundleOptions
+ * 경로에서 처리. 따라서 dev path 의 filter 는 buildBundleOptions 가 cover.
+ *
+ * extractCssPostcssOverride 와 동일 sentinel match 조건 (predicate 일관) —
+ * drift 위험 차단.
  *
  * @param {Array<{name?:string,__cssOptions?:object}>} plugins
  * @returns {Array<unknown>} caller-pre-warm 활성 css plugin 제거된 새 array
@@ -745,9 +753,12 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   if (opts.clean) rmSync(outdir, { recursive: true, force: true });
   // RFC #3833 v3 D1a'' caller-side pre-warm — extractCssPostcssOverride helper 참조.
   const postcssOverride = extractCssPostcssOverride(appPlugins);
-  // dropCallerPreWarmedCssPlugin: caller-pre-warm 활성화 시 그 css plugin 을
-  // dispatcher 에서 제거. buildBundleOptions 와 동일 logic 공유 (drift 방지).
-  const dispatchPlugins = postcssOverride ? dropCallerPreWarmedCssPlugin(appPlugins) : appPlugins;
+  // dropCallerPreWarmedCssPlugin: sentinel 가진 css plugin 을 항상 dispatcher 에서
+  // 제거 (buildBundleOptions 와 동일 무조건 적용). /code-review max #5: 조건부
+  // (postcssOverride truthy 시만) 분기는 비대칭 — 사용자가 sentinel 만 가진
+  // plugin (예: `__cssOptions:{someFutureKey}` — extract null) 등록 시
+  // BundleFailed 회귀 가능. 무조건 drop 으로 future-key 안전 + 양쪽 path 일관.
+  const dispatchPlugins = dropCallerPreWarmedCssPlugin(appPlugins);
   let pipelineRoot = null;
   try {
     const pipeline = await web.prepareAppCssPipelineRoot(

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -712,6 +712,10 @@ function extractCssPostcssOverride(plugins) {
       root: opts.root,
     };
   }
+  // review #2 — `css({root})` 단독 명시 (postcss override 없이) 시 root 가
+  // auto-discover path 에서 silent ignore. fix 가 design 변경 (prepare 가 새
+  // cssAutoDiscoverRoot 옵션 받아 findPostcssConfig 의 search base swap) 필요 —
+  // monorepo edge case, 본 PR scope 외 별도 issue (TODO).
   return null;
 }
 

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -706,6 +706,25 @@ function extractCssPostcssOverride(plugins) {
   return null;
 }
 
+/**
+ * RFC #3833 v3 D1a'' — caller-pre-warm sentinel (`__cssOptions !== undefined`)
+ * 가진 css plugin 을 dispatcher plugin chain 에서 제거. caller (runAppBuild /
+ * runAppDev) 가 옵션 추출해 prepare 의 PostCSS 단계에서 이미 처리한 plugin —
+ * dispatcher 에 또 보내면:
+ *   - build (sync dispatcher): async onLoad → syncPluginPromiseFailure → BundleFailed
+ *   - dev (async dispatcher): 같은 PostCSS 두 번 실행 → double-pass
+ * 양쪽 모두 본 helper 의 filter 로 해소. extractCssPostcssOverride 와 같은
+ * sentinel match 조건 (predicate 일관) — drift 위험 차단.
+ *
+ * @param {Array<{name?:string,__cssOptions?:object}>} plugins
+ * @returns {Array<unknown>} caller-pre-warm 활성 css plugin 제거된 새 array
+ */
+function dropCallerPreWarmedCssPlugin(plugins) {
+  return plugins.filter(
+    (p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined),
+  );
+}
+
 async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   // JS plugin 로드 — bundle pipeline 의 buildBundleOptions 와 동일 패턴. app
   // pipeline 도 plugin dispatcher 통과 (#2538 4-4 PR-1).
@@ -728,13 +747,10 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   if (opts.clean) rmSync(outdir, { recursive: true, force: true });
   // RFC #3833 v3 D1a'' caller-side pre-warm — extractCssPostcssOverride helper 참조.
   const postcssOverride = extractCssPostcssOverride(appPlugins);
-  // **caller-pre-warm 활성화 시 그 css plugin 을 dispatcher 에 보내지 않음**:
-  // buildAppSync 의 sync dispatcher 가 css() 의 async onLoad 받으면 즉시
-  // `syncPluginPromiseFailure` → BundleFailed. caller 가 옵션 추출 후 그
-  // plugin 자체를 dispatcher 에서 제거 — onLoad 가 dispatch 안 됨. 다른
-  // user plugin (non-css) 은 그대로.
+  // dropCallerPreWarmedCssPlugin: caller-pre-warm 활성화 시 그 css plugin 을
+  // dispatcher 에서 제거. buildBundleOptions 와 동일 logic 공유 (drift 방지).
   const dispatchPlugins = postcssOverride
-    ? appPlugins.filter((p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined))
+    ? dropCallerPreWarmedCssPlugin(appPlugins)
     : appPlugins;
   let pipelineRoot = null;
   try {
@@ -1409,15 +1425,10 @@ async function buildBundleOptions(opts, config) {
       plugins.push(cfg);
     }
   }
-  // RFC #3833 v3 D1a'' caller-side pre-warm — `__cssOptions` sentinel 가진
-  // css plugin 은 caller (runAppBuild/runAppDev) 가 옵션 추출해 prepare 의
-  // PostCSS 단계에서 이미 처리. dispatcher 에 또 보내면:
-  //  - build (sync dispatcher): async onLoad 가 syncPluginPromiseFailure → BundleFailed
-  //  - dev (async dispatcher): onLoad 가 같은 PostCSS 한 번 더 실행 → double-pass
-  // 양쪽 모두 caller-pre-warm 활성 plugin filter 로 해소 (issue #3847 root cause).
-  const dispatchPlugins = plugins.filter(
-    (p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined),
-  );
+  // RFC #3833 v3 D1a'' caller-side pre-warm — dropCallerPreWarmedCssPlugin helper
+  // 로 sentinel 가진 css plugin 을 dispatcher chain 에서 제거. runAppBuild 와
+  // 동일 logic 공유 (drift 방지).
+  const dispatchPlugins = dropCallerPreWarmedCssPlugin(plugins);
 
   applySingleFileDynamicImportDefault(opts);
 

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -720,9 +720,7 @@ function extractCssPostcssOverride(plugins) {
  * @returns {Array<unknown>} caller-pre-warm 활성 css plugin 제거된 새 array
  */
 function dropCallerPreWarmedCssPlugin(plugins) {
-  return plugins.filter(
-    (p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined),
-  );
+  return plugins.filter((p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined));
 }
 
 async function runAppBuild(opts, config, configEnv, _dotenvVars) {
@@ -749,9 +747,7 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   const postcssOverride = extractCssPostcssOverride(appPlugins);
   // dropCallerPreWarmedCssPlugin: caller-pre-warm 활성화 시 그 css plugin 을
   // dispatcher 에서 제거. buildBundleOptions 와 동일 logic 공유 (drift 방지).
-  const dispatchPlugins = postcssOverride
-    ? dropCallerPreWarmedCssPlugin(appPlugins)
-    : appPlugins;
+  const dispatchPlugins = postcssOverride ? dropCallerPreWarmedCssPlugin(appPlugins) : appPlugins;
   let pipelineRoot = null;
   try {
     const pipeline = await web.prepareAppCssPipelineRoot(

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -728,6 +728,14 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   if (opts.clean) rmSync(outdir, { recursive: true, force: true });
   // RFC #3833 v3 D1a'' caller-side pre-warm — extractCssPostcssOverride helper 참조.
   const postcssOverride = extractCssPostcssOverride(appPlugins);
+  // **caller-pre-warm 활성화 시 그 css plugin 을 dispatcher 에 보내지 않음**:
+  // buildAppSync 의 sync dispatcher 가 css() 의 async onLoad 받으면 즉시
+  // `syncPluginPromiseFailure` → BundleFailed. caller 가 옵션 추출 후 그
+  // plugin 자체를 dispatcher 에서 제거 — onLoad 가 dispatch 안 됨. 다른
+  // user plugin (non-css) 은 그대로.
+  const dispatchPlugins = postcssOverride
+    ? appPlugins.filter((p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined))
+    : appPlugins;
   let pipelineRoot = null;
   try {
     const pipeline = await web.prepareAppCssPipelineRoot(
@@ -758,7 +766,7 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
       jsxFactory: opts.jsxFactory,
       jsxFragment: opts.jsxFragment,
       compiler: config?.compiler,
-      plugins: appPlugins.length > 0 ? appPlugins : undefined,
+      plugins: dispatchPlugins.length > 0 ? dispatchPlugins : undefined,
     });
     const htmlEnv = loadEnv(
       configEnv.mode,
@@ -1401,6 +1409,15 @@ async function buildBundleOptions(opts, config) {
       plugins.push(cfg);
     }
   }
+  // RFC #3833 v3 D1a'' caller-side pre-warm — `__cssOptions` sentinel 가진
+  // css plugin 은 caller (runAppBuild/runAppDev) 가 옵션 추출해 prepare 의
+  // PostCSS 단계에서 이미 처리. dispatcher 에 또 보내면:
+  //  - build (sync dispatcher): async onLoad 가 syncPluginPromiseFailure → BundleFailed
+  //  - dev (async dispatcher): onLoad 가 같은 PostCSS 한 번 더 실행 → double-pass
+  // 양쪽 모두 caller-pre-warm 활성 plugin filter 로 해소 (issue #3847 root cause).
+  const dispatchPlugins = plugins.filter(
+    (p) => !(p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined),
+  );
 
   applySingleFileDynamicImportDefault(opts);
 
@@ -1512,7 +1529,7 @@ async function buildBundleOptions(opts, config) {
     watchExclude: opts.watchExclude?.length ? opts.watchExclude : undefined,
     jobs: opts.jobs,
     outbase: opts.outbase,
-    plugins: plugins.length > 0 ? plugins : undefined,
+    plugins: dispatchPlugins.length > 0 ? dispatchPlugins : undefined,
     // compiler.styledComponents / compiler.emotion 도 bundle 모드에서 forward.
     // 누락 시 `zntc.config.json` 의 `compiler` 설정이 silently drop 돼 1st-party transform
     // (autoLabel 등) 이 활성화 안 됨.

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -669,6 +669,41 @@ function getAutoConfigSearchDir(opts) {
   return process.cwd();
 }
 
+/**
+ * RFC #3833 v3 D1a'' (caller-side pre-warm) helper — runAppBuild/runAppDev 가
+ * 공유. 사용자 explicit `plugins: [css({postcss:{...}})]` 의 옵션을 추출해
+ * prepare 단계의 `postcssOverride` 로 전달. buildAppSync 의 sync dispatcher ×
+ * async cssOnLoad 충돌 회피 — Vite/esbuild 의 main thread pre-process → sync
+ * bundle 패턴.
+ *
+ * 분기:
+ *   1. disabled:true     → explicit PostCSS 끄기 (override={plugins:[]} 로
+ *                          auto-discover 도 차단, prepare 가 length 0 skip)
+ *   2. postcss 명시       → presence check, plugins ?? [] 정규화. options-only
+ *                          override 도 explicit no-op (Vite inline override
+ *                          시맨틱)
+ *   3. 둘 다 없으면       → override=null → prepare 가 auto-discover path
+ *
+ * **findLast**: 미래 default `css()` prepend 와 user override 가 동시 존재 시
+ * 마지막 등록이 winner (Vite plugins 순서 의미). sentinel `__cssOptions` 는
+ * runtime 위장 방어 0 — 의도 매치용.
+ *
+ * @param {Array<{name?:string,__cssOptions?:object}>} plugins
+ * @returns {{plugins: unknown[], options: Record<string,unknown> | undefined} | null}
+ */
+function extractCssPostcssOverride(plugins) {
+  const cssPlugin = plugins.findLast(
+    (p) => p?.name === '@zntc/web/css' && p.__cssOptions !== undefined,
+  );
+  if (!cssPlugin?.__cssOptions) return null;
+  const opts = cssPlugin.__cssOptions;
+  if (opts.disabled === true) return { plugins: [], options: undefined };
+  if (opts.postcss) {
+    return { plugins: opts.postcss.plugins ?? [], options: opts.postcss.options };
+  }
+  return null;
+}
+
 async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   // JS plugin 로드 — bundle pipeline 의 buildBundleOptions 와 동일 패턴. app
   // pipeline 도 plugin dispatcher 통과 (#2538 4-4 PR-1).
@@ -689,32 +724,8 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   const root = resolve(opts.appRoot ?? '.');
   const outdir = resolve(opts.outdir ?? join(root, 'dist'));
   if (opts.clean) rmSync(outdir, { recursive: true, force: true });
-  // RFC #3833 v3 D1a'' (caller-side pre-warm): 사용자 explicit `plugins: [css({...})]`
-  // 의 옵션을 prepare 에 전달. buildAppSync 의 sync dispatcher × async onLoad 충돌
-  // 우회 — `css()` factory 가 `__cssOptions` sentinel 로 노출 (web/css/index.ts).
-  // **findLast**: 미래 default `css()` prepend (PR-3b 후속) 와 user override `css()` 가
-  // 같이 있을 때 user 가 winner (Vite 의 plugins 순서 의미와 일관). sentinel 은
-  // unique property 가 아닌 단순 string field — 의도 위장 방어보다 의도 매치용.
-  const cssPlugin = appPlugins.findLast(
-    (p) => p?.name === '@zntc/web/css' && p.__cssOptions !== undefined,
-  );
-  // postcssOverride 분기 (Vite parity 추정 — file config 자동발견 vs inline 명시 우선):
-  //   1. disabled:true  → explicit PostCSS 끄기. override={plugins:[]} 로 auto-discover skip
-  //   2. postcss 명시   → presence check, plugins ?? [] 로 정규화. options-only 도 explicit
-  //                       no-op 으로 (Vite 의 inline override = file config skip)
-  //   3. 둘 다 없으면   → override=null → auto-discover path
-  let postcssOverride = null;
-  if (cssPlugin?.__cssOptions) {
-    const opts = cssPlugin.__cssOptions;
-    if (opts.disabled === true) {
-      postcssOverride = { plugins: [], options: undefined };
-    } else if (opts.postcss) {
-      postcssOverride = {
-        plugins: opts.postcss.plugins ?? [],
-        options: opts.postcss.options,
-      };
-    }
-  }
+  // RFC #3833 v3 D1a'' caller-side pre-warm — extractCssPostcssOverride helper 참조.
+  const postcssOverride = extractCssPostcssOverride(appPlugins);
   let pipelineRoot = null;
   try {
     const pipeline = await web.prepareAppCssPipelineRoot(
@@ -776,9 +787,7 @@ async function runAppDev(opts, config, configEnv, _dotenvVars) {
   const web = await loadWebModule();
   const root = resolve(opts.appRoot ?? '.');
   opts.outdir = opts.outdir || join(root, '.zntc-dev');
-  // RFC #3833 v3 D1a'' Phase 2: dev path 도 build path (runAppBuild) 와 동일하게
-  // 사용자 explicit `plugins: [css({postcss:{...}})]` 를 caller-side pre-warm 으로
-  // controller 에 전달. dev/build divergence 해소.
+  // RFC #3833 v3 D1a'' Phase 2: build path 와 동일 plugin walk + helper 추출.
   const devUserPlugins = [];
   if (config && Array.isArray(config.plugins)) devUserPlugins.push(...config.plugins);
   for (const pluginPath of opts.pluginPaths) {
@@ -787,20 +796,8 @@ async function runAppDev(opts, config, configEnv, _dotenvVars) {
     if (Array.isArray(cfg.plugins)) devUserPlugins.push(...cfg.plugins);
     else if (typeof cfg.setup === 'function') devUserPlugins.push(cfg);
   }
-  const devCssPlugin = devUserPlugins.findLast(
-    (p) => p?.name === '@zntc/web/css' && p.__cssOptions !== undefined,
-  );
-  let devPostcssOverride = null;
-  if (devCssPlugin?.__cssOptions) {
-    const o = devCssPlugin.__cssOptions;
-    if (o.disabled === true) {
-      devPostcssOverride = { plugins: [], options: undefined };
-    } else if (o.postcss) {
-      devPostcssOverride = { plugins: o.postcss.plugins ?? [], options: o.postcss.options };
-    }
-  }
   const appDev = web.createAppDevController(
-    { ...opts, postcssOverride: devPostcssOverride },
+    { ...opts, postcssOverride: extractCssPostcssOverride(devUserPlugins) },
     root,
     configEnv,
     { fallbackRequire: requireFromCli, cliNodeModules },

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -701,7 +701,16 @@ function extractCssPostcssOverride(plugins) {
   const opts = cssPlugin.__cssOptions;
   if (opts.disabled === true) return { plugins: [], options: undefined };
   if (opts.postcss) {
-    return { plugins: opts.postcss.plugins ?? [], options: opts.postcss.options };
+    return {
+      plugins: opts.postcss.plugins ?? [],
+      options: opts.postcss.options,
+      // issue #3851 — css({root}) 의 root 가 caller-pre-warm path 에서 silent
+      // ignore 였던 회귀 fix. override path 의 postcss require base 로 routing.
+      // mode 는 override.plugins 명시 시 loadPostcssConfig 미호출이라 무의미 —
+      // routing 안 함 (사용자가 root 와 mode 둘 다 명시한 경우 mode 는 onLoad
+      // 의 dispatcher path 에서만 의미 있었음, caller-pre-warm 에선 dead).
+      root: opts.root,
+    };
   }
   return null;
 }

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -839,6 +839,10 @@ async function runAppDev(opts, config, configEnv, _dotenvVars) {
 
   opts.entryPoints = [prepared.entryPath];
   opts.serveDir = opts.outdir;
+  // issue #3852 — runAppDev 가 collect 한 plugin 을 stash → runServe 의
+  // buildBundleOptions 가 재import 안 함. ESM cache hit 라 시맨틱 회귀는 0 였지만
+  // perf + cache invalidate edge 안전.
+  opts._resolvedPlugins = devUserPlugins;
 
   return runServe(opts, config, { appDev });
 }
@@ -1417,19 +1421,27 @@ function mergeCliRuntimeTargets(runtimePolyfills, runtimeTargetQueries) {
  * runBundle (single-shot) 와 watch (incremental HMR, #3779) 의 옵션 drift 차단.
  */
 async function buildBundleOptions(opts, config, { filterCallerPreWarmCss = false } = {}) {
-  const plugins = [];
-  if (config && Array.isArray(config.plugins)) {
-    plugins.push(...config.plugins);
-  }
-  for (const pluginPath of opts.pluginPaths) {
-    const absPath = resolve(pluginPath);
-    // importAndResolveDefault 는 pathToFileURL 으로 Windows 경로를 안전하게 처리하고
-    // ENOENT/객체 검증을 통일한다 (config-loader 와 공유).
-    const cfg = await importAndResolveDefault(absPath);
-    if (Array.isArray(cfg.plugins)) {
-      plugins.push(...cfg.plugins);
-    } else if (typeof cfg.setup === 'function') {
-      plugins.push(cfg);
+  // issue #3852 — caller (runAppDev) 가 이미 plugin walk 했으면 `_resolvedPlugins`
+  // 로 stash → 재import skip. ESM cache hit 이라 시맨틱 회귀 없지만 perf +
+  // cache invalidate edge 안전.
+  let plugins;
+  if (Array.isArray(opts._resolvedPlugins)) {
+    plugins = [...opts._resolvedPlugins];
+  } else {
+    plugins = [];
+    if (config && Array.isArray(config.plugins)) {
+      plugins.push(...config.plugins);
+    }
+    for (const pluginPath of opts.pluginPaths) {
+      const absPath = resolve(pluginPath);
+      // importAndResolveDefault 는 pathToFileURL 으로 Windows 경로를 안전하게 처리하고
+      // ENOENT/객체 검증을 통일한다 (config-loader 와 공유).
+      const cfg = await importAndResolveDefault(absPath);
+      if (Array.isArray(cfg.plugins)) {
+        plugins.push(...cfg.plugins);
+      } else if (typeof cfg.setup === 'function') {
+        plugins.push(cfg);
+      }
     }
   }
   // RFC #3833 v3 D1a'' caller-side pre-warm — dropCallerPreWarmedCssPlugin helper

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -1439,9 +1439,7 @@ async function buildBundleOptions(opts, config, { filterCallerPreWarmCss = false
   // app 모드만 caller-pre-warm 로 prepare 가 처리하므로 dispatcher dispatch 차단
   // 필요, bundle 모드는 native async dispatcher 가 onLoad 호출 (단 caller-pre-warm
   // 없어 PostCSS 적용 안 되지만 사용자 의도 그대로 dispatcher 에 전달).
-  const dispatchPlugins = filterCallerPreWarmCss
-    ? dropCallerPreWarmedCssPlugin(plugins)
-    : plugins;
+  const dispatchPlugins = filterCallerPreWarmCss ? dropCallerPreWarmedCssPlugin(plugins) : plugins;
 
   applySingleFileDynamicImportDefault(opts);
 

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -1416,7 +1416,7 @@ function mergeCliRuntimeTargets(runtimePolyfills, runtimeTargetQueries) {
  * plugins 머지 + applySingleFileDynamicImportDefault + 옵션 매핑을 한 곳에 모아
  * runBundle (single-shot) 와 watch (incremental HMR, #3779) 의 옵션 drift 차단.
  */
-async function buildBundleOptions(opts, config) {
+async function buildBundleOptions(opts, config, { filterCallerPreWarmCss = false } = {}) {
   const plugins = [];
   if (config && Array.isArray(config.plugins)) {
     plugins.push(...config.plugins);
@@ -1433,9 +1433,15 @@ async function buildBundleOptions(opts, config) {
     }
   }
   // RFC #3833 v3 D1a'' caller-side pre-warm — dropCallerPreWarmedCssPlugin helper
-  // 로 sentinel 가진 css plugin 을 dispatcher chain 에서 제거. runAppBuild 와
-  // 동일 logic 공유 (drift 방지).
-  const dispatchPlugins = dropCallerPreWarmedCssPlugin(plugins);
+  // 로 sentinel 가진 css plugin 을 dispatcher chain 에서 제거. **app caller
+  // (runServe with appDev) 만 적용** — bundle/transpile 모드 사용자가 css()
+  // 명시한 경우 무조건 drop 하면 PostCSS 효과 0 silent regression (review #2).
+  // app 모드만 caller-pre-warm 로 prepare 가 처리하므로 dispatcher dispatch 차단
+  // 필요, bundle 모드는 native async dispatcher 가 onLoad 호출 (단 caller-pre-warm
+  // 없어 PostCSS 적용 안 되지만 사용자 의도 그대로 dispatcher 에 전달).
+  const dispatchPlugins = filterCallerPreWarmCss
+    ? dropCallerPreWarmedCssPlugin(plugins)
+    : plugins;
 
   applySingleFileDynamicImportDefault(opts);
 
@@ -1909,7 +1915,12 @@ async function runServe(opts, config, { appDev = null } = {}) {
   // 후 watch worker 가 outdir 출력 + appDev hooks 담당. HTTP listen 은 watchReadyPromise 까지
   // wait → server listen 시점에 outdir 채워진 상태 (race-free).
   if (opts.bundle && opts.watch && appDev && hmr) {
-    const watchBuildOpts = await buildBundleOptions(opts, config);
+    // app dev path (appDev 활성) — caller-pre-warm 으로 prepare 가 처리한
+    // css plugin 을 dispatcher 에서 제거 필요. bundle 모드 (appDev=null) 는
+    // filter false (사용자 명시 css() 가 dispatcher 에 정상 전달).
+    const watchBuildOpts = await buildBundleOptions(opts, config, {
+      filterCallerPreWarmCss: true,
+    });
     watchBuildOpts.devMode = true;
     watchBuildOpts.onReady = async (event) => {
       try {

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -698,15 +698,23 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   const cssPlugin = appPlugins.findLast(
     (p) => p?.name === '@zntc/web/css' && p.__cssOptions !== undefined,
   );
-  // **presence check**: `postcss !== undefined` — 사용자가 의도적으로 `plugins:[]`
-  // 명시한 경우 (postcss 명시 disable) 도 override path 진입. plugins.length 로
-  // 분기하면 빈 배열이 silently auto-discover 로 fallback 되어 Vite 비호환.
-  const postcssOverride = cssPlugin?.__cssOptions?.postcss
-    ? {
-        plugins: cssPlugin.__cssOptions.postcss.plugins ?? [],
-        options: cssPlugin.__cssOptions.postcss.options,
-      }
-    : null;
+  // postcssOverride 분기 (Vite parity 추정 — file config 자동발견 vs inline 명시 우선):
+  //   1. disabled:true  → explicit PostCSS 끄기. override={plugins:[]} 로 auto-discover skip
+  //   2. postcss 명시   → presence check, plugins ?? [] 로 정규화. options-only 도 explicit
+  //                       no-op 으로 (Vite 의 inline override = file config skip)
+  //   3. 둘 다 없으면   → override=null → auto-discover path
+  let postcssOverride = null;
+  if (cssPlugin?.__cssOptions) {
+    const opts = cssPlugin.__cssOptions;
+    if (opts.disabled === true) {
+      postcssOverride = { plugins: [], options: undefined };
+    } else if (opts.postcss) {
+      postcssOverride = {
+        plugins: opts.postcss.plugins ?? [],
+        options: opts.postcss.options,
+      };
+    }
+  }
   let pipelineRoot = null;
   try {
     const pipeline = await web.prepareAppCssPipelineRoot(

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -776,10 +776,35 @@ async function runAppDev(opts, config, configEnv, _dotenvVars) {
   const web = await loadWebModule();
   const root = resolve(opts.appRoot ?? '.');
   opts.outdir = opts.outdir || join(root, '.zntc-dev');
-  const appDev = web.createAppDevController(opts, root, configEnv, {
-    fallbackRequire: requireFromCli,
-    cliNodeModules,
-  });
+  // RFC #3833 v3 D1a'' Phase 2: dev path 도 build path (runAppBuild) 와 동일하게
+  // 사용자 explicit `plugins: [css({postcss:{...}})]` 를 caller-side pre-warm 으로
+  // controller 에 전달. dev/build divergence 해소.
+  const devUserPlugins = [];
+  if (config && Array.isArray(config.plugins)) devUserPlugins.push(...config.plugins);
+  for (const pluginPath of opts.pluginPaths) {
+    const absPath = resolve(pluginPath);
+    const cfg = await importAndResolveDefault(absPath);
+    if (Array.isArray(cfg.plugins)) devUserPlugins.push(...cfg.plugins);
+    else if (typeof cfg.setup === 'function') devUserPlugins.push(cfg);
+  }
+  const devCssPlugin = devUserPlugins.findLast(
+    (p) => p?.name === '@zntc/web/css' && p.__cssOptions !== undefined,
+  );
+  let devPostcssOverride = null;
+  if (devCssPlugin?.__cssOptions) {
+    const o = devCssPlugin.__cssOptions;
+    if (o.disabled === true) {
+      devPostcssOverride = { plugins: [], options: undefined };
+    } else if (o.postcss) {
+      devPostcssOverride = { plugins: o.postcss.plugins ?? [], options: o.postcss.options };
+    }
+  }
+  const appDev = web.createAppDevController(
+    { ...opts, postcssOverride: devPostcssOverride },
+    root,
+    configEnv,
+    { fallbackRequire: requireFromCli, cliNodeModules },
+  );
   const prepared = await appDev.prepare();
 
   opts.entryPoints = [prepared.entryPath];

--- a/packages/core/test/cli/app-builder/helpers.ts
+++ b/packages/core/test/cli/app-builder/helpers.ts
@@ -17,6 +17,7 @@ export {
   join,
   CLI,
   RUNTIME,
+  PROJECT_ROOT,
   waitForServer,
   waitForText,
   findFreePort,

--- a/packages/core/test/cli/app-builder/styles/dev.ts
+++ b/packages/core/test/cli/app-builder/styles/dev.ts
@@ -94,4 +94,51 @@ describe('CLI: Vite-style app builder > styles > dev', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // RFC #3833 v3 D1a'' Phase 2 — dev path 도 caller-side pre-warm. 사용자 explicit
+  // `plugins:[css({postcss:{...override}})]` 가 controller 의 postcssOverride 로
+  // 전달되어 prepare 의 PostCSS 단계에 적용. build path 와 동일 시맨틱 검증.
+  test('dev applies user explicit css({postcss}) override (D1a Phase 2)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-override-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<title>dev-override</title><link rel="stylesheet" href="/src/style.css"><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, 'src', 'main.ts'), 'console.log("ok");');
+    writeFileSync(join(dir, 'src', 'style.css'), '.x{color:red}');
+    // postcss.config 부재 → 자동발견 path null. override 만 활성화 확인.
+    writeFileSync(
+      join(dir, 'zntc.config.mjs'),
+      [
+        'export default {',
+        '  plugins: [',
+        '    {',
+        "      name: '@zntc/web/css',",
+        '      __cssOptions: {',
+        '        postcss: {',
+        '          plugins: [',
+        "            { postcssPlugin: 'dev-override-marker', Once(root) { root.append({ selector: '.dev-override-applied', nodes: [] }); } },",
+        '          ],',
+        '        },',
+        '      },',
+        '      setup() {},',
+        '    },',
+        '  ],',
+        '};',
+      ].join('\n'),
+    );
+
+    const port = await findFreePort();
+    const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      const css = await fetch(`http://localhost:${port}/src/style.css`).then((r) => r.text());
+      expect(css).toContain('.dev-override-applied');
+      expect(css).toContain('.x');
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/core/test/cli/app-builder/styles/dev.ts
+++ b/packages/core/test/cli/app-builder/styles/dev.ts
@@ -141,4 +141,105 @@ describe('CLI: Vite-style app builder > styles > dev', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // issue #3847 fix 회귀 가드 — dev 의 zero-config PostCSS 가 **한 번만** 적용
+  // (이전엔 prepare + afterBundle 둘 다 호출되어 마지막 emit 된 css 에 marker
+  // 2번 emit). controller 의 preparePostcssApplied flag + runPostcssForAppDev
+  // 의 skipPostcssRun 분기로 mirror 만 — emit 결과 marker 1번 보장. stderr
+  // capture 가 timing-flaky 이므로 HTTP 응답 의 marker count 만 단언.
+  test('dev zero-config PostCSS 1번만 적용 (#3847 double-pass 해소)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-singlepass-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<link rel="stylesheet" href="/src/style.css"><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, 'src', 'main.ts'), 'console.log("ok");');
+    writeFileSync(join(dir, 'src', 'style.css'), '.x{color:red}');
+    writeFileSync(
+      join(dir, 'postcss.config.mjs'),
+      [
+        'export default {',
+        '  plugins: [',
+        "    { postcssPlugin: 'single-marker', Once(root) { root.append({ selector: '.single-pass', nodes: [] }); } },",
+        '  ],',
+        '};',
+      ].join('\n'),
+    );
+
+    const port = await findFreePort();
+    const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      const css = await fetch(`http://localhost:${port}/src/style.css`).then((r) => r.text());
+      // marker 가 **정확히 1번** — double-pass 이전엔 2번 emit
+      const markerMatches = css.match(/\.single-pass/g) ?? [];
+      expect(markerMatches.length).toBe(1);
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // dev + Sass 시나리오 — D1a'' Phase 2 + #3847 fix 후에도 Sass 컴파일 정상.
+  // prepare 의 transformCssPreprocessors 가 sass 처리 → mirror 가 결과 .css 응답.
+  test('dev Sass — $variable + nested 컴파일 결과 응답', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-sass-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<link rel="stylesheet" href="/src/style.css"><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, 'src', 'main.ts'), 'console.log("sass");');
+    writeFileSync(
+      join(dir, 'src', 'style.scss'),
+      '$primary: red;\n.card { color: $primary; .inner { padding: 4px; } }',
+    );
+
+    const port = await findFreePort();
+    const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      // sass 컴파일 결과 .css 가 mirror 에 — HTML 의 link 가 .css 가리켜야
+      const css = await fetch(`http://localhost:${port}/src/style.css`).then((r) => r.text());
+      expect(css).toContain('color: red'); // $primary 변수 expanded
+      expect(css).toMatch(/\.card\s+\.inner/); // nested rule expanded
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // dev + CSS Modules 시나리오 — D1a'' Phase 2 + #3847 fix 후 scoped class
+  // names 가 bundle.js 안에 inline. proxy.js 자체는 bundler 가 처리 → bundle.js
+  // 응답에 mapping 포함.
+  test('dev CSS Modules — bundle.js 안 scoped class names mapping', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-cssmod-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'index.html'), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(
+      join(dir, 'src', 'main.ts'),
+      'import styles from "./Button.module.css"; globalThis.__styles = styles;',
+    );
+    writeFileSync(
+      join(dir, 'src', 'Button.module.css'),
+      '.primary { color: red; }\n.danger { color: darkred; }',
+    );
+
+    const port = await findFreePort();
+    const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      // bundle.js 안에 CSS Modules mapping inline (bundler 가 proxy 처리)
+      const bundle = await fetch(`http://localhost:${port}/bundle.js`).then((r) => r.text());
+      // scoped class names + mapping key 양쪽 검증
+      expect(bundle).toMatch(/Button_primary__[A-Za-z0-9_-]{8}/);
+      expect(bundle).toMatch(/Button_danger__[A-Za-z0-9_-]{8}/);
+      expect(bundle).toContain('primary');
+      expect(bundle).toContain('danger');
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/core/test/cli/app-builder/styles/dev.ts
+++ b/packages/core/test/cli/app-builder/styles/dev.ts
@@ -232,11 +232,19 @@ describe('CLI: Vite-style app builder > styles > dev', () => {
     try {
       // bundle.js 안에 CSS Modules mapping inline (bundler 가 proxy 처리)
       const bundle = await fetch(`http://localhost:${port}/bundle.js`).then((r) => r.text());
-      // scoped class names + mapping key 양쪽 검증
+      // 404/HTML fallback 회피 가드 (review #2)
+      expect(bundle).not.toContain('<html');
+      expect(bundle).not.toMatch(/Not\s*Found/i);
+      // scoped class names — generated CSS Modules 결과
       expect(bundle).toMatch(/Button_primary__[A-Za-z0-9_-]{8}/);
       expect(bundle).toMatch(/Button_danger__[A-Za-z0-9_-]{8}/);
-      expect(bundle).toContain('primary');
-      expect(bundle).toContain('danger');
+      // mapping shape — proxy module 의 default mapping 이 JSON-literal 로
+      // `{ "primary": "Button_primary__<hash>", "danger": "..." }` 형태 inline
+      // (bundler 가 whitespace 보존). 단순 substring `primary`/`danger` 는
+      // scoped 이름 안에 포함되어 false-green — JSON key 패턴 (`:\s*` 허용) 명시
+      // 검증 (review #1).
+      expect(bundle).toMatch(/"primary":\s*"Button_primary__[A-Za-z0-9_-]{8}"/);
+      expect(bundle).toMatch(/"danger":\s*"Button_danger__[A-Za-z0-9_-]{8}"/);
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });

--- a/packages/core/test/cli/app-builder/styles/postcss.ts
+++ b/packages/core/test/cli/app-builder/styles/postcss.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from 'node:url';
+
 import {
   describe,
   test,
@@ -9,8 +11,15 @@ import {
   mkdirSync,
   tmpdir,
   join,
+  PROJECT_ROOT,
   runCli,
 } from '../helpers';
+
+// 실 css() factory 의 file URL — fixture 가 monorepo 안 packages/web/dist 의
+// 빌드된 css/index.js 를 file:// URL 로 import. node_modules walk 회피.
+// build:dts 가 dist/css/index.js 생성 보장 (pretest hook).
+const CSS_FACTORY_URL = pathToFileURL(join(PROJECT_ROOT, 'packages/web/dist/css/index.js'))
+  .href;
 
 describe('CLI: Vite-style app builder > styles > PostCSS', () => {
   test('JS-imported CSS is linked from HTML and processed by PostCSS', () => {
@@ -63,24 +72,22 @@ describe('CLI: Vite-style app builder > styles > PostCSS', () => {
     writeFileSync(join(dir, 'src', 'main.ts'), 'import "./style.css";');
     writeFileSync(join(dir, 'src', 'style.css'), '.card { color: red; }\n');
     // postcss.config 부재 — 자동 발견 path 가 null 이어야 override path 가 활성화됨.
-    // fixture 가 @zntc/web 미설치 → css() 반환과 동등 plain object 직접 정의.
-    // caller (runAppBuild) 가 name + __cssOptions sentinel 만 검사 (D1a'' design).
+    // 실 css() factory import — fixture 가 monorepo 의 packages/web/dist/css/index.js
+    // 를 file:// URL 로 import (#5 fix). caller (runAppBuild) 가 실 css() 반환 객체의
+    // __cssOptions sentinel 을 추출 — plain object 와 동등성 + 실 factory path 검증.
     writeFileSync(
       join(dir, 'zntc.config.mjs'),
       [
+        `import { css } from ${JSON.stringify(CSS_FACTORY_URL)};`,
         'export default {',
         '  plugins: [',
-        '    {',
-        "      name: '@zntc/web/css',",
-        '      __cssOptions: {',
-        '        postcss: {',
-        '          plugins: [',
-        "            { postcssPlugin: 'override-marker', Once(root) { root.append({ selector: '.override-applied', nodes: [] }); } },",
-        '          ],',
-        '        },',
+        '    css({',
+        '      postcss: {',
+        '        plugins: [',
+        "          { postcssPlugin: 'override-marker', Once(root) { root.append({ selector: '.override-applied', nodes: [] }); } },",
+        '        ],',
         '      },',
-        '      setup() {},',
-        '    },',
+        '    }),',
         '  ],',
         '};',
       ].join('\n'),

--- a/packages/core/test/cli/app-builder/styles/postcss.ts
+++ b/packages/core/test/cli/app-builder/styles/postcss.ts
@@ -96,6 +96,85 @@ describe('CLI: Vite-style app builder > styles > PostCSS', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  // D1a'' 의 disabled:true 분기 — 사용자 명시적으로 PostCSS 끄기. postcss.config 가
+  // 있어도 자동발견 차단되어야 (extractCssPostcssOverride 가 {plugins:[]} 반환 →
+  // prepare 의 length 0 skip).
+  test('explicit css({disabled:true}) — auto-discover 차단 (D1a)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-css-disabled-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<div class="card">disabled</div><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, 'src', 'main.ts'), 'import "./style.css";');
+    writeFileSync(join(dir, 'src', 'style.css'), '.card { color: red; }\n');
+    // postcss.config 있음 — 자동발견 path 가 평소엔 적용되지만 disabled:true 가
+    // override path 진입시켜 차단해야.
+    writeFileSync(
+      join(dir, 'postcss.config.mjs'),
+      [
+        'export default {',
+        '  plugins: [',
+        "    { postcssPlugin: 'auto-marker', Once(root) { root.append({ selector: '.should-not-appear', nodes: [] }); } },",
+        '  ],',
+        '};',
+      ].join('\n'),
+    );
+    writeFileSync(
+      join(dir, 'zntc.config.mjs'),
+      [
+        'export default {',
+        '  plugins: [',
+        "    { name: '@zntc/web/css', __cssOptions: { disabled: true }, setup() {} },",
+        '  ],',
+        '};',
+      ].join('\n'),
+    );
+
+    const outdir = join(dir, 'dist');
+    const { exitCode } = runCli(['build', dir, '--outdir', outdir], { cwd: dir });
+    expect(exitCode).toBe(0);
+    const css = readFileSync(join(outdir, 'main.css'), 'utf8');
+    // disabled 가 자동발견 차단 → marker 안 나타남
+    expect(css).not.toContain('.should-not-appear');
+    expect(css).toContain('.card');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // D1a'' 의 findLast 분기 — user explicit css() 가 default prepend 보다 winner.
+  // 본 fixture 는 두 css() 명시 — 마지막 (override marker) 만 적용 확인.
+  test('findLast — 마지막 css() 가 winner (default + user override 동시)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-app-css-findlast-'));
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(
+      join(dir, 'index.html'),
+      '<div class="card">findLast</div><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, 'src', 'main.ts'), 'import "./style.css";');
+    writeFileSync(join(dir, 'src', 'style.css'), '.card { color: red; }\n');
+    // 두 css() — 첫 번째 가 default-like (plugins=[]), 마지막 이 user override.
+    // findLast 가 마지막 winner → .winner-marker 만 적용, .default-marker 미적용.
+    writeFileSync(
+      join(dir, 'zntc.config.mjs'),
+      [
+        'export default {',
+        '  plugins: [',
+        "    { name: '@zntc/web/css', __cssOptions: { postcss: { plugins: [{ postcssPlugin: 'default-marker', Once(root) { root.append({ selector: '.default-marker', nodes: [] }); } }] } }, setup() {} },",
+        "    { name: '@zntc/web/css', __cssOptions: { postcss: { plugins: [{ postcssPlugin: 'winner-marker', Once(root) { root.append({ selector: '.winner-marker', nodes: [] }); } }] } }, setup() {} },",
+        '  ],',
+        '};',
+      ].join('\n'),
+    );
+
+    const outdir = join(dir, 'dist');
+    const { exitCode } = runCli(['build', dir, '--outdir', outdir], { cwd: dir });
+    expect(exitCode).toBe(0);
+    const css = readFileSync(join(outdir, 'main.css'), 'utf8');
+    expect(css).toContain('.winner-marker'); // findLast = 마지막 winner
+    expect(css).not.toContain('.default-marker');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test('Tailwind v4 @tailwindcss/postcss app fixture', () => {
     const dir = mkdtempSync(join(tmpdir(), 'zntc-app-tailwind-'));
     mkdirSync(join(dir, 'src'), { recursive: true });

--- a/packages/core/test/cli/app-builder/styles/postcss.ts
+++ b/packages/core/test/cli/app-builder/styles/postcss.ts
@@ -18,8 +18,7 @@ import {
 // 실 css() factory 의 file URL — fixture 가 monorepo 안 packages/web/dist 의
 // 빌드된 css/index.js 를 file:// URL 로 import. node_modules walk 회피.
 // build:dts 가 dist/css/index.js 생성 보장 (pretest hook).
-const CSS_FACTORY_URL = pathToFileURL(join(PROJECT_ROOT, 'packages/web/dist/css/index.js'))
-  .href;
+const CSS_FACTORY_URL = pathToFileURL(join(PROJECT_ROOT, 'packages/web/dist/css/index.js')).href;
 
 describe('CLI: Vite-style app builder > styles > PostCSS', () => {
   test('JS-imported CSS is linked from HTML and processed by PostCSS', () => {

--- a/packages/web/src/css/css.test.ts
+++ b/packages/web/src/css/css.test.ts
@@ -39,6 +39,32 @@ describe('css() plugin factory', () => {
     expect(typeof plugin.setup).toBe('function');
   });
 
+  // RFC #3833 v3 D1a'' (caller-side pre-warm): css() 반환 객체에 `__cssOptions`
+  // sentinel — runAppBuild/runAppDev 의 extractCssPostcssOverride helper 가
+  // 이걸로 explicit override 추출. dispatcher 는 name/setup 만 사용, sentinel 무영향.
+  test('__cssOptions sentinel — caller-side pre-warm 용 (D1a)', () => {
+    // 기본 옵션 — empty 객체로 sentinel 부착
+    const plugin1 = css() as { __cssOptions: unknown };
+    expect(plugin1.__cssOptions).toEqual({});
+
+    // postcss override 명시
+    const plugin2 = css({ postcss: { plugins: [{ postcssPlugin: 'x', Once() {} }] } }) as {
+      __cssOptions: { postcss?: { plugins?: unknown[] } };
+    };
+    expect(plugin2.__cssOptions.postcss?.plugins).toHaveLength(1);
+
+    // disabled flag
+    const plugin3 = css({ disabled: true }) as { __cssOptions: { disabled?: boolean } };
+    expect(plugin3.__cssOptions.disabled).toBe(true);
+
+    // root / mode 옵션 sentinel 보존
+    const plugin4 = css({ root: '/abs', mode: 'production' }) as {
+      __cssOptions: { root?: string; mode?: string };
+    };
+    expect(plugin4.__cssOptions.root).toBe('/abs');
+    expect(plugin4.__cssOptions.mode).toBe('production');
+  });
+
   test('zero-config 호출 — onLoad hook 1개 등록 (.css filter)', () => {
     const plugin = css();
     const { build, tracked } = makeMockBuild();

--- a/packages/web/src/css/index.ts
+++ b/packages/web/src/css/index.ts
@@ -60,8 +60,12 @@ export interface CssPluginOptions {
  * export default defineConfig({ plugins: [css({ disabled: true })] });
  * ```
  */
-/** ZntcPlugin + caller-side pre-warm sentinel (RFC #3833 v3 D1a'', @internal). */
-export type CssZntcPlugin = ZntcPlugin & { readonly __cssOptions: CssPluginOptions };
+/**
+ * ZntcPlugin + caller-side pre-warm sentinel (RFC #3833 v3 D1a'').
+ * @internal — caller (runAppBuild) 만 사용. 사용자 type-import 차단 위해 unexported.
+ * sentinel 은 string property 라 runtime 위장 방어 0 — 의도 매치용.
+ */
+type CssZntcPlugin = ZntcPlugin & { readonly __cssOptions: CssPluginOptions };
 
 export function css(options: CssPluginOptions = {}): CssZntcPlugin {
   // RFC #3833 v3 D1a'' (caller-side pre-warm): `__cssOptions` sentinel 로 caller

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -73,7 +73,14 @@ export interface AppDevControllerOptions {
    *  추출해 controller 에 전달. prepare 의 `postcssOverride` + afterBundle 의
    *  `runPostcssForAppDev` override 둘 다에 동일 값. build path 와 dev path 의
    *  PostCSS plugin set 일치 (dev/build divergence 해소). */
-  postcssOverride?: { plugins: unknown[]; options?: Record<string, unknown> } | null;
+  postcssOverride?: {
+    plugins: unknown[];
+    options?: Record<string, unknown>;
+    /** issue #3851 — css({root}) override 가 controller path 로 전달될 때 type
+     *  보존 (TS 사용자가 명시적으로 root 줄 수 있도록). runtime 은 prepare →
+     *  runPostcssIfConfigured 가 동일 field name 으로 read. */
+    root?: string;
+  } | null;
 }
 
 export interface AppDevControllerDeps {
@@ -103,7 +110,14 @@ export interface PrepareAppCssPipelineRootOptions {
    *  explicit `plugins: [css({ postcss: {...override} })]` 의 옵션을 runAppBuild 가
    *  추출해 prepareAppCssPipelineRoot 로 전달. truthy + plugins.length>0 면 자동 발견
    *  skip 후 override 직접 사용. sync dispatcher × async onLoad 충돌 회피용 path. */
-  postcssOverride?: { plugins: unknown[]; options?: Record<string, unknown> } | null;
+  postcssOverride?: {
+    plugins: unknown[];
+    options?: Record<string, unknown>;
+    /** issue #3851 — css({root}) override 의 postcss require base. 미지정 시
+     *  root 인자 fallback. AppDevControllerOptions.postcssOverride.root 와 동일
+     *  field — controller 가 forward. */
+    root?: string;
+  } | null;
 }
 
 export interface AppCssPipelineResult {

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -68,6 +68,12 @@ export interface AppDevControllerOptions {
   envDir?: string | undefined;
   envPrefixes?: readonly string[] | undefined;
   logLevel?: string | undefined;
+  /** caller-side pre-warm PostCSS override (RFC #3833 v3 D1a'' Phase 2). 사용자
+   *  explicit `plugins: [css({postcss:{...override}})]` 의 옵션을 runAppDev 가
+   *  추출해 controller 에 전달. prepare 의 `postcssOverride` + afterBundle 의
+   *  `runPostcssForAppDev` override 둘 다에 동일 값. build path 와 dev path 의
+   *  PostCSS plugin set 일치 (dev/build divergence 해소). */
+  postcssOverride?: { plugins: unknown[]; options?: Record<string, unknown> } | null;
 }
 
 export interface AppDevControllerDeps {
@@ -518,6 +524,10 @@ export function createAppDevController(
       ) {
         pipelineCache = null;
       }
+      // RFC #3833 v3 D1a'' Phase 2: build path (runAppBuild) 와 동일하게 caller
+      // (runAppDev) 의 explicit `css({postcss:{...override}})` 를 prepare 의
+      // PostCSS 단계에 전달. dev/build divergence 해소.
+      const postcssOverride = opts.postcssOverride ?? null;
       const pipeline = await prepareAppCssPipelineRoot(
         root,
         outdir,
@@ -526,8 +536,14 @@ export function createAppDevController(
         'dev',
         deps,
         reuseRoot
-          ? { existingTempRoot: pipelineRoot, dirtyPaths, cache: pipelineCache, sassReverseDep }
-          : { sassReverseDep },
+          ? {
+              existingTempRoot: pipelineRoot,
+              dirtyPaths,
+              cache: pipelineCache,
+              sassReverseDep,
+              postcssOverride,
+            }
+          : { sassReverseDep, postcssOverride },
       );
       pipelineRoot = pipeline?.tempRoot ?? null;
       pipelineCache = pipeline?.cache ?? null;
@@ -578,6 +594,8 @@ export function createAppDevController(
       return prepared;
     },
     async afterBundle({ changedPath = null } = {}) {
+      // RFC #3833 v3 D1a'' Phase 2: prepare 와 동일 override 를 afterBundle 에도
+      // 전달 — 일관된 PostCSS plugin set (build path 와 시맨틱 일치).
       const result = await runPostcssForAppDev({
         root,
         outdir,
@@ -586,6 +604,7 @@ export function createAppDevController(
         base,
         changedPath,
         fallbackRequire,
+        postcssOverride: opts.postcssOverride ?? null,
       });
       cssDeps = result.deps;
       cssDirDeps = result.dirDeps;

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -392,9 +392,12 @@ export async function prepareAppCssPipelineRoot(
       dirtyPaths.some((p) => isCssFile(p) || isCssPreprocessorFile(p) || isPostcssConfigFile(p)));
   // issue #3850 — runPostcssIfConfigured 의 deps/dirDeps 결과 보존. afterBundle
   // 의 skipPostcssRun path 가 tailwind @source 같은 dir-dep watch trigger 정합
-  // 위해 사용. postcssRelevant 가 false 면 빈 set (이전 prep 결과 재사용 가정).
-  let postcssDeps = new Set<string>();
-  let postcssDirDeps = new Set<string>();
+  // 위해 사용. **postcssRelevant=false (incremental dirty=non-CSS)** 면 PostCSS
+  // 호출 skip 후 undefined 반환 — controller 가 이전 prep 의 deps/dirDeps 를
+  // carry-over (회귀 가드: /code-review max #1). prep 마다 빈 set 으로 reset
+  // 하면 .ts 파일 1개 edit 만 해도 tailwind @source dir-dep 손실.
+  let postcssDeps: Set<string> | undefined;
+  let postcssDirDeps: Set<string> | undefined;
   if (postcssRelevant) {
     const postcssResult = await runPostcssIfConfigured(
       tempRoot,
@@ -575,8 +578,15 @@ export function createAppDevController(
       preparePostcssApplied = !!pipeline;
       // issue #3850 — prepare result 의 postcssDeps/postcssDirDeps 보존.
       // afterBundle skipPostcssRun path 가 watch trigger 정합 위해 사용.
-      preparePostcssDeps = pipeline?.postcssDeps ?? new Set();
-      preparePostcssDirDeps = pipeline?.postcssDirDeps ?? new Set();
+      // **carry-over (review #1)**: pipeline.postcssDeps 가 undefined 면
+      // PostCSS 호출 skip (incremental + non-CSS dirty) — 이전 prep 의 dirDeps
+      // 보존. defined 면 새 값으로 overwrite.
+      if (pipeline?.postcssDeps !== undefined) {
+        preparePostcssDeps = pipeline.postcssDeps;
+      }
+      if (pipeline?.postcssDirDeps !== undefined) {
+        preparePostcssDirDeps = pipeline.postcssDirDeps;
+      }
       const prepareRoot = pipelineRoot ?? root;
       const envDir = opts.envDir ? resolve(opts.envDir) : prepareRoot;
       const prepared = prepareAppDevSync({

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -114,14 +114,6 @@ export interface AppCssPipelineResult {
    *  path 가 watch trigger 정합 위해 사용 (tailwind `@source` 같은 dir-dep). */
   postcssDeps?: Set<string>;
   postcssDirDeps?: Set<string>;
-  /** review #1 — PostCSS 가 **실제로** 적용됐는지(`runPostcssIfConfigured` 의
-   *  early-return 이 아니라 cssFiles 에 process 가 돌아간 경우만 true). controller
-   *  의 `preparePostcssApplied` flag 가 sass-only app(prepare 진입했으나 PostCSS
-   *  미실행)에서 잘못 skipPostcssRun=true 로 set 되어 afterBundle 의 PostCSS pass
-   *  를 부당하게 skip 하지 않도록. postcssRelevant=false(incremental + 비-CSS dirty)
-   *  면 prepare 가 PostCSS 호출 자체를 skip — 그 경우 undefined → controller 가
-   *  이전 prep 의 값을 carry-over 한다. */
-  postcssApplied?: boolean;
 }
 
 function normalizeBase(base: string | undefined): string {
@@ -406,7 +398,6 @@ export async function prepareAppCssPipelineRoot(
   // 하면 .ts 파일 1개 edit 만 해도 tailwind @source dir-dep 손실.
   let postcssDeps: Set<string> | undefined;
   let postcssDirDeps: Set<string> | undefined;
-  let postcssApplied: boolean | undefined;
   if (postcssRelevant) {
     const postcssResult = await runPostcssIfConfigured(
       tempRoot,
@@ -419,7 +410,6 @@ export async function prepareAppCssPipelineRoot(
     );
     postcssDeps = postcssResult.deps;
     postcssDirDeps = postcssResult.dirDeps;
-    postcssApplied = postcssResult.applied;
   }
   // `*.module.scss` 는 위 sass 단계에서 `*.module.css` 가 새로 만들어지므로, 사전 walk
   // 가 본 모듈 리스트엔 빠져 있다. preprocessor 출력 경로를 재계산해 보강.
@@ -451,7 +441,6 @@ export async function prepareAppCssPipelineRoot(
     cache: { stylePipelineFiles, styleSourceFiles },
     postcssDeps,
     postcssDirDeps,
-    postcssApplied,
   };
 }
 
@@ -583,15 +572,10 @@ export function createAppDevController(
       pipelineRoot = pipeline?.tempRoot ?? null;
       pipelineCache = pipeline?.cache ?? null;
       hasPipelineCss = (pipeline?.generatedCssAbsPaths.length ?? 0) > 0;
-      // issue #3847 / review #1 — PostCSS 가 **실제로** 적용된 경우에만 flag set.
-      // `pipeline` 자체는 sass-only / css-modules-only 진입 시도 truthy 라
-      // `!!pipeline` 은 false-positive. `prepareAppCssPipelineRoot` 가 노출하는
-      // `postcssApplied` (cssFiles 에 process 가 돌아갔는지) 를 신뢰. undefined =
-      // postcssRelevant=false 면 carry-over (이전 prep 의 값 유지) — incremental
-      // 비-CSS dirty rebuild 가 flag 를 잘못 false 로 reset 하지 않도록.
-      if (pipeline?.postcssApplied !== undefined) {
-        preparePostcssApplied = pipeline.postcssApplied;
-      }
+      // issue #3847 — pipeline truthy = prepareAppCssPipelineRoot 진입 →
+      // runPostcssIfConfigured 호출됨 (override 또는 자동발견 어느 path 든 PostCSS
+      // 처리 가능). afterBundle 가 redundant pass 차단할 수 있도록 flag set.
+      preparePostcssApplied = !!pipeline;
       // issue #3850 — prepare result 의 postcssDeps/postcssDirDeps 보존.
       // afterBundle skipPostcssRun path 가 watch trigger 정합 위해 사용.
       // **carry-over (review #1)**: pipeline.postcssDeps 가 undefined 면

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -110,6 +110,10 @@ export interface AppCssPipelineResult {
   tempRoot: string;
   generatedCssAbsPaths: string[];
   cache: PipelineCache;
+  /** issue #3850 — PostCSS message 의 deps/dirDeps 보존. afterBundle skipPostcssRun
+   *  path 가 watch trigger 정합 위해 사용 (tailwind `@source` 같은 dir-dep). */
+  postcssDeps?: Set<string>;
+  postcssDirDeps?: Set<string>;
 }
 
 function normalizeBase(base: string | undefined): string {
@@ -386,8 +390,13 @@ export async function prepareAppCssPipelineRoot(
     !isIncremental ||
     (dirtyPaths !== null &&
       dirtyPaths.some((p) => isCssFile(p) || isCssPreprocessorFile(p) || isPostcssConfigFile(p)));
+  // issue #3850 — runPostcssIfConfigured 의 deps/dirDeps 결과 보존. afterBundle
+  // 의 skipPostcssRun path 가 tailwind @source 같은 dir-dep watch trigger 정합
+  // 위해 사용. postcssRelevant 가 false 면 빈 set (이전 prep 결과 재사용 가정).
+  let postcssDeps = new Set<string>();
+  let postcssDirDeps = new Set<string>();
   if (postcssRelevant) {
-    await runPostcssIfConfigured(
+    const postcssResult = await runPostcssIfConfigured(
       tempRoot,
       tempRoot,
       null,
@@ -396,6 +405,8 @@ export async function prepareAppCssPipelineRoot(
       fallbackRequire,
       postcssOverride,
     );
+    postcssDeps = postcssResult.deps;
+    postcssDirDeps = postcssResult.dirDeps;
   }
   // `*.module.scss` 는 위 sass 단계에서 `*.module.css` 가 새로 만들어지므로, 사전 walk
   // 가 본 모듈 리스트엔 빠져 있다. preprocessor 출력 경로를 재계산해 보강.
@@ -425,6 +436,8 @@ export async function prepareAppCssPipelineRoot(
     tempRoot,
     generatedCssAbsPaths,
     cache: { stylePipelineFiles, styleSourceFiles },
+    postcssDeps,
+    postcssDirDeps,
   };
 }
 
@@ -485,6 +498,10 @@ export function createAppDevController(
   // true. afterBundle 가 그 flag 보고 runPostcssForAppDev 의 redundant PostCSS
   // pass 차단 (zero-config double-pass 해소). prepare 의 pipeline 결과로 결정.
   let preparePostcssApplied = false;
+  // issue #3850 — prepare 의 postcssDeps/postcssDirDeps 보존. afterBundle 가
+  // skipPostcssRun path 에서 머지 (tailwind @source 같은 dir-dep watch trigger).
+  let preparePostcssDeps = new Set<string>();
+  let preparePostcssDirDeps = new Set<string>();
   // #71: sass @import reverse-dep 맵(tempRoot 기준 path). prepare(full pipeline) 와 fast-path
   // (rebuildScssIncremental) 가 갱신하고, isSassOnlyChange 가 조회해 dep 있는 파일은 fast-path
   // 박탈 → full pipeline 의 transitive 재컴파일로 dependents 까지 갱신. 세션 내내 누적.
@@ -556,6 +573,10 @@ export function createAppDevController(
       // runPostcssIfConfigured 호출됨 (override 또는 자동발견 어느 path 든 PostCSS
       // 처리 가능). afterBundle 가 redundant pass 차단할 수 있도록 flag set.
       preparePostcssApplied = !!pipeline;
+      // issue #3850 — prepare result 의 postcssDeps/postcssDirDeps 보존.
+      // afterBundle skipPostcssRun path 가 watch trigger 정합 위해 사용.
+      preparePostcssDeps = pipeline?.postcssDeps ?? new Set();
+      preparePostcssDirDeps = pipeline?.postcssDirDeps ?? new Set();
       const prepareRoot = pipelineRoot ?? root;
       const envDir = opts.envDir ? resolve(opts.envDir) : prepareRoot;
       const prepared = prepareAppDevSync({
@@ -620,8 +641,16 @@ export function createAppDevController(
       });
       cssDeps = result.deps;
       cssDirDeps = result.dirDeps;
+      // issue #3850 — skipPostcssRun path 의 result.dirDeps 가 빈 set 라
+      // tailwind @source 같은 dir-dep watch trigger 누락. prepare 의 결과를
+      // 머지 (preparePostcssDeps/Dirs) — controller 의 cssDeps/cssDirDeps 가
+      // 양쪽 source 의 union 으로 watch 정합.
+      if (preparePostcssApplied) {
+        for (const d of preparePostcssDeps) cssDeps.add(d);
+        for (const d of preparePostcssDirDeps) cssDirDeps.add(d);
+      }
       primaryHref = result.primaryHref;
-      return result;
+      return { ...result, deps: cssDeps, dirDeps: cssDirDeps };
     },
     injectBundleCssLinks(bundleResult: BundleResult) {
       // pipeline 이 SCSS / CSS Modules generated CSS 를 inject 한 상태면 bundler 의

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -114,6 +114,14 @@ export interface AppCssPipelineResult {
    *  path 가 watch trigger 정합 위해 사용 (tailwind `@source` 같은 dir-dep). */
   postcssDeps?: Set<string>;
   postcssDirDeps?: Set<string>;
+  /** review #1 — PostCSS 가 **실제로** 적용됐는지(`runPostcssIfConfigured` 의
+   *  early-return 이 아니라 cssFiles 에 process 가 돌아간 경우만 true). controller
+   *  의 `preparePostcssApplied` flag 가 sass-only app(prepare 진입했으나 PostCSS
+   *  미실행)에서 잘못 skipPostcssRun=true 로 set 되어 afterBundle 의 PostCSS pass
+   *  를 부당하게 skip 하지 않도록. postcssRelevant=false(incremental + 비-CSS dirty)
+   *  면 prepare 가 PostCSS 호출 자체를 skip — 그 경우 undefined → controller 가
+   *  이전 prep 의 값을 carry-over 한다. */
+  postcssApplied?: boolean;
 }
 
 function normalizeBase(base: string | undefined): string {
@@ -398,6 +406,7 @@ export async function prepareAppCssPipelineRoot(
   // 하면 .ts 파일 1개 edit 만 해도 tailwind @source dir-dep 손실.
   let postcssDeps: Set<string> | undefined;
   let postcssDirDeps: Set<string> | undefined;
+  let postcssApplied: boolean | undefined;
   if (postcssRelevant) {
     const postcssResult = await runPostcssIfConfigured(
       tempRoot,
@@ -410,6 +419,7 @@ export async function prepareAppCssPipelineRoot(
     );
     postcssDeps = postcssResult.deps;
     postcssDirDeps = postcssResult.dirDeps;
+    postcssApplied = postcssResult.applied;
   }
   // `*.module.scss` 는 위 sass 단계에서 `*.module.css` 가 새로 만들어지므로, 사전 walk
   // 가 본 모듈 리스트엔 빠져 있다. preprocessor 출력 경로를 재계산해 보강.
@@ -441,6 +451,7 @@ export async function prepareAppCssPipelineRoot(
     cache: { stylePipelineFiles, styleSourceFiles },
     postcssDeps,
     postcssDirDeps,
+    postcssApplied,
   };
 }
 
@@ -572,10 +583,15 @@ export function createAppDevController(
       pipelineRoot = pipeline?.tempRoot ?? null;
       pipelineCache = pipeline?.cache ?? null;
       hasPipelineCss = (pipeline?.generatedCssAbsPaths.length ?? 0) > 0;
-      // issue #3847 — pipeline truthy = prepareAppCssPipelineRoot 진입 →
-      // runPostcssIfConfigured 호출됨 (override 또는 자동발견 어느 path 든 PostCSS
-      // 처리 가능). afterBundle 가 redundant pass 차단할 수 있도록 flag set.
-      preparePostcssApplied = !!pipeline;
+      // issue #3847 / review #1 — PostCSS 가 **실제로** 적용된 경우에만 flag set.
+      // `pipeline` 자체는 sass-only / css-modules-only 진입 시도 truthy 라
+      // `!!pipeline` 은 false-positive. `prepareAppCssPipelineRoot` 가 노출하는
+      // `postcssApplied` (cssFiles 에 process 가 돌아갔는지) 를 신뢰. undefined =
+      // postcssRelevant=false 면 carry-over (이전 prep 의 값 유지) — incremental
+      // 비-CSS dirty rebuild 가 flag 를 잘못 false 로 reset 하지 않도록.
+      if (pipeline?.postcssApplied !== undefined) {
+        preparePostcssApplied = pipeline.postcssApplied;
+      }
       // issue #3850 — prepare result 의 postcssDeps/postcssDirDeps 보존.
       // afterBundle skipPostcssRun path 가 watch trigger 정합 위해 사용.
       // **carry-over (review #1)**: pipeline.postcssDeps 가 undefined 면

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -481,6 +481,10 @@ export function createAppDevController(
   const base = normalizeBase(opts.base ?? opts.publicPath ?? '/');
   let cssDeps = new Set<string>();
   let cssDirDeps = new Set<string>();
+  // issue #3847 — prepare 가 PostCSS 처리 (auto-discover 또는 override) 한 경우
+  // true. afterBundle 가 그 flag 보고 runPostcssForAppDev 의 redundant PostCSS
+  // pass 차단 (zero-config double-pass 해소). prepare 의 pipeline 결과로 결정.
+  let preparePostcssApplied = false;
   // #71: sass @import reverse-dep 맵(tempRoot 기준 path). prepare(full pipeline) 와 fast-path
   // (rebuildScssIncremental) 가 갱신하고, isSassOnlyChange 가 조회해 dep 있는 파일은 fast-path
   // 박탈 → full pipeline 의 transitive 재컴파일로 dependents 까지 갱신. 세션 내내 누적.
@@ -548,6 +552,10 @@ export function createAppDevController(
       pipelineRoot = pipeline?.tempRoot ?? null;
       pipelineCache = pipeline?.cache ?? null;
       hasPipelineCss = (pipeline?.generatedCssAbsPaths.length ?? 0) > 0;
+      // issue #3847 — pipeline truthy = prepareAppCssPipelineRoot 진입 →
+      // runPostcssIfConfigured 호출됨 (override 또는 자동발견 어느 path 든 PostCSS
+      // 처리 가능). afterBundle 가 redundant pass 차단할 수 있도록 flag set.
+      preparePostcssApplied = !!pipeline;
       const prepareRoot = pipelineRoot ?? root;
       const envDir = opts.envDir ? resolve(opts.envDir) : prepareRoot;
       const prepared = prepareAppDevSync({
@@ -595,7 +603,8 @@ export function createAppDevController(
     },
     async afterBundle({ changedPath = null } = {}) {
       // RFC #3833 v3 D1a'' Phase 2: prepare 와 동일 override 를 afterBundle 에도
-      // 전달 — 일관된 PostCSS plugin set (build path 와 시맨틱 일치).
+      // 전달. issue #3847: prepare 가 PostCSS 처리한 경우 skipPostcssRun=true 로
+      // redundant pass 차단 (zero-config double-pass + caller-pre-warm 모두).
       const result = await runPostcssForAppDev({
         root,
         outdir,
@@ -605,6 +614,9 @@ export function createAppDevController(
         changedPath,
         fallbackRequire,
         postcssOverride: opts.postcssOverride ?? null,
+        skipPostcssRun: preparePostcssApplied,
+        // issue #3847 — mirror 의 source 가 prepare 의 tempRoot (PostCSS 처리됨)
+        sourceRoot: pipelineRoot ?? root,
       });
       cssDeps = result.deps;
       cssDirDeps = result.dirDeps;

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -248,6 +248,15 @@ export async function runPostcssForAppDev(
     skipPostcssRun = false,
     sourceRoot,
   } = options;
+  // issue #3853 — skipPostcssRun=true 시 sourceRoot 명시 의무화. fallback (raw
+  // root) 으로 silent 떨어지면 PostCSS 미적용 .css 가 outdir 로 copy → dev server
+  // 응답 stale. early throw 로 미래 caller 의 silent regression 차단.
+  if (skipPostcssRun && sourceRoot === undefined) {
+    throw new Error(
+      'runPostcssForAppDev: skipPostcssRun=true 시 sourceRoot 명시 필수 (issue #3853). ' +
+        'prepare 의 tempRoot path 전달하지 않으면 raw root 의 PostCSS 미적용 .css 가 mirror 됨.',
+    );
+  }
   const mirrorRoot = sourceRoot ?? root;
   const deps = new Set<string>();
   const dirDeps = new Set<string>();

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -267,7 +267,12 @@ export async function runPostcssForAppDev(
       return { deps, dirDeps, primaryHref, processed: 0 };
     }
     const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss['postcss'];
-    loaded = { postcss, plugins: postcssOverride.plugins, options: postcssOverride.options ?? {}, configFile: null };
+    loaded = {
+      postcss,
+      plugins: postcssOverride.plugins,
+      options: postcssOverride.options ?? {},
+      configFile: null,
+    };
   } else {
     loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
   }

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -206,6 +206,10 @@ export interface AppDevPostcssOptions {
   base: string | undefined;
   changedPath?: string | null;
   fallbackRequire: NodeRequire;
+  /** caller-side pre-warm 으로 전달되는 PostCSS override (RFC #3833 v3 D1a''
+   *  Phase 2). build path 의 `runPostcssIfConfigured` 와 동일 시맨틱 — truthy
+   *  면 자동발견 skip, plugins.length === 0 면 explicit no-op. */
+  postcssOverride?: { plugins: unknown[]; options?: Record<string, unknown> } | null;
 }
 
 export interface AppDevPostcssResult {
@@ -223,20 +227,53 @@ export interface AppDevPostcssResult {
 export async function runPostcssForAppDev(
   options: AppDevPostcssOptions,
 ): Promise<AppDevPostcssResult> {
-  const { root, outdir, configEnv, logLevel, base, changedPath = null, fallbackRequire } = options;
+  const {
+    root,
+    outdir,
+    configEnv,
+    logLevel,
+    base,
+    changedPath = null,
+    fallbackRequire,
+    postcssOverride = null,
+  } = options;
   const deps = new Set<string>();
   const dirDeps = new Set<string>();
   let primaryHref: string | null = null;
-  const configPath = findPostcssConfig(root);
-  if (!configPath) {
+  // override 가 있으면 자동발견 skip. plugins.length === 0 면 explicit no-op
+  // (build path 의 runPostcssIfConfigured 와 동일 시맨틱).
+  const configPath = postcssOverride ? null : findPostcssConfig(root);
+  if (!configPath && !postcssOverride) {
     const first = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile })[0];
     if (first) primaryHref = joinUrl(base, relative(root, first));
     return { deps, dirDeps, primaryHref, processed: 0 };
   }
 
-  const loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
+  let loaded: LoadedPostcss | null;
+  if (postcssOverride) {
+    if (postcssOverride.plugins.length === 0) {
+      // explicit no-op — primaryHref 만 첫 CSS 로 채워 link 유지.
+      const first = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile })[0];
+      if (first) primaryHref = joinUrl(base, relative(root, first));
+      return { deps, dirDeps, primaryHref, processed: 0 };
+    }
+    let postcssModule: { default?: LoadedPostcss['postcss'] } & LoadedPostcss['postcss'];
+    try {
+      postcssModule = requireFromAppRoot(root, fallbackRequire, 'postcss') as typeof postcssModule;
+    } catch {
+      if (logLevel !== 'silent') {
+        console.error('[postcss] override path (dev): postcss require 실패 — skip');
+      }
+      return { deps, dirDeps, primaryHref, processed: 0 };
+    }
+    const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss['postcss'];
+    loaded = { postcss, plugins: postcssOverride.plugins, options: postcssOverride.options ?? {}, configFile: null };
+  } else {
+    loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
+  }
   if (!loaded) return { deps, dirDeps, primaryHref, processed: 0 };
-  deps.add(resolve(loaded.configFile ?? configPath));
+  if (loaded.configFile) deps.add(resolve(loaded.configFile));
+  else if (configPath) deps.add(resolve(configPath));
 
   mkdirSync(outdir, { recursive: true });
   const allCssFiles = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile });

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -153,6 +153,12 @@ export interface RunPostcssIfConfiguredResult {
   /** issue #3850 — PostCSS message 의 dir-dep tracking. tailwind v4 의
    *  @source "../html" 같은 directory watch. */
   dirDeps: Set<string>;
+  /** review #1 — PostCSS 가 실제로 .css 파일들에 process 를 적용했는지.
+   *  override.plugins=[] / postcss 미설치 / config 부재 / cssFiles 0 등의
+   *  early-return 은 false. caller (dev-controller) 가 sass-only app 의
+   *  redundant afterBundle PostCSS pass 를 false 판단으로 허용해야 함
+   *  (skipPostcssRun 을 truthy 로 잘못 set 하지 않도록). */
+  applied: boolean;
 }
 
 export async function runPostcssIfConfigured(
@@ -176,7 +182,7 @@ export async function runPostcssIfConfigured(
   if (override) {
     // explicit override path. plugins 가 빈 배열이면 PostCSS process 자체 skip
     // (Vite 식 'explicit no-op' — auto-discover 로 fallback 안 함).
-    if (override.plugins.length === 0) return { deps, dirDeps };
+    if (override.plugins.length === 0) return { deps, dirDeps, applied: false };
     // postcss 자체만 require (app-first / fallback-second).
     // issue #3851 — override.root 가 있으면 그것 use, 아니면 root.
     const requireBase = override.root ?? root;
@@ -193,7 +199,7 @@ export async function runPostcssIfConfigured(
       if (logLevel !== 'silent') {
         console.error('[postcss] override path: postcss require 실패 — skip');
       }
-      return { deps, dirDeps };
+      return { deps, dirDeps, applied: false };
     }
     const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss['postcss'];
     loaded = {
@@ -205,8 +211,9 @@ export async function runPostcssIfConfigured(
   } else {
     loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
   }
-  if (!loaded) return { deps, dirDeps };
+  if (!loaded) return { deps, dirDeps, applied: false };
   const cssFiles = collectAppFiles(cssDir, { skipDir, predicate: isCssFile });
+  if (cssFiles.length === 0) return { deps, dirDeps, applied: false };
   await Promise.all(
     cssFiles.map(async (file) => {
       const input = readFileSync(file, 'utf8');
@@ -223,7 +230,7 @@ export async function runPostcssIfConfigured(
     }),
   );
   logPostcssProcessed(logLevel, cssFiles.length, loaded.configFile);
-  return { deps, dirDeps };
+  return { deps, dirDeps, applied: true };
 }
 
 export interface AppDevPostcssOptions {

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -152,7 +152,13 @@ export async function runPostcssIfConfigured(
   configEnv: ConfigEnv,
   logLevel: string | undefined,
   fallbackRequire: NodeRequire,
-  override?: { plugins: unknown[]; options?: Record<string, unknown> } | null,
+  override?: {
+    plugins: unknown[];
+    options?: Record<string, unknown>;
+    /** issue #3851 — css({root}) 의 root override. postcss module require 의
+     *  base. 미지정 시 root 인자 사용. */
+    root?: string;
+  } | null,
 ): Promise<void> {
   let loaded: LoadedPostcss | null;
   if (override) {
@@ -160,9 +166,15 @@ export async function runPostcssIfConfigured(
     // (Vite 식 'explicit no-op' — auto-discover 로 fallback 안 함).
     if (override.plugins.length === 0) return;
     // postcss 자체만 require (app-first / fallback-second).
+    // issue #3851 — override.root 가 있으면 그것 use, 아니면 root.
+    const requireBase = override.root ?? root;
     let postcssModule: { default?: LoadedPostcss['postcss'] } & LoadedPostcss['postcss'];
     try {
-      postcssModule = requireFromAppRoot(root, fallbackRequire, 'postcss') as typeof postcssModule;
+      postcssModule = requireFromAppRoot(
+        requireBase,
+        fallbackRequire,
+        'postcss',
+      ) as typeof postcssModule;
     } catch {
       // postcss 미설치. 자동 발견 path 는 silent skip 인데 override path 는
       // 사용자 explicit intent 라 silent 가 silent-bug 가능 — warn 후 skip.
@@ -208,8 +220,13 @@ export interface AppDevPostcssOptions {
   fallbackRequire: NodeRequire;
   /** caller-side pre-warm 으로 전달되는 PostCSS override (RFC #3833 v3 D1a''
    *  Phase 2). build path 의 `runPostcssIfConfigured` 와 동일 시맨틱 — truthy
-   *  면 자동발견 skip, plugins.length === 0 면 explicit no-op. */
-  postcssOverride?: { plugins: unknown[]; options?: Record<string, unknown> } | null;
+   *  면 자동발견 skip, plugins.length === 0 면 explicit no-op. issue #3851:
+   *  root override 도 routing (postcss require base). */
+  postcssOverride?: {
+    plugins: unknown[];
+    options?: Record<string, unknown>;
+    root?: string;
+  } | null;
   /** dev path zero-config double-pass 회피 (issue #3847). controller 의
    *  prepare 가 PostCSS 처리 (auto-discover 또는 override) 했음을 caller 가
    *  알린 경우 true — runPostcssForAppDev 가 PostCSS 호출 skip + sourceRoot
@@ -305,9 +322,15 @@ export async function runPostcssForAppDev(
       if (allCssFiles[0]) primaryHref = joinUrl(base, relative(root, allCssFiles[0]));
       return { deps, dirDeps, primaryHref, processed: 0 };
     }
+    // issue #3851 — override.root 가 있으면 그것 use, 아니면 root.
+    const requireBase = postcssOverride.root ?? root;
     let postcssModule: { default?: LoadedPostcss['postcss'] } & LoadedPostcss['postcss'];
     try {
-      postcssModule = requireFromAppRoot(root, fallbackRequire, 'postcss') as typeof postcssModule;
+      postcssModule = requireFromAppRoot(
+        requireBase,
+        fallbackRequire,
+        'postcss',
+      ) as typeof postcssModule;
     } catch {
       if (logLevel !== 'silent') {
         console.error('[postcss] override path (dev): postcss require 실패 — skip');

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -210,6 +210,15 @@ export interface AppDevPostcssOptions {
    *  Phase 2). build path 의 `runPostcssIfConfigured` 와 동일 시맨틱 — truthy
    *  면 자동발견 skip, plugins.length === 0 면 explicit no-op. */
   postcssOverride?: { plugins: unknown[]; options?: Record<string, unknown> } | null;
+  /** dev path zero-config double-pass 회피 (issue #3847). controller 의
+   *  prepare 가 PostCSS 처리 (auto-discover 또는 override) 했음을 caller 가
+   *  알린 경우 true — runPostcssForAppDev 가 PostCSS 호출 skip + sourceRoot
+   *  의 .css 를 outdir 로 mirror (PostCSS 미적용, 이미 처리된 결과 그대로).
+   *  cssDeps 는 raw root path 로 유지 (watch trigger 정합). */
+  skipPostcssRun?: boolean;
+  /** skipPostcssRun=true 시 mirror 의 source root (prepare 의 tempRoot 또는
+   *  raw root). 미지정 시 root 사용. controller 가 pipelineRoot 전달. */
+  sourceRoot?: string;
 }
 
 export interface AppDevPostcssResult {
@@ -236,10 +245,36 @@ export async function runPostcssForAppDev(
     changedPath = null,
     fallbackRequire,
     postcssOverride = null,
+    skipPostcssRun = false,
+    sourceRoot,
   } = options;
+  const mirrorRoot = sourceRoot ?? root;
   const deps = new Set<string>();
   const dirDeps = new Set<string>();
   let primaryHref: string | null = null;
+  // issue #3847 — controller 의 prepare 가 이미 PostCSS 처리 (auto-discover
+  // 또는 override) 했음을 caller 가 알린 경우 redundant PostCSS pass 차단.
+  // 단 file mirror 는 유지 — 기존 runPostcssForAppDev 가 outdir 에 emit 하는
+  // 역할 (dev server 가 outdir 에서 서빙). PostCSS 미적용 file copy 만.
+  if (skipPostcssRun) {
+    // mirror: mirrorRoot (= prepare 의 tempRoot) 의 .css → outdir. PostCSS
+    // 미적용 (이미 prepare 가 처리한 결과). raw root 와 path 다른 경우 (caller
+    // 가 pipelineRoot 명시) tempRoot 의 처리된 결과를 outdir 로 copy.
+    const mirrorCssFiles = collectAppFiles(mirrorRoot, { skipDir: outdir, predicate: isCssFile });
+    mkdirSync(outdir, { recursive: true });
+    for (const f of mirrorCssFiles) {
+      const outputRel = relative(mirrorRoot, f);
+      const outputPath = join(outdir, outputRel);
+      mkdirSync(dirname(outputPath), { recursive: true });
+      const input = readFileSync(f, 'utf8');
+      writeFileSync(outputPath, input);
+    }
+    // cssDeps: raw root 의 .css path — watch trigger 정합 (사용자 file edit 감지).
+    const watchCssFiles = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile });
+    for (const f of watchCssFiles) deps.add(resolve(f));
+    if (watchCssFiles[0]) primaryHref = joinUrl(base, relative(root, watchCssFiles[0]));
+    return { deps, dirDeps, primaryHref, processed: 0 };
+  }
   // override 가 있으면 자동발견 skip. plugins.length === 0 면 explicit no-op
   // (build path 의 runPostcssIfConfigured 와 동일 시맨틱).
   const configPath = postcssOverride ? null : findPostcssConfig(root);

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -145,6 +145,16 @@ export async function loadPostcssConfig(
  * require — 미설치 시 logLevel != silent 면 warn 출력 후 skip (override path
  * 가 silently no-op 안 되도록 가시성 확보).
  */
+export interface RunPostcssIfConfiguredResult {
+  /** issue #3850 — PostCSS message 의 dep tracking. tailwind @source 등의
+   *  file dependency. caller (prepareAppCssPipelineRoot) 가 보존 후 dev path
+   *  의 skipPostcssRun 가 watch trigger 정합 위해 사용. */
+  deps: Set<string>;
+  /** issue #3850 — PostCSS message 의 dir-dep tracking. tailwind v4 의
+   *  @source "../html" 같은 directory watch. */
+  dirDeps: Set<string>;
+}
+
 export async function runPostcssIfConfigured(
   root: string,
   cssDir: string,
@@ -159,12 +169,14 @@ export async function runPostcssIfConfigured(
      *  base. 미지정 시 root 인자 사용. */
     root?: string;
   } | null,
-): Promise<void> {
+): Promise<RunPostcssIfConfiguredResult> {
+  const deps = new Set<string>();
+  const dirDeps = new Set<string>();
   let loaded: LoadedPostcss | null;
   if (override) {
     // explicit override path. plugins 가 빈 배열이면 PostCSS process 자체 skip
     // (Vite 식 'explicit no-op' — auto-discover 로 fallback 안 함).
-    if (override.plugins.length === 0) return;
+    if (override.plugins.length === 0) return { deps, dirDeps };
     // postcss 자체만 require (app-first / fallback-second).
     // issue #3851 — override.root 가 있으면 그것 use, 아니면 root.
     const requireBase = override.root ?? root;
@@ -181,7 +193,7 @@ export async function runPostcssIfConfigured(
       if (logLevel !== 'silent') {
         console.error('[postcss] override path: postcss require 실패 — skip');
       }
-      return;
+      return { deps, dirDeps };
     }
     const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss['postcss'];
     loaded = {
@@ -193,7 +205,7 @@ export async function runPostcssIfConfigured(
   } else {
     loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
   }
-  if (!loaded) return;
+  if (!loaded) return { deps, dirDeps };
   const cssFiles = collectAppFiles(cssDir, { skipDir, predicate: isCssFile });
   await Promise.all(
     cssFiles.map(async (file) => {
@@ -205,9 +217,13 @@ export async function runPostcssIfConfigured(
       });
       writeFileSync(file, result.css);
       if (result.map) writeFileSync(`${file}.map`, result.map.toString());
+      // issue #3850 — PostCSS message 의 deps/dirDeps 수집. tailwind @source
+      // 등 dir-dep watch trigger 정합.
+      collectPostcssMessages(result.messages, deps, dirDeps);
     }),
   );
   logPostcssProcessed(logLevel, cssFiles.length, loaded.configFile);
+  return { deps, dirDeps };
 }
 
 export interface AppDevPostcssOptions {

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -252,9 +252,13 @@ export async function runPostcssForAppDev(
   let loaded: LoadedPostcss | null;
   if (postcssOverride) {
     if (postcssOverride.plugins.length === 0) {
-      // explicit no-op — primaryHref 만 첫 CSS 로 채워 link 유지.
-      const first = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile })[0];
-      if (first) primaryHref = joinUrl(base, relative(root, first));
+      // explicit no-op — primaryHref 만 첫 CSS 로 채워 link 유지. 단 watch deps
+      // 는 모든 .css 파일 추가 — controller 의 isCssOnlyChange / cssDeps 가 변경
+      // 감지에 사용. 빈 deps 반환 시 watch 가 reload trigger 누락 가능 (/code-review
+      // max #3).
+      const allCssFiles = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile });
+      for (const f of allCssFiles) deps.add(resolve(f));
+      if (allCssFiles[0]) primaryHref = joinUrl(base, relative(root, allCssFiles[0]));
       return { deps, dirDeps, primaryHref, processed: 0 };
     }
     let postcssModule: { default?: LoadedPostcss['postcss'] } & LoadedPostcss['postcss'];

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -153,12 +153,6 @@ export interface RunPostcssIfConfiguredResult {
   /** issue #3850 — PostCSS message 의 dir-dep tracking. tailwind v4 의
    *  @source "../html" 같은 directory watch. */
   dirDeps: Set<string>;
-  /** review #1 — PostCSS 가 실제로 .css 파일들에 process 를 적용했는지.
-   *  override.plugins=[] / postcss 미설치 / config 부재 / cssFiles 0 등의
-   *  early-return 은 false. caller (dev-controller) 가 sass-only app 의
-   *  redundant afterBundle PostCSS pass 를 false 판단으로 허용해야 함
-   *  (skipPostcssRun 을 truthy 로 잘못 set 하지 않도록). */
-  applied: boolean;
 }
 
 export async function runPostcssIfConfigured(
@@ -182,7 +176,7 @@ export async function runPostcssIfConfigured(
   if (override) {
     // explicit override path. plugins 가 빈 배열이면 PostCSS process 자체 skip
     // (Vite 식 'explicit no-op' — auto-discover 로 fallback 안 함).
-    if (override.plugins.length === 0) return { deps, dirDeps, applied: false };
+    if (override.plugins.length === 0) return { deps, dirDeps };
     // postcss 자체만 require (app-first / fallback-second).
     // issue #3851 — override.root 가 있으면 그것 use, 아니면 root.
     const requireBase = override.root ?? root;
@@ -199,7 +193,7 @@ export async function runPostcssIfConfigured(
       if (logLevel !== 'silent') {
         console.error('[postcss] override path: postcss require 실패 — skip');
       }
-      return { deps, dirDeps, applied: false };
+      return { deps, dirDeps };
     }
     const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss['postcss'];
     loaded = {
@@ -211,9 +205,8 @@ export async function runPostcssIfConfigured(
   } else {
     loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
   }
-  if (!loaded) return { deps, dirDeps, applied: false };
+  if (!loaded) return { deps, dirDeps };
   const cssFiles = collectAppFiles(cssDir, { skipDir, predicate: isCssFile });
-  if (cssFiles.length === 0) return { deps, dirDeps, applied: false };
   await Promise.all(
     cssFiles.map(async (file) => {
       const input = readFileSync(file, 'utf8');
@@ -230,7 +223,7 @@ export async function runPostcssIfConfigured(
     }),
   );
   logPostcssProcessed(logLevel, cssFiles.length, loaded.configFile);
-  return { deps, dirDeps, applied: true };
+  return { deps, dirDeps };
 }
 
 export interface AppDevPostcssOptions {


### PR DESCRIPTION
## Summary

RFC #3833 v3 D1a'' (Phase 1/2 머지 후) 의 follow-up bug fix 7 PR 을 stacked chain 으로 진행했으나, 각 PR 의 base 가 main 이 아닌 다른 stacked branch 였던 탓에 머지 후에도 main 미도달. 본 PR 이 chain 전체를 main 으로 통합.

## 닫는 이슈

Closes #3847 — dev path zero-config PostCSS double-pass
Closes #3850 — `skipPostcssRun` 시 PostCSS message dir-dependency 누락 (tailwind `@source`)
Closes #3851 — `css({root})` caller-pre-warm 시 root 가 silent ignore
Closes #3852 — `runAppDev` 의 plugin walk 이중 수행
Closes #3853 — `runPostcssForAppDev` 의 `skipPostcssRun=true + sourceRoot=undefined` fallback trap

## 영역별 변경

| 영역 | 변경 |
|---|---|
| `packages/core/bin/zntc.mjs` | `extractCssPostcssOverride` helper / `dropCallerPreWarmedCssPlugin` 추출. `runAppBuild` 가 caller-pre-warm sentinel 가진 css plugin 을 dispatcher 에서 drop (sync × async BundleFailed). `runAppDev` 가 동일 처리 + plugin walk 이중 import 제거. `buildBundleOptions` 의 css filter 가 app caller 만 적용 (bundle 모드 silent drop 회피). |
| `packages/web/src/css/index.ts` | `__cssOptions` sentinel field 신설 — caller 가 plain object 비파괴 추출. `CssZntcPlugin` 내부 type. |
| `packages/web/src/style/postcss.ts` | `RunPostcssIfConfiguredResult { deps, dirDeps }` 신설 (이전 void). PostCSS message 의 deps/dirDeps 수집 (`collectPostcssMessages`). override path 의 `requireBase = override.root ?? root` (#3851). `runPostcssForAppDev.skipPostcssRun + sourceRoot` 명시 throw guard (#3853). |
| `packages/web/src/dev-controller.ts` | `AppCssPipelineResult.postcssDeps/postcssDirDeps` 보존. controller state `preparePostcssApplied / preparePostcssDeps / preparePostcssDirDeps`. `prepare()` 의 carry-over (incremental + 비-CSS dirty 시 undefined → 이전 값 유지). `afterBundle()` 의 skipPostcssRun mirror 통합. |
| `packages/core/test/cli/app-builder/styles/` | 통합 test — explicit override / disabled / findLast / 실 `css()` factory import (`PROJECT_ROOT` + `pathToFileURL`) / dev 의 zero-config single-pass / dev sass / dev CSS Modules mapping shape. |

## chain 머지 mechanics 문제 회고

5 PR (#3848 #3849 #3854 #3855 #3856) 모두 MERGED 상태이나 base 가 stacked branch 라 squash commit 들이 chain 안에만 머무름. chain root 가 main 으로 도달 안 하면 모든 fix 가 main 미도달 + `Closes #N` auto-close 도 미발동. 본 통합 PR 이 단일 머지로 해소.

## 검증

- web build (bundle + dts) pass
- web 단위 test 181 pass / 0 fail
- CLI styles 통합 test 21 pass / 0 fail
- rebase 21 commit 충돌 0

## 후속 (follow-up issue)

- #3857 — `css({root})` 단독 명시 (postcss override 없이) silent ignore (monorepo edge, 별도 분리)
- #3858 — dev `skipPostcssRun` mirror 가 신규 raw root `.css` 첫 fetch 1-cycle 지연 (self-heal, low priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)