### PR TITLE
fix(server): JSON-RPC 2.0 notification 응답 금지 + 204 헤더 정리 (#3867 follow-up)

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -978,33 +978,59 @@ pub const DevServer = struct {
         defer resp.deinit(self.allocator);
         const w = resp.writer(self.allocator);
 
-        try self.dispatchMcpRequest(body, w);
+        const kind = try self.dispatchMcpRequest(body, w);
 
-        request.respond(resp.items, .{
-            .status = .ok,
-            .extra_headers = &json_headers,
-        }) catch {};
+        switch (kind) {
+            .response => request.respond(resp.items, .{
+                .status = .ok,
+                .extra_headers = &json_headers,
+            }) catch {},
+            .notification => request.respond("", .{
+                .status = .no_content,
+                .extra_headers = &json_headers,
+            }) catch {},
+        }
     }
 
     /// Transport-agnostic JSON-RPC 2.0 dispatcher.
     /// HTTP 와 (예정된) stdio 양쪽이 공유. body 한 통을 받아 응답 한 통을 `writer` 에 쓴다.
     ///
+    /// JSON-RPC 2.0 spec: notification (method 가 `notifications/*` 인 경우) 에는 응답을
+    /// 보내지 않는다 ("The Server MUST NOT reply to a Notification"). dispatcher 의 결과를
+    /// caller (HTTP / stdio transport) 가 분기해 처리할 수 있도록 enum 반환.
+    pub const DispatchResult = enum {
+        /// 응답 1통이 writer 에 쓰임. caller 는 transport 별 framing (HTTP 200 body /
+        /// stdio newline) 으로 client 에 forward.
+        response,
+        /// notification — writer 에 아무것도 쓰이지 않음. caller 는 응답/framing 안 보냄
+        /// (HTTP: 204 No Content, stdio: newline 안 추가).
+        notification,
+    };
+
     /// 응답을 내부 임시 buffer 에 먼저 build 한 뒤 한 번에 `writer` 로 flush.
     /// build 도중 error 발생 시 buffer 를 폐기하고 `-32603 Internal error` fallback 을
     /// 새로 build 해서 보낸다 → transport wrapper 의 outer catch 없이도 항상 완결된
     /// 응답 1통이 writer 에 쓰이는 것을 보장 (stdio 의 frame 깨짐 방지).
-    pub fn dispatchMcpRequest(self: *DevServer, body: []const u8, writer: anytype) !void {
+    ///
+    /// 반환:
+    /// - `.response` — writer 에 응답 1통 쓰임
+    /// - `.notification` — writer 변경 없음 (JSON-RPC notification, 응답 금지)
+    pub fn dispatchMcpRequest(self: *DevServer, body: []const u8, writer: anytype) !DispatchResult {
         var resp: std.ArrayList(u8) = .empty;
         defer resp.deinit(self.allocator);
         const inner = resp.writer(self.allocator);
 
-        self.buildMcpResponse(body, inner) catch |err| {
+        const kind = self.buildMcpResponse(body, inner) catch |err| blk: {
             getLog().print("  [mcp] dispatch error: {}, sending -32603 fallback\n", .{err}) catch {};
             // partial 응답 폐기 후 -32603 fallback 새로 build.
             // 이 단계도 OOM 으로 fail 하면 caller 가 처리 (마지막 안전망 — transport wrapper).
             resp.clearRetainingCapacity();
             try inner.writeAll("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32603,\"message\":\"Internal error\"},\"id\":null}");
+            break :blk DispatchResult.response;
         };
+
+        // notification 이면 응답 byte 가 0 — writer 에 아무것도 안 쓰고 즉시 반환.
+        if (kind == .notification) return .notification;
 
         // 응답을 single-line 으로 정규화 — `tools/list` 등이 가독성 위해 multi-line raw
         // string 으로 작성됐기 때문에 응답 buffer 에 raw `\n` 이 섞일 수 있다.
@@ -1028,18 +1054,21 @@ pub const DevServer = struct {
         } else {
             try writer.writeAll(resp.items);
         }
+        return .response;
     }
 
     /// dispatcher 본문 — JSON parse + method dispatch + response build.
     /// 지원 method: initialize, tools/list, tools/call (reset_cache, get_build_events,
-    /// verify_in_chrome), notifications/initialized. 그 외 → -32601 Method not found.
-    /// JSON parse 실패 → -32700 Parse error (응답을 writer 에 쓰고 정상 종료).
+    /// verify_in_chrome). 그 외 → -32601 Method not found.
+    /// `notifications/*` (예: `notifications/initialized`, `notifications/cancelled`) →
+    /// JSON-RPC 2.0 spec 상 응답 없음. writer 변경 없이 `.notification` 반환.
+    /// JSON parse 실패 → -32700 Parse error (응답을 writer 에 쓰고 `.response` 반환).
     /// 그 외 error 는 propagate — caller (`dispatchMcpRequest`) 가 -32603 fallback 처리.
-    fn buildMcpResponse(self: *DevServer, body: []const u8, writer: anytype) !void {
+    fn buildMcpResponse(self: *DevServer, body: []const u8, writer: anytype) !DispatchResult {
         // JSON 파싱
         var parsed = std.json.parseFromSlice(std.json.Value, self.allocator, body, .{}) catch {
             try writer.writeAll("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32700,\"message\":\"Parse error\"},\"id\":null}");
-            return;
+            return .response;
         };
         defer parsed.deinit();
         const root = parsed.value;
@@ -1055,6 +1084,12 @@ pub const DevServer = struct {
             .object => |o| o.get("id") orelse .null,
             else => .null,
         };
+
+        // JSON-RPC 2.0: notification 은 응답 금지. method namespace `notifications/`
+        // 로 식별 (MCP spec 의 모든 notification 이 이 prefix 사용).
+        if (std.mem.startsWith(u8, method, "notifications/")) {
+            return .notification;
+        }
 
         try writer.writeAll("{\"jsonrpc\":\"2.0\",\"id\":");
         try writeJsonValue(writer, id_val);
@@ -1074,13 +1109,11 @@ pub const DevServer = struct {
             );
         } else if (std.mem.eql(u8, method, "tools/call")) {
             try self.handleToolsCall(writer, root);
-        } else if (std.mem.eql(u8, method, "notifications/initialized")) {
-            // MCP 클라이언트 initialized 통지는 응답 없음 (notification)
-            try writer.writeAll("\"result\":{}");
         } else {
             try writer.writeAll("\"error\":{\"code\":-32601,\"message\":\"Method not found\"}");
         }
         try writer.writeAll("}");
+        return .response;
     }
 
     fn handleToolsCall(self: *DevServer, w: anytype, root: std.json.Value) !void {
@@ -1952,7 +1985,7 @@ test "dispatchMcpRequest: initialize → protocolVersion + serverInfo + id 보�
     defer resp.deinit(std.testing.allocator);
     const w = resp.writer(std.testing.allocator);
 
-    try dev_server.dispatchMcpRequest(
+    _ = try dev_server.dispatchMcpRequest(
         \\{"jsonrpc":"2.0","id":42,"method":"initialize"}
     , w);
 
@@ -1979,7 +2012,7 @@ test "dispatchMcpRequest: tools/list → 3개 tool 명세 포함" {
     defer resp.deinit(std.testing.allocator);
     const w = resp.writer(std.testing.allocator);
 
-    try dev_server.dispatchMcpRequest(
+    _ = try dev_server.dispatchMcpRequest(
         \\{"jsonrpc":"2.0","id":1,"method":"tools/list"}
     , w);
 
@@ -1989,7 +2022,7 @@ test "dispatchMcpRequest: tools/list → 3개 tool 명세 포함" {
     try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"error\"") == null);
 }
 
-test "dispatchMcpRequest: notifications/initialized → result:{} 응답" {
+test "dispatchMcpRequest: notifications/initialized → .notification + 응답 0 byte (JSON-RPC spec)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
@@ -2002,12 +2035,56 @@ test "dispatchMcpRequest: notifications/initialized → result:{} 응답" {
     defer resp.deinit(std.testing.allocator);
     const w = resp.writer(std.testing.allocator);
 
-    try dev_server.dispatchMcpRequest(
+    const kind = try dev_server.dispatchMcpRequest(
         \\{"jsonrpc":"2.0","method":"notifications/initialized"}
     , w);
 
-    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"result\":{}") != null);
-    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"error\"") == null);
+    // JSON-RPC 2.0: notification 은 응답 금지. writer 변경 0, kind 가 .notification.
+    try std.testing.expectEqual(DevServer.DispatchResult.notification, kind);
+    try std.testing.expectEqual(@as(usize, 0), resp.items.len);
+}
+
+test "dispatchMcpRequest: 임의 notifications/* prefix → .notification + 응답 0 byte" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var dev_server = try DevServer.init(std.testing.allocator, .{ .root_dir = dir_path });
+    defer dev_server.deinit();
+
+    var resp: std.ArrayList(u8) = .empty;
+    defer resp.deinit(std.testing.allocator);
+    const w = resp.writer(std.testing.allocator);
+
+    // initialized 외 다른 notification (cancelled, progress 등) 도 동일하게 응답 0 byte.
+    const kind = try dev_server.dispatchMcpRequest(
+        \\{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":7}}
+    , w);
+
+    try std.testing.expectEqual(DevServer.DispatchResult.notification, kind);
+    try std.testing.expectEqual(@as(usize, 0), resp.items.len);
+}
+
+test "dispatchMcpRequest: regular method → .response 반환" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var dev_server = try DevServer.init(std.testing.allocator, .{ .root_dir = dir_path });
+    defer dev_server.deinit();
+
+    var resp: std.ArrayList(u8) = .empty;
+    defer resp.deinit(std.testing.allocator);
+    const w = resp.writer(std.testing.allocator);
+
+    const kind = try dev_server.dispatchMcpRequest(
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize"}
+    , w);
+
+    try std.testing.expectEqual(DevServer.DispatchResult.response, kind);
+    try std.testing.expect(resp.items.len > 0);
 }
 
 test "dispatchMcpRequest: unknown method → -32601 Method not found" {
@@ -2023,7 +2100,7 @@ test "dispatchMcpRequest: unknown method → -32601 Method not found" {
     defer resp.deinit(std.testing.allocator);
     const w = resp.writer(std.testing.allocator);
 
-    try dev_server.dispatchMcpRequest(
+    _ = try dev_server.dispatchMcpRequest(
         \\{"jsonrpc":"2.0","id":7,"method":"completely/unknown"}
     , w);
 
@@ -2046,7 +2123,7 @@ test "dispatchMcpRequest: invalid JSON body → -32700 Parse error + id null" {
     defer resp.deinit(std.testing.allocator);
     const w = resp.writer(std.testing.allocator);
 
-    try dev_server.dispatchMcpRequest("not-a-json{", w);
+    _ = try dev_server.dispatchMcpRequest("not-a-json{", w);
 
     try std.testing.expect(std.mem.indexOf(u8, resp.items, "-32700") != null);
     try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"Parse error\"") != null);
@@ -2070,7 +2147,7 @@ test "dispatchMcpRequest: tools/call reset_cache → cache_reset_requested 플�
     defer resp.deinit(std.testing.allocator);
     const w = resp.writer(std.testing.allocator);
 
-    try dev_server.dispatchMcpRequest(
+    _ = try dev_server.dispatchMcpRequest(
         \\{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"reset_cache","arguments":{}}}
     , w);
 
@@ -2095,7 +2172,7 @@ test "dispatchMcpRequest: tools/call unknown tool → -32602" {
     defer resp.deinit(std.testing.allocator);
     const w = resp.writer(std.testing.allocator);
 
-    try dev_server.dispatchMcpRequest(
+    _ = try dev_server.dispatchMcpRequest(
         \\{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"nope","arguments":{}}}
     , w);
 

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -987,7 +987,9 @@ pub const DevServer = struct {
             }) catch {},
             .notification => request.respond("", .{
                 .status = .no_content,
-                .extra_headers = &json_headers,
+                // RFC 9110 §8.3: 본문 없는 응답에 Content-Type SHOULD NOT 보내야 함.
+                // cors_headers 만 사용 (json_headers 의 Content-Type 제외).
+                .extra_headers = &cors_headers,
             }) catch {},
         }
     }
@@ -1085,9 +1087,11 @@ pub const DevServer = struct {
             else => .null,
         };
 
-        // JSON-RPC 2.0: notification 은 응답 금지. method namespace `notifications/`
-        // 로 식별 (MCP spec 의 모든 notification 이 이 prefix 사용).
-        if (std.mem.startsWith(u8, method, "notifications/")) {
+        // JSON-RPC 2.0 §4.1: "A Notification is a Request object without an id member."
+        // method namespace `notifications/` (MCP convention) + `id` 필드 부재 두 조건을
+        // 모두 충족할 때만 notification 으로 처리. strict 한 spec 준수 + 잘못 작성된
+        // client (id 동반 notifications/* 송신) 가 응답을 영원히 기다리는 misuse 방어.
+        if (std.mem.startsWith(u8, method, "notifications/") and id_val == .null) {
             return .notification;
         }
 
@@ -2042,6 +2046,30 @@ test "dispatchMcpRequest: notifications/initialized → .notification + 응답 0
     // JSON-RPC 2.0: notification 은 응답 금지. writer 변경 0, kind 가 .notification.
     try std.testing.expectEqual(DevServer.DispatchResult.notification, kind);
     try std.testing.expectEqual(@as(usize, 0), resp.items.len);
+}
+
+test "dispatchMcpRequest: id 동반 notifications/* → .response (JSON-RPC §4.1 strict: id 부재 + prefix)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var dev_server = try DevServer.init(std.testing.allocator, .{ .root_dir = dir_path });
+    defer dev_server.deinit();
+
+    var resp: std.ArrayList(u8) = .empty;
+    defer resp.deinit(std.testing.allocator);
+    const w = resp.writer(std.testing.allocator);
+
+    // id 가 있는 notifications/* — spec 위반 client 의 misuse. notification 으로 처리되지 않고
+    // 일반 method 분기에서 -32601 Method not found 응답이 가야 client 가 hang 안 함.
+    const kind = try dev_server.dispatchMcpRequest(
+        \\{"jsonrpc":"2.0","id":11,"method":"notifications/initialized"}
+    , w);
+
+    try std.testing.expectEqual(DevServer.DispatchResult.response, kind);
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"id\":11") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "-32601") != null);
 }
 
 test "dispatchMcpRequest: 임의 notifications/* prefix → .notification + 응답 0 byte" {

--- a/src/server/mcp_stdio.zig
+++ b/src/server/mcp_stdio.zig
@@ -46,8 +46,10 @@ pub fn serveStdio(
         const line = maybe_line orelse return; // EOF
         if (line.len == 0) continue; // 빈 줄 skip
 
-        try dev_server.dispatchMcpRequest(line, writer);
-        try writer.writeByte('\n');
+        // notification (JSON-RPC 2.0 spec: 응답 금지) 이면 newline 도 안 보냄 — stdio
+        // 의 빈 줄은 client 가 skip 하지만, spec 상 byte 도 안 보내는 게 정석.
+        const kind = try dev_server.dispatchMcpRequest(line, writer);
+        if (kind == .response) try writer.writeByte('\n');
     }
 }
 
