### PR TITLE
fix(cli,web): css({root}) 단독 명시 시 auto-discover search base routing (Closes #3857)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -746,7 +746,11 @@ function extractCssAutoDiscoverRoot(plugins) {
   const opts = extractCssOptions(plugins);
   if (!opts || opts.disabled === true) return null;
   if (opts.postcss) return null;
-  return opts.root ?? null;
+  // /code-review max #3/#4: type/empty guard — non-string 또는 빈 string 거부.
+  // findPostcssConfig(non-string) → TypeError, findPostcssConfig('') → cwd 기준
+  // wrong-base search. 사용자 invalid 입력은 silent null (auto-discover skip).
+  if (typeof opts.root !== 'string' || opts.root.length === 0) return null;
+  return opts.root;
 }
 
 /**

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -700,14 +700,22 @@ function getAutoConfigSearchDir(opts) {
  * @param {Array<{name?:string,__cssOptions?:object}>} plugins
  * @returns {{plugins: unknown[], options: Record<string,unknown> | undefined} | null}
  */
-function extractCssPostcssOverride(plugins) {
+/**
+ * sentinel `__cssOptions` 보유 css plugin 의 raw options 추출. 매치 안 되면 null.
+ * extractCssPostcssOverride / extractCssAutoDiscoverRoot 의 공통 helper.
+ */
+function extractCssOptions(plugins) {
   const cssPlugin = plugins.findLast(
     // 두 항 모두 optional chain — predicate 순서 변경 시 null/undefined deref 회귀
     // 차단 (/code-review max #1 latent finding).
     (p) => p?.name === '@zntc/web/css' && p?.__cssOptions !== undefined,
   );
-  if (!cssPlugin?.__cssOptions) return null;
-  const opts = cssPlugin.__cssOptions;
+  return cssPlugin?.__cssOptions ?? null;
+}
+
+function extractCssPostcssOverride(plugins) {
+  const opts = extractCssOptions(plugins);
+  if (!opts) return null;
   if (opts.disabled === true) return { plugins: [], options: undefined };
   if (opts.postcss) {
     return {
@@ -721,11 +729,24 @@ function extractCssPostcssOverride(plugins) {
       root: opts.root,
     };
   }
-  // review #2 — `css({root})` 단독 명시 (postcss override 없이) 시 root 가
-  // auto-discover path 에서 silent ignore. fix 가 design 변경 (prepare 가 새
-  // cssAutoDiscoverRoot 옵션 받아 findPostcssConfig 의 search base swap) 필요 —
-  // monorepo edge case, 본 PR scope 외 별도 issue (TODO).
   return null;
+}
+
+/**
+ * issue #3857 — `css({root})` 단독 명시 (postcss override 없이) 시 root 가
+ * auto-discover path 의 findPostcssConfig 시작 base 로 사용되게 caller 가 전달.
+ * monorepo edge: postcss.config 가 monorepo root 에 있고 app 이 sub-package
+ * 인 경우 사용자가 root='/monorepo-root' 명시.
+ *
+ * - opts.disabled 면 null (자동발견 차단은 disabled true 의 책임)
+ * - opts.postcss truthy 면 null (override path 가 root 직접 routing)
+ * - opts.root 만 있으면 그것 반환
+ */
+function extractCssAutoDiscoverRoot(plugins) {
+  const opts = extractCssOptions(plugins);
+  if (!opts || opts.disabled === true) return null;
+  if (opts.postcss) return null;
+  return opts.root ?? null;
 }
 
 /**
@@ -775,6 +796,9 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   if (opts.clean) rmSync(outdir, { recursive: true, force: true });
   // RFC #3833 v3 D1a'' caller-side pre-warm — extractCssPostcssOverride helper 참조.
   const postcssOverride = extractCssPostcssOverride(appPlugins);
+  // issue #3857 — css({root}) 단독 명시 시 findPostcssConfig search base
+  // (monorepo edge: app 이 sub-package, postcss.config 가 monorepo root).
+  const cssAutoDiscoverRoot = extractCssAutoDiscoverRoot(appPlugins);
   // dropCallerPreWarmedCssPlugin: sentinel 가진 css plugin 을 항상 dispatcher 에서
   // 제거 (buildBundleOptions 와 동일 무조건 적용). /code-review max #5: 조건부
   // (postcssOverride truthy 시만) 분기는 비대칭 — 사용자가 sentinel 만 가진
@@ -790,7 +814,7 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
       opts.logLevel,
       'build',
       { fallbackRequire: requireFromCli, cliNodeModules },
-      { postcssOverride },
+      { postcssOverride, cssAutoDiscoverRoot },
     );
     pipelineRoot = pipeline?.tempRoot ?? null;
     const result = buildAppSync({
@@ -852,7 +876,14 @@ async function runAppDev(opts, config, configEnv, _dotenvVars) {
     else if (typeof cfg.setup === 'function') devUserPlugins.push(cfg);
   }
   const appDev = web.createAppDevController(
-    { ...opts, postcssOverride: extractCssPostcssOverride(devUserPlugins) },
+    {
+      ...opts,
+      postcssOverride: extractCssPostcssOverride(devUserPlugins),
+      // issue #3857 — css({root}) 단독 명시 (postcss override 없이) 시 root 를
+      // findPostcssConfig 의 search base 로 전달. monorepo 의 sub-package app
+      // 이 monorepo root 의 postcss.config 참조하는 시나리오.
+      cssAutoDiscoverRoot: extractCssAutoDiscoverRoot(devUserPlugins),
+    },
     root,
     configEnv,
     { fallbackRequire: requireFromCli, cliNodeModules },

--- a/packages/core/test/cli/app-builder/styles/postcss.ts
+++ b/packages/core/test/cli/app-builder/styles/postcss.ts
@@ -181,6 +181,97 @@ describe('CLI: Vite-style app builder > styles > PostCSS', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  // issue #3857 — `css({root})` 단독 명시 (postcss override 없이) 시 root 가
+  // auto-discover path 의 findPostcssConfig/loadPostcssConfig search base 로
+  // 사용. monorepo edge: app 이 sub-package (`apps/web/`), postcss.config 는
+  // monorepo root (`./postcss.config.mjs`). 기존 동작 = app 안에서만 search
+  // → 발견 0 → PostCSS no-op. fix 후 = root 명시로 monorepo root 의 config
+  // 발견 → PostCSS marker 적용.
+  test('css({root: monorepoRoot}) — auto-discover path 의 root 위치 search (#3857)', () => {
+    const monorepoRoot = mkdtempSync(join(tmpdir(), 'zntc-app-monorepo-'));
+    const appDir = join(monorepoRoot, 'apps', 'web');
+    mkdirSync(join(appDir, 'src'), { recursive: true });
+
+    // monorepo root 에만 postcss.config.mjs
+    writeFileSync(
+      join(monorepoRoot, 'postcss.config.mjs'),
+      [
+        'export default {',
+        '  plugins: [',
+        "    { postcssPlugin: 'monorepo-root-marker', Once(root) { root.append({ selector: '.monorepo-applied', nodes: [] }); } },",
+        '  ],',
+        '};',
+      ].join('\n'),
+    );
+
+    // app 안 zntc.config.mjs — css({root: monorepoRoot}) 만 명시 (override X)
+    // monorepoRoot 의 절대 경로를 JSON.stringify 로 safely embed.
+    writeFileSync(
+      join(appDir, 'index.html'),
+      '<div class="card">monorepo</div><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(appDir, 'src', 'main.ts'), 'import "./style.css";');
+    writeFileSync(join(appDir, 'src', 'style.css'), '.card { color: red; }\n');
+    writeFileSync(
+      join(appDir, 'zntc.config.mjs'),
+      [
+        `import { css } from ${JSON.stringify(CSS_FACTORY_URL)};`,
+        'export default {',
+        '  plugins: [',
+        `    css({ root: ${JSON.stringify(monorepoRoot)} }),`,
+        '  ],',
+        '};',
+      ].join('\n'),
+    );
+
+    const outdir = join(appDir, 'dist');
+    const { exitCode, stderr } = runCli(['build', appDir, '--outdir', outdir], { cwd: appDir });
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain('[postcss] processed 1 CSS file');
+    const css = readFileSync(join(outdir, 'main.css'), 'utf8');
+    // monorepo root 의 postcss.config 가 적용됨 → marker 존재
+    expect(css).toContain('.monorepo-applied');
+    expect(css).toContain('.card');
+    rmSync(monorepoRoot, { recursive: true, force: true });
+  });
+
+  // 회귀 가드 — css({root}) 미명시 시 기존 동작 유지 (app root 만 search).
+  // monorepo root 에 postcss.config 있어도 app 안에서 search 못 찾으면 no-op.
+  test('css() root 미명시 — 기존 app-only search 동작 유지 (#3857 회귀)', () => {
+    const monorepoRoot = mkdtempSync(join(tmpdir(), 'zntc-app-monorepo-noopt-'));
+    const appDir = join(monorepoRoot, 'apps', 'web');
+    mkdirSync(join(appDir, 'src'), { recursive: true });
+
+    writeFileSync(
+      join(monorepoRoot, 'postcss.config.mjs'),
+      [
+        'export default {',
+        '  plugins: [',
+        "    { postcssPlugin: 'should-not-apply', Once(root) { root.append({ selector: '.should-not-apply', nodes: [] }); } },",
+        '  ],',
+        '};',
+      ].join('\n'),
+    );
+
+    writeFileSync(
+      join(appDir, 'index.html'),
+      '<div class="card">noopt</div><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(appDir, 'src', 'main.ts'), 'import "./style.css";');
+    writeFileSync(join(appDir, 'src', 'style.css'), '.card { color: red; }\n');
+    // zntc.config 없음 → css() 도 없음 → cssAutoDiscoverRoot 없음
+    // → findPostcssConfig 가 app root 만 search
+
+    const outdir = join(appDir, 'dist');
+    const { exitCode } = runCli(['build', appDir, '--outdir', outdir], { cwd: appDir });
+    expect(exitCode).toBe(0);
+    const css = readFileSync(join(outdir, 'main.css'), 'utf8');
+    // monorepo root 의 marker 가 적용되지 않아야 (search base = app root)
+    expect(css).not.toContain('.should-not-apply');
+    expect(css).toContain('.card');
+    rmSync(monorepoRoot, { recursive: true, force: true });
+  });
+
   test('Tailwind v4 @tailwindcss/postcss app fixture', () => {
     const dir = mkdtempSync(join(tmpdir(), 'zntc-app-tailwind-'));
     mkdirSync(join(dir, 'src'), { recursive: true });

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -324,6 +324,14 @@ export async function prepareAppCssPipelineRoot(
   // issue #3857 — cssAutoDiscoverRoot 가 있으면 그것을 findPostcssConfig 시작 base
   // 로 사용 (monorepo edge: app 이 sub-package, postcss.config 가 monorepo root).
   const configPath = postcssOverride ? null : findPostcssConfig(cssAutoDiscoverRoot ?? root);
+  // /code-review max #2 — 사용자가 cssAutoDiscoverRoot 명시했는데 그 path 에서
+  // postcss.config 발견 못 했을 때 silent skip 회피. issue #3857 의 silent ignore
+  // 패턴 재발 차단 — typo (`css({root:'/wrong/path'})`) 진단 가시화.
+  if (cssAutoDiscoverRoot && !configPath && !postcssOverride && logLevel !== 'silent') {
+    console.error(
+      `[postcss] css({root}) 명시 — ${cssAutoDiscoverRoot} 에서 postcss.config.* 발견 못함 — auto-discover skip`,
+    );
+  }
   // F1 cache: 이전 prep 의 stylePipelineFiles 를 재사용. 호출자가 구조 변화 (.scss/.module.css
   // 추가/삭제) 시 cache=null 로 무효화한다. 재사용이면 full tree walk 를 통째 회피.
   const stylePipelineFiles =

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -81,6 +81,10 @@ export interface AppDevControllerOptions {
      *  runPostcssIfConfigured 가 동일 field name 으로 read. */
     root?: string;
   } | null;
+  /** issue #3857 — css({root}) 단독 명시 시 findPostcssConfig search base.
+   *  controller 가 prepareAppCssPipelineRoot 의 cssAutoDiscoverRoot 옵션으로
+   *  forward. monorepo edge (app 이 sub-package, postcss.config 가 monorepo root). */
+  cssAutoDiscoverRoot?: string | null;
 }
 
 export interface AppDevControllerDeps {
@@ -118,6 +122,11 @@ export interface PrepareAppCssPipelineRootOptions {
      *  field — controller 가 forward. */
     root?: string;
   } | null;
+  /** issue #3857 — css({root}) 단독 명시 (postcss override 없이) 시 root 가
+   *  auto-discover path 의 findPostcssConfig 시작 base 로 사용되게 caller 가
+   *  전달. monorepo edge: app 이 sub-package, postcss.config 가 monorepo root.
+   *  미지정 시 root 인자 사용 — 기존 동작 유지. */
+  cssAutoDiscoverRoot?: string | null;
 }
 
 export interface AppCssPipelineResult {
@@ -308,10 +317,13 @@ export async function prepareAppCssPipelineRoot(
     cache = null,
     sassReverseDep = null,
     postcssOverride = null,
+    cssAutoDiscoverRoot = null,
   } = options;
   const { fallbackRequire, cliNodeModules } = deps;
   // configPath 자동 발견은 override 없을 때만 필요. override 가 있으면 자동 발견 skip.
-  const configPath = postcssOverride ? null : findPostcssConfig(root);
+  // issue #3857 — cssAutoDiscoverRoot 가 있으면 그것을 findPostcssConfig 시작 base
+  // 로 사용 (monorepo edge: app 이 sub-package, postcss.config 가 monorepo root).
+  const configPath = postcssOverride ? null : findPostcssConfig(cssAutoDiscoverRoot ?? root);
   // F1 cache: 이전 prep 의 stylePipelineFiles 를 재사용. 호출자가 구조 변화 (.scss/.module.css
   // 추가/삭제) 시 cache=null 로 무효화한다. 재사용이면 full tree walk 를 통째 회피.
   const stylePipelineFiles =
@@ -421,6 +433,7 @@ export async function prepareAppCssPipelineRoot(
       logLevel,
       fallbackRequire,
       postcssOverride,
+      cssAutoDiscoverRoot,
     );
     postcssDeps = postcssResult.deps;
     postcssDirDeps = postcssResult.dirDeps;
@@ -566,6 +579,8 @@ export function createAppDevController(
       // (runAppDev) 의 explicit `css({postcss:{...override}})` 를 prepare 의
       // PostCSS 단계에 전달. dev/build divergence 해소.
       const postcssOverride = opts.postcssOverride ?? null;
+      // issue #3857 — controller 가 cssAutoDiscoverRoot 도 prepare 로 forward.
+      const cssAutoDiscoverRoot = opts.cssAutoDiscoverRoot ?? null;
       const pipeline = await prepareAppCssPipelineRoot(
         root,
         outdir,
@@ -580,8 +595,9 @@ export function createAppDevController(
               cache: pipelineCache,
               sassReverseDep,
               postcssOverride,
+              cssAutoDiscoverRoot,
             }
-          : { sassReverseDep, postcssOverride },
+          : { sassReverseDep, postcssOverride, cssAutoDiscoverRoot },
       );
       pipelineRoot = pipeline?.tempRoot ?? null;
       pipelineCache = pipeline?.cache ?? null;
@@ -662,6 +678,8 @@ export function createAppDevController(
         skipPostcssRun: preparePostcssApplied,
         // issue #3847 — mirror 의 source 가 prepare 의 tempRoot (PostCSS 처리됨)
         sourceRoot: pipelineRoot ?? root,
+        // issue #3857 — auto-discover path 의 search base forward
+        cssAutoDiscoverRoot: opts.cssAutoDiscoverRoot ?? null,
       });
       cssDeps = result.deps;
       cssDirDeps = result.dirDeps;

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -169,6 +169,11 @@ export async function runPostcssIfConfigured(
      *  base. 미지정 시 root 인자 사용. */
     root?: string;
   } | null,
+  /** issue #3857 — css({root}) 단독 명시 시 auto-discover path 의 search base.
+   *  override 없을 때 loadPostcssConfig(cssAutoDiscoverRoot ?? root) 로 호출 →
+   *  postcss.config 가 monorepo root 에 있고 app 이 sub-package 인 시나리오 cover.
+   *  미지정 시 root 인자 사용 — 기존 동작 유지. */
+  cssAutoDiscoverRoot?: string | null,
 ): Promise<RunPostcssIfConfiguredResult> {
   const deps = new Set<string>();
   const dirDeps = new Set<string>();
@@ -203,7 +208,9 @@ export async function runPostcssIfConfigured(
       configFile: null,
     };
   } else {
-    loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
+    // issue #3857 — auto-discover path 의 search base. cssAutoDiscoverRoot
+    // (monorepo root 등) 가 있으면 그것 사용, 없으면 root 인자 (tempRoot).
+    loaded = await loadPostcssConfig(cssAutoDiscoverRoot ?? root, configEnv, fallbackRequire);
   }
   if (!loaded) return { deps, dirDeps };
   const cssFiles = collectAppFiles(cssDir, { skipDir, predicate: isCssFile });
