### PR TITLE
chore(react-native): MCP deferred cosmetic 묶음 (PR-C F4 / PR-D F8 / PR-E2 F3+F6)

### DIFF
--- a/packages/react-native/runtime/mcp-runtime.cjs
+++ b/packages/react-native/runtime/mcp-runtime.cjs
@@ -9,6 +9,12 @@
 //
 // production 빌드에는 inject 안 됨 (`dev: false`).
 //
+// **Runtime 적용 범위 — JS thread only**:
+//   본 runtime 은 RN 의 main JS thread (RN 앱 main bundle) 에서만 동작.
+//   Reanimated worklet runtime / UI thread / Hermes worker 등 별도 realm 에는
+//   `__ZNTC_MCP_RUNTIME__` 등록 안 됨. 후속 PR 가 worklet runtime 의 fiber tree
+//   직렬화를 지원하려면 별도 inject 전략 (worklet preamble) 필요.
+//
 // Wire contract (Zig 측 `src/server/mcp_app_channel.zig` 참조):
 //   - URL path: `/__mcp-app`
 //   - server hello: `{"jsonrpc":"2.0","method":"connected","params":{"protocol":"mcp-app-1"}}`
@@ -58,6 +64,12 @@ function startMcpRuntime(g) {
   };
 
   // public API surface — 후속 PR 이 `runtime.handlers[name] = fn` 으로 tool 추가.
+  //
+  // **의도된 mutable assignment** (Object.defineProperty 의 freeze 안 함):
+  //   HMR 재평가 시 새 startMcpRuntime 호출 가능해야 reconfigure 가능. idempotent 분기
+  //   (`loaded === true` early return) 가 두 번째 호출은 막지만, user 가 `loaded = false`
+  //   로 reset 후 재 init 하는 escape hatch 필요. 또한 `connectionState` getter 같은
+  //   accessor 패턴 유지를 위해 일반 assignment 가 더 단순.
   g.__ZNTC_MCP_RUNTIME__ = {
     version: '0.1.0',
     loaded: true,

--- a/packages/react-native/src/mcp-runtime.test.ts
+++ b/packages/react-native/src/mcp-runtime.test.ts
@@ -259,6 +259,19 @@ describe('mcp-runtime.cjs (PR-E2) — dispatch', () => {
 });
 
 describe('mcp-runtime.cjs (PR-E2) — reconnect', () => {
+  test('WebSocket constructor throw — scheduleReconnect 호출 (F6 deferred 회귀 잠금)', () => {
+    // 일부 RN 버전 / 이상한 URL / 네트워크 정책 issue 로 `new WebSocket(...)` 가 즉시
+    // throw 가능. catch 후 reconnect schedule 되어야 함.
+    g.WebSocket = function ThrowingWebSocket() {
+      throw new Error('socket creation failed');
+    } as unknown as FakeGlobal['WebSocket'];
+    loadRuntime(g);
+    // 첫 setTimeout(connect, 0) 실행 → connect 안 throw → catch → scheduleReconnect (1000ms)
+    const scheduled = g.setTimeout_calls!.filter((c) => c.ms > 0);
+    expect(scheduled.length).toBeGreaterThanOrEqual(1);
+    expect(scheduled[0].ms).toBe(1000);
+  });
+
   test('connection close 후 reconnect schedule (지수 backoff)', () => {
     loadRuntime(g);
     lastWs!.triggerOpen();

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -503,6 +503,14 @@ describe('buildRnBundleOptions — define / banner / footer / polyfills', () => 
     expect(opts.alias?.['__zntc_webview_original__']).toBeUndefined();
   });
 
+  test('alias — react-native-webview 가 RN_SINGLETON_PACKAGES 에 없음 (wrapper override 회귀 가드, PR-D F8)', async () => {
+    // RN_SINGLETON_PACKAGES 에 react-native-webview 가 추가되면 buildRnSingletonAliases
+    // 의 alias 가 buildMcpWebViewAliases 의 wrapper alias 를 spread merge 시 덮어쓰는
+    // 회귀 위험. singleton 추가 의도 시 wrapper alias 도 명시 우선 처리 필요.
+    const { RN_SINGLETON_PACKAGES } = await import('./rn-constants.ts');
+    expect(RN_SINGLETON_PACKAGES).not.toContain('react-native-webview');
+  });
+
   test('alias — react-native-webview 미설치 시 silent fallback (alias 자체가 안 등록)', () => {
     mkdirSync(join(dir, 'node_modules/@zntc/react-native/runtime'), { recursive: true });
     writeFileSync(


### PR DESCRIPTION
## Summary
- #3867 epic 의 **deferred cosmetic 묶음 PR**
- code-review max 발견 5건 중 cosmetic/coverage 4건 — 변경 작아 single PR

## 변경

| 항목 | 변경 |
|---|---|
| **PR-C F4** | mcp-runtime.cjs doc 에 "JS thread only — worklet runtime 미커버" 명시 |
| **PR-D F8** | preset.test.ts 에 `RN_SINGLETON_PACKAGES` 가 webview 안 포함 회귀 잠금 |
| **PR-E2 F3** | `g.__ZNTC_MCP_RUNTIME__` 가 freeze 안 하는 의도 (HMR reconfigure + accessor) 주석 |
| **PR-E2 F6** | `new WebSocket(...)` throw 케이스 test 추가 (scheduleReconnect 검증) |

## Test
- mcp-runtime.test.ts: 18 → 19 pass
- preset.test.ts: 88 → 89 pass
- 전체 107 pass + zig build test 회귀 0

## Defer (별도 큰 PR)
- **PR-D F7** (wrapper 의 jsdom + React-test-renderer 단위 test 인프라) — scope 크고 testing infra 결정 필요. PR-E3 이후 별도 RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)