### PR TITLE
feat(napi): startDevServer / stopDevServer — HTTPS dev server in-process (PR-G2)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -205,6 +205,23 @@ interface NativeModule {
    * 후속 HTTPS dev server NAPI entry 의 토대 + 사용자 cert/key 유효성 빠른 확인.
    */
   tlsSelfCheck(options: { certPath: string; keyPath: string }): void;
+  /**
+   * In-process dev server (HTTP 또는 HTTPS) 를 native thread 에서 시작.
+   * `certPath` + `keyPath` 양쪽 주면 HTTPS, 둘 다 없으면 HTTP. 한쪽만 주면 throw.
+   * 반환값은 opaque handle — `stopDevServer(handle)` 으로 graceful shutdown 가능.
+   * JS GC 가 handle 수거 시 자동 cleanup (safety net) 이지만 명시 stop 이 정석.
+   */
+  startDevServer(options: {
+    rootDir: string;
+    port?: number;
+    host?: string;
+    entry?: string;
+    open?: boolean;
+    certPath?: string;
+    keyPath?: string;
+  }): unknown;
+  /** startDevServer 가 반환한 handle 로 graceful shutdown. idempotent. */
+  stopDevServer(handle: unknown): void;
 }
 
 let native: NativeModule | null = null;
@@ -558,6 +575,52 @@ export interface TlsSelfCheckOptions {
  */
 export function tlsSelfCheck(options: TlsSelfCheckOptions): void {
   ensureNative().tlsSelfCheck(options);
+}
+
+/** @see {@link NativeModule.startDevServer} */
+export interface StartDevServerOptions {
+  rootDir: string;
+  /** TCP port (1-65535). Default 12300. */
+  port?: number;
+  /** Bind host. "localhost"/"127.0.0.1" (default) 또는 "0.0.0.0". */
+  host?: string;
+  /** `--bundle` entry. 지정 시 dev server 가 bundle 결과 서빙. */
+  entry?: string;
+  /** Open default browser at server URL. Default false. */
+  open?: boolean;
+  /** HTTPS cert (PEM). keyPath 와 함께 줘야. */
+  certPath?: string;
+  /** HTTPS key (PEM). certPath 와 함께 줘야. */
+  keyPath?: string;
+}
+
+/** Opaque handle from {@link startDevServer}. */
+export type DevServerHandle = object;
+
+/**
+ * In-process dev server (HTTP / HTTPS) 를 native thread 에서 시작.
+ *
+ * 일반 `zntc --serve` 와 동일한 listener / routing / HMR / SSE 동작. NAPI 임베드라
+ * Node event loop 는 자유 (별도 thread 에서 listen).
+ *
+ * 반환된 handle 은 opaque. `stopDevServer(handle)` 로 graceful shutdown. JS GC
+ * 가 handle 수거 시 finalizer 가 자동 stop (safety net) — 명시 stop 권장.
+ *
+ * @example
+ * const handle = startDevServer({ rootDir: './public', port: 5173 });
+ * try {
+ *   await new Promise(r => setTimeout(r, 60_000));
+ * } finally {
+ *   stopDevServer(handle);
+ * }
+ */
+export function startDevServer(options: StartDevServerOptions): DevServerHandle {
+  return ensureNative().startDevServer(options) as DevServerHandle;
+}
+
+/** Graceful shutdown — idempotent. */
+export function stopDevServer(handle: DevServerHandle): void {
+  ensureNative().stopDevServer(handle);
 }
 
 // ─── Build API ───

--- a/packages/core/src/napi/serve_entry.zig
+++ b/packages/core/src/napi/serve_entry.zig
@@ -1,0 +1,261 @@
+//! HTTPS-capable dev server NAPI entry.
+//!
+//! `startDevServer({rootDir, port?, host?, entry?, open?, certPath?, keyPath?})`
+//!   → opaque handle (napi_external).
+//! `stopDevServer(handle)` → undefined. shutdown + thread join + deinit.
+//!
+//! 동작:
+//!   - HTTPS 옵션 `certPath`/`keyPath` 양쪽 주면 BoringSSL TLS context 로 listener.
+//!     fix chain (#3894/#3898/#3899 + PR-G1 sanity) 의 결실.
+//!   - `start()` 는 blocking 이라 별도 native thread 에서 실행. Node event loop
+//!     는 자유.
+//!   - handle 은 `napi_create_external` — JS GC 가 수거 시 자동 stop (safety net).
+//!     명시 `stopDevServer(handle)` 호출이 정석 (예측 가능한 종료 시점).
+//!
+//! **Memory model (F1/F2 fix)**: `callconv(.c)` callback 는 plain `c.napi_value`
+//! 반환이라 Zig `errdefer` 가 dead code. 모든 error path 는 명시 cleanup. 또
+//! `DevServer.init` 가 옵션 string 의 own copy 안 만들기 때문에 (`root_dir`, `host`,
+//! `entry`, `certPath`, `keyPath`) NAPI 측이 dupe 해서 handle 에 보관 — server
+//! lifetime 과 align. arena 패턴 (string 만 짧게 살리는 것) 은 listener thread /
+//! handler thread 가 종료 후에도 일시 reference 가능해 UAF 위험 → 제거.
+//!
+//! **Dev-only entry — caller 신뢰 전제**: arbitrary host/port bind + cert/key 파일
+//! 읽기. 일반 사용자 머신의 dev workflow 가정.
+
+const std = @import("std");
+const zntc_lib = @import("zntc_lib");
+const common = @import("common.zig");
+const c = common.c;
+
+const DevServer = zntc_lib.server.DevServer;
+
+const native_alloc = common.nativeAlloc();
+const throwError = common.throwError;
+const getObjectString = common.getObjectString;
+const getObjectBool = common.getObjectBool;
+const getNamedProperty = common.getNamedProperty;
+
+/// JS 쪽에서 보유하는 opaque handle. heap alloc — JS reference 가 유지하는 동안
+/// 살아있고 finalize 시점에 자원 해제. 옵션 string 들의 own copy 도 같이 보관.
+const DevServerHandle = struct {
+    server: *DevServer,
+    thread: std.Thread,
+
+    // string 들은 server 가 reference 만 보관 → handle 안에서 own. shutdown 시
+    // server.deinit() 이후 free (server 가 reference 끊은 후).
+    root_dir: []u8,
+    host: []u8,
+    entry: ?[]u8,
+    cert_path: ?[]u8,
+    key_path: ?[]u8,
+
+    /// stopDevServer 가 한 번 호출되면 idempotent 처리 위해 atomic flag.
+    /// finalize callback 이 GC 후에 다시 stop 시도해도 no-op.
+    stopped: std.atomic.Value(bool),
+
+    fn shutdown(self: *DevServerHandle) void {
+        // shutdown() 자체가 atomic flag set + self-connect 라 race 안전. 다만
+        // join / deinit / free 는 race 가능하므로 single-shot.
+        if (self.stopped.swap(true, .acq_rel)) return;
+        self.server.shutdown();
+        self.thread.join();
+        self.server.deinit();
+        native_alloc.destroy(self.server);
+        native_alloc.free(self.root_dir);
+        native_alloc.free(self.host);
+        if (self.entry) |s| native_alloc.free(s);
+        if (self.cert_path) |s| native_alloc.free(s);
+        if (self.key_path) |s| native_alloc.free(s);
+    }
+};
+
+/// thread entry — server.start() 호출. start() 가 정상 종료 (shutdown_requested)
+/// 되면 thread 도 종료. fail 시 stderr log 만.
+fn serveThreadEntry(server: *DevServer) void {
+    server.start() catch |err| {
+        std.fs.File.stderr().deprecatedWriter().print(
+            "zntc: dev server thread error: {}\n",
+            .{err},
+        ) catch {};
+    };
+}
+
+/// finalize callback — JS GC 가 external value 를 수거할 때 호출. 명시 stop 안
+/// 됐으면 여기서 정리.
+fn finalizeHandle(env: c.napi_env, finalize_data: ?*anyopaque, finalize_hint: ?*anyopaque) callconv(.c) void {
+    _ = env;
+    _ = finalize_hint;
+    if (finalize_data == null) return;
+    const handle: *DevServerHandle = @ptrCast(@alignCast(finalize_data.?));
+    handle.shutdown();
+    native_alloc.destroy(handle);
+}
+
+pub fn napiStartDevServer(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 1;
+    var argv: [1]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throwError(env, "startDevServer: failed to get arguments");
+    }
+    if (argc < 1) return throwError(env, "startDevServer requires an options object");
+
+    var arg_type: c.napi_valuetype = undefined;
+    if (c.napi_typeof(env, argv[0], &arg_type) != c.napi_ok or arg_type != c.napi_object) {
+        return throwError(env, "startDevServer: options must be an object");
+    }
+
+    // String 들은 어차피 native_alloc 에서 dupe — 임시 alloc 도 native_alloc 사용해
+    // 본 함수 안에서 명시 free. errdefer 가 callconv(.c) 에서 dead code 라 모든
+    // error path 가 직접 정리해야 함.
+    var root_dir: ?[]u8 = null;
+    var host: ?[]u8 = null;
+    var entry: ?[]u8 = null;
+    var cert_path: ?[]u8 = null;
+    var key_path: ?[]u8 = null;
+
+    // 에러 시 alloc 된 옵션 string 들 free 하는 inline cleanup.
+    const cleanupStrings = struct {
+        fn run(rd: ?[]u8, h: ?[]u8, e: ?[]u8, cp: ?[]u8, kp: ?[]u8) void {
+            if (rd) |s| native_alloc.free(s);
+            if (h) |s| native_alloc.free(s);
+            if (e) |s| native_alloc.free(s);
+            if (cp) |s| native_alloc.free(s);
+            if (kp) |s| native_alloc.free(s);
+        }
+    }.run;
+
+    // root_dir — required.
+    const rd_slice = getObjectString(env, argv[0], "rootDir", native_alloc) orelse {
+        return throwError(env, "startDevServer: 'rootDir' string option is required");
+    };
+    root_dir = @constCast(rd_slice);
+
+    // optional / 기본값. getObjectString 는 caller-owned slice 반환.
+    if (getObjectString(env, argv[0], "host", native_alloc)) |s| host = @constCast(s);
+    if (getObjectString(env, argv[0], "entry", native_alloc)) |s| entry = @constCast(s);
+    if (getObjectString(env, argv[0], "certPath", native_alloc)) |s| cert_path = @constCast(s);
+    if (getObjectString(env, argv[0], "keyPath", native_alloc)) |s| key_path = @constCast(s);
+
+    // host 가 비어있으면 default "127.0.0.1" 로 채우기 (DevServer 가 비빈 string
+    // 받으면 listen fail).
+    if (host == null) {
+        host = native_alloc.dupe(u8, "127.0.0.1") catch {
+            cleanupStrings(root_dir, host, entry, cert_path, key_path);
+            return throwError(env, "startDevServer: out of memory (host default)");
+        };
+    }
+
+    // port — required type number, default 12300.
+    var port: u16 = 12300;
+    if (getNamedProperty(env, argv[0], "port")) |port_val| {
+        var port_type: c.napi_valuetype = undefined;
+        _ = c.napi_typeof(env, port_val, &port_type);
+        if (port_type == c.napi_number) {
+            var port_u32: u32 = 0;
+            if (c.napi_get_value_uint32(env, port_val, &port_u32) != c.napi_ok) {
+                cleanupStrings(root_dir, host, entry, cert_path, key_path);
+                return throwError(env, "startDevServer: failed to read 'port' number");
+            }
+            if (port_u32 == 0 or port_u32 > 65535) {
+                cleanupStrings(root_dir, host, entry, cert_path, key_path);
+                return throwError(env, "startDevServer: 'port' must be 1..65535");
+            }
+            port = @intCast(port_u32);
+        } else if (port_type != c.napi_undefined and port_type != c.napi_null) {
+            cleanupStrings(root_dir, host, entry, cert_path, key_path);
+            return throwError(env, "startDevServer: 'port' must be a number");
+        }
+    }
+
+    const open = getObjectBool(env, argv[0], "open", false);
+
+    // cert 와 key 둘 다 있거나 둘 다 없거나.
+    if ((cert_path == null) != (key_path == null)) {
+        cleanupStrings(root_dir, host, entry, cert_path, key_path);
+        return throwError(env, "startDevServer: both 'certPath' and 'keyPath' must be provided together (or neither)");
+    }
+
+    // heap alloc DevServer — thread 가 reference 유지하는 동안 살아있어야.
+    const server = native_alloc.create(DevServer) catch {
+        cleanupStrings(root_dir, host, entry, cert_path, key_path);
+        return throwError(env, "startDevServer: out of memory (DevServer alloc)");
+    };
+
+    server.* = DevServer.init(native_alloc, .{
+        .root_dir = root_dir.?,
+        .port = port,
+        .host = host.?,
+        .open = open,
+        .entry_point = entry,
+        .cert_path = cert_path,
+        .key_path = key_path,
+    }) catch |err| {
+        native_alloc.destroy(server);
+        cleanupStrings(root_dir, host, entry, cert_path, key_path);
+        var msg_buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrintZ(&msg_buf, "startDevServer: DevServer.init failed: {}", .{err}) catch
+            "startDevServer: DevServer.init failed";
+        return throwError(env, msg.ptr);
+    };
+
+    const handle = native_alloc.create(DevServerHandle) catch {
+        server.deinit();
+        native_alloc.destroy(server);
+        cleanupStrings(root_dir, host, entry, cert_path, key_path);
+        return throwError(env, "startDevServer: out of memory (handle alloc)");
+    };
+
+    const thread = std.Thread.spawn(.{}, serveThreadEntry, .{server}) catch {
+        native_alloc.destroy(handle);
+        server.deinit();
+        native_alloc.destroy(server);
+        cleanupStrings(root_dir, host, entry, cert_path, key_path);
+        return throwError(env, "startDevServer: failed to spawn thread");
+    };
+
+    handle.* = .{
+        .server = server,
+        .thread = thread,
+        .root_dir = root_dir.?,
+        .host = host.?,
+        .entry = entry,
+        .cert_path = cert_path,
+        .key_path = key_path,
+        .stopped = std.atomic.Value(bool).init(false),
+    };
+
+    var external_value: c.napi_value = undefined;
+    if (c.napi_create_external(env, handle, finalizeHandle, null, &external_value) != c.napi_ok) {
+        // external 생성 실패 — handle.shutdown() 으로 thread join + server deinit
+        // + string free 한 후 handle 자체 free.
+        handle.shutdown();
+        native_alloc.destroy(handle);
+        return throwError(env, "startDevServer: napi_create_external failed");
+    }
+    return external_value;
+}
+
+pub fn napiStopDevServer(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 1;
+    var argv: [1]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throwError(env, "stopDevServer: failed to get arguments");
+    }
+    if (argc < 1) return throwError(env, "stopDevServer requires a handle argument");
+
+    var arg_type: c.napi_valuetype = undefined;
+    if (c.napi_typeof(env, argv[0], &arg_type) != c.napi_ok or arg_type != c.napi_external) {
+        return throwError(env, "stopDevServer: argument must be a handle from startDevServer");
+    }
+
+    var data: ?*anyopaque = null;
+    if (c.napi_get_value_external(env, argv[0], &data) != c.napi_ok or data == null) {
+        return throwError(env, "stopDevServer: failed to unwrap handle");
+    }
+    const handle: *DevServerHandle = @ptrCast(@alignCast(data.?));
+    handle.shutdown();
+
+    var undefined_val: c.napi_value = undefined;
+    _ = c.napi_get_undefined(env, &undefined_val);
+    return undefined_val;
+}

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -33,6 +33,7 @@ const napiWatch = watch_mod.napiWatch;
 
 const mcp_stdio_entry = @import("napi/mcp_stdio_entry.zig");
 const tls_smoke = @import("napi/tls_smoke.zig");
