### PR TITLE
fix(napi,cli): reconcileOutdirCss 회귀 + rescan boundary (PR #3860 /code-review max)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -14,7 +14,6 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
-  statSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -1831,55 +1830,62 @@ async function emitRestartAfter(opts, reason, beforeSpawn) {
 // ─── Serve 모드 ───
 
 /**
- * #3858 — raw root 와 outdir 의 `.css` set diff → outdir 에만 있는 .css unlink.
- * dev mode 에서 사용자가 raw root 의 .css 를 삭제했을 때 outdir 의 mirror file
- * 도 stale 잔존 회피. native event 의 race / circular event 와 무관하게 fs
- * truth 로 reconcile. cost: O(n) walk, typical CSS count 작아 무시할 수준.
+ * #3858 — raw root .css 의 diff 기반 reconcile. 이전 scan 결과와 비교해
+ * **사라진 path** 만 outdir 에서 unlink. 이전 design (raw vs outdir set diff)
+ * 은 outdir 의 bundler/sass/css-modules 가 emit 한 transient file (chunk.css,
+ * Button.module.zntc.css 등) 을 stale 오판 → unlink 회귀 (/code-review max #4/#5).
+ *
+ * caller 가 closure 로 prevRawSet 보관 — 매 cycle current scan + diff:
+ *   - removed = prev ∖ current → outdir 의 동일 rel path unlink
+ *   - prev := current
+ *
+ * .scss/.sass 는 sass pipeline 이 별도 outdir 에 emit, raw root 의 .scss 자체
+ * 삭제 시 sass 산출물도 dev_controller 가 cleanup. reconcile 은 plain raw .css
+ * 만 cover (사용자가 직접 만든 .css 파일).
+ *
+ * cost: O(raw .css count) walk per rebuild — 일반적 small (dozens).
  */
-function reconcileOutdirCss(rawRoot, outdir) {
-  const rawCssSet = new Set();
-  function walkRaw(dir, relBase) {
-    let entries;
-    try {
-      entries = readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const e of entries) {
-      // node_modules / .git / outdir 의 sub-tree skip — outdir 가 rawRoot 안에 있을 수 있음.
-      if (e.name === 'node_modules' || e.name === '.git') continue;
-      if (e.name.startsWith('.zntc-')) continue;
-      const full = join(dir, e.name);
-      const rel = relBase ? `${relBase}/${e.name}` : e.name;
-      if (e.isDirectory()) walkRaw(full, rel);
-      else if (e.isFile() && e.name.endsWith('.css')) rawCssSet.add(rel);
-    }
-  }
-  walkRaw(rawRoot, '');
+function createReconcileOutdirCss(rawRoot, outdir) {
+  let prevRawSet = new Set();
 
-  function walkOutdir(dir, relBase) {
-    let entries;
-    try {
-      entries = readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const e of entries) {
-      const full = join(dir, e.name);
-      const rel = relBase ? `${relBase}/${e.name}` : e.name;
-      if (e.isDirectory()) walkOutdir(full, rel);
-      else if (e.isFile() && e.name.endsWith('.css')) {
-        if (!rawCssSet.has(rel)) {
-          try {
-            unlinkSync(full);
-          } catch {
-            // best-effort
-          }
-        }
+  function scanRawCss() {
+    const set = new Set();
+    function walk(dir, relBase) {
+      let entries;
+      try {
+        entries = readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const e of entries) {
+        if (e.name === 'node_modules' || e.name === '.git') continue;
+        if (e.name.startsWith('.zntc-')) continue;
+        const rel = relBase ? `${relBase}/${e.name}` : e.name;
+        if (e.isDirectory()) walk(join(dir, e.name), rel);
+        else if (e.isFile() && e.name.endsWith('.css')) set.add(rel);
       }
     }
+    walk(rawRoot, '');
+    return set;
   }
-  walkOutdir(outdir, '');
+
+  // 첫 호출 시 prev 를 현재 raw scan 으로 초기화 — 첫 reconcile cycle 에서
+  // 모든 outdir .css 가 stale 로 오판되는 것 회피.
+  prevRawSet = scanRawCss();
+
+  return function reconcile() {
+    const current = scanRawCss();
+    for (const rel of prevRawSet) {
+      if (current.has(rel)) continue;
+      const target = join(outdir, rel);
+      try {
+        unlinkSync(target);
+      } catch {
+        // best-effort — file 이 없거나 race
+      }
+    }
+    prevRawSet = current;
+  };
 }
 
 async function runServe(opts, config, { appDev = null } = {}) {
@@ -2016,6 +2022,7 @@ async function runServe(opts, config, { appDev = null } = {}) {
     // native watcher (TrackedFileSet 의 dir-watch) 가 처리하도록 root_dir 등록.
     // opts._appWatchRoot 는 runAppDev 가 stash 한 사용자 source code root (outdir
     // 아닌 진짜 src/ 컨테이너). 사용자 명시 watchFolders 가 있으면 union — 우선순위 유지.
+    let reconcileOutdir = null;
     if (opts._appWatchRoot) {
       const autoWatchRoot = resolve(opts._appWatchRoot);
       const existing = Array.isArray(watchBuildOpts.watchFolders)
@@ -2023,6 +2030,11 @@ async function runServe(opts, config, { appDev = null } = {}) {
         : [];
       if (!existing.includes(autoWatchRoot)) {
         watchBuildOpts.watchFolders = [...existing, autoWatchRoot];
+      }
+      // issue #3858 — reconcileOutdir factory 생성 (closure 가 prev/current raw
+      // .css set 추적). onRebuild 마다 호출 — sass/.module/.chunk emit 영향 0.
+      if (opts.outdir) {
+        reconcileOutdir = createReconcileOutdirCss(autoWatchRoot, resolve(opts.outdir));
       }
     }
     watchBuildOpts.onReady = async (event) => {
@@ -2058,11 +2070,6 @@ async function runServe(opts, config, { appDev = null } = {}) {
           // sync 가 필요 (afterBundle 의 mirror 가 tempRoot 만 scan). prepare 가
           // dirty=cssChanges 받아 tempRoot 에 새 .css cpSync + PostCSS process.
           // graphChanged 면 아래 runBundle 분기가 처리 — 중복 회피.
-          // issue #3858 — changed 에 .css 가 포함되어 있고 graphChanged 아니면
-          // prepare + afterBundle 호출. graph 외 신규 .css 는 prepare 의 tempRoot
-          // sync 가 필요 (afterBundle 의 mirror 가 tempRoot 만 scan). prepare 가
-          // dirty=cssChanges 받아 tempRoot 에 새 .css cpSync + PostCSS process.
-          // graphChanged 면 아래 runBundle 분기가 처리 — 중복 회피.
           if (event && event.success && Array.isArray(event.changed) && !event.graphChanged) {
             const cssChanges = event.changed.filter(
               (p) =>
@@ -2078,11 +2085,11 @@ async function runServe(opts, config, { appDev = null } = {}) {
               }
             }
           }
-          // issue #3858 — 매 rebuild 마다 outdir reconcile (raw root .css 와 diff
-          // 후 outdir stale unlink). native delete event 의 race / circular event
-          // 회피. cost: O(.css count) walk per rebuild — 일반적 small.
-          if (event && event.success && opts._appWatchRoot && opts.outdir) {
-            reconcileOutdirCss(opts._appWatchRoot, opts.outdir);
+          // issue #3858 — 매 rebuild 마다 outdir reconcile (raw root .css diff
+          // 후 사라진 path 만 outdir unlink). closure factory 의 prev/current
+          // diff 로 outdir 의 sass/.module/.chunk emit 영향 0.
+          if (event && event.success && reconcileOutdir) {
+            reconcileOutdir();
           }
           if (event && event.success && event.graphChanged) {
             try {

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -692,7 +692,11 @@ fn rescanWatchRootDirty(
     var tit = tracked.keyIterator();
     while (tit.next()) |tp| {
         if (tracked.isDirPath(tp.*)) continue;
+        // /code-review max #1 — startsWith path boundary. root='/foo' 가
+        // '/foobar/x.css' 를 false-positive 매치하지 않도록 separator 또는
+        // 정확 일치 강제. multi-watchFolders 시 다른 root 의 file 영향 차단.
         if (!std.mem.startsWith(u8, tp.*, root)) continue;
+        if (tp.*.len > root.len and tp.*[root.len] != '/' and tp.*[root.len] != '\\') continue;
         if (new_paths.contains(tp.*)) continue;
         const dupe = allocator.dupe(u8, tp.*) catch continue;
         to_remove.append(allocator, dupe) catch {

--- a/packages/core/test/cli/app-builder/styles/dev.ts
+++ b/packages/core/test/cli/app-builder/styles/dev.ts
@@ -257,9 +257,11 @@ describe('CLI: Vite-style app builder > styles > dev', () => {
     }
   });
 
-  // #3858 의 ADD case 는 PASS. DELETE case (reconcile + native event race) 는
-  // test 환경의 macOS /var/folders symlink + APFS dirent cache 와의 상호작용으로
-  // unstable — 별도 follow-up issue 로 분리. `.todo` 표기.
+  // #3858 의 DELETE case 는 design 적용됨 (reconcileOutdirCss diff-based factory).
+  // 실 환경 (`/private/tmp/...` manual test) 에선 작동 (unlink 후 fetch 404). 단
+  // test 환경 (`/var/folders/...` macOS tmpdir) 에선 unlink 후에도 readdirSync/
+  // dev server fetch 가 stale dirent 봐 200 반환 — APFS dirent cache 또는 spawn
+  // child 와 test process 의 fs visibility 차이. 별도 follow-up issue #3861.
   test.todo('dev: 신규 .css add+delete cycle (#3858 follow-up)', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'zntc-app-dev-cssdel-'));
     mkdirSync(join(dir, 'src'), { recursive: true });
@@ -273,19 +275,28 @@ describe('CLI: Vite-style app builder > styles > dev', () => {
 
     const port = await findFreePort();
     const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
+    const stderrChunks: string[] = [];
+    proc.stderr?.on('data', (chunk) => stderrChunks.push(chunk.toString()));
     await waitForServer(port);
     try {
       // (1) 신규 .css 추가 + 200 검증
       writeFileSync(join(dir, 'src', 'tmp.css'), '.tmp{color:blue}');
-      await new Promise((r) => setTimeout(r, 2500));
+      await new Promise((r) => setTimeout(r, 3000));
       const r1 = await fetch(`http://localhost:${port}/src/tmp.css`);
       expect(r1.status).toBe(200);
 
-      // (2) 삭제 → fetch 404 (mirror 정리 검증)
+      // (2) 삭제 → poll fetch 까지 404 (reconcile + fs cache race window 회피).
+      // reconcileOutdirCss 의 prev/current diff 로 사라진 path unlink 후 APFS
+      // dirent cache 가 갱신되기까지 추가 cycle 가능 — 최대 8초 poll.
       rmSync(join(dir, 'src', 'tmp.css'));
-      await new Promise((r) => setTimeout(r, 2500));
-      const r2 = await fetch(`http://localhost:${port}/src/tmp.css`);
-      expect(r2.status).toBe(404);
+      let last = 200;
+      for (let i = 0; i < 16; i++) {
+        await new Promise((r) => setTimeout(r, 500));
+        const r2 = await fetch(`http://localhost:${port}/src/tmp.css`);
+        last = r2.status;
+        if (last === 404) break;
+      }
+      expect(last).toBe(404);
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

PR #3860 (#3858 main 머지) 후속 \`/code-review max\` finding fix.

## 5 finding fix

| # | severity | 변경 |
|---|---|---|
| #4/#5 | **HIGH** | reconcileOutdirCss 가 raw vs outdir set diff → sass/.module.zntc.css/chunk .css 등 transient emit 까지 unlink 회귀. closure factory \`createReconcileOutdirCss\` 로 변경 (prev vs current raw diff 만 unlink) |
| #1 | MEDIUM | rescanWatchRootDirty 의 startsWith boundary 누락. root='/foo' 가 '/foobar/x.css' 매치 차단 |
| #6 | LOW | 중복 6-line comment block 제거 |
| #12 | LOW | dead \`statSync\` import 제거 |
| #11 | REFUTED | inotify dir-watch 분기가 IN.CREATE/DELETE/MOVED_* 만 통과 — file modify 는 dir 분기 skip, file 분기만 dispatch. cost 없음 |

## DELETE case follow-up (#3861)

reconcileOutdirCss diff-based design 적용으로 manual 환경 (\`/private/tmp/...\`) 에선 작동. test 환경 (\`/var/folders/...\`) 의 APFS dirent cache + spawn child vs test process fs visibility race 로 fetch 가 200 잔존 → \`.todo\` 유지. follow-up issue #3861 에 진단 결과 update.

## 회귀 가드

- styles 통합 23 pass / 1 todo / 0 fail
- FileWatcher 30 pass
- Zig build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)