### PR TITLE
feat(cli): zntc mcp root 옵션 — positional + ZNTC_ROOT env (#3867 follow-up)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -2731,7 +2731,10 @@ async function main() {
   //   3) process.cwd()  (default)
   if (opts.appCommand === 'mcp') {
     try {
-      const rootDir = resolve(opts.appRoot ?? process.env.ZNTC_ROOT ?? '.');
+      // `||` 사용 — `ZNTC_ROOT=""` (빈 값) 처럼 truthy 가 아닌 입력은 cwd 로 fallback.
+      // `??` 는 `''` 도 채택해 `resolve('')` (cwd) 로 떨어지긴 하나, 의도가 cwd 면
+      // 명시적 fallback 이 더 안전.
+      const rootDir = resolve(opts.appRoot || process.env.ZNTC_ROOT || '.');
       coreModule.mcpStdioServe({ rootDir });
       process.exit(0);
     } catch (err) {

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -185,7 +185,8 @@ function usageLines(command) {
     '       zntc dev [root]',
     '       zntc build [root]',
     '       zntc preview [outdir]',
-    '       zntc mcp                          MCP stdio transport (Cursor/Claude Code)',
+    '       zntc mcp [root]                   MCP stdio transport (Cursor/Claude Code)',
+    '                                         root: positional > ZNTC_ROOT env > cwd',
     '',
     'Options:',
     '  --bundle                   Bundle dependencies',
@@ -427,7 +428,7 @@ function parseArgs(argv) {
 
     // positional (파일 경로)
     if (!arg.startsWith('-')) {
-      if (opts.appCommand === 'dev' || opts.appCommand === 'build') {
+      if (opts.appCommand === 'dev' || opts.appCommand === 'build' || opts.appCommand === 'mcp') {
         opts.appRoot = opts.appRoot ?? arg;
       } else if (opts.appCommand === 'preview') {
         opts.previewDir = opts.previewDir ?? arg;
@@ -2723,9 +2724,15 @@ async function main() {
   // Claude Code / Claude Desktop 등 stdio MCP 클라이언트가 `npx zntc mcp` 형태로
   // spawn. config / build pipeline 우회 — DevServer in-memory state (cache_reset 등)
   // 만 띄움 (HTTP listener 없음).
+  //
+  // root 결정 우선순위 (Cursor/Claude Desktop spawn cwd 불확실 회피):
+  //   1) positional arg (`zntc mcp /path/to/project`)
+  //   2) ZNTC_ROOT 환경변수
+  //   3) process.cwd()  (default)
   if (opts.appCommand === 'mcp') {
     try {
-      coreModule.mcpStdioServe({ rootDir: resolve('.') });
+      const rootDir = resolve(opts.appRoot ?? process.env.ZNTC_ROOT ?? '.');
+      coreModule.mcpStdioServe({ rootDir });
       process.exit(0);
     } catch (err) {
       console.error(`error: ${err.message}`);


### PR DESCRIPTION
## Summary
- #3867 epic 의 PR-B (#3873) `/code-review max` 발견 follow-up
- `zntc mcp` 의 root 가 항상 `process.cwd()` 였음 — Cursor / Claude Desktop spawn cwd 가 workspace root 와 다른 경우 DevServer in-memory state 가 엉뚱한 root 로 init
- positional arg + ZNTC_ROOT env fallback 추가

## 변경

root 결정 우선순위:
1. **positional** — `zntc mcp /path/to/project`
2. **`ZNTC_ROOT` 환경변수**
3. **`process.cwd()`** (default, 기존 동작)

`parseArgs` 의 positional 분기에 `appCommand === 'mcp'` 추가 (`dev`/`build` 와 동일 패턴). usage line 갱신. `||` 사용으로 `ZNTC_ROOT=""` (빈 값) 도 cwd 로 안전하게 fallback.

## E2E (수동 검증)

```sh
# positional
$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize"}' | zntc mcp /my/project
{"jsonrpc":"2.0","id":1,"result":{...}}

# env
$ ZNTC_ROOT=/my/project zntc mcp <<< '{...}'
{"jsonrpc":"2.0","id":1,"result":{...}}
```

Cursor / Claude Desktop config 권장 (명시적 절대 경로):
```jsonc
{ "mcpServers": { "zntc": {
  "command": "npx",
  "args": ["zntc", "mcp", "/absolute/path/to/project"]
}}}
```

## Test plan
- [x] `zig build test` 회귀 0 (이 PR 은 JS-only)
- [x] `bun run --cwd packages/core build:js` 통과
- [x] E2E (positional / ZNTC_ROOT env) 수동 검증
- [x] `/code-review max` 통과 — N1 (empty-string edge case) 도 같은 PR 안 fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)