### PR TITLE
fix(build): BoringSSL sanitize_c=.off — Linux NAPI dlopen 의 __ubsan symbol fix

### DIFF
--- a/build/boringssl.zig
+++ b/build/boringssl.zig
@@ -38,6 +38,13 @@ pub fn build(
             // relocation 에러 발생. exe binary 도 PIC 코드 OK (현대 Linux 의 PIE default
             // 와 일치) — overhead 무시 수준.
             .pic = true,
+            // **`sanitize_c = .off`** — Zig 의 default sanitize_c (Debug 빌드 시 on)
+            // 는 `__ubsan_handle_*` symbol 들을 호출하는 코드를 emit. 그런데 Linux 의
+            // libubsan 은 Zig 가 자동 link 안 해서 NAPI binary dlopen 시
+            // `undefined symbol: __ubsan_handle_type_mismatch_v1` 발생 (관찰 환경:
+            // CI ubuntu-latest, packages/core 의 build:js:cjs step 에서 require).
+            // vendored BoringSSL 은 외부 코드라 자체 sanitize 무의미 — off 가 정합.
+            .sanitize_c = .off,
         }),
     });
     lib.linkLibC();


### PR DESCRIPTION
## Summary
- PR #3898 (PIC) 후에도 main CI 의 NAPI Build & Test (ubuntu-latest) + Package Smoke (linux-x64-gnu / linux-x64-musl / linux-arm64-gnu / linux-arm64-musl / win32-ia32) 가 \`Build JS wrapper + dts\` step 에서 fail.
- 원인: NAPI binary dlopen 시 \`undefined symbol: __ubsan_handle_type_mismatch_v1\` — Zig 의 default \`sanitize_c=on\` (Debug 빌드) 가 emit 한 UBSan stub 을 Linux libubsan 가 resolve 못 함.

## Symptom
\`\`\`
$ node bin/zntc.mjs --bundle index.ts --outfile dist/index.cjs --format=cjs ...
error: /home/runner/work/zntc/zntc/zig-out/lib/zntc.node:
  undefined symbol: __ubsan_handle_type_mismatch_v1
error: script "build:js:cjs" exited with code 1
\`\`\`

\`build:js:cjs\` 는 \`node bin/zntc.mjs --bundle ...\` — 사용자가 처음 보고한 명령과 동일. NAPI dlopen 자체 fail.

## Why this matters
- 사용자가 epic #3867 진행 중 처음 발견한 SSL_CTX_free undefined 의 진짜 후속 — PR #3894 가 BoringSSL static link 추가했고, PR #3898 가 PIC 추가했지만, 한 단계 더 (sanitize stub) 남아 있었음.
- NAPI 는 모든 target 빌드 + 로드 되어야 한다는 사용자 명시 요구 (WASM 은 best-effort).
- macOS / win32-arm64 는 통과 — Linux + win32-ia32 만 fail. Linux 의 libubsan 자동 link 안 됨이 root cause.

## Fix
\`build/boringssl.zig\` 의 \`b.createModule\` 에 \`.sanitize_c = .off\` 추가. vendored BoringSSL 은 외부 코드라 자체 sanitize 무의미 — off 가 자연.

## Test plan
- [x] \`zig build napi\` → 빌드 OK
- [x] \`node -e "require('./zig-out/lib/zntc.node')"\` → \`napi load OK, exports: 12\`
- [x] \`cd packages/core && bun run build:js\` (사용자 보고 명령) → exit 0
- [x] \`zig build test\` 전체 통과
- [ ] CI 검증: linux-x64-gnu Package Smoke + NAPI Build & Test (ubuntu-latest) — 머지 후 main CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)