### PR TITLE
feat(perf): samply sampling profiler workflow + -Dkeep-debug option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,6 +16,17 @@ pub fn build(b: *std.Build) void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
+    // `-Dkeep-debug=true` 로 ReleaseFast/Safe/Small 빌드에서도 debug info 유지.
+    // samply / Instruments / dtrace 같은 sampling profiler 가 함수명을 해석하려면
+    // DWARF 가 필요하다. 기본은 false (Zig optimize mode 기본값 = Release* 면 strip).
+    // docs/PERF_PROFILING.md 참고.
+    const keep_debug = b.option(
+        bool,
+        "keep-debug",
+        "Keep debug info in Release* builds (for samply/Instruments profiling). Default: false",
+    ) orelse false;
+    const strip_setting: ?bool = if (keep_debug) false else null;
+
     // This creates a "module", which represents a collection of source files alongside
     // some compilation options, such as optimization mode and linked system libraries.
     // Every executable or library we compile will be based on one or more modules.
@@ -27,6 +38,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
+        .strip = strip_setting,
     });
 
     // We will also create a module for our other entry point, 'main.zig'.
@@ -38,6 +50,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .strip = strip_setting,
     });
 
     // Modules can depend on one another using the `std.Build.Module.addImport` function.

--- a/docs/PERF_PROFILING.md
+++ b/docs/PERF_PROFILING.md
@@ -1,0 +1,113 @@
+# PERF — Sampling Profiler 측정
+
+ZNTC 의 wall time hotspot 을 sampling profiler (`samply`) 로 격리하는 절차.
+ZNTC 자체의 `--profile` 인프라는 phase·sub-phase 단위 wall 누적을 보여 주지만,
+호출 빈도가 큰 hot path 함수에서는 `std.time.Timer` 의 read 오버헤드가 self time 을
+부풀려 dominant 영역을 흐린다 ([[feedback_profile_self_timer_artifact]] 참고). 함수
+단위 self time 의 정확한 분포가 필요할 때 본 절차를 쓴다.
+
+## 전제
+
+* macOS / Linux. Windows 는 `samply` 가 ETW 백엔드를 쓰며 별도 검증 안 됨.
+* `samply` 설치 — `cargo install samply` 또는 `brew install samply`.
+* macOS 는 `dsymutil` 필요 (Xcode CLT 에 포함).
+
+## 빌드
+
+`-Dkeep-debug=true` 를 주면 ReleaseFast 빌드에서도 DWARF 가 보존돼 samply 가
+함수명을 해석할 수 있다. 기본값은 `false` 라 프로덕션 배포 결과물에는 영향이 없다.
+
+```sh
+zig build -Doptimize=ReleaseFast -Dkeep-debug=true
+# macOS 만:
+dsymutil zig-out/bin/zntc
+```
+
+## 측정
+
+`scripts/profile-parse-samply.sh` 가 빌드 + dsymutil + samply record 를 한 줄로
+처리한다. 기본 fixture 는 `tests/benchmark/node_modules/node_modules/typescript/lib/typescript.js`
+(약 9MB, 단일 파일 transpile 의 worst-case 워크로드).
+
+```sh
+scripts/profile-parse-samply.sh                                       # 기본
+scripts/profile-parse-samply.sh path/to/fixture.ts 5 4000              # fixture, iters, rate(Hz)
+ZNTC_SAMPLY_OUT=./profile-out scripts/profile-parse-samply.sh          # 출력 디렉토리 변경
+```
+
+iteration 수가 늘어날수록 sample 수가 늘고 noise 가 줄어든다. 이론적 상한은
+`iter × rate × wall_ms / 1000` 이지만 실제는 thread sleep / I/O wait / sampler
+드롭 때문에 그보다 적다 — 5 iter × 4kHz × ~170ms wall 의 *이론 ~3,400 sample*
+이 typescript.js 9MB 에서 실측 ~1,600~2,500 정도 잡힌다. 회귀 비교용으로는 이
+정도면 충분하다.
+
+## 분석
+
+```sh
+python3 scripts/analyze-samply.py /tmp/zntc-samply                     # 기본 디렉토리
+python3 scripts/analyze-samply.py /tmp/zntc-samply --top 20             # top 20 만
+python3 scripts/analyze-samply.py /tmp/zntc-samply --filter Scanner    # Scanner 만
+```
+
+함수별 self count (leaf-frame 기준) 와 inclusive count (스택 어디든 등장) 표가 나온다.
+self 가 진짜 hotspot 지표, inclusive 는 caller chain 파악용.
+
+UI 가 필요하면 Firefox profiler:
+
+```sh
+samply load /tmp/zntc-samply/profile.json.gz
+# localhost:3000 에 Firefox profiler 열림
+```
+
+## 측정 예시 (main d0fe8e10, typescript.js 9MB, 5 iter × 4kHz)
+
+총 1,621 sample 기준 top self:
+
+| 순위 | self% | 함수 |
+| ---: | ---: | --- |
+| 1 | 15.05% | `lexer.scanner.Scanner.next` |
+| 2 | 14.74% | `_platform_memmove` (libsystem_platform) |
+| 3 |  4.75% | `transformer.node_dispatch.visitNodeInner` |
+| 4 |  4.32% | `codegen.node_dispatch.emitNode` |
+| 5 |  4.26% | `bundler.resolver.DirEntryCache.HashMap.getIndex` |
+| 6 |  3.58% | `lexer.scanner.Scanner.skipWhitespace` |
+| 7 |  3.27% | `parser.ast.Ast.addNode` |
+| 8 |  2.90% | `semantic.analyzer.SemanticAnalyzer.visitNode` |
+| 9 |  2.16% | `lexer.scanner.Scanner.scanIdentifierTail` |
+
+Scanner family (next + skipWhitespace + scanIdentifierTail + parser.advance) 합계
+약 22% self — ZNTC `--profile` 의 `scan` phase 표시 (24%) 와 비슷하지만, 본 데이터는
+`parse` phase 안에서 호출되는 lex 비용까지 포함하므로 `parse` 의 dominant 도
+사실 Scanner 임을 보여 준다.
+
+`parse.expression.assignment` `self time` 이 `--profile-level=detailed` 에서 45ms 로
+크게 잡히는 부분은 대부분 timer 오버헤드이고, 진짜 parser 함수 self 는 합쳐도 ~6%
+수준 (parseAssignmentExpression / parsePrimaryExpression / parseBinaryExpression /
+parseCallExpression / parseStatement 각 1% 안팎). 이 결론은 호출-빈도 큰 scope 의
+self time 절대값을 ROI 근거로 쓰지 말라는 기존 ([[feedback_profile_self_timer_artifact]])
+가이드와 같은 방향이다.
+
+## 회귀 비교
+
+PR 머지 전후로 동일 절차로 두 번 측정한 뒤 `diff <(analyze A) <(analyze B)` 또는
+top N self 표의 함수별 비율 차이를 확인한다. sample noise 가 5~10% 정도라 1% 미만
+변화는 신호가 아닐 가능성이 높다 — 회귀 게이트는 typescript.js 9MB wall median
+(`zntc --profile=all` 의 `wall:` 줄) 5회 median ±5% 정도를 기준으로 잡는 게 안전.
+
+## 알려진 함정
+
+* macOS: `dsymutil` 를 빠뜨리면 함수명이 `<0x…>` 만 나온다. 스크립트가 자동 수행하지만
+  수동 빌드 시 주의.
+* `--unstable-presymbolicate` 옵션은 samply 의 미정안정 API (samply ≥0.12). 향후
+  버전에서 sidecar 대신 profile 에 통합될 수 있다. 그 때는 `scripts/analyze-samply.py`
+  의 `build_addr_map()` 가 그대로 깨질 가능성이 있어 수정 필요.
+* `analyze-samply.py` 는 `known_addresses` 의 union 으로 RVA→함수 매핑을 만든다.
+  samply 가 `frameTable.nativeSymbol[]` 를 비워둔 채 sidecar 로 분리해 두기 때문에
+  frame 단위 lib 식별이 불가능 — 이론적으로 lib 간 RVA 충돌 시 마지막 lib 의 이름이
+  덮어쓴다. 실측에선 충돌 0건 (1,500개 unique address) 이지만, 스크립트가 충돌을
+  탐지하면 stderr 로 경고하고 영향 받은 RVA 를 표시한다.
+* Linux: dSYM 대신 `.debug` 섹션이 in-binary 로 들어가 자동 인식. `dsymutil` 단계는
+  스크립트가 macOS 에서만 실행.
+* 동시 실행 / CI A/B 비교 시 기본 출력 디렉토리 `/tmp/zntc-samply` 가 충돌한다.
+  `ZNTC_SAMPLY_OUT=./out-A scripts/profile-parse-samply.sh` 처럼 분리할 것.
+* 첫 iteration 은 파일 시스템 캐시 cold 영향이 크다. 스크립트가 warmup 1회를 자동 수행.