@@ -252,6 +259,10 @@ export interface AppDevPostcssOptions {
   /** skipPostcssRun=true 시 mirror 의 source root (prepare 의 tempRoot 또는
    *  raw root). 미지정 시 root 사용. controller 가 pipelineRoot 전달. */
   sourceRoot?: string;
+  /** issue #3857 — auto-discover path 의 findPostcssConfig/loadPostcssConfig
+   *  search base. monorepo edge: app 이 sub-package, postcss.config 가
+   *  monorepo root. 미지정 시 root 인자 사용. */
+  cssAutoDiscoverRoot?: string | null;
 }
 
 export interface AppDevPostcssResult {
@@ -280,6 +291,7 @@ export async function runPostcssForAppDev(
     postcssOverride = null,
     skipPostcssRun = false,
     sourceRoot,
+    cssAutoDiscoverRoot = null,
   } = options;
   // issue #3853 — skipPostcssRun=true 시 sourceRoot 명시 의무화. fallback (raw
   // root) 으로 silent 떨어지면 PostCSS 미적용 .css 가 outdir 로 copy → dev server
@@ -319,7 +331,9 @@ export async function runPostcssForAppDev(
   }
   // override 가 있으면 자동발견 skip. plugins.length === 0 면 explicit no-op
   // (build path 의 runPostcssIfConfigured 와 동일 시맨틱).
-  const configPath = postcssOverride ? null : findPostcssConfig(root);
+  // issue #3857 — auto-discover path 의 search base. cssAutoDiscoverRoot 가
+  // 있으면 그것 사용 (monorepo edge).
+  const configPath = postcssOverride ? null : findPostcssConfig(cssAutoDiscoverRoot ?? root);
   if (!configPath && !postcssOverride) {
     const first = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile })[0];
     if (first) primaryHref = joinUrl(base, relative(root, first));
