### PR TITLE
fix(cli,web): dev-incremental PostCSS 회귀 fix + DELETE test 통과 (main CI 복구)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -2100,53 +2100,14 @@ async function runServe(opts, config, { appDev = null } = {}) {
       // 시점 — cold-start 는 watch 1회만).
       void (async () => {
         try {
-          // issue #3858 — changed 에 .css 가 포함되어 있고 graphChanged 아니면
-          // prepare + afterBundle 호출. graph 외 신규 .css 는 prepare 의 tempRoot
-          // sync 가 필요 (afterBundle 의 mirror 가 tempRoot 만 scan). prepare 가
-          // dirty=cssChanges 받아 tempRoot 에 새 .css cpSync + PostCSS process.
-          // graphChanged 면 아래 runBundle 분기가 처리 — 중복 회피.
-          if (event && event.success && Array.isArray(event.changed) && !event.graphChanged) {
-            // #3861 — outdir 안 path 는 cssChanges 에서 제외. reconcileOutdir 의
-            // unlink 가 kqueue NOTE.DELETE 발생 → outdir path 가 changed_files
-            // 에 들어가 다음 cycle 의 prepare/afterBundle 가 mirror 다시 → unlink
-            // 효과 무효화 → 무한 loop. outdir 의 fs event 는 dev 결과 (mirror /
-            // bundler emit) 이므로 source-of-truth 가 아니라 처음부터 무시.
-            // /code-review max #1: path boundary — outdir='/a/dist' 가 sibling
-            // '/a/dist-vendor/foo.css' false-positive 매치 방지. line 2467 의
-            // drain filter (`${outdirAbs}${sep}`) 와 동형 (exact + sep prefix).
-            // /code-review max #2: outdir 가 source root 와 동일/상위면 filter
-            // skip — outdir == watchRoot (e.g. `--outdir .`) 시 raw root 의
-            // .css 전부 false-positive 제외되어 dev HMR 차단. opts._appWatchRoot
-            // 를 보호 — outdir 가 watchRoot 와 무관 (외부 dir) 일 때만 filter.
-            const resolvedOutdir = opts.outdir ? resolve(opts.outdir) : null;
-            const resolvedWatchRoot = opts._appWatchRoot ? resolve(opts._appWatchRoot) : null;
-            const outdirEqualsOrContainsWatchRoot =
-              resolvedOutdir &&
-              resolvedWatchRoot &&
-              (resolvedOutdir === resolvedWatchRoot ||
-                resolvedWatchRoot.startsWith(`${resolvedOutdir}${sep}`));
-            const resolvedOutdirPrefix =
-              resolvedOutdir && !outdirEqualsOrContainsWatchRoot ? `${resolvedOutdir}${sep}` : null;
-            const cssChanges = event.changed.filter((p) => {
-              if (typeof p !== 'string') return false;
-              if (!(p.endsWith('.css') || p.endsWith('.scss') || p.endsWith('.sass'))) return false;
-              if (
-                resolvedOutdirPrefix &&
-                (p === resolvedOutdir || p.startsWith(resolvedOutdirPrefix))
-              ) {
-                return false;
-              }
-              return true;
-            });
-            if (cssChanges.length > 0) {
-              try {
-                await appDev.prepare(cssChanges);
-                await appDev.afterBundle({ changedPath: cssChanges[0] });
-              } catch (cssErr) {
-                console.error('[serve] css prepare+afterBundle failed:', cssErr);
-              }
-            }
-          }
+          // issue #3858 — native onRebuild 의 cssChanges 분기는 PR #3859 머지로
+          // 도입됐으나, drain (fs.watch) 가 이미 같은 fs event 받아 rebuildAppDevCss
+          // (syncDirty + afterBundle, PostCSS incremental) 로 처리. dual watch race
+          // 의 source 였음 + prepare 호출이 PostCSS 를 tempRoot 전체 reprocess →
+          // "processed N" 회귀 (dev-hmr/postcss test fail). drain 단일 처리로 통합.
+          // graph 외 .css ADD case (#3858 핵심) 는 drain 의 fs.watch (recursive)
+          // 가 신규 add event 받아 처리 — native 의 cssChanges 분기 redundant.
+          // 단 graphChanged 시 outdir 갱신은 아래 runBundle 분기가 cover.
           // issue #3858 — 매 rebuild 마다 outdir reconcile (raw root .css diff
           // 후 사라진 path 만 outdir unlink). closure factory 의 prev/current
           // diff 로 outdir 의 sass/.module/.chunk emit 영향 0.
@@ -2349,25 +2310,21 @@ async function runServe(opts, config, { appDev = null } = {}) {
     // fsWatch + drain (CSS / sass / postcss / restart) 만 — JS 변경은 native watch 가 단독 처리.
 
     async function rebuildAppDevCss(changedPath) {
-      // issue #3861 — prepare 도 호출. drain 이 prepare skip 시 tempRoot 가
-      // raw root 의 변경 (특히 delete) 와 동기 안 되어 afterBundle 의 mirror 가
-      // stale .css 를 outdir 에 다시 write → reconcileOutdirCss 의 unlink 무효화
-      // (drain 과 native onRebuild 의 dual watch race). prepare 가 raw root 의
-      // 현재 상태로 tempRoot sync — delete 시 tempRoot 에서도 unlink → mirror
-      // 도 안 함.
-      // prepare/afterBundle 의 throw — drain outer catch (line 2460) 가
-      // hmr.reportThrownError + console.error('[serve] rebuild error') 처리.
-      // 내부 catch 에서 reportThrownError 중복 호출은 동일 err 가 2 번 broadcast
-      // 됨 (review max #1). css-specific 진단 메시지만 추가 + throw (드레인 finally
-      // 가 rebuilding=false 보장).
+      // issue #3861 — drain (fs.watch) 가 prepare skip 시 tempRoot 가 raw root
+      // 와 동기 안 되어 afterBundle 의 mirror 가 stale .css 를 outdir 에 다시
+      // write → reconcileOutdirCss 의 unlink 무효화 (dual watch race).
+      // syncDirty 는 prepare 의 syncDirtyFilesIntoTempRoot 만 호출 — PostCSS
+      // 재실행 skip (prepare 가 full PostCSS reprocess 라 단일 CSS modify 시
+      // 전체 .css 처리 → "processed N" 회귀, dev-hmr/postcss test fail). PostCSS
+      // incremental 처리는 아래 afterBundle 의 changedPath 분기가 cover.
+      appDev.syncDirty([changedPath]);
       try {
-        await appDev.prepare([changedPath]);
         await appDev.afterBundle({ changedPath });
       } catch (cssErr) {
         if (opts.logLevel !== 'silent') {
-          console.error('[serve] css prepare+afterBundle failed:', cssErr);
+          console.error('[serve] css afterBundle failed:', cssErr);
         }
-        throw cssErr;
+        throw cssErr; // drain outer catch (line 2460) 가 hmr.reportThrownError.
       }
       hmr?.clearError();
       hmr?.broadcast({

--- a/packages/core/test/cli/app-builder/styles/dev.ts
+++ b/packages/core/test/cli/app-builder/styles/dev.ts
@@ -274,13 +274,11 @@ describe('CLI: Vite-style app builder > styles > dev', () => {
 
     const port = await findFreePort();
     const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
-    const stderrChunks: string[] = [];
-    proc.stderr?.on('data', (chunk) => stderrChunks.push(chunk.toString()));
     await waitForServer(port);
     try {
       // (1) 신규 .css 추가 + 200 검증
       writeFileSync(join(dir, 'src', 'tmp.css'), '.tmp{color:blue}');
-      await new Promise((r) => setTimeout(r, 3000));
+      await new Promise((r) => setTimeout(r, 1500));
       const r1 = await fetch(`http://localhost:${port}/src/tmp.css`);
       expect(r1.status).toBe(200);
 

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -488,6 +488,15 @@ export interface AppDevController {
   readonly outdir: string;
   readonly base: string;
   prepare(dirtyPaths?: readonly string[] | null): Promise<AppDevPrepareResult>;
+  /**
+   * issue #3861 follow-up — drain (fs.watch) 의 CSS incremental path 가 PostCSS
+   * 재실행 없이 tempRoot 만 raw root 와 동기시키기 위한 minimal sync. prepare 가
+   * full pipeline (sync + PostCSS reprocess) 라 단일 CSS modify 시 전체 .css
+   * reprocess 회귀. PostCSS 는 afterBundle 의 changedPath 분기가 incremental
+   * 처리 — sync 만 충분. dirtyPaths 가 modify 면 cpSync, delete 면 rmSync
+   * (sync flow 는 prepare 와 동일 invariant).
+   */
+  syncDirty(dirtyPaths: readonly string[]): void;
   afterBundle(options?: { changedPath?: string | null }): Promise<{
     deps: Set<string>;
     dirDeps: Set<string>;
@@ -670,10 +679,24 @@ export function createAppDevController(
       }
       return prepared;
     },
+    syncDirty(dirtyPaths) {
+      // issue #3861 follow-up — drain CSS incremental 의 PostCSS 재실행 회피.
+      // prepare 의 syncDirtyFilesIntoTempRoot 와 동일 logic, PostCSS skip.
+      // pipelineRoot 가 null (prepare 미경유) 시 noop — 그 경우 drain 의
+      // rebuildAppDevCss 가 afterBundle 의 mirror 만 호출하면 충분.
+      if (!pipelineRoot) return;
+      syncDirtyFilesIntoTempRoot(root, pipelineRoot, dirtyPaths);
+    },
     async afterBundle({ changedPath = null } = {}) {
       // RFC #3833 v3 D1a'' Phase 2: prepare 와 동일 override 를 afterBundle 에도
       // 전달. issue #3847: prepare 가 PostCSS 처리한 경우 skipPostcssRun=true 로
       // redundant pass 차단 (zero-config double-pass + caller-pre-warm 모두).
+      // issue #3861 follow-up — changedPath 명시 시 single-file PostCSS dispatch.
+      // skipPostcssRun=true 라도 changedPath 의 단일 .css 만 reprocess —
+      // dev-hmr/postcss test 의 "processed 1 CSS file" incremental 만족 + 신규
+      // .css 의 PostCSS 적용 보장. changedPath 없을 때만 skipPostcssRun 적용
+      // (initial / bundler emit / full mirror cycle).
+      const skipPostcssRun = preparePostcssApplied && !changedPath;
       const result = await runPostcssForAppDev({
         root,
         outdir,
@@ -683,7 +706,7 @@ export function createAppDevController(
         changedPath,
         fallbackRequire,
         postcssOverride: opts.postcssOverride ?? null,
-        skipPostcssRun: preparePostcssApplied,
+        skipPostcssRun,
         // issue #3847 — mirror 의 source 가 prepare 의 tempRoot (PostCSS 처리됨)
         sourceRoot: pipelineRoot ?? root,
         // issue #3857 — auto-discover path 의 search base forward

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -343,8 +343,28 @@ export async function runPostcssForAppDev(
   // 있으면 그것 사용 (monorepo edge).
   const configPath = postcssOverride ? null : findPostcssConfig(cssAutoDiscoverRoot ?? root);
   if (!configPath && !postcssOverride) {
-    const first = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile })[0];
-    if (first) primaryHref = joinUrl(base, relative(root, first));
+    // #3858/#3861 — PostCSS config 없을 때도 mirror sourceRoot (또는 root) 의
+    // .css 를 outdir 으로 copy. drain 의 rebuildAppDevCss 가 changedPath 명시 +
+    // PostCSS no-op 시 outdir 갱신 보장 — 신규 raw .css 가 outdir 에 도달.
+    const mirrorBase = sourceRoot ?? root;
+    const allCssFiles = collectAppFiles(mirrorBase, { skipDir: outdir, predicate: isCssFile });
+    const targets =
+      changedPath && changedPath.endsWith('.css')
+        ? allCssFiles.filter(
+            (p) => p === changedPath || relative(root, p) === relative(root, changedPath),
+          )
+        : allCssFiles;
+    mkdirSync(outdir, { recursive: true });
+    for (const file of targets) {
+      const outputRel = relative(mirrorBase, file);
+      const outputPath = join(outdir, outputRel);
+      mkdirSync(dirname(outputPath), { recursive: true });
+      writeFileSync(outputPath, readFileSync(file, 'utf8'));
+    }
+    // cssDeps: raw root 의 .css path — watch trigger 정합 (사용자 file edit 감지).
+    const watchCssFiles = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile });
+    for (const f of watchCssFiles) deps.add(resolve(f));
+    if (watchCssFiles[0]) primaryHref = joinUrl(base, relative(root, watchCssFiles[0]));
     return { deps, dirDeps, primaryHref, processed: 0 };
   }
 
@@ -386,7 +406,32 @@ export async function runPostcssForAppDev(
     // issue #3857 — auto-discover path 의 search base. require base 는 app root.
     loaded = await loadPostcssConfig(cssAutoDiscoverRoot ?? root, configEnv, fallbackRequire, root);
   }
-  if (!loaded) return { deps, dirDeps, primaryHref, processed: 0 };
+  if (!loaded) {
+    // #3858/#3861 — postcss config 발견됐어도 plugins=[] / no-op 인 경우.
+    // mirror sourceRoot 의 changedPath (또는 전체) 를 outdir 으로 copy —
+    // drain 의 신규 .css 가 outdir 도달 보장. 위 `!configPath && !postcssOverride`
+    // 분기 의 mirror logic 과 동형.
+    const mirrorBase = sourceRoot ?? root;
+    const allCssFiles = collectAppFiles(mirrorBase, { skipDir: outdir, predicate: isCssFile });
+    // changedPath 는 raw root path, p 는 mirrorBase (tempRoot or root) path.
+    // 같은 rel path 비교 — mirrorBase 기준 p 의 rel == root 기준 changedPath 의 rel.
+    const changedRel =
+      changedPath && changedPath.endsWith('.css') ? relative(root, changedPath) : null;
+    const targets = changedRel
+      ? allCssFiles.filter((p) => relative(mirrorBase, p) === changedRel)
+      : allCssFiles;
+    mkdirSync(outdir, { recursive: true });
+    for (const file of targets) {
+      const outputRel = relative(mirrorBase, file);
+      const outputPath = join(outdir, outputRel);
+      mkdirSync(dirname(outputPath), { recursive: true });
+      writeFileSync(outputPath, readFileSync(file, 'utf8'));
+    }
+    const watchCssFiles = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile });
+    for (const f of watchCssFiles) deps.add(resolve(f));
+    if (watchCssFiles[0]) primaryHref = joinUrl(base, relative(root, watchCssFiles[0]));
+    return { deps, dirDeps, primaryHref, processed: 0 };
+  }
   if (loaded.configFile) deps.add(resolve(loaded.configFile));
   else if (configPath) deps.add(resolve(configPath));
 


### PR DESCRIPTION
## Summary

main CI fail (NAPI Build & Test) — \`dev incremental PostCSS reprocesses only the changed CSS\` test 가 PR #3859 부터 fail (cancelled 로 가려졌다가 PR #3866 후 visible).

## Root cause

PR #3859 에서 native onRebuild 의 cssChanges 분기 추가 (graph 외 .css 감지) — 그 분기가 \`prepare(cssChanges)\` 호출 → prepare 의 PostCSS 가 tempRoot 전체 reprocess → "processed 2 CSS file" → test "processed 1" 위반. drain 도 같은 fs event 받음 — dual watch race.

## Fix

1. **native onRebuild 의 cssChanges 분기 제거** — drain (fs.watch recursive) 가 이미 같은 event 받아 처리. dual watch 통합.
2. **controller 에 `syncDirty(dirtyPaths)` 추가** (prepare sync 만, PostCSS skip). \`rebuildAppDevCss\` 가 prepare → syncDirty + afterBundle. PostCSS incremental 처리는 afterBundle 의 changedPath 분기.
3. **\`afterBundle\` 의 skipPostcssRun = preparePostcssApplied && !changedPath** — changedPath 명시 시 single-file PostCSS dispatch 강제 (#3858 신규 .css PostCSS 적용 + dev-hmr "processed 1" 양쪽 만족).
4. **\`runPostcssForAppDev\` 의 \`!loaded\` / \`!configPath\` 분기에 mirror logic 추가** — PostCSS no-op 시도 sourceRoot → outdir copy. filter 는 \`mirrorBase\` (tempRoot) 기준 relative 비교 (root 기준 시 path mismatch).

## 회귀 가드

- styles 25 pass / 0 fail (add+delete cycle .todo → 정식 test)
- dev incremental PostCSS PASS ("processed 1")
- web 단위 181 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)