### PR TITLE
feat(mangler): R1-a PR-3-a — linker 가 free-var map 을 mangler input 에 연결 (inert)

### DIFF
--- a/src/bundler/graph/parse_module.zig
+++ b/src/bundler/graph/parse_module.zig
@@ -194,6 +194,10 @@ pub fn parseModule(self: *ModuleGraph, idx: ModuleIndex) void {
                 .unresolved_references = analyzer.unresolved_references,
                 .references = analyzer.references.items,
                 .numeric_const_texts = analyzer.numeric_const_texts,
+                // R1-a PR-3-a: analyzer.free_vars (PR-2-b 에서 env-gated build) 의
+                // borrow pointer. analyzer 와 함께 parse_arena 가 lifecycle 관리.
+                // env unset 시 analyzer.free_vars=null → here 도 null = inert.
+                .free_vars = if (analyzer.free_vars) |*fv| fv else null,
             };
             // TLA 감지: semantic analyzer가 스코프 체인을 추적하며 정확히 판별
             module.uses_top_level_await = analyzer.has_top_level_await;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -832,6 +832,12 @@ pub const Linker = struct {
         const modules = try self.allocator.alloc(um.ModuleMangleInput, mod_count);
         errdefer self.allocator.free(modules);
 
+        // R1-a PR-3-a: `ZNTC_R1A_PRECISE_REUSE` env set 시 mangler 가 free-var map
+        // 사용 (mangler `markScopeSubtree(0)` 보수 마킹을 PR-3-b 에서 정밀화). 함수
+        // 진입점에서 한 번 검사 — module 별 매번 env get 회피.
+        const precise_reuse = @import("../semantic/closure_analysis.zig")
+            .isPreciseReuseEnabled(self.allocator);
+
         const bitsets = try self.allocator.alloc(std.DynamicBitSet, mod_count);
         var created: usize = 0;
         errdefer {
@@ -1137,6 +1143,11 @@ pub const Linker = struct {
                     .module_scope_symbols = bitsets[mi],
                     .cross_module_imports = ir_owned,
                     .wrapper_isolated = m.wrap_kind.isWrapped(),
+                    // R1-a PR-3-a: precise_reuse 시만 analyzer 의 free-var map 연결.
+                    // PR-3-b 의 mangler 가 이걸 사용해 `markScopeSubtree(0)` 의 보수
+                    // 마킹을 정밀화. env unset 또는 sem.free_vars=null → null = mangler
+                    // 가 기존 동작 (byte-identical 자동 보장).
+                    .free_vars_per_scope = if (precise_reuse) sem.free_vars else null,
                 };
             } else {
                 modules[mi] = emptyInput(m.source, bitsets[mi]);

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -105,6 +105,12 @@ pub const ModuleSemanticData = struct {
     unresolved_references: std.StringHashMap(void),
     /// per-reference 배열. 현재 consumer: mangler liveness.
     references: []const Reference = &.{},
+    /// R1-a (`RFC_MANGLER_SAFE_C2.md`) PR-3 free-var (closure capture) map.
+    /// analyzer 가 `ZNTC_R1A_FREEVAR_INFRA` / `ZNTC_R1A_PRECISE_REUSE` 환경변수
+    /// set 됐을 때만 build (PR-2-b). linker 가 `ZNTC_R1A_PRECISE_REUSE` 시만 mangler
+    /// input 의 `free_vars_per_scope` 에 연결 (PR-3-a). mangler 가 그 후 사용 (PR-3-b).
+    /// borrowed — parse_arena 가 backing 메모리 lifecycle 관리.
+    free_vars: ?*const @import("../semantic/closure_analysis.zig").FreeVarMap = null,
     /// `Symbol.const_kind == .number` 인 심볼의 원본 numeric_literal 텍스트 사이드테이블 (#2505).
     /// Symbol 에 16B slice 를 박지 않으려고 분리 — 보통 numeric const 는 전체 심볼의 극소수.
     /// parse_arena 가 backing — value slice 는 source 또는 string_table 참조.

--- a/src/semantic/closure_analysis.zig
+++ b/src/semantic/closure_analysis.zig
@@ -32,6 +32,16 @@ pub const FreeVarMap = std.AutoHashMap(u32, std.DynamicBitSet);
 /// 별도 flag `ZNTC_R1A_PRECISE_REUSE` 로 게이트 — 두 단계 독립 측정.
 pub const FREEVAR_INFRA_ENV = "ZNTC_R1A_FREEVAR_INFRA";
 
+/// R1-a PR-3 mangler reuse 활성화 env flag. set 되면:
+///  - linker 가 `m.semantic.free_vars` 를 mangler input 의 `free_vars_per_scope` 에 연결
+///  - linker 가 1글자 reserved 등록을 free-var 에 *참조된 1글자만* 으로 축소 (PR-3-b)
+///  - mangler `markScopeSubtree(0)` 보수 대신 free-var 기반 정밀 마킹 (PR-3-b)
+///
+/// PRECISE_REUSE 가 set 됐는데 FREEVAR_INFRA 가 off 면 `isInfraEnabled` 가 자동 true
+/// 반환 — analyzer 가 free-var build 안 하면 PR-3 의 정밀 reuse 불가능하므로 implicit
+/// promotion.
+pub const PRECISE_REUSE_ENV = "ZNTC_R1A_PRECISE_REUSE";
+
 /// `descendant` 가 `maybe_ancestor` 의 *strict descendant* (= maybe_ancestor 자체 아님,
 /// parent 체인 따라 도달 가능) 인지. 같은 scope 는 false (outer-ref 아님 — 자기 scope
 /// 내 ref 는 closure capture 아님). mangler.markScopeSubtree 의 보수 대체로 PR-3 에서
@@ -52,14 +62,24 @@ pub fn isStrictDescendant(scopes: []const Scope, maybe_ancestor: ScopeId, descen
     return false;
 }
 
-/// 현재 환경에서 R1-a free-var infra 가 활성화됐는지. env `ZNTC_R1A_FREEVAR_INFRA`
-/// 설정값 무관 *존재* 만 검사 (`=0`/`=false` 도 활성). 단순 toggle 의도.
-/// allocator 가 필요한 이유: zig `std.process.getEnvVarOwned` 는 owned slice 반환.
-/// 호출 빈도 = analyze() 호출당 1회 (= 파일당 1회 빌드) → 매번 호출도 overhead 무시 가능.
-pub fn isInfraEnabled(allocator: std.mem.Allocator) bool {
-    const v = std.process.getEnvVarOwned(allocator, FREEVAR_INFRA_ENV) catch return false;
+/// env 변수가 *존재* 하면 true (값 무관, `=0`/`=false` 도 활성). zig
+/// `getEnvVarOwned` 는 owned slice 반환 — caller 가 free. analyzer/linker 호출당
+/// 1회 빈도라 overhead 무시 가능.
+fn envIsSet(allocator: std.mem.Allocator, key: []const u8) bool {
+    const v = std.process.getEnvVarOwned(allocator, key) catch return false;
     defer allocator.free(v);
     return v.len > 0;
+}
+
+/// 현재 환경에서 R1-a free-var infra 가 활성화됐는지. PRECISE_REUSE 가 set 됐으면
+/// FREEVAR_INFRA 도 implicit ON (PR-3 의 mangler reuse 는 analyzer build 가 선행 조건).
+pub fn isInfraEnabled(allocator: std.mem.Allocator) bool {
+    return envIsSet(allocator, FREEVAR_INFRA_ENV) or envIsSet(allocator, PRECISE_REUSE_ENV);
+}
+
+/// 현재 환경에서 R1-a mangler precise reuse (PR-3) 가 활성화됐는지.
+pub fn isPreciseReuseEnabled(allocator: std.mem.Allocator) bool {
+    return envIsSet(allocator, PRECISE_REUSE_ENV);
 }
 
 /// nested scope 별 outer-ref symbol bitset 을 build. references 1회 순회로


### PR DESCRIPTION
## Summary
- RFC `RFC_MANGLER_SAFE_C2.md` §4.3 PR-3 의 **1단계**: analyzer 가 PR-2-b 에서 build 한 nested-scope free-var map 을 `ModuleSemanticData` → linker 를 거쳐 `ModuleMangleInput.free_vars_per_scope` 에 borrow pointer 로 연결
- **mangler 미사용** — PR-3-b 가 `markScopeSubtree(0)` 보수 마킹을 정밀화할 때 이 입력 사용
- **byte-identical 자동 보장** (mangler 코드 path 변경 0)
- `ZNTC_R1A_PRECISE_REUSE` flag 등록 (default OFF)

## 변경 파일

| 파일 | 변경 | 라인 |
|---|---|---|
| `src/semantic/closure_analysis.zig` | `PRECISE_REUSE_ENV` 상수 + `envIsSet` helper + `isInfraEnabled` 확장 + `isPreciseReuseEnabled` 신규 | +26 / -6 |
| `src/bundler/module.zig` | `ModuleSemanticData.free_vars: ?*const FreeVarMap = null` field | +6 |
| `src/bundler/graph/parse_module.zig` | `analyzer.free_vars` borrow pointer 를 `module.semantic.free_vars` 에 전달 | +4 |
| `src/bundler/linker.zig` | `collectUnifiedInput` 진입에서 `precise_reuse` 1회 검사 + `ModuleMangleInput.free_vars_per_scope` 조건부 연결 | +11 |

총 47 추가, 6 삭제.

## 동작

| env state | linker 동작 | mangler 동작 |
|---|---|---|
| **unset (default)** | `precise_reuse=false` → `free_vars_per_scope=null` | 기존 그대로 |
| `ZNTC_R1A_PRECISE_REUSE=1` only | analyzer.free_vars=null (PR-2-b 미활성) → here 도 null | 기존 그대로 |
| `ZNTC_R1A_FREEVAR_INFRA=1` + `ZNTC_R1A_PRECISE_REUSE=1` | free_vars 연결 | PR-3-b 까지 미참조 = output 동일 |

`isInfraEnabled` 가 PRECISE_REUSE 도 검사하도록 확장 — PRECISE_REUSE 만 set 해도 analyzer 가 free-var build (implicit promotion).

## byte-identical 보장 근거

1. env unset: linker 의 `precise_reuse=false` → 분기 미실행
2. env set + PR-3-b 미머지: mangler 코드가 `free_vars_per_scope` 미참조 → 입력만 흐를 뿐 output 동일

## 다음 단계 (RFC §4 참조)

- **PR-3-b**: `mangler.zig:155-176` 의 `markScopeSubtree(0)` 보수 마킹 → free-var 기반 정밀 마킹. flag ON 시 분기. RFC §5 측정 게이트:
  - zod **-2,300B 이상** / effect 회귀 0 / rxjs 회귀 0
  - 144-lib corpus 감소 / runtime MATCH 144/144 / collision assert 0
  - transformer wall time +5% 이내
- **PR-3-c**: `linker.zig:909-913` 의 모든 1글자 reserved → free-var 에 참조된 1글자만 으로 축소 (PR-3-b 와 같이)

## 박제 충돌

RFC #3288 c2/M2 NO-GO 영역 **의도적 재시도** (RFC #3918 §0 명시). PR-3-b 게이트 미달 시 본 RFC NO-GO 박제 격하 + 영구 종결 (RFC #3918 §7).

## Test plan
- [x] `zig build -Doptimize=ReleaseFast` 통과
- [x] `zig build test` 통과 (회귀 0)
- [ ] CI 통과 확인
- [ ] 머지 후 PR-3-b 진행 — 진짜 size 효과 측정

Refs: PR #3918 (RFC) · PR #3919 (PR-2-a) · PR #3920 (PR-2-b) · `docs/RFC_MANGLER_SAFE_C2.md`