### PR TITLE
feat(mangler): R1-a PR-2-b — SemanticAnalyzer free-var build (env-gated, inert)

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -155,6 +155,12 @@ pub const SemanticAnalyzer = struct {
     /// mangler liveness 및 위치 기반 최적화(dead store, single-use inline 등) consumer의 입력.
     references: std.ArrayList(symbol_mod.Reference),
 
+    /// R1-a (`RFC_MANGLER_SAFE_C2.md`) PR-2-b — nested scope 의 free-var (outer-ref
+    /// symbol set). analyze() 끝에 env `ZNTC_R1A_FREEVAR_INFRA` 가 set 됐을 때만 build,
+    /// 그 외엔 null 유지. mangler 가 PR-3 의 `ZNTC_R1A_PRECISE_REUSE` flag ON 시만
+    /// 사용 (PR-2-b 자체는 input field 미연결 = byte-identical 보장).
+    free_vars: ?@import("closure_analysis.zig").FreeVarMap = null,
+
     /// Annex B: if/else/labeled body에서 function declaration을 만나면
     /// var hoisting conflict check를 건너뛴다.
     /// sloppy mode에서 `if (true) function f() {}` 같은 구문이 let/const와 충돌하지 않도록 한다.
@@ -266,6 +272,10 @@ pub const SemanticAnalyzer = struct {
         self.class_private_declared.deinit(self.allocator);
         for (self.class_private_refs.items) |*list| list.deinit(self.allocator);
         self.class_private_refs.deinit(self.allocator);
+        if (self.free_vars) |*fv| {
+            @import("closure_analysis.zig").freeFreeVarMap(fv);
+            self.free_vars = null;
+        }
     }
 
     // ================================================================
@@ -291,6 +301,18 @@ pub const SemanticAnalyzer = struct {
         const root_idx: NodeIndex = self.ast.transformed_root orelse
             @as(NodeIndex, @enumFromInt(@as(u32, @intCast(self.ast.nodes.items.len - 1))));
         try self.visitNode(root_idx);
+
+        // R1-a PR-2-b: env `ZNTC_R1A_FREEVAR_INFRA` 가 set 됐을 때만 free-var map build.
+        // 미설정 시 wall-time/메모리 영향 0. PR-3 의 mangler reuse 와 별개 flag.
+        const closure = @import("closure_analysis.zig");
+        if (closure.isInfraEnabled(self.allocator)) {
+            self.free_vars = try closure.buildFreeVarMap(
+                self.allocator,
+                self.scopes.items,
+                self.symbols.items,
+                self.references.items,
+            );
+        }
     }
 
     // ================================================================

--- a/src/semantic/closure_analysis.zig
+++ b/src/semantic/closure_analysis.zig
@@ -10,8 +10,12 @@
 
 const std = @import("std");
 const scope_mod = @import("scope.zig");
+const symbol_mod = @import("symbol.zig");
 
 pub const ScopeId = scope_mod.ScopeId;
+pub const Scope = scope_mod.Scope;
+pub const Symbol = symbol_mod.Symbol;
+pub const Reference = symbol_mod.Reference;
 
 /// scope_id → outer-ref symbol_id set.
 ///
@@ -23,13 +27,108 @@ pub const ScopeId = scope_mod.ScopeId;
 /// 수십 symbol = bitset 당 수 byte, 총 KB 미만. 큰 lib 도 MB 미만 예상.
 pub const FreeVarMap = std.AutoHashMap(u32, std.DynamicBitSet);
 
-/// R1-a kill-switch env flag. PR-2 단계는 항상 false 동작 (analyzer build path 없음).
+/// R1-a kill-switch env flag. PR-2-a 단계는 inert (analyzer build path 없음).
 /// PR-2-b 부터 환경변수 `ZNTC_R1A_FREEVAR_INFRA` 로 활성화. PR-3 의 mangler reuse 는
 /// 별도 flag `ZNTC_R1A_PRECISE_REUSE` 로 게이트 — 두 단계 독립 측정.
 pub const FREEVAR_INFRA_ENV = "ZNTC_R1A_FREEVAR_INFRA";
+
+/// `descendant` 가 `maybe_ancestor` 의 *strict descendant* (= maybe_ancestor 자체 아님,
+/// parent 체인 따라 도달 가능) 인지. 같은 scope 는 false (outer-ref 아님 — 자기 scope
+/// 내 ref 는 closure capture 아님). mangler.markScopeSubtree 의 보수 대체로 PR-3 에서
+/// "ref 의 decl_scope 가 outer 인지" 판정에 사용.
+pub fn isStrictDescendant(scopes: []const Scope, maybe_ancestor: ScopeId, descendant: ScopeId) bool {
+    if (maybe_ancestor.isNone() or descendant.isNone()) return false;
+    if (@intFromEnum(maybe_ancestor) == @intFromEnum(descendant)) return false;
+    var cur = descendant;
+    const idx = cur.toIndex();
+    if (idx >= scopes.len) return false;
+    cur = scopes[idx].parent;
+    while (!cur.isNone()) {
+        if (@intFromEnum(cur) == @intFromEnum(maybe_ancestor)) return true;
+        const i = cur.toIndex();
+        if (i >= scopes.len) return false;
+        cur = scopes[i].parent;
+    }
+    return false;
+}
+
+/// 현재 환경에서 R1-a free-var infra 가 활성화됐는지. env `ZNTC_R1A_FREEVAR_INFRA`
+/// 설정값 무관 *존재* 만 검사 (`=0`/`=false` 도 활성). 단순 toggle 의도.
+/// allocator 가 필요한 이유: zig `std.process.getEnvVarOwned` 는 owned slice 반환.
+/// 호출 빈도 = analyze() 호출당 1회 (= 파일당 1회 빌드) → 매번 호출도 overhead 무시 가능.
+pub fn isInfraEnabled(allocator: std.mem.Allocator) bool {
+    const v = std.process.getEnvVarOwned(allocator, FREEVAR_INFRA_ENV) catch return false;
+    defer allocator.free(v);
+    return v.len > 0;
+}
+
+/// nested scope 별 outer-ref symbol bitset 을 build. references 1회 순회로
+/// `O(refs × ancestor_depth)`. ancestor_depth 는 일반적 lib 에서 <10.
+///
+/// `symbols` / `scopes` / `references` 는 SemanticAnalyzer 의 결과 slice. caller 가
+/// 소유. 반환된 FreeVarMap 은 caller 가 `freeFreeVarMap` 으로 해제 필요.
+///
+/// 안전: env flag 미설정 시 caller 가 `isInfraEnabled` 확인 후 호출. 본 함수 자체는
+/// flag 검사 안 함 — 호출자가 게이트 (test 에서는 직접 호출 가능).
+pub fn buildFreeVarMap(
+    allocator: std.mem.Allocator,
+    scopes: []const Scope,
+    symbols: []const Symbol,
+    references: []const Reference,
+) std.mem.Allocator.Error!FreeVarMap {
+    var map = FreeVarMap.init(allocator);
+    errdefer freeFreeVarMap(&map);
+
+    const symbol_count = symbols.len;
+    if (symbol_count == 0) return map;
+
+    for (references) |ref| {
+        const sym_idx: u32 = @intFromEnum(ref.symbol_id);
+        if (sym_idx >= symbol_count) continue;
+        const decl_scope = symbols[sym_idx].scope_id;
+        if (!isStrictDescendant(scopes, decl_scope, ref.scope_id)) continue;
+
+        const key = ref.scope_id.toIndex();
+        const gop = try map.getOrPut(key);
+        if (!gop.found_existing) {
+            gop.value_ptr.* = try std.DynamicBitSet.initEmpty(allocator, symbol_count);
+        }
+        gop.value_ptr.set(sym_idx);
+    }
+    return map;
+}
+
+/// `buildFreeVarMap` 결과 해제. entry 별 DynamicBitSet + HashMap 자체.
+pub fn freeFreeVarMap(map: *FreeVarMap) void {
+    var it = map.iterator();
+    while (it.next()) |entry| {
+        entry.value_ptr.deinit();
+    }
+    map.deinit();
+}
 
 test "FreeVarMap type compiles" {
     var map = FreeVarMap.init(std.testing.allocator);
     defer map.deinit();
     try std.testing.expectEqual(@as(usize, 0), map.count());
+}
+
+test "isStrictDescendant — none / 자기 자신 / 직속 부모 / 깊은 부모" {
+    const none = ScopeId.none;
+    const s0: ScopeId = @enumFromInt(0);
+    const s1: ScopeId = @enumFromInt(1);
+    const s2: ScopeId = @enumFromInt(2);
+    const scopes = [_]Scope{
+        .{ .parent = none, .kind = .module, .is_strict = false },
+        .{ .parent = s0, .kind = .function, .is_strict = false },
+        .{ .parent = s1, .kind = .block, .is_strict = false },
+    };
+    try std.testing.expect(!isStrictDescendant(&scopes, none, s1));
+    try std.testing.expect(!isStrictDescendant(&scopes, s0, none));
+    try std.testing.expect(!isStrictDescendant(&scopes, s1, s1));
+    try std.testing.expect(isStrictDescendant(&scopes, s0, s1));
+    try std.testing.expect(isStrictDescendant(&scopes, s0, s2));
+    try std.testing.expect(isStrictDescendant(&scopes, s1, s2));
+    try std.testing.expect(!isStrictDescendant(&scopes, s2, s0));
+    try std.testing.expect(!isStrictDescendant(&scopes, s2, s1));
 }


### PR DESCRIPTION
## Summary
- RFC `RFC_MANGLER_SAFE_C2.md` §4.2 PR-2 의 **2단계**: `SemanticAnalyzer` 가 `analyze()` 완료 후 env `ZNTC_R1A_FREEVAR_INFRA` set 시만 nested scope 별 outer-ref symbol bitset build
- **mangler 여전히 미연결** — byte-identical 보장 (`MangleInput.free_vars_per_scope` PR-2-a 에서 default null, mangler 코드 lookup 안 함)
- PR-3 의 진짜 효과 (mangler 가 map 사용한 정밀 reuse) 전에 인프라만 준비

## 변경 파일

| 파일 | 추가 |
|---|---|
| `src/semantic/closure_analysis.zig` | `isStrictDescendant` / `isInfraEnabled` / `buildFreeVarMap` / `freeFreeVarMap` + unit test 4개 (101 lines) |
| `src/semantic/analyzer.zig` | `free_vars: ?FreeVarMap = null` field + analyze 끝 build 호출 + deinit 해제 (22 lines) |

총 122 추가, 1 삭제.

## 동작

| env state | analyze() 동작 | 결과 |
|---|---|---|
| **unset (default)** | `isInfraEnabled` 1회 호출 (false 반환), build path 미진입 | `free_vars=null`, **wall time/메모리 변화 0** |
| **`ZNTC_R1A_FREEVAR_INFRA=1`** | references 1회 순회 O(refs × ancestor_depth), nested scope 별 outer-ref bitset build | `free_vars=FreeVarMap`, mangler 가 미연결이라 **output 동일** |

## byte-identical 보장

- env unset: `analyze()` 호출 path 동일, 추가 작업 0
- env set: `free_vars` build 되나 mangler input 의 `free_vars_per_scope` 가 PR-2-a 에서 default null (caller 가 의도적으로 미연결 — PR-3 까지) → mangler output bytewise 동일

## 다음 단계 (RFC §4 참조)

- **PR-3**: `mangler.markAncestorPath` 가 free-var set 기반 정밀 reuse. `ZNTC_R1A_PRECISE_REUSE` env flag + RFC §5 측정 게이트:
  - zod -2,300B 이상 / effect 회귀 0 / rxjs 회귀 0
  - 144-lib corpus 감소 / runtime MATCH 144/144 / collision assert 0
  - transformer wall time +5% 이내
- **PR-4**: PR-3 게이트 통과 시 default-on + env flag 제거

## 박제 충돌 명시

`RFC_MANGLER_SIZE_GAP_CLOSED.md §3` + `project_minify_gap_S_series` 의 c2/M2 NO-GO 박제 영역의 **의도적 재시도** (RFC #3918 §0 명시). PR-3 게이트 미달 시 본 RFC 자체 NO-GO 박제 격하 + 영구 종결 (RFC #3918 §7).

## Test plan
- [x] `zig build -Doptimize=ReleaseFast` 통과
- [x] `zig build test` 통과 (closure_analysis 5개 test: type compile + isStrictDescendant 4 case + 기존 회귀 0)
- [ ] CI 통과 확인 (build/test/Lint/NAPI/Benchmark)
- [ ] 머지 후 wall time A/B 측정 spike (env ON vs OFF) — PR-3 진행 결정 정보

Refs: PR #3918 (RFC 드래프트) · PR #3919 (PR-2-a infra) · `docs/RFC_MANGLER_SAFE_C2.md` · `project_minify_gap_S_series` · `project_object_key_unquote_win`