### PR TITLE
test(integration): MCP App Channel E2E — /__mcp-app + ping_app 양방향 (#3867)

### DIFF
--- a/tests/integration/tests/mcp-app-channel-e2e.test.ts
+++ b/tests/integration/tests/mcp-app-channel-e2e.test.ts
@@ -1,0 +1,310 @@
+// MCP App Channel E2E — Zig dev_server 의 `/__mcp-app` WebSocket 과 MCP HTTP `/mcp`
+// 의 양방향 흐름을 진짜 server 띄워서 검증.
+//
+// 시나리오:
+//   1. dev_server 시작 (`zntc --serve --bundle entry.ts --port <free>`).
+//   2. Mock app — Bun 의 `new WebSocket(...)` 으로 `/__mcp-app` 접속, hello 메시지 받음.
+//      RN 안 mcp-runtime.cjs 가 하는 일을 test thread 안에서 모방.
+//   3. MCP HTTP `/mcp tools/call ping_app` 호출 → Zig dispatcher 가 AppChannel 통해
+//      mock app 에 `method:"ping"` request 송신 → mock 이 응답 → dispatcher 가 결과를
+//      MCP client 에 forward.
+//   4. content[0].text 가 `{"pong":...}` 형태 JSON string 임을 검증.
+//
+// IMPORTANT: 반드시 tests/integration 디렉토리에서 `bun test`로 실행할 것 (메모리 가이드).
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { waitForServer } from '@zntc/test-helpers';
+import { createFixture, ZNTC_BIN } from './helpers';
+import { join } from 'node:path';
+
+interface Server {
+  port: number;
+  kill: () => Promise<void>;
+}
+
+async function findFreePort(): Promise<number> {
+  const sock = Bun.listen({ hostname: '127.0.0.1', port: 0, socket: { data() {} } });
+  const port = sock.port;
+  sock.stop(true);
+  return port;
+}
+
+async function startServer(args: string[]): Promise<Server> {
+  const port = await findFreePort();
+  const proc = Bun.spawn({
+    cmd: [ZNTC_BIN, ...args, '--port', String(port)],
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  await waitForServer(port, {
+    host: '127.0.0.1',
+    path: '/bundle.js',
+    timeoutMs: 5_000,
+    intervalMs: 100,
+    requestTimeoutMs: 200,
+    acceptStatus: (s) => s === 200 || s === 500,
+  });
+
+  return {
+    port,
+    kill: async () => {
+      proc.kill();
+      await proc.exited;
+    },
+  };
+}
+
+async function mcpCall(port: number, body: object): Promise<any> {
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}
+
+/**
+ * Mock RN app — `/__mcp-app` 에 접속해 server 의 request 받으면 `handlers` 의
+ * function 호출 후 response 송신. Real `mcp-runtime.cjs` 의 JSON-RPC dispatcher
+ * 단순화 버전.
+ */
+interface MockApp {
+  ws: WebSocket;
+  helloReceived: Promise<void>;
+  close: () => void;
+}
+
+function connectMockApp(
+  port: number,
+  handlers: Record<string, (params: unknown) => unknown>,
+): MockApp {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/__mcp-app`);
+  let helloResolve!: () => void;
+  const helloReceived = new Promise<void>((r) => (helloResolve = r));
+
+  ws.addEventListener('message', (ev) => {
+    if (typeof ev.data !== 'string') return;
+    let msg: any;
+    try {
+      msg = JSON.parse(ev.data);
+    } catch {
+      return;
+    }
+    // hello — 받았다고 신호만.
+    if (msg.method === 'connected' && msg.id == null) {
+      helloResolve();
+      return;
+    }
+    // server → app request (id + method) → handler 호출 → response 송신.
+    if (typeof msg.method === 'string' && msg.id != null) {
+      const fn = handlers[msg.method];
+      if (typeof fn !== 'function') {
+        ws.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: msg.id,
+            error: { code: -32601, message: `Method not found: ${msg.method}` },
+          }),
+        );
+        return;
+      }
+      try {
+        const result = fn(msg.params ?? {});
+        ws.send(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: result ?? {} }));
+      } catch (err: any) {
+        ws.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: msg.id,
+            error: { code: -32603, message: String(err?.message ?? err) },
+          }),
+        );
+      }
+    }
+  });
+
+  return {
+    ws,
+    helloReceived,
+    close: () => {
+      try {
+        ws.close();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+async function waitForWsOpen(ws: WebSocket, timeoutMs = 3000): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('ws open timeout')), timeoutMs);
+    ws.addEventListener(
+      'open',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+    ws.addEventListener(
+      'error',
+      () => {
+        clearTimeout(timer);
+        reject(new Error('ws error before open'));
+      },
+      { once: true },
+    );
+  });
+}
+
+describe('MCP App Channel E2E (/__mcp-app + /mcp ping_app)', () => {
+  let killServer: (() => Promise<void>) | undefined;
+  let cleanupFixture: (() => Promise<void>) | undefined;
+  let mockApp: MockApp | undefined;
+
+  afterEach(async () => {
+    if (mockApp) {
+      mockApp.close();
+      mockApp = undefined;
+    }
+    if (killServer) {
+      await killServer();
+      killServer = undefined;
+    }
+    if (cleanupFixture) {
+      await cleanupFixture();
+      cleanupFixture = undefined;
+    }
+  });
+
+  async function setupServer(): Promise<Server> {
+    const fixture = await createFixture({ 'entry.ts': 'console.log("ok");' });
+    cleanupFixture = fixture.cleanup;
+    const server = await startServer(['--serve', '--bundle', join(fixture.dir, 'entry.ts')]);
+    killServer = server.kill;
+    return server;
+  }
+
+  test('hello 메시지 — connect 직후 `method:"connected"` + protocol id', async () => {
+    const server = await setupServer();
+    mockApp = connectMockApp(server.port, {});
+    await waitForWsOpen(mockApp.ws);
+    // 5초 timeout — hello 가 핸드셰이크 직후 송신되어 거의 즉시 도착.
+    await Promise.race([
+      mockApp.helloReceived,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('hello timeout')), 5000)),
+    ]);
+  });
+
+  test('tools/list — ping_app 노출', async () => {
+    const server = await setupServer();
+    const result = await mcpCall(server.port, { jsonrpc: '2.0', id: 1, method: 'tools/list' });
+    const names = result.result.tools.map((t: any) => t.name);
+    expect(names).toContain('ping_app');
+  });
+
+  test('ping_app — app 미연결 시 -32603 + "app not connected" 진단', async () => {
+    const server = await setupServer();
+    // mock app connect 안 함.
+    const result = await mcpCall(server.port, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'ping_app', arguments: {} },
+    });
+    expect(result.error).toBeDefined();
+    expect(result.error.code).toBe(-32603);
+    expect(result.error.message).toContain('app not connected');
+  });
+
+  test('ping_app — mock app 연결 + ping handler → 양방향 round-trip', async () => {
+    const server = await setupServer();
+    let pingReceived = false;
+    mockApp = connectMockApp(server.port, {
+      ping: (params) => {
+        pingReceived = true;
+        return { pong: true, src: 'mock', echo: params };
+      },
+    });
+    await waitForWsOpen(mockApp.ws);
+    await mockApp.helloReceived;
+
+    const result = await mcpCall(server.port, {
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: { name: 'ping_app', arguments: {} },
+    });
+
+    expect(pingReceived).toBe(true);
+    expect(result.id).toBe(3);
+    expect(result.error).toBeUndefined();
+    // content[0].text 가 raw JSON string — double-encoded (MCP 2024-11-05 content[] text-only)
+    expect(result.result.content[0].type).toBe('text');
+    const innerJson = JSON.parse(result.result.content[0].text);
+    expect(innerJson.pong).toBe(true);
+    expect(innerJson.src).toBe('mock');
+  });
+
+  test('ping_app — mock app 의 handler 가 throw → -32603 forward', async () => {
+    const server = await setupServer();
+    mockApp = connectMockApp(server.port, {
+      ping: () => {
+        throw new Error('mock app handler boom');
+      },
+    });
+    await waitForWsOpen(mockApp.ws);
+    await mockApp.helloReceived;
+
+    const result = await mcpCall(server.port, {
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: { name: 'ping_app', arguments: {} },
+    });
+
+    // dispatcher 가 app 의 error response 를 받음 → `result` 가 없어서 -32603 응답
+    // (dispatcher 의 "app response missing 'result'" 분기).
+    expect(result.error).toBeDefined();
+    expect(result.error.code).toBe(-32603);
+  });
+
+  test('app 두 번째 연결 — first-wins 거절', async () => {
+    const server = await setupServer();
+    mockApp = connectMockApp(server.port, {});
+    await waitForWsOpen(mockApp.ws);
+    await mockApp.helloReceived;
+
+    // 두 번째 connect — error 메시지 (`-32000 another app already connected`) 후 close.
+    // listener race 회피: WebSocket 인스턴스 생성 직후 (open 전) listener 등록.
+    const second = new WebSocket(`ws://127.0.0.1:${server.port}/__mcp-app`);
+    const messages: string[] = [];
+    second.addEventListener('message', (ev) => {
+      if (typeof ev.data === 'string') messages.push(ev.data);
+    });
+    await waitForWsOpen(second);
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, 1000);
+      second.addEventListener(
+        'close',
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+    });
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    const errMsg = messages[0];
+    expect(errMsg).toContain('-32000');
+    expect(errMsg).toContain('another app already connected');
+    try {
+      second.close();
+    } catch {
+      /* already closed */
+    }
+  });
+});

