### PR TITLE
feat(react-native): MCP runtime preamble — dev 빌드 entry 자동 inject (PR-C of #3867)

### DIFF
--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -99,6 +99,10 @@ export function buildRnBundleExtra(config, opts = {}) {
     sourceRoot: cfg.sourcemapSourcesRoot ?? undefined,
     silentConsoleErrorPatterns: server.silentConsoleErrorPatterns ?? undefined,
     forwardClientLogs: server.forwardClientLogs !== false,
+    // PR-C — `extra.mcp` opt-out. zntc.config / metro.config 의 최상위 `mcp` 또는
+    // `server.mcp` 필드로 noise-sensitive 빌드 (CI bundle 분석 등) 가 MCP runtime
+    // preamble 을 끌 수 있게 forward. undefined 면 default (dev 시 자동 inject).
+    mcp: cfg.mcp ?? server.mcp ?? undefined,
   };
 }
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -37,7 +37,8 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./runtime/zntc-hmr-client.cjs": "./runtime/zntc-hmr-client.cjs"
+    "./runtime/zntc-hmr-client.cjs": "./runtime/zntc-hmr-client.cjs",
+    "./runtime/mcp-runtime.cjs": "./runtime/mcp-runtime.cjs"
   },
   "scripts": {
     "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external @babel/core --external @react-native/babel-plugin-codegen --external @react-native/babel-preset --external metro-resolver --external react-native --external @react-native/js-polyfills",

--- a/packages/react-native/runtime/mcp-runtime.cjs
+++ b/packages/react-native/runtime/mcp-runtime.cjs
@@ -1,0 +1,29 @@
+'use strict';
+
+// MCP (Model Context Protocol) RN runtime — dev 빌드 한정 preamble.
+//
+// zntc transform pass 가 entry preamble (`runBeforeMain`) 로 inject. 앱 시작 시
+// 즉시 실행되어 global registry 만 등록 (silent + idempotent). 실제 MCP server
+// 연결 / Fiber tree 직렬화 / 네트워크 캡처 등 본격 로직은 후속 PR-E 에서 흡수.
+//
+// 이 placeholder 의 역할:
+//   1. dev 빌드의 entry preamble inject 메커니즘 검증 (`buildRnBundleOptions`)
+//   2. `globalThis.__ZNTC_MCP_RUNTIME__` extension point 예약 — 후속 PR-E 가 같은
+//      slot 에 실제 runtime API 등록
+//   3. 다중 import 안전 (idempotent) — pnpm peer 등으로 module 이 중복 import 돼도
+//      hooks 등록은 1회만
+//
+// production 빌드에는 inject 안 됨 (`dev: false`).
+
+(function () {
+  var g =
+    typeof globalThis !== 'undefined' ? globalThis : typeof global !== 'undefined' ? global : null;
+  if (!g) return;
+  if (g.__ZNTC_MCP_RUNTIME__) return; // 이미 loaded
+  g.__ZNTC_MCP_RUNTIME__ = {
+    version: '0.1.0-placeholder',
+    loaded: true,
+    // 후속 PR-E 에서 채워질 API surface:
+    //   takeSnapshot, findElement, inspectState, evalCode, networkMock, ...
+  };
+})();

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -343,6 +343,72 @@ describe('buildRnBundleOptions — define / banner / footer / polyfills', () => 
     ]);
   });
 
