### PR TITLE
feat(napi): tlsSelfCheck export — BoringSSL static link runtime 검증 (PR-G1)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -199,6 +199,12 @@ interface NativeModule {
   };
   /** MCP (Model Context Protocol) stdio transport — blocking, returns on stdin EOF. */
   mcpStdioServe(options: { rootDir: string }): void;
+  /**
+   * TLS sanity check — BoringSSL static link 의 runtime 동작 검증.
+   * cert/key 한 번 로드 후 즉시 해제. 성공 → undefined, 실패 → throw.
+   * 후속 HTTPS dev server NAPI entry 의 토대 + 사용자 cert/key 유효성 빠른 확인.
+   */
+  tlsSelfCheck(options: { certPath: string; keyPath: string }): void;
 }
 
 let native: NativeModule | null = null;
@@ -531,6 +537,27 @@ export interface McpStdioOptions {
  */
 export function mcpStdioServe(options: McpStdioOptions): void {
   ensureNative().mcpStdioServe(options);
+}
+
+/** @see {@link NativeModule.tlsSelfCheck} */
+export interface TlsSelfCheckOptions {
+  certPath: string;
+  keyPath: string;
+}
+
+/**
+ * TLS context init/deinit 만 호출하는 BoringSSL sanity 진입점.
+ *
+ * cert/key 파일을 한 번 로드해 BoringSSL 의 SSL_CTX 가 정상 생성되는지 검증.
+ * Throw 시 message 에 Zig error name 이 포함되어 caller 가 분류 가능
+ * (CertLoadFailed / KeyLoadFailed / KeyMismatch 등).
+ *
+ * NAPI binary 에 BoringSSL 이 static link 되어 있는지 + dlopen 후 symbol resolve
+ * 가 동작하는지 빠르게 확인하는 용도. 향후 본격 HTTPS dev server NAPI entry 가
+ * 추가되면 그 entry 가 같은 path 사용.
+ */
+export function tlsSelfCheck(options: TlsSelfCheckOptions): void {
+  ensureNative().tlsSelfCheck(options);
 }
 
 // ─── Build API ───

--- a/packages/core/src/napi/tls_smoke.zig
+++ b/packages/core/src/napi/tls_smoke.zig
@@ -1,0 +1,68 @@
+//! TLS sanity NAPI entry — BoringSSL static link 의 runtime 동작 검증용.
+//!
+//! `tlsSelfCheck({ certPath, keyPath })` 를 호출하면 `TlsContext.init` 으로 cert/key
+//! 를 한 번 로드 + 해제. 성공 시 undefined 반환, fail 시 throw.
+//!
+//! 용도:
+//!   - NAPI binary 가 BoringSSL symbol 을 정상 호출하는지 자동 검증 (fix chain
+//!     #3894 / #3898 / #3899 의 효과 잠금).
+//!   - 사용자 RN dev 환경에서 cert/key 파일 자체의 유효성 빠르게 확인.
+//!
+//! **Dev-only entry — caller 신뢰 전제**: 임의 파일 경로 (`certPath`/`keyPath`) 를
+//! 받아 BoringSSL 로 읽는다. NAPI 프로세스 권한으로 파일 시스템 접근 가능 — 신뢰
+//! 안 되는 RPC 표면을 통해 노출하지 말 것. 일반 dev workflow 에서는 사용자 본인의
+//! cert/key 파일을 자기 머신에서 검증하는 용도.
+//!
+//! 후속 PR: 본격 HTTPS dev server NAPI entry — listener thread + handle.
+
+const std = @import("std");
+const zntc_lib = @import("zntc_lib");
+const common = @import("common.zig");
+const c = common.c;
+
+const tls = zntc_lib.server.tls;
+
+const native_alloc = common.nativeAlloc();
+const throwError = common.throwError;
+const getObjectString = common.getObjectString;
+
+/// tlsSelfCheck({ certPath: string, keyPath: string }) → undefined.
+///
+/// BoringSSL 의 SSL_CTX_new / SSL_CTX_use_certificate_file /
+/// SSL_CTX_use_PrivateKey_file / SSL_CTX_check_private_key 를 순차 호출.
+/// 실패 시 throw — 메시지에 Zig error name 포함.
+pub fn napiTlsSelfCheck(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 1;
+    var argv: [1]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throwError(env, "tlsSelfCheck: failed to get arguments");
+    }
+    if (argc < 1) return throwError(env, "tlsSelfCheck requires an options object");
+
+    // **F3**: argv[0] type 검증. object 아니면 후속 getObjectString 이 "field required"
+    // 로 throw 해 사용자가 type 문제를 missing field 로 오해. 명시 메시지로 분리.
+    var arg_type: c.napi_valuetype = undefined;
+    if (c.napi_typeof(env, argv[0], &arg_type) != c.napi_ok or arg_type != c.napi_object) {
+        return throwError(env, "tlsSelfCheck: options must be an object");
+    }
+
+    var arena = std.heap.ArenaAllocator.init(native_alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const cert_path = getObjectString(env, argv[0], "certPath", arena_alloc) orelse
+        return throwError(env, "tlsSelfCheck: 'certPath' string option is required");
+    const key_path = getObjectString(env, argv[0], "keyPath", arena_alloc) orelse
+        return throwError(env, "tlsSelfCheck: 'keyPath' string option is required");
+
+    var ctx = tls.TlsContext.init(cert_path, key_path) catch |err| {
+        var msg_buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrintZ(&msg_buf, "tlsSelfCheck: TlsContext.init failed: {}", .{err}) catch "tlsSelfCheck: TlsContext.init failed";
+        return throwError(env, msg.ptr);
+    };
+    ctx.deinit();
+
+    var undefined_val: c.napi_value = undefined;
+    _ = c.napi_get_undefined(env, &undefined_val);
+    return undefined_val;
+}

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -32,6 +32,7 @@ const watch_mod = @import("napi/watch.zig");
 const napiWatch = watch_mod.napiWatch;
 
 const mcp_stdio_entry = @import("napi/mcp_stdio_entry.zig");
+const tls_smoke = @import("napi/tls_smoke.zig");
 
 // ─── 모듈 등록 ───
 
@@ -106,6 +107,10 @@ export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi
     var mcp_stdio_fn: c.napi_value = undefined;
     _ = c.napi_create_function(env, "mcpStdioServe", "mcpStdioServe".len, mcp_stdio_entry.napiMcpStdioServe, null, &mcp_stdio_fn);
     _ = c.napi_set_named_property(env, exports, "mcpStdioServe", mcp_stdio_fn);
+
+    var tls_self_check_fn: c.napi_value = undefined;
+    _ = c.napi_create_function(env, "tlsSelfCheck", "tlsSelfCheck".len, tls_smoke.napiTlsSelfCheck, null, &tls_self_check_fn);
+    _ = c.napi_set_named_property(env, exports, "tlsSelfCheck", tls_self_check_fn);
 
     return exports;
 }

