### PR TITLE
chore(ci): pin bun-version to 1.3.11 across all workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - uses: ./.github/actions/bun-cache
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - name: Audit AST addNode variants (#1797, #1802)
         run: bun scripts/audit_addnode_variants.ts --strict-cosmetic
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - uses: ./.github/actions/bun-cache
 
@@ -243,7 +243,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -400,7 +400,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - uses: ./.github/actions/bun-cache
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - uses: ./.github/actions/bun-cache
 

--- a/.github/workflows/napi-leak-gate.yml
+++ b/.github/workflows/napi-leak-gate.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - uses: ./.github/actions/bun-cache
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,7 +194,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       # registry-url 을 지정하면 setup-node 가 NPM_CONFIG_USERCONFIG 를 $RUNNER_TEMP/.npmrc
       # 로 설정해, 아래 Publish step 이 $HOME/.npmrc 에 쓴 토큰을 npm 이 무시한다.


### PR DESCRIPTION
## Summary
- CI workflow 8곳의 `bun-version: latest` → fixed pin `"1.3.11"` 통일 (integration.yml 이 이미 사용하는 같은 pin)
- 매 CI run 마다 Bun 버전이 달라져 measurement 재현성을 해치던 환경 차이 정정

## 변경 파일
- `.github/workflows/benchmark.yml` (1 곳)
- `.github/workflows/release.yml` (1 곳)
- `.github/workflows/docs.yml` (1 곳)
- `.github/workflows/napi-leak-gate.yml` (1 곳)
- `.github/workflows/ci.yml` (4 곳)

## 배경
이번 세션의 4-tool smoke 측정 (`RFC_MANGLER_SIZE_GAP_CLOSED.md` §7 도장, PR #3912) + baseline regenerate (PR #3915) 작업 중 로컬 Bun 1.3.11 과 CI `latest` 사이의 잠재 차이가 measurement 신뢰성 저해 요인으로 지적됨. Bun 업그레이드는 별도 PR 에서 의도적으로 진행하도록 명시.

## Test plan
- [x] `grep -rn "bun-version: latest" .github/workflows/` 0 줄 확인 (통일 완료)
- [ ] CI 통과 확인 (Bun 1.3.11 로 모든 잡 정상 실행)