### PR TITLE
fix(server): mcp_app_channel test race — thread setup 직렬화

### DIFF
--- a/src/server/mcp_app_channel.zig
+++ b/src/server/mcp_app_channel.zig
@@ -527,9 +527,22 @@ test "AppChannel.resolveResponse: 두 동시 request — id 별 매칭, out-of-o
         .writer = BufWriter{ .out = &written, .alloc = std.testing.allocator },
         .method = "beta",
     };
+    // thread setup 을 직렬화 — 단순 sleep 만 쓰면 OS scheduler 에 따라 alpha 가 id 2,
+    // beta 가 id 1 을 받아 검증 단계에서 ctx_a 가 beta 응답을 받게 됨 (race). 본 테스트의
+    // 본질 (out-of-order 응답이 id 로 정확히 매칭) 은 pending 등록 후 응답 순서만
+    // 뒤집어도 검증 가능 — id 할당 순서까지 굳혀 결정성 확보.
     const t_a = try std.Thread.spawn(.{}, RunCtx.run, .{&ctx_a});
+    var spin: usize = 0;
+    while (spin < 400 and ch.stats().pending_count < 1) : (spin += 1) {
+        std.Thread.sleep(5 * std.time.ns_per_ms);
+    }
+    try std.testing.expectEqual(@as(usize, 1), ch.stats().pending_count);
     const t_b = try std.Thread.spawn(.{}, RunCtx.run, .{&ctx_b});
-    std.Thread.sleep(30 * std.time.ns_per_ms);
+    spin = 0;
+    while (spin < 400 and ch.stats().pending_count < 2) : (spin += 1) {
+        std.Thread.sleep(5 * std.time.ns_per_ms);
+    }
+    try std.testing.expectEqual(@as(usize, 2), ch.stats().pending_count);
 
     // out-of-order: id 2 (beta) 먼저, id 1 (alpha) 나중.
     ch.resolveResponse(2, "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"who\":\"beta\"}}");


### PR DESCRIPTION
## Summary

`AppChannel.resolveResponse: 두 동시 request — id 별 매칭, out-of-order 응답` 테스트가 OS scheduler 의존으로 CI (aarch64-macos) 에서 비결정적으로 실패하던 문제 수정.

## 루트커즈

기존 테스트는 두 thread (`t_a`=alpha, `t_b`=beta) 를 동시에 spawn 한 뒤 30ms sleep 후 `id 2 (beta) → id 1 (alpha)` 순으로 응답을 주입했음. 하지만 `next_request_id` 할당은 `mutex` 안에서 발생하므로 OS scheduler 가 어느 thread 를 먼저 깨우느냐에 따라:

- 정상: alpha=id1, beta=id2 → 테스트 통과
- **회귀**: beta=id1, alpha=id2 → `ctx_a.result` 에 `"beta"` 포함, `"alpha"` 매칭 실패

CI 머신에서 후자가 발생.

```
src/server/mcp_app_channel.zig:544:5: ... test.AppChannel.resolveResponse: 두 동시 request
    try std.testing.expect(std.mem.indexOf(u8, ctx_a.result.?, "\"alpha\"") != null);
```

## 수정

`t_a` spawn 직후 `ch.stats().pending_count == 1` polling 으로 등록 완료 확인 → `t_b` spawn 후 `pending_count == 2` 확인. id 할당 순서를 결정적으로 만들면서 테스트의 본질 (out-of-order 응답이 id 로 정확히 매칭) 은 그대로 유지.

**mitigation 이 아닌 루트커즈 fix**:
- ❌ sleep 늘리기 / retry / 검증 완화는 비결정성 그대로
- ✅ thread setup 직렬화로 비결정성의 원인 (scheduling) 자체 제거

**프로덕션 코드는 무결**: `AppChannel.request` / `resolveResponse` 의 id-별 매칭 로직은 정상. 테스트가 잘못된 invariant ("spawn 순서 == id 순서") 를 가정한 것이 진짜 문제였음.

## Test plan

- [x] 로컬 `zig build test` 통과 (5645/5645 + 5 skipped)
- [ ] CI green
- [ ] Linux/Windows runner 도 결정적으로 통과 확인

Related: #3867 (PR-E1 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)