### PR TITLE
feat(server,napi,cli): MCP stdio transport + zntc mcp subcommand (PR-B of #3867)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -185,6 +185,7 @@ function usageLines(command) {
     '       zntc dev [root]',
     '       zntc build [root]',
     '       zntc preview [outdir]',
+    '       zntc mcp                          MCP stdio transport (Cursor/Claude Code)',
     '',
     'Options:',
     '  --bundle                   Bundle dependencies',
@@ -233,7 +234,7 @@ function printUsage(command, stream = console.log) {
 
 function parseArgs(argv) {
   const args = argv.slice(2);
-  const appCommands = new Set(['dev', 'build', 'preview', 'verify']);
+  const appCommands = new Set(['dev', 'build', 'preview', 'verify', 'mcp']);
   const appCommand = appCommands.has(args[0]) ? args.shift() : undefined;
   const opts = {
     appCommand,
@@ -2712,6 +2713,20 @@ async function main() {
       const { runVerify } = await import('./verify.mjs');
       const r = await runVerify(opts);
       process.exit(r.exitCode);
+    } catch (err) {
+      console.error(`error: ${err.message}`);
+      process.exit(1);
+    }
+  }
+
+  // mcp — stdio transport. NAPI mcpStdioServe 가 stdin EOF 까지 blocking. Cursor /
+  // Claude Code / Claude Desktop 등 stdio MCP 클라이언트가 `npx zntc mcp` 형태로
+  // spawn. config / build pipeline 우회 — DevServer in-memory state (cache_reset 등)
+  // 만 띄움 (HTTP listener 없음).
+  if (opts.appCommand === 'mcp') {
+    try {
+      coreModule.mcpStdioServe({ rootDir: resolve('.') });
+      process.exit(0);
     } catch (err) {
       console.error(`error: ${err.message}`);
       process.exit(1);

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -197,6 +197,8 @@ interface NativeModule {
       }
     >;
   };
+  /** MCP (Model Context Protocol) stdio transport — blocking, returns on stdin EOF. */
+  mcpStdioServe(options: { rootDir: string }): void;
 }
 
 let native: NativeModule | null = null;
@@ -508,6 +510,27 @@ export function configureProfile(
 
 export function profileReport(format: 'table' | 'tree' | 'json' | 'csv' = 'table'): string {
   return ensureNative().profileReport(format);
+}
+
+// ─── MCP (Model Context Protocol) stdio transport ───
+
+export interface McpStdioOptions {
+  /** DevServer in-memory state 보유 root (cache_reset_requested, event_ring 등). */
+  rootDir: string;
+}
+
+/**
+ * MCP JSON-RPC 2.0 stdio transport 를 실행. stdin EOF 까지 blocking.
+ *
+ * stdin 의 newline-delimited JSON request 를 한 줄씩 읽어 dispatcher 에 forward,
+ * 응답을 stdout 에 한 줄씩 쓴다. Cursor / Claude Code / Claude Desktop 등 stdio
+ * 기반 MCP 클라이언트가 이 진입점을 child process 로 spawn.
+ *
+ * 호출은 blocking — Node 이벤트 루프가 stdio loop 안에서 멈춘다. CLI `zntc mcp`
+ * subcommand 처럼 main thread 가 거기 잡혀도 되는 상황에서만 사용.
+ */
+export function mcpStdioServe(options: McpStdioOptions): void {
+  ensureNative().mcpStdioServe(options);
 }
 
 // ─── Build API ───

--- a/packages/core/src/napi/mcp_stdio_entry.zig
+++ b/packages/core/src/napi/mcp_stdio_entry.zig
@@ -1,0 +1,68 @@
+//! MCP (Model Context Protocol) stdio transport NAPI entry.
+//!
+//! JS bin (`zntc mcp` subcommand) 가 호출하는 sync blocking 함수.
+//! stdin EOF (Cursor / Claude Code 가 연결 종료) 시 정상 반환.
+
+const std = @import("std");
+const zntc_lib = @import("zntc_lib");
+const common = @import("common.zig");
+const c = common.c;
+
+const DevServer = zntc_lib.server.DevServer;
+const serveStdio = zntc_lib.server.mcp_stdio.serveStdio;
+
+const native_alloc = common.nativeAlloc();
+const throwError = common.throwError;
+const getObjectString = common.getObjectString;
+
+/// mcpStdioServe({ rootDir: string }) → undefined.
+///
+/// stdin 에서 newline-delimited JSON-RPC 2.0 request 한 줄씩 읽어
+/// `DevServer.dispatchMcpRequest` 에 forward, 응답을 stdout 에 한 줄씩 쓴다.
+/// stdin EOF → 정상 종료 (undefined 반환).
+///
+/// 이 함수는 blocking — JS event loop 이 stdio loop 안에 갇힌다.
+/// 호출자(`zntc mcp` bin)는 main thread 에서 부르므로 의도적 동작.
+pub fn napiMcpStdioServe(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 1;
+    var argv: [1]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throwError(env, "failed to get arguments");
+    }
+    if (argc < 1) return throwError(env, "mcpStdioServe requires an options object");
+
+    var arena = std.heap.ArenaAllocator.init(native_alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const root_dir = getObjectString(env, argv[0], "rootDir", arena_alloc) orelse
+        return throwError(env, "mcpStdioServe: 'rootDir' string option is required");
+
+    // DevServer 인스턴스 — HTTP listener 는 띄우지 않고 in-memory state (cache_reset_requested,
+    // event_ring) 만 활용. build 도메인 tool (reset_cache 등) 이 flag 를 토글하면 같은
+    // 프로세스 안에서 후속 build 가 그 flag 를 본다 (PR-E 에서 dev server 합본 lifecycle).
+    var dev_server = DevServer.init(native_alloc, .{ .root_dir = root_dir }) catch |err| {
+        var msg_buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrintZ(&msg_buf, "mcpStdioServe: DevServer.init failed: {}", .{err}) catch "mcpStdioServe: DevServer.init failed";
+        return throwError(env, msg.ptr);
+    };
+    defer dev_server.deinit();
+
+    // stdin / stdout file handles.
+    var stdin_file = std.fs.File.stdin();
+    var stdout_file = std.fs.File.stdout();
+    const stdout_writer = stdout_file.deprecatedWriter();
+
+    // line buffer — HTTP 와 같은 64KB 한도. LineTooLong 시 dispatcher 안 닿고 error 반환.
+    var line_buf: [64 * 1024]u8 = undefined;
+
+    serveStdio(&dev_server, &stdin_file, stdout_writer, &line_buf) catch |err| {
+        var msg_buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrintZ(&msg_buf, "mcpStdioServe: stdio loop error: {}", .{err}) catch "mcpStdioServe: stdio loop error";
+        return throwError(env, msg.ptr);
+    };
+
+    var undefined_val: c.napi_value = undefined;
+    _ = c.napi_get_undefined(env, &undefined_val);
+    return undefined_val;
+}

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -31,6 +31,8 @@ const build_async_entry = @import("napi/build_async_entry.zig");
 const watch_mod = @import("napi/watch.zig");
 const napiWatch = watch_mod.napiWatch;
 
+const mcp_stdio_entry = @import("napi/mcp_stdio_entry.zig");
+
 // ─── 모듈 등록 ───
 
 export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi_value {
@@ -100,6 +102,10 @@ export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi
     var bench_fn: c.napi_value = undefined;
     _ = c.napi_create_function(env, "benchmark", "benchmark".len, benchmark_mod.napiBenchmark, null, &bench_fn);
     _ = c.napi_set_named_property(env, exports, "benchmark", bench_fn);
+
+    var mcp_stdio_fn: c.napi_value = undefined;
+    _ = c.napi_create_function(env, "mcpStdioServe", "mcpStdioServe".len, mcp_stdio_entry.napiMcpStdioServe, null, &mcp_stdio_fn);
+    _ = c.napi_set_named_property(env, exports, "mcpStdioServe", mcp_stdio_fn);
 
     return exports;
 }

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -1011,8 +1011,22 @@ pub const DevServer = struct {
         // stdio transport 는 newline-delimited 라 framing 이 깨지므로 여기서 통일.
         // JSON spec 상 raw `\n`/`\r` 는 string literal 안에 못 들어가고 (`\\n` escape 만 허용)
         // structural whitespace 라서 제거해도 의미 손실 없음 (HTTP transport 도 동일하게 안전).
-        for (resp.items) |b| {
-            if (b != '\n' and b != '\r') try writer.writeByte(b);
+        //
+        // Fast path: 대부분의 응답엔 newline 없음 → 한 번에 writeAll (unbuffered stdout
+        // 의 per-byte syscall 폭증 회피, tools/list 만 chunk loop).
+        if (std.mem.indexOfAny(u8, resp.items, "\n\r")) |_| {
+            var i: usize = 0;
+            while (i < resp.items.len) {
+                // 다음 newline 까지의 chunk 1개를 한 번에 write.
+                var j = i;
+                while (j < resp.items.len and resp.items[j] != '\n' and resp.items[j] != '\r') : (j += 1) {}
+                if (j > i) try writer.writeAll(resp.items[i..j]);
+                // 연속된 newline/cr skip.
+                while (j < resp.items.len and (resp.items[j] == '\n' or resp.items[j] == '\r')) : (j += 1) {}
+                i = j;
+            }
+        } else {
+            try writer.writeAll(resp.items);
         }
     }
 

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -993,7 +993,7 @@ pub const DevServer = struct {
     /// build 도중 error 발생 시 buffer 를 폐기하고 `-32603 Internal error` fallback 을
     /// 새로 build 해서 보낸다 → transport wrapper 의 outer catch 없이도 항상 완결된
     /// 응답 1통이 writer 에 쓰이는 것을 보장 (stdio 의 frame 깨짐 방지).
-    fn dispatchMcpRequest(self: *DevServer, body: []const u8, writer: anytype) !void {
+    pub fn dispatchMcpRequest(self: *DevServer, body: []const u8, writer: anytype) !void {
         var resp: std.ArrayList(u8) = .empty;
         defer resp.deinit(self.allocator);
         const inner = resp.writer(self.allocator);
@@ -1006,7 +1006,14 @@ pub const DevServer = struct {
             try inner.writeAll("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32603,\"message\":\"Internal error\"},\"id\":null}");
         };
 
-        try writer.writeAll(resp.items);
+        // 응답을 single-line 으로 정규화 — `tools/list` 등이 가독성 위해 multi-line raw
+        // string 으로 작성됐기 때문에 응답 buffer 에 raw `\n` 이 섞일 수 있다.
+        // stdio transport 는 newline-delimited 라 framing 이 깨지므로 여기서 통일.
+        // JSON spec 상 raw `\n`/`\r` 는 string literal 안에 못 들어가고 (`\\n` escape 만 허용)
+        // structural whitespace 라서 제거해도 의미 손실 없음 (HTTP transport 도 동일하게 안전).
+        for (resp.items) |b| {
+            if (b != '\n' and b != '\r') try writer.writeByte(b);
+        }
     }
 
     /// dispatcher 본문 — JSON parse + method dispatch + response build.

--- a/src/server/mcp_stdio.zig
+++ b/src/server/mcp_stdio.zig
@@ -18,8 +18,14 @@ pub const StdioError = error{
     LineTooLong,
 };
 
+const TOO_LARGE_RESPONSE: []const u8 = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Request line too large\"},\"id\":null}";
+
 /// stdin (reader) ← request line, stdout (writer) → response line + \n.
 /// `line_buf` 는 한 줄 임시 buffer — 호출자가 64KB 정도 권장 (HTTP 와 동일 한도).
+///
+/// `line_buf` 초과 라인은 dispatcher 거치지 않고 `-32600 Request line too large`
+/// 응답을 client 에 보낸 뒤 reader 잔여 byte 를 다음 `\n` 까지 drain → 다음 줄 정상
+/// 처리 계속 (HTTP transport 의 max_body 정책과 동등).
 pub fn serveStdio(
     dev_server: *DevServer,
     reader: anytype,
@@ -27,12 +33,31 @@ pub fn serveStdio(
     line_buf: []u8,
 ) !void {
     while (true) {
-        const maybe_line = try readLine(reader, line_buf);
+        const maybe_line = readLine(reader, line_buf) catch |err| switch (err) {
+            StdioError.LineTooLong => {
+                // 라인 너무 김 → -32600 응답 + 남은 line drain → resync.
+                try writer.writeAll(TOO_LARGE_RESPONSE);
+                try writer.writeByte('\n');
+                try drainToNewline(reader);
+                continue;
+            },
+            else => return err,
+        };
         const line = maybe_line orelse return; // EOF
         if (line.len == 0) continue; // 빈 줄 skip
 
         try dev_server.dispatchMcpRequest(line, writer);
         try writer.writeByte('\n');
+    }
+}
+
+/// `\n` 까지 (또는 EOF 까지) byte 를 모두 소비. LineTooLong 후 resync 용.
+fn drainToNewline(reader: anytype) !void {
+    var one: [1]u8 = undefined;
+    while (true) {
+        const n = try reader.read(&one);
+        if (n == 0) return; // EOF
+        if (one[0] == '\n') return;
     }
 }
 
@@ -261,6 +286,46 @@ test "serveStdio: tools/call reset_cache → cache_reset_requested set + 응답"
 
     try std.testing.expectEqual(true, dev_server.cache_reset_requested.load(.acquire));
     try std.testing.expect(std.mem.indexOf(u8, resp.items, "Cache reset requested") != null);
+}
+
+test "serveStdio: LineTooLong → -32600 응답 + 다음 줄 정상 처리 (resync)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var dev_server = try DevServer.init(std.testing.allocator, .{ .root_dir = dir_path });
+    defer dev_server.deinit();
+
+    // 첫 줄(35 byte) 이 buf(32) 초과 → LineTooLong. 둘째 줄(21 byte) 은 buf 안에 fit
+    // → unknown method 응답 (`x`). resync 검증: LineTooLong 후 다음 줄 dispatch 동작.
+    var mr = MockReader{
+        .data =
+        \\01234567890abcdef-too-long-for-buf
+        \\{"id":2,"method":"x"}
+        \\
+        ,
+    };
+
+    var resp: std.ArrayList(u8) = .empty;
+    defer resp.deinit(std.testing.allocator);
+    const w = resp.writer(std.testing.allocator);
+
+    // 의도적으로 작은 buf — 첫 줄 LineTooLong 유도, 둘째 줄은 fit.
+    var line_buf: [32]u8 = undefined;
+    try serveStdio(&dev_server, &mr, w, &line_buf);
+
+    // -32600 응답 + 둘째 줄 unknown method `x` (-32601) 응답, 정상 종료.
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "-32600") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "Request line too large") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"id\":2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "-32601") != null);
+    // 정확히 2 newline (응답 2개)
+    var nl_count: usize = 0;
+    for (resp.items) |b| if (b == '\n') {
+        nl_count += 1;
+    };
+    try std.testing.expectEqual(@as(usize, 2), nl_count);
 }
 
 test "serveStdio: invalid JSON 줄 → -32700 응답 후 다음 줄 처리 계속" {

--- a/src/server/mcp_stdio.zig
+++ b/src/server/mcp_stdio.zig
@@ -1,0 +1,294 @@
+//! MCP (Model Context Protocol) JSON-RPC 2.0 stdio transport.
+//!
+//! HTTP transport (`dev_server.handleMcp`) 와 동일한 dispatcher
+//! (`DevServer.dispatchMcpRequest`) 를 newline-delimited JSON loop 으로 구동한다.
+//!
+//! 입력: stdin 에서 한 줄 = JSON-RPC request 한 통 (`\n` 종결).
+//! 출력: stdout 에 JSON-RPC response 한 통 + `\n`.
+//! EOF → 정상 종료. 빈 줄 → skip.
+//!
+//! `reader` / `writer` 는 generic 으로 받아 test 가 mock 주입 가능.
+//! 실제 caller (NAPI entry) 는 `std.fs.File.stdin()` / `std.fs.File.stdout()`
+//! 의 reader / writer 를 전달.
+
+const std = @import("std");
+const DevServer = @import("dev_server.zig").DevServer;
+
+pub const StdioError = error{
+    LineTooLong,
+};
+
+/// stdin (reader) ← request line, stdout (writer) → response line + \n.
+/// `line_buf` 는 한 줄 임시 buffer — 호출자가 64KB 정도 권장 (HTTP 와 동일 한도).
+pub fn serveStdio(
+    dev_server: *DevServer,
+    reader: anytype,
+    writer: anytype,
+    line_buf: []u8,
+) !void {
+    while (true) {
+        const maybe_line = try readLine(reader, line_buf);
+        const line = maybe_line orelse return; // EOF
+        if (line.len == 0) continue; // 빈 줄 skip
+
+        try dev_server.dispatchMcpRequest(line, writer);
+        try writer.writeByte('\n');
+    }
+}
+
+/// `reader` 에서 `\n` 까지 한 줄 읽기.
+/// 반환:
+///   - `null` — 첫 바이트 직전 EOF (정상 종료 시그널)
+///   - `[]u8` slice into `buf` — 한 줄 (개행 제외)
+///   - `error.LineTooLong` — `buf.len` 초과
+///   - 그 외 reader error
+///
+/// `\r\n` 인 경우 trailing `\r` 도 제거.
+fn readLine(reader: anytype, buf: []u8) !?[]u8 {
+    var i: usize = 0;
+    while (i < buf.len) {
+        var one: [1]u8 = undefined;
+        const n = try reader.read(&one);
+        if (n == 0) {
+            // EOF
+            if (i == 0) return null;
+            return stripTrailingCr(buf[0..i]);
+        }
+        const b = one[0];
+        if (b == '\n') return stripTrailingCr(buf[0..i]);
+        buf[i] = b;
+        i += 1;
+    }
+    return StdioError.LineTooLong;
+}
+
+fn stripTrailingCr(line: []u8) []u8 {
+    if (line.len > 0 and line[line.len - 1] == '\r') return line[0 .. line.len - 1];
+    return line;
+}
+
+// ─── 테스트 ───
+
+/// 테스트용 mock reader — `[]const u8` 슬라이스를 byte 스트림으로 노출.
+const MockReader = struct {
+    data: []const u8,
+    pos: usize = 0,
+
+    pub fn read(self: *MockReader, dst: []u8) !usize {
+        if (self.pos >= self.data.len) return 0;
+        const remaining = self.data.len - self.pos;
+        const n = @min(dst.len, remaining);
+        @memcpy(dst[0..n], self.data[self.pos .. self.pos + n]);
+        self.pos += n;
+        return n;
+    }
+};
+
+test "readLine: single line + EOF" {
+    var buf: [64]u8 = undefined;
+    var mr = MockReader{ .data = "hello\n" };
+    const line = try readLine(&mr, &buf);
+    try std.testing.expect(line != null);
+    try std.testing.expectEqualStrings("hello", line.?);
+
+    const eof = try readLine(&mr, &buf);
+    try std.testing.expectEqual(@as(?[]u8, null), eof);
+}
+
+test "readLine: CRLF normalized to LF (trailing \\r 제거)" {
+    var buf: [64]u8 = undefined;
+    var mr = MockReader{ .data = "hello\r\nworld\n" };
+    const line1 = try readLine(&mr, &buf);
+    try std.testing.expectEqualStrings("hello", line1.?);
+    const line2 = try readLine(&mr, &buf);
+    try std.testing.expectEqualStrings("world", line2.?);
+}
+
+test "readLine: last line without newline → returned at EOF" {
+    var buf: [64]u8 = undefined;
+    var mr = MockReader{ .data = "no-newline" };
+    const line = try readLine(&mr, &buf);
+    try std.testing.expectEqualStrings("no-newline", line.?);
+
+    const eof = try readLine(&mr, &buf);
+    try std.testing.expectEqual(@as(?[]u8, null), eof);
+}
+
+test "readLine: 빈 줄" {
+    var buf: [64]u8 = undefined;
+    var mr = MockReader{ .data = "\n" };
+    const line = try readLine(&mr, &buf);
+    try std.testing.expect(line != null);
+    try std.testing.expectEqual(@as(usize, 0), line.?.len);
+}
+
+test "readLine: buf 초과 → LineTooLong" {
+    var buf: [4]u8 = undefined;
+    var mr = MockReader{ .data = "12345\n" };
+    const result = readLine(&mr, &buf);
+    try std.testing.expectError(StdioError.LineTooLong, result);
+}
+
+test "serveStdio: 단일 initialize → 한 줄 응답 + EOF 종료" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var dev_server = try DevServer.init(std.testing.allocator, .{ .root_dir = dir_path });
+    defer dev_server.deinit();
+
+    var mr = MockReader{
+        .data =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize"}
+        \\
+        ,
+    };
+
+    var resp: std.ArrayList(u8) = .empty;
+    defer resp.deinit(std.testing.allocator);
+    const w = resp.writer(std.testing.allocator);
+
+    var line_buf: [64 * 1024]u8 = undefined;
+    try serveStdio(&dev_server, &mr, w, &line_buf);
+
+    // 응답: 1줄 + 끝에 \n
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"protocolVersion\":\"2024-11-05\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"id\":1") != null);
+    try std.testing.expect(resp.items.len > 0);
+    try std.testing.expectEqual(@as(u8, '\n'), resp.items[resp.items.len - 1]);
+    // 정확히 1개의 newline (응답 1개)
+    var nl_count: usize = 0;
+    for (resp.items) |b| if (b == '\n') {
+        nl_count += 1;
+    };
+    try std.testing.expectEqual(@as(usize, 1), nl_count);
+}
+
+test "serveStdio: 여러 request 연속 처리" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var dev_server = try DevServer.init(std.testing.allocator, .{ .root_dir = dir_path });
+    defer dev_server.deinit();
+
+    var mr = MockReader{
+        .data =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize"}
+        \\{"jsonrpc":"2.0","id":2,"method":"tools/list"}
+        \\
+        ,
+    };
+
+    var resp: std.ArrayList(u8) = .empty;
+    defer resp.deinit(std.testing.allocator);
+    const w = resp.writer(std.testing.allocator);
+
+    var line_buf: [64 * 1024]u8 = undefined;
+    try serveStdio(&dev_server, &mr, w, &line_buf);
+
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"id\":1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"id\":2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"reset_cache\"") != null); // tools/list 응답
+    // 정확히 2 개 newline (응답 2개)
+    var nl_count: usize = 0;
+    for (resp.items) |b| if (b == '\n') {
+        nl_count += 1;
+    };
+    try std.testing.expectEqual(@as(usize, 2), nl_count);
+}
+
+test "serveStdio: 빈 줄은 skip (응답 안 보냄)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var dev_server = try DevServer.init(std.testing.allocator, .{ .root_dir = dir_path });
+    defer dev_server.deinit();
+
+    var mr = MockReader{
+        .data =
+        \\
+        \\
+        \\{"jsonrpc":"2.0","id":7,"method":"initialize"}
+        \\
+        ,
+    };
+
+    var resp: std.ArrayList(u8) = .empty;
+    defer resp.deinit(std.testing.allocator);
+    const w = resp.writer(std.testing.allocator);
+
+    var line_buf: [64 * 1024]u8 = undefined;
+    try serveStdio(&dev_server, &mr, w, &line_buf);
+
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"id\":7") != null);
+    // 빈 줄 2개는 skip → 응답 1개
+    var nl_count: usize = 0;
+    for (resp.items) |b| if (b == '\n') {
+        nl_count += 1;
+    };
+    try std.testing.expectEqual(@as(usize, 1), nl_count);
+}
+
+test "serveStdio: tools/call reset_cache → cache_reset_requested set + 응답" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var dev_server = try DevServer.init(std.testing.allocator, .{ .root_dir = dir_path });
+    defer dev_server.deinit();
+
+    try std.testing.expectEqual(false, dev_server.cache_reset_requested.load(.acquire));
+
+    var mr = MockReader{
+        .data =
+        \\{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"reset_cache","arguments":{}}}
+        \\
+        ,
+    };
+
+    var resp: std.ArrayList(u8) = .empty;
+    defer resp.deinit(std.testing.allocator);
+    const w = resp.writer(std.testing.allocator);
+
+    var line_buf: [64 * 1024]u8 = undefined;
+    try serveStdio(&dev_server, &mr, w, &line_buf);
+
+    try std.testing.expectEqual(true, dev_server.cache_reset_requested.load(.acquire));
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "Cache reset requested") != null);
+}
+
+test "serveStdio: invalid JSON 줄 → -32700 응답 후 다음 줄 처리 계속" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var dev_server = try DevServer.init(std.testing.allocator, .{ .root_dir = dir_path });
+    defer dev_server.deinit();
+
+    var mr = MockReader{
+        .data =
+        \\not-a-json{
+        \\{"jsonrpc":"2.0","id":2,"method":"initialize"}
+        \\
+        ,
+    };
+
+    var resp: std.ArrayList(u8) = .empty;
+    defer resp.deinit(std.testing.allocator);
+    const w = resp.writer(std.testing.allocator);
+
+    var line_buf: [64 * 1024]u8 = undefined;
+    try serveStdio(&dev_server, &mr, w, &line_buf);
+
+    // 첫 줄 → -32700, 둘째 줄 → initialize 응답
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "-32700") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"id\":2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"protocolVersion\"") != null);
+}

