### PR TITLE
feat(mcp): eval_code tool — 동기 expression 평가 + ref context 바인딩 (PR-F3)

### DIFF
--- a/packages/react-native/runtime/mcp-runtime.cjs
+++ b/packages/react-native/runtime/mcp-runtime.cjs
@@ -434,6 +434,124 @@ function startMcpRuntime(g) {
     }
     return snapshot;
   };
+
+  // ─── eval_code (PR-F3) ───
+  //
+  // user 가 보낸 JavaScript expression 을 RN main JS thread 에서 평가. ref 가 있으면
+  // 그 fiber 의 context (stateNode → class 인스턴스 / host NativeView / 없으면 props/
+  // state snapshot) 를 `this` + `$ctx` 양쪽에 바인딩.
+  //
+  // **중요한 contract**:
+  //   - 동기 expression 전용 — `await` / `yield` 는 SyntaxError. `new Function` 이라
+  //     async function 안 됨. Promise 반환 가능 (resolve 안 기다림, marker 직렬화).
+  //   - 평가는 RN main JS thread 에서 발생 — **side-effect 가능**. `this.setState(...)`
+  //     로 컴포넌트 mutate, `globalThis.foo = ...` 로 global 변경. dev 디버거 console
+  //     처럼 동작 (pure observer 아님).
+  //   - 'use strict' — sloppy mode 의 묵시적 global 변수 생성 차단. props 가 frozen
+  //     이면 `this.props = {}` 가 TypeError 로 표면화.
+  //
+  // 보안: arbitrary code 평가 — dev 빌드에만 inject 되므로 production 우려 없음.
+  //
+  // Hermes 호환: 일부 Hermes 빌드는 `enableEval = false` 라 `new Function` 자체가 throw.
+  // 첫 호출 시 1회 probe → unsupported kind 로 의미 있는 메시지 반환 (모든 eval_code
+  // 호출이 cryptic "syntax error" 로 보이는 anti-pattern 회피).
+  //
+  // 에러 분류:
+  //   - system error (params 누락, unknown ref) → throw → dispatcher 가 -32603 wrap.
+  //     find_element / inspect_state 와 동일 contract.
+  //   - runtime / syntax error → {ok:false, error, kind, stack} 으로 result 안에. user
+  //     input 의 결과는 result 채널로 — IDE / repl 의 통상 동작.
+  //   - JS engine 이 eval 비허용 → {ok:false, kind:'unsupported', error}. 다른 tool
+  //     (inspect_state) 로 대체 안내.
+
+  // 1회 probe — install time. typeof Function 자체는 항상 있지만 `new Function('...')`
+  // 가 Hermes enableEval=false 일 때 throw. 매 호출마다 probe 하면 매번 overhead +
+  // exception throw 비용이라 cached.
+  var EVAL_SUPPORTED = (function () {
+    try {
+      // 부작용 0 — 그냥 빈 함수 만들기만.
+      new Function('return 0;');
+      return true;
+    } catch (_) {
+      return false;
+    }
+  })();
+
+  handlers.eval_code = function (params) {
+    if (!params || typeof params.expression !== 'string') {
+      throw new Error('eval_code: params requires `expression` (string)');
+    }
+    if (!EVAL_SUPPORTED) {
+      return {
+        ok: false,
+        kind: 'unsupported',
+        error:
+          'eval_code unavailable -- JS engine disables `new Function` (typically Hermes ' +
+          'enableEval=false). Use inspect_state for read-only fiber inspection.',
+      };
+    }
+    var expr = params.expression;
+    var ctx = null;
+    if (typeof params.ref === 'string') {
+      var fiber = refMap.get(params.ref);
+      if (!fiber) {
+        throw new Error('eval_code: ref `' + params.ref + '` not found (expired or unknown)');
+      }
+      // class → component 인스턴스 (this.props/this.state 접근 + setState 호출 가능),
+      // host (type=string) → NativeView (stateNode), 그 외 (function/forwardRef/memo/
+      // Fragment) → props + memoizedState snapshot. function component 의 memoizedState
+      // 는 Hook linked list 라 일반 `state.x` 접근은 inspect_state 결과 보고 따로.
+      if (
+        fiber.stateNode &&
+        typeof fiber.stateNode === 'object' &&
+        fiber.stateNode.isReactComponent
+      ) {
+        ctx = fiber.stateNode;
+      } else if (typeof fiber.type === 'string') {
+        // host fiber 가 pre-mount 면 stateNode null — `this` 가 undefined 라 user
+        // 코드의 `this.foo` 가 runtime error. acceptable (감지 가능).
+        ctx = fiber.stateNode || null;
+      } else {
+        // forwardRef / memo / Fragment / function component — stateNode null.
+        // memoizedState 는 hook chain (function component) 일 수 있어 raw 노출이지만
+        // 일반 inspect 용도로는 충분.
+        ctx = { props: fiber.memoizedProps, memoizedState: fiber.memoizedState };
+      }
+    }
+
+    var fn;
+    try {
+      // `new Function` body — expression 을 괄호로 감싸 statement 와 구분.
+      // `$ctx` 는 명시 파라미터, `this` 는 .call 의 first arg 로 동시 바인딩.
+      fn = new Function('$ctx', '"use strict"; return (' + expr + ');');
+    } catch (synErr) {
+      return {
+        ok: false,
+        error: (synErr && synErr.message) || String(synErr),
+        kind: 'syntax',
+      };
+    }
+
+    try {
+      var result = fn.call(ctx, ctx);
+      return {
+        ok: true,
+        value: safeSerialize(result, new Set(), 0),
+        type: typeof result,
+      };
+    } catch (runErr) {
+      // stack 은 길어질 수 있어 cap (2KB) — fiber tree 같은 거대 객체 사용 안 했지만 안전.
+      var stack = runErr && runErr.stack ? String(runErr.stack) : null;
+      if (stack && stack.length > 2000) stack = stack.slice(0, 2000) + '...';
+      return {
+        ok: false,
+        error: (runErr && runErr.message) || String(runErr),
+        kind: 'runtime',
+        stack: stack,
+      };
+    }
+  };
+
   // closedExplicitly: 사용자 `runtime.close()` 호출 (사용자 의도, reconnect 금지)
   // protocolMismatch: server 가 광고한 protocol version 이 client EXPECTED 와 불일치
   // — reconnect 무의미 (RN reload 필요). 별도 sentinel 로 두 가지 케이스 구분.

