### PR TITLE
feat(mcp): find_element tool — RN fiber tree 첫 매칭 + opaque ref (PR-F1)

### DIFF
--- a/packages/react-native/runtime/mcp-runtime.cjs
+++ b/packages/react-native/runtime/mcp-runtime.cjs
@@ -63,6 +63,194 @@ function startMcpRuntime(g) {
       echo: params || null,
     };
   };
+
+  // ─── Fiber tree 순회 + ref 시스템 (PR-F1 baseline) ───
+  //
+  // React DevTools 의 global hook 통해 fiber root 접근 → DFS 순회로 component 검색.
+  // 각 매칭 element 에 opaque ref (`e1`, `e2`, ...) 부여 + Map 으로 reverse-lookup.
+  // 후속 tool (inspect_state, eval_code 등) 이 ref 로 instance 호출.
+  //
+  // 메모리 가이드: 매 find 호출마다 새 ref 부여 — 기존 ref invalidate 안 함. caller
+  // 가 stale ref 받아도 inspect_state 가 null 응답. RN fast-refresh 시 tree 재구성
+  // 되어도 동작.
+  //
+  // refMap 의 unbounded growth 방지 — REF_MAP_MAX (256) 도달 시 가장 오래된 entry
+  // 를 FIFO 로 evict. Map 의 insertion-order 보장 사용 (ES2015+). fiber 는 strong
+  // reference 라 evict 안 하면 unmount 된 subtree 까지 GC 못 함 — 디버그 세션에서
+  // find_element 를 hot loop 로 호출하면 누적. 256 은 동시 inspect 대상 가정 평균
+  // (Playwright MCP 도 비슷한 ref 회전 사용).
+  var REF_MAP_MAX = 256;
+  var refMap = new Map(); // ref string → fiber pointer (insertion-ordered)
+  var refIdCounter = 1;
+
+  function nextRefId() {
+    var id = refIdCounter;
+    refIdCounter += 1;
+    return 'e' + id;
+  }
+
+  function rememberRef(ref, fiber) {
+    if (refMap.size >= REF_MAP_MAX) {
+      // 가장 오래된 entry (Map iteration order = insertion order) drop.
+      var oldest = refMap.keys().next().value;
+      if (oldest != null) refMap.delete(oldest);
+    }
+    refMap.set(ref, fiber);
+  }
+
+  function getFiberRoots() {
+    var hook = g.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    if (!hook || typeof hook.getFiberRoots !== 'function') return [];
+    // RN 은 보통 renderer 1개 (RCTHostView), 그러나 multi-renderer 가능성 위해
+    // hook.renderers (Map<rendererID, RendererInterface>) 전체를 iterate.
+    var roots = [];
+    try {
+      var renderers = hook.renderers;
+      if (renderers && typeof renderers.forEach === 'function') {
+        renderers.forEach(function (_, rendererID) {
+          var rootsSet = hook.getFiberRoots(rendererID);
+          if (rootsSet && typeof rootsSet.forEach === 'function') {
+            rootsSet.forEach(function (root) {
+              roots.push(root);
+            });
+          }
+        });
+      }
+    } catch (err) {
+      // DevTools hook 이 unexpected state — silent ignore 면 디버그 어려움.
+      // RN console 가 있으면 warn (loop 가능성 낮음, getFiberRoots 는 매 find 마다 한번).
+      if (g.console && typeof g.console.warn === 'function') {
+        try {
+          g.console.warn('[zntc:mcp:runtime] getFiberRoots failed:', err && err.message);
+        } catch (_) {
+          /* console 자체 throw — 더 할 수 있는 게 없음 */
+        }
+      }
+    }
+    return roots;
+  }
+
+  function getComponentName(fiber) {
+    if (!fiber || !fiber.type) return null;
+    var t = fiber.type;
+    if (typeof t === 'string') return t; // host component (View, Text, etc)
+    return t.displayName || t.name || null;
+  }
+
+  function getTextContent(fiber) {
+    // RN host text fiber 는 두 패턴:
+    //   1. `<Text>Hello</Text>` → memoizedProps.children === 'Hello'
+    //   2. host text node (RN 의 RCTText 내부) → memoizedProps === 'Hello' (string 자체)
+    // children 가 array (e.g. `<Text>Hi {name}</Text>`) 인 경우는 미지원 — 후속 PR.
+    if (!fiber) return null;
+    if (typeof fiber.memoizedProps === 'string') return fiber.memoizedProps;
+    if (fiber.memoizedProps && typeof fiber.memoizedProps.children === 'string') {
+      return fiber.memoizedProps.children;
+    }
+    return null;
+  }
+
+  // DFS — fiber.child 따라 내려가고 fiber.sibling 따라 옆으로. parent chain 은
+  // fiber.return.
+  function walkFiber(root, visitor) {
+    var current = root.current; // FiberRoot 의 current = root fiber
+    if (!current) return;
+    var stack = [current];
+    while (stack.length > 0) {
+      var fiber = stack.pop();
+      if (!fiber) continue;
+      if (visitor(fiber) === false) return; // early stop
+      if (fiber.sibling) stack.push(fiber.sibling);
+      if (fiber.child) stack.push(fiber.child);
+    }
+  }
+
+  function matchByText(fiber, value) {
+    var text = getTextContent(fiber);
+    return typeof text === 'string' && text.indexOf(value) !== -1;
+  }
+
+  function matchByComponent(fiber, value) {
+    return getComponentName(fiber) === value;
+  }
+
+  function matchByRole(fiber, value) {
+    var props = fiber.memoizedProps;
+    if (!props || typeof props !== 'object') return false;
+    return props.accessibilityRole === value || props.role === value;
+  }
+
+  function serializeFiber(fiber, ref) {
+    var name = getComponentName(fiber) || '(unknown)';
+    var text = getTextContent(fiber);
+    var props = fiber.memoizedProps || {};
+    var summary = {
+      ref: ref,
+      component: name,
+    };
+    if (text != null) summary.text = text;
+    var role = (props && (props.accessibilityRole || props.role)) || null;
+    if (role) summary.role = role;
+    var label = (props && (props.accessibilityLabel || props['aria-label'])) || null;
+    if (label) summary.label = label;
+    if (props && typeof props.testID === 'string') summary.testID = props.testID;
+    // source — React 의 _debugSource 가 fileName + lineNumber 보유 (dev only).
+    var src = fiber._debugSource;
+    if (src && typeof src.fileName === 'string') {
+      summary.source =
+        src.fileName + (typeof src.lineNumber === 'number' ? ':' + src.lineNumber : '');
+    }
+    return summary;
+  }
+
+  // find_element({ by, value }) — by: 'text' / 'role' / 'component'. value: string.
+  // 첫 매칭 element 반환. 매칭 없으면 `{ found: false }`.
+  //
+  // 잘못된 input (params 누락, unknown `by`, fiber root 없음) 는 **throw** 한다 —
+  // dispatcher (onmessage) 가 catch 해서 JSON-RPC `-32603 Internal error` 로 wrap →
+  // MCP client 가 표준 error 채널로 받음. `{error:...}` 객체 반환은 result content
+  // 안에 묻혀 silent fail 처럼 보이는 anti-pattern (PR-F1 review F4).
+  handlers.find_element = function (params) {
+    if (!params || typeof params.by !== 'string' || typeof params.value !== 'string') {
+      throw new Error(
+        'find_element: params requires `by` (text/role/component) and `value` (string)',
+      );
+    }
+    var matcher;
+    if (params.by === 'text') matcher = matchByText;
+    else if (params.by === 'role') matcher = matchByRole;
+    else if (params.by === 'component') matcher = matchByComponent;
+    else {
+      throw new Error('find_element: unknown `by` -- only text/role/component supported');
+    }
+
+    var roots = getFiberRoots();
+    if (roots.length === 0) {
+      throw new Error(
+        'find_element: no React fiber root found (DevTools hook not installed or React not mounted yet)',
+      );
+    }
+
+    var found = null;
+    for (var i = 0; i < roots.length && !found; i++) {
+      walkFiber(roots[i], function (fiber) {
+        if (matcher(fiber, params.value)) {
+          var ref = nextRefId();
+          rememberRef(ref, fiber);
+          found = serializeFiber(fiber, ref);
+          return false; // early stop
+        }
+        return true;
+      });
+    }
+    return found || { found: false };
+  };
+
+  // (internal) refMap 노출 — 후속 tool (inspect_state) 이 ref → fiber 조회. test 도 사용.
+  handlers.__getFiberByRef = function (params) {
+    if (!params || typeof params.ref !== 'string') return { fiber: null };
+    return { has: refMap.has(params.ref) };
+  };
   // closedExplicitly: 사용자 `runtime.close()` 호출 (사용자 의도, reconnect 금지)
   // protocolMismatch: server 가 광고한 protocol version 이 client EXPECTED 와 불일치
   // — reconnect 무의미 (RN reload 필요). 별도 sentinel 로 두 가지 케이스 구분.