+  test('runBeforeMain — dev 시 @zntc/react-native/runtime/mcp-runtime.cjs 자동 inject (PR-C)', () => {
+    // InitializeCore + mcp-runtime.cjs 두 path 가 runBeforeMain 에 포함되어야 함.
+    mkdirSync(join(dir, 'node_modules/react-native/Libraries/Core'), { recursive: true });
+    writeFileSync(join(dir, 'node_modules/react-native/package.json'), '{"name":"react-native"}');
+    writeFileSync(join(dir, 'node_modules/react-native/Libraries/Core/InitializeCore.js'), '');
+    mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/@zntc/react-native/package.json'),
+      '{"name":"@zntc/react-native"}',
+    );
+    writeFileSync(join(dir, 'node_modules/@zntc/react-native/runtime/mcp-runtime.cjs'), '');
+
+    const opts = buildRnBundleOptions(baseInput({ dev: true }));
+    expect(opts.runBeforeMain).toEqual([
+      join(dir, 'node_modules/react-native/Libraries/Core/InitializeCore.js'),
+      join(dir, 'node_modules/@zntc/react-native/runtime/mcp-runtime.cjs'),
+    ]);
+  });
+
+  test('runBeforeMain — prod 빌드 (dev=false) 는 mcp-runtime inject 안 됨', () => {
+    mkdirSync(join(dir, 'node_modules/react-native/Libraries/Core'), { recursive: true });
+    writeFileSync(join(dir, 'node_modules/react-native/package.json'), '{"name":"react-native"}');
+    writeFileSync(join(dir, 'node_modules/react-native/Libraries/Core/InitializeCore.js'), '');
+    mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/@zntc/react-native/package.json'),
+      '{"name":"@zntc/react-native"}',
+    );
+    writeFileSync(join(dir, 'node_modules/@zntc/react-native/runtime/mcp-runtime.cjs'), '');
+
+    const opts = buildRnBundleOptions(baseInput({ dev: false }));
+    // production 빌드는 InitializeCore 만 (mcp-runtime 제외)
+    expect(opts.runBeforeMain).toEqual([
+      join(dir, 'node_modules/react-native/Libraries/Core/InitializeCore.js'),
+    ]);
+  });
+
+  test('runBeforeMain — extra.mcp=false 는 dev 빌드라도 mcp-runtime inject 안 됨 (opt-out)', () => {
+    mkdirSync(join(dir, 'node_modules/react-native/Libraries/Core'), { recursive: true });
+    writeFileSync(join(dir, 'node_modules/react-native/package.json'), '{"name":"react-native"}');
+    writeFileSync(join(dir, 'node_modules/react-native/Libraries/Core/InitializeCore.js'), '');
+    mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/@zntc/react-native/package.json'),
+      '{"name":"@zntc/react-native"}',
+    );
+    writeFileSync(join(dir, 'node_modules/@zntc/react-native/runtime/mcp-runtime.cjs'), '');
+
+    const opts = buildRnBundleOptions(baseInput({ dev: true, extra: { mcp: false } }));
+    expect(opts.runBeforeMain).toEqual([
+      join(dir, 'node_modules/react-native/Libraries/Core/InitializeCore.js'),
+    ]);
+  });
+
+  test('runBeforeMain — @zntc/react-native 미설치 시 silent fallback (inject 안 함, throw 없음)', () => {
+    mkdirSync(join(dir, 'node_modules/react-native/Libraries/Core'), { recursive: true });
+    writeFileSync(join(dir, 'node_modules/react-native/package.json'), '{"name":"react-native"}');
+    writeFileSync(join(dir, 'node_modules/react-native/Libraries/Core/InitializeCore.js'), '');
+    // @zntc/react-native 패키지 부재
+
+    const opts = buildRnBundleOptions(baseInput({ dev: true }));
+    expect(opts.runBeforeMain).toEqual([
+      join(dir, 'node_modules/react-native/Libraries/Core/InitializeCore.js'),
+    ]);
+  });
+
   test('extra.prelude — 사용자 prelude 가 projectRoot 기준 절대화 + runBeforeMain 에 append', () => {
     const opts = buildRnBundleOptions(
       baseInput({ extra: { prelude: ['./shims/extra-prelude.js'] } }),

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -397,6 +397,42 @@ describe('buildRnBundleOptions — define / banner / footer / polyfills', () => 
     ]);
   });
 
