### PR TITLE
feat(mcp): inspect_state tool — fiber props/state/hooks 직렬화 (PR-F2)

### DIFF
--- a/packages/react-native/runtime/mcp-runtime.cjs
+++ b/packages/react-native/runtime/mcp-runtime.cjs
@@ -251,6 +251,189 @@ function startMcpRuntime(g) {
     if (!params || typeof params.ref !== 'string') return { fiber: null };
     return { has: refMap.has(params.ref) };
   };
+
+  // ─── inspect_state (PR-F2) ───
+  //
+  // safeSerialize — JSON.stringify 의 cycle / non-serializable 값 핸들링.
+  // - function/symbol/undefined → marker string ('[Function]' 등)
+  // - Map/Set/Date/Promise/Error/TypedArray → 명시적 marker
+  // - cycle → '[Circular]'
+  // - max depth → '[MaxDepth]' (RN 의 큰 fiber tree 가 nested props 갖기도)
+  // - throwing getter/Proxy → '[Throws ...]' (해당 key 만 marker, 전체 inspect 실패 방지)
+  // - 긴 array → 앞 N 개만 + '[...M more]'
+  // 결과는 plain object/array/primitive 만 — JSON.stringify 안전.
+  var SERIALIZE_MAX_DEPTH = 8;
+  var SERIALIZE_MAX_ARRAY = 256;
+  function safeSerialize(value, seen, depth) {
+    if (depth > SERIALIZE_MAX_DEPTH) return '[MaxDepth]';
+    if (value === null) return null;
+    var t = typeof value;
+    if (t === 'string' || t === 'boolean') return value;
+    if (t === 'number') {
+      // NaN / Infinity 는 JSON 표현 불가 → marker.
+      if (value !== value) return '[NaN]';
+      if (value === Infinity) return '[+Infinity]';
+      if (value === -Infinity) return '[-Infinity]';
+      return value;
+    }
+    if (t === 'undefined') return '[Undefined]';
+    if (t === 'function') {
+      return '[Function' + (value.name ? ' ' + value.name : '') + ']';
+    }
+    if (t === 'symbol') return '[Symbol]';
+    if (t === 'bigint') return '[BigInt ' + value.toString() + ']';
+    if (t !== 'object') return '[' + t + ']';
+
+    if (seen.has(value)) return '[Circular]';
+    seen.add(value);
+
+    try {
+      if (Array.isArray(value)) {
+        var arr = [];
+        var cap = Math.min(value.length, SERIALIZE_MAX_ARRAY);
+        for (var i = 0; i < cap; i++) {
+          arr.push(safeSerialize(value[i], seen, depth + 1));
+        }
+        if (value.length > SERIALIZE_MAX_ARRAY) {
+          arr.push('[...' + (value.length - SERIALIZE_MAX_ARRAY) + ' more]');
+        }
+        return arr;
+      }
+      // 잘 알려진 instance 들 — 빈 object 로 직렬화되지 않게 marker.
+      if (value instanceof Date) return '[Date ' + value.toISOString() + ']';
+      if (typeof Map !== 'undefined' && value instanceof Map)
+        return '[Map size=' + value.size + ']';
+      if (typeof Set !== 'undefined' && value instanceof Set)
+        return '[Set size=' + value.size + ']';
+      if (typeof Error !== 'undefined' && value instanceof Error) {
+        return '[Error ' + (value.message || value.name || '?') + ']';
+      }
+      if (typeof Promise !== 'undefined' && value instanceof Promise) return '[Promise]';
+      // TypedArray (Uint8Array/Int32Array/...) — large image/audio buffer 가 props 에
+      // 들어오면 전체 byte 직렬화로 폭주. ArrayBuffer.isView 가 모든 typed array + DataView
+      // 커버. byteLength 만 marker 에 포함.
+      if (typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView && ArrayBuffer.isView(value)) {
+        var ctor = (value.constructor && value.constructor.name) || 'TypedArray';
+        var len = typeof value.byteLength === 'number' ? value.byteLength : value.length || 0;
+        return '[' + ctor + ' byteLength=' + len + ']';
+      }
+      if (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer) {
+        return '[ArrayBuffer byteLength=' + value.byteLength + ']';
+      }
+      // React element ($$typeof Symbol) — 거대한 children 트리 직렬화 방지. Proxy 가
+      // 임의 get trap 으로 throw 할 수 있어 try/catch.
+      try {
+        if (value.$$typeof) return '[ReactElement]';
+      } catch (e) {
+        return '[Throws ' + ((e && e.message) || '?') + ']';
+      }
+
+      var out = {};
+      // Own enumerable keys 만 — prototype chain (e.g. component instance methods) 제외.
+      // F3: 사용자 정의 getter / Proxy get trap 이 throw 하면 한 key 만 marker — 전체
+      // inspect_state 실패 방지.
+      for (var key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+          try {
+            out[key] = safeSerialize(value[key], seen, depth + 1);
+          } catch (e2) {
+            out[key] = '[Throws ' + ((e2 && e2.message) || '?') + ']';
+          }
+        }
+      }
+      return out;
+    } finally {
+      seen.delete(value);
+    }
+  }
+
+  // React 18 fiber 의 memoizedState 가 function component 면 Hook linked list:
+  //   { memoizedState, baseState, queue, next } chain.
+  // _debugHookTypes (dev only) 가 hook 이름 array — index 로 매칭.
+  function serializeHooks(fiber) {
+    var hook = fiber.memoizedState;
+    if (!hook || typeof hook !== 'object') return null;
+    // class component 의 state 객체 인지 hook chain 인지 판별 — hook 은 `next` field 와
+    // `memoizedState` field 동시 보유 (React 가 internal contract). 그 외는 class state.
+    if (!('next' in hook) || !('memoizedState' in hook)) return null;
+
+    var types = Array.isArray(fiber._debugHookTypes) ? fiber._debugHookTypes : [];
+    var hooks = [];
+    var cur = hook;
+    var idx = 0;
+    var MAX_HOOKS = 64; // 안전 한도 — 정상 component 는 수개~수십개.
+    var seen = new Set();
+    while (cur && hooks.length < MAX_HOOKS) {
+      if (seen.has(cur)) break; // cycle guard (이론상 없지만 방어)
+      seen.add(cur);
+      // useEffect 등의 Effect 객체는 fiber-wide Effect linked list 의 next 를 갖고 있어서
+      // memoizedState 그대로 직렬화하면 동일 chain 이 hook 마다 중복 트리화. tag/create/
+      // destroy/deps 시그너처로 Effect 감지 → marker.
+      var hookValue = cur.memoizedState;
+      var isEffectLike =
+        hookValue != null &&
+        typeof hookValue === 'object' &&
+        typeof hookValue.tag === 'number' &&
+        'create' in hookValue &&
+        'deps' in hookValue;
+      hooks.push({
+        type: types[idx] || null,
+        value: isEffectLike
+          ? '[Effect tag=' + hookValue.tag + ']'
+          : safeSerialize(hookValue, new Set(), 0),
+      });
+      cur = cur.next;
+      idx += 1;
+    }
+    // 64 hook 초과 시 silent truncate 면 reader 가 완전한 list 로 오인. marker 명시.
+    if (cur && hooks.length >= MAX_HOOKS) {
+      hooks.push({ type: '[...truncated]', value: null });
+    }
+    return hooks;
+  }
+
+  // inspect_state({ ref }) — find_element 가 부여한 ref 로 fiber lookup, props/state/hooks
+  // 직렬화. ref 가 없거나 fiber 가 unmount 됐으면 throw → -32603.
+  handlers.inspect_state = function (params) {
+    if (!params || typeof params.ref !== 'string') {
+      throw new Error('inspect_state: params requires `ref` (string from find_element)');
+    }
+    var fiber = refMap.get(params.ref);
+    if (!fiber) {
+      throw new Error('inspect_state: ref `' + params.ref + '` not found (expired or unknown)');
+    }
+
+    var name = getComponentName(fiber) || '(unknown)';
+    // fiber kind 판별:
+    //   - host: `fiber.type` 이 string (View, Text 등 RN 내장 / DOM 의 div). stateNode
+    //     는 NativeViewInstance 라 React Component 아님.
+    //   - class: stateNode 가 React.Component 인스턴스 — Component.prototype 에
+    //     `isReactComponent = {}` (빈 객체) 가 박혀 있어 truthy check (F1 fix:
+    //     `=== true` 는 잘못된 contract, 실제 React 는 `{}`).
+    //   - function: 그 외 (hook 기반 컴포넌트). memoizedState 가 Hook linked list.
+    var isHost = typeof fiber.type === 'string';
+    var isClass =
+      !isHost &&
+      fiber.stateNode != null &&
+      typeof fiber.stateNode === 'object' &&
+      !!fiber.stateNode.isReactComponent;
+    var kind = isHost ? 'host' : isClass ? 'class' : 'function';
+
+    var snapshot = {
+      ref: params.ref,
+      component: name,
+      kind: kind,
+      props: safeSerialize(fiber.memoizedProps, new Set(), 0),
+    };
+
+    if (isClass) {
+      snapshot.state = safeSerialize(fiber.memoizedState, new Set(), 0);
+    } else if (!isHost) {
+      var hooks = serializeHooks(fiber);
+      if (hooks != null) snapshot.hooks = hooks;
+    }
+    return snapshot;
+  };
   // closedExplicitly: 사용자 `runtime.close()` 호출 (사용자 의도, reconnect 금지)
   // protocolMismatch: server 가 광고한 protocol version 이 client EXPECTED 와 불일치
   // — reconnect 무의미 (RN reload 필요). 별도 sentinel 로 두 가지 케이스 구분.