+const serve_entry = @import("napi/serve_entry.zig");
 
 // ─── 모듈 등록 ───
 
@@ -111,6 +112,14 @@ export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi
     var tls_self_check_fn: c.napi_value = undefined;
     _ = c.napi_create_function(env, "tlsSelfCheck", "tlsSelfCheck".len, tls_smoke.napiTlsSelfCheck, null, &tls_self_check_fn);
     _ = c.napi_set_named_property(env, exports, "tlsSelfCheck", tls_self_check_fn);
+
+    var start_dev_server_fn: c.napi_value = undefined;
+    _ = c.napi_create_function(env, "startDevServer", "startDevServer".len, serve_entry.napiStartDevServer, null, &start_dev_server_fn);
+    _ = c.napi_set_named_property(env, exports, "startDevServer", start_dev_server_fn);
+
+    var stop_dev_server_fn: c.napi_value = undefined;
+    _ = c.napi_create_function(env, "stopDevServer", "stopDevServer".len, serve_entry.napiStopDevServer, null, &stop_dev_server_fn);
+    _ = c.napi_set_named_property(env, exports, "stopDevServer", stop_dev_server_fn);
 
     return exports;
 }

--- a/tests/integration/tests/napi-dev-server.test.ts
+++ b/tests/integration/tests/napi-dev-server.test.ts
@@ -1,0 +1,176 @@
+// NAPI startDevServer / stopDevServer — in-process HTTP & HTTPS dev server.
+//
+// 시나리오:
+//   1. mkdtemp 으로 임시 root + index.html.
+//   2. startDevServer({rootDir, port, ...}) → handle.
+//   3. fetch http://host:port/index.html → 200 + body.
+//   4. stopDevServer(handle) — graceful shutdown.
+//   5. HTTPS 변형 — self-signed cert + NODE_TLS_REJECT_UNAUTHORIZED=0 으로 fetch.
+//
+// 메모리 가이드: 반드시 tests/integration 디렉토리에서 `bun test`.
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+
+const repoRoot = resolve(__dirname, '..', '..', '..');
+const requireFromHere = createRequire(__filename);
+const native: any = requireFromHere(join(repoRoot, 'zig-out', 'lib', 'zntc.node'));
+
+let tmpRoot: string;
+let certPath: string;
+let keyPath: string;
+
+// 16xxx range — 시스템 사용 적은 port. 동시 실행 시 충돌 없게 test 별 다른 port.
+let nextPort = 16400;
+function reservePort(): number {
+  return nextPort++;
+}
+
+beforeAll(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'zntc-napi-serve-'));
+  writeFileSync(join(tmpRoot, 'index.html'), '<h1>NAPI serve OK</h1>');
+  certPath = join(tmpRoot, 'cert.pem');
+  keyPath = join(tmpRoot, 'key.pem');
+  execSync(
+    `openssl req -x509 -newkey rsa:2048 -keyout ${keyPath} -out ${certPath} -days 1 -nodes -subj "/CN=localhost" 2>/dev/null`,
+  );
+});
+
+afterAll(() => {
+  if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+async function waitUntilReady(url: string, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.status === 200) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`server at ${url} not ready within ${timeoutMs}ms`);
+}
+
+describe('NAPI startDevServer / stopDevServer', () => {
+  test('exports 존재', () => {
+    expect(typeof native.startDevServer).toBe('function');
+    expect(typeof native.stopDevServer).toBe('function');
+  });
+
+  test('HTTP — start → fetch index.html (200, body) → stop', async () => {
+    const port = reservePort();
+    const handle = native.startDevServer({ rootDir: tmpRoot, port, host: '127.0.0.1' });
+    expect(typeof handle).toBe('object');
+    try {
+      await waitUntilReady(`http://127.0.0.1:${port}/index.html`);
+      const res = await fetch(`http://127.0.0.1:${port}/index.html`);
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body.trim()).toBe('<h1>NAPI serve OK</h1>');
+    } finally {
+      native.stopDevServer(handle);
+    }
+  });
+
+  test('HTTPS — cert + key 양쪽 줘서 BoringSSL listener', async () => {
+    const port = reservePort();
+    const handle = native.startDevServer({
+      rootDir: tmpRoot,
+      port,
+      host: '127.0.0.1',
+      certPath,
+      keyPath,
+    });
+    try {
+      // self-signed cert 라 verify off.
+      const origRejectUnauth = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+      try {
+        await waitUntilReady(`https://127.0.0.1:${port}/index.html`);
+        const res = await fetch(`https://127.0.0.1:${port}/index.html`);
+        expect(res.status).toBe(200);
+        const body = await res.text();
+        expect(body.trim()).toBe('<h1>NAPI serve OK</h1>');
+      } finally {
+        if (origRejectUnauth == null) delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+        else process.env.NODE_TLS_REJECT_UNAUTHORIZED = origRejectUnauth;
+      }
+    } finally {
+      native.stopDevServer(handle);
+    }
+  });
+
+  test('stopDevServer idempotent — 두 번 호출해도 throw 없음', () => {
+    const port = reservePort();
+    const handle = native.startDevServer({ rootDir: tmpRoot, port, host: '127.0.0.1' });
+    native.stopDevServer(handle);
+    expect(() => native.stopDevServer(handle)).not.toThrow();
+  });
+
+  test('cert 만 주고 key 없음 → throw "both"', () => {
+    const port = reservePort();
+    expect(() =>
+      native.startDevServer({ rootDir: tmpRoot, port, host: '127.0.0.1', certPath }),
+    ).toThrow(/both/);
+  });
+
+  test('rootDir 누락 → throw "rootDir"', () => {
+    expect(() => (native.startDevServer as any)({})).toThrow(/rootDir/);
+  });
+
+  test('options 누락 → throw "options object"', () => {
+    expect(() => (native.startDevServer as any)()).toThrow(/options object/);
+  });
+
+  test('non-object handle → stopDevServer throw "handle"', () => {
+    expect(() => (native.stopDevServer as any)({ fake: true })).toThrow(/handle/);
+    expect(() => (native.stopDevServer as any)(null)).toThrow(/handle/);
+  });
+
+  test('port 범위 검증 (0 / 65536+ → throw)', () => {
+    expect(() => native.startDevServer({ rootDir: tmpRoot, port: 0 })).toThrow(/port/);
+    expect(() => native.startDevServer({ rootDir: tmpRoot, port: 70000 })).toThrow(/port/);
+  });
+
+  test('port 가 string 등 non-number → throw (F4 type check)', () => {
+    expect(() => native.startDevServer({ rootDir: tmpRoot, port: '5173' as any })).toThrow(/port/);
+  });
+
+  test('concurrent handles — 두 개 동시 실행 + 독립 stop (F9)', async () => {
+    const portA = reservePort();
+    const portB = reservePort();
+    const handleA = native.startDevServer({ rootDir: tmpRoot, port: portA, host: '127.0.0.1' });
+    const handleB = native.startDevServer({ rootDir: tmpRoot, port: portB, host: '127.0.0.1' });
+    try {
+      await waitUntilReady(`http://127.0.0.1:${portA}/index.html`);
+      await waitUntilReady(`http://127.0.0.1:${portB}/index.html`);
+      const [resA, resB] = await Promise.all([
+        fetch(`http://127.0.0.1:${portA}/index.html`),
+        fetch(`http://127.0.0.1:${portB}/index.html`),
+      ]);
+      expect(resA.status).toBe(200);
+      expect(resB.status).toBe(200);
+      // A 만 stop 후에도 B 는 작동.
+      native.stopDevServer(handleA);
+      const resBAfter = await fetch(`http://127.0.0.1:${portB}/index.html`);
+      expect(resBAfter.status).toBe(200);
+    } finally {
+      native.stopDevServer(handleB);
+    }
+  });
+
+  // GC-only cleanup (no explicit stopDevServer) — finalize callback 가 자동 정리한다는
+  // 점은 코드 review 로만 검증. Bun.gc(true) 가 NAPI external finalizer 를 동기 실행
+  // 보장 안 해서 timing 의존 test 는 flaky. 본 인프라 의 contract:
+  //   - finalizeHandle 가 handle.shutdown() (server.shutdown + thread.join + deinit + free) +
+  //     native_alloc.destroy(handle) 호출.
+  //   - stopped atomic flag 가 명시 stop 과 finalizer 의 race 차단.
+  // production 사용자에게는 명시 stopDevServer 권장 — finalize 는 GC safety net.
+});