--- a/tests/integration/tests/mcp-app-channel-e2e.test.ts
+++ b/tests/integration/tests/mcp-app-channel-e2e.test.ts
@@ -31,10 +31,13 @@ async function findFreePort(): Promise<number> {
 
 async function startServer(args: string[]): Promise<Server> {
   const port = await findFreePort();
+  // F1: stdout/stderr pipe 를 drain 안 하면 OS pipe buffer (~16-64KB) 가득 차서
+  // server write block → response 멎음. dev_server 가 verbose log 송신 (`[mcp-app]`,
+  // `[bundle.js]` 등) 라 6 test 동안 누적 → flaky. `ignore` 로 drain 우회.
   const proc = Bun.spawn({
     cmd: [ZNTC_BIN, ...args, '--port', String(port)],
-    stdout: 'pipe',
-    stderr: 'pipe',
+    stdout: 'ignore',
+    stderr: 'ignore',
   });
 
   await waitForServer(port, {
@@ -81,7 +84,19 @@ function connectMockApp(
 ): MockApp {
   const ws = new WebSocket(`ws://127.0.0.1:${port}/__mcp-app`);
   let helloResolve!: () => void;
-  const helloReceived = new Promise<void>((r) => (helloResolve = r));
+  let helloReject!: (e: Error) => void;
+  const helloReceived = new Promise<void>((res, rej) => {
+    helloResolve = res;
+    helloReject = rej;
+  });
+  // F2: hello 가 도착하기 전 close/error 시 helloReceived 가 영원히 pending → test
+  // 가 bun default timeout 까지 hang. close 시 reject 로 명확 fail.
+  ws.addEventListener('close', () => helloReject(new Error('ws closed before hello')), {
+    once: true,
+  });
+  ws.addEventListener('error', () => helloReject(new Error('ws error before hello')), {
+    once: true,
+  });
 
   ws.addEventListener('message', (ev) => {
     if (typeof ev.data !== 'string') return;
@@ -267,9 +282,11 @@ describe('MCP App Channel E2E (/__mcp-app + /mcp ping_app)', () => {
     });
 
     // dispatcher 가 app 의 error response 를 받음 → `result` 가 없어서 -32603 응답
-    // (dispatcher 의 "app response missing 'result'" 분기).
+    // (dispatcher 의 "app response missing 'result'" 분기). assertion 강화 — 정확한
+    // 분기 메시지 검증 (F3: spec drift 가드).
     expect(result.error).toBeDefined();
     expect(result.error.code).toBe(-32603);
+    expect(result.error.message).toContain("missing 'result'");
   });
 
   test('app 두 번째 연결 — first-wins 거절', async () => {


### PR DESCRIPTION
## Summary
- #3867 epic 의 PR-E3 **통합 test 인프라**
- Zig 단위 test 와 mcp-runtime.test.ts mock 검증을 넘어 실제 ZNTC binary spawn + Bun WebSocket client 양방향 round-trip 검증
- PR-E3c+ 의 본격 tool 추가 시 회귀 가드 baseline

## 신설 `tests/integration/tests/mcp-app-channel-e2e.test.ts` (6 test)

### Helper
- `connectMockApp(port, handlers)` — `/__mcp-app` 접속 + JSON-RPC dispatcher (mcp-runtime.cjs 의 단순화)
- `mcpCall(port, body)` — `/mcp` HTTP POST helper

### 검증 시나리오
1. hello 메시지 — `method:"connected"` + protocol 식별자
2. tools/list — `ping_app` 노출
3. ping_app + app 미연결 — `-32603 + "app not connected"` 진단
4. ping_app round-trip — mock handler 결과가 MCP `content[0].text` JSON string 으로 forward
5. ping_app + handler throw — `-32603 + "missing 'result'"` 분기 (assertion 강화)
6. first-wins — 두 번째 connect `-32000` + close

## `/code-review max` 결과 (3건 같은 PR fix)

| Finding | Severity | 처리 |
|---|---|---|
| F1 | Medium | stdout/stderr pipe drain → `ignore` 로 변경 (flaky 회피) |
| F2 | Low-Medium | helloReceived 가 reject 경로 없음 → close/error 시 reject |
| F3 | Low | throw test assertion 강화 (`error.message.toContain('missing'`)) |
| F4-F6 | Low | close-frame race / coverage gap / port TOCTOU — defer |

## 메모리 가이드 준수
- `zig build install` 후 실행 — `ZNTC_BIN` stale 회피
- 반드시 `tests/integration` cwd 에서 `bun test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)