@@ -153,7 +341,10 @@ function startMcpRuntime(g) {
       if (g.console && typeof g.console.warn === 'function') {
         var idHint = obj && obj.id != null ? ' id=' + String(obj.id) : '';
         g.console.warn(
-          '[zntc:mcp:runtime] send drop — WS 닫힘 (state=' + state.connectionState + ')' + idHint,
+          '[zntc:mcp:runtime] send dropped — WS closed (state=' +
+            state.connectionState +
+            ')' +
+            idHint,
         );
       }
       return false;

--- a/packages/react-native/src/mcp-runtime.test.ts
+++ b/packages/react-native/src/mcp-runtime.test.ts
@@ -379,3 +379,264 @@ describe('mcp-runtime.cjs (PR-E2) — reconnect', () => {
     expect(scheduled.length).toBe(0);
   });
 });
+
+// PR-F1 — find_element. fiber tree 순회 + opaque ref. 실 React 없이 minimal mock
+// fiber 로 검증 — Playwright MCP 의 ref(e1, e2) 패턴 동치 동작 확인.
+interface FakeFiber {
+  type?: unknown;
+  memoizedProps?: unknown;
+  child?: FakeFiber | null;
+  sibling?: FakeFiber | null;
+  stateNode?: unknown;
+  _debugSource?: { fileName?: string; lineNumber?: number };
+}
+
+interface FakeFiberRoot {
+  current: FakeFiber;
+}
+
+function makeFiberHook(g: FakeGlobal, roots: FakeFiberRoot[]): void {
+  (g as unknown as Record<string, unknown>).__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+    renderers: new Map([[1, {}]]),
+    getFiberRoots: (_rendererID: number) => new Set(roots),
+  };
+}
+
+describe('mcp-runtime.cjs (PR-F1) — find_element', () => {
+  // PR-F1 review F4: 잘못된 input 은 `{error}` return 대신 throw — dispatcher (onmessage) 가
+  // catch 해서 JSON-RPC `-32603 Internal error` 로 wrap.
+  test('params 누락 → throw: requires `by` and `value`', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    expect(() => rt.handlers.find_element({})).toThrow(/requires `by`/);
+    expect(() => rt.handlers.find_element({ by: 'text' })).toThrow(/requires `by`/);
+  });
+
+  test('unknown `by` → throw: only text/role/component supported', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    expect(() => rt.handlers.find_element({ by: 'xpath', value: '//div' })).toThrow(/unknown `by`/);
+  });
+
+  test('DevTools hook 없음 → throw: no React fiber root found', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    expect(() => rt.handlers.find_element({ by: 'text', value: 'Hello' })).toThrow(
+      /no React fiber root/,
+    );
+  });
+
+  test('by=text — fiber.memoizedProps.children 매칭 + opaque ref 부여', () => {
+    // App > View > Text("Hello world")
+    const textFiber: FakeFiber = {
+      type: 'Text',
+      memoizedProps: { children: 'Hello world' },
+    };
+    const viewFiber: FakeFiber = {
+      type: 'View',
+      memoizedProps: { accessibilityRole: 'group' },
+      child: textFiber,
+    };
+    const appFiber: FakeFiber = {
+      type: { displayName: 'App' },
+      memoizedProps: {},
+      child: viewFiber,
+    };
+    makeFiberHook(g, [{ current: appFiber }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.find_element({ by: 'text', value: 'Hello' }) as {
+      ref?: string;
+      component?: string;
+      text?: string;
+    };
+    expect(r.ref).toMatch(/^e\d+$/);
+    expect(r.component).toBe('Text');
+    expect(r.text).toBe('Hello world');
+
+    // 같은 인스턴스 두 번 find → 새 ref 부여 (캐시 안 함 — 매번 fresh)
+    const r2 = rt.handlers.find_element({ by: 'text', value: 'Hello' }) as { ref?: string };
+    expect(r2.ref).not.toBe(r.ref);
+  });
+
+  test('by=role — props.accessibilityRole 또는 props.role 매칭', () => {
+    const btnFiber: FakeFiber = {
+      type: 'View',
+      memoizedProps: { accessibilityRole: 'button', accessibilityLabel: 'Submit' },
+    };
+    const linkFiber: FakeFiber = {
+      type: 'View',
+      memoizedProps: { role: 'link' },
+    };
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: btnFiber,
+    };
+    btnFiber.sibling = linkFiber;
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r1 = rt.handlers.find_element({ by: 'role', value: 'button' }) as {
+      ref?: string;
+      role?: string;
+      label?: string;
+    };
+    expect(r1.ref).toBeDefined();
+    expect(r1.role).toBe('button');
+    expect(r1.label).toBe('Submit');
+
+    const r2 = rt.handlers.find_element({ by: 'role', value: 'link' }) as { role?: string };
+    expect(r2.role).toBe('link');
+  });
+
+  test('by=component — getComponentName 매칭 (host string + displayName/name)', () => {
+    const myButton: FakeFiber = {
+      type: { displayName: 'MyButton' },
+      memoizedProps: {},
+    };
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: myButton,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.find_element({ by: 'component', value: 'MyButton' }) as {
+      component?: string;
+    };
+    expect(r.component).toBe('MyButton');
+  });
+
+  test('DFS first-match 순서 — child 가 sibling 보다 먼저 visited (review F4 회귀 잠금)', () => {
+    // root
+    //   ├ child  (Component A — accessibilityRole=button)
+    //   └ sibling (Component B — accessibilityRole=button)
+    // DFS stack push 순서: sibling → child → child pop 먼저 → A 매칭.
+    // walkFiber 의 push order (sibling first, child last) 가 child-first 보장.
+    const fiberA: FakeFiber = {
+      type: { displayName: 'A' },
+      memoizedProps: { accessibilityRole: 'button' },
+    };
+    const fiberB: FakeFiber = {
+      type: { displayName: 'B' },
+      memoizedProps: { accessibilityRole: 'button' },
+    };
+    fiberA.sibling = fiberB;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fiberA,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.find_element({ by: 'role', value: 'button' }) as { component?: string };
+    expect(r.component).toBe('A');
+  });
+
+  test('refMap LRU cap — 256 entry 후 oldest evicted (review F3 회귀 잠금)', () => {
+    // 매우 큰 트리는 비현실 — root child chain 으로 LRU 검증.
+    // 257번째 find 시 e1 이 evicted, e2~e257 + e258 살아있음.
+    // walkFiber 가 stack 기반 DFS — child 만 따라가는 chain 만들기.
+    function makeChain(n: number): FakeFiber {
+      let last: FakeFiber = {
+        type: 'Text',
+        memoizedProps: { children: 'leaf' },
+      };
+      for (let i = 0; i < n; i++) {
+        last = {
+          type: { displayName: 'C' + i },
+          memoizedProps: {},
+          child: last,
+        };
+      }
+      return last;
+    }
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: makeChain(1),
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    // 260번 find — 같은 'leaf' 매칭. 매 호출마다 새 ref. e1~e260.
+    const refs: string[] = [];
+    for (let i = 0; i < 260; i++) {
+      const r = rt.handlers.find_element({ by: 'text', value: 'leaf' }) as { ref: string };
+      refs.push(r.ref);
+    }
+    expect(refs.length).toBe(260);
+    // 256 cap — e1~e4 evicted, e5~e260 살아있음.
+    const has = (ref: string) =>
+      (rt.handlers.__getFiberByRef({ ref }) as { has?: boolean }).has === true;
+    expect(has('e1')).toBe(false);
+    expect(has('e4')).toBe(false);
+    expect(has('e5')).toBe(true);
+    expect(has('e260')).toBe(true);
+  });
+
+  test('__getFiberByRef — 등록된 ref 는 has:true, 없는 ref 는 has:false', () => {
+    const fiber: FakeFiber = {
+      type: 'Text',
+      memoizedProps: { children: 'X' },
+    };
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.find_element({ by: 'text', value: 'X' }) as { ref: string };
+    expect((rt.handlers.__getFiberByRef({ ref: r.ref }) as { has?: boolean }).has).toBe(true);
+    expect((rt.handlers.__getFiberByRef({ ref: 'e9999' }) as { has?: boolean }).has).toBe(false);
+  });
+
+  test('매칭 없음 → { found: false }', () => {
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.find_element({ by: 'text', value: 'NotPresent' }) as {
+      found?: boolean;
+    };
+    expect(r.found).toBe(false);
+  });
+
+  test('serializeFiber — testID + source(_debugSource) 포함', () => {
+    const fiber: FakeFiber = {
+      type: 'Text',
+      memoizedProps: { children: 'Tagged', testID: 'btn-1' },
+      _debugSource: { fileName: '/abs/path/App.tsx', lineNumber: 42 },
+    };
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.find_element({ by: 'text', value: 'Tagged' }) as {
+      testID?: string;
+      source?: string;
+    };
+    expect(r.testID).toBe('btn-1');
+    expect(r.source).toBe('/abs/path/App.tsx:42');
+  });
+});

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -23,6 +23,12 @@ const buildErrorJsonFromDiagnostics = server_events.buildErrorJsonFromDiagnostic
 const writeJsonValue = server_events.writeJsonValue;
 const mcp_app_channel_mod = @import("mcp_app_channel.zig");
 