### PR DESCRIPTION
## Summary
PR-G1 (#3905) tlsSelfCheck 후속. NAPI 에서 본격 HTTPS dev server 시작 가능. listener 가 native thread 에서 동작 — Node event loop 자유. 사용자 명시 "NAPI 도 SSL 지원해야" 의 핵심 단계 완성.

## 주요 변경

### \`packages/core/src/napi/serve_entry.zig\` (신규)
- \`DevServerHandle\` struct — \`server*\`, \`thread\`, 옵션 string own copy, atomic \`stopped\` flag.
- \`napiStartDevServer({rootDir, port?, host?, entry?, open?, certPath?, keyPath?})\` — 옵션 parse + heap alloc DevServer + spawn thread + napi external handle 반환.
- \`napiStopDevServer(handle)\` — graceful shutdown (atomic flag + self-connect + thread join + deinit + string free + handle destroy).
- \`finalizeHandle\` — JS GC 시 자동 stop (safety net).

### \`packages/core/src/napi_entry.zig\`
\`startDevServer\` / \`stopDevServer\` 함수 등록 (13 → 15 exports).

### \`packages/core/index.ts\`
\`StartDevServerOptions\` interface + \`DevServerHandle\` opaque type + wrapper + JSDoc + 예제.

### Tests (\`tests/integration/tests/napi-dev-server.test.ts\` 신규)
11 case — exports / HTTP round-trip / **HTTPS w/ self-signed cert** / idempotent stop / cert+key mismatch / missing rootDir/options / non-handle stop / port range / port type / **concurrent handles 독립 stop**.

## Self-review fixes

| ID | Severity | 내용 |
| --- | --- | --- |
| F1 | **critical** | \`errdefer\` 가 \`callconv(.c) napi_value\` callback 에서 dead code → arena 패턴 폐기 + 명시 cleanup |
| F2 | critical-medium | arena 수명 vs concurrent handler UAF → handle 안에 string own copy |
| F4 | medium | port non-number → 명시 type check + throw |
| F9 | low | concurrent handles test 추가. GC-only test 는 finalizer timing 의존이라 doc 만 |
| F5 | low | port 0 미허용 schema 명시 |

## 검증
- \`zig build napi\` — clean rebuild OK
- HTTP smoke 200, HTTPS smoke 200 (BoringSSL TLS handshake 정상)
- 11 unit/E2E case 통과
- \`zig build test\` + \`tsc -b --force\` 통과

## 후속
- banner stderr silence (\`quiet?\`)
- shutdown grace period option
- port 0 (OS-assigned) 지원 — \`getDevServerPort(handle)\`
- WebSocket upgrade test

🤖 Generated with [Claude Code](https://claude.com/claude-code)