### PR TITLE
feat(react-native,bundler): MCP WebView wrapper alias + AliasEntry exact opt-in (PR-D of #3867)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -848,6 +848,18 @@ interface BuildOptionsCommon {
    * `fallback` instead (applied only on failure). The array form is also
    * supported in buildSync(), which uses only sync hooks. */
   alias?: Record<string, string> | Array<{ find: string | RegExp; replacement: string }>;
+  /** alias 의 prefix matching 을 끄는 from 목록 — exact 매칭만 허용.
+   *
+   * `alias` object form 의 기본 동작은 esbuild 처럼 정확/접두사 둘 다 매칭이라
+   * `react: "preact/compat"` 가 `react/hooks → preact/compat/hooks` 로도 동작한다.
+   * 그러나 alias 값이 **단일 파일** (예: `react-native-webview` → `./wrapper.cjs`)
+   * 인 경우 prefix 매칭이 `react-native-webview/lib/X → ./wrapper.cjs/lib/X` 로
+   * 깨진다. 이 list 에 from 을 적으면 그 entry 는 exact 매칭만 적용 — subpath
+   * import 는 alias 미적용되어 원본 패키지로 resolve.
+   *
+   * 일반적인 package-to-package alias (`react → preact/compat`) 는 list 에 안 넣음.
+   * 주로 wrapper / shim 파일 alias 에서 사용. */
+  aliasExact?: string[];
   /** Fallback resolution — applied **only when** normal resolution fails
    * (webpack `resolve.fallback` / Metro `resolver.extraNodeModules`-compatible).
    * If the value is a string, re-resolve to that specifier; if `false`,

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -449,14 +449,29 @@ pub fn parseBuildOptions(
     }
 
     // alias: { "from": "to" } → []AliasEntry (tsconfig paths 는 tsconfig 로드 후 아래에서 append).
+    // `aliasExact: ["from1", "from2"]` — prefix-match 를 끄는 from 목록. wrapper 같은
+    // 단일 파일 alias 가 subpath import 를 깨뜨리지 않도록 명시적 opt-in.
     const alias_pairs = getObjectKeyValuePairs(env, opts_obj, "alias", native_alloc);
+    const alias_exact = getObjectStringArray(env, opts_obj, "aliasExact", native_alloc);
+    if (alias_exact) |list| for (list) |item| if (!trackStr(owned_strings, item)) return null;
+    defer if (alias_exact) |list| native_alloc.free(list);
     var alias_list: std.ArrayList(bundler_mod.types.AliasEntry) = .empty;
     if (alias_pairs) |pairs| {
         defer native_alloc.free(pairs);
         for (pairs) |pair| {
             if (!trackStr(owned_strings, pair[0])) return null;
             if (!trackStr(owned_strings, pair[1])) return null;
-            alias_list.append(native_alloc, .{ .from = pair[0], .to = pair[1] }) catch return null;
+            const is_exact = blk: {
+                if (alias_exact) |list| for (list) |ex| {
+                    if (std.mem.eql(u8, ex, pair[0])) break :blk true;
+                };
+                break :blk false;
+            };
+            alias_list.append(native_alloc, .{
+                .from = pair[0],
+                .to = pair[1],
+                .exact = is_exact,
+            }) catch return null;
         }
     }
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -38,7 +38,8 @@
       "import": "./dist/index.js"
     },
     "./runtime/zntc-hmr-client.cjs": "./runtime/zntc-hmr-client.cjs",
-    "./runtime/mcp-runtime.cjs": "./runtime/mcp-runtime.cjs"
+    "./runtime/mcp-runtime.cjs": "./runtime/mcp-runtime.cjs",
+    "./runtime/webview-wrapper.cjs": "./runtime/webview-wrapper.cjs"
   },
   "scripts": {
     "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external @babel/core --external @react-native/babel-plugin-codegen --external @react-native/babel-preset --external metro-resolver --external react-native --external @react-native/js-polyfills",

--- a/packages/react-native/runtime/webview-wrapper.cjs
+++ b/packages/react-native/runtime/webview-wrapper.cjs
@@ -1,0 +1,76 @@
+'use strict';
+
+// MCP WebView wrapper — dev 빌드 한정. zntc resolver alias 가 `react-native-webview`
+// import 를 이 파일로 redirect 하고, 원본 패키지는 escape alias `__zntc_webview_original__`
+// 로만 접근하게 한다 (alias self-loop 회피).
+//
+// 목적:
+//   `<WebView />` 의 forwardRef 안 instance 를 mount 시 자동으로 `__ZNTC_WEBVIEW_REGISTRY__`
+//   에 등록 → 후속 PR (PR-E `webview_evaluate_script`) 가 instance.injectJavaScript() 등
+//   imperative method 를 ref 로 호출 가능.
+//
+// 핵심 invariant:
+//   - JSX 안 건드림 (Babel plugin 0)
+//   - 사용자가 직접 단 ref 와 wrapper 의 inner ref 가 충돌하지 않도록 mergeRefs
+//   - 원본 패키지의 named exports (WebViewMessageEvent 등) 모두 spread re-export
+//   - production 빌드에는 alias 가 적용 안 됨 — 사용자 코드는 원본 그대로
+//   - registry global 은 mcp-runtime 의 `__ZNTC_MCP_RUNTIME__` 과 분리 (PR-E 가
+//     필요 시 두 entry point 연결)
+
+const React = require('react');
+const Original = require('__zntc_webview_original__');
+
+const _registry = (() => {
+  const g = typeof globalThis !== 'undefined' ? globalThis : global;
+  if (g.__ZNTC_WEBVIEW_REGISTRY__) return g.__ZNTC_WEBVIEW_REGISTRY__;
+  const map = new Map();
+  Object.defineProperty(g, '__ZNTC_WEBVIEW_REGISTRY__', {
+    value: map,
+    writable: false,
+    configurable: false,
+    enumerable: false,
+  });
+  return map;
+})();
+
+let _nextId = 1;
+
+function mergeRefs(...refs) {
+  return (value) => {
+    for (const ref of refs) {
+      if (typeof ref === 'function') ref(value);
+      else if (ref != null) ref.current = value;
+    }
+  };
+}
+
+const OriginalWebView = Original && Original.WebView ? Original.WebView : Original.default;
+
+const ZntcWebView = React.forwardRef(function ZntcWebView(props, userRef) {
+  const innerRef = React.useRef(null);
+  const idRef = React.useRef(null);
+
+  React.useEffect(() => {
+    const id = 'wv_' + _nextId++;
+    idRef.current = id;
+    _registry.set(id, innerRef.current);
+    return () => {
+      _registry.delete(id);
+      idRef.current = null;
+    };
+  }, []);
+
+  return React.createElement(OriginalWebView, {
+    ...props,
+    ref: mergeRefs(innerRef, userRef),
+  });
+});
+ZntcWebView.displayName = 'ZntcWebView';
+
+// 원본 모듈의 named/default exports 모두 보존 — WebView 만 wrap 으로 덮어쓴다.
+// caller 가 `import { WebViewMessageEvent } from 'react-native-webview'` 처럼 가져가는
+// 부수 export 가 깨지지 않게 spread.
+module.exports = Object.assign({}, Original, {
+  WebView: ZntcWebView,
+  default: ZntcWebView,
+});

--- a/packages/react-native/runtime/webview-wrapper.cjs
+++ b/packages/react-native/runtime/webview-wrapper.cjs
@@ -44,7 +44,19 @@ function mergeRefs(...refs) {
   };
 }
 
-const OriginalWebView = Original && Original.WebView ? Original.WebView : Original.default;
+// CJS / ESM interop: 원본 패키지가 named `WebView`, default, 또는 `module.exports = WebView`
+// 셋 중 어느 형태든 받음. 셋 다 falsy 면 명시적 throw (silent 깨짐 대신 fail-loud).
+const OriginalWebView =
+  (Original && Original.WebView) ||
+  (Original && Original.default) ||
+  (typeof Original === 'function' ? Original : null);
+if (!OriginalWebView) {
+  throw new Error(
+    '[zntc:mcp:webview-wrapper] react-native-webview 모듈 의 WebView export 를 찾지 못했습니다. ' +
+      '지원 형태: named `WebView`, `default`, 또는 `module.exports = WebView` (legacy CJS). ' +
+      'react-native-webview 버전 호환성 확인 필요.',
+  );
+}
 
 const ZntcWebView = React.forwardRef(function ZntcWebView(props, userRef) {
   const innerRef = React.useRef(null);
@@ -70,7 +82,13 @@ ZntcWebView.displayName = 'ZntcWebView';
 // 원본 모듈의 named/default exports 모두 보존 — WebView 만 wrap 으로 덮어쓴다.
 // caller 가 `import { WebViewMessageEvent } from 'react-native-webview'` 처럼 가져가는
 // 부수 export 가 깨지지 않게 spread.
-module.exports = Object.assign({}, Original, {
+const wrapperExports = Object.assign({}, Original, {
   WebView: ZntcWebView,
   default: ZntcWebView,
 });
+// `__esModule: true` 명시 — pure CJS 원본 패키지 (marker 부재) 에서도 zntc/Metro 의
+// CJS→ESM interop 이 default import 를 `module.default` 로 unwrap 하도록 보장.
+// 미 명시 시 `import WebView from 'react-native-webview'` 가 wrapper module 객체
+// 전체를 받아 JSX `<WebView />` 가 invariant violation 으로 깨진다.
+Object.defineProperty(wrapperExports, '__esModule', { value: true });
+module.exports = wrapperExports;

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -445,6 +445,78 @@ describe('buildRnBundleOptions — define / banner / footer / polyfills', () => 
     ]);
   });
 
+  test('alias — dev 시 react-native-webview → wrapper.cjs + __zntc_webview_original__ → 원본 (PR-D)', () => {
+    mkdirSync(join(dir, 'node_modules/react-native-webview'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/react-native-webview/package.json'),
+      '{"name":"react-native-webview"}',
+    );
+    mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/@zntc/react-native/package.json'),
+      '{"name":"@zntc/react-native"}',
+    );
+    writeFileSync(join(dir, 'node_modules/@zntc/react-native/runtime/webview-wrapper.cjs'), '');
+
+    const opts = buildRnBundleOptions(baseInput({ dev: true }));
+    expect(opts.alias?.['react-native-webview']).toBe(
+      join(dir, 'node_modules/@zntc/react-native/runtime/webview-wrapper.cjs'),
+    );
+    expect(opts.alias?.['__zntc_webview_original__']).toBe(
+      join(dir, 'node_modules/react-native-webview'),
+    );
+  });
+
+  test('alias — prod 빌드는 react-native-webview wrapper alias 미등록', () => {
+    mkdirSync(join(dir, 'node_modules/react-native-webview'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/react-native-webview/package.json'),
+      '{"name":"react-native-webview"}',
+    );
+    mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/@zntc/react-native/package.json'),
+      '{"name":"@zntc/react-native"}',
+    );
+    writeFileSync(join(dir, 'node_modules/@zntc/react-native/runtime/webview-wrapper.cjs'), '');
+
+    const opts = buildRnBundleOptions(baseInput({ dev: false }));
+    expect(opts.alias?.['react-native-webview']).toBeUndefined();
+    expect(opts.alias?.['__zntc_webview_original__']).toBeUndefined();
+  });
+
+  test('alias — extra.mcp=false 면 wrapper alias 미등록 (dev 라도 opt-out)', () => {
+    mkdirSync(join(dir, 'node_modules/react-native-webview'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/react-native-webview/package.json'),
+      '{"name":"react-native-webview"}',
+    );
+    mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/@zntc/react-native/package.json'),
+      '{"name":"@zntc/react-native"}',
+    );
+    writeFileSync(join(dir, 'node_modules/@zntc/react-native/runtime/webview-wrapper.cjs'), '');
+
+    const opts = buildRnBundleOptions(baseInput({ dev: true, extra: { mcp: false } }));
+    expect(opts.alias?.['react-native-webview']).toBeUndefined();
+    expect(opts.alias?.['__zntc_webview_original__']).toBeUndefined();
+  });
+
+  test('alias — react-native-webview 미설치 시 silent fallback (alias 자체가 안 등록)', () => {
+    mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/@zntc/react-native/package.json'),
+      '{"name":"@zntc/react-native"}',
+    );
+    writeFileSync(join(dir, 'node_modules/@zntc/react-native/runtime/webview-wrapper.cjs'), '');
+    // react-native-webview 패키지 부재
+
+    const opts = buildRnBundleOptions(baseInput({ dev: true }));
+    expect(opts.alias?.['react-native-webview']).toBeUndefined();
+    expect(opts.alias?.['__zntc_webview_original__']).toBeUndefined();
+  });
+
   test('extra.prelude — 사용자 prelude 가 projectRoot 기준 절대화 + runBeforeMain 에 append', () => {
     const opts = buildRnBundleOptions(
       baseInput({ extra: { prelude: ['./shims/extra-prelude.js'] } }),

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -517,6 +517,44 @@ describe('buildRnBundleOptions — define / banner / footer / polyfills', () => 
     expect(opts.alias?.['__zntc_webview_original__']).toBeUndefined();
   });
 
+  test('aliasExact — wrapper 등록 시 두 specifier 모두 exact list 포함 (subpath import 보존)', () => {
+    mkdirSync(join(dir, 'node_modules/react-native-webview'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/react-native-webview/package.json'),
+      '{"name":"react-native-webview"}',
+    );
+    mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/@zntc/react-native/package.json'),
+      '{"name":"@zntc/react-native"}',
+    );
+    writeFileSync(join(dir, 'node_modules/@zntc/react-native/runtime/webview-wrapper.cjs'), '');
+
+    const opts = buildRnBundleOptions(baseInput({ dev: true }));
+    expect(opts.aliasExact).toEqual(['react-native-webview', '__zntc_webview_original__']);
+  });
+
+  test('aliasExact — wrapper 미등록 시 (prod / opt-out / 미설치) 빈 배열', () => {
+    mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
+    writeFileSync(
+      join(dir, 'node_modules/@zntc/react-native/package.json'),
+      '{"name":"@zntc/react-native"}',
+    );
+    writeFileSync(join(dir, 'node_modules/@zntc/react-native/runtime/webview-wrapper.cjs'), '');
+
+    // prod
+    const prod = buildRnBundleOptions(baseInput({ dev: false }));
+    expect(prod.aliasExact).toEqual([]);
+
+    // dev + opt-out
+    const optOut = buildRnBundleOptions(baseInput({ dev: true, extra: { mcp: false } }));
+    expect(optOut.aliasExact).toEqual([]);
+
+    // dev + react-native-webview 미설치
+    const noWv = buildRnBundleOptions(baseInput({ dev: true }));
+    expect(noWv.aliasExact).toEqual([]);
+  });
+
   test('extra.prelude — 사용자 prelude 가 projectRoot 기준 절대화 + runBeforeMain 에 append', () => {
     const opts = buildRnBundleOptions(
       baseInput({ extra: { prelude: ['./shims/extra-prelude.js'] } }),

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -277,6 +277,39 @@ function buildRnSingletonAliases(projectRoot: string): Record<string, string> {
 }
 
 /**
+ * MCP WebView wrapper alias 등록. `react-native-webview` import 를 zntc 의 forwardRef
+ * wrapper 로 redirect — JSX 안 건드리고 mount 시 instance 를 `__ZNTC_WEBVIEW_REGISTRY__`
+ * 에 자동 등록 (후속 `webview_evaluate_script` MCP tool 이 imperative method 호출 가능).
+ * wrapper 가 원본 패키지를 require 할 때는 escape specifier `__zntc_webview_original__`
+ * 로만 접근 (alias self-loop 회피).
+ *
+ * 등록 조건 (모두 충족 시):
+ *   1. `dev === true` — production 빌드 영향 0
+ *   2. `extra.mcp !== false` — MCP 비활성 시 wrapper 도 우회
+ *   3. `react-native-webview` 가 projectRoot 에 설치됨
+ *   4. `@zntc/react-native` 의 wrapper.cjs 가 발견됨
+ */
+function buildMcpWebViewAliases(
+  projectRoot: string,
+  dev: boolean,
+  mcpEnabled: boolean,
+): Record<string, string> {
+  if (!dev || !mcpEnabled) return {};
+  const webviewRoot = tryResolvePackageRoot('react-native-webview', projectRoot);
+  if (!webviewRoot) return {};
+  const zntcRnRoot = tryResolvePackageRoot('@zntc/react-native', projectRoot);
+  if (!zntcRnRoot) return {};
+  const wrapperPath = resolve(zntcRnRoot, 'runtime/webview-wrapper.cjs');
+  if (!existsSync(wrapperPath)) return {};
+  return {
+    'react-native-webview': wrapperPath,
+    // wrapper 가 원본 모듈에 접근하는 전용 specifier — alias 두 번 적용되어
+    // 자기 자신으로 돌아오는 무한 루프 회피.
+    __zntc_webview_original__: webviewRoot,
+  };
+}
+
+/**
  * prelude 가 이미 declare 한 식별자 — Hermes strict 모드에서 var 재선언 시
  * SyntaxError. caller 가 prelude 식별자를 override 할 의도면 `define` 사용.
  */
@@ -538,7 +571,10 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     // RN core package 는 singleton 이어야 한다. pnpm peer folder 에서
     // react-native/react 가 별도 module 로 들어오면 InitializeCore/DevTools 가
     // 다시 실행되어 Fabric 이 깨질 수 있다.
-    alias: buildRnSingletonAliases(projectRoot),
+    alias: {
+      ...buildRnSingletonAliases(projectRoot),
+      ...buildMcpWebViewAliases(projectRoot, dev, extra?.mcp !== false),
+    },
     // Metro 설정과 맞춰 pnpm symlink 를 처리한다. resolver 는 표준 pnpm package
     // symlink 의 module identity 를 실제 .pnpm package path 로 정규화하되, workspace
     // symlink 는 logical path 를 유지한다.

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -293,10 +293,20 @@ function buildMcpWebViewAliases(
   projectRoot: string,
   dev: boolean,
   mcpEnabled: boolean,
+  explicitOn = false,
 ): Record<string, string> {
   if (!dev || !mcpEnabled) return {};
   const webviewRoot = tryResolvePackageRoot('react-native-webview', projectRoot);
-  if (!webviewRoot) return {};
+  if (!webviewRoot) {
+    if (explicitOn) {
+      // mcp=true 명시했는데 react-native-webview 가 없으면 디버깅 hint — wrapper alias
+      // 가 어떤 디버깅 시도 없이 silent skip 되는 걸 막는다.
+      console.warn(
+        "[zntc:rn] mcp WebView wrapper 비활성 — 'react-native-webview' 가 projectRoot 에서 resolve 안 됨.",
+      );
+    }
+    return {};
+  }
   const zntcRnRoot = tryResolvePackageRoot('@zntc/react-native', projectRoot);
   if (!zntcRnRoot) return {};
   const wrapperPath = resolve(zntcRnRoot, 'runtime/webview-wrapper.cjs');
@@ -307,6 +317,21 @@ function buildMcpWebViewAliases(
     // 자기 자신으로 돌아오는 무한 루프 회피.
     __zntc_webview_original__: webviewRoot,
   };
+}
+
+/**
+ * `buildMcpWebViewAliases` 가 등록한 alias 중 prefix matching 을 꺼야 하는 from list.
+ * `react-native-webview` 는 단일 파일 wrapper 라 subpath import 가 깨지므로 exact only.
+ * `__zntc_webview_original__` 은 escape specifier 라 wrapper 외 사용처 없음, 그래도
+ * 안전상 exact only.
+ */
+function buildMcpWebViewAliasExactList(
+  projectRoot: string,
+  dev: boolean,
+  mcpEnabled: boolean,
+): string[] {
+  const aliases = buildMcpWebViewAliases(projectRoot, dev, mcpEnabled);
+  return Object.keys(aliases);
 }
 
 /**
@@ -573,8 +598,13 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     // 다시 실행되어 Fabric 이 깨질 수 있다.
     alias: {
       ...buildRnSingletonAliases(projectRoot),
-      ...buildMcpWebViewAliases(projectRoot, dev, extra?.mcp !== false),
+      ...buildMcpWebViewAliases(projectRoot, dev, extra?.mcp !== false, extra?.mcp === true),
     },
+    // MCP WebView wrapper alias 는 단일 .cjs 파일이라 prefix matching 으로 subpath
+    // import (`react-native-webview/lib/X`) 가 깨진다. exact 매칭만 적용해 subpath
+    // 는 원본 패키지로 resolve. wrapper 가 미등록된 경우 (prod / opt-out / 미설치)
+    // 에는 list 가 비어 무영향.
+    aliasExact: buildMcpWebViewAliasExactList(projectRoot, dev, extra?.mcp !== false),
     // Metro 설정과 맞춰 pnpm symlink 를 처리한다. resolver 는 표준 pnpm package
     // symlink 의 module identity 를 실제 .pnpm package path 로 정규화하되, workspace
     // symlink 는 logical path 를 유지한다.

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -451,6 +451,9 @@ pub const Resolver = struct {
             if (std.mem.eql(u8, specifier, entry.from)) {
                 return try allocator.dupe(u8, entry.to);
             }
+            // `exact = true` 인 entry 는 prefix 매칭 skip — `to` 가 단일 파일이면 subpath
+            // import 가 깨지므로 명시적 opt-in 한 경우에만 prefix 도 허용.
+            if (entry.exact) continue;
             // 접두사 매칭: specifier가 "from/" 로 시작
             if (specifier.len > entry.from.len and
                 std.mem.startsWith(u8, specifier, entry.from) and

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -757,6 +757,33 @@ test "resolve.alias — no match partial name" {
     try std.testing.expectEqual(@as(?[]const u8, null), result);
 }
 
+test "resolve.alias — exact=true 는 prefix match 를 건너뛴다 (wrapper 단일 파일 alias 보호)" {
+    const aliases: []const AliasEntry = &.{
+        .{ .from = "react-native-webview", .to = "/abs/wrapper.cjs", .exact = true },
+    };
+    // exact 매칭은 작동
+    const exact = try Resolver.applyAlias(std.testing.allocator, aliases, "react-native-webview");
+    defer std.testing.allocator.free(exact.?);
+    try std.testing.expectEqualStrings("/abs/wrapper.cjs", exact.?);
+    // prefix 매칭은 비활성 — subpath 가 원본 패키지로 resolve 되도록 alias 가 안 적용되어야 함
+    const prefix = try Resolver.applyAlias(std.testing.allocator, aliases, "react-native-webview/lib/X");
+    try std.testing.expectEqual(@as(?[]const u8, null), prefix);
+}
+
+test "resolve.alias — exact=false (default) 는 기존대로 prefix match 동작" {
+    const aliases: []const AliasEntry = &.{
+        .{ .from = "react", .to = "preact/compat" }, // exact 미명시 → false
+    };
+    // exact 도 작동
+    const exact = try Resolver.applyAlias(std.testing.allocator, aliases, "react");
+    defer std.testing.allocator.free(exact.?);
+    try std.testing.expectEqualStrings("preact/compat", exact.?);
+    // prefix 도 작동 (회귀 검증)
+    const prefix = try Resolver.applyAlias(std.testing.allocator, aliases, "react/hooks");
+    defer std.testing.allocator.free(prefix.?);
+    try std.testing.expectEqualStrings("preact/compat/hooks", prefix.?);
+}
+
 test "resolve.alias — multiple entries first match wins" {
     const aliases: []const AliasEntry = &.{
         .{ .from = "react", .to = "preact/compat" },

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -117,9 +117,15 @@ pub const ModuleIndex = enum(u32) {
 /// import 경로 별칭. resolve 시 specifier 앞부분을 치환.
 /// 정확 매칭: "react" → "preact/compat"
 /// 접두사 매칭: "react/hooks" → "preact/compat/hooks"
+///
+/// `exact = true` 인 entry 는 prefix 매칭을 건너뛴다 — `from` 과 specifier 가 완전
+/// 일치할 때만 적용. `to` 가 디렉토리가 아닌 단일 파일 (예: `runtime/webview-wrapper.cjs`)
+/// 인 경우 prefix 매칭이 `from/subpath` → `wrapper.cjs/subpath` (디렉토리 취급) 으로
+/// 깨지므로 명시적 opt-in.
 pub const AliasEntry = struct {
     from: []const u8,
     to: []const u8,
+    exact: bool = false,
 };
 
 /// Fallback 엔트리 (webpack `resolve.fallback` / Metro `resolver.extraNodeModules` 호환).

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -40,6 +40,7 @@ const pure_zig_only_fields = [_][]const u8{
 const bundler_only_fields = [_][]const u8{
     "external",
     "alias",
+    "aliasExact",
     "loader",
     "conditions",
     "resolveExtensions",


### PR DESCRIPTION
## Summary
- #3867 epic 의 **PR-D**
- `react-native-webview` import 를 zntc resolver alias 로 forwardRef wrapper 로 redirect — JSX 안 건드림, **Babel plugin 0** 달성
- mount 시 instance 를 `__ZNTC_WEBVIEW_REGISTRY__` 자동 등록 → 후속 PR 의 `webview_evaluate_script` MCP tool 이 imperative method 호출 가능

## 변경

### `packages/react-native/runtime/webview-wrapper.cjs` (신설, ~85줄)
- forwardRef + useRef + useEffect 로 mount/unmount lifecycle 에 registry 관리
- mergeRefs — 사용자 ref + inner ref atomic
- 원본 `react-native-webview` 의 named/default/legacy CJS export 모두 시도 + 못 찾으면 explicit throw (silent 깨짐 방지)
- `__esModule: true` 명시 — CJS 원본도 default import interop 보장

### `packages/react-native/src/preset.ts`
- `buildMcpWebViewAliases` — dev + RN + `react-native-webview` 설치 + mcp 비-opt-out 시 alias 등록
  - `'react-native-webview'` → wrapper.cjs (단일 파일)
  - `'__zntc_webview_original__'` → 원본 패키지 (alias self-loop 회피 escape)
- `buildMcpWebViewAliasExactList` — 위 두 specifier 를 `aliasExact` 에 등록
- `extra.mcp === true` 명시 + 미설치 시 `console.warn`

### `src/bundler/types.zig` + `src/bundler/resolver.zig`
- `AliasEntry` 에 `exact: bool = false` 옵션 추가
- `applyAlias` 가 `exact = true` entry 는 prefix matching 건너뜀

### `packages/core/index.ts` + `packages/core/src/napi/options.zig`
- `BuildOptions.aliasExact?: string[]` — exact 처리할 from 목록
- NAPI `getObjectStringArray("aliasExact")` → AliasEntry 의 `exact` 설정

### `src/config_options_dto_test.zig`
- `bundler_only_fields` 에 `"aliasExact"` 추가 (JS↔Zig schema sync — 메모리 가이드)

### `packages/react-native/package.json`
- `exports` 에 `./runtime/webview-wrapper.cjs` 추가

## Test (10개 새 케이스)
- `applyAlias` exact=true → exact 작동 + prefix 비활성
- `applyAlias` exact=false (default) → 기존 동작 보존 (회귀 검증)
- preset alias: dev / prod / opt-out / 미설치 4 케이스
- preset aliasExact: 등록 시 / 미등록 시 (prod, opt-out, 미설치)

전체 RN preset test 87 pass + zig build test 회귀 0 (5631 통과).

## `/code-review max` 결과

- **F1 [HIGH]**: subpath import 깨짐 (`resolver.zig:457` prefix-match) → `AliasEntry.exact` 옵션 추가 fix
- **F2 [MEDIUM]**: `OriginalWebView` undefined silent → explicit throw fix
- **F5 [MEDIUM]**: `__esModule` 미보존 → `defineProperty` 명시 fix
- **F6 [LOW] partial**: 미설치 silent 디버깅 어려움 → `extra.mcp === true` 명시 시 warn
- F3/F4 (HMR/strict mode race), F7 (jsdom 단위 test), F8 (회귀 가드): PR-E 또는 별도 PR

## 결과 — Babel plugin 0 달성

| 원본 react-native-mcp Babel plugin | 흡수 결과 |
|---|---|
| `app-registry.cjs` (123줄) — runtime import 자동 prepend | **PR-C**: zntc transform pass 가 `runBeforeMain` 에 mcp-runtime.cjs 추가 |
| `inject-testid.cjs` (345줄) — JSX testID + WebView ref | **runtime ref 시스템** (PR-E) + **PR-D**: WebView wrapper alias |

`babel.config.js` 수정 0, JSX 변환 0.

## 다음 단계
- **PR-E**: WebSocket app channel — `mcp-runtime.cjs` 의 placeholder 를 실제 WS connect / Fiber 직렬화 / network 캡처 본격 runtime 으로 채움

🤖 Generated with [Claude Code](https://claude.com/claude-code)