### PR TITLE
fix(build): BoringSSL static lib 에 -fPIC — NAPI cross-target build 회복

### DIFF
--- a/build/boringssl.zig
+++ b/build/boringssl.zig
@@ -31,6 +31,13 @@ pub fn build(
         .root_module = b.createModule(.{
             .target = target,
             .optimize = optimize,
+            // **`pic = true`** — NAPI binary (`zig-out/lib/zntc.node`) 는 shared library
+            // 라 link 되는 모든 코드가 PIC 여야 한다. non-PIC archive 를 dynamic library
+            // 에 link 하면 `R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol
+            // 'malloc'; recompile with -fPIC` (ARM64) / `R_X86_64_PC32 ... (X86_64)`
+            // relocation 에러 발생. exe binary 도 PIC 코드 OK (현대 Linux 의 PIE default
+            // 와 일치) — overhead 무시 수준.
+            .pic = true,
         }),
     });
     lib.linkLibC();


### PR DESCRIPTION
## Summary
- PR #3894 가 \`napi_lib\` 에 \`boringssl_build.attach\` 추가했으나 boringssl module 이 PIC 빌드 아니어서 cross-target shared library link 시 fail.
- \`build/boringssl.zig\` 의 \`b.createModule\` 에 \`.pic = true\` 한 줄 추가 — PIC archive 가 exe (static) 와 NAPI (dynamic) 둘 다 link 가능.

## Symptom
\`\`\`
error: ld.lld: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'malloc'; recompile with -fPIC
error: ld.lld: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'OPENSSL_malloc'; recompile with -fPIC
...
\`\`\`

영향 받은 target:
- ❌ Build NAPI: linux-arm64-musl, linux-x64-musl, win32-x64/arm64/ia32-msvc
- ❌ NAPI Build & Test (ubuntu-latest)
- ❌ NAPI Package Smoke (multiple targets)

## Root cause
\`b.createModule\` 의 \`pic\` 옵션이 default null → exe target 은 PIC 안 켬. 다음 step 들 일관:
1. PR #3894 가 \`napi_lib\` 에 boringssl_lib attach.
2. napi_lib 는 \`.linkage = .dynamic\` (zntc.node = shared library).
3. dynamic library 에 link 되는 모든 코드는 PIC 필요.
4. boringssl_lib 의 .o 가 non-PIC → relocation error.

## Why this matters
사용자 명시: **NAPI 는 모든 target 빌드 되어야 함**. (WASM 은 best-effort.) 현재 main 의 NAPI build 가 musl + Windows cross-target 에서 broken — 본 fix 가 직접 해결.

## Test plan
- [x] \`zig build napi\` → \`zntc.node\` 빌드 OK
- [x] \`node -e "require('./zig-out/lib/zntc.node')"\` → \`napi load OK, exports: 12\`
- [x] \`zig build install\` 통과
- [x] \`zig build test\` 전체 통과 (회귀 없음)
- [ ] CI 검증: linux-arm64-* / linux-x64-musl / win32-* Build NAPI + linux-x64-gnu Package Smoke (사용자 보고 환경) — 머지 후 main CI 에서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)