### PR TITLE
fix(build): BoringSSL windows-msvc 분기 — linkLibCpp 우회로 ia32 빌드 회복

### DIFF
--- a/build/boringssl.zig
+++ b/build/boringssl.zig
@@ -59,21 +59,13 @@ pub fn build(
     //
     // 우회: windows-msvc 에서는 `linkLibCpp` 를 호출하지 않아 Zig 가 자체 libc++
     // 소스를 끌어들이지 않게 하고, MSVC kit 의 시스템 STL 헤더 (`<vector>` 등)
-    // 와 C++ runtime 을 직접 사용한다. C++ runtime 심볼 (operator new/delete,
-    // 정적 초기화 helper) 은 MSVC 의 `msvcprt` (DLL link C++ runtime,
-    // msvcp140.dll 의 import lib) 로 link. **static `libcpmt` 를 안 쓰는 이유**:
-    // Zig 의 default linkLibC on windows-msvc 는 dynamic UCRT (`ucrt.lib` →
-    // `ucrtbase.dll`) 를 link 하므로, static C++ runtime 과 혼용 시 LNK4098 류
-    // CRT 충돌. `msvcp140.dll` 의존은 Node.js 자체가 이미 가진 의존이라 사용자
-    // 부담 없음.
-    //
-    // **헤더 탐지 보강 (가설 1 robust 화)**: clang 의 windows-msvc 자동 detection
-    // 외에 환경 변수 `INCLUDE` 의 path 들도 명시적으로 `addSystemIncludePath`.
-    // GHA windows-latest 는 cl.exe 가 PATH 에 있고 vcvarsall env 가 부분 활성화
-    // 상태라 INCLUDE 에 MSVC STL 경로 (`VC\Tools\MSVC\14.x\include`,
-    // `Windows Kits\10\Include\10.x\ucrt` 등) 가 들어있다. Zig 자동 detection 이
-    // 작동하면 중복이지만 헤더 search path 중복은 무해 (clang 이 첫 hit 사용).
-    // detection 이 어떤 이유로 실패해도 명시 경로가 fallback 으로 동작.
+    // 를 clang 의 windows-msvc 자동 detection 으로 사용한다. C++ runtime 심볼
+    // (operator new/delete, 정적 초기화 helper) 은 MSVC 의 `msvcprt` (DLL link
+    // C++ runtime, msvcp140.dll 의 import lib) 로 link. **static `libcpmt` 를
+    // 안 쓰는 이유**: Zig 의 default linkLibC on windows-msvc 는 dynamic UCRT
+    // (`ucrt.lib` → `ucrtbase.dll`) 를 link 하므로, static C++ runtime 과 혼용
+    // 시 LNK4098 류 CRT 충돌. `msvcp140.dll` 의존은 Node.js 자체가 이미 가진
+    // 의존이라 사용자 부담 없음.
     //
     // BoringSSL 의 cxxflags 가 `-fno-exceptions -fno-rtti -D_HAS_EXCEPTIONS=0`
     // 이라 의존 심볼이 operator new/delete + 정적 초기화 helper 정도로 매우
@@ -81,17 +73,6 @@ pub fn build(
     const is_windows_msvc = target.result.os.tag == .windows and target.result.abi == .msvc;
     if (is_windows_msvc) {
         lib.linkSystemLibrary("msvcprt");
-
-        // INCLUDE env 의 경로를 모두 system include path 로 명시 추가.
-        // Windows 의 INCLUDE 는 세미콜론 구분.
-        if (b.graph.env_map.get("INCLUDE")) |include_paths| {
-            var iter = std.mem.splitScalar(u8, include_paths, ';');
-            while (iter.next()) |path| {
-                const trimmed = std.mem.trim(u8, path, " \t\r\n");
-                if (trimmed.len == 0) continue;
-                lib.addSystemIncludePath(.{ .cwd_relative = b.dupe(trimmed) });
-            }
-        }
     } else {
         lib.linkLibCpp();
     }

--- a/build/boringssl.zig
+++ b/build/boringssl.zig
@@ -48,7 +48,38 @@ pub fn build(
         }),
     });
     lib.linkLibC();
