### PR TITLE
feat(react-native): MCP runtime WS client (PR-E2 of #3867)

### DIFF
--- a/packages/react-native/runtime/mcp-runtime.cjs
+++ b/packages/react-native/runtime/mcp-runtime.cjs
@@ -46,11 +46,15 @@ function startMcpRuntime(g) {
 
   var url = g.__ZNTC_MCP_APP_WS_URL__ || DEFAULT_URL;
   var handlers = Object.create(null);
+  // closedExplicitly: 사용자 `runtime.close()` 호출 (사용자 의도, reconnect 금지)
+  // protocolMismatch: server 가 광고한 protocol version 이 client EXPECTED 와 불일치
+  // — reconnect 무의미 (RN reload 필요). 별도 sentinel 로 두 가지 케이스 구분.
   var state = {
     ws: null,
     connectionState: 'closed',
     reconnectMs: RECONNECT_MIN_MS,
     closedExplicitly: false,
+    protocolMismatch: false,
   };
 
   // public API surface — 후속 PR 이 `runtime.handlers[name] = fn` 으로 tool 추가.
@@ -75,15 +79,9 @@ function startMcpRuntime(g) {
     },
   };
 
-  function dispatch(text) {
-    var msg;
-    try {
-      msg = JSON.parse(text);
-    } catch (_) {
-      return;
-    }
-    if (!msg || typeof msg !== 'object') return;
-
+  // `msg` 는 이미 parse 된 object. onmessage 가 parse 1회 후 hello 분기 + 일반 dispatch
+  // 양쪽에 같은 결과 forward.
+  function dispatch(msg) {
     // server 가 보낸 request (id + method) — handler 호출 → response.
     if (typeof msg.method === 'string' && msg.id != null) {
       var fn = handlers[msg.method];
@@ -134,7 +132,7 @@ function startMcpRuntime(g) {
   }
 
   function scheduleReconnect() {
-    if (state.closedExplicitly) return;
+    if (state.closedExplicitly || state.protocolMismatch) return;
     var delay = state.reconnectMs;
     state.reconnectMs = Math.min(state.reconnectMs * 2, RECONNECT_MAX_MS);
     // `g.setTimeout` 명시 — runtime 안에서 bare `setTimeout` 은 closure 의
@@ -165,20 +163,29 @@ function startMcpRuntime(g) {
     ws.onmessage = function (ev) {
       var data = ev && ev.data;
       if (typeof data !== 'string') return;
-      // hello 메시지 — protocol version 검증.
-      // wire contract (Zig 측) 기준 단 1회 도착. 이후는 일반 RPC.
-      if (data.indexOf('"method":"connected"') !== -1) {
-        // protocol 식별자 mismatch 시 close — 향후 spec 변경 시 graceful 대응.
-        if (data.indexOf('"protocol":"' + EXPECTED_PROTOCOL + '"') === -1) {
-          state.closedExplicitly = true;
+      // 단 1회 parse — substring 검사 (false-positive 위험) 대신 typed check.
+      var msg;
+      try {
+        msg = JSON.parse(data);
+      } catch (_) {
+        return;
+      }
+      if (!msg || typeof msg !== 'object') return;
+
+      // hello 메시지 — top-level `method === "connected"` 만 검출. nested object 의
+      // `method` field 가 우연히 "connected" 여도 영향 없음.
+      if (msg.method === 'connected' && msg.id == null) {
+        var serverProtocol =
+          msg.params && typeof msg.params.protocol === 'string' ? msg.params.protocol : null;
+        if (serverProtocol !== EXPECTED_PROTOCOL) {
+          state.protocolMismatch = true;
           try {
             ws.close();
           } catch (_) {}
-          return;
         }
         return;
       }
-      dispatch(data);
+      dispatch(msg);
     };
 
     ws.onerror = function () {

--- a/packages/react-native/runtime/mcp-runtime.cjs
+++ b/packages/react-native/runtime/mcp-runtime.cjs
@@ -3,27 +3,223 @@
 // MCP (Model Context Protocol) RN runtime — dev 빌드 한정 preamble.
 //
 // zntc transform pass 가 entry preamble (`runBeforeMain`) 로 inject. 앱 시작 시
-// 즉시 실행되어 global registry 만 등록 (silent + idempotent). 실제 MCP server
-// 연결 / Fiber tree 직렬화 / 네트워크 캡처 등 본격 로직은 후속 PR-E 에서 흡수.
-//
-// 이 placeholder 의 역할:
-//   1. dev 빌드의 entry preamble inject 메커니즘 검증 (`buildRnBundleOptions`)
-//   2. `globalThis.__ZNTC_MCP_RUNTIME__` extension point 예약 — 후속 PR-E 가 같은
-//      slot 에 실제 runtime API 등록
-//   3. 다중 import 안전 (idempotent) — pnpm peer 등으로 module 이 중복 import 돼도
-//      hooks 등록은 1회만
+// 즉시 실행되어 dev_server 의 `/__mcp-app` WebSocket 에 connect, JSON-RPC 2.0
+// 메시지 dispatcher 등록. 후속 PR (PR-E3+) 가 `__ZNTC_MCP_RUNTIME__.handlers` 에
+// 본격 tool 핸들러 (takeSnapshot / findElement / inspectState 등) 채움.
 //
 // production 빌드에는 inject 안 됨 (`dev: false`).
+//
+// Wire contract (Zig 측 `src/server/mcp_app_channel.zig` 참조):
+//   - URL path: `/__mcp-app`
+//   - server hello: `{"jsonrpc":"2.0","method":"connected","params":{"protocol":"mcp-app-1"}}`
+//   - server reject: `{"jsonrpc":"2.0","error":{"code":-32000,...}}` + close frame
+//
+// URL discovery:
+//   1. `globalThis.__ZNTC_MCP_APP_WS_URL__` — 사용자 또는 빌드 시 inject (override)
+//   2. fallback: `ws://localhost:12300/__mcp-app` — RN 시뮬레이터 default
+//
+// Reconnect: 지수 backoff (1s → 2s → 4s → ... → max 30s) — server restart / network
+// hiccup 시 복구. dev 환경의 noise 줄이기 위해 console 출력 최소.
 
-(function () {
-  var g =
-    typeof globalThis !== 'undefined' ? globalThis : typeof global !== 'undefined' ? global : null;
+function startMcpRuntime(g) {
   if (!g) return;
-  if (g.__ZNTC_MCP_RUNTIME__) return; // 이미 loaded
-  g.__ZNTC_MCP_RUNTIME__ = {
-    version: '0.1.0-placeholder',
-    loaded: true,
-    // 후속 PR-E 에서 채워질 API surface:
-    //   takeSnapshot, findElement, inspectState, evalCode, networkMock, ...
+  if (g.__ZNTC_MCP_RUNTIME__ && g.__ZNTC_MCP_RUNTIME__.loaded) return; // 이미 loaded — HMR idempotent
+
+  var DEFAULT_URL = 'ws://localhost:12300/__mcp-app';
+  var EXPECTED_PROTOCOL = 'mcp-app-1';
+  var RECONNECT_MIN_MS = 1000;
+  var RECONNECT_MAX_MS = 30000;
+
+  // RN 환경에서 WebSocket 은 RN core (Libraries/WebSocket) 가 polyfill 제공.
+  // RN runtime 초기화 후에만 사용 가능 (InitializeCore 이후 — runBeforeMain 순서로 보장).
+  if (typeof g.WebSocket !== 'function') {
+    // RN 외 환경 (Node CLI 테스트 등) — 등록만 하고 connect skip.
+    g.__ZNTC_MCP_RUNTIME__ = {
+      version: '0.1.0',
+      loaded: true,
+      connectionState: 'unsupported',
+      ws: null,
+      handlers: Object.create(null),
+    };
+    return;
+  }
+
+  var url = g.__ZNTC_MCP_APP_WS_URL__ || DEFAULT_URL;
+  var handlers = Object.create(null);
+  var state = {
+    ws: null,
+    connectionState: 'closed',
+    reconnectMs: RECONNECT_MIN_MS,
+    closedExplicitly: false,
   };
-})();
+
+  // public API surface — 후속 PR 이 `runtime.handlers[name] = fn` 으로 tool 추가.
+  g.__ZNTC_MCP_RUNTIME__ = {
+    version: '0.1.0',
+    loaded: true,
+    get connectionState() {
+      return state.connectionState;
+    },
+    get ws() {
+      return state.ws;
+    },
+    handlers: handlers,
+    /** 명시적 종료 — 테스트나 reconfigure 시 호출. reconnect loop 도 멈춤. */
+    close: function () {
+      state.closedExplicitly = true;
+      if (state.ws) {
+        try {
+          state.ws.close();
+        } catch (_) {}
+      }
+    },
+  };
+
+  function dispatch(text) {
+    var msg;
+    try {
+      msg = JSON.parse(text);
+    } catch (_) {
+      return;
+    }
+    if (!msg || typeof msg !== 'object') return;
+
+    // server 가 보낸 request (id + method) — handler 호출 → response.
+    if (typeof msg.method === 'string' && msg.id != null) {
+      var fn = handlers[msg.method];
+      if (typeof fn !== 'function') {
+        send({
+          jsonrpc: '2.0',
+          id: msg.id,
+          error: { code: -32601, message: 'Method not found: ' + msg.method },
+        });
+        return;
+      }
+      try {
+        var result = fn(msg.params || {});
+        // sync 결과만 우선 — async (Promise) 처리는 후속 PR
+        send({ jsonrpc: '2.0', id: msg.id, result: result == null ? {} : result });
+      } catch (err) {
+        send({
+          jsonrpc: '2.0',
+          id: msg.id,
+          error: { code: -32603, message: String((err && err.message) || err) },
+        });
+      }
+      return;
+    }
+
+    // notification (id 없음) — 핸들러만 호출, 응답 안 보냄.
+    if (typeof msg.method === 'string') {
+      var nfn = handlers[msg.method];
+      if (typeof nfn === 'function') {
+        try {
+          nfn(msg.params || {});
+        } catch (_) {}
+      }
+      return;
+    }
+
+    // server-initiated response (result/error + id) — 후속 PR 에서 pending Map 매칭.
+  }
+
+  function send(obj) {
+    if (!state.ws || state.connectionState !== 'open') return false;
+    try {
+      state.ws.send(JSON.stringify(obj));
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function scheduleReconnect() {
+    if (state.closedExplicitly) return;
+    var delay = state.reconnectMs;
+    state.reconnectMs = Math.min(state.reconnectMs * 2, RECONNECT_MAX_MS);
+    // `g.setTimeout` 명시 — runtime 안에서 bare `setTimeout` 은 closure 의
+    // host realm setTimeout 을 참조해 test mock 이 안 통한다. RN 환경에선
+    // `g === globalThis` 라 동일 동작.
+    if (typeof g.setTimeout === 'function') {
+      g.setTimeout(connect, delay);
+    }
+  }
+
+  function connect() {
+    if (state.closedExplicitly) return;
+    state.connectionState = 'connecting';
+    var ws;
+    try {
+      ws = new g.WebSocket(url);
+    } catch (_) {
+      scheduleReconnect();
+      return;
+    }
+    state.ws = ws;
+
+    ws.onopen = function () {
+      state.connectionState = 'open';
+      state.reconnectMs = RECONNECT_MIN_MS; // 성공 connect → backoff reset
+    };
+
+    ws.onmessage = function (ev) {
+      var data = ev && ev.data;
+      if (typeof data !== 'string') return;
+      // hello 메시지 — protocol version 검증.
+      // wire contract (Zig 측) 기준 단 1회 도착. 이후는 일반 RPC.
+      if (data.indexOf('"method":"connected"') !== -1) {
+        // protocol 식별자 mismatch 시 close — 향후 spec 변경 시 graceful 대응.
+        if (data.indexOf('"protocol":"' + EXPECTED_PROTOCOL + '"') === -1) {
+          state.closedExplicitly = true;
+          try {
+            ws.close();
+          } catch (_) {}
+          return;
+        }
+        return;
+      }
+      dispatch(data);
+    };
+
+    ws.onerror = function () {
+      // 별도 처리 없음 — onclose 가 이어 호출됨.
+    };
+
+    ws.onclose = function () {
+      state.connectionState = 'closed';
+      state.ws = null;
+      scheduleReconnect();
+    };
+  }
+
+  // 첫 connect — RN 의 InitializeCore 가 fetch/XHR 등을 준비한 후 호출됨 (runBeforeMain
+  // 순서 보장). 즉시 동기 호출하면 WebSocket polyfill 이 아직 mount 안 된 케이스가
+  // 있어 microtask 로 살짝 늦춤.
+  if (typeof g.setTimeout === 'function') {
+    g.setTimeout(connect, 0);
+  } else {
+    connect();
+  }
+}
+
+// Auto-execute — RN preamble (runBeforeMain) 으로 inject 시 자동 실행.
+// **RN-only guard**: `navigator.product === 'ReactNative'` 가 RN 환경의 표준 detection.
+// Node test runner / Bun / 일반 브라우저 환경에서는 skip — 그 환경엔 polyfill WebSocket
+// 이 있어도 ws://localhost:12300 으로 실제 connect 시도가 process hang 유발 (reconnect
+// loop) 가능. test 는 `require('mcp-runtime.cjs').startMcpRuntime(mockG)` 로 직접 호출.
+function __zntcIsReactNative(g) {
+  return (
+    g != null &&
+    typeof g.navigator === 'object' &&
+    g.navigator != null &&
+    g.navigator.product === 'ReactNative'
+  );
+}
+
+var __zntcAutoG =
+  typeof globalThis !== 'undefined' ? globalThis : typeof global !== 'undefined' ? global : null;
+if (__zntcAutoG && __zntcIsReactNative(__zntcAutoG)) startMcpRuntime(__zntcAutoG);
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { startMcpRuntime: startMcpRuntime };
+}

--- a/packages/react-native/src/mcp-runtime.test.ts
+++ b/packages/react-native/src/mcp-runtime.test.ts
@@ -160,9 +160,40 @@ describe('mcp-runtime.cjs (PR-E2) — dispatch', () => {
       '{"jsonrpc":"2.0","method":"connected","params":{"protocol":"mcp-app-99"}}',
     );
     expect(lastWs!.closed).toBe(true);
-    // closedExplicitly 라 reconnect schedule 안 됨 — 0-delay 외 추가 setTimeout 없음
+    // protocolMismatch sentinel 로 reconnect schedule 안 됨 — 0-delay 외 추가 setTimeout 없음.
+    // close() API 의 closedExplicitly 와 별도 sentinel — 두 case 구분.
     const reconnectScheduled = g.setTimeout_calls!.some((c) => c.ms > 0);
     expect(reconnectScheduled).toBe(false);
+  });
+
+  test('일반 RPC 의 nested params 에 "method":"connected" 가 있어도 hello 로 오인 안 함 (F1 회귀 잠금)', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    let dispatched: unknown = null;
+    rt.handlers['app/dispatch'] = (params) => {
+      dispatched = params;
+      return { ok: true };
+    };
+    lastWs!.triggerOpen();
+    // nested action 안에 `"method":"connected"` 문자열이 들어있는 정상 RPC.
+    lastWs!.triggerMessage(
+      '{"jsonrpc":"2.0","id":99,"method":"app/dispatch","params":{"action":{"method":"connected","payload":{}}}}',
+    );
+    // close 되면 안 됨 (이전 substring 기반 코드는 여기서 protocol mismatch 분기로 close 했었음).
+    expect(lastWs!.closed).toBe(false);
+    expect(dispatched).toEqual({ action: { method: 'connected', payload: {} } });
+    expect(lastWs!.sent.length).toBe(1);
+    const resp = JSON.parse(lastWs!.sent[0]);
+    expect(resp.id).toBe(99);
+    expect(resp.result).toEqual({ ok: true });
+  });
+
+  test('hello 의 protocol 키 부재 (server bug) — mismatch 로 처리, close', () => {
+    loadRuntime(g);
+    lastWs!.triggerOpen();
+    // `connected` method 인데 params.protocol 누락.
+    lastWs!.triggerMessage('{"jsonrpc":"2.0","method":"connected","params":{}}');
+    expect(lastWs!.closed).toBe(true);
   });
 
   test('request 메시지 (id + method) — handler 호출 → response send', () => {

--- a/packages/react-native/src/mcp-runtime.test.ts
+++ b/packages/react-native/src/mcp-runtime.test.ts
@@ -1,0 +1,264 @@
+// mcp-runtime.cjs (PR-E2) — WS client 단위 test.
+//
+// 실 WebSocket 안 사용. mock WebSocket 으로 connect → hello parse → dispatch →
+// reconnect lifecycle 검증.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+const RUNTIME_PATH = join(__dirname, '..', 'runtime', 'mcp-runtime.cjs');
+const reqFromHere = createRequire(__filename);
+const { startMcpRuntime } = reqFromHere(RUNTIME_PATH) as {
+  startMcpRuntime: (g: unknown) => void;
+};
+
+interface MockWsEvent {
+  data?: unknown;
+}
+
+interface MockWs {
+  url: string;
+  sent: string[];
+  onopen?: () => void;
+  onmessage?: (ev: MockWsEvent) => void;
+  onerror?: () => void;
+  onclose?: () => void;
+  send: (data: string) => void;
+  close: () => void;
+  triggerOpen: () => void;
+  triggerMessage: (data: string) => void;
+  triggerClose: () => void;
+  closed: boolean;
+}
+
+interface FakeGlobal {
+  WebSocket?: (url: string) => MockWs;
+  __ZNTC_MCP_RUNTIME__?: unknown;
+  __ZNTC_MCP_APP_WS_URL__?: string;
+  setTimeout?: (fn: () => void, ms: number) => unknown;
+  clearTimeout?: (id: unknown) => void;
+  setTimeout_calls?: Array<{ fn: () => void; ms: number }>;
+  // helper to flush all pending setTimeout 0-delay tasks
+  __flushImmediate?: () => void;
+}
+
+/**
+ * runtime 의 startMcpRuntime 함수를 mock global 과 함께 호출. cross-context closure
+ * 문제 없이 단순 function call — outer Bun realm 에서 직접 실행.
+ */
+function loadRuntime(g: FakeGlobal): void {
+  startMcpRuntime(g);
+}
+
+function makeMockWs(url: string): MockWs {
+  const ws: MockWs = {
+    url,
+    sent: [],
+    closed: false,
+    send(data: string) {
+      this.sent.push(data);
+    },
+    close() {
+      if (this.closed) return;
+      this.closed = true;
+      this.onclose?.();
+    },
+    triggerOpen() {
+      this.onopen?.();
+    },
+    triggerMessage(data: string) {
+      this.onmessage?.({ data });
+    },
+    triggerClose() {
+      this.close();
+    },
+  };
+  return ws;
+}
+
+let g: FakeGlobal;
+let lastWs: MockWs | null;
+
+beforeEach(() => {
+  lastWs = null;
+  g = {};
+  // Regular function — `new` 가능. arrow function 은 constructor 못 됨.
+  g.WebSocket = function MockWebSocketCtor(url: string) {
+    const ws = makeMockWs(url);
+    lastWs = ws;
+    return ws;
+  } as unknown as FakeGlobal['WebSocket'];
+  g.setTimeout_calls = [];
+  g.setTimeout = ((fn: () => void, ms: number) => {
+    g.setTimeout_calls!.push({ fn, ms });
+    // 0-delay task 는 즉시 실행으로 시뮬레이션 (microtask 대용)
+    if (ms === 0) fn();
+    return 0;
+  }) as FakeGlobal['setTimeout'];
+});
+
+afterEach(() => {
+  // explicit cleanup
+  if (lastWs) lastWs.close();
+});
+
+describe('mcp-runtime.cjs (PR-E2) — load + connect', () => {
+  test('runtime 등록 — __ZNTC_MCP_RUNTIME__ 의 핵심 field', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as Record<string, unknown>;
+    expect(rt).toBeDefined();
+    expect(rt.loaded).toBe(true);
+    expect(typeof rt.version).toBe('string');
+    expect(typeof rt.handlers).toBe('object');
+  });
+
+  test('idempotent — 두 번 evaluate 해도 1번만 connect', () => {
+    loadRuntime(g);
+    const calls1 = g.setTimeout_calls!.length;
+    loadRuntime(g);
+    const calls2 = g.setTimeout_calls!.length;
+    // 두 번째 evaluate 는 early return (loaded=true)
+    expect(calls2).toBe(calls1);
+  });
+
+  test('WebSocket 미지원 환경 — connectionState=unsupported, ws=null', () => {
+    g.WebSocket = undefined as unknown as FakeGlobal['WebSocket'];
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as Record<string, unknown>;
+    expect(rt.connectionState).toBe('unsupported');
+    expect(rt.ws).toBe(null);
+  });
+
+  test('default URL — ws://localhost:12300/__mcp-app', () => {
+    loadRuntime(g);
+    expect(lastWs).toBeDefined();
+    expect(lastWs!.url).toBe('ws://localhost:12300/__mcp-app');
+  });
+
+  test('__ZNTC_MCP_APP_WS_URL__ override — 사용자 / 빌드 inject URL 우선', () => {
+    g.__ZNTC_MCP_APP_WS_URL__ = 'ws://10.0.0.1:8080/__mcp-app';
+    loadRuntime(g);
+    expect(lastWs!.url).toBe('ws://10.0.0.1:8080/__mcp-app');
+  });
+});
+
+describe('mcp-runtime.cjs (PR-E2) — dispatch', () => {
+  test('hello 메시지 (`method: "connected"`, protocol mcp-app-1) — 정상 통과, close 안 함', () => {
+    loadRuntime(g);
+    lastWs!.triggerOpen();
+    lastWs!.triggerMessage(
+      '{"jsonrpc":"2.0","method":"connected","params":{"protocol":"mcp-app-1"}}',
+    );
+    expect(lastWs!.closed).toBe(false);
+  });
+
+  test('hello 의 protocol mismatch — close 후 reconnect 안 함', () => {
+    loadRuntime(g);
+    lastWs!.triggerOpen();
+    lastWs!.triggerMessage(
+      '{"jsonrpc":"2.0","method":"connected","params":{"protocol":"mcp-app-99"}}',
+    );
+    expect(lastWs!.closed).toBe(true);
+    // closedExplicitly 라 reconnect schedule 안 됨 — 0-delay 외 추가 setTimeout 없음
+    const reconnectScheduled = g.setTimeout_calls!.some((c) => c.ms > 0);
+    expect(reconnectScheduled).toBe(false);
+  });
+
+  test('request 메시지 (id + method) — handler 호출 → response send', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    rt.handlers.ping = (params: unknown) => ({ pong: true, params });
+
+    lastWs!.triggerOpen();
+    lastWs!.triggerMessage('{"jsonrpc":"2.0","id":42,"method":"ping","params":{"hello":1}}');
+
+    expect(lastWs!.sent.length).toBe(1);
+    const resp = JSON.parse(lastWs!.sent[0]);
+    expect(resp).toEqual({
+      jsonrpc: '2.0',
+      id: 42,
+      result: { pong: true, params: { hello: 1 } },
+    });
+  });
+
+  test('request 메시지 — unknown method → -32601 error response', () => {
+    loadRuntime(g);
+    lastWs!.triggerOpen();
+    lastWs!.triggerMessage('{"jsonrpc":"2.0","id":7,"method":"nope"}');
+    expect(lastWs!.sent.length).toBe(1);
+    const resp = JSON.parse(lastWs!.sent[0]);
+    expect(resp.error).toBeDefined();
+    expect(resp.error.code).toBe(-32601);
+    expect(resp.id).toBe(7);
+  });
+
+  test('request handler 가 throw → -32603 Internal error', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    rt.handlers.kaboom = () => {
+      throw new Error('test failure');
+    };
+    lastWs!.triggerOpen();
+    lastWs!.triggerMessage('{"jsonrpc":"2.0","id":3,"method":"kaboom"}');
+    const resp = JSON.parse(lastWs!.sent[0]);
+    expect(resp.error.code).toBe(-32603);
+    expect(resp.error.message).toContain('test failure');
+  });
+
+  test('notification (id 없음) — 핸들러 호출 후 응답 안 보냄', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    let called = false;
+    rt.handlers['hello/notify'] = () => {
+      called = true;
+    };
+    lastWs!.triggerOpen();
+    lastWs!.triggerMessage('{"jsonrpc":"2.0","method":"hello/notify","params":{}}');
+    expect(called).toBe(true);
+    expect(lastWs!.sent.length).toBe(0);
+  });
+
+  test('invalid JSON → 무시 (응답 안 보냄, throw 안 함)', () => {
+    loadRuntime(g);
+    lastWs!.triggerOpen();
+    lastWs!.triggerMessage('not-json{');
+    expect(lastWs!.sent.length).toBe(0);
+  });
+});
+
+describe('mcp-runtime.cjs (PR-E2) — reconnect', () => {
+  test('connection close 후 reconnect schedule (지수 backoff)', () => {
+    loadRuntime(g);
+    lastWs!.triggerOpen();
+    // backoff 시작값 1000ms
+    lastWs!.triggerClose();
+    const scheduled = g.setTimeout_calls!.filter((c) => c.ms > 0);
+    expect(scheduled.length).toBeGreaterThanOrEqual(1);
+    expect(scheduled[0].ms).toBe(1000);
+  });
+
+  test('open 성공 시 backoff reset — 다음 close 도 1000ms 부터 시작', () => {
+    loadRuntime(g);
+    // 첫 connect open → close → reconnect (1000ms)
+    lastWs!.triggerOpen();
+    lastWs!.triggerClose();
+    // setTimeout 콜 발화
+    const firstReconnect = g.setTimeout_calls!.filter((c) => c.ms > 0)[0];
+    firstReconnect.fn(); // 두 번째 connect
+    lastWs!.triggerOpen(); // success
+    lastWs!.triggerClose();
+    const reconnects = g.setTimeout_calls!.filter((c) => c.ms > 0);
+    // 두 번째 reconnect 도 1000ms (open 후 reset)
+    expect(reconnects[reconnects.length - 1].ms).toBe(1000);
+  });
+
+  test('close() 호출 — reconnect 안 함', () => {
+    loadRuntime(g);
+    lastWs!.triggerOpen();
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { close: () => void };
+    rt.close();
+    const scheduled = g.setTimeout_calls!.filter((c) => c.ms > 0);
+    expect(scheduled.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- #3867 epic 의 **PR-E2** — PR-E1 의 dev_server `/__mcp-app` endpoint 와 짝
- `mcp-runtime.cjs` placeholder 를 실 WebSocket client 로 진화. dispatcher / reconnect / hello protocol parse 본격 구현

## 변경

### `packages/react-native/runtime/mcp-runtime.cjs`
- IIFE → `startMcpRuntime(g)` 함수로 추출 + `module.exports` 로 test 가능
- **Auto-execute** + RN-only guard (`navigator.product === 'ReactNative'`)
- WS connect: `ws://localhost:12300/__mcp-app` default + `globalThis.__ZNTC_MCP_APP_WS_URL__` override
- Hello: `msg.method === 'connected' && msg.id == null` typed check + protocol parse
- JSON-RPC dispatcher: request (`-32601`/`-32603`) / notification / response (후속 PR-E3)
- Reconnect: 1s → 2s → 4s → 30s 지수 backoff, open 시 reset
- 두 sentinel 분리: `closedExplicitly` (사용자 `close()`) / `protocolMismatch` (server protocol 광고 불일치)

### `packages/react-native/src/mcp-runtime.test.ts` (신설, 17 tests)
- load + connect (5): runtime field / idempotent / WebSocket 미지원 / default URL / override
- dispatch (8): hello / protocol mismatch / **nested method false-positive 회귀 잠금** / protocol 키 부재 / request / unknown method / handler throw / notification / invalid JSON
- reconnect (3): 지수 backoff / open 후 reset / close() 후 no-reconnect

## `/code-review max` 결과 (3건 같은 PR 안 fix)

- **F1 [Medium]** substring 기반 hello detection 의 false-positive — JSON.parse 후 typed check
- **F2 [Medium]** protocol mismatch 영구 차단 — 별도 `protocolMismatch` sentinel
- **F4 [Low]** protocol id JSON-escape — typed compare 로 자연 해결

F3/F5/F6/F7 (defineProperty / jest guard / test gap / send drop log) — 별도 후속 PR.

## Wire contract (PR-E1 과 일치)
- URL: `/__mcp-app` (`APP_DEV_MCP_APP_WS_PATH` JS 상수)
- protocol version: `mcp-app-1`
- hello: `{jsonrpc, method:"connected", params:{protocol}}`

## 다음 단계
- **PR-E3**: 첫 tool 통합 + Zig 측 dispatcher 가 AppChannel 통해 forward + streaming WS reader (`readSmallMessage` 125 byte 한계 해결, PR-E1 F3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)