+  test('runBeforeMain — extra.mcp=true 명시 (default 와 동등하게 dev 시 inject)', () => {
+    mkdirSync(join(dir, 'node_modules/react-native/Libraries/Core'), { recursive: true });
+    writeFileSync(join(dir, 'node_modules/react-native/package.json'), '{"name":"react-native"}');
+    writeFileSync(join(dir, 'node_modules/react-native/Libraries/Core/InitializeCore.js'), '');
+    mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/@zntc/react-native/package.json'),
+      '{"name":"@zntc/react-native"}',
+    );
+    writeFileSync(join(dir, 'node_modules/@zntc/react-native/runtime/mcp-runtime.cjs'), '');
+
+    const opts = buildRnBundleOptions(baseInput({ dev: true, extra: { mcp: true } }));
+    expect(opts.runBeforeMain).toEqual([
+      join(dir, 'node_modules/react-native/Libraries/Core/InitializeCore.js'),
+      join(dir, 'node_modules/@zntc/react-native/runtime/mcp-runtime.cjs'),
+    ]);
+  });
+
+  test('runBeforeMain — extra 자체 undefined 일 때 dev 시 default 로 inject (회귀 방지)', () => {
+    mkdirSync(join(dir, 'node_modules/react-native/Libraries/Core'), { recursive: true });
+    writeFileSync(join(dir, 'node_modules/react-native/package.json'), '{"name":"react-native"}');
+    writeFileSync(join(dir, 'node_modules/react-native/Libraries/Core/InitializeCore.js'), '');
+    mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/@zntc/react-native/package.json'),
+      '{"name":"@zntc/react-native"}',
+    );
+    writeFileSync(join(dir, 'node_modules/@zntc/react-native/runtime/mcp-runtime.cjs'), '');
+
+    // extra 미전달 — `?? undefined` 분기로 default 동작 검증.
+    const opts = buildRnBundleOptions(baseInput({ dev: true }));
+    expect(opts.runBeforeMain).toContain(
+      join(dir, 'node_modules/@zntc/react-native/runtime/mcp-runtime.cjs'),
+    );
+  });
+
   test('runBeforeMain — @zntc/react-native 미설치 시 silent fallback (inject 안 함, throw 없음)', () => {
     mkdirSync(join(dir, 'node_modules/react-native/Libraries/Core'), { recursive: true });
     writeFileSync(join(dir, 'node_modules/react-native/package.json'), '{"name":"react-native"}');

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -156,6 +156,15 @@ export interface RnBundleInput {
      * dev server 터미널로 forwarding. 기본 true.
      */
     forwardClientLogs?: boolean;
+    /**
+     * MCP (Model Context Protocol) runtime preamble 활성화. 기본 true — dev 빌드일
+     * 때 `@zntc/react-native/runtime/mcp-runtime.cjs` 가 `runBeforeMain` 에 추가되어
+     * 앱 시작 시 global registry (`__ZNTC_MCP_RUNTIME__`) 를 등록한다.
+     * `false` 로 명시 시 inject 우회 — CI bundle 분석 같은 noise 회피, 또는
+     * `@zntc/react-native` 미설치 환경에서 silent fallback 외 명시적 opt-out.
+     * production 빌드 (`dev: false`) 는 옵션과 무관하게 inject 안 됨.
+     */
+    mcp?: boolean;
   };
   /** RN prelude 끝에 append 할 사용자 banner string. */
   bannerExtras?: string;
@@ -460,9 +469,22 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     projectRoot,
   );
   if (initCore) runBeforeMain.push(initCore);
+  // MCP runtime preamble — dev 빌드 한정. `@zntc/react-native/runtime/mcp-runtime.cjs`
+  // 가 InitializeCore 직후 실행되어 global registry (`__ZNTC_MCP_RUNTIME__`) 등록.
+  // 후속 PR-E 가 같은 slot 에 실제 WS connect / Fiber 직렬화 / network 캡처 등
+  // 본격 runtime 채움. production 빌드에는 inject 안 됨.
+  // `extra?.mcp === false` 로 명시적 opt-out 가능 (CI bundle 분석 등 noise 회피).
+  if (dev && extra?.mcp !== false) {
+    const mcpRuntime = tryResolvePackageFile(
+      '@zntc/react-native',
+      'runtime/mcp-runtime.cjs',
+      projectRoot,
+    );
+    if (mcpRuntime) runBeforeMain.push(mcpRuntime);
+  }
   if (extra?.prelude && extra.prelude.length > 0) {
-    // 사용자 추가 prelude — InitializeCore 이후에 실행. 절대/상대 모두 projectRoot
-    // 기준으로 정규화.
+    // 사용자 추가 prelude — InitializeCore + MCP runtime 이후에 실행. 절대/상대 모두
+    // projectRoot 기준으로 정규화.
     for (const p of extra.prelude) runBeforeMain.push(resolve(projectRoot, p));
   }
 

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -480,7 +480,17 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
       'runtime/mcp-runtime.cjs',
       projectRoot,
     );