@@ -361,7 +375,8 @@ export async function runPostcssForAppDev(
       configFile: null,
     };
   } else {
-    loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
+    // issue #3857 — auto-discover path 의 search base.
+    loaded = await loadPostcssConfig(cssAutoDiscoverRoot ?? root, configEnv, fallbackRequire);
   }
   if (!loaded) return { deps, dirDeps, primaryHref, processed: 0 };
   if (loaded.configFile) deps.add(resolve(loaded.configFile));

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -110,12 +110,18 @@ export async function loadPostcssConfig(
   root: string,
   configEnv: ConfigEnv,
   fallbackRequire: NodeRequire,
+  /** issue #3857 /code-review max #1 — postcss / postcss-load-config 의
+   *  require base. config search 가 monorepo root 인 경우에도 module require
+   *  는 app root 가 정상 (pnpm strict / nohoist 환경에서 monorepo root 에
+   *  postcss 미설치 가능). 미지정 시 root 인자 사용 — 기존 동작 유지. */
+  requireBase?: string,
 ): Promise<LoadedPostcss | null> {
-  const postcssrc = requireFromAppRoot(root, fallbackRequire, 'postcss-load-config') as (
+  const reqBase = requireBase ?? root;
+  const postcssrc = requireFromAppRoot(reqBase, fallbackRequire, 'postcss-load-config') as (
     env: { cwd: string; env: string },
     root: string,
   ) => Promise<PostcssrcConfig>;
-  const postcssModule = requireFromAppRoot(root, fallbackRequire, 'postcss') as {
+  const postcssModule = requireFromAppRoot(reqBase, fallbackRequire, 'postcss') as {
     default?: LoadedPostcss['postcss'];
   } & LoadedPostcss['postcss'];
   const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss['postcss'];
@@ -210,7 +216,9 @@ export async function runPostcssIfConfigured(
   } else {
     // issue #3857 — auto-discover path 의 search base. cssAutoDiscoverRoot
     // (monorepo root 등) 가 있으면 그것 사용, 없으면 root 인자 (tempRoot).
-    loaded = await loadPostcssConfig(cssAutoDiscoverRoot ?? root, configEnv, fallbackRequire);
+    // /code-review max #1: require base 는 app root 유지 (pnpm strict 환경에서
+    // monorepo root 에 postcss 미설치 가능 — module resolve 는 app root 기준).
+    loaded = await loadPostcssConfig(cssAutoDiscoverRoot ?? root, configEnv, fallbackRequire, root);
   }
   if (!loaded) return { deps, dirDeps };
   const cssFiles = collectAppFiles(cssDir, { skipDir, predicate: isCssFile });
@@ -375,8 +383,8 @@ export async function runPostcssForAppDev(
       configFile: null,
     };
   } else {
-    // issue #3857 — auto-discover path 의 search base.
-    loaded = await loadPostcssConfig(cssAutoDiscoverRoot ?? root, configEnv, fallbackRequire);
+    // issue #3857 — auto-discover path 의 search base. require base 는 app root.
+    loaded = await loadPostcssConfig(cssAutoDiscoverRoot ?? root, configEnv, fallbackRequire, root);
   }
   if (!loaded) return { deps, dirDeps, primaryHref, processed: 0 };
   if (loaded.configFile) deps.add(resolve(loaded.configFile));


### PR DESCRIPTION
## Summary

issue #3857 — \`css({root: monorepoRoot})\` 단독 명시 (postcss override 없이) 시 root 가 silent ignore 됐던 monorepo edge case fix.

Closes #3857

## 설계

- \`extractCssOptions\` helper 분리 (extractCssPostcssOverride / extractCssAutoDiscoverRoot 공통 base)
- \`extractCssAutoDiscoverRoot\`: opts.disabled/postcss truthy → null, opts.root 만 있으면 그것 (type/empty guard 포함)
- \`cssAutoDiscoverRoot\` 옵션을 AppDevControllerOptions / PrepareAppCssPipelineRootOptions / AppDevPostcssOptions / runPostcssIfConfigured 에 추가
- prepareAppCssPipelineRoot 의 findPostcssConfig + runPostcssIfConfigured 의 loadPostcssConfig 가 cssAutoDiscoverRoot ?? root 사용
- runPostcssForAppDev 도 동일 routing
- runAppBuild / runAppDev 가 extract + 전달

## /code-review max finding fix (5)

- **HIGH** loadPostcssConfig 가 config search base + require base 양쪽 같은 root 사용 → pnpm strict 환경에서 monorepo root 의 postcss 미설치 시 fail. → signature 에 \`requireBase\` 옵션 추가, caller 가 명시적으로 (search=monorepoRoot, require=appRoot) 분리.
- **MEDIUM** cssAutoDiscoverRoot 명시 + 발견 실패 시 silent skip → typo 진단 어려움. logLevel != silent 시 warn.
- **LOW #3** empty string ('') nullish 우회 → wrong-base search. \`length > 0\` 가드.
- **LOW #4** non-string type → TypeError. \`typeof === 'string'\` 가드.
- **INFO #5** tailwind config 의 상대 path 가 cssAutoDiscoverRoot 기준 resolve — 사용자 의도. docs 후속.

## 회귀 가드 test (2)

- monorepo edge: monorepo root 의 postcss.config 가 app 안 css({root:monorepoRoot}) 로 발견 → marker 적용 검증
- css() root 미명시: 기존 app-only search 동작 유지 — monorepo root marker 가 app 빌드에 안 들어감 검증

## 검증

- styles 통합 25 pass / 1 todo (#3861 follow-up) / 0 fail
- web 단위 181 pass / 0 fail
- web build (bundle + dts) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)