### PR TITLE
fix(build): napi target 에 BoringSSL static link — SSL_CTX_free undefined symbol

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -282,6 +282,14 @@ pub fn build(b: *std.Build) void {
         //  import library가 필요해서 아래에서 별도 처리한다.)
         napi_lib.linker_allow_shlib_undefined = true;
 
+        // BoringSSL static link — `src/root.zig` 가 `server/mod.zig` 를 export 하고
+        // 그 안에서 `boringssl`/`tls` 를 re-export 하므로 napi target 도 BoringSSL
+        // symbol 을 reference 한다. attach 안 하면 `linker_allow_shlib_undefined=true`
+        // 가 link 단계는 통과시키지만 dlopen 시 `SSL_CTX_free` 등 undefined symbol 로
+        // require('./zig-out/lib/zntc.node') 가 fail (regression: server/boringssl.zig
+        // 추가 후 napi target attach 누락).
+        boringssl_build.attach(napi_lib, boringssl_lib, b);
+
         // ─── Windows: NAPI import library 생성 ───
         // Windows 링커(lld-link)는 undefined 심볼을 허용하지 않으므로,
         // node-api-headers가 제공하는 .def 파일로부터 `zig dlltool`을 이용해


### PR DESCRIPTION
## Summary
- \`src/root.zig\` → \`server/mod.zig\` → \`boringssl/tls\` re-export 로 NAPI binary 도 BoringSSL symbol 을 transitively reference 한다. build.zig 의 napi target 이 \`boringssl_build.attach\` 누락해서 \`zntc.node\` 의 \`SSL_CTX_free\` 가 undefined.
- \`linker_allow_shlib_undefined=true\` 가 link 단계는 통과시키지만, runtime \`dlopen\` 시 \`undefined symbol: SSL_CTX_free\` 로 fail. CI Linux x64 (\`NAPI Package Smoke\`) 에서 \`require('./zig-out/lib/zntc.node')\` 실패로 명시 관찰.

## Why
- \`server/boringssl.zig\` 추가된 #2538 series 이후 회귀.
- main 에서 NAPI binary 가 못 로드되면 CLI 진입 자체가 fail → 후속 PR-F3 \`eval_code\` 도 CI fail 누적.
- 메모리 가이드 "발견하면 별도 PR 작업 먼저" 에 따라 epic 흐름과 분리해 작은 fix.

## Fix
build.zig 의 napi block 에 한 줄 추가:
\`\`\`zig
boringssl_build.attach(napi_lib, boringssl_lib, b);
\`\`\`
exe / lib_unit_tests / exe_unit_tests 와 동일 패턴 (line 108/146/154).

## Trade-off
- \`zntc.node\` 크기 ~11 MB → 15 MB (BoringSSL static link).
- Cleaner fix 는 \`src/root.zig\` 에서 \`server\` export 분리 + NAPI/WASM 용 server-less entry — follow-up PR.

## 검증
- [x] \`zig build napi\` → zntc.node 빌드 OK
- [x] \`node -e "require('./zig-out/lib/zntc.node')"\` → \`napi load OK, exports: 12\` (이전엔 undefined symbol)
- [x] zntc CLI bundle round-trip 동작 (\`node packages/core/bin/zntc.mjs --bundle ...\`)
- [x] \`zig build test\` 전체 통과 — 회귀 없음

## 후속
- root.zig 의 server export 분리 (cleaner) — 별도 PR
- CI 의 \`NAPI Package Smoke (linux-x64-gnu)\` 가 본 PR 머지 후 통과해야 의도대로 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)