--- a/tests/integration/tests/napi-tls-self-check.test.ts
+++ b/tests/integration/tests/napi-tls-self-check.test.ts
@@ -1,0 +1,95 @@
+// NAPI tlsSelfCheck — BoringSSL static link 가 NAPI binary 안에서 실제로
+// 동작하는지 검증 (fix #3894 / #3898 / #3899 의 jacent assertion).
+//
+// 시나리오:
+//   1. openssl 로 self-signed cert/key 생성.
+//   2. zig-out/lib/zntc.node 직접 require → tlsSelfCheck 호출.
+//   3. valid cert/key → undefined (no throw).
+//   4. 없는 path → throw with 'CertLoadFailed' / 'KeyLoadFailed'.
+//   5. params 누락 → throw with 명시 메시지.
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+
+const repoRoot = resolve(__dirname, '..', '..', '..');
+const requireFromHere = createRequire(__filename);
+const native: any = requireFromHere(join(repoRoot, 'zig-out', 'lib', 'zntc.node'));
+
+let tmpDir: string;
+let certPath: string;
+let keyPath: string;
+let mismatchedKeyPath: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'zntc-napi-tls-'));
+  certPath = join(tmpDir, 'cert.pem');
+  keyPath = join(tmpDir, 'key.pem');
+  mismatchedKeyPath = join(tmpDir, 'mismatch-key.pem');
+  execSync(
+    `openssl req -x509 -newkey rsa:2048 -keyout ${keyPath} -out ${certPath} -days 1 -nodes -subj "/CN=localhost" 2>/dev/null`,
+  );
+  // 별도 RSA key — cert 와 mismatch (KeyMismatch path 검증).
+  execSync(`openssl genrsa -out ${mismatchedKeyPath} 2048 2>/dev/null`);
+});
+
+afterAll(() => {
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('NAPI tlsSelfCheck — BoringSSL link/runtime sanity', () => {
+  test('tlsSelfCheck export 존재', () => {
+    expect(typeof native.tlsSelfCheck).toBe('function');
+  });
+
+  test('valid cert + key — undefined (no throw)', () => {
+    const result = native.tlsSelfCheck({ certPath, keyPath });
+    expect(result).toBeUndefined();
+  });
+
+  test('없는 certPath → throw CertLoadFailed', () => {
+    expect(() => native.tlsSelfCheck({ certPath: '/nonexistent/cert.pem', keyPath })).toThrow(
+      /CertLoadFailed/,
+    );
+  });
+
+  test('없는 keyPath → throw KeyLoadFailed', () => {
+    expect(() => native.tlsSelfCheck({ certPath, keyPath: '/nonexistent/key.pem' })).toThrow(
+      /KeyLoadFailed/,
+    );
+  });
+
+  test('cert ↔ key mismatch → throw (KeyMismatch 또는 KeyLoadFailed)', () => {
+    // BoringSSL 의 PrivateKey_file 가 load 단계에서 cert 와 algo 비교 시도 가능 —
+    // mismatch 면 load 자체 fail (KeyLoadFailed) 또는 load 후 check_private_key
+    // 단계 fail (KeyMismatch). 본 test 는 invalid 결합이 명시 throw 되는 것만 검증.
+    expect(() => native.tlsSelfCheck({ certPath, keyPath: mismatchedKeyPath })).toThrow(
+      /KeyMismatch|KeyLoadFailed/,
+    );
+  });
+
+  test('certPath 누락 → throw "certPath" 메시지', () => {
+    expect(() => native.tlsSelfCheck({ keyPath } as any)).toThrow(/certPath/);
+  });
+
+  test('keyPath 누락 → throw "keyPath" 메시지', () => {
+    expect(() => native.tlsSelfCheck({ certPath } as any)).toThrow(/keyPath/);
+  });
+
+  test('options 누락 → throw "options object" 메시지', () => {
+    expect(() => (native.tlsSelfCheck as any)()).toThrow(/options object/);
+  });
+
+  test('argv[0] 가 non-object (string) → throw "must be an object" (F3 review)', () => {
+    // type 검증 없으면 후속 getObjectString 이 "field required" 로 throw 되어
+    // 사용자가 type 문제를 missing field 로 오해.
+    expect(() => (native.tlsSelfCheck as any)('not-an-object')).toThrow(/must be an object/);
+  });
+
+  test('argv[0] 가 null → throw "must be an object"', () => {
+    expect(() => (native.tlsSelfCheck as any)(null)).toThrow(/must be an object/);
+  });
+});


### PR DESCRIPTION
## Summary
사용자 명시 "NAPI 도 SSL 지원해야" 의 첫 단계. fix chain (#3894/#3898/#3899) 로 BoringSSL static link 됐지만 NAPI 측에 호출 path 없어 dead code 였음. sanity self-check entry 로 BoringSSL runtime 동작 잠금 + 후속 HTTPS dev server NAPI entry 의 토대.

## Why
- 현재 NAPI binary 가 BoringSSL static link (~4MB) 만 됐고 \`SSL_CTX_*\` symbol 호출 path 없음.
- 첫 단계로 \`tlsSelfCheck({certPath, keyPath})\` 추가 — \`TlsContext.init/deinit\` 호출 → runtime symbol resolve 검증.
- 사용자 RN dev 환경에서 cert/key 파일 유효성 빠르게 확인 가능.

## 주요 변경

### \`packages/core/src/napi/tls_smoke.zig\` (신규)
- \`napiTlsSelfCheck(env, info)\` — \`TlsContext.init(certPath, keyPath)\` + 즉시 \`deinit\`. 성공 → undefined. 실패 → throw with Zig error name.
- dev-only / arbitrary path read 보안 경고 주석.

### \`packages/core/src/napi_entry.zig\`
\`tls_smoke\` import + \`tlsSelfCheck\` 함수 register (13 export → 14).

### \`packages/core/index.ts\`
- \`NativeModule.tlsSelfCheck(...)\` type + \`TlsSelfCheckOptions\` interface + \`tlsSelfCheck()\` wrapper + JSDoc.

### Tests (\`tests/integration/tests/napi-tls-self-check.test.ts\` 신규)
10 case — export 존재, valid cert/key OK, missing cert/key/options, mismatched key, certPath/keyPath 누락, non-object argv (string + null).

## Self-review fixes (PR-G1 review)

| ID | Severity | 내용 |
| --- | --- | --- |
| F3 | medium | non-object argv[0] 가 \"field required\" 로 misleading throw → \`napi_typeof\` 검증 후 명시 \"must be an object\" |
| F7 | low | dev-only / arbitrary path read 보안 경고 주석 |

## Test plan
- [x] \`zig build napi\` → zntc.node 빌드
- [x] \`node -e "require('./zig-out/lib/zntc.node').tlsSelfCheck({...})"\` — valid 통과, invalid throw
- [x] \`bun test tests/napi-tls-self-check.test.ts\` (tests/integration cwd) — 10 pass / 0 fail
- [x] \`zig build test\` 전체 통과
- [x] \`bun x tsc -b --force\` — 통과

## 후속
- 본격 HTTPS dev server NAPI entry — listener thread + handle (별도 PR).
- 본 entry 가 BoringSSL runtime path 잠금했으니 후속 PR 가 SSL_CTX 관련 코드 추가 시 회귀 즉시 검출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)