--- a/packages/react-native/src/mcp-runtime.test.ts
+++ b/packages/react-native/src/mcp-runtime.test.ts
@@ -998,3 +998,281 @@ describe('mcp-runtime.cjs (PR-F2) — inspect_state', () => {
     expect(result.hooks[0]).toEqual({ type: 'useEffect', value: '[Effect tag=5]' });
   });
 });
+
+// PR-F3 — eval_code. user expression 평가 + ref 가 있으면 fiber stateNode 를
+// `this`/`$ctx` 로 바인딩. system error → throw, runtime/syntax → {ok:false}.
+describe('mcp-runtime.cjs (PR-F3) — eval_code', () => {
+  test('params 누락 → throw: requires `expression`', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    expect(() => rt.handlers.eval_code({})).toThrow(/requires `expression`/);
+    expect(() => rt.handlers.eval_code({ expression: 123 })).toThrow(/requires `expression`/);
+  });
+
+  test('unknown ref → throw: not found', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    expect(() => rt.handlers.eval_code({ expression: '1+1', ref: 'e9999' })).toThrow(/not found/);
+  });
+
+  test('ref 없이 단순 expression — ok + value + type', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.eval_code({ expression: '1 + 2 * 3' }) as {
+      ok: boolean;
+      value: unknown;
+      type: string;
+    };
+    expect(r.ok).toBe(true);
+    expect(r.value).toBe(7);
+    expect(r.type).toBe('number');
+  });
+
+  test('global access — Math.PI / JSON.stringify 작동', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const pi = rt.handlers.eval_code({ expression: 'Math.PI' }) as { value: number };
+    expect(pi.value).toBeCloseTo(3.14159, 4);
+    const json = rt.handlers.eval_code({ expression: 'JSON.stringify({a:1})' }) as {
+      value: string;
+    };
+    expect(json.value).toBe('{"a":1}');
+  });
+
+  test('syntax error → {ok:false, kind:"syntax"}', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.eval_code({ expression: '1 +' }) as {
+      ok: boolean;
+      kind?: string;
+      error?: string;
+    };
+    expect(r.ok).toBe(false);
+    expect(r.kind).toBe('syntax');
+    expect(typeof r.error).toBe('string');
+  });
+
+  test('runtime error → {ok:false, kind:"runtime", stack}', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.eval_code({ expression: 'nonExistentVar.foo' }) as {
+      ok: boolean;
+      kind?: string;
+      error?: string;
+      stack?: string;
+    };
+    expect(r.ok).toBe(false);
+    expect(r.kind).toBe('runtime');
+    expect(r.error).toContain('nonExistentVar');
+    expect(typeof r.stack).toBe('string');
+  });
+
+  test('ref (class) — this.state / this.props 접근', () => {
+    const classInstance = {
+      isReactComponent: {},
+      props: { title: 'Hello' },
+      state: { count: 5 },
+    } as any;
+    const classFiber: FakeFiber = {
+      type: { displayName: 'Card' },
+      memoizedProps: { title: 'Hello' },
+      stateNode: classInstance,
+    } as any;
+    (classFiber as any).memoizedState = { count: 5 };
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: classFiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const f = rt.handlers.find_element({ by: 'component', value: 'Card' }) as { ref: string };
+    const r = rt.handlers.eval_code({
+      expression: 'this.state.count + 1',
+      ref: f.ref,
+    }) as { ok: boolean; value: number };
+    expect(r.ok).toBe(true);
+    expect(r.value).toBe(6);
+  });
+
+  test('ref ($ctx) — $ctx.props 로도 접근 가능 (this 대안)', () => {
+    const classInstance = {
+      isReactComponent: {},
+      props: { name: 'Bob' },
+      state: {},
+    } as any;
+    const classFiber: FakeFiber = {
+      type: { displayName: 'Greet' },
+      memoizedProps: { name: 'Bob' },
+      stateNode: classInstance,
+    } as any;
+    (classFiber as any).memoizedState = null;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: classFiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const f = rt.handlers.find_element({ by: 'component', value: 'Greet' }) as { ref: string };
+    const r = rt.handlers.eval_code({
+      expression: '"Hi " + $ctx.props.name',
+      ref: f.ref,
+    }) as { value: string };
+    expect(r.value).toBe('Hi Bob');
+  });
+
+  test('ref (function component) — $ctx 는 props/state snapshot (stateNode null 일 때)', () => {
+    const fnFiber: FakeFiber = {
+      type: { displayName: 'FnCmp' },
+      memoizedProps: { x: 42 },
+      stateNode: null,
+    } as any;
+    (fnFiber as any).memoizedState = null;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fnFiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const f = rt.handlers.find_element({ by: 'component', value: 'FnCmp' }) as { ref: string };
+    const r = rt.handlers.eval_code({
+      expression: '$ctx.props.x * 2',
+      ref: f.ref,
+    }) as { ok: boolean; value: number };
+    expect(r.ok).toBe(true);
+    expect(r.value).toBe(84);
+  });
+
+  test('safeSerialize 통과 — function 결과는 marker', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.eval_code({
+      expression: '(function namedFn() {})',
+    }) as { value: string; type: string };
+    expect(r.value).toBe('[Function namedFn]');
+    expect(r.type).toBe('function');
+  });
+
+  test('strict mode — undeclared assignment 은 ReferenceError', () => {
+    // "use strict" 로 sloppy mode 우회 차단 — undeclared 변수 assignment 가 throw.
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.eval_code({
+      expression: '(undeclared = 5)',
+    }) as { ok: boolean; error: string };
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('undeclared');
+  });
+
+  test('F2 contract — this.x = ... 으로 stateNode 인스턴스 mutation 실행 (debugger console 시맨틱)', () => {
+    // PR-F3 review F2: 의도된 동작 — `this` 가 live React 인스턴스. 변경 가능.
+    // 사용자 계약: side-effect 허용 (this.setState/globalThis 대입 등). 본 test 가
+    // 미래 refactor 가 silent 하게 read-only proxy 로 wrap 안 하게 lock.
+    const instance: any = {
+      isReactComponent: {},
+      props: { v: 1 },
+      state: { count: 0 },
+      setState(patch: any) {
+        this.state = Object.assign({}, this.state, patch);
+      },
+    };
+    const fiber: FakeFiber = {
+      type: { displayName: 'Mut' },
+      memoizedProps: instance.props,
+      stateNode: instance,
+    } as any;
+    (fiber as any).memoizedState = instance.state;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const f = rt.handlers.find_element({ by: 'component', value: 'Mut' }) as { ref: string };
+    // setState 호출 → state 변경
+    const r1 = rt.handlers.eval_code({
+      expression: 'this.setState({count: 42}), this.state.count',
+      ref: f.ref,
+    }) as { ok: boolean; value: number };
+    expect(r1.ok).toBe(true);
+    expect(r1.value).toBe(42);
+    expect(instance.state.count).toBe(42); // 실제 인스턴스 변경됨
+  });
+
+  test('F3 — forwardRef-like fiber (stateNode null + type 이 object) → $ctx 가 snapshot', () => {
+    // React.forwardRef / React.memo / React.Fragment 등 — type 이 string 도 아니고
+    // class instance 도 아닌 fiber. snapshot ctx 로 fallback.
+    const forwardRefFiber: FakeFiber = {
+      type: { $$typeof: Symbol.for('react.forward_ref'), displayName: 'Wrapped' } as any,
+      memoizedProps: { label: 'forward' },
+      stateNode: null,
+    } as any;
+    (forwardRefFiber as any).memoizedState = null;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: forwardRefFiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const f = rt.handlers.find_element({ by: 'component', value: 'Wrapped' }) as { ref: string };
+    const r = rt.handlers.eval_code({
+      expression: '$ctx.props.label.toUpperCase()',
+      ref: f.ref,
+    }) as { ok: boolean; value: string };
+    expect(r.ok).toBe(true);
+    expect(r.value).toBe('FORWARD');
+  });
+
+  test('F4 — await / yield 는 syntax error (sync 전용 — contract lock)', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r1 = rt.handlers.eval_code({
+      expression: 'await Promise.resolve(1)',
+    }) as { ok: boolean; kind?: string };
+    expect(r1.ok).toBe(false);
+    expect(r1.kind).toBe('syntax');
+    const r2 = rt.handlers.eval_code({
+      expression: 'yield 1',
+    }) as { ok: boolean; kind?: string };
+    expect(r2.ok).toBe(false);
+    expect(r2.kind).toBe('syntax');
+  });
+
+  test('F6 — globalThis 같은 큰 cyclic graph 반환도 safeSerialize 가 bound', () => {
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.eval_code({
+      expression: 'globalThis',
+    }) as { ok: boolean; value: unknown };
+    expect(r.ok).toBe(true);
+    // JSON.stringify 가 throw 안 함 → depth/cycle/array cap 이 효과
+    expect(typeof JSON.stringify(r.value)).toBe('string');
+  });
+
+  test('F1 — new Function 이 throw 하는 환경 (Hermes enableEval=false) 시 kind:"unsupported"', () => {
+    // bun:test 의 Function 자체를 override 못 함 (Function global 은 const). 대신
+    // module-cache reset + bun runtime 에서 new Function 자체는 항상 작동하므로,
+    // 이 test 는 EVAL_SUPPORTED probe 의 동작 자체 검증 — Hermes 시뮬레이션이 어려워
+    // sanity 만 확인. 진짜 Hermes path 는 device test 영역.
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.eval_code({ expression: '1+1' }) as { ok: boolean; value?: number };
+    // Bun 환경에서는 항상 ok:true. unsupported 분기는 코드 review 로만 확인.
+    expect(r.ok).toBe(true);
+    expect(r.value).toBe(2);
+  });
+});

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -29,6 +29,10 @@ const mcp_app_channel_mod = @import("mcp_app_channel.zig");
 const PING_TIMEOUT_MS: u64 = 5000;
 const FIND_ELEMENT_TIMEOUT_MS: u64 = 5000;
 const INSPECT_STATE_TIMEOUT_MS: u64 = 5000;
