### PR TITLE
feat(mangler): R1-a PR-2-a — FreeVarMap type + mangler input field (inert, byte-identical)

### DIFF
--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -91,6 +91,11 @@ pub const MangleInput = struct {
     /// `external_reserved` 가 *per-module* (예: Phase A 의 이 모듈 mangled 이름)
     /// 라면 본 필드는 *전 모듈 공통* (예: runtime helper 이름) 으로 분리된다.
     external_reserved_global: ?*const std.StringHashMap(void) = null,
+    /// R1-a (`RFC_MANGLER_SAFE_C2.md`) PR-2 inert infra — nested scope 의 free-var
+    /// (outer scope 의 사용 symbol set). default null 이면 mangler 가 보수 fallback
+    /// (`markAncestorPath` 전체 마킹) 그대로. PR-3 의 `ZNTC_R1A_PRECISE_REUSE` flag
+    /// ON 시만 reuse. borrowed — caller 소유 유지.
+    free_vars_per_scope: ?*const @import("../semantic/closure_analysis.zig").FreeVarMap = null,
 };
 
 /// Liveness 기반 mangling.

--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -57,6 +57,11 @@ pub const ModuleMangleInput = struct {
     /// pool 후보). false (bare scope-hoist) 는 top-level 이 한 scope 라 globally
     /// unique 필수. J-step3a (RFC #3288) 측정용.
     wrapper_isolated: bool = false,
+    /// R1-a (`RFC_MANGLER_SAFE_C2.md`) PR-2 inert infra — nested scope 의 free-var
+    /// (outer scope 의 사용 symbol set). default null 이면 mangler 가 보수 fallback
+    /// (`markAncestorPath` 전체 마킹) 그대로. PR-3 의 `ZNTC_R1A_PRECISE_REUSE` flag
+    /// ON 시만 reuse. borrowed — caller (linker/collectUnifiedInput) 소유 유지.
+    free_vars_per_scope: ?*const @import("../semantic/closure_analysis.zig").FreeVarMap = null,
 };
 
 /// Phase A 의 mangling 후보. 호출부가 빈도/필터링을 수행해 넘긴다

--- a/src/semantic/closure_analysis.zig
+++ b/src/semantic/closure_analysis.zig
@@ -1,0 +1,35 @@
+//! R1-a free-var (closure capture) 분석 — RFC `RFC_MANGLER_SAFE_C2.md` §4.2 PR-2 inert infra.
+//!
+//! 각 nested scope 가 *사용하는 outer scope 의 symbol set* 을 명시적 bitset 으로 보관.
+//! 현 main 의 `mangler.markAncestorPath` (전체 ancestor 마킹, RFC §2.1) 보수성을 R1-a PR-3
+//! 에서 *참조된 outer symbol 만* 회피하도록 좁히기 위한 입력 자료.
+//!
+//! **PR-2 단계는 inert** — `FreeVarMap` type 정의 + mangler input 의 `free_vars_per_scope`
+//! field (default null) 추가만. analyzer 가 build 하는 PR-2-b, mangler 가 사용하는 PR-3 는
+//! 별도 sub-PR. PR-2 자체는 코드 path 변경 0 → byte-identical 자동 보장.
+
+const std = @import("std");
+const scope_mod = @import("scope.zig");
+
+pub const ScopeId = scope_mod.ScopeId;
+
+/// scope_id → outer-ref symbol_id set.
+///
+/// key 는 `ScopeId.toIndex()` (u32), value 는 `DynamicBitSet` (symbol_id 인덱스 bit).
+/// caller (analyzer) 가 build 후 mangler input 에 borrow 로 전달. mangler 가 lookup 시
+/// `get(scope_id)` 가 null 이면 free-ref 없음 또는 분석 미수행 — 보수 fallback (현 동작).
+///
+/// 메모리: lib 별 평균 nested scope 수 × 평균 free-var symbol 수. zod ~수십 scope ×
+/// 수십 symbol = bitset 당 수 byte, 총 KB 미만. 큰 lib 도 MB 미만 예상.
+pub const FreeVarMap = std.AutoHashMap(u32, std.DynamicBitSet);
+
+/// R1-a kill-switch env flag. PR-2 단계는 항상 false 동작 (analyzer build path 없음).
+/// PR-2-b 부터 환경변수 `ZNTC_R1A_FREEVAR_INFRA` 로 활성화. PR-3 의 mangler reuse 는
+/// 별도 flag `ZNTC_R1A_PRECISE_REUSE` 로 게이트 — 두 단계 독립 측정.
+pub const FREEVAR_INFRA_ENV = "ZNTC_R1A_FREEVAR_INFRA";
+
+test "FreeVarMap type compiles" {
+    var map = FreeVarMap.init(std.testing.allocator);
+    defer map.deinit();
+    try std.testing.expectEqual(@as(usize, 0), map.count());
+}