--- a/scripts/analyze-samply.py
+++ b/scripts/analyze-samply.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""samply profile.json + presymbolicate sidecar 를 분석해 함수별 self/inclusive sample 수를 표로 출력.
+
+사용법:
+  python3 scripts/analyze-samply.py [profile_dir] [--top N] [--filter SUBSTR]
+
+profile_dir 의 기본값은 /tmp/zntc-samply 이고 scripts/profile-parse-samply.sh 가 만들어둔
+profile.json.gz + profile.json.syms.json 쌍을 가정한다. samply 의 `--unstable-presymbolicate`
+플래그가 켜져 있어야 .syms.json 가 같이 생성된다.
+
+매핑 흐름:
+  thread.samples.stack[i] -> stackTable.frame[stack] -> frameTable.address[frame] (lib-relative RVA)
+  syms.data[lib].known_addresses[(addr, sym_idx)] -> syms.data[lib].symbol_table[sym_idx]
+  symbol_table.{symbol, frames[-1].function} -> syms.string_table -> 실 함수명.
+
+samply UI 가 같은 매핑을 lazy 하게 적용하지만, CLI 에서 한 번에 전체 self/inclusive 표를
+보고 싶을 때 본 스크립트가 더 편하다 (특히 회귀 비교 시).
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+def load_profile(profile_dir: Path):
+    profile_path = profile_dir / "profile.json.gz"
+    syms_path = profile_dir / "profile.json.syms.json"
+    if not profile_path.exists():
+        sys.exit(f"error: {profile_path} not found. run scripts/profile-parse-samply.sh first.")
+    if not syms_path.exists():
+        sys.exit(
+            f"error: {syms_path} not found. samply must have been invoked with "
+            "--unstable-presymbolicate (scripts/profile-parse-samply.sh handles this)."
+        )
+    with gzip.open(profile_path, "rt") as fh:
+        prof = json.load(fh)
+    with syms_path.open() as fh:
+        syms = json.load(fh)
+    return prof, syms
+
+
+def build_addr_map(syms: dict) -> tuple[dict[int, tuple[str, str]], list]:
+    """profile.json frame.address (lib-relative RVA) -> (lib_name, function_name).
+
+    Note: known_addresses is a union across all libs. samply doesn't currently emit
+    enough metadata in --unstable-presymbolicate output for us to identify which lib
+    a given frame.address belongs to (frameTable.nativeSymbol[] is null and
+    nativeSymbols.length=0 in practice). So this map can in theory mislabel a frame
+    if two libs publish the same RVA in their known_addresses lists. We detect those
+    collisions and surface them; in observed runs the count is 0, but we warn loudly
+    if it ever happens so the table's lib labels aren't silently wrong.
+    """
+    string_table = syms["string_table"]
+    addr_map: dict[int, tuple[str, str]] = {}
+    collisions: list = []
+    for lib_entry in syms["data"]:
+        lib_name = lib_entry.get("debug_name", "?")
+        sts = lib_entry.get("symbol_table", [])
+        for addr, sym_idx in lib_entry.get("known_addresses", []):
+            if not (0 <= sym_idx < len(sts)):
+                continue
+            sym_entry = sts[sym_idx]
+            si = sym_entry.get("symbol", -1)
+            name = string_table[si] if 0 <= si < len(string_table) else "<?>"
+            frames = sym_entry.get("frames", [])
+            if frames:
+                fn_idx = frames[-1].get("function")
+                if fn_idx is not None and 0 <= fn_idx < len(string_table):
+                    name = string_table[fn_idx]
+            new_entry = (lib_name, name)
+            existing = addr_map.get(addr)
+            if existing is not None and existing != new_entry:
+                collisions.append((addr, existing, new_entry))
+            addr_map[addr] = new_entry
+    return addr_map, collisions
+
+
+def collect_counts(prof: dict, addr_map: dict[int, tuple[str, str]]):
+    self_count: Counter[str] = Counter()
+    inclusive_count: Counter[str] = Counter()
+    total = 0
+    unmapped = 0
+    for thread in prof["threads"]:
+        samples = thread["samples"]
+        stack_table = thread["stackTable"]
+        frame_addr = thread["frameTable"]["address"]
+        stack_frame = stack_table["frame"]
+        stack_prefix = stack_table["prefix"]
+        for stack_idx in samples["stack"]:
+            if stack_idx is None or stack_idx < 0:
+                continue
+            total += 1
+            chain: list[str] = []
+            cur = stack_idx
+            while cur is not None and cur >= 0:
+                f_idx = stack_frame[cur]
+                addr = frame_addr[f_idx]
+                # samply currently always writes a non-negative RVA, but guard against
+                # 0/-1 sentinels in case the format gains synthesized inline frames.
+                if addr is None or addr < 0:
+                    chain.append("[?] <synthetic>")
+                else:
+                    mapped = addr_map.get(addr)
+                    if mapped is None:
+                        unmapped += 1
+                        chain.append(f"[?] <0x{addr:x}>")
+                    else:
+                        lib, fn = mapped
+                        chain.append(f"[{lib}] {fn}")
+                cur = stack_prefix[cur]
+            if not chain:
+                continue
+            self_count[chain[0]] += 1
+            for name in set(chain):
+                inclusive_count[name] += 1
+    return total, unmapped, self_count, inclusive_count
+
+
+def print_table(title: str, counter: Counter[str], total: int, top: int, filt: str | None):
+    print(f"=== {title} ===")
+    rows = counter.most_common()
+    if filt:
+        rows = [r for r in rows if filt in r[0]]
+    for name, cnt in rows[:top]:
+        pct = 100.0 * cnt / total if total else 0.0
+        print(f"{cnt:6d} ({pct:5.2f}%)  {name[:150]}")
+    print()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("profile_dir", nargs="?", default="/tmp/zntc-samply", type=Path)
+    ap.add_argument("--top", type=int, default=40, help="number of rows per table (default 40)")
+    ap.add_argument("--filter", default=None, help="substring filter applied to function name (case-sensitive)")
+    args = ap.parse_args()
+
+    prof, syms = load_profile(args.profile_dir)
+    addr_map, collisions = build_addr_map(syms)
+    total, unmapped, self_count, inclusive_count = collect_counts(prof, addr_map)
+
+    print(f"profile_dir   : {args.profile_dir}")
+    print(f"total samples : {total}  (unmapped frame addresses: {unmapped})")
+    if collisions:
+        # In observed runs this is 0; if it ever fires the table's lib labels for
+        # those RVAs are not reliable and the analyzer needs to be revisited.
+        print(
+            f"warning       : {len(collisions)} known_addresses collisions across libs "
+            "— lib labels for affected RVAs may be wrong.",
+            file=sys.stderr,
+        )
+        for addr, a, b in collisions[:5]:
+            print(f"  0x{addr:x}: {a} vs {b}", file=sys.stderr)
+    print()
+    print_table("Top self count", self_count, total, args.top, args.filter)
+    print_table("Top inclusive count", inclusive_count, total, args.top, args.filter)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/profile-parse-samply.sh
+++ b/scripts/profile-parse-samply.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# samply 로 zntc 의 transpile 핫스팟을 sampling profile 한다.
+#
+# 사용법:
+#   scripts/profile-parse-samply.sh                                 # 기본 fixture(typescript.js 9MB) x 5 iter
+#   scripts/profile-parse-samply.sh <fixture.ts> <iters> <rate_hz>  # 인자 커스텀
+#
+# 출력:
+#   /tmp/zntc-samply/profile.json.gz
+#   /tmp/zntc-samply/profile.json.syms.json
+#
+# 분석:
+#   scripts/analyze-samply.py /tmp/zntc-samply
+#   samply load /tmp/zntc-samply/profile.json.gz    # Firefox profiler UI
+#
+# 전제: `cargo install samply` 또는 `brew install samply`.
+# docs/PERF_PROFILING.md 참고.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RAW_FIXTURE="${1:-tests/benchmark/node_modules/node_modules/typescript/lib/typescript.js}"
+ITERS="${2:-5}"
+RATE="${3:-4000}"
+OUT_DIR="${ZNTC_SAMPLY_OUT:-/tmp/zntc-samply}"
+
+# Resolve fixture against the caller's cwd before we cd into the repo root.
+# Otherwise `./foo.ts` would be looked up under $REPO_ROOT and the "not found"
+# error message wouldn't hint that the path was relative.
+if [[ "$RAW_FIXTURE" = /* ]]; then
+  FIXTURE="$RAW_FIXTURE"
+elif [[ -e "$RAW_FIXTURE" ]]; then
+  FIXTURE="$(cd "$(dirname "$RAW_FIXTURE")" && pwd)/$(basename "$RAW_FIXTURE")"
+else
+  # Relative path that doesn't exist in the caller's cwd — try $REPO_ROOT next.
+  FIXTURE="$REPO_ROOT/$RAW_FIXTURE"
+fi
+
+if ! command -v samply >/dev/null 2>&1; then
+  echo "error: samply not found. install via 'cargo install samply' or 'brew install samply'" >&2
+  exit 1
+fi
+
+# --unstable-presymbolicate is samply ≥0.12 (released 2024). Detect via --help
+# rather than parsing a version so future renames don't silently break.
+if ! samply record --help 2>&1 | grep -q -- "--unstable-presymbolicate"; then
+  echo "error: installed samply lacks --unstable-presymbolicate (need samply ≥0.12)." >&2
+  echo "       upgrade via 'cargo install --force samply' or 'brew upgrade samply'." >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+echo "==> building zntc (-Doptimize=ReleaseFast -Dkeep-debug=true) ..."
+zig build -Doptimize=ReleaseFast -Dkeep-debug=true
+
+# macOS: regenerate .dSYM unconditionally. The `-nt` mtime check is unreliable
+# because `zig build` can hardlink a cache-hit binary while leaving an older
+# dSYM in place (e.g. previous run used -Dkeep-debug=false). Re-running dsymutil
+# costs a few seconds and guarantees the dSYM matches the binary we just built.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  echo "==> running dsymutil to produce zntc.dSYM ..."
+  dsymutil zig-out/bin/zntc
+fi
+
+if [[ ! -f "$FIXTURE" ]]; then
+  echo "error: fixture not found: $FIXTURE" >&2
+  echo "  (resolved from: '$RAW_FIXTURE')" >&2
+  echo "  hint: 'cd tests/benchmark && bun install' to populate node_modules" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+# Warm filesystem cache so the first iteration is not cold I/O biased.
+echo "==> warming filesystem cache ..."
+./zig-out/bin/zntc "$FIXTURE" -o /dev/null >/dev/null 2>&1 || true
+
+echo "==> recording $ITERS iterations at ${RATE}Hz on fixture: $FIXTURE"
+samply record \
+  --save-only \
+  --no-open \
+  --output "$OUT_DIR/profile.json.gz" \
+  --rate "$RATE" \
+  --iteration-count "$ITERS" \
+  --unstable-presymbolicate \
+  -- ./zig-out/bin/zntc "$FIXTURE" -o /dev/null
+
+echo
+echo "done. analyze with:"
+echo "  python3 scripts/analyze-samply.py $OUT_DIR"
+echo "  samply load $OUT_DIR/profile.json.gz   # Firefox profiler UI"


### PR DESCRIPTION
## 배경

ZNTC 자체 `--profile` 인프라는 phase 별 wall 누적 측정엔 충분하지만, 호출 빈도가 큰 hot path 함수의 self time 은 `std.time.Timer.read()` 오버헤드로 부풀려진다 ([[feedback_profile_self_timer_artifact]]). 본 PR 이전 typescript.js 9MB 측정에서 `parse.expression.assignment` self 가 45ms (parse 의 43%) 로 잡혔는데, 실측 sampling 결과 parser 분기 자체는 ~6% 에 불과하고 진짜 dominant 는 *parser 가 호출하는 Scanner* (25%) 였다.

→ sampling profiler (`samply`) 를 코드베이스에 표준 워크플로우로 추가해 함수 단위 hotspot 을 정확히 격리한다.

## 변경 사항

- **`build.zig`** — `-Dkeep-debug=true` 옵션 추가. ReleaseFast/Safe/Small 빌드에서도 DWARF 보존 (samply / Instruments / dtrace 가 함수명 해석 가능). 기본값은 `false` 라 프로덕션 배포 결과물에는 변화 없음 (`strip = null` → Zig optimize mode 기본값 위임).
- **`scripts/profile-parse-samply.sh`** — `zig build -Dkeep-debug=true` → macOS 라면 `dsymutil` → `samply record --save-only --unstable-presymbolicate` 5 iter. fixture/iter/rate 위치 인자, `ZNTC_SAMPLY_OUT` 환경변수 지원. samply 미설치/구버전·fixture 부재 등 흔한 함정 사전 차단.
- **`scripts/analyze-samply.py`** — Python stdlib 만으로 `profile.json.gz` + presymbolicate sidecar (`profile.json.syms.json`) 파싱 → 함수별 self / inclusive sample count 표 출력. `--top N` `--filter` 인자. samply 가 `frameTable.nativeSymbol[]` 를 비워두고 sidecar 로 분리하므로 frame 단위 lib 식별 불가 — `known_addresses` 의 union 매핑이 best effort 임을 코드에 명시하고, 만약 lib 간 RVA 충돌이 발생하면 stderr 로 경고 (실측 0건).
- **`docs/PERF_PROFILING.md`** — 절차 / 측정 예시 (top 9 self count) / 회귀 비교 가이드 / 알려진 함정 (cross-lib RVA, dSYM staleness, OUT_DIR race) 정리.

## 측정 예시 (main HEAD d0fe8e10, typescript.js 9MB, 5 iter × 4kHz)

총 ~2,100 sample 기준 Top self count:

| 순위 | self% | 함수 |
| ---: | ---: | --- |
| 1 | **16.79%** | `lexer.scanner.Scanner.next` |
| 2 | 11.99% | `_platform_memmove` (ArrayList realloc) |
| 3 | 4.70% | `bundler.resolver.DirEntryCache HashMap.getIndex` |
| 4 | 4.56% | `semantic.SemanticAnalyzer.visitNode` |
| 5 | 4.47% | `lexer.scanner.Scanner.skipWhitespace` |
| 6 | 4.33% | `transformer.node_dispatch.visitNodeInner` |
| 7 | 3.76% | `codegen.node_dispatch.emitNode` |
| 8 | 2.73% | `parser.ast.Ast.addNode` |
| 9 | 2.35% | `lexer.scanner.Scanner.scanIdentifierTail` |

영역별 합산: Lexer ~25% / Codegen ~9.5% / Semantic ~8.7% / AST alloc ~8.5% / Parser logic ~7.4% / Transformer ~7.3% / Resolver HashMap ~6.5%.

## 검증

- `zig build -Doptimize=ReleaseFast` (기본) — 기존과 동일 (strip 동작 변화 없음).
- `zig build -Doptimize=ReleaseFast -Dkeep-debug=true` — DWARF 보존 빌드 통과.
- `scripts/profile-parse-samply.sh` end-to-end — 5 iter 측정 + `analyze-samply.py` Top 50 출력 확인. cross-lib RVA 충돌 0건 / unmapped frame 0~9 (worker thread join 노이즈).
- `/code-review max` 한 차례 → analyze-samply.py 의 cross-lib 매핑 안전망 + 0-주소 sentinel 가드 + sh 의 `realpath` 변환 + samply 버전 precheck + dsymutil 항상 재실행 + OUT_DIR race 문서화까지 반영.

## 영향

- 프로덕션 빌드/배포 경로 변화 없음 (`-Dkeep-debug` default false).
- CI 영향 없음 (스크립트는 수동 실행).
- 향후 lexer / parser / codegen 영역 perf R&D 시 회귀 비교 표준 측정 도구.

🤖 Generated with [Claude Code](https://claude.com/claude-code)