+// MCP `tools/call` 의 RN-app forward 도구별 timeout. RN handler 는 보통 ms 단위 응답
+// 인데 cold start / 첫 fiber walk 가 모바일 디바이스에서 수백 ms 까지 갈 수 있어 5초
+// 여유. tool 별로 더 길어야 하면 별도 const 추가 (예: take_snapshot 큰 트리 직렬화).
+const PING_TIMEOUT_MS: u64 = 5000;
+const FIND_ELEMENT_TIMEOUT_MS: u64 = 5000;
+
 fn getLog() std.fs.File.DeprecatedWriter {
     return std.fs.File.stderr().deprecatedWriter();
 }
@@ -1269,7 +1275,8 @@ pub const DevServer = struct {
                 \\{"name":"reset_cache","description":"Clear the build cache. Next build will be a full rebuild.","inputSchema":{"type":"object","properties":{},"additionalProperties":false}},
                 \\{"name":"get_build_events","description":"Subscribe to bundler events for a duration and return collected events.","inputSchema":{"type":"object","properties":{"duration":{"type":"number","minimum":1000,"maximum":60000,"default":10000,"description":"milliseconds to listen"}},"additionalProperties":false}},
                 \\{"name":"verify_in_chrome","description":"Run `zntc verify` (headless Chromium) against the dev server (or a custom target) and return the JSON report. Requires Playwright in the Node CLI environment; set ZNTC_CLI env to the path of bin/zntc.mjs (npm-install environments find `zntc` on PATH automatically).","inputSchema":{"type":"object","properties":{"target":{"type":"string","description":"Path or URL to verify. Defaults to the dev server root URL."},"timeout":{"type":"number","minimum":1000,"maximum":60000,"description":"Page load timeout in ms (default: 10000)"},"ignore":{"type":"array","items":{"type":"string"},"description":"Regex patterns; matching console/url events are skipped."},"allowConsoleError":{"type":"boolean","description":"If true, console.error events do not affect exit code."}},"additionalProperties":false}},
-                \\{"name":"ping_app","description":"Ping the connected RN app's MCP runtime over the /__mcp-app WebSocket. Returns the app's pong response (verifies bi-directional channel).","inputSchema":{"type":"object","properties":{},"additionalProperties":false}}
+                \\{"name":"ping_app","description":"Ping the connected RN app's MCP runtime over the /__mcp-app WebSocket. Returns the app's pong response (verifies bi-directional channel).","inputSchema":{"type":"object","properties":{},"additionalProperties":false}},
+                \\{"name":"find_element","description":"Find the first matching React component in the connected RN app's fiber tree. Returns an opaque ref (e1/e2/...) for subsequent tool calls (inspect_state, eval_code, etc).","inputSchema":{"type":"object","properties":{"by":{"type":"string","enum":["text","role","component"],"description":"Match strategy: 'text' (substring of Text node), 'role' (accessibilityRole), 'component' (displayName)"},"value":{"type":"string","description":"Value to match"}},"required":["by","value"],"additionalProperties":false}}
                 \\]}
             );
         } else if (std.mem.eql(u8, method, "tools/call")) {
@@ -1306,54 +1313,17 @@ pub const DevServer = struct {
             return;
         }
 
+        if (std.mem.eql(u8, tool_name, "find_element")) {
+            // RN app 의 fiber tree 순회 — `by` / `value` args 그대로 forward.
+            try self.forwardAppTool(w, "find_element", args, FIND_ELEMENT_TIMEOUT_MS);
+            return;
+        }
+
         if (std.mem.eql(u8, tool_name, "ping_app")) {
-            // 앱 MCP runtime 의 `handlers.ping` 호출. typical RN handler 는 ms 단위
-            // 응답이라 PING_TIMEOUT_MS (5초) 면 cold start 까지도 여유. 후속 본격 tool
-            // (take_snapshot 등) 은 자체 default 또는 args.timeout 별도 처리.
-            const PING_TIMEOUT_MS: u64 = 5000;
-            const resp_json = self.app_channel.requestStored("ping", "{}", PING_TIMEOUT_MS) catch |err| {
-                const msg = switch (err) {
-                    mcp_app_channel_mod.RequestError.NotConnected => "app not connected on /__mcp-app",
-                    mcp_app_channel_mod.RequestError.Timeout => "app response timeout (5s)",
-                    mcp_app_channel_mod.RequestError.AppDisconnected => "app disconnected mid-request",
-                    mcp_app_channel_mod.RequestError.WriteFailed => "ws write failed",
-                    mcp_app_channel_mod.RequestError.OutOfMemory => "out of memory",
-                };
-                try w.writeAll("\"error\":{\"code\":-32603,\"message\":\"");
-                try writeJsonEscaped(w, msg);
-                try w.writeAll("\"}");
-                return;
-            };
-            defer self.allocator.free(resp_json);
-
-            // 앱 response 는 JSON-RPC envelope `{jsonrpc, id, result/error}`. result 만
-            // 추출해 MCP client 에 forward (content text 로 raw JSON 직렬화).
-            var resp_parsed = std.json.parseFromSlice(std.json.Value, self.allocator, resp_json, .{}) catch {
-                try w.writeAll("\"error\":{\"code\":-32603,\"message\":\"app response was not valid JSON\"}");
-                return;
-            };
-            defer resp_parsed.deinit();
-            const result_val = switch (resp_parsed.value) {
-                .object => |o| o.get("result"),
-                else => null,
-            };
-            if (result_val == null) {
-                try w.writeAll("\"error\":{\"code\":-32603,\"message\":\"app response missing 'result'\"}");
-                return;
-            }
-            // MCP 2024-11-05 의 `content[]` 는 `{type:"text", text:<string>}` 만 지원
-            // (`{type:"json", ...}` 추가는 후속 spec). 앱의 raw result JSON 을 string
-            // 안에 임베드하려면 두 단계 encode 필요:
-            //   1. valueAlloc — result_val (Value) 를 JSON 문자열로 직렬화
-            //   2. writeJsonEscaped — 그 문자열을 또 JSON 문자열 리터럴로 escape (`"` → `\"`)
-            // client 는 결과로 받은 text 를 다시 JSON.parse 해야 함. 향후 MCP spec 이
-            // `{type:"json", value:...}` 지원하면 single-encode 로 단순화 가능.
-            const result_str = try std.json.Stringify.valueAlloc(self.allocator, result_val.?, .{});
-            defer self.allocator.free(result_str);
-
-            try w.writeAll("\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"");
-            try writeJsonEscaped(w, result_str);
-            try w.writeAll("\"}]}");
+            // 앱 MCP runtime 의 `handlers.ping` 호출. ping 은 params 없음 — empty
+            // object forward. forwardAppTool 가 args (json Value) 받아 직렬화 하지만
+            // here args 가 .null/.object 모두 valid.
+            try self.forwardAppTool(w, "ping", args, PING_TIMEOUT_MS);
             return;
         }
 
@@ -1431,6 +1401,97 @@ pub const DevServer = struct {
         }
 
         try w.writeAll("\"error\":{\"code\":-32602,\"message\":\"Unknown tool\"}");
+    }
+
+    /// AppChannel 너머 RN 앱의 MCP runtime 으로 단일 method 를 forward 하는 helper.
+    /// `args` (JSON Value) 를 그대로 직렬화해 `method:<name> params:<args>` request 송신
+    /// 후 timeout_ms 안에 응답 받기. 결과는 MCP 2024-11-05 `content[]` 의 text 로 wrap
+    /// (raw JSON 을 string 안에 double-encode).
+    ///
+    /// 에러는 모두 영어 메시지 — MCP client 가 표시할 수 있도록.
+    fn forwardAppTool(
+        self: *DevServer,
+        w: anytype,
+        method: []const u8,
+        args: std.json.Value,
+        timeout_ms: u64,
+    ) !void {
+        // args 직렬화 — params 없이 `{}` 로도 충분하지만 일반화 위해 그대로 dump.
+        // args 가 `.null` 이면 "null" 이 되는데, 앱 handler 는 `params ?? {}` 로 처리.
+        // OOM 도 unified `-32603` MCP error path 로 통일 — propagate 하면 HTTP 500.
+        const args_json = std.json.Stringify.valueAlloc(self.allocator, args, .{}) catch {
+            try w.writeAll("\"error\":{\"code\":-32603,\"message\":\"args serialization failed\"}");
+            return;
+        };
+        defer self.allocator.free(args_json);
+
+        const resp_json = self.app_channel.requestStored(method, args_json, timeout_ms) catch |err| {
+            try w.writeAll("\"error\":{\"code\":-32603,\"message\":\"");
+            switch (err) {
+                mcp_app_channel_mod.RequestError.NotConnected => try writeJsonEscaped(w, "app not connected on /__mcp-app"),
+                mcp_app_channel_mod.RequestError.Timeout => {
+                    // ms 포함 — 도구별 timeout 이 달라질 수 있어 self-describing.
+                    var buf: [64]u8 = undefined;
+                    const s = std.fmt.bufPrint(&buf, "app response timeout ({d}ms)", .{timeout_ms}) catch "app response timeout";
+                    try writeJsonEscaped(w, s);
+                },
+                mcp_app_channel_mod.RequestError.AppDisconnected => try writeJsonEscaped(w, "app disconnected mid-request"),
+                mcp_app_channel_mod.RequestError.WriteFailed => try writeJsonEscaped(w, "ws write failed"),
+                mcp_app_channel_mod.RequestError.OutOfMemory => try writeJsonEscaped(w, "out of memory"),
+            }
+            try w.writeAll("\"}");
+            return;
+        };
+        defer self.allocator.free(resp_json);
+
+        // 앱 response 는 JSON-RPC envelope `{jsonrpc, id, result/error}`. result 가
+        // 있으면 그걸 MCP content text 로 wrap, error 만 있으면 그대로 client 에 forward
+        // (PR-F1 review F4 — app handler throw 시 의미 있는 메시지가 묻히지 않도록).
+        var resp_parsed = std.json.parseFromSlice(std.json.Value, self.allocator, resp_json, .{}) catch {
+            try w.writeAll("\"error\":{\"code\":-32603,\"message\":\"app response was not valid JSON\"}");
+            return;
+        };
+        defer resp_parsed.deinit();
+        const result_val = switch (resp_parsed.value) {
+            .object => |o| o.get("result"),
+            else => null,
+        };
+        if (result_val == null) {
+            // app 이 result 대신 error 를 보냈으면 그걸 forward. else missing 'result'.
+            const err_val: ?std.json.Value = switch (resp_parsed.value) {
+                .object => |o| o.get("error"),
+                else => null,
+            };
+            const err_msg: []const u8 = blk: {
+                if (err_val) |ev| switch (ev) {
+                    .object => |eo| switch (eo.get("message") orelse .null) {
+                        .string => |s| break :blk s,
+                        else => {},
+                    },
+                    else => {},
+                };
+                break :blk "app response missing 'result'";
+            };
+            try w.writeAll("\"error\":{\"code\":-32603,\"message\":\"");
+            try writeJsonEscaped(w, err_msg);
+            try w.writeAll("\"}");
+            return;
+        }
+        // MCP 2024-11-05 의 `content[]` 는 `{type:"text", text:<string>}` 만 지원. 앱의
+        // raw result JSON 을 string 안에 임베드 — 두 단계 encode:
+        //   1. valueAlloc — Value → JSON string
+        //   2. writeJsonEscaped — 그 string 을 또 JSON string literal 로 escape
+        // client 는 받은 text 를 다시 JSON.parse 해야 함. 향후 `{type:"json", ...}` 지원
+        // 시 single-encode 로 단순화 가능.
+        const result_str = std.json.Stringify.valueAlloc(self.allocator, result_val.?, .{}) catch {
+            try w.writeAll("\"error\":{\"code\":-32603,\"message\":\"result serialization failed\"}");
+            return;
+        };
+        defer self.allocator.free(result_str);
+
+        try w.writeAll("\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"");
+        try writeJsonEscaped(w, result_str);
+        try w.writeAll("\"}]}");
     }
 
     /// `verify_in_chrome` MCP 도구. Node CLI (`zntc verify --verify-json ...`) 를

--- a/tests/integration/tests/mcp-app-channel-e2e.test.ts
+++ b/tests/integration/tests/mcp-app-channel-e2e.test.ts
@@ -281,12 +281,87 @@ describe('MCP App Channel E2E (/__mcp-app + /mcp ping_app)', () => {
       params: { name: 'ping_app', arguments: {} },
     });
 
-    // dispatcher 가 app 의 error response 를 받음 → `result` 가 없어서 -32603 응답
-    // (dispatcher 의 "app response missing 'result'" 분기). assertion 강화 — 정확한
-    // 분기 메시지 검증 (F3: spec drift 가드).
+    // dispatcher 가 app 의 error response 를 받음 → result 없음 → app 의 error.message
+    // 를 추출해 -32603 으로 forward (PR-F1 review F4). throw message ("mock app handler
+    // boom") 가 그대로 client 에 도달해야 진단 가능.
     expect(result.error).toBeDefined();
     expect(result.error.code).toBe(-32603);
-    expect(result.error.message).toContain("missing 'result'");
+    expect(result.error.message).toContain('mock app handler boom');
+  });
+
+  test('tools/list — find_element 노출', async () => {
+    const server = await setupServer();
+    const result = await mcpCall(server.port, { jsonrpc: '2.0', id: 10, method: 'tools/list' });
+    const names = result.result.tools.map((t: any) => t.name);
+    expect(names).toContain('find_element');
+  });
+
+  test('find_element — mock app 의 fiber search 결과 round-trip', async () => {
+    const server = await setupServer();
+    let receivedParams: any = null;
+    mockApp = connectMockApp(server.port, {
+      find_element: (params) => {
+        receivedParams = params;
+        // mock app 이 fiber tree 순회 흉내 — 매칭 element 반환.
+        return { ref: 'e1', component: 'Text', text: 'Hello world' };
+      },
+    });
+    await waitForWsOpen(mockApp.ws);
+    await mockApp.helloReceived;
+
+    const result = await mcpCall(server.port, {
+      jsonrpc: '2.0',
+      id: 11,
+      method: 'tools/call',
+      params: { name: 'find_element', arguments: { by: 'text', value: 'Hello' } },
+    });
+
+    // dispatcher 가 args 를 그대로 app params 로 forward 했는지 확인.
+    expect(receivedParams).toEqual({ by: 'text', value: 'Hello' });
+    expect(result.id).toBe(11);
+    expect(result.error).toBeUndefined();
+    expect(result.result.content[0].type).toBe('text');
+    const innerJson = JSON.parse(result.result.content[0].text);
+    expect(innerJson.ref).toBe('e1');
+    expect(innerJson.component).toBe('Text');
+    expect(innerJson.text).toBe('Hello world');
+  });
+
+  test('find_element — mock app handler throw → -32603 + 원본 message forward', async () => {
+    const server = await setupServer();
+    mockApp = connectMockApp(server.port, {
+      find_element: () => {
+        throw new Error('fiber root missing');
+      },
+    });
+    await waitForWsOpen(mockApp.ws);
+    await mockApp.helloReceived;
+
+    const result = await mcpCall(server.port, {
+      jsonrpc: '2.0',
+      id: 13,
+      method: 'tools/call',
+      params: { name: 'find_element', arguments: { by: 'text', value: 'x' } },
+    });
+
+    // F4: app 의 error.message ("fiber root missing") 가 그대로 client 에 forward.
+    expect(result.error).toBeDefined();
+    expect(result.error.code).toBe(-32603);
+    expect(result.error.message).toContain('fiber root missing');
+  });
+
+  test('find_element — mock app 미연결 → -32603 + "app not connected"', async () => {
+    const server = await setupServer();
+    // mock app connect 안 함.
+    const result = await mcpCall(server.port, {
+      jsonrpc: '2.0',
+      id: 12,
+      method: 'tools/call',
+      params: { name: 'find_element', arguments: { by: 'text', value: 'x' } },
+    });
+    expect(result.error).toBeDefined();
+    expect(result.error.code).toBe(-32603);
+    expect(result.error.message).toContain('app not connected');
   });
 
   test('app 두 번째 연결 — first-wins 거절', async () => {


### PR DESCRIPTION
## Summary
- 첫 본격 MCP debugging tool. `find_element({by: text/role/component, value})` → RN fiber tree DFS 순회 → 첫 매칭 element + opaque ref (`e1`, `e2`, ...) 부여. 후속 tool (inspect_state, eval_code 등) 이 ref 로 instance 호출.
- Zig dispatcher 의 `ping_app` 의 forward 로직을 `forwardAppTool` helper 로 extract — `find_element` 와 공유. 후속 tool 추가 시 동일 helper 재사용.
- JS runtime 에 fiber tree 순회 helpers (`getFiberRoots`/`walkFiber`/`matchBy*`/`serializeFiber`) 와 256-entry FIFO bounded refMap 추가.

## Why
Epic #3867 (RN MCP server 흡수) 의 첫 debugging tool. Playwright MCP 의 ref 패턴 (snapshot + opaque id) 을 RN 의 fiber tree 에 적용 — Babel plugin (전 react-native-mcp-server 가 testID 주입) 없이 zntc transform pass + `__REACT_DEVTOOLS_GLOBAL_HOOK__` 로 동일 효과.

## 주요 변경

### Zig (`src/server/dev_server.zig`)
- `forwardAppTool(method, args, timeout_ms)` — args 직렬화 → `AppChannel.requestStored` → response result 추출 → MCP `content[]` text wrap. ping_app 도 이 helper 호출로 refactor (중복 제거).
- result 없을 시 app 의 `error.message` 를 추출해 forward — 이전 \`missing 'result'\` 한 줄로만 보이던 진단을 \`app error: <real-msg>\` 로 개선.
- `tools/list` schema 에 `find_element` 추가 (`by` enum + `value`, required).
- `5000` magic → file-scope `PING_TIMEOUT_MS` / `FIND_ELEMENT_TIMEOUT_MS` const.

### JS runtime (`packages/react-native/runtime/mcp-runtime.cjs`)
- DevTools hook 통해 모든 renderer 의 fiber root iterate.
- `walkFiber` — child-first stack-pop DFS (visitor `return false` 로 early-stop).
- `handlers.find_element` — 매칭 시 `serializeFiber` (component, text, role, label, testID, source). 잘못된 input 은 throw → dispatcher 가 `-32603` 으로 wrap.
- `refMap` 256-entry FIFO bound — fiber strong ref 누적으로 unmount 된 subtree GC 막는 leak 방지.

### Tests
- **unit** (`packages/react-native/src/mcp-runtime.test.ts`) — 11 test 추가: params 검증 throw, by 별 match, DFS first-match 순서 lock, 매칭 없음, serialize testID/source, `__getFiberByRef` lookup.
- **E2E** (`tests/integration/tests/mcp-app-channel-e2e.test.ts`) — 4 test 추가: tools/list 노출, mock app round-trip, app 미연결, handler throw → 원본 message forward.

## Self-review fixes (PR-F1 review pass)

| ID | Severity | 내용 |
| --- | --- | --- |
| F3 | medium | refMap unbounded growth → 256 FIFO cap |
| F3 | medium | forwardAppTool 의 OOM 도 unified `-32603` (HTTP 500 회피) |
| F4 | medium | `{error}` 반환 대신 throw — silent fail 방지 |
| F4 | medium | result 없을 시 app error.message forward — 진단 개선 |
| F4 | medium | DFS first-match 순서 unit test 로 lock |
| F4 | medium | find_element handler throw → -32603 + 원본 메시지 E2E |
| F5 | low | timeout 메시지에 `(Xms)` suffix |
| F5 | low | getFiberRoots 의 catch 가 console.warn 출력 |
| F6 | low | refIdCounter closure-local |

## Test plan
- [x] `zig build install` (CLI 최신 빌드)
- [x] `zig build test` — 전체 통과 (PR-F1 무관)
- [x] `bun test src/mcp-runtime.test.ts` (packages/react-native) — 33 pass, 0 fail
- [x] `bun test tests/mcp-app-channel-e2e.test.ts` (tests/integration cwd) — 10 pass, 0 fail
- [x] `bun x tsc -b --force` (incremental cache 우회) — 통과
- [ ] 실 RN 디바이스 / 시뮬레이터 검증 — 후속 (사용자 환경 필요)

## 후속

- PR-F2 — `inspect_state`: ref 로 fiber 의 memoizedState/props/hooks 직렬화.
- PR-F3 — `eval_code`: ref 의 인스턴스 context 에서 표현식 평가.
- `walkFiber` cycle guard (fiber 가 partial-render 시 cycle 가능성), Text children array (`<Text>Hi {name}</Text>`) 지원 등은 후속 PR 의 first-class scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)