### PR TITLE
test(napi): NativeModule parity test + quiet-scope doc canonical 참조

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -580,9 +580,10 @@ export interface StartDevServerOptions {
   /** HTTPS key (PEM). certPath 와 함께 줘야. */
   keyPath?: string;
   /**
-   * stderr 의 banner + 모든 routine log (request access 200/500, HMR / WS /
-   * watcher / sse / bundle progress / cache reset) silence. NAPI embed
-   * default true (자체 logger 가정). false 로 명시하면 stderr 출력.
+   * stderr 의 banner + 모든 routine log silence. NAPI embed default true
+   * (자체 logger 가정). false 로 명시하면 stderr 출력. quiet 가드되는 카테고리
+   * 전체 리스트는 `src/server/dev_server.zig` 의 `DevServer.routineLog` doc
+   * (CANONICAL SCOPE LIST) 참조 — 단일 진실 소스.
    *
    * **critical 진단은 quiet 와 무관 항상 stderr** — init failure (cert 로드 /
    * 디렉토리 못 찾음 / overlay sentinel), start fatal (host parse / listen 실패

--- a/packages/core/src/napi/serve_entry.zig
+++ b/packages/core/src/napi/serve_entry.zig
@@ -171,8 +171,9 @@ pub fn napiStartDevServer(env: c.napi_env, info: c.napi_callback_info) callconv(
 
     const open = getObjectBool(env, argv[0], "open", false);
     // NAPI embed 는 자체 logger 가 있는 경우가 많아 default quiet=true. 사용자가
-    // 명시 false 면 stderr 에 banner + 모든 routine log (request access / HMR /
-    // WS / watcher / sse / bundle progress / cache reset) 출력.
+    // 명시 false 면 stderr 에 banner + 모든 routine log 출력. 카테고리 전체
+    // 리스트는 src/server/dev_server.zig 의 `DevServer.routineLog` doc 의
+    // CANONICAL SCOPE LIST 참조 (단일 진실 소스).
     // **critical 진단 (init failure / start fatal / deinit UAF) 은 quiet 와 무관
     // 하게 항상 stderr** — 사용자가 throw 메시지 너머 진단 못 보면 NAPI throwError
     // generic 메시지로 root cause 추적 불가.

--- a/src/napi_parity_test.zig
+++ b/src/napi_parity_test.zig
@@ -1,0 +1,224 @@
+//! NAPI export ↔ TS `NativeModule` interface parity 검증.
+//!
+//! `packages/core/src/napi_entry.zig` 의 `napi_register_module_v1` 가 `exports`
+//! 에 set 하는 함수 이름과, `packages/core/index.ts` 의 `interface NativeModule`
+//! 멤버가 1:1 로 일치해야 한다. 두 사이트는 별개 파일에 hand-maintain 되므로
+//! 한쪽만 수정하면 컴파일은 통과하고 **runtime 에서만** `TypeError:
+//! ensureNative().X is not a function` 으로 터진다.
+//!
+//! 본 테스트는 두 파일을 파싱해 양쪽 집합이 일치하는지 검증.
+//!
+//! 검증 원칙:
+//!   - NAPI 측에서 export 한 이름은 전부 TS NativeModule 에 존재해야 함.
+//!   - TS NativeModule 멤버는 전부 NAPI 측에서 export 돼야 함.
+//!   - 예외는 allowlist 에 등록.
+//!
+//! 파일 경로는 저장소 루트 기준. CI 외 환경에서는 SkipZigTest.
+
+const std = @import("std");
+
+/// TS NativeModule 에만 있고 NAPI 측에 없는 멤버 — 현재는 없음. 의도된 추가 시
+/// 여기 등록.
+const ts_only_allowlist = [_][]const u8{};
+
+/// NAPI 측에서만 export 하고 TS NativeModule 에 없는 이름 — 현재는 없음. 의도된
+/// 추가 시 (e.g. 내부 전용 helper) 여기 등록.
+const napi_only_allowlist = [_][]const u8{};
+
+/// `napi_register_module_v1` 본문에서 `napi_set_named_property(env, exports, "X", ...)`
+/// 패턴의 `X` 들을 추출. 단순 substring 스캔 — comment / string literal 안의 매칭은
+/// 발생 안 함 (zig source 에 동일 패턴이 자연스럽게 나올 일 없음).
+fn parseNapiExports(
+    source: []const u8,
+    list: *std.ArrayList([]const u8),
+    allocator: std.mem.Allocator,
+) !void {
+    const marker = "napi_set_named_property(env, exports, \"";
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, source, i, marker)) |hit| {
+        const name_start = hit + marker.len;
+        const name_end = std.mem.indexOfScalarPos(u8, source, name_start, '"') orelse return error.MalformedExport;
+        try list.append(allocator, source[name_start..name_end]);
+        i = name_end + 1;
+    }
+}
+
+/// TS interface 본문에서 멤버 이름을 추출. `interface NativeModule {` 본문 안에서
+/// 각 줄의 첫 식별자가 `:` / `(` / `?:` / `?(` 로 끝나면 멤버.
+/// 주석 (`//`, `/**`, `*`) 과 빈 줄은 스킵. nested object literal 의 inner 필드는
+/// depth 추적으로 무시 (NativeModule 의 method 만 잡음).
+fn parseTsInterface(
+    source: []const u8,
+    interface_name: []const u8,
+    list: *std.ArrayList([]const u8),
+    allocator: std.mem.Allocator,
+) !void {
+    var marker_buf: [128]u8 = undefined;
+    const marker = try std.fmt.bufPrint(&marker_buf, "interface {s} {{", .{interface_name});
+    const body_start = (std.mem.indexOf(u8, source, marker) orelse return error.InterfaceNotFound) + marker.len;
+    var depth: usize = 1;
+    var i: usize = body_start;
+    var body_end = body_start;
+    while (i < source.len and depth > 0) : (i += 1) {
+        switch (source[i]) {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if (depth == 0) body_end = i;
+            },
+            else => {},
+        }
+    }
+    const body = source[body_start..body_end];
+
+    // 줄 단위 + brace/paren depth 추적으로 top-level 멤버만 잡음.
+    // `transpile(source: string)` 같은 멤버는 `(` 가 그 줄 끝까지 안 닫히면
+    // 다음 줄들 (`source: string,`) 은 line_depth>0 으로 잡혀 무시됨.
+    var line_depth: i32 = 0;
+    var line_iter = std.mem.splitScalar(u8, body, '\n');
+    while (line_iter.next()) |raw_line| {
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        const indent_depth = line_depth;
+        for (raw_line) |ch| {
+            switch (ch) {
+                '{', '(' => line_depth += 1,
+                '}', ')' => line_depth -= 1,
+                else => {},
+            }
+        }
+        if (indent_depth != 0) continue; // nested 안 — 무시
+        if (line.len == 0) continue;
+        if (std.mem.startsWith(u8, line, "//")) continue;
+        if (std.mem.startsWith(u8, line, "*")) continue;
+        if (std.mem.startsWith(u8, line, "/*")) continue;
+        if (std.mem.startsWith(u8, line, "}")) continue;
+
+        // 식별자 추출.
+        var end: usize = 0;
+        while (end < line.len and (std.ascii.isAlphanumeric(line[end]) or line[end] == '_')) end += 1;
+        if (end == 0) continue;
+        const name = line[0..end];
+        const after = line[end..];
+        // `method(` 또는 `prop?(` 또는 `prop:` / `prop?:` 형태.
+        const is_member = std.mem.startsWith(u8, after, "(") or
+            std.mem.startsWith(u8, after, "?(") or
+            std.mem.startsWith(u8, after, ":") or
+            std.mem.startsWith(u8, after, "?:");
+        if (!is_member) continue;
+
+        // 중복 방지 (overload signature 같은 경우).
+        var dup = false;
+        for (list.items) |existing| {
+            if (std.mem.eql(u8, existing, name)) {
+                dup = true;
+                break;
+            }
+        }
+        if (!dup) try list.append(allocator, name);
+    }
+}
+
+fn contains(haystack: []const []const u8, needle: []const u8) bool {
+    for (haystack) |s| if (std.mem.eql(u8, s, needle)) return true;
+    return false;
+}
+
+test "schema diff: NAPI exports == TS NativeModule members" {
+    const allocator = std.testing.allocator;
+
+    const napi_source = std.fs.cwd().readFileAlloc(
+        allocator,
+        "packages/core/src/napi_entry.zig",
+        2 * 1024 * 1024,
+    ) catch |err| {
+        if (err == error.FileNotFound) return error.SkipZigTest;
+        return err;
+    };
+    defer allocator.free(napi_source);
+
+    const ts_source = std.fs.cwd().readFileAlloc(
+        allocator,
+        "packages/core/index.ts",
+        2 * 1024 * 1024,
+    ) catch |err| {
+        if (err == error.FileNotFound) return error.SkipZigTest;
+        return err;
+    };
+    defer allocator.free(ts_source);
+
+    var napi_names: std.ArrayList([]const u8) = .empty;
+    defer napi_names.deinit(allocator);
+    try parseNapiExports(napi_source, &napi_names, allocator);
+    try std.testing.expect(napi_names.items.len > 0);
+
+    var ts_names: std.ArrayList([]const u8) = .empty;
+    defer ts_names.deinit(allocator);
+    try parseTsInterface(ts_source, "NativeModule", &ts_names, allocator);
+    try std.testing.expect(ts_names.items.len > 0);
+
+    // 1. NAPI export 가 TS NativeModule 에 모두 존재해야 함.
+    for (napi_names.items) |napi_name| {
+        if (contains(ts_names.items, napi_name)) continue;
+        if (contains(&ts_only_allowlist, napi_name)) continue;
+        if (contains(&napi_only_allowlist, napi_name)) continue;
+        std.debug.print(
+            "\n[NativeModule parity drift] NAPI export '{s}' is not declared in TS `interface NativeModule` " ++
+                "(packages/core/index.ts). " ++
+                "Add the method signature there, or register '{s}' in napi_only_allowlist if intentional.\n",
+            .{ napi_name, napi_name },
+        );
+        return error.NapiExportMissingFromTs;
+    }
+
+    // 2. TS NativeModule 멤버가 NAPI export 에 모두 존재해야 함.
+    for (ts_names.items) |ts_name| {
+        if (contains(napi_names.items, ts_name)) continue;
+        if (contains(&ts_only_allowlist, ts_name)) continue;
+        std.debug.print(
+            "\n[NativeModule parity drift] TS NativeModule.{s} has no matching NAPI export in " ++
+                "packages/core/src/napi_entry.zig. " ++
+                "Add the `napi_set_named_property(env, exports, \"{s}\", ...)` call, " ++
+                "or add '{s}' to ts_only_allowlist if intentional.\n",
+            .{ ts_name, ts_name, ts_name },
+        );
+        return error.TsMemberMissingFromNapi;
+    }
+}
+
+test "parseNapiExports: basic extraction" {
+    const source =
+        \\    _ = c.napi_create_function(env, "foo", "foo".len, foo_fn, null, &fn_value);
+        \\    _ = c.napi_set_named_property(env, exports, "foo", fn_value);
+        \\    _ = c.napi_set_named_property(env, exports, "bar", bar_fn);
+    ;
+    var list: std.ArrayList([]const u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try parseNapiExports(source, &list, std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 2), list.items.len);
+    try std.testing.expectEqualStrings("foo", list.items[0]);
+    try std.testing.expectEqualStrings("bar", list.items[1]);
+}
+
+test "parseTsInterface: basic extraction with methods and nested object" {
+    const source =
+        \\interface Other { x: number }
+        \\interface NativeModule {
+        \\  /** doc */
+        \\  transpile(source: string): void;
+        \\  tokenize(source: string): TokenizeToken[];
+        \\  benchmark(opts: Record<string, unknown>): {
+        \\    phases: Record<string, { samples: number }>;
+        \\  };
+        \\  // inline comment
+        \\  watch(opts: Record<string, unknown>): NativeWatchHandle;
+        \\}
+    ;
+    var list: std.ArrayList([]const u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try parseTsInterface(source, "NativeModule", &list, std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 4), list.items.len);
+    try std.testing.expectEqualStrings("transpile", list.items[0]);
+    try std.testing.expectEqualStrings("tokenize", list.items[1]);
+    try std.testing.expectEqualStrings("benchmark", list.items[2]);
+    try std.testing.expectEqualStrings("watch", list.items[3]);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -63,4 +63,5 @@ test {
     // test files
     _ = @import("config_test.zig");
     _ = @import("config_options_dto_test.zig");
+    _ = @import("napi_parity_test.zig");
 }

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -28,8 +28,21 @@ pub const DevServer = struct {
     /// Routine log helper — `quiet=true` 면 silent. instance method 안에서 사용.
     /// CLI 환경 (default quiet=false) 은 그대로 출력, NAPI embed 는 silent.
     ///
-    /// **scope (quiet 가드 됨)**: routine progress 만 — request access (200/500),
-    /// HMR / WS / watcher / sse / bundle progress / cache reset etc.
+    /// ── CANONICAL SCOPE LIST ─────────────────────────────────────────────────
+    /// quiet 가드되는 routine progress 카테고리 (단일 진실 소스):
+    ///   1. request access (200/500)
+    ///   2. HMR
+    ///   3. WS
+    ///   4. watcher
+    ///   5. sse
+    ///   6. bundle progress
+    ///   7. cache reset
+    ///
+    /// 카테고리 추가/제거 시 본 리스트를 갱신 + 다음 사이트도 sync 필수:
+    ///   - dev_server.zig `Options.quiet` field doc (직접 enumerate)
+    ///   - packages/core/src/napi/serve_entry.zig napiStartDevServer 주석
+    ///   - packages/core/index.ts `StartDevServerOptions.quiet` TSDoc
+    /// 세 사이트는 본 canonical 리스트를 가리키는 "see" 참조만 유지.
     ///
     /// **scope 외 (quiet 와 무관 항상 stderr)**: critical 진단 — init failure (cert
     /// 로드/디렉토리/overlay sentinel), start fatal (host parse / listen fail / watch
@@ -125,11 +138,12 @@ pub const DevServer = struct {
         /// 둘 다 null 이면 plain HTTP. 한쪽만 set 하면 init error (`error.TlsKeyMissing`).
         cert_path: ?[]const u8 = null,
         key_path: ?[]const u8 = null,
-        /// banner + routine log (request access, HMR / WS / watcher /
-        /// sse / bundle progress) 모두 stderr silence. **critical** 진단 (init
-        /// failure, host/listen fatal, deinit UAF 경고) 은 quiet 와 무관하게 항상
-        /// 출력 — 사용자가 진단 못 보면 NAPI throwError generic 메시지로 root cause
-        /// 추적 불가. CLI 기본 false, NAPI embed default true.
+        /// banner + routine log silence. **critical** 진단 (init failure,
+        /// host/listen fatal, deinit UAF 경고) 은 quiet 와 무관하게 항상 출력.
+        /// CLI 기본 false, NAPI embed default true.
+        ///
+        /// quiet 가드되는 카테고리 전체 리스트는 `DevServer.routineLog` doc 의
+        /// CANONICAL SCOPE LIST 참조 (단일 진실 소스).
         quiet: bool = false,
     };
 


### PR DESCRIPTION
## Summary

PR #3913 (`MCP epic 전체 롤백`) 의 `/code-review max` follow-up 2건 처리.

### Follow-up 1 — NativeModule TS ↔ Zig NAPI export parity test (Finding I2)

`packages/core/index.ts` 의 `interface NativeModule` 과 `packages/core/src/napi_entry.zig` 의 `napi_register_module_v1` exports 사이 sync 가 수작업이라 한쪽만 수정하면 컴파일은 통과하고 **runtime 에서만** `TypeError` 로 터지는 silent drift 위험. 기존 `src/config_options_dto_test.zig` (TranspileOptions DTO parity) 패턴을 그대로 차용해 build-test 시점에 자동 검증.

- `src/napi_parity_test.zig` 신규
  - `parseNapiExports`: Zig source 에서 `napi_set_named_property(env, exports, "X", ...)` 패턴 추출
  - `parseTsInterface`: TS source 에서 `interface NativeModule {` 본문의 top-level 멤버 추출 (paren/brace depth 추적으로 nested object literal 무시)
  - 양쪽 집합 비교 — 어느 한쪽에만 있으면 drift 메시지 + fail
  - 의도된 비대칭은 `ts_only_allowlist` / `napi_only_allowlist` (현재 둘 다 빈 배열)
  - self-test 2개 — basic extraction 검증
- `src/root.zig` test block import 추가

현재 15개 NAPI export ↔ NativeModule 인터페이스 1:1 일치 확인됨.

### Follow-up 2 — quiet-scope doc copy-paste 정리 (Finding I4)

routine-log 카테고리 리스트 (`"request access, HMR / WS / watcher / sse / bundle progress / cache reset"`) 가 4 사이트에 verbatim copy-paste — `dev_server.zig:33`, `dev_server.zig:142`, `serve_entry.zig:175`, `index.ts:583`. 미래 카테고리 추가/제거 시 4× edit 강제.

enum 추출은 over-engineering 이라 **canonical 참조** 방식 채택:
- `src/server/dev_server.zig` `routineLog` doc 을 단일 진실 소스로 — 7개 카테고리 명시적 enumerate + 카테고리 변경 시 sync 필요한 3 사이트 명시
- 나머지 3 사이트는 "see `DevServer.routineLog` doc 의 CANONICAL SCOPE LIST" 한 줄로 단순화

drift 발생 시 grep `"CANONICAL SCOPE LIST"` 로 추적 가능.

## 검증

- ✅ `zig build` / `zig build test` exit 0 — `napi_parity_test."schema diff: NAPI exports == TS NativeModule members"` 통과
- ✅ `bun x tsc -b --force` exit 0
- ✅ `napi_parity_test` self-test 2개 통과

## Test plan

- [x] `zig build install` + `zig build test`
- [x] parity test fail 시나리오 수동 검증 (테스트 작성 중 transpile 시그니처의 `source` 가 잘못 잡혔던 nested object parsing 버그 잡음 — 이후 `(` / `)` depth 추적 추가로 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)