--- a/packages/react-native/src/mcp-runtime.test.ts
+++ b/packages/react-native/src/mcp-runtime.test.ts
@@ -640,3 +640,361 @@ describe('mcp-runtime.cjs (PR-F1) — find_element', () => {
     expect(r.source).toBe('/abs/path/App.tsx:42');
   });
 });
+
+// PR-F2 — inspect_state. find_element 가 부여한 ref 로 fiber 의 props/state/hooks 직렬화.
+describe('mcp-runtime.cjs (PR-F2) — inspect_state', () => {
+  function findThenInspect(
+    rt: { handlers: Record<string, (p: unknown) => unknown> },
+    by: 'text' | 'role' | 'component',
+    value: string,
+  ): { ref: string; result: any } {
+    const f = rt.handlers.find_element({ by, value }) as { ref: string };
+    return { ref: f.ref, result: rt.handlers.inspect_state({ ref: f.ref }) };
+  }
+
+  test('params 누락 → throw: requires `ref`', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    expect(() => rt.handlers.inspect_state({})).toThrow(/requires `ref`/);
+    expect(() => rt.handlers.inspect_state({ ref: 123 })).toThrow(/requires `ref`/);
+  });
+
+  test('unknown ref → throw: not found (expired or unknown)', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    expect(() => rt.handlers.inspect_state({ ref: 'e9999' })).toThrow(/not found/);
+  });
+
+  test('function component — props + hooks 직렬화 (_debugHookTypes 활용)', () => {
+    // function component (memoizedState 가 Hook linked list)
+    // hook0: useState(count=3), hook1: useState(name='hi')
+    const hook1: any = { memoizedState: 'hi', next: null };
+    const hook0: any = { memoizedState: 3, next: hook1 };
+    const fnFiber: FakeFiber = {
+      type: { displayName: 'Counter' },
+      memoizedProps: { label: 'click', step: 1 },
+      stateNode: null,
+      _debugHookTypes: ['useState', 'useState'],
+    } as any;
+    (fnFiber as any).memoizedState = hook0;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fnFiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const { result } = findThenInspect(rt, 'component', 'Counter');
+    expect(result.component).toBe('Counter');
+    expect(result.kind).toBe('function');
+    expect(result.props).toEqual({ label: 'click', step: 1 });
+    expect(result.hooks).toEqual([
+      { type: 'useState', value: 3 },
+      { type: 'useState', value: 'hi' },
+    ]);
+    expect(result.state).toBeUndefined();
+  });
+
+  test('class component — memoizedState 직렬화, hooks 없음 (F1: isReactComponent 는 빈 객체 {})', () => {
+    // PR-F2 review F1: 실제 React 는 Component.prototype.isReactComponent = {} (빈 객체).
+    // 이전 stub 가 `true` 였어 production class 컴포넌트가 'function' 으로 오분류 됐던
+    // bug 를 mask 했었음. 이제 React 와 동일한 contract 로 검증.
+    const classFiber: FakeFiber = {
+      type: { displayName: 'Modal' },
+      memoizedProps: { visible: true },
+      stateNode: { isReactComponent: {} } as any,
+    } as any;
+    (classFiber as any).memoizedState = { open: true, count: 7 };
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: classFiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const { result } = findThenInspect(rt, 'component', 'Modal');
+    expect(result.kind).toBe('class');
+    expect(result.props).toEqual({ visible: true });
+    expect(result.state).toEqual({ open: true, count: 7 });
+    expect(result.hooks).toBeUndefined();
+  });
+
+  test('safeSerialize — function/cycle/undefined/Date/Map 등 non-JSON 값 marker 로 대체', () => {
+    const cycle: any = { name: 'self' };
+    cycle.me = cycle; // cycle
+    const fiber: FakeFiber = {
+      type: { displayName: 'Mix' },
+      memoizedProps: {
+        cb: function namedFn() {},
+        n: undefined,
+        when: new Date('2026-01-01T00:00:00.000Z'),
+        map: new Map([['k', 'v']]),
+        set: new Set([1, 2]),
+        nan: NaN,
+        inf: Infinity,
+        cycle: cycle,
+      },
+      stateNode: null,
+    } as any;
+    (fiber as any).memoizedState = null;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const { result } = findThenInspect(rt, 'component', 'Mix');
+    const p = result.props;
+    expect(p.cb).toBe('[Function namedFn]');
+    expect(p.n).toBe('[Undefined]');
+    expect(p.when).toBe('[Date 2026-01-01T00:00:00.000Z]');
+    expect(p.map).toBe('[Map size=1]');
+    expect(p.set).toBe('[Set size=2]');
+    expect(p.nan).toBe('[NaN]');
+    expect(p.inf).toBe('[+Infinity]');
+    expect(p.cycle).toEqual({ name: 'self', me: '[Circular]' });
+  });
+
+  test('React element ($$typeof) → [ReactElement] marker (children 트리 폭주 방지)', () => {
+    var element = { $$typeof: Symbol.for('react.element'), type: 'div', props: {} };
+    const fiber: FakeFiber = {
+      type: { displayName: 'Wrap' },
+      memoizedProps: { children: element },
+      stateNode: null,
+    } as any;
+    (fiber as any).memoizedState = null;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const { result } = findThenInspect(rt, 'component', 'Wrap');
+    expect(result.props.children).toBe('[ReactElement]');
+  });
+
+  test('max depth — 깊이 8 초과 시 [MaxDepth]', () => {
+    // 9 레벨 nested object
+    let deep: any = 'leaf';
+    for (let i = 0; i < 9; i++) deep = { v: deep };
+    const fiber: FakeFiber = {
+      type: { displayName: 'Deep' },
+      memoizedProps: { tree: deep },
+      stateNode: null,
+    } as any;
+    (fiber as any).memoizedState = null;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const { result } = findThenInspect(rt, 'component', 'Deep');
+    // depth 8 에서 truncate — root props (depth 0) → .tree (1) → .v×N. depth 9 호출에서
+    // marker 반환되므로 depth 8 위치 obj 의 `.v` 가 '[MaxDepth]'.
+    let cur = result.props.tree;
+    for (let i = 0; i < 7; i++) cur = cur.v; // depth 8 까지 내려감 (8 - 1 = 7번)
+    expect(cur.v).toBe('[MaxDepth]');
+  });
+
+  test('hook cycle guard — next pointer 가 자기 자신이면 안전 종료', () => {
+    const hook: any = { memoizedState: 'a' };
+    hook.next = hook; // 비정상 cycle
+    const fnFiber: FakeFiber = {
+      type: { displayName: 'Cyc' },
+      memoizedProps: {},
+      stateNode: null,
+      _debugHookTypes: ['useState'],
+    } as any;
+    (fnFiber as any).memoizedState = hook;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fnFiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const { result } = findThenInspect(rt, 'component', 'Cyc');
+    expect(Array.isArray(result.hooks)).toBe(true);
+    expect(result.hooks.length).toBe(1); // 첫 hook 만 직렬화 후 cycle 감지로 stop
+  });
+
+  test('host fiber (RN View / Text) → kind:"host", hooks/state 없음 (review F1)', () => {
+    // host fiber 의 type 은 string. stateNode 는 NativeViewInstance (React.Component
+    // 아님). 이전 코드는 `kind: 'function'` 으로 잘못 분류했음 + serializeHooks 가
+    // class state 인 척 wrong 결과 가능성.
+    const hostFiber: FakeFiber = {
+      type: 'View',
+      memoizedProps: { style: { padding: 8 }, accessible: true },
+      stateNode: { _nativeTag: 42 } as any,
+    } as any;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: hostFiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const f = rt.handlers.find_element({ by: 'component', value: 'View' }) as { ref: string };
+    const r = rt.handlers.inspect_state({ ref: f.ref }) as {
+      kind?: string;
+      props?: any;
+      hooks?: unknown;
+      state?: unknown;
+    };
+    expect(r.kind).toBe('host');
+    expect(r.props.accessible).toBe(true);
+    expect(r.hooks).toBeUndefined();
+    expect(r.state).toBeUndefined();
+  });
+
+  test('safeSerialize — TypedArray / ArrayBuffer / Promise 는 marker (size/buffer 폭주 방지)', () => {
+    const fiber: FakeFiber = {
+      type: { displayName: 'Buf' },
+      memoizedProps: {
+        u8: new Uint8Array(1024),
+        i32: new Int32Array([1, 2, 3]),
+        ab: new ArrayBuffer(64),
+        pr: Promise.resolve(1),
+      },
+      stateNode: null,
+    } as any;
+    (fiber as any).memoizedState = null;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const { result } = findThenInspect(rt, 'component', 'Buf');
+    expect(result.props.u8).toBe('[Uint8Array byteLength=1024]');
+    expect(result.props.i32).toBe('[Int32Array byteLength=12]');
+    expect(result.props.ab).toBe('[ArrayBuffer byteLength=64]');
+    expect(result.props.pr).toBe('[Promise]');
+  });
+
+  test('safeSerialize — throwing getter → "[Throws ...]" marker, 다른 key 는 정상 직렬화', () => {
+    const props: any = { ok: 1 };
+    Object.defineProperty(props, 'boom', {
+      enumerable: true,
+      get() {
+        throw new Error('getter exploded');
+      },
+    });
+    const fiber: FakeFiber = {
+      type: { displayName: 'Boom' },
+      memoizedProps: props,
+      stateNode: null,
+    } as any;
+    (fiber as any).memoizedState = null;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const { result } = findThenInspect(rt, 'component', 'Boom');
+    expect(result.props.ok).toBe(1);
+    expect(result.props.boom).toContain('[Throws');
+    expect(result.props.boom).toContain('getter exploded');
+  });
+
+  test('safeSerialize — 긴 array (length > 256) 는 앞 256개 + "...more" marker', () => {
+    const big = Array.from({ length: 300 }, (_, i) => i);
+    const fiber: FakeFiber = {
+      type: { displayName: 'Big' },
+      memoizedProps: { list: big },
+      stateNode: null,
+    } as any;
+    (fiber as any).memoizedState = null;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const { result } = findThenInspect(rt, 'component', 'Big');
+    expect(result.props.list.length).toBe(257); // 256 + 1 marker
+    expect(result.props.list[256]).toBe('[...44 more]');
+  });
+
+  test('hook truncation — 65 hook 일 때 64 + truncated marker', () => {
+    // 65개 hook chain
+    let tail: any = null;
+    const types: string[] = [];
+    for (let i = 64; i >= 0; i--) {
+      tail = { memoizedState: i, next: tail };
+      types.unshift('useState');
+    }
+    const fnFiber: FakeFiber = {
+      type: { displayName: 'Many' },
+      memoizedProps: {},
+      stateNode: null,
+      _debugHookTypes: types,
+    } as any;
+    (fnFiber as any).memoizedState = tail;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fnFiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const { result } = findThenInspect(rt, 'component', 'Many');
+    expect(result.hooks.length).toBe(65); // 64 hook + 1 truncated marker
+    expect(result.hooks[64].type).toBe('[...truncated]');
+  });
+
+  test('useEffect-like hook (tag + create + deps) → "[Effect tag=N]" marker (chain 폭주 방지)', () => {
+    const effect2: any = { tag: 5, create: () => {}, deps: [], destroy: undefined };
+    const effect1: any = { tag: 5, create: () => {}, deps: [], destroy: undefined, next: effect2 };
+    effect2.next = effect1; // 동일 fiber Effect chain
+    const hook1: any = { memoizedState: effect1, next: null };
+    const fnFiber: FakeFiber = {
+      type: { displayName: 'WithEffect' },
+      memoizedProps: {},
+      stateNode: null,
+      _debugHookTypes: ['useEffect'],
+    } as any;
+    (fnFiber as any).memoizedState = hook1;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fnFiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const { result } = findThenInspect(rt, 'component', 'WithEffect');
+    expect(result.hooks[0]).toEqual({ type: 'useEffect', value: '[Effect tag=5]' });
+  });
+});

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -28,6 +28,7 @@ const mcp_app_channel_mod = @import("mcp_app_channel.zig");
 // 여유. tool 별로 더 길어야 하면 별도 const 추가 (예: take_snapshot 큰 트리 직렬화).
 const PING_TIMEOUT_MS: u64 = 5000;
 const FIND_ELEMENT_TIMEOUT_MS: u64 = 5000;