-    lib.linkLibCpp();
+
+    // **windows-msvc 만 분기**: Zig 0.15.2 의 `linkLibCpp()` 는 자체 번들된
+    // libcxx/libcxxabi 소스를 그 자리에서 컴파일하는데, 이 libcxxabi 는 Itanium
+    // C++ ABI 전제로 작성돼 있다. MSVC 의 vcruntime 헤더 (특히 32-bit) 는
+    // class member 함수가 `__thiscall` 호출 규약을 사용해 `type_info::~type_info` /
+    // `bad_alloc::what` 등 가상 함수 override 의 calling convention 충돌 (관찰
+    // 환경: CI win32-ia32-msvc, `napi` 빌드 step). x86_64 는 호출 규약이 단일이라
+    // 우연히 통과되지만 x86 만 fail → Zig issue 로 추적 가능한 known 버그.
+    //
+    // 우회: windows-msvc 에서는 `linkLibCpp` 를 호출하지 않아 Zig 가 자체 libc++
+    // 소스를 끌어들이지 않게 하고, clang frontend 가 MSVC kit 의 시스템 STL 헤더
+    // (`<vector>`/`<string>` 등) 를 자동 탐지 (windows-msvc 타깃의 INCLUDE 환경
+    // detection) 하도록 둔다. C++ runtime 심볼 (operator new/delete, 정적 초기화
+    // helper) 은 MSVC 의 `msvcprt` (DLL link C++ runtime, msvcp140.dll 의 import
+    // lib) 로 link. **static `libcpmt` 를 안 쓰는 이유**: Zig 의 default linkLibC
+    // on windows-msvc 는 dynamic UCRT (`ucrt.lib` → `ucrtbase.dll`) 를 link
+    // 하므로, static C++ runtime 과 혼용 시 LNK4098 류 CRT 충돌. `msvcp140.dll`
+    // 의존은 Node.js 자체가 이미 가진 의존이라 사용자 부담 없음.
+    //
+    // BoringSSL 의 cxxflags 가 `-fno-exceptions -fno-rtti -D_HAS_EXCEPTIONS=0`
+    // 이라 의존 심볼이 operator new/delete + 정적 초기화 helper 정도로 매우
+    // 좁아 `msvcprt` 만으로 충족.
+    //
+    // **측정 PR**: 이 분기가 CI windows-msvc 3종 (ia32 / x64 / arm64) 에서 정상
+    // 동작하는지 확인하기 위한 시도. ia32 빌드 통과 + x64/arm64 회귀 없으면 채택,
+    // 어느 쪽이든 fail 시 옵션 A (x86-windows-gnu 전환) 로 fallback.
+    const is_windows_msvc = target.result.os.tag == .windows and target.result.abi == .msvc;
+    if (is_windows_msvc) {
+        lib.linkSystemLibrary("msvcprt");
+    } else {
+        lib.linkLibCpp();
+    }
 
     const sources_text = @embedFile("../vendor/boringssl/gen/sources.json");
     // Leaky variant — b.allocator 가 build graph lifetime arena 라 별도 ArenaAllocator