+// eval_code 는 user expression 실행이라 longer ceiling. sync JS 면 timeout 으로
+// cancel 불가 (RN main JS thread block) — 한도는 "응답 안 올 때 다음 request 까지
+// 차단 막는 안전망" 역할.
+const EVAL_CODE_TIMEOUT_MS: u64 = 10000;
 
 fn getLog() std.fs.File.DeprecatedWriter {
     return std.fs.File.stderr().deprecatedWriter();
@@ -1278,7 +1282,8 @@ pub const DevServer = struct {
                 \\{"name":"verify_in_chrome","description":"Run `zntc verify` (headless Chromium) against the dev server (or a custom target) and return the JSON report. Requires Playwright in the Node CLI environment; set ZNTC_CLI env to the path of bin/zntc.mjs (npm-install environments find `zntc` on PATH automatically).","inputSchema":{"type":"object","properties":{"target":{"type":"string","description":"Path or URL to verify. Defaults to the dev server root URL."},"timeout":{"type":"number","minimum":1000,"maximum":60000,"description":"Page load timeout in ms (default: 10000)"},"ignore":{"type":"array","items":{"type":"string"},"description":"Regex patterns; matching console/url events are skipped."},"allowConsoleError":{"type":"boolean","description":"If true, console.error events do not affect exit code."}},"additionalProperties":false}},
                 \\{"name":"ping_app","description":"Ping the connected RN app's MCP runtime over the /__mcp-app WebSocket. Returns the app's pong response (verifies bi-directional channel).","inputSchema":{"type":"object","properties":{},"additionalProperties":false}},
                 \\{"name":"find_element","description":"Find the first matching React component in the connected RN app's fiber tree. Returns an opaque ref (e1/e2/...) for subsequent tool calls (inspect_state, eval_code, etc).","inputSchema":{"type":"object","properties":{"by":{"type":"string","enum":["text","role","component"],"description":"Match strategy: 'text' (substring of Text node), 'role' (accessibilityRole), 'component' (displayName)"},"value":{"type":"string","description":"Value to match"}},"required":["by","value"],"additionalProperties":false}},
-                \\{"name":"inspect_state","description":"Inspect the React state of an element previously returned by find_element. Pass the opaque ref (e.g. 'e1') and receive a JSON snapshot. Result kind: 'class' (memoizedState as state object), 'function' (hooks array from memoizedState linked list + _debugHookTypes), 'host' (RN native component — only props returned).","inputSchema":{"type":"object","properties":{"ref":{"type":"string","description":"Opaque ref returned by find_element (e1, e2, ...)"}},"required":["ref"],"additionalProperties":false}}
+                \\{"name":"inspect_state","description":"Inspect the React state of an element previously returned by find_element. Pass the opaque ref (e.g. 'e1') and receive a JSON snapshot. Result kind: 'class' (memoizedState as state object), 'function' (hooks array from memoizedState linked list + _debugHookTypes), 'host' (RN native component — only props returned).","inputSchema":{"type":"object","properties":{"ref":{"type":"string","description":"Opaque ref returned by find_element (e1, e2, ...)"}},"required":["ref"],"additionalProperties":false}},
+                \\{"name":"eval_code","description":"Evaluate a synchronous JavaScript expression in the connected RN app's JS thread. With optional ref (from find_element), the element's stateNode (class instance / NativeView) is bound to both `this` and `$ctx`. Returns {ok:true, value, type} on success, {ok:false, error, kind, stack?} on failure (kind: 'syntax' | 'runtime' | 'unsupported'). Side-effects ALLOWED — this.setState() and global mutations execute against the running app (think debugger console, not pure observer). No await/yield/async (sync expressions only — Promise return serializes as marker). Hermes builds with enableEval=false return kind:'unsupported' (fall back to inspect_state for read-only). Dev-only.","inputSchema":{"type":"object","properties":{"expression":{"type":"string","description":"JavaScript expression (NOT statement). Examples: '1+1', 'this.props.title', 'Object.keys($ctx)'"},"ref":{"type":"string","description":"Optional opaque ref from find_element (e1, e2, ...). When given, the element's stateNode is bound to `this` and `$ctx`."}},"required":["expression"],"additionalProperties":false}}
                 \\]}
             );
         } else if (std.mem.eql(u8, method, "tools/call")) {
@@ -1325,6 +1330,15 @@ pub const DevServer = struct {
             // refMap lookup + memoizedProps/memoizedState/hooks 직렬화. sync 작업이라
             // 동일 5초 timeout. ref invalid 시 app handler 가 throw → -32603 forward.
             try self.forwardAppTool(w, "inspect_state", args, INSPECT_STATE_TIMEOUT_MS);
+            return;
+        }
+
+        if (std.mem.eql(u8, tool_name, "eval_code")) {
+            // user expression 평가 — sync JS 라 RN main thread block 가능. 10초 ceiling
+            // 은 응답 못 받을 때 다음 request 차단 막는 안전망 (실제 cancel 은 못 함).
+            // params 누락 / unknown ref 는 throw → -32603, runtime/syntax error 는
+            // {ok:false, error} 로 result 안에 — user input 의 결과는 결과 채널이 자연.
+            try self.forwardAppTool(w, "eval_code", args, EVAL_CODE_TIMEOUT_MS);
             return;
         }
 

--- a/tests/integration/tests/mcp-app-channel-e2e.test.ts
+++ b/tests/integration/tests/mcp-app-channel-e2e.test.ts
@@ -426,6 +426,65 @@ describe('MCP App Channel E2E (/__mcp-app + /mcp ping_app)', () => {
     expect(result.error.message).toContain('not found');
   });
 
+  test('tools/list — eval_code 노출', async () => {
+    const server = await setupServer();
+    const result = await mcpCall(server.port, { jsonrpc: '2.0', id: 20, method: 'tools/list' });
+    const names = result.result.tools.map((t: any) => t.name);
+    expect(names).toContain('eval_code');
+  });
+
+  test('eval_code — expression + optional ref forward + 결과 round-trip', async () => {
+    const server = await setupServer();
+    let receivedParams: any = null;
+    mockApp = connectMockApp(server.port, {
+      eval_code: (params: any) => {
+        receivedParams = params;
+        return { ok: true, value: 42, type: 'number' };
+      },
+    });
+    await waitForWsOpen(mockApp.ws);
+    await mockApp.helloReceived;
+
+    const result = await mcpCall(server.port, {
+      jsonrpc: '2.0',
+      id: 21,
+      method: 'tools/call',
+      params: {
+        name: 'eval_code',
+        arguments: { expression: '6*7', ref: 'e1' },
+      },
+    });
+
+    expect(receivedParams).toEqual({ expression: '6*7', ref: 'e1' });
+    expect(result.error).toBeUndefined();
+    const inner = JSON.parse(result.result.content[0].text);
+    expect(inner.ok).toBe(true);
+    expect(inner.value).toBe(42);
+    expect(inner.type).toBe('number');
+  });
+
+  test('eval_code — params 누락 → app throw → -32603 + 원본 메시지 forward', async () => {
+    const server = await setupServer();
+    mockApp = connectMockApp(server.port, {
+      eval_code: () => {
+        throw new Error('eval_code: params requires `expression` (string)');
+      },
+    });
+    await waitForWsOpen(mockApp.ws);
+    await mockApp.helloReceived;
+
+    const result = await mcpCall(server.port, {
+      jsonrpc: '2.0',
+      id: 22,
+      method: 'tools/call',
+      params: { name: 'eval_code', arguments: {} },
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error.code).toBe(-32603);
+    expect(result.error.message).toContain('requires `expression`');
+  });
+
   test('app 두 번째 연결 — first-wins 거절', async () => {
     const server = await setupServer();
     mockApp = connectMockApp(server.port, {});


### PR DESCRIPTION
## Summary
- find_element / inspect_state 의 ref 로 fiber stateNode 를 \`this\` / \`\$ctx\` 양쪽에 바인딩해 임의 JS expression 평가. 세 번째 MCP debugging tool — RN 디버거 console 동치.
- system error (params 누락, unknown ref) → throw → dispatcher \`-32603\`. runtime / syntax / unsupported → \`{ok:false, error, kind, stack?}\` 으로 result 안에.
- Hermes \`enableEval=false\` 환경을 install-time probe 해 의미 있는 \`kind:'unsupported'\` 메시지로 fallback.

## Why
Epic #3867 의 세 번째 tool. inspect_state 가 read-only 라면 eval_code 는 mutation 까지 가능한 console. 사용자가 LLM 통해 \`this.setState({...})\` 호출, props 검증, action dispatch 등을 자연어로 trigger.

## 주요 변경

### Zig (\`src/server/dev_server.zig\`)
- \`tools/list\` 에 \`eval_code\` schema (kind 명시 / sync-only / mutation 허용 / Hermes unsupported 안내).
- \`tools/call eval_code\` → \`forwardAppTool\` 재사용.
- \`EVAL_CODE_TIMEOUT_MS = 10000\` — sync JS 라 cancel 안 되지만 dispatcher 응답 timeout 안전망.

### JS runtime (\`packages/react-native/runtime/mcp-runtime.cjs\`)
- **\`EVAL_SUPPORTED\` install-time probe** — \`new Function('return 0')\` 1회 시도. Hermes \`enableEval=false\` 환경에서 모든 호출이 syntax error 로 보이는 anti-pattern 방지.
- **\`handlers.eval_code({expression, ref?})\`**:
  - ctx 선택: class instance / host NativeView / forwardRef·memo·Fragment 등 → \`{props, memoizedState}\` snapshot
  - \`new Function('\$ctx', '"use strict"; return (' + expr + ');')\` + \`.call(ctx, ctx)\` → \`this\` 와 \`\$ctx\` 양쪽 바인딩
  - safeSerialize (PR-F2) 통과 — globalThis 같은 cyclic 반환도 bound

### Tests
- **unit (16 신규)** — params/unknown ref throw, simple expr, global access, syntax/runtime error, ref class \`this\` / \`\$ctx\` / function snapshot, function 결과 marker, strict mode, mutation contract lock, forwardRef ctx, await/yield syntax error, globalThis 직렬화, EVAL_SUPPORTED probe sanity.
- **E2E (3 신규)** — tools/list 노출, expression+ref forward round-trip, app throw → \`-32603\` + 원본 메시지.

## Self-review fixes (PR-F3 review pass)

| ID | Severity | 내용 |
| --- | --- | --- |
| F1 | blocker | Hermes \`enableEval=false\` 환경에서 모든 호출이 cryptic syntax error 로 보이던 문제 → install-time probe + \`kind:'unsupported'\` 의미 있는 메시지 |
| F2 | blocker | class \`this\` 가 live React 인스턴스라 mutation 가능 — schema description + JS 주석으로 contract 명시 (debugger console 시맨틱). mutation 작동 test 로 lock |
| F3 | medium | forwardRef/memo/Fragment 도 snapshot ctx — 주석 + test 추가 |
| F4 | medium | await/yield 는 sync 전용이라 SyntaxError — schema 에 sync-only 명시 + test 로 lock |
| F5 | low | schema description 에 \`kind\` 필드 명시 |
| F6 | low | globalThis cyclic graph 직렬화 bounded test |
| F7 | low | function component ctx field 명확화 (\`state\` → \`memoizedState\`, hook chain 노출) |

## Test plan
- [x] \`zig build install\`
- [x] \`zig build test\` 전체 통과 (flaky retry 후 깨끗)
- [x] \`bun test src/mcp-runtime.test.ts\` — 63 pass / 0 fail (47 기존 + 16 신규)
- [x] \`bun test tests/mcp-app-channel-e2e.test.ts\` (tests/integration cwd) — 16 pass / 0 fail (13 기존 + 3 신규)
- [x] \`bun x tsc -b --force\` — 통과
- [ ] 실 RN 디바이스 검증 — 후속

## 후속
- PR-F4 — \`get_logs\` (RN console.log/warn/error tail).
- async/await 지원 (\`new AsyncFunction\`) — 별도 PR. 본 PR-F3 는 sync-only contract 잠금.

🤖 Generated with [Claude Code](https://claude.com/claude-code)