### PR TITLE
docs(readme): fix dev server example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ npx zntc src/index.ts --outdir dist
 npx zntc src/index.ts --bundle --outdir dist --format=esm --target=es2022
 
 # Dev server + HMR + Fast Refresh
-npx zntc serve src/main.tsx --port 5173
+npx zntc --serve --bundle src/main.tsx --port 5173
+# Or with the `dev` subcommand (root-based):
+# npx zntc dev --port 5173
 
 # React Native (Metro-compatible)
 npx zntc --bundle index.js --platform=react-native --rn-platform=ios -o bundle.js

--- a/README_KO.md
+++ b/README_KO.md
@@ -50,7 +50,9 @@ npx zntc src/index.ts --outdir dist
 npx zntc src/index.ts --bundle --outdir dist --format=esm --target=es2022
 
 # Dev server + HMR + Fast Refresh
-npx zntc serve src/main.tsx --port 5173
+npx zntc --serve --bundle src/main.tsx --port 5173
+# 또는 `dev` 서브커맨드 (root 기준):
+# npx zntc dev --port 5173
 
 # React Native (Metro 호환)
 npx zntc --bundle index.js --platform=react-native --rn-platform=ios -o bundle.js


### PR DESCRIPTION
## Summary
- README 의 dev server 예제 `npx zntc serve src/main.tsx --port 5173` 가 동작하지 않음 — `serve` 는 subcommand 가 아니라 `--serve` flag 임 (`packages/core/bin/zntc.mjs:227` 의 `appCommands` 는 `dev`/`build`/`preview`/`verify` 뿐). 이 형태로 입력하면 `serve` 가 entry 파일명으로 해석되어 fail.
- `npx zntc --serve --bundle <entry> --port <n>` (help 의 canonical form, `zntc.mjs:175`) 으로 교체하고, root 기준의 `dev` 서브커맨드를 주석으로 대안 안내.
- 영문/한글 README 둘 다 동일하게 수정.

## Test plan
- [x] `cli-flags.mjs` 에서 `--serve` / `--bundle` / `--port` / `dev` subcommand 모두 등록 확인
- [x] pre-push (zig build test + oxlint + oxfmt) 통과
- [ ] PR preview 에서 코드 블록 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)