### PR TITLE
feat(server): AppChannel.request API + response matching (PR-E3a of #3867)

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -39,8 +39,8 @@ pub const DevServer = struct {
     abs_entry: ?[]const u8,
     ws_clients: WsClients = .{},
     /// MCP app channel — `/__mcp-app` WS 연결로 RN 앱과 양방향 통신.
-    /// 후속 PR 가 request/response Map 을 여기에 추가.
-    app_channel: mcp_app_channel_mod.AppChannel = .{},
+    /// init/deinit 필수 (pending request Map 보유).
+    app_channel: mcp_app_channel_mod.AppChannel,
     sse_clients: SseClients = .{},
     /// 모노토닉 이벤트 시퀀스 (SSE payload의 id 필드).
     event_seq: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
@@ -191,6 +191,7 @@ pub const DevServer = struct {
             .event_ring = EventRing.init(allocator),
             .overlay_client = overlay_client,
             .tls_ctx = tls_ctx,
+            .app_channel = mcp_app_channel_mod.AppChannel.init(allocator),
         };
     }
 
@@ -203,6 +204,9 @@ pub const DevServer = struct {
         self.root_dir.close();
         self.event_ring.deinit();
         self.error_state.deinit(self.allocator);
+        // pending requests 모두 fail (caller waiter 깨움) + pending map storage 해제.
+        self.app_channel.disconnect();
+        self.app_channel.deinit();
     }
 
     /// dev overlay client raw template 의 `__ZNTC_HMR_*__` sentinel 들을
@@ -598,7 +602,38 @@ pub const DevServer = struct {
 
             switch (msg.opcode) {
                 .text => {
-                    getLog().print("  [mcp-app] recv: {s}\n", .{msg.data}) catch {};
+                    // JSON parse 후 response (`id` + `result`/`error`) 면 pending 매칭 →
+                    // AppChannel.resolveResponse 호출. method 가 있으면 app → server
+                    // request — 후속 PR 에서 server-side handler dispatch.
+                    var parsed = std.json.parseFromSlice(std.json.Value, self.allocator, msg.data, .{}) catch {
+                        getLog().print("  [mcp-app] invalid JSON: {s}\n", .{msg.data}) catch {};
+                        continue;
+                    };
+                    defer parsed.deinit();
+                    const root = parsed.value;
+                    const id_val = switch (root) {
+                        .object => |o| o.get("id") orelse .null,
+                        else => .null,
+                    };
+                    const has_result_or_error = switch (root) {
+                        .object => |o| o.get("result") != null or o.get("error") != null,
+                        else => false,
+                    };
+                    if (has_result_or_error) {
+                        // response — id 를 u64 로 추출 후 pending 매칭.
+                        const id_u64: ?u64 = switch (id_val) {
+                            .integer => |n| if (n >= 0) @intCast(n) else null,
+                            else => null,
+                        };
+                        if (id_u64) |id| {
+                            self.app_channel.resolveResponse(id, msg.data);
+                        } else {
+                            getLog().print("  [mcp-app] response 의 id 가 invalid (non-integer)\n", .{}) catch {};
+                        }
+                    } else {
+                        // method 있고 result 없음 — app 측 request. 후속 PR 에서 dispatch.
+                        getLog().print("  [mcp-app] app→server request (not yet handled): {s}\n", .{msg.data}) catch {};
+                    }
                 },
                 .connection_close => break,
                 else => {},

--- a/src/server/mcp_app_channel.zig
+++ b/src/server/mcp_app_channel.zig
@@ -37,13 +37,20 @@ pub const RequestError = error{
     WriteFailed,
 };
 
+/// 슬롯의 종결 상태 — `failed` 가 단일 boolean 이었던 이전 design 은 disconnect 와
+/// OOM 을 구분 못 해 caller 가 wrong error 받았다 (F3). 명시 enum 으로 분리.
+const SlotState = enum {
+    pending,
+    success, // response 있음
+    disconnected, // disconnect 으로 fail
+    oom, // resolveResponse 의 dupe OOM
+};
+
 /// `request` 가 wait 하는 동안 reader thread 가 채우는 슬롯. caller 가 lifetime 관리.
 const PendingSlot = struct {
     /// 응답 JSON 본문 — caller allocator 로 alloc/free.
     response: ?[]const u8 = null,
-    /// `true` 면 disconnect 등으로 fail. response 는 null.
-    failed: bool = false,
-    completed: bool = false,
+    state: SlotState = .pending,
 };
 
 /// 앱 ↔ MCP server 간 WebSocket 채널의 단일 연결 상태 + pending request map.
@@ -51,6 +58,9 @@ const PendingSlot = struct {
 pub const AppChannel = struct {
     allocator: std.mem.Allocator,
     mutex: std.Thread.Mutex = .{},
+    /// 별도 mutex — write_mutex 가 WS frame 송신 직렬화 보호. mutex (pending Map) 와
+    /// 분리해 reader 의 resolveResponse 가 write 동안 blocking 안 됨 (F2).
+    write_mutex: std.Thread.Mutex = .{},
     cond: std.Thread.Condition = .{},
     connected: bool = false,
     /// 핸드셰이크 누적 성공 횟수.
@@ -103,8 +113,9 @@ pub const AppChannel = struct {
         // 모든 pending slot fail 처리 + cond broadcast 로 waiter 깨움.
         var it = self.pending.valueIterator();
         while (it.next()) |slot_ptr| {
-            slot_ptr.*.failed = true;
-            slot_ptr.*.completed = true;
+            // pending → disconnected. 이미 success/oom 상태면 그대로 보존
+            // (race: response 가 거의 동시에 도착했으면 caller 에게 그 결과 우선).
+            if (slot_ptr.*.state == .pending) slot_ptr.*.state = .disconnected;
         }
         self.cond.broadcast();
         self.mutex.unlock();
@@ -122,15 +133,16 @@ pub const AppChannel = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         const slot_ptr = self.pending.get(id) orelse return; // orphan response — drop
+        // 이미 종결됐으면 (caller 가 timeout/disconnect 으로 떠남) 새 response 무시.
+        // caller stack 변수 ref 라 race window 닫음 (F1).
+        if (slot_ptr.state != .pending) return;
         const copy = self.allocator.dupe(u8, response_json) catch {
-            // OOM — slot 이 fail 처리 (response null)
-            slot_ptr.failed = true;
-            slot_ptr.completed = true;
+            slot_ptr.state = .oom;
             self.cond.broadcast();
             return;
         };
         slot_ptr.response = copy;
-        slot_ptr.completed = true;
+        slot_ptr.state = .success;
         self.cond.broadcast();
     }
 
@@ -169,8 +181,8 @@ pub const AppChannel = struct {
         }
         self.mutex.unlock();
 
-        // WS frame build + 송신 (mutex 밖에서) — writer 가 caller thread 의 buffer 와
-        // WebSocket output stream 사용. caller serialize 보장 (stdio 단일 thread).
+        // WS frame build — main mutex 밖. write 자체는 write_mutex 로 직렬화 (F2):
+        // 여러 caller 가 동시 request 호출 시 frame interleave 회피.
         var frame: std.ArrayList(u8) = .empty;
         defer frame.deinit(self.allocator);
         const w = frame.writer(self.allocator);
@@ -181,7 +193,10 @@ pub const AppChannel = struct {
         w.writeAll(params_json) catch return RequestError.OutOfMemory;
         w.writeAll("}") catch return RequestError.OutOfMemory;
 
-        writer.write(frame.items) catch return RequestError.WriteFailed;
+        self.write_mutex.lock();
+        const write_result = writer.write(frame.items);
+        self.write_mutex.unlock();
+        write_result catch return RequestError.WriteFailed;
 
         // 응답 wait — deadline 까지 timedWait. monotonic 안 쓰는 이유: timedWait 가 relative
         // delta 받아 처리. nanoTimestamp 는 wall-clock 이라 NTP jump 시 spurious wake 가능
@@ -193,20 +208,23 @@ pub const AppChannel = struct {
         const deadline_ns = start_ns +| total_ns; // saturating add
         self.mutex.lock();
         defer self.mutex.unlock();
-        while (!slot.completed) {
+        while (slot.state == .pending) {
             const now_i128 = std.time.nanoTimestamp();
             const now_ns: u64 = if (now_i128 > 0) @intCast(now_i128) else 0;
-            if (now_ns >= deadline_ns) {
-                return RequestError.Timeout;
-            }
+            if (now_ns >= deadline_ns) break; // deadline 도달 — 아래 final check
             const remaining = deadline_ns - now_ns;
             self.cond.timedWait(&self.mutex, remaining) catch {
-                // timeout — slot 도 completed 안 됨. 응답 안 옴.
-                return RequestError.Timeout;
+                break; // timeout — 아래 final check
             };
         }
-        if (slot.failed) return RequestError.AppDisconnected;
-        return slot.response orelse return RequestError.AppDisconnected;
+        // Final state 매핑 — mutex 잡은 상태에서 state 재확인. timeout race window
+        // (response 가 timeout 직후 도착) 도 여기서 success 분기로 흡수해 leak/UAF 방지 (F1).
+        switch (slot.state) {
+            .success => return slot.response orelse RequestError.AppDisconnected,
+            .disconnected => return RequestError.AppDisconnected,
+            .oom => return RequestError.OutOfMemory,
+            .pending => return RequestError.Timeout,
+        }
     }
 
     pub fn stats(self: *AppChannel) struct {
@@ -410,6 +428,73 @@ test "AppChannel.request: disconnect 중 pending → AppDisconnected" {
     ch.disconnect();
     thr.join();
     try std.testing.expectEqual(@as(?RequestError, RequestError.AppDisconnected), ctx.err);
+}
+
+test "AppChannel.resolveResponse: timeout 직후 도착한 응답 — slot.state 가 이미 종결이라 무시 (F1 race)" {
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
+    _ = ch.connect();
+
+    var written: std.ArrayList(u8) = .empty;
+    defer written.deinit(std.testing.allocator);
+    const writer = BufWriter{ .out = &written, .alloc = std.testing.allocator };
+    // 짧은 timeout — 즉시 종결.
+    try std.testing.expectError(RequestError.Timeout, ch.request("late", "{}", 10, writer));
+    // 정상 동작이면 pending 0 (defer 가 remove). resolveResponse 후속 호출은 orphan.
+    try std.testing.expectEqual(@as(usize, 0), ch.stats().pending_count);
+    ch.resolveResponse(1, "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"late\":true}}");
+    // leak 또는 throw 없음 (testing.allocator 가 leak 검증).
+}
+
+test "AppChannel.resolveResponse: 두 동시 request — id 별 매칭, out-of-order 응답" {
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
+    _ = ch.connect();
+
+    var written: std.ArrayList(u8) = .empty;
+    defer written.deinit(std.testing.allocator);
+
+    const RunCtx = struct {
+        ch: *AppChannel,
+        writer: BufWriter,
+        method: []const u8,
+        result: ?[]const u8 = null,
+        err: ?RequestError = null,
+
+        fn run(self: *@This()) void {
+            const r = self.ch.request(self.method, "{}", 2000, self.writer) catch |e| {
+                self.err = e;
+                return;
+            };
+            self.result = r;
+        }
+    };
+    var ctx_a = RunCtx{
+        .ch = &ch,
+        .writer = BufWriter{ .out = &written, .alloc = std.testing.allocator },
+        .method = "alpha",
+    };
+    var ctx_b = RunCtx{
+        .ch = &ch,
+        .writer = BufWriter{ .out = &written, .alloc = std.testing.allocator },
+        .method = "beta",
+    };
+    const t_a = try std.Thread.spawn(.{}, RunCtx.run, .{&ctx_a});
+    const t_b = try std.Thread.spawn(.{}, RunCtx.run, .{&ctx_b});
+    std.Thread.sleep(30 * std.time.ns_per_ms);
+
+    // out-of-order: id 2 (beta) 먼저, id 1 (alpha) 나중.
+    ch.resolveResponse(2, "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"who\":\"beta\"}}");
+    ch.resolveResponse(1, "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"who\":\"alpha\"}}");
+
+    t_a.join();
+    t_b.join();
+    try std.testing.expect(ctx_a.result != null);
+    try std.testing.expect(ctx_b.result != null);
+    defer std.testing.allocator.free(ctx_a.result.?);
+    defer std.testing.allocator.free(ctx_b.result.?);
+    try std.testing.expect(std.mem.indexOf(u8, ctx_a.result.?, "\"alpha\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ctx_b.result.?, "\"beta\"") != null);
 }
 
 test "AppChannel.resolveResponse: orphan id (unknown) → silent drop, throw 없음" {

--- a/src/server/mcp_app_channel.zig
+++ b/src/server/mcp_app_channel.zig
@@ -3,17 +3,20 @@
 //! 흐름:
 //!   1. RN 앱 시작 시 mcp-runtime.cjs 가 `ws://localhost:<port>/__mcp-app` 접속.
 //!   2. dev_server 가 `handleMcpAppWebSocket` 으로 핸드셰이크 + 메시지 loop.
-//!   3. MCP server (`zntc mcp` stdio) 가 `take_snapshot` 같은 tool 호출 →
+//!   3. MCP server (`zntc mcp` stdio) 가 `ping_app` / `take_snapshot` 등 tool 호출 →
 //!      `AppChannel.request(method, params)` → WS 로 forward → 앱 응답 → caller 반환.
 //!
-//! 본 PR-E1 의 범위:
-//!   - `AppChannel` struct (단일 연결, mutex 보호)
-//!   - `connect` / `disconnect` 라이프사이클 helper
-//!   - 텍스트 메시지 echo log (디버깅용) — request/response 매칭은 후속 PR
+//! Threading model:
+//!   - WS reader thread (handleMcpAppWebSocket 의 loop): incoming 메시지 parse +
+//!     response 의 경우 `resolveResponse` 호출 (pending 깨움).
+//!   - Caller thread (stdio MCP dispatcher 또는 HTTP /mcp handler): `request` 가
+//!     blocking — pending Map 에 등록 후 condvar 으로 wait.
+//!   - 두 thread 가 같은 `*WebSocket` 의 write 접근 안 함 (caller 만 write, reader 만 read).
 //!
-//! 멀티 디바이스 (`deviceId` 별 라우팅) 와 request/response Map 은 후속 PR-E3+ 에서 흡수.
+//! 멀티 디바이스 (`deviceId` 별 라우팅) 는 추후 PR — 현재 first connection wins.
 
 const std = @import("std");
+const http = std.http;
 
 /// 핸드셰이크 hello 메시지 — 앱 측 mcp-runtime.cjs 가 connect 확인용 parse.
 /// "protocol":"mcp-app-1" 은 wire-level version negotiation 키 — 변경 시
@@ -26,40 +29,85 @@ pub const HELLO_MESSAGE: []const u8 =
 pub const REJECT_MESSAGE: []const u8 =
     "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"another app already connected\"}}";
 
-/// 앱 ↔ MCP server 간 WebSocket 채널의 단일 연결 상태.
+pub const RequestError = error{
+    NotConnected,
+    Timeout,
+    AppDisconnected,
+    OutOfMemory,
+    WriteFailed,
+};
+
+/// `request` 가 wait 하는 동안 reader thread 가 채우는 슬롯. caller 가 lifetime 관리.
+const PendingSlot = struct {
+    /// 응답 JSON 본문 — caller allocator 로 alloc/free.
+    response: ?[]const u8 = null,
+    /// `true` 면 disconnect 등으로 fail. response 는 null.
+    failed: bool = false,
+    completed: bool = false,
+};
+
+/// 앱 ↔ MCP server 간 WebSocket 채널의 단일 연결 상태 + pending request map.
 /// 멀티 디바이스 지원은 추후 PR — 현재는 first connection wins.
 pub const AppChannel = struct {
+    allocator: std.mem.Allocator,
     mutex: std.Thread.Mutex = .{},
+    cond: std.Thread.Condition = .{},
     connected: bool = false,
     /// 핸드셰이크 누적 성공 횟수.
     connect_count: u64 = 0,
     /// 연결 끊김 누적 횟수 (성공 연결만).
     disconnect_count: u64 = 0,
-    /// First-wins 거절 누적 — "두 번째 디바이스가 같은 dev server 접속" 같은 misconfig
-    /// 진단용. dev 환경에서 자주 0 보다 크면 같은 port 두 시뮬레이터 / RN 앱 두 개 띄움 등 hint.
+    /// First-wins 거절 누적 — 같은 port 두 시뮬레이터 등 misconfig 진단용.
     reject_count: u64 = 0,
+    /// JSON-RPC request id 카운터 — 0 부터 monotonic. wrap 가능성 거의 없음 (u64).
+    next_request_id: u64 = 1,
+    /// id → 대기 슬롯. caller 가 owns slot 의 lifetime — request 함수가 stack 에 놓고
+    /// pending.put(id, slot_ptr), 응답/timeout 후 remove.
+    pending: std.AutoHashMapUnmanaged(u64, *PendingSlot) = .{},
 
-    /// 앱이 핸드셰이크 직후 호출. 이미 다른 앱이 연결돼 있으면 `false` 반환 — caller 가
-    /// 그 의미를 보고 새 연결 거절할지 (현재 first-wins) 결정.
+    pub fn init(allocator: std.mem.Allocator) AppChannel {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *AppChannel) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        // pending request 가 남아 있으면 caller 가 이미 wait 중 — graceful 하게는 deinit 직전
+        // failAllPending 호출 권장. 여기서는 map storage 만 정리 (slot 의 owner = caller).
+        self.pending.deinit(self.allocator);
+    }
+
+    /// 앱이 핸드셰이크 직후 호출. first-wins.
     pub fn connect(self: *AppChannel) bool {
         self.mutex.lock();
         defer self.mutex.unlock();
         if (self.connected) {
             self.reject_count += 1;
-            return false; // first-wins
+            return false;
         }
         self.connected = true;
         self.connect_count += 1;
         return true;
     }
 
-    /// WS read loop 종료 (EOF / 에러 / 명시적 close) 시 호출.
+    /// WS read loop 종료 시 호출 — pending 모두 AppDisconnected 로 fail.
     pub fn disconnect(self: *AppChannel) void {
         self.mutex.lock();
-        defer self.mutex.unlock();
-        if (!self.connected) return;
+        if (!self.connected) {
+            self.mutex.unlock();
+            return;
+        }
         self.connected = false;
         self.disconnect_count += 1;
+
+        // 모든 pending slot fail 처리 + cond broadcast 로 waiter 깨움.
+        var it = self.pending.valueIterator();
+        while (it.next()) |slot_ptr| {
+            slot_ptr.*.failed = true;
+            slot_ptr.*.completed = true;
+        }
+        self.cond.broadcast();
+        self.mutex.unlock();
     }
 
     pub fn isConnected(self: *AppChannel) bool {
@@ -68,11 +116,105 @@ pub const AppChannel = struct {
         return self.connected;
     }
 
+    /// WS reader 가 response 메시지 (id + result/error) 받으면 호출. response_json 은
+    /// caller 의 임시 buffer — 본 함수가 owned copy 를 만들어 slot 에 저장.
+    pub fn resolveResponse(self: *AppChannel, id: u64, response_json: []const u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const slot_ptr = self.pending.get(id) orelse return; // orphan response — drop
+        const copy = self.allocator.dupe(u8, response_json) catch {
+            // OOM — slot 이 fail 처리 (response null)
+            slot_ptr.failed = true;
+            slot_ptr.completed = true;
+            self.cond.broadcast();
+            return;
+        };
+        slot_ptr.response = copy;
+        slot_ptr.completed = true;
+        self.cond.broadcast();
+    }
+
+    /// app 에 JSON-RPC request 보내고 timeout_ms 까지 response wait. 응답 본문 (full
+    /// JSON-RPC response object) 을 caller-owned slice 로 반환.
+    ///
+    /// `params_json` 은 valid JSON Value 문자열 (예: `{"target":"foo"}` 또는 `null`).
+    /// `writer` 는 `.write(frame: []const u8) !void` method 갖는 callable struct.
+    /// Zig 의 stateless function 한계 회피용 — closure 가 필요한 caller (test/handler)
+    /// 가 struct 안에 state (ws ptr, buffer 등) 보관.
+    pub fn request(
+        self: *AppChannel,
+        method: []const u8,
+        params_json: []const u8,
+        timeout_ms: u64,
+        writer: anytype,
+    ) RequestError![]const u8 {
+        // 연결 안 되어 있으면 즉시 fail.
+        self.mutex.lock();
+        if (!self.connected) {
+            self.mutex.unlock();
+            return RequestError.NotConnected;
+        }
+        const id = self.next_request_id;
+        self.next_request_id += 1;
+        var slot = PendingSlot{};
+        self.pending.put(self.allocator, id, &slot) catch {
+            self.mutex.unlock();
+            return RequestError.OutOfMemory;
+        };
+        // pending Map 정리는 함수 종료 시.
+        defer {
+            self.mutex.lock();
+            _ = self.pending.remove(id);
+            self.mutex.unlock();
+        }
+        self.mutex.unlock();
+
+        // WS frame build + 송신 (mutex 밖에서) — writer 가 caller thread 의 buffer 와
+        // WebSocket output stream 사용. caller serialize 보장 (stdio 단일 thread).
+        var frame: std.ArrayList(u8) = .empty;
+        defer frame.deinit(self.allocator);
+        const w = frame.writer(self.allocator);
+        std.fmt.format(w, "{{\"jsonrpc\":\"2.0\",\"id\":{d},\"method\":\"", .{id}) catch return RequestError.OutOfMemory;
+        // method 가 controlled (Zig 측 literal) — escape 불필요.
+        w.writeAll(method) catch return RequestError.OutOfMemory;
+        w.writeAll("\",\"params\":") catch return RequestError.OutOfMemory;
+        w.writeAll(params_json) catch return RequestError.OutOfMemory;
+        w.writeAll("}") catch return RequestError.OutOfMemory;
+
+        writer.write(frame.items) catch return RequestError.WriteFailed;
+
+        // 응답 wait — deadline 까지 timedWait. monotonic 안 쓰는 이유: timedWait 가 relative
+        // delta 받아 처리. nanoTimestamp 는 wall-clock 이라 NTP jump 시 spurious wake 가능
+        // 한데, 우리 case 는 timeout 이라 잘못된 방향 (jump backward) 이면 retry, jump
+        // forward 면 일찍 끝남 — 둘 다 무해.
+        const start_i128 = std.time.nanoTimestamp();
+        const start_ns: u64 = if (start_i128 > 0) @intCast(start_i128) else 0;
+        const total_ns = timeout_ms * std.time.ns_per_ms;
+        const deadline_ns = start_ns +| total_ns; // saturating add
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        while (!slot.completed) {
+            const now_i128 = std.time.nanoTimestamp();
+            const now_ns: u64 = if (now_i128 > 0) @intCast(now_i128) else 0;
+            if (now_ns >= deadline_ns) {
+                return RequestError.Timeout;
+            }
+            const remaining = deadline_ns - now_ns;
+            self.cond.timedWait(&self.mutex, remaining) catch {
+                // timeout — slot 도 completed 안 됨. 응답 안 옴.
+                return RequestError.Timeout;
+            };
+        }
+        if (slot.failed) return RequestError.AppDisconnected;
+        return slot.response orelse return RequestError.AppDisconnected;
+    }
+
     pub fn stats(self: *AppChannel) struct {
         connected: bool,
         connect_count: u64,
         disconnect_count: u64,
         reject_count: u64,
+        pending_count: usize,
     } {
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -81,6 +223,7 @@ pub const AppChannel = struct {
             .connect_count = self.connect_count,
             .disconnect_count = self.disconnect_count,
             .reject_count = self.reject_count,
+            .pending_count = self.pending.count(),
         };
     }
 };
@@ -88,7 +231,8 @@ pub const AppChannel = struct {
 // ─── 테스트 ───
 
 test "AppChannel: connect first-wins, second 가 false" {
-    var ch: AppChannel = .{};
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
     try std.testing.expect(ch.connect());
     try std.testing.expect(!ch.connect());
     try std.testing.expect(ch.isConnected());
@@ -97,7 +241,8 @@ test "AppChannel: connect first-wins, second 가 false" {
 }
 
 test "AppChannel: disconnect 후 다시 connect 가능" {
-    var ch: AppChannel = .{};
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
     _ = ch.connect();
     ch.disconnect();
     try std.testing.expect(!ch.isConnected());
@@ -108,18 +253,20 @@ test "AppChannel: disconnect 후 다시 connect 가능" {
 }
 
 test "AppChannel: reject_count — 두 번째 connect 실패 시 증가, 성공한 connect 는 영향 없음" {
-    var ch: AppChannel = .{};
-    _ = ch.connect(); // ok
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
+    _ = ch.connect();
     try std.testing.expectEqual(@as(u64, 0), ch.stats().reject_count);
-    _ = ch.connect(); // reject
-    _ = ch.connect(); // reject again
+    _ = ch.connect();
+    _ = ch.connect();
     const s = ch.stats();
     try std.testing.expectEqual(@as(u64, 1), s.connect_count);
     try std.testing.expectEqual(@as(u64, 2), s.reject_count);
 }
 
 test "AppChannel: 연결 안 된 상태에서 disconnect — no-op" {
-    var ch: AppChannel = .{};
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
     ch.disconnect();
     try std.testing.expect(!ch.isConnected());
     const s = ch.stats();
@@ -127,11 +274,8 @@ test "AppChannel: 연결 안 된 상태에서 disconnect — no-op" {
 }
 
 test "wire contract: HELLO_MESSAGE 의 protocol 식별자 + valid JSON" {
-    // wire-level contract — JS 측 (mcp-runtime.cjs) parser 가 의존. 변경 시 PR
-    // 함께 갱신하라는 회귀 잠금.
     try std.testing.expect(std.mem.indexOf(u8, HELLO_MESSAGE, "\"protocol\":\"mcp-app-1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, HELLO_MESSAGE, "\"method\":\"connected\"") != null);
-    // JSON parse 가능 검증
     var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, HELLO_MESSAGE, .{});
     defer parsed.deinit();
 }
@@ -144,9 +288,8 @@ test "wire contract: REJECT_MESSAGE — JSON-RPC error code -32000" {
 }
 
 test "AppChannel: 64 thread 동시 connect — 정확히 1개만 성공 (contended path 검증)" {
-    // 단순 2-thread 테스트는 OS scheduler 가 t1 을 t2 보다 한참 먼저 끝내 mutex 의
-    // contended path 가 거의 안 실행됨. 64 thread 로 압박해 race 진짜 검증.
-    var ch: AppChannel = .{};
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
 
     const Ctx = struct {
         channel: *AppChannel,
@@ -171,4 +314,110 @@ test "AppChannel: 64 thread 동시 connect — 정확히 1개만 성공 (contend
     const s = ch.stats();
     try std.testing.expectEqual(@as(u64, 1), s.connect_count);
     try std.testing.expectEqual(@as(u64, N - 1), s.reject_count);
+}
+
+const NoopWriter = struct {
+    pub fn write(_: @This(), _: []const u8) !void {}
+};
+
+const BufWriter = struct {
+    out: *std.ArrayList(u8),
+    alloc: std.mem.Allocator,
+    pub fn write(self: @This(), frame: []const u8) !void {
+        try self.out.appendSlice(self.alloc, frame);
+    }
+};
+
+test "AppChannel.request: 연결 안 된 상태 → NotConnected" {
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
+    try std.testing.expectError(RequestError.NotConnected, ch.request("ping", "{}", 100, NoopWriter{}));
+}
+
+test "AppChannel.request: timeout — response 안 옴" {
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
+    _ = ch.connect();
+    var written: std.ArrayList(u8) = .empty;
+    defer written.deinit(std.testing.allocator);
+    const writer = BufWriter{ .out = &written, .alloc = std.testing.allocator };
+    try std.testing.expectError(RequestError.Timeout, ch.request("ping", "{}", 50, writer));
+    // request frame 은 송신됨 (timeout 전에).
+    try std.testing.expect(std.mem.indexOf(u8, written.items, "\"method\":\"ping\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written.items, "\"id\":1") != null);
+}
+
+test "AppChannel.request: response 도착 시 caller 반환" {
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
+    _ = ch.connect();
+
+    var written: std.ArrayList(u8) = .empty;
+    defer written.deinit(std.testing.allocator);
+
+    const RunCtx = struct {
+        ch: *AppChannel,
+        writer: BufWriter,
+        result: ?[]const u8 = null,
+        err: ?RequestError = null,
+
+        fn run(self: *@This()) void {
+            const r = self.ch.request("ping", "{}", 1000, self.writer) catch |e| {
+                self.err = e;
+                return;
+            };
+            self.result = r;
+        }
+    };
+    var ctx = RunCtx{
+        .ch = &ch,
+        .writer = BufWriter{ .out = &written, .alloc = std.testing.allocator },
+    };
+    const thr = try std.Thread.spawn(.{}, RunCtx.run, .{&ctx});
+
+    // request frame 이 송신될 시간 — small sleep
+    std.Thread.sleep(20 * std.time.ns_per_ms);
+    // response 시뮬레이션
+    ch.resolveResponse(1, "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"pong\":true}}");
+
+    thr.join();
+    try std.testing.expect(ctx.err == null);
+    try std.testing.expect(ctx.result != null);
+    defer std.testing.allocator.free(ctx.result.?);
+    try std.testing.expect(std.mem.indexOf(u8, ctx.result.?, "\"pong\":true") != null);
+}
+
+test "AppChannel.request: disconnect 중 pending → AppDisconnected" {
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
+    _ = ch.connect();
+
+    const RunCtx = struct {
+        ch: *AppChannel,
+        err: ?RequestError = null,
+
+        fn run(self: *@This()) void {
+            const r = self.ch.request("never", "{}", 5000, NoopWriter{}) catch |e| {
+                self.err = e;
+                return;
+            };
+            std.testing.allocator.free(r);
+        }
+    };
+    var ctx = RunCtx{ .ch = &ch };
+    const thr = try std.Thread.spawn(.{}, RunCtx.run, .{&ctx});
+    std.Thread.sleep(20 * std.time.ns_per_ms);
+    ch.disconnect();
+    thr.join();
+    try std.testing.expectEqual(@as(?RequestError, RequestError.AppDisconnected), ctx.err);
+}
+
+test "AppChannel.resolveResponse: orphan id (unknown) → silent drop, throw 없음" {
+    var ch = AppChannel.init(std.testing.allocator);
+    defer ch.deinit();
+    _ = ch.connect();
+    // pending 없는 id 에 대한 response — 무시되어야 함.
+    ch.resolveResponse(9999, "{\"jsonrpc\":\"2.0\",\"id\":9999,\"result\":{}}");
+    // 검증: pending 0, 에러 없음
+    try std.testing.expectEqual(@as(usize, 0), ch.stats().pending_count);
 }


### PR DESCRIPTION
## Summary
- #3867 epic 의 **PR-E3a** — server → app blocking request API + response matching 인프라
- PR-E3b 가 그 위에 첫 tool (`ping_app`) 통합

## 변경

### `src/server/mcp_app_channel.zig`
- `init(allocator)` / `deinit()` 패턴 (pending request Map 보유)
- `request(method, params, timeout, writer): RequestError![]const u8` — caller blocking, owned slice 반환
- `resolveResponse(id, json)` — reader thread 가 호출, pending slot 의 response 채움
- `SlotState` enum (`pending`/`success`/`disconnected`/`oom`) — 4 경우 명확 구분
- 별도 `write_mutex` — frame 송신 직렬화 (reader 의 resolveResponse 와 비-blocking)

### `src/server/dev_server.zig`
- `app_channel` field 의 init/deinit 패턴 (allocator 전달)
- `handleMcpAppWebSocket` 가 JSON parse → response (`id+result/error`) 면 `resolveResponse` 호출

## Threading model

- WS reader thread (`handleMcpAppWebSocket`): read → JSON parse → `resolveResponse` (mutex 안)
- Caller thread (stdio MCP dispatcher 또는 HTTP `/mcp`): `request` 호출 → frame build → `write_mutex` 안 송신 → mutex + cond.timedWait
- `write_mutex` 분리 — reader 의 response 매칭이 write 도중 blocking 안 됨

## Test (13개)

- 기존 connect/disconnect/64-thread race (init/deinit 패턴 갱신)
- NotConnected / Timeout / Response / Disconnect 중 pending → AppDisconnected
- **timeout 직후 도착 race** (F1 회귀 잠금)
- **두 동시 request out-of-order id 매칭**
- orphan id silent drop

## `/code-review max` 결과 (3건 같은 PR fix)

| Finding | Severity | 처리 |
|---|---|---|
| **F1** | High | timeout race + UAF window → SlotState + mutex 안 final check |
| **F2** | High | concurrent writer interleave → 별도 `write_mutex` |
| **F3** | Medium | OOM 이 AppDisconnected 로 wrong report → `RequestError.OutOfMemory` 분리 |
| F4/F6/F7 | Low | next_id hole / string-id support / test gap — 후속 |
| **F5** | High | DevServer.deinit vs reader thread race — connection lifecycle 별도 PR |

## CI 노트
GitHub Actions 의 token 권한 issue (계정 suspended) 로 submodule clone 403 — 코드 회귀 아님. workflow 의 `persist-credentials: false` 별도 PR 로 시도 가능.

## 다음 단계 (PR-E3b)
- `AppChannel` 에 ws ptr 저장 (caller 가 별도 인자 없이 request 가능)
- `ping_app` tool dispatcher 등록
- mcp-runtime.cjs default `ping` handler
- E2E 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)