--- a/src/server/mod.zig
+++ b/src/server/mod.zig
@@ -8,6 +8,7 @@ pub const watch_scan = @import("watch_scan.zig");
 pub const events = @import("events.zig");
 pub const boringssl = @import("boringssl.zig");
 pub const tls = @import("tls.zig");
+pub const mcp_stdio = @import("mcp_stdio.zig");
 
 test {
     _ = @import("dev_server.zig");
@@ -18,6 +19,7 @@ test {
     _ = @import("events.zig");
     _ = @import("boringssl.zig");
     _ = @import("tls.zig");
+    _ = @import("mcp_stdio.zig");
 
     // test files
     _ = @import("dev_server_test.zig");


### PR DESCRIPTION
## Summary
- #3867 (epic: zntc native MCP 서버) **PR-B**
- PR-A (#3872) 의 transport-agnostic `dispatchMcpRequest` 를 stdio transport 로 구동
- Cursor / Claude Code / Claude Desktop 등 stdio 기반 MCP 클라이언트가 `npx zntc mcp` 한 줄로 연결

## 구현

### `src/server/mcp_stdio.zig` (신설, ~340줄 incl. 10 tests)
- `serveStdio(dev_server, reader, writer, line_buf)` — newline-delimited JSON loop
- `readLine` — CRLF/LF 모두 정규화, EOF 정상 처리, buf 초과 시 LineTooLong
- `LineTooLong` 발생 시 `-32600 Request line too large` 응답 + drain to `\n` → 다음 줄 정상 dispatch 계속 (HTTP transport 의 max_body 정책과 동등)

### `src/server/dev_server.zig`
- `dispatchMcpRequest` 를 `pub` 으로 (mcp_stdio 가 접근)
- 응답 single-line 정규화 + **fast path** — newline 없으면 한 번에 `writeAll`, 있으면 chunk 단위 (stdout unbuffered writer 의 per-byte syscall 폭증 회피)

### `packages/core/src/napi/mcp_stdio_entry.zig` (신설)
- `napiMcpStdioServe({ rootDir })` — DevServer init + serveStdio blocking call

### `packages/core/index.ts`
- `NativeModule` interface 에 `mcpStdioServe` 추가
- `export function mcpStdioServe(options: McpStdioOptions): void` 공개 API

### `packages/core/bin/zntc.mjs`
- `appCommands` 에 `mcp` 추가
- verify 옆 early dispatch — config / build pipeline 우회
- usage line 추가

## E2E

```sh
$ printf '%s\n%s\n' \
    '{"jsonrpc":"2.0","id":1,"method":"initialize"}' \
    '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
  | node packages/core/bin/zntc.mjs mcp
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05",...}}
{"jsonrpc":"2.0","id":2,"result":{"tools":[...]}}
```

Cursor / Claude Code config:
```jsonc
{ "mcpServers": { "zntc": { "command": "npx", "args": ["zntc", "mcp"] } } }
```

## Test plan
- [x] **10개 새 테스트** (mock reader + DevServer fixture):
  - readLine: 단일/CRLF/EOF-mid-line/빈 줄/buf 초과
  - serveStdio: 단일 initialize / 연속 request / 빈 줄 skip / reset_cache flag / **LineTooLong resync** / invalid JSON 후 다음 줄 처리
- [x] `zig build test` 전체 통과 (PR-A 의 7개 dispatcher test + 새 10개 stdio test)
- [x] `zig build napi` + JS bundle 통과
- [x] E2E 수동 검증 (3 request 연속, exit 0)
- [x] `/code-review max` 통과 (5 angle), finding 2건 fix:
  - **LineTooLong resync** (HTTP 와 동등 contract 회복)
  - **응답 정규화 fast path** (per-byte syscall 폭증 해결)

## /code-review 후속 (1차 비-스코프, 별도 PR 권장)
- `notifications/initialized` 의 응답 송신 — JSON-RPC 2.0 spec 위반 (notification 에 응답 없어야). PR-A 부터 있던 기존 동작, stdio 에서 처음 노출.
- `rootDir: resolve('.')` 가 spawn cwd 의존 — Cursor/Claude Desktop spawn 위치에 따라 다름. `--root` 플래그 또는 `ZNTC_ROOT` env 추가 권장.
- `get_build_events` 의 `std.Thread.sleep` 이 stdio loop 안에서 HOL blocking — 다른 request 가 sleep 동안 지연. 후속 PR 에서 async pattern 검토.

## 다음 단계
- **PR-C**: zntc transform pass 가 entry 에 `mcp-runtime.cjs` preamble inject

🤖 Generated with [Claude Code](https://claude.com/claude-code)