-    if (mcpRuntime) runBeforeMain.push(mcpRuntime);
+    if (mcpRuntime) {
+      runBeforeMain.push(mcpRuntime);
+    } else if (extra?.mcp === true) {
+      // 사용자가 명시적으로 mcp=true 로 활성화했는데 path 못 찾으면 silent 가
+      // 디버깅 어렵다 — explicit on 일 때만 warn. default (extra.mcp 미지정) 는
+      // 기존 `resolveRnPolyfills` 의 silent 정책 유지 (`@zntc/react-native`
+      // 미설치 환경 friendly).
+      console.warn(
+        "[zntc:rn] mcp preamble 활성화됐으나 '@zntc/react-native/runtime/mcp-runtime.cjs' 를 찾지 못함. @zntc/react-native 설치 여부 확인.",
+      );
+    }
   }
   if (extra?.prelude && extra.prelude.length > 0) {
     // 사용자 추가 prelude — InitializeCore + MCP runtime 이후에 실행. 절대/상대 모두


### PR DESCRIPTION
## Summary
- #3867 epic 의 **PR-C**
- zntc transform pass (RN preset) 가 dev 빌드 시 entry 의 `runBeforeMain` 에 `@zntc/react-native/runtime/mcp-runtime.cjs` 자동 prepend
- 앱 시작 시 즉시 `globalThis.__ZNTC_MCP_RUNTIME__` 등록 (silent + idempotent)
- 후속 PR-E 가 같은 slot 에 실제 WS connect / Fiber 직렬화 / network 캡처 본격 runtime 채울 **extension point** 구축

## 변경

### `packages/react-native/runtime/mcp-runtime.cjs` (신설)
- self-execute IIFE placeholder (~30줄)
- `globalThis.__ZNTC_MCP_RUNTIME__ = { version, loaded }` 등록

### `packages/react-native/src/preset.ts`
- `buildRnBundleOptions` 의 `runBeforeMain` 에서 **dev 모드 + RN platform 시** mcp-runtime.cjs 를 InitializeCore 직후 자동 추가
- `RnBundleInput.extra.mcp` 옵션 — `false` 명시 시 inject 우회 (opt-out). default 자동 활성

### `packages/core/bin/rn-dev-input.mjs`
- `buildRnBundleExtra` 가 `cfg.mcp` 또는 `server.mcp` 를 forward — CLI/metro.config 에서 opt-out 가능

### `packages/react-native/package.json`
- `exports` 에 `./runtime/mcp-runtime.cjs` 추가

## Test (6개 새 케이스)
- [x] dev=true + `@zntc/react-native` installed → mcp-runtime 포함
- [x] dev=false (prod) → mcp-runtime 제외
- [x] dev=true + `extra.mcp=false` → opt-out 우회
- [x] dev=true + `extra.mcp=true` 명시 → 정상 inject
- [x] dev=true + `extra` undefined → default 동작 회귀 방지
- [x] dev=true + `@zntc/react-native` 미설치 → silent fallback

전체 RN preset test 81 pass + zig build test 회귀 0.

## `/code-review max` 결과 (이미 fix)
- **F3 [critical]**: `buildRnBundleExtra` 가 `mcp` forward 안 함 → CLI control surface 끊김. fix 완료.
- **F1 [medium]**: silent fail 디버깅 어려움. `extra.mcp === true` 명시일 때만 `console.warn` 추가 (default silent 유지).
- F2/F4 (멱등성, worklet runtime): 후속 PR-E 책임.
- F5/F6: 회귀 방지 test 추가 (F5) / publint OK (F6).

## E2E

dev RN 빌드 시 entry 시작 직후 placeholder self-execute → `__ZNTC_MCP_RUNTIME__` global 등록. 별도 `zntc mcp` 프로세스 (PR-B) 와 WS 연결은 후속 PR.

## 다음 단계
- **PR-D**: WebView module wrapper alias (`react-native-webview` → forwardRef wrapper) — Babel plugin 의 마지막 잔존 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)