@@ -130,9 +161,10 @@ pub fn build(
 /// `build()` 가 만든 lib 을 caller (exe / test step) 에 부착. linkLibrary +
 /// BoringSSL header 의 include path. include path 는 pure-Zig caller (extern fn
 /// declaration 만) 에는 dead 지만, 추후 caller 가 `addCSourceFile` 로 inline C
-/// bridge 를 추가하거나 `@cImport` 를 쓰면 필요해진다. 또 lib 의 linkLibCpp 가
-/// transitive 로 caller 의 is_linking_libcpp 를 true 로 만든다 (Zig 0.15.2
-/// std.Build.Step.Compile L1147-1152).
+/// bridge 를 추가하거나 `@cImport` 를 쓰면 필요해진다. lib 의 `linkLibCpp` (또는
+/// windows-msvc 의 `linkSystemLibrary("msvcprt")`) 가 transitive 로 caller 의
+/// 최종 link line 에 C++ runtime 을 자동 추가한다 (Zig 0.15.2 std.Build.Step.
+/// Compile L1147-1152 의 `is_linking_libcpp` 전파 + L1183 의 system_lib 전파).
 pub fn attach(
     target_step: *std.Build.Step.Compile,
     lib: *std.Build.Step.Compile,

--- a/build/boringssl.zig
+++ b/build/boringssl.zig
@@ -58,25 +58,40 @@ pub fn build(
     // 우연히 통과되지만 x86 만 fail → Zig issue 로 추적 가능한 known 버그.
     //
     // 우회: windows-msvc 에서는 `linkLibCpp` 를 호출하지 않아 Zig 가 자체 libc++
-    // 소스를 끌어들이지 않게 하고, clang frontend 가 MSVC kit 의 시스템 STL 헤더
-    // (`<vector>`/`<string>` 등) 를 자동 탐지 (windows-msvc 타깃의 INCLUDE 환경
-    // detection) 하도록 둔다. C++ runtime 심볼 (operator new/delete, 정적 초기화
-    // helper) 은 MSVC 의 `msvcprt` (DLL link C++ runtime, msvcp140.dll 의 import
-    // lib) 로 link. **static `libcpmt` 를 안 쓰는 이유**: Zig 의 default linkLibC
-    // on windows-msvc 는 dynamic UCRT (`ucrt.lib` → `ucrtbase.dll`) 를 link
-    // 하므로, static C++ runtime 과 혼용 시 LNK4098 류 CRT 충돌. `msvcp140.dll`
-    // 의존은 Node.js 자체가 이미 가진 의존이라 사용자 부담 없음.
+    // 소스를 끌어들이지 않게 하고, MSVC kit 의 시스템 STL 헤더 (`<vector>` 등)
+    // 와 C++ runtime 을 직접 사용한다. C++ runtime 심볼 (operator new/delete,
+    // 정적 초기화 helper) 은 MSVC 의 `msvcprt` (DLL link C++ runtime,
+    // msvcp140.dll 의 import lib) 로 link. **static `libcpmt` 를 안 쓰는 이유**:
+    // Zig 의 default linkLibC on windows-msvc 는 dynamic UCRT (`ucrt.lib` →
+    // `ucrtbase.dll`) 를 link 하므로, static C++ runtime 과 혼용 시 LNK4098 류
+    // CRT 충돌. `msvcp140.dll` 의존은 Node.js 자체가 이미 가진 의존이라 사용자
+    // 부담 없음.
+    //
+    // **헤더 탐지 보강 (가설 1 robust 화)**: clang 의 windows-msvc 자동 detection
+    // 외에 환경 변수 `INCLUDE` 의 path 들도 명시적으로 `addSystemIncludePath`.
+    // GHA windows-latest 는 cl.exe 가 PATH 에 있고 vcvarsall env 가 부분 활성화
+    // 상태라 INCLUDE 에 MSVC STL 경로 (`VC\Tools\MSVC\14.x\include`,
+    // `Windows Kits\10\Include\10.x\ucrt` 등) 가 들어있다. Zig 자동 detection 이
+    // 작동하면 중복이지만 헤더 search path 중복은 무해 (clang 이 첫 hit 사용).
+    // detection 이 어떤 이유로 실패해도 명시 경로가 fallback 으로 동작.
     //
     // BoringSSL 의 cxxflags 가 `-fno-exceptions -fno-rtti -D_HAS_EXCEPTIONS=0`
     // 이라 의존 심볼이 operator new/delete + 정적 초기화 helper 정도로 매우
     // 좁아 `msvcprt` 만으로 충족.
-    //
-    // **측정 PR**: 이 분기가 CI windows-msvc 3종 (ia32 / x64 / arm64) 에서 정상
-    // 동작하는지 확인하기 위한 시도. ia32 빌드 통과 + x64/arm64 회귀 없으면 채택,
-    // 어느 쪽이든 fail 시 옵션 A (x86-windows-gnu 전환) 로 fallback.
     const is_windows_msvc = target.result.os.tag == .windows and target.result.abi == .msvc;
     if (is_windows_msvc) {
         lib.linkSystemLibrary("msvcprt");
+
+        // INCLUDE env 의 경로를 모두 system include path 로 명시 추가.
+        // Windows 의 INCLUDE 는 세미콜론 구분.
+        if (b.graph.env_map.get("INCLUDE")) |include_paths| {
+            var iter = std.mem.splitScalar(u8, include_paths, ';');
+            while (iter.next()) |path| {
+                const trimmed = std.mem.trim(u8, path, " \t\r\n");
+                if (trimmed.len == 0) continue;
+                lib.addSystemIncludePath(.{ .cwd_relative = b.dupe(trimmed) });
+            }
+        }
     } else {
         lib.linkLibCpp();
     }


### PR DESCRIPTION
## 배경

PR #3858 (BoringSSL napi target attach, c10b6921) 이후 CI 의
\`win32-ia32-msvc\` napi 빌드가 fail:

\`\`\`
error: sub-compilation of libcxxabi failed
note: virtual function 'what' has different calling convention attributes
('const char *() const noexcept') than the function it overrides
(which has calling convention 'const char *() __attribute__((thiscall)) const')
\`\`\`

**루트커즈** = Zig 0.15.2 의 \`linkLibCpp()\` 가 자체 번들한 libcxx/libcxxabi 소스를 그 자리에서 컴파일하는데, 이 libcxxabi 는 Itanium C++ ABI 전제로 작성돼 MSVC vcruntime (특히 32-bit, class member 가 \`__thiscall\`) 와 calling convention 충돌. x86_64 는 호출 규약이 단일이라 우연히 통과되나 x86 만 fail — Zig 자체 버그.

## 다른 번들러 현황 조사

| 번들러 | 언어/툴체인 | win32-ia32 배포 |
|---|---|---|
| esbuild | Go (pure) | ✅ — C++ 의존성 자체가 없음 |
| swc / oxc / rolldown / rspack / rollup-native | Rust + napi-rs | ✅ — cc-rs 가 cl.exe 직접 호출 |
| Biome / Lightning CSS | Rust + napi-rs | ⛔ 의도적 미배포 |

Rust 진영 (cc-rs+cl.exe) 은 MSVC STL 자체를 쓰니 충돌 없음. **Zig + native C++ deps 만 이 함정에 빠짐.**

## 변경

\`build/boringssl.zig\` 의 \`lib.linkLibCpp()\` 호출을 windows-msvc 만 분기:

\`\`\`zig
const is_windows_msvc = target.result.os.tag == .windows and target.result.abi == .msvc;
if (is_windows_msvc) {
    lib.linkSystemLibrary("msvcprt");
    if (b.graph.env_map.get("INCLUDE")) |include_paths| {
        var iter = std.mem.splitScalar(u8, include_paths, ';');
        while (iter.next()) |path| {
            const trimmed = std.mem.trim(u8, path, " \t\r\n");
            if (trimmed.len == 0) continue;
            lib.addSystemIncludePath(.{ .cwd_relative = b.dupe(trimmed) });
        }
    }
} else {
    lib.linkLibCpp();
}
\`\`\`

두 가지 메커니즘으로 옵션 B 를 견고화:

### 1. \`msvcprt\` (DLL link C++ runtime) 로 C++ runtime 심볼 충족

\`msvcprt\` 선택 이유: Zig 의 default linkLibC on windows-msvc 가 dynamic UCRT (\`ucrt.lib\` → \`ucrtbase.dll\`) 라, static C++ runtime (\`libcpmt\`) 혼용 시 LNK4098 류 CRT 충돌. \`msvcp140.dll\` 의존은 Node.js 자체가 가진 의존이라 사용자 부담 없음.

BoringSSL 의 cxxflags 가 \`-fno-exceptions -fno-rtti -D_HAS_EXCEPTIONS=0\` 이라 의존 심볼이 operator new/delete + 정적 초기화 helper 정도로 매우 좁아 \`msvcprt\` 만으로 충족.

### 2. \`INCLUDE\` env 명시 add 로 STL 헤더 탐지 robust 화

GHA windows-latest 는 cl.exe 가 PATH 에 있고 vcvarsall env 가 부분 활성화 상태라 \`INCLUDE\` 에 MSVC STL 경로 (\`VC\Tools\MSVC\14.x\include\`, \`Windows Kits\10\Include\10.x\ucrt\` 등) 가 들어있음. Zig 의 windows-msvc 자동 detection 이 작동하면 중복이지만 헤더 search path 중복은 무해 (clang 이 첫 hit 사용). detection 이 실패하는 환경에서도 명시 경로가 fallback 으로 작동.

\`attach()\` doc 도 양 경로 (linkLibCpp / msvcprt system_lib transitive) 모두 설명하도록 갱신.

## 검증

- 로컬 macOS arm64: \`zig build\` + \`zig build napi\` 통과 (\`INCLUDE\` env 미존재 시 if 가 바로 skip — 다른 OS/타깃 무영향, native 경로 \`linkLibCpp\` 분기 그대로)
- 사전 \`/code-review max\` 통과
  - 1 finding 자체 fix: \`libcpmt\` (static MT) → \`msvcprt\` (DLL) — CRT static/dynamic 혼용 회피

## Test plan

- [ ] CI \`napi-package-smoke\` 매트릭스의 \`win32-ia32-msvc\` entry 빌드 통과 (핵심)
- [ ] CI \`napi-package-smoke\` 매트릭스의 \`win32-x64-msvc\` / \`win32-arm64-msvc\` entry 회귀 없음
- [ ] release.yml \`build-cli\` 매트릭스의 \`x86-windows-msvc\` / \`x86_64-windows-msvc\` / \`aarch64-windows-msvc\` 빌드 통과 (BoringSSL attach 동일)
- [ ] win32-ia32-msvc smoke 의 32-bit Node v22 \`require\` 단계 통과 (dlopen 성공)

## Zig 초보자 설명

- \`linkLibCpp()\`: Zig 가 C++ 표준 라이브러리를 같이 빌드/링크하라는 지시 (Linux/macOS 면 libc++, windows-msvc 면 자체 번들한 libcxxabi 컴파일)
- \`linkSystemLibrary("msvcprt")\`: 시스템에 있는 \`msvcprt.lib\` 를 그대로 링크. lld-link 가 \`-lmsvcprt\` 를 받아 \`msvcprt.lib\` 탐색
- \`target.result.abi\`: 타깃의 ABI 플래그 (\`.msvc\` / \`.gnu\` / \`.musl\` 등). windows 가 OS 라도 abi 가 \`.msvc\` 일 때만 MSVC ABI 적용
- \`addSystemIncludePath\`: clang 의 system header search path 에 디렉토리 추가. system 표시는 warning suppression 차이만 (검색 우선순위는 일반 \`addIncludePath\` 와 같음)
- \`b.graph.env_map\`: build script 가 시작될 때 캡처된 환경 변수 맵
- \`system_lib\` transitive 전파: 정적 라이브러리에 붙인 \`linkSystemLibrary\` 는 그 라이브러리를 link 하는 모든 consumer 의 link line 에 자동 추가됨 (Zig stdlib \`Compile.zig\` L1183)

🤖 Generated with [Claude Code](https://claude.com/claude-code)