### PR TITLE
fix(server): connection recv buffer 8KB → 256KB (PR-E1 F3 deferred)

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -432,7 +432,17 @@ pub const DevServer = struct {
         defer connection.stream.close();
 
         var send_buf: [8192]u8 = undefined;
-        var recv_buf: [8192]u8 = undefined;
+        // recv_buf: 256KB heap alloc — large WebSocket frame (JSON-RPC payload, MCP
+        // app channel 의 take_snapshot 같은 대형 응답) 지원. std.http.Server.WebSocket
+        // 의 readSmallMessage 는 single-frame (fin=true) 만 받고 `payload > buffer.len`
+        // 시 MessageTooBig. typical MCP request/response (KB~수십 KB) 는 충분히 fit.
+        // PNG 등 binary payload 가 base64 로 MB 단위가 될 경우는 PR-E3+ 의 streaming
+        // 또는 자체 readMessage 구현으로 별도 처리.
+        const recv_buf = self.allocator.alloc(u8, 256 * 1024) catch |err| {
+            getLog().print("zntc: failed to alloc connection recv buffer: {}\n", .{err}) catch {};
+            return;
+        };
+        defer self.allocator.free(recv_buf);
 
         if (self.tls_ctx) |*ctx| {
             // HTTPS path — SSL_accept handshake 후 TlsReader/TlsWriter 어댑터로 http.Server.
@@ -442,13 +452,13 @@ pub const DevServer = struct {
             };
             defer tls_conn.deinit();
 
-            var tls_reader = tls_conn.reader(&recv_buf);
+            var tls_reader = tls_conn.reader(recv_buf);
             var tls_writer = tls_conn.writer(&send_buf);
             var server: http.Server = .init(&tls_reader.interface, &tls_writer.interface);
             self.serveOnConnection(&server, &tls_writer.interface);
         } else {
             // plain HTTP path.
-            var conn_reader = connection.stream.reader(&recv_buf);
+            var conn_reader = connection.stream.reader(recv_buf);
             var conn_writer = connection.stream.writer(&send_buf);
             var server: http.Server = .init(conn_reader.interface(), &conn_writer.interface);
             self.serveOnConnection(&server, &conn_writer.interface);


### PR DESCRIPTION
## Summary
- #3867 epic 의 **PR-E1 F3 deferred fix**
- 기존 `recv_buf: [8192]u8` 가 large WebSocket frame (MCP app channel 의 JSON-RPC payload) 받으면 `MessageTooBig`
- PR-E3 의 첫 tool dispatch 차단 요소 해소

## 변경
- `handleConnection` 의 recv_buf 를 256KB heap alloc 으로 변경
- stack overflow 회피 (macOS thread stack 512KB)

## Covers / Doesn't cover
- ✅ JSON-RPC tools/list, inspect_state, find_element 등 typical KB~수십 KB 응답
- ❌ single-frame > 256KB (PNG base64 binary 등 MB) — PR-E3 의 take_screenshot 직전 자체 readMessage / fragmentation 지원 별도 PR

## Test
- `zig build test` 전체 5631 통과 (회귀 0)
- 통합 test (real HTTP server + 200KB frame send) 는 별도 infrastructure 필요 — 본 PR 은 std `readSmallMessage` 의 `buffer.len` 한계만 늘리는 1-line semantic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)