### PR TITLE
fix(react-native): mcp-runtime jest opt-out + send drop warn (PR-E2 F5+F7 deferred)

### DIFF
--- a/packages/react-native/runtime/mcp-runtime.cjs
+++ b/packages/react-native/runtime/mcp-runtime.cjs
@@ -122,7 +122,18 @@ function startMcpRuntime(g) {
   }
 
   function send(obj) {
-    if (!state.ws || state.connectionState !== 'open') return false;
+    if (!state.ws || state.connectionState !== 'open') {
+      // handler 실행 중 / 직후에 onclose 발화 race — pending response 손실.
+      // dev console.warn 으로 디버깅 hint (서버는 timeout 까지 hang). 후속 PR 에서
+      // pending response queue 또는 retry 로 강화 가능.
+      if (typeof g.console !== 'undefined' && typeof g.console.warn === 'function') {
+        var idHint = obj && obj.id != null ? ' id=' + String(obj.id) : '';
+        g.console.warn(
+          '[zntc:mcp:runtime] send drop — WS 닫힘 (state=' + state.connectionState + ')' + idHint,
+        );
+      }
+      return false;
+    }
     try {
       state.ws.send(JSON.stringify(obj));
       return true;
@@ -210,10 +221,15 @@ function startMcpRuntime(g) {
 }
 
 // Auto-execute — RN preamble (runBeforeMain) 으로 inject 시 자동 실행.
-// **RN-only guard**: `navigator.product === 'ReactNative'` 가 RN 환경의 표준 detection.
-// Node test runner / Bun / 일반 브라우저 환경에서는 skip — 그 환경엔 polyfill WebSocket
-// 이 있어도 ws://localhost:12300 으로 실제 connect 시도가 process hang 유발 (reconnect
-// loop) 가능. test 는 `require('mcp-runtime.cjs').startMcpRuntime(mockG)` 로 직접 호출.
+//
+// **RN-only guard**: `navigator.product === 'ReactNative'` 가 RN 환경 표준 detection.
+// Node test runner / Bun / 일반 브라우저는 skip — 그 환경엔 polyfill WebSocket 이
+// 있어도 ws://localhost:12300 으로 실제 connect 시도가 process hang 유발 가능.
+//
+// **Opt-out**: 사용자 / jest setup 이 `globalThis.__ZNTC_DISABLE_MCP_RUNTIME__ = true`
+// 로 명시 설정 시 RN 환경이라도 skip. jest-environment-node + react-native preset 가
+// `navigator.product = 'ReactNative'` 를 set 해서 RN detection 이 false-positive
+// 인 unit test 시나리오 대응.
 function __zntcIsReactNative(g) {
   return (
     g != null &&
@@ -223,9 +239,14 @@ function __zntcIsReactNative(g) {
   );
 }
 
+function __zntcShouldAutoStart(g) {
+  if (!g || g.__ZNTC_DISABLE_MCP_RUNTIME__ === true) return false;
+  return __zntcIsReactNative(g);
+}
+
 var __zntcAutoG =
   typeof globalThis !== 'undefined' ? globalThis : typeof global !== 'undefined' ? global : null;
-if (__zntcAutoG && __zntcIsReactNative(__zntcAutoG)) startMcpRuntime(__zntcAutoG);
+if (__zntcShouldAutoStart(__zntcAutoG)) startMcpRuntime(__zntcAutoG);
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = { startMcpRuntime: startMcpRuntime };

--- a/packages/react-native/src/mcp-runtime.test.ts
+++ b/packages/react-native/src/mcp-runtime.test.ts
@@ -284,6 +284,33 @@ describe('mcp-runtime.cjs (PR-E2) — reconnect', () => {
     expect(reconnects[reconnects.length - 1].ms).toBe(1000);
   });
 
+  test('send drop warn — WS 닫힘 후 응답 send 시 console.warn (F7 deferred)', () => {
+    const warnings: unknown[] = [];
+    g.console = {
+      warn: (...args: unknown[]) => warnings.push(args),
+      log: () => {},
+      error: () => {},
+    } as unknown as Console;
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    // handler 가 동기 응답을 send 시도 — 그 사이 WS 가 닫혀 있다면?
+    rt.handlers.echo = () => ({ ok: true });
+
+    lastWs!.triggerOpen();
+    // close 먼저 발생 후 dispatcher 가 try send.
+    lastWs!.triggerClose();
+    // close 후 message 받으면 — runtime 의 dispatch 가 호출되어 handler → send 시도.
+    // 단 onmessage 가 close 후엔 호출 안 됨 (mockWs 의 spec). 직접 send 호출 시뮬레이션:
+    // runtime 의 내부 send 는 직접 access 불가 — handler 호출 시뮬레이션 어려움.
+    // 대신 onmessage 가 closed 상태에서 호출됐을 때 send 가 warn 하는지 검증:
+    lastWs!.onmessage?.({ data: '{"jsonrpc":"2.0","id":1,"method":"echo"}' });
+    // send 호출 시 state.connectionState !== 'open' 라 warn + return false
+    const warnedCount = warnings.filter(
+      (w) => Array.isArray(w) && typeof w[0] === 'string' && w[0].includes('send drop'),
+    ).length;
+    expect(warnedCount).toBeGreaterThanOrEqual(1);
+  });
+
   test('close() 호출 — reconnect 안 함', () => {
     loadRuntime(g);
     lastWs!.triggerOpen();


### PR DESCRIPTION
## Summary
- #3867 epic 의 **PR-E2 F5+F7 deferred fix**
- F5: `__ZNTC_DISABLE_MCP_RUNTIME__` opt-out — jest+RN preset 환경 false-positive 회피
- F7: `send()` silent drop 시 `console.warn` (디버깅 hint)

## 변경

### F5 — Opt-out flag
사용자가 `globalThis.__ZNTC_DISABLE_MCP_RUNTIME__ = true` 로 명시 설정 시 RN 환경 (`navigator.product==='ReactNative'`) 이어도 auto-start skip. jest-environment-node + react-native preset 환경에서 RN detection 이 false-positive 라 사용자 unit test 마다 `ws://localhost:12300` 으로 connect 시도하던 노이즈 회피.

### F7 — Send drop warn
`send()` 가 `connectionState !== 'open'` 일 때 `console.warn('[zntc:mcp:runtime] send drop — WS 닫힘 (state=...) id=X')`. dev 환경에서 pending response 손실 디버깅 가능 (서버가 timeout 까지 hang 하는 케이스).

## Test
- 기존 17 → 18 pass (send drop warn 검증 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)