### PR TITLE
fix(mcp): fiber cycle guard + missing-result fallback E2E (deferred)

### DIFF
--- a/packages/react-native/runtime/mcp-runtime.cjs
+++ b/packages/react-native/runtime/mcp-runtime.cjs
@@ -155,13 +155,19 @@ function startMcpRuntime(g) {
 
   // DFS — fiber.child 따라 내려가고 fiber.sibling 따라 옆으로. parent chain 은
   // fiber.return.
+  //
+  // **Cycle guard**: corrupted fiber (partial render / 외부 mutation 결과로 child
+  // 또는 sibling 이 자기 자신 또는 조상을 가리키는 상황) 에서 무한 loop 막기 위해
+  // WeakSet 으로 visited 추적. WeakSet 은 fiber 객체 reference 만 잡고 GC 영향 X.
   function walkFiber(root, visitor) {
     var current = root.current; // FiberRoot 의 current = root fiber
     if (!current) return;
+    var visited = new WeakSet();
     var stack = [current];
     while (stack.length > 0) {
       var fiber = stack.pop();
-      if (!fiber) continue;
+      if (!fiber || visited.has(fiber)) continue;
+      visited.add(fiber);
       if (visitor(fiber) === false) return; // early stop
       if (fiber.sibling) stack.push(fiber.sibling);
       if (fiber.child) stack.push(fiber.child);
@@ -704,6 +710,18 @@ function startMcpRuntime(g) {
       state.truncated = true;
       return null;
     }
+    // Cycle guard — fiber.child / fiber.sibling 이 조상 또는 자기 자신을 가리키면
+    // recursion stack overflow 발생. state.visited (WeakSet) 으로 차단.
+    //
+    // `__cycle` marker 는 의도적으로 ref 없음 (`__depth_truncated` 와 비대칭):
+    //   - depth-truncated 는 미방문 subtree — caller 가 ref 로 expand 가능.
+    //   - cycle 은 이미 다른 자리에 동일 fiber 가 직렬화됨 — expand 불필요.
+    //   - state.nodes 증가 안 함 (이미 첫 방문 시 카운트).
+    if (state.visited.has(fiber)) {
+      state.truncated = true;
+      return { __cycle: true };
+    }
+    state.visited.add(fiber);
     if (depth > maxDepth) {
       // depth-truncated node — fresh ref 부여해 caller 가 후속 take_snapshot({ref})
       // 로 그 subtree 를 expand 할 수 있게 (review F4). state.nodes 도 카운트 —
@@ -749,7 +767,13 @@ function startMcpRuntime(g) {
         ? Math.min(Math.floor(p.max_nodes), SNAPSHOT_MAX_NODES_CAP)
         : SNAPSHOT_DEFAULT_NODES;
 
-    var state = { nodes: 0, maxNodes: maxNodes, truncated: false };
+    var state = {
+      nodes: 0,
+      maxNodes: maxNodes,
+      truncated: false,
+      // visited fiber set — cycle 시 무한 recursion 방지. WeakSet 이라 fiber GC 영향 X.
+      visited: new WeakSet(),
+    };
 
     // ref 있으면 그 subtree 만, 없으면 모든 fiber root.
     if (typeof p.ref === 'string') {

--- a/packages/react-native/src/mcp-runtime.test.ts
+++ b/packages/react-native/src/mcp-runtime.test.ts
@@ -1707,3 +1707,80 @@ describe('mcp-runtime.cjs (PR-F5) — take_snapshot', () => {
     expect(r.nodes).toBe(6);
   });
 });
+
+// Fiber cycle guard (post-F5 deferred) — corrupted fiber 의 자기 참조 child/sibling
+// 이 walkFiber 무한 loop / snapshotFiber stack overflow 일으키지 않도록 WeakSet
+// visited 보호.
+describe('mcp-runtime.cjs — fiber cycle guard (post-F5 deferred)', () => {
+  test('walkFiber — child self-cycle + 매치 없는 search → 무한 loop 없이 found:false', () => {
+    // PR review F3: 매치 있는 값을 찾으면 first-match 에서 early stop 라 cycle guard
+    // 작동 검증이 안 됨. 매치 없는 값으로 walk 가 끝까지 가게 해야 cycle 진짜 hit.
+    const fiber: FakeFiber = {
+      type: 'Text',
+      memoizedProps: { children: 'cycle' },
+    };
+    fiber.child = fiber; // self cycle
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: fiber,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    // 매치 없는 검색 — visited set 으로 cycle 차단 안 되면 무한 loop.
+    const r = rt.handlers.find_element({ by: 'text', value: 'nope' }) as { found?: boolean };
+    expect(r.found).toBe(false);
+  });
+
+  test('walkFiber — sibling chain cycle + 매치 없는 search → 무한 loop 없이 found:false', () => {
+    const a: FakeFiber = { type: { displayName: 'A' }, memoizedProps: {} };
+    const b: FakeFiber = { type: { displayName: 'B' }, memoizedProps: {} };
+    a.sibling = b;
+    b.sibling = a; // cycle
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: a,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    // 매치 없는 search — visited set 없으면 sibling chain 무한 loop.
+    const r = rt.handlers.find_element({ by: 'component', value: 'Missing' }) as {
+      found?: boolean;
+    };
+    expect(r.found).toBe(false);
+  });
+
+  test('snapshotFiber — child 자기 참조 → __cycle marker + truncated:true', () => {
+    const cyc: FakeFiber = {
+      type: { displayName: 'Cyc' },
+      memoizedProps: {},
+    };
+    cyc.child = cyc;
+    const root: FakeFiber = {
+      type: { name: 'Root' },
+      memoizedProps: {},
+      child: cyc,
+    };
+    makeFiberHook(g, [{ current: root }]);
+
+    loadRuntime(g);
+    const rt = g.__ZNTC_MCP_RUNTIME__ as { handlers: Record<string, (p: unknown) => unknown> };
+    const r = rt.handlers.take_snapshot({}) as {
+      roots: Array<any>;
+      nodes: number;
+      truncated: boolean;
+    };
+    // Root → Cyc (1번 직렬화) → child=Cyc 의 두 번째 진입은 __cycle marker.
+    expect(r.truncated).toBe(true);
+    const rootNode = r.roots[0];
+    const cycNode = rootNode.children[0];
+    expect(cycNode.component).toBe('Cyc');
+    // cycNode.children[0] 는 self 의 두 번째 진입 → __cycle marker
+    expect(cycNode.children[0].__cycle).toBe(true);
+  });
+});

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -687,12 +687,16 @@ pub const DevServer = struct {
                         .object => |o| o.get("id") orelse .null,
                         else => .null,
                     };
-                    const has_result_or_error = switch (root) {
-                        .object => |o| o.get("result") != null or o.get("error") != null,
+                    const has_method = switch (root) {
+                        .object => |o| o.get("method") != null,
                         else => false,
                     };
-                    if (has_result_or_error) {
-                        // response — id 를 u64 로 추출 후 pending 매칭.
+                    // response 분류: id 있고 method 없으면 response (spec 상 result 또는
+                    // error 가 있어야 하지만 둘 다 없는 spec-violating envelope 도 forward
+                    // — forwardAppTool 의 "missing 'result'" fallback 이 진단 메시지 제공
+                    // (#50 deferred fix). 이전엔 silent drop 으로 5초 timeout 만 발생.
+                    const id_present = id_val != .null;
+                    if (id_present and !has_method) {
                         const id_u64: ?u64 = switch (id_val) {
                             .integer => |n| if (n >= 0) @intCast(n) else null,
                             else => null,
@@ -702,9 +706,11 @@ pub const DevServer = struct {
                         } else {
                             getLog().print("  [mcp-app] response 의 id 가 invalid (non-integer)\n", .{}) catch {};
                         }
-                    } else {
-                        // method 있고 result 없음 — app 측 request. 후속 PR 에서 dispatch.
+                    } else if (has_method) {
+                        // app→server request 또는 notification — 후속 PR 에서 dispatch.
                         getLog().print("  [mcp-app] app→server request (not yet handled): {s}\n", .{msg.data}) catch {};
+                    } else {
+                        getLog().print("  [mcp-app] unknown frame (no id, no method): {s}\n", .{msg.data}) catch {};
                     }
                 },
                 .connection_close => break,

--- a/tests/integration/tests/mcp-app-channel-e2e.test.ts
+++ b/tests/integration/tests/mcp-app-channel-e2e.test.ts
@@ -126,7 +126,13 @@ function connectMockApp(
       }
       try {
         const result = fn(msg.params ?? {});
-        ws.send(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: result ?? {} }));
+        // raw escape hatch — `{__raw:true, body:{...}}` 반환 시 wrap 우회.
+        // result/error 둘 다 없는 응답 같은 spec-violating case 직접 송신용.
+        if (result && (result as any).__raw === true) {
+          ws.send(JSON.stringify({ jsonrpc: '2.0', id: msg.id, ...(result as any).body }));
+        } else {
+          ws.send(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: result ?? {} }));
+        }
       } catch (err: any) {
         ws.send(
           JSON.stringify({
@@ -619,6 +625,30 @@ describe('MCP App Channel E2E (/__mcp-app + /mcp ping_app)', () => {
     expect(result.error).toBeDefined();
     expect(result.error.code).toBe(-32603);
     expect(result.error.message).toContain('not found');
+  });
+
+  test('forwardAppTool fallback — app response 가 result/error 둘 다 없으면 "missing \'result\'" (#50)', async () => {
+    // PR-F1 review F4 fallback path. 정상 mock 은 항상 result 또는 error 를 보내지만,
+    // spec-violating app (또는 race condition 으로 partial response) 가 둘 다 없는
+    // envelope 송신 시 dispatcher 가 silent fail 안 하고 명시 진단. raw escape hatch
+    // 로 직접 mock.
+    const server = await setupServer();
+    mockApp = connectMockApp(server.port, {
+      ping: () => ({ __raw: true, body: {} }), // {jsonrpc, id} 만, result/error 없음
+    });
+    await waitForWsOpen(mockApp.ws);
+    await mockApp.helloReceived;
+
+    const result = await mcpCall(server.port, {
+      jsonrpc: '2.0',
+      id: 50,
+      method: 'tools/call',
+      params: { name: 'ping_app', arguments: {} },
+    });
+
+    expect(result.error).toBeDefined();
+    expect(result.error.code).toBe(-32603);
+    expect(result.error.message).toContain("missing 'result'");
   });
 
   test('app 두 번째 연결 — first-wins 거절', async () => {


### PR DESCRIPTION
## Summary
Epic #3867 의 두 deferred 항목 묶음 처리:

1. **Fiber cycle guard** (PR-F1 + PR-F5 review deferred) — \`walkFiber\` / \`snapshotFiber\` 의 자기 참조 fiber 무한 loop 차단.
2. **missing-result fallback E2E** (#50, PR-F1 review F4) — forwardAppTool 의 진단 분기가 unreachable 였던 문제 fix + E2E lock.

## (1) Cycle guard

### Why
\`walkFiber\` (PR-F1) 와 \`snapshotFiber\` (PR-F5) 가 corrupted fiber 의 \`child === self\` / sibling chain cycle 에 무한 loop / stack overflow 가능. partial-render 또는 외부 mutation 으로 발생.

### Fix
- \`walkFiber\`: pop 시 \`visited.has(fiber)\` 검사 + WeakSet add.
- \`snapshotFiber\`: \`state.visited\` (WeakSet) 첫 진입 add, 재진입 → \`{__cycle:true}\` marker + \`truncated:true\`.
- \`__cycle\` marker 는 의도적으로 ref 없음 (\`__depth_truncated\` 와 비대칭) — cycle 은 이미 다른 자리에 동일 fiber 직렬화 되어 expand 불필요. 주석 추가.

## (2) missing-result fallback E2E

### Why
PR-F1 의 forwardAppTool 가 \"missing 'result'\" 진단 분기 갖고 있지만, 그 분기 도달이 불가능했음. \`dev_server.zig\` 의 mcp-app dispatcher 가 \`id\` 있고 \`result\` / \`error\` 둘 다 없는 envelope 을 silent drop → caller 는 5초 timeout 만 봄 (\"app not connected\" 와 구분 안 됨).

### Fix
\`handleMcpAppWebSocket\` 의 분류 변경:
- 기존: \`has_result_or_error → resolveResponse\` (spec-violating envelope drop)
- 변경: \`id_present && !has_method → resolveResponse\` (모든 response-shape forward)

spec-violating envelope 도 forwardAppTool 로 흘려서 명시 진단 emit. mock app helper 에 \`__raw\` escape hatch 추가 — test 한정으로 spec-위반 raw 송신 가능.

## Tests
- **unit (3 신규)**:
  - walkFiber self-cycle + 매치 없는 search → found:false (cycle guard 실제 hit 검증, review F3)
  - walkFiber sibling cycle + 매치 없는 search → found:false
  - snapshotFiber child=self → \`__cycle\` marker + truncated:true
- **E2E (1 신규)**: app 의 raw envelope (\`{jsonrpc, id}\` 만) → -32603 + \"missing 'result'\" 진단 forward

## Self-review fixes (post-merge review)

| ID | Severity | 내용 |
| --- | --- | --- |
| F3 | medium | walkFiber test 가 first-match early-stop 으로 cycle path hit 안 하던 문제 → 매치 없는 value 로 walk 끝까지 진행하게 변경 |
| F4 | medium | \`__cycle\` marker ref 미부여 의도 주석 (\`__depth_truncated\` 와 비대칭) |

## Test plan
- [x] \`zig build install\`
- [x] \`zig build test\` 전체 통과
- [x] \`bun test src/mcp-runtime.test.ts\` — 91 pass / 0 fail (88 기존 + 3 신규)
- [x] \`bun test tests/mcp-app-channel-e2e.test.ts\` — 23 pass / 0 fail (22 기존 + 1 신규)

## 후속
- async/await eval (\`new AsyncFunction\`) — 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)