### PR TITLE
fix(server): DevServer.deinit graceful shutdown — connection thread wait (retroactive PR-E3a F5)

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -201,8 +201,10 @@ pub const DevServer = struct {
     }
 
     pub fn deinit(self: *DevServer) void {
-        // shutdown_requested set + tcp_server close — 새 connection 안 받음.
-        self.shutdown_requested.store(true, .release);
+        // shutdown() 호출 — shutdown_requested set + self-connect trigger 로 blocking
+        // accept() 를 깨움 (macOS/Linux 에서 listen socket close 만으론 accept 안 깨움).
+        // 그 뒤 listen socket 정리.
+        self.shutdown();
         if (self.tcp_server) |*s| s.deinit();
         // 살아있는 connection (handleConnection thread) 가 종료할 때까지 wait —
         // reader thread 가 app_channel mutex/pending Map 사용 중인데 deinit 가
@@ -212,12 +214,16 @@ pub const DevServer = struct {
         const DEINIT_TIMEOUT_MS: u64 = 2000;
         const start_ns: u128 = @intCast(@max(0, std.time.nanoTimestamp()));
         const deadline_ns: u128 = start_ns + DEINIT_TIMEOUT_MS * std.time.ns_per_ms;
-        while (self.active_connections.load(.acquire) > 0) {
+        while (true) {
+            const count = self.active_connections.load(.acquire);
+            if (count == 0) break;
             const now_ns: u128 = @intCast(@max(0, std.time.nanoTimestamp()));
             if (now_ns >= deadline_ns) {
+                // 같은 load 결과 (count) 를 log — re-load 시 사이에 0 으로 떨어졌으면
+                // "0 개 아직 살아있음 (UAF 위험)" 같은 모순적 메시지 (F4 retro).
                 getLog().print(
                     "  [deinit] connection thread {d} 개 아직 살아있음 — 2초 timeout, deinit 진행 (UAF 위험)\n",
-                    .{self.active_connections.load(.acquire)},
+                    .{count},
                 ) catch {};
                 break;
             }
@@ -439,7 +445,13 @@ pub const DevServer = struct {
                 getLog().print("zntc: accept failed: {}\n", .{err}) catch {};
                 continue;
             };
+            // active_connections 를 spawn 전에 증가 — handleConnection 의 fetchAdd 가
+            // OS scheduler 지연으로 늦게 실행되면 deinit 의 wait loop 가 counter=0 으로
+            // 보고 일찍 통과 → UAF race window. 여기서 카운트 ownership 잡고 spawn
+            // 실패 시만 즉시 감소. 성공 시 handleConnection 의 defer fetchSub 가 처리.
+            _ = self.active_connections.fetchAdd(1, .acq_rel);
             const thread = std.Thread.spawn(.{ .stack_size = 8 * 1024 * 1024 }, handleConnection, .{ self, connection }) catch {
+                _ = self.active_connections.fetchSub(1, .acq_rel);
                 connection.stream.close();
                 continue;
             };
@@ -461,9 +473,8 @@ pub const DevServer = struct {
     }
 
     fn handleConnection(self: *DevServer, connection: std.net.Server.Connection) void {
-        // DevServer.deinit 가 reader thread (이 connection) 가 종료할 때까지 wait —
-        // app_channel 의 mutex/pending Map 사용 중인 thread 와 race 회피.
-        _ = self.active_connections.fetchAdd(1, .acq_rel);
+        // active_connections 의 fetchAdd 는 acceptLoop 가 이미 수행 (spawn 전 race
+        // window 회피). 여기선 defer 로 fetchSub 만 — handleConnection 종료 시 한 번.
         defer _ = self.active_connections.fetchSub(1, .acq_rel);
         defer connection.stream.close();
 

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -54,6 +54,11 @@ pub const DevServer = struct {
     event_ring: EventRing,
     /// shutdown() 호출 시 set; acceptLoop가 다음 iteration에서 종료.
     shutdown_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    /// 현재 살아있는 connection (handleConnection thread) 수. deinit 가 0 까지 wait —
+    /// reader thread 가 AppChannel.resolveResponse 호출 중인데 main thread 가
+    /// app_channel.deinit() 호출하면 mutex/pending Map UAF. counter 로 graceful
+    /// 종료 보장.
+    active_connections: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
     plugins: []const plugin_mod.Plugin = &.{},
     proxy: []const ProxyRule = &.{},
     base_path: []const u8 = "/",
@@ -196,7 +201,29 @@ pub const DevServer = struct {
     }
 
     pub fn deinit(self: *DevServer) void {
+        // shutdown_requested set + tcp_server close — 새 connection 안 받음.
+        self.shutdown_requested.store(true, .release);
         if (self.tcp_server) |*s| s.deinit();
+        // 살아있는 connection (handleConnection thread) 가 종료할 때까지 wait —
+        // reader thread 가 app_channel mutex/pending Map 사용 중인데 deinit 가
+        // 그것 free 하면 UAF. 최대 2초 wait (best-effort) — production 은 process
+        // exit 직전 deinit 라 그 시점엔 thread 종료된 상태가 일반적. 2초 넘어가면
+        // log + 그대로 진행 (RN app 의 keep-alive WS 가 idle 상태인 경우 등).
+        const DEINIT_TIMEOUT_MS: u64 = 2000;
+        const start_ns: u128 = @intCast(@max(0, std.time.nanoTimestamp()));
+        const deadline_ns: u128 = start_ns + DEINIT_TIMEOUT_MS * std.time.ns_per_ms;
+        while (self.active_connections.load(.acquire) > 0) {
+            const now_ns: u128 = @intCast(@max(0, std.time.nanoTimestamp()));
+            if (now_ns >= deadline_ns) {
+                getLog().print(
+                    "  [deinit] connection thread {d} 개 아직 살아있음 — 2초 timeout, deinit 진행 (UAF 위험)\n",
+                    .{self.active_connections.load(.acquire)},
+                ) catch {};
+                break;
+            }
+            std.Thread.sleep(10 * std.time.ns_per_ms);
+        }
+
         if (self.abs_entry) |ae| self.allocator.free(ae);
         // overlay_client 는 init 에서 반드시 알록된 owned slice (default 미제공).
         self.allocator.free(self.overlay_client);
@@ -205,6 +232,7 @@ pub const DevServer = struct {
         self.event_ring.deinit();
         self.error_state.deinit(self.allocator);
         // pending requests 모두 fail (caller waiter 깨움) + pending map storage 해제.
+        // 위 active_connections wait 이 reader thread 종료 보장 — race 0.
         self.app_channel.disconnect();
         self.app_channel.deinit();
     }
@@ -433,6 +461,10 @@ pub const DevServer = struct {
     }
 
     fn handleConnection(self: *DevServer, connection: std.net.Server.Connection) void {
+        // DevServer.deinit 가 reader thread (이 connection) 가 종료할 때까지 wait —
+        // app_channel 의 mutex/pending Map 사용 중인 thread 와 race 회피.
+        _ = self.active_connections.fetchAdd(1, .acq_rel);
+        defer _ = self.active_connections.fetchSub(1, .acq_rel);
         defer connection.stream.close();
 
         var send_buf: [8192]u8 = undefined;


### PR DESCRIPTION
## Summary
- PR-E3a `/code-review max` F5 deferred fix + 후속 review 발견 F2/F4/F5 같은 PR 안 처리
- DevServer.deinit 가 connection thread 종료까지 wait — `app_channel.deinit` 의 race UAF 회피

## 변경

### `active_connections: std.atomic.Value(u32)` field
- `acceptLoop` 가 **spawn 전** `fetchAdd(1)` (F5 race window 닫음)
- `handleConnection` 의 `defer fetchSub(1)`
- spawn 실패 시 acceptLoop 가 즉시 fetchSub

### `DevServer.deinit` graceful shutdown
- `self.shutdown()` 호출 — `shutdown_requested = true` + self-connect 로 blocking accept() 깨움 (F2)
- `tcp_server.deinit()` — listen socket 정리
- `active_connections > 0` 인 동안 10ms polling, 최대 2초
- 0 도달 시 통과, timeout 시 warning log + best-effort 진행
- 모든 connection thread 종료 후 `app_channel.disconnect/deinit` — race 0

## `/code-review max` 결과

| Finding | Severity | 처리 |
|---|---|---|
| **F1** | HIGH | `tcp_server.deinit` 가 child socket blocking read 안 깨움 → 일반 idle WS 가 2초 timeout 까지 wait. 진짜 fix 는 connection list + 각 child fd shutdown(2) — **별도 RFC PR** |
| **F2** | Medium | `deinit` 가 self-connect 없이 listener close — accept() blocked thread 못 깨움. fix: `self.shutdown()` 호출 |
| **F4** | Low | log 의 count re-load → race window 의 "0 개 살아있음 (UAF 위험)" 모순. fix: local 변수 capture |
| **F5** | Medium | acceptLoop 의 spawn → fetchAdd 사이 race. fix: spawn 전 fetchAdd |
| **F3** | Low | counter 가 app_channel 안 쓰는 connection 도 포함 — 의미상 over-counting. comment 만으로 처리 — defer |

## Trade-off

- production process exit 직전 deinit 라 대부분 wait 0
- F1 의 한계: idle keep-alive 한 RN app / browser tab 있으면 2초 timeout 까지 wait 후 best-effort. UAF 위험 잔존이라 별도 RFC 가 필요한 진짜 fix
- 본 PR 은 race window 들 중 spawn-race / accept-blocked / log-stale 3개 닫음

`zig build test` 회귀 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)