### PR TITLE
feat(napi): DevServer quiet + port 0 auto + getDevServerPort (PR-G3)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -219,9 +219,16 @@ interface NativeModule {
     open?: boolean;
     certPath?: string;
     keyPath?: string;
+    quiet?: boolean;
   }): unknown;
   /** startDevServer 가 반환한 handle 로 graceful shutdown. idempotent. */
   stopDevServer(handle: unknown): void;
+  /**
+   * startDevServer 반환 handle 의 실제 listen port. port=0 (OS-assigned) 으로 시작
+   * 했을 때 유용 — 실제 bound port 반환. handle 이 이미 stop 됐으면 throw.
+   * 호출은 server.listen() 완료까지 blocking (최대 1s polling).
+   */
+  getDevServerPort(handle: unknown): number;
 }
 
 let native: NativeModule | null = null;
@@ -580,7 +587,10 @@ export function tlsSelfCheck(options: TlsSelfCheckOptions): void {
 /** @see {@link NativeModule.startDevServer} */
 export interface StartDevServerOptions {
   rootDir: string;
-  /** TCP port (1-65535). Default 12300. */
+  /**
+   * TCP port (0-65535). Default 12300. 0 은 OS-assigned ephemeral port —
+   * `getDevServerPort(handle)` 로 실제 값 조회.
+   */
   port?: number;
   /** Bind host. "localhost"/"127.0.0.1" (default) 또는 "0.0.0.0". */
   host?: string;
@@ -592,6 +602,15 @@ export interface StartDevServerOptions {
   certPath?: string;
   /** HTTPS key (PEM). certPath 와 함께 줘야. */
   keyPath?: string;
+  /**
+   * stderr 의 banner ("zntc dev server / Local: ...") 와 listen-fail log 출력 silence.
+   * NAPI embed 의 기본값은 true (자체 logger 가정). false 로 명시하면 stderr 출력.
+   *
+   * **scope 명시**: 본 옵션은 banner 와 listen 에러 한정. HMR / WS / watcher /
+   * bundle / request 등 routine log 는 별도 — 현재 모두 stderr 직접 출력. 완전
+   * silent 가 필요하면 후속 PR 에서 verbose log 도 quiet 범위에 포함 예정.
+   */
+  quiet?: boolean;
 }
 
 /** Opaque handle from {@link startDevServer}. */
@@ -621,6 +640,21 @@ export function startDevServer(options: StartDevServerOptions): DevServerHandle 
 /** Graceful shutdown — idempotent. */
 export function stopDevServer(handle: DevServerHandle): void {
   ensureNative().stopDevServer(handle);
+}
+
+/**
+ * startDevServer handle 의 실제 listen port.
+ *
+ * port=0 (OS-assigned ephemeral) 로 시작했을 때 실 bound port 조회. 일반적인
+ * test fixture / dynamic 환경에서 free port 자동 할당받고 그 값을 즉시 사용.
+ *
+ * @example
+ * const handle = startDevServer({ rootDir: './public', port: 0 });
+ * const port = getDevServerPort(handle);
+ * const res = await fetch(`http://127.0.0.1:${port}/`);
+ */
+export function getDevServerPort(handle: DevServerHandle): number {
+  return ensureNative().getDevServerPort(handle);
 }
 
 // ─── Build API ───

--- a/packages/core/src/napi/serve_entry.zig
+++ b/packages/core/src/napi/serve_entry.zig
@@ -145,7 +145,9 @@ pub fn napiStartDevServer(env: c.napi_env, info: c.napi_callback_info) callconv(
         };
     }
 
-    // port — required type number, default 12300.
+    // port — required type number, default 12300. **0 은 OS-assigned ephemeral**:
+    // start() 가 listen 후 실제 port 로 self.port 갱신 → `getDevServerPort(handle)`
+    // 로 조회 가능. 일반 테스트 fixture 가 free port 자동 할당받을 때 유용.
     var port: u16 = 12300;
     if (getNamedProperty(env, argv[0], "port")) |port_val| {
         var port_type: c.napi_valuetype = undefined;
@@ -156,9 +158,9 @@ pub fn napiStartDevServer(env: c.napi_env, info: c.napi_callback_info) callconv(
                 cleanupStrings(root_dir, host, entry, cert_path, key_path);
                 return throwError(env, "startDevServer: failed to read 'port' number");
             }
-            if (port_u32 == 0 or port_u32 > 65535) {
+            if (port_u32 > 65535) {
                 cleanupStrings(root_dir, host, entry, cert_path, key_path);
-                return throwError(env, "startDevServer: 'port' must be 1..65535");
+                return throwError(env, "startDevServer: 'port' must be 0..65535 (0 = OS-assigned)");
             }
             port = @intCast(port_u32);
         } else if (port_type != c.napi_undefined and port_type != c.napi_null) {
@@ -168,6 +170,9 @@ pub fn napiStartDevServer(env: c.napi_env, info: c.napi_callback_info) callconv(
     }
 
     const open = getObjectBool(env, argv[0], "open", false);
+    // NAPI embed 는 자체 logger 가 있는 경우가 많아 default quiet=true. 사용자가
+    // 명시 false 면 stderr 에 banner + listen log 출력.
+    const quiet = getObjectBool(env, argv[0], "quiet", true);
 
     // cert 와 key 둘 다 있거나 둘 다 없거나.
     if ((cert_path == null) != (key_path == null)) {
@@ -189,6 +194,7 @@ pub fn napiStartDevServer(env: c.napi_env, info: c.napi_callback_info) callconv(
         .entry_point = entry,
         .cert_path = cert_path,
         .key_path = key_path,
+        .quiet = quiet,
     }) catch |err| {
         native_alloc.destroy(server);
         cleanupStrings(root_dir, host, entry, cert_path, key_path);
@@ -233,6 +239,51 @@ pub fn napiStartDevServer(env: c.napi_env, info: c.napi_callback_info) callconv(
         return throwError(env, "startDevServer: napi_create_external failed");
     }
     return external_value;
+}
+
+pub fn napiGetDevServerPort(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 1;
+    var argv: [1]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throwError(env, "getDevServerPort: failed to get arguments");
+    }
+    if (argc < 1) return throwError(env, "getDevServerPort requires a handle argument");
+
+    var arg_type: c.napi_valuetype = undefined;
+    if (c.napi_typeof(env, argv[0], &arg_type) != c.napi_ok or arg_type != c.napi_external) {
+        return throwError(env, "getDevServerPort: argument must be a handle from startDevServer");
+    }
+
+    var data: ?*anyopaque = null;
+    if (c.napi_get_value_external(env, argv[0], &data) != c.napi_ok or data == null) {
+        return throwError(env, "getDevServerPort: failed to unwrap handle");
+    }
+    const handle: *DevServerHandle = @ptrCast(@alignCast(data.?));
+    if (handle.stopped.load(.acquire)) {
+        return throwError(env, "getDevServerPort: handle has been stopped");
+    }
+
+    // listen_ready atomic flag 가 release-store 됐을 때 acquire-load 로 self.port 값이
+    // 다른 thread (worker thread 의 start()) 의 write 와 happens-before relation 형성.
+    // ARM64 같은 weakly-ordered 환경에서 silent stale-read (옵션 값 0) 방지 (F1 fix).
+    const POLL_INTERVAL_NS = 10 * std.time.ns_per_ms;
+    const POLL_MAX_ATTEMPTS: u32 = 100; // 10ms × 100 = 1s 한도
+    var attempts: u32 = 0;
+    while (!handle.server.listen_ready.load(.acquire) and attempts < POLL_MAX_ATTEMPTS) : (attempts += 1) {
+        std.Thread.sleep(POLL_INTERVAL_NS);
+        if (handle.stopped.load(.acquire)) {
+            return throwError(env, "getDevServerPort: handle stopped before listen completed");
+        }
+    }
+    if (!handle.server.listen_ready.load(.acquire)) {
+        return throwError(env, "getDevServerPort: server listen did not complete within 1s");
+    }
+
+    var port_val: c.napi_value = undefined;
+    if (c.napi_create_uint32(env, @intCast(handle.server.port), &port_val) != c.napi_ok) {
+        return throwError(env, "getDevServerPort: failed to create return value");
+    }
+    return port_val;
 }
 
 pub fn napiStopDevServer(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -121,5 +121,9 @@ export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi
     _ = c.napi_create_function(env, "stopDevServer", "stopDevServer".len, serve_entry.napiStopDevServer, null, &stop_dev_server_fn);
     _ = c.napi_set_named_property(env, exports, "stopDevServer", stop_dev_server_fn);
 
+    var get_dev_server_port_fn: c.napi_value = undefined;
+    _ = c.napi_create_function(env, "getDevServerPort", "getDevServerPort".len, serve_entry.napiGetDevServerPort, null, &get_dev_server_port_fn);
+    _ = c.napi_set_named_property(env, exports, "getDevServerPort", get_dev_server_port_fn);
+
     return exports;
 }

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -52,9 +52,13 @@ pub const DevServer = struct {
     allocator: std.mem.Allocator,
     root_dir: std.fs.Dir,
     root_path: []const u8,
+    /// 실제 listen 중인 port. listen 전엔 init 시점 옵션값, listen 후엔 OS-assigned
+    /// port (옵션이 0 이었던 경우) 포함 실제 값. NAPI `getDevServerPort` 가 이 필드 노출.
     port: u16,
     host: []const u8,
     open: bool,
+    /// stderr 출력 silence. NAPI embed 등 외부 logger 가 있을 때 true.
+    quiet: bool,
     tcp_server: ?std.net.Server,
     entry_point: ?[]const u8,
     abs_entry: ?[]const u8,
@@ -75,6 +79,10 @@ pub const DevServer = struct {
     event_ring: EventRing,
     /// shutdown() 호출 시 set; acceptLoop가 다음 iteration에서 종료.
     shutdown_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    /// listen 완료 + self.port 갱신 완료 신호 (release / acquire 로 cross-thread
+    /// publish). `getDevServerPort` 가 acquire 로 읽기 — port 0 (OS-assigned) 의 실
+    /// 값을 다른 thread 에서 안전 조회.
+    listen_ready: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     /// 현재 살아있는 connection (handleConnection thread) 수. deinit 가 0 까지 wait —
     /// 직접 보호 대상은 `app_channel` (reader thread 가 mutex/pending Map 사용) 이지만
     /// counter 는 **모든** handleConnection thread (plain HTTP / SSE / HMR WS / MCP app)
@@ -133,6 +141,10 @@ pub const DevServer = struct {
         /// 둘 다 null 이면 plain HTTP. 한쪽만 set 하면 init error (`error.TlsKeyMissing`).
         cert_path: ?[]const u8 = null,
         key_path: ?[]const u8 = null,
+        /// stderr 의 banner ("zntc dev server / Local: ...") 와 routine progress 출력
+        /// 억제. CLI 는 사용자에게 보여줘야 하므로 기본 false, NAPI embed (Vite plugin
+        /// 등) 는 자체 logger 사용해서 true 권장.
+        quiet: bool = false,
     };
 
     const max_file_size: u64 = 50 * 1024 * 1024;
@@ -205,6 +217,7 @@ pub const DevServer = struct {
             .port = options.port,
             .host = options.host,
             .open = options.open,
+            .quiet = options.quiet,
             .tcp_server = null,
             .entry_point = options.entry_point,
             .abs_entry = abs_entry,
@@ -316,22 +329,36 @@ pub const DevServer = struct {
         self.tcp_server = address.listen(.{
             .reuse_address = true,
         }) catch |err| {
-            getLog().print("zntc: failed to listen on {s}:{d}: {}\n", .{ self.host, self.port, err }) catch {};
+            if (!self.quiet) {
+                getLog().print("zntc: failed to listen on {s}:{d}: {}\n", .{ self.host, self.port, err }) catch {};
+            }
             return err;
         };
 
-        const w = getLog();
-        const scheme: []const u8 = if (self.tls_ctx != null) "https" else "http";
-        w.print("\n  zntc dev server\n\n", .{}) catch {};
-        w.print("  Local: {s}://{s}:{d}/\n", .{ scheme, self.host, self.port }) catch {};
-        if (std.mem.eql(u8, self.host, "0.0.0.0")) {
-            w.print("  Network: {s}://0.0.0.0:{d}/\n", .{ scheme, self.port }) catch {};
+        // port 0 (OS-assigned ephemeral) 였으면 실제 bound port 로 self.port 갱신
+        // — caller (NAPI getDevServerPort 등) 가 실 값 조회 가능.
+        if (self.tcp_server) |s| {
+            self.port = s.listen_address.getPort();
         }
-        w.print("  Root:  {s}\n", .{self.root_path}) catch {};
-        if (self.entry_point) |ep| {
-            w.print("  Entry: {s}\n", .{ep}) catch {};
+        // F1: atomic release — self.port 쓰기가 reader 의 acquire load 와 happens-
+        // before relation 형성. ARM64 (Apple Silicon) 같은 weakly-ordered 환경에서
+        // self.port 값이 reorder 되어 옵션 default (0) 로 읽히는 문제 차단.
+        self.listen_ready.store(true, .release);
+
+        if (!self.quiet) {
+            const w = getLog();
+            const scheme: []const u8 = if (self.tls_ctx != null) "https" else "http";
+            w.print("\n  zntc dev server\n\n", .{}) catch {};
+            w.print("  Local: {s}://{s}:{d}/\n", .{ scheme, self.host, self.port }) catch {};
+            if (std.mem.eql(u8, self.host, "0.0.0.0")) {
+                w.print("  Network: {s}://0.0.0.0:{d}/\n", .{ scheme, self.port }) catch {};
+            }
+            w.print("  Root:  {s}\n", .{self.root_path}) catch {};
+            if (self.entry_point) |ep| {
+                w.print("  Entry: {s}\n", .{ep}) catch {};
+            }
+            w.print("\n", .{}) catch {};
         }
-        w.print("\n", .{}) catch {};
 
         // --open: 브라우저 자동 열기
         if (self.open) {

--- a/tests/integration/tests/napi-dev-server.test.ts
+++ b/tests/integration/tests/napi-dev-server.test.ts
@@ -134,8 +134,7 @@ describe('NAPI startDevServer / stopDevServer', () => {
     expect(() => (native.stopDevServer as any)(null)).toThrow(/handle/);
   });
 
-  test('port 범위 검증 (0 / 65536+ → throw)', () => {
-    expect(() => native.startDevServer({ rootDir: tmpRoot, port: 0 })).toThrow(/port/);
+  test('port 65536+ → throw (PR-G3: 0 은 OS-assigned 으로 허용)', () => {
     expect(() => native.startDevServer({ rootDir: tmpRoot, port: 70000 })).toThrow(/port/);
   });
 
@@ -164,6 +163,47 @@ describe('NAPI startDevServer / stopDevServer', () => {
     } finally {
       native.stopDevServer(handleB);
     }
+  });
+
+  test('port 0 (OS-assigned ephemeral) + getDevServerPort — 실 bound port 조회 (PR-G3)', async () => {
+    const handle = native.startDevServer({ rootDir: tmpRoot, port: 0, host: '127.0.0.1' });
+    try {
+      const port = native.getDevServerPort(handle);
+      expect(typeof port).toBe('number');
+      // F1 fix detector: race (stale read) 시 0 반환되면 즉시 fail.
+      expect(port).not.toBe(0);
+      expect(port).toBeGreaterThan(1024);
+      expect(port).toBeLessThan(65536);
+      await waitUntilReady(`http://127.0.0.1:${port}/index.html`);
+      const res = await fetch(`http://127.0.0.1:${port}/index.html`);
+      expect(res.status).toBe(200);
+    } finally {
+      native.stopDevServer(handle);
+    }
+  });
+
+  test('getDevServerPort 가 stopped handle 에 throw', () => {
+    const port = reservePort();
+    const handle = native.startDevServer({ rootDir: tmpRoot, port, host: '127.0.0.1' });
+    native.stopDevServer(handle);
+    expect(() => native.getDevServerPort(handle)).toThrow(/stopped/);
+  });
+
+  test('getDevServerPort 가 non-handle 에 throw', () => {
+    expect(() => (native.getDevServerPort as any)({})).toThrow(/handle/);
+    expect(() => (native.getDevServerPort as any)(null)).toThrow(/handle/);
+  });
+
+  test('quiet:false → banner stderr 출력 (PR-G3 quiet 기능 — 명시 false)', () => {
+    // 본 test 는 stderr capture 가 어려우니 동작 자체만 검증 (throw 없음).
+    const port = reservePort();
+    const handle = native.startDevServer({
+      rootDir: tmpRoot,
+      port,
+      host: '127.0.0.1',
+      quiet: false,
+    });
+    native.stopDevServer(handle);
   });
 
   // GC-only cleanup (no explicit stopDevServer) — finalize callback 가 자동 정리한다는


### PR DESCRIPTION
## Summary
PR-G2 (#3906) 후속 — NAPI embed UX 3종 추가:
1. **\`quiet?\` 옵션** — stderr banner + listen-fail log silence. NAPI default true (Vite plugin 등 embed 가정).
2. **port 0 (OS-assigned ephemeral)** — \`port: 0\` 으로 시작 시 OS 가 free port 할당. 일반 test fixture / dynamic 환경.
3. **\`getDevServerPort(handle)\`** — 실 bound port 조회 (port=0 사용 시 핵심).

## Why
- 이전 PR-G2 는 listen 성공 후 banner 가 stderr 로 출력 → Vite plugin / Bun test 등 embed 시 노이즈.
- port hard-coded 강요는 test fixture / dynamic 환경에서 충돌 위험. \`port: 0\` 가 표준 패턴.

## 주요 변경

### \`src/server/dev_server.zig\`
- \`Options.quiet: bool = false\` (CLI 기본 false / NAPI 명시 true).
- struct field + init forward + start() 의 banner/error log 가드.
- listen 후 \`self.port = tcp_server.listen_address.getPort()\` 로 실 값 갱신.
- atomic \`listen_ready\` flag (release-store) — cross-thread publish.

### \`packages/core/src/napi/serve_entry.zig\`
- port range 0..65535.
- \`quiet\` default true.
- 새 \`napiGetDevServerPort(handle)\` — listen_ready acquire-load polling (10ms × 100 = 1s 한도) 후 실 port 반환.

### \`packages/core/src/napi_entry.zig\` + \`packages/core/index.ts\`
\`getDevServerPort\` 등록 (16 exports) + interface + JSDoc + scope disclaimer (quiet 가 banner+listen 한정).

### Tests
4 신규 — port 0 round-trip (race detector w/ \`expect(port).not.toBe(0)\`), stopped handle throw, non-handle throw, quiet:false explicit. 기존 port=0 throw test 는 70000 만 검증하게 갱신.

## Self-review fixes (PR-G3 review)

| ID | Severity | 내용 |
| --- | --- | --- |
| F1 | **critical** | napiGetDevServerPort 의 non-atomic cross-thread read → ARM64 (Apple Silicon) reorder 로 silent stale 0 반환 가능. atomic \`listen_ready\` + acquire/release fence |
| F3 | medium | quiet scope 가 banner+listen 한정 → JSDoc disclaimer |
| F5 | low | polling magic number 상수화 |
| F6 | low | port=0 test 에 race detector assertion |

## 검증
- \`zig build napi\` clean rebuild OK
- HTTP + HTTPS + port 0 + getDevServerPort 모두 통과
- 15 unit/E2E case 통과
- \`zig build test\` + \`tsc -b --force\` 통과

## 후속
- F2: worker_threads handle race UAF (별도 PR)
- F3: routine log quiet 범위 확장 (HMR / WS / watcher / bundle / request)
- F7: getDevServerPort 의 thread fail 명시 surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)