--- a/src/semantic/mod.zig
+++ b/src/semantic/mod.zig
@@ -19,8 +19,10 @@ pub const analyzer = @import("analyzer.zig");
 pub const checker = @import("checker.zig");
 pub const scope = @import("scope.zig");
 pub const symbol = @import("symbol.zig");
+pub const closure_analysis = @import("closure_analysis.zig");
 
 pub const SemanticAnalyzer = analyzer.SemanticAnalyzer;
+pub const FreeVarMap = closure_analysis.FreeVarMap;
 pub const Diagnostic = @import("../diagnostic.zig").Diagnostic;
 pub const Scope = scope.Scope;
 pub const ScopeId = scope.ScopeId;
@@ -37,6 +39,7 @@ test {
     _ = checker;
     _ = scope;
     _ = symbol;
+    _ = closure_analysis;
 
     // test files
     _ = @import("analyzer_test.zig");


### PR DESCRIPTION
## Summary
- RFC `RFC_MANGLER_SAFE_C2.md` §4.2 PR-2 의 1단계: nested scope 의 free-var (outer 사용 symbol set) 을 명시 bitset 으로 보관할 type 정의 + mangler 입력 슬롯 추가
- **type/field 만, analyzer build 없음, mangler 사용 없음** — 코드 path 변경 0 으로 byte-identical 자동 보장
- R1-a 의 reference 0 영역 (precise free-var 분석 + 통합 slot pool) 의 첫 안전 스텝

## 변경 파일

| 파일 | 변경 |
|---|---|
| `src/semantic/closure_analysis.zig` (신규, 35 라인) | `FreeVarMap = AutoHashMap(u32, DynamicBitSet)` + env flag 상수 + type test |
| `src/semantic/mod.zig` (+3) | `closure_analysis` 모듈 + `FreeVarMap` re-export + test aggregate |
| `src/codegen/mangler.zig` (+5) | `MangleInput.free_vars_per_scope: ?*const FreeVarMap = null` |
| `src/codegen/unified_mangler.zig` (+5) | `ModuleMangleInput.free_vars_per_scope: ?*const FreeVarMap = null` |

총 48 추가, 0 삭제.

## byte-identical 보장 근거

- `FreeVarMap` type 정의는 사용처 없음 (analyzer build 없음)
- mangler input 의 `free_vars_per_scope` field 는 default `null`, mangler 코드가 lookup 안 함
- 즉 144-lib smoke 결과 byte 동일 (코드 path 변경 0)

## 다음 sub-PR 계획 (RFC §4 참조)

- **PR-2-b**: `SemanticAnalyzer` 가 `ZNTC_R1A_FREEVAR_INFRA` env ON 시만 free-var map build (mangler 여전히 미사용)
- **PR-3**: `mangler.markAncestorPath` 가 free-var set 기반 정밀 reuse. `ZNTC_R1A_PRECISE_REUSE` flag + RFC §5 측정 게이트:
  - zod **-2,300B** 이상
  - effect 회귀 0
  - rxjs 회귀 0
  - 144-lib corpus 감소
  - runtime MATCH 144/144
  - collision assert fire 0
  - transformer wall time +5% 이내
- **PR-4**: PR-3 게이트 통과 시만 default-on

## 박제 충돌 명시

RFC `RFC_MANGLER_SIZE_GAP_CLOSED.md` §3 + `project_minify_gap_S_series` 의 c2/M2 NO-GO 박제 영역의 **의도적 재시도**. c2 (zod +3.2KB / effect +61KB 회귀) 의 실패 root cause 를 frequency 손실이 아닌 *outer alive 보수성* (`markScopeSubtree(0)`) 으로 재해석, precise free-var 분석으로 안전화 가능 가설.

**PR-3 게이트 미달 시 본 RFC 자체 NO-GO 박제 격하 + 영구 종결** (RFC §7). 사용자 명령 "임시방편 금지 + 루트커즈 수정" 준수.

## Test plan
- [x] `zig build -Doptimize=ReleaseFast` 통과
- [x] `zig build test` 통과 (closure_analysis.zig 의 type test + 기존 회귀 0)
- [ ] CI 통과 확인 (build/test/Lint/NAPI/Benchmark 등)
- [ ] 머지 후 main 에서 144-lib smoke byte-identical 확인 (별도 검증, mangler 비결정성으로 size 기준만)

Refs: `docs/RFC_MANGLER_SAFE_C2.md` (PR #3918 머지) · `docs/RFC_MANGLER_SIZE_GAP_CLOSED.md` §3 · `project_minify_gap_S_series` · `project_object_key_unquote_win`