### PR TITLE
fix(server): recv_buf 256KB → 32KB (retroactive F2 — memory growth)

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -432,17 +432,16 @@ pub const DevServer = struct {
         defer connection.stream.close();
 
         var send_buf: [8192]u8 = undefined;
-        // recv_buf: 256KB heap alloc — large WebSocket frame (JSON-RPC payload, MCP
-        // app channel 의 take_snapshot 같은 대형 응답) 지원. std.http.Server.WebSocket
-        // 의 readSmallMessage 는 single-frame (fin=true) 만 받고 `payload > buffer.len`
-        // 시 MessageTooBig. typical MCP request/response (KB~수십 KB) 는 충분히 fit.
-        // PNG 등 binary payload 가 base64 로 MB 단위가 될 경우는 PR-E3+ 의 streaming
-        // 또는 자체 readMessage 구현으로 별도 처리.
-        const recv_buf = self.allocator.alloc(u8, 256 * 1024) catch |err| {
-            getLog().print("zntc: failed to alloc connection recv buffer: {}\n", .{err}) catch {};
-            return;
-        };
-        defer self.allocator.free(recv_buf);
+        // recv_buf: 32KB stack alloc — typical HTTP request header + body / MCP app
+        // channel 의 JSON-RPC payload (KB~수십 KB) 다 fit. 이전 256KB heap 은 SSE/HMR
+        // WS 같은 long-lived connection 의 entire lifetime 점유 → 100 tab × 2 connection
+        // × 256KB = 25MB unused 메모리 burden. 32KB stack alloc 으로 memory 8× 절감
+        // (32KB × 100 = 3.2MB) + heap alloc OOM 위험 제거.
+        //
+        // 32KB 초과 single-frame 은 readSmallMessage 가 MessageTooBig. PR-E3 의
+        // take_snapshot 같은 대형 binary payload 는 streaming / 자체 readMessage 구현
+        // 별도 PR 로 처리 — 256KB 가 그 시나리오에도 충분치 않음 (PNG base64 가 MB 단위).
+        var recv_buf: [32 * 1024]u8 = undefined;
 
         if (self.tls_ctx) |*ctx| {
             // HTTPS path — SSL_accept handshake 후 TlsReader/TlsWriter 어댑터로 http.Server.
@@ -452,13 +451,13 @@ pub const DevServer = struct {
             };
             defer tls_conn.deinit();
 
-            var tls_reader = tls_conn.reader(recv_buf);
+            var tls_reader = tls_conn.reader(&recv_buf);
             var tls_writer = tls_conn.writer(&send_buf);
             var server: http.Server = .init(&tls_reader.interface, &tls_writer.interface);
             self.serveOnConnection(&server, &tls_writer.interface);
         } else {
             // plain HTTP path.
-            var conn_reader = connection.stream.reader(recv_buf);
+            var conn_reader = connection.stream.reader(&recv_buf);
             var conn_writer = connection.stream.writer(&send_buf);
             var server: http.Server = .init(conn_reader.interface(), &conn_writer.interface);
             self.serveOnConnection(&server, &conn_writer.interface);


### PR DESCRIPTION
## Summary
- retroactive `/code-review max` F2 [Medium] — PR-E1 F3 deferred (#3881) 의 256KB heap recv_buf 가 SSE/HMR WS lifetime 점유
- 100 browser tab × 2 long-lived connection × 256KB = 25MB unused memory
- **32KB stack alloc** 으로 축소 — 8× 절감, OOM silent drop 위험도 제거

## Trade-off
typical JSON-RPC payload (~수십 KB) 는 충분. 대형 binary payload (PR-E3 의 take_snapshot 등 MB 단위) 는 256KB 도 부족 — 결국 PR-E3 의 자체 streaming reader 가 본질적 해결. 256KB 는 over-provisioning 이었음.

## Test
- `zig build test` 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)