@@ -326,6 +328,44 @@ test "serveStdio: LineTooLong → -32600 응답 + 다음 줄 정상 처리 (resy
         nl_count += 1;
     };
     try std.testing.expectEqual(@as(usize, 2), nl_count);
+}
+
+test "serveStdio: notification 은 응답/newline 0 byte (JSON-RPC spec)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var dev_server = try DevServer.init(std.testing.allocator, .{ .root_dir = dir_path });
+    defer dev_server.deinit();
+
+    // notification 1개 + 일반 method 1개 — notification 은 0 byte, initialize 는 1줄 응답
+    var mr = MockReader{
+        .data =
+        \\{"jsonrpc":"2.0","method":"notifications/initialized"}
+        \\{"jsonrpc":"2.0","id":5,"method":"initialize"}
+        \\
+        ,
+    };
+
+    var resp: std.ArrayList(u8) = .empty;
+    defer resp.deinit(std.testing.allocator);
+    const w = resp.writer(std.testing.allocator);
+
+    var line_buf: [64 * 1024]u8 = undefined;
+    try serveStdio(&dev_server, &mr, w, &line_buf);
+
+    // notification 응답 prefix 가 없어야 함
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"id\":null") == null);
+    // initialize 응답은 있음
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"id\":5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp.items, "\"protocolVersion\"") != null);
+    // 정확히 1 newline (notification 0 byte + initialize 1줄)
+    var nl_count: usize = 0;
+    for (resp.items) |b| if (b == '\n') {
+        nl_count += 1;
+    };
+    try std.testing.expectEqual(@as(usize, 1), nl_count);
 }
 
 test "serveStdio: invalid JSON 줄 → -32700 응답 후 다음 줄 처리 계속" {


### PR DESCRIPTION
## Summary
- #3867 epic 의 PR-B (#3873) `/code-review max` 발견 follow-up
- JSON-RPC 2.0 notification spec 준수 (`"The Server MUST NOT reply to a Notification"`)
- 204 No Content 응답 헤더 정리

## 변경

### dispatcher 시그니처 `!void` → `!DispatchResult`

```zig
pub const DispatchResult = enum {
    response,     // writer 에 응답 1통
    notification, // writer 변경 0 byte (spec: 응답 금지)
};
```

### notification 검사 — strict spec (prefix + id 부재)

JSON-RPC 2.0 §4.1: "A Notification is a Request object without an id member." 두 조건 모두 충족 시에만 `.notification` 처리:

```zig
if (std.mem.startsWith(u8, method, "notifications/") and id_val == .null) {
    return .notification;
}
```

spec 위반 client (`{"id":1,"method":"notifications/initialized"}`) 는 일반 분기 → `-32601 Method not found` 응답 (client hang 회피).

### caller 분기

- **HTTP** (`handleMcp`): `.notification` → `204 No Content` + empty body + `cors_headers` (Content-Type 제외, RFC 9110 §8.3 준수)
- **stdio** (`serveStdio`): `.notification` → newline 도 안 보냄

## E2E

```sh
$ printf '%s\n%s\n%s\n' \
    '{"jsonrpc":"2.0","id":1,"method":"initialize"}' \
    '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
    '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
  | node packages/core/bin/zntc.mjs mcp
{"jsonrpc":"2.0","id":1,"result":{...}}    # initialize 응답
                                            # ← notifications 응답 0 byte
{"jsonrpc":"2.0","id":2,"result":{...}}    # tools/list 응답
```

## Test plan
- [x] **테스트 5개 추가/갱신**:
  - `notifications/initialized` → `.notification` + 응답 0 byte (의미 변경)
  - `notifications/cancelled` → 동일 (다른 namespace)
  - 일반 method → `.response` 반환 검증
  - id 동반 `notifications/initialized` → `.response` + `-32601` (strict spec)
  - stdio: notification + 일반 request 혼합 시 newline 1개만
- [x] 기존 7 dispatcher test + 11 stdio test 회귀 0
- [x] `zig build test` 전체 통과
- [x] `zig build napi` + JS bundle 통과
- [x] E2E (notification skip 검증)
- [x] `/code-review max` 통과 — finding 2건 같은 PR 안 fix

## 후속 (별도 PR)
- MCP Streamable HTTP (2025-03-26+) spec 의 `202 Accepted` — 현재는 2024-11-05 protocolVersion 광고 중이라 204 가 spec 부합. protocolVersion 업그레이드 시 같이 변경.
- JSON-RPC 2.0 §6 batch (array root) 미지원 — pre-existing, 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)