+const INSPECT_STATE_TIMEOUT_MS: u64 = 5000;
 
 fn getLog() std.fs.File.DeprecatedWriter {
     return std.fs.File.stderr().deprecatedWriter();
@@ -1276,7 +1277,8 @@ pub const DevServer = struct {
                 \\{"name":"get_build_events","description":"Subscribe to bundler events for a duration and return collected events.","inputSchema":{"type":"object","properties":{"duration":{"type":"number","minimum":1000,"maximum":60000,"default":10000,"description":"milliseconds to listen"}},"additionalProperties":false}},
                 \\{"name":"verify_in_chrome","description":"Run `zntc verify` (headless Chromium) against the dev server (or a custom target) and return the JSON report. Requires Playwright in the Node CLI environment; set ZNTC_CLI env to the path of bin/zntc.mjs (npm-install environments find `zntc` on PATH automatically).","inputSchema":{"type":"object","properties":{"target":{"type":"string","description":"Path or URL to verify. Defaults to the dev server root URL."},"timeout":{"type":"number","minimum":1000,"maximum":60000,"description":"Page load timeout in ms (default: 10000)"},"ignore":{"type":"array","items":{"type":"string"},"description":"Regex patterns; matching console/url events are skipped."},"allowConsoleError":{"type":"boolean","description":"If true, console.error events do not affect exit code."}},"additionalProperties":false}},
                 \\{"name":"ping_app","description":"Ping the connected RN app's MCP runtime over the /__mcp-app WebSocket. Returns the app's pong response (verifies bi-directional channel).","inputSchema":{"type":"object","properties":{},"additionalProperties":false}},
-                \\{"name":"find_element","description":"Find the first matching React component in the connected RN app's fiber tree. Returns an opaque ref (e1/e2/...) for subsequent tool calls (inspect_state, eval_code, etc).","inputSchema":{"type":"object","properties":{"by":{"type":"string","enum":["text","role","component"],"description":"Match strategy: 'text' (substring of Text node), 'role' (accessibilityRole), 'component' (displayName)"},"value":{"type":"string","description":"Value to match"}},"required":["by","value"],"additionalProperties":false}}
+                \\{"name":"find_element","description":"Find the first matching React component in the connected RN app's fiber tree. Returns an opaque ref (e1/e2/...) for subsequent tool calls (inspect_state, eval_code, etc).","inputSchema":{"type":"object","properties":{"by":{"type":"string","enum":["text","role","component"],"description":"Match strategy: 'text' (substring of Text node), 'role' (accessibilityRole), 'component' (displayName)"},"value":{"type":"string","description":"Value to match"}},"required":["by","value"],"additionalProperties":false}},
+                \\{"name":"inspect_state","description":"Inspect the React state of an element previously returned by find_element. Pass the opaque ref (e.g. 'e1') and receive a JSON snapshot. Result kind: 'class' (memoizedState as state object), 'function' (hooks array from memoizedState linked list + _debugHookTypes), 'host' (RN native component — only props returned).","inputSchema":{"type":"object","properties":{"ref":{"type":"string","description":"Opaque ref returned by find_element (e1, e2, ...)"}},"required":["ref"],"additionalProperties":false}}
                 \\]}
             );
         } else if (std.mem.eql(u8, method, "tools/call")) {
@@ -1316,6 +1318,13 @@ pub const DevServer = struct {
         if (std.mem.eql(u8, tool_name, "find_element")) {
             // RN app 의 fiber tree 순회 — `by` / `value` args 그대로 forward.
             try self.forwardAppTool(w, "find_element", args, FIND_ELEMENT_TIMEOUT_MS);
+            return;
+        }
+
+        if (std.mem.eql(u8, tool_name, "inspect_state")) {
+            // refMap lookup + memoizedProps/memoizedState/hooks 직렬화. sync 작업이라
+            // 동일 5초 timeout. ref invalid 시 app handler 가 throw → -32603 forward.
+            try self.forwardAppTool(w, "inspect_state", args, INSPECT_STATE_TIMEOUT_MS);
             return;
         }
 

--- a/tests/integration/tests/mcp-app-channel-e2e.test.ts
+++ b/tests/integration/tests/mcp-app-channel-e2e.test.ts
@@ -364,6 +364,68 @@ describe('MCP App Channel E2E (/__mcp-app + /mcp ping_app)', () => {
     expect(result.error.message).toContain('app not connected');
   });
 
+  test('tools/list — inspect_state 노출', async () => {
+    const server = await setupServer();
+    const result = await mcpCall(server.port, { jsonrpc: '2.0', id: 14, method: 'tools/list' });
+    const names = result.result.tools.map((t: any) => t.name);
+    expect(names).toContain('inspect_state');
+  });
+
+  test('inspect_state — ref forward + round-trip', async () => {
+    const server = await setupServer();
+    let receivedParams: any = null;
+    mockApp = connectMockApp(server.port, {
+      inspect_state: (params) => {
+        receivedParams = params;
+        return {
+          ref: 'e1',
+          component: 'Counter',
+          kind: 'function',
+          props: { step: 1 },
+          hooks: [{ type: 'useState', value: 3 }],
+        };
+      },
+    });
+    await waitForWsOpen(mockApp.ws);
+    await mockApp.helloReceived;
+
+    const result = await mcpCall(server.port, {
+      jsonrpc: '2.0',
+      id: 15,
+      method: 'tools/call',
+      params: { name: 'inspect_state', arguments: { ref: 'e1' } },
+    });
+
+    expect(receivedParams).toEqual({ ref: 'e1' });
+    expect(result.error).toBeUndefined();
+    const inner = JSON.parse(result.result.content[0].text);
+    expect(inner.component).toBe('Counter');
+    expect(inner.kind).toBe('function');
+    expect(inner.hooks[0]).toEqual({ type: 'useState', value: 3 });
+  });
+
+  test('inspect_state — unknown ref → app throw → -32603 + 원본 메시지 forward', async () => {
+    const server = await setupServer();
+    mockApp = connectMockApp(server.port, {
+      inspect_state: (params: any) => {
+        throw new Error('inspect_state: ref `' + params.ref + '` not found');
+      },
+    });
+    await waitForWsOpen(mockApp.ws);
+    await mockApp.helloReceived;
+
+    const result = await mcpCall(server.port, {
+      jsonrpc: '2.0',
+      id: 16,
+      method: 'tools/call',
+      params: { name: 'inspect_state', arguments: { ref: 'e9999' } },
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error.code).toBe(-32603);
+    expect(result.error.message).toContain('not found');
+  });
+
   test('app 두 번째 연결 — first-wins 거절', async () => {
     const server = await setupServer();
     mockApp = connectMockApp(server.port, {});


### PR DESCRIPTION
## Summary
- PR-F1 의 opaque ref (`e1`/`e2`/...) 로 fiber lookup → memoizedProps / memoizedState / hooks (function component) 를 JSON-safe snapshot 으로 직렬화해 client 에 반환.
- 두 번째 MCP debugging tool. `find_element` → `inspect_state` 의 단순 chain 으로 RN 컴포넌트 검사 가능.
- forwardAppTool helper 재사용 — Zig 측 변경 최소.

## Why
Epic #3867 의 두 번째 tool. 첫 PR-F1 (`find_element`) 가 컴포넌트 위치만 알려주고 실 상태를 보여주지 않았던 한계 해결. Playwright MCP 의 `browser_evaluate` 와 비슷한 위치지만 ref 기반이라 LLM 토큰 효율적.

## 주요 변경

### Zig (`src/server/dev_server.zig`)
- `tools/list` 에 `inspect_state` schema (`ref` required, host/class/function kind 명시).
- `tools/call inspect_state` → `forwardAppTool` 재사용 (PR-F1 의 helper).
- `INSPECT_STATE_TIMEOUT_MS` file-scope const (5s).

### JS runtime (`packages/react-native/runtime/mcp-runtime.cjs`)
- **`safeSerialize`** — JSON.stringify 안전:
  - cycle / depth(8) / array length(256) cap
  - Date / Map / Set / Error / Promise / TypedArray / ArrayBuffer / Symbol / BigInt / NaN / Infinity / undefined → marker
  - `\\$\\$typeof` → `[ReactElement]` (children tree 폭주 방지)
  - throwing getter / Proxy → `[Throws ...]` per key (전체 inspect 실패 방지)
- **`serializeHooks`** — Hook linked list 순회:
  - cycle / MAX_HOOKS(64) 가드 + `[...truncated]` marker
  - Effect 객체 (\`tag\`/\`create\`/\`deps\` 시그너처) → `[Effect tag=N]` (fiber-wide Effect chain 폭주 방지)
- **`handlers.inspect_state({ref})`**:
  - refMap lookup → kind 판별: `host` (\`typeof fiber.type === 'string'\`) / `class` (\`!!stateNode.isReactComponent\`) / `function`
  - `host` → `props` 만, `class` → `state`, `function` → `hooks`
  - params 누락 / unknown ref → throw → dispatcher 가 `-32603` 으로 wrap (PR-F1 의 contract 따름)

### Tests
- **unit (14 신규)** — params/unknown ref throw, class/function/host kind, hooks 직렬화, safeSerialize 의 cycle / function / Date / Map / Set / NaN / TypedArray / ArrayBuffer / Promise / getter throw, max depth, hook cycle / truncation, Effect marker.
- **E2E (3 신규)** — tools/list 노출, round-trip, app throw → `-32603` + 원본 메시지 forward.

## Self-review fixes (PR-F2 review pass)

| ID | Severity | 내용 |
| --- | --- | --- |
| F1 | blocker | React 의 `Component.prototype.isReactComponent` 는 빈 객체 `{}` — 이전 `=== true` 는 production class 컴포넌트를 'function' 으로 오분류 (state 안 보임). truthy check + test stub 갱신 |
| F1 | blocker | host fiber (`typeof type === 'string'`) → `kind: 'host'` 신설 (이전엔 'function' 으로 잘못 분류) |
| F3 | medium | TypedArray / ArrayBuffer / Promise marker — 1KB+ buffer 직렬화 폭주 방지 |
| F3 | medium | throwing getter / Proxy → 해당 key 만 `[Throws ...]` marker |
| F4 | medium | useEffect 의 Effect 객체 → `[Effect tag=N]` marker (chain 중복 방지) |
| F4 | medium | hook MAX_HOOKS(64) 초과 시 `[...truncated]` marker |
| F6 | low | array length cap 256 + `[...N more]` marker |
| F5 | low | `safeStringify` typo → `safeSerialize` |

## Test plan
- [x] \`zig build install\`
- [x] \`zig build test\` — 전체 통과 (flaky retry 후 깨끗)
- [x] \`bun test src/mcp-runtime.test.ts\` — 47 pass / 0 fail (33 기존 + 14 신규)
- [x] \`bun test tests/mcp-app-channel-e2e.test.ts\` (tests/integration cwd) — 13 pass / 0 fail (10 기존 + 3 신규)
- [x] \`bun x tsc -b --force\` — 통과
- [ ] 실 RN 디바이스 / 시뮬레이터 검증 — 후속 (사용자 환경 필요)

## 후속

- PR-F3 — \`eval_code\`: ref 의 인스턴스 context 에서 표현식 평가.
- text children array (\`<Text>Hi {name}</Text>\`), cycle guard 강화 등은 future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)