### PR TITLE
feat(parser): pre-warm ast.nodes capacity by source length

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1079,8 +1079,16 @@ pub const Ast = struct {
     const StringInternMap = std.HashMapUnmanaged(Span, void, SpanCtx, std.hash_map.default_max_load_percentage);
 
     pub fn init(allocator: std.mem.Allocator, source: []const u8) Ast {
+        var nodes: std.ArrayList(Node) = .empty;
+        // typescript.js 9MB 측정에서 노드 1 개당 약 8 source 바이트의 밀도. 한 번에
+        // capacity 를 잡아 lazy realloc 의 2x peak (이전 buffer + 새 buffer 공존)를
+        // 회피한다. 87MB synthetic 입력 실측: pre-warm RSS 2.32 GB vs lazy 2.99 GB
+        // (-22%). 큰 입력 폭주 가설은 측정으로 반증돼 별도 cap 은 두지 않는다.
+        // 시그니처가 error union 이 아니므로 OOM 은 `catch {}` 후 기존 lazy grow
+        // 경로로 fallback.
+        nodes.ensureTotalCapacity(allocator, source.len / 8) catch {};
         return .{
-            .nodes = .empty,
+            .nodes = nodes,
             .extra_data = .empty,
             .string_table = .empty,
             .string_interns = .empty,


### PR DESCRIPTION
## 배경

samply 측정 ([PR #3925](https://github.com/ohah/zntc/pull/3925) 인프라) 으로 typescript.js 9MB 의 진짜 hotspot 분석:

| 순위 | self% | 함수 |
| ---: | ---: | --- |
| 1 | 16.79% | `lexer.scanner.Scanner.next` |
| 2 | **11.99%** | `_platform_memmove` (libsystem) |

memmove 12% 의 다수는 **ArrayList 의 lazy grow 시 발생하는 2x peak**: realloc 마다 새 buffer 할당 → 기존 데이터 복사 → 기존 buffer free 의 *복사 중 순간* 에 old + new buffer 둘 다 메모리에 존재. growth factor 1.5~2x 가 amplify.

ast.nodes 는 매 토큰 (수십만~수백만) AST node 를 누적하는 가장 hot 한 ArrayList. Parser.init 시점에는 이미 `scanner.source.len` 을 알고 있어, 측정 기반 밀도 (~1 노드/8 source 바이트) 로 `ensureTotalCapacity(source.len / 8)` 한 번에 잡으면 realloc 자체 제거.

## 변경

`src/parser/ast.zig` 의 `Ast.init` 한 줄 추가:

```zig
pub fn init(allocator: std.mem.Allocator, source: []const u8) Ast {
    var nodes: std.ArrayList(Node) = .empty;
    nodes.ensureTotalCapacity(allocator, source.len / 8) catch {};
    return .{ .nodes = nodes, ... };
}
```

`catch {}` 패턴은 같은 파일의 기존 `bracket_stack.ensureTotalCapacity(...) catch {}` 와 일치 (`Ast.init` 시그니처가 error union 이 아니므로 OOM 은 lazy grow 경로로 fallback).

## 측정

### 1. typescript.js 9MB 단일 transpile (ReleaseFast, 10회 인터리브 median)

| 지표 | main | pre-warm | Δ |
| --- | ---: | ---: | ---: |
| wall median | 166.73ms | 163.47ms | **-3.26ms (-1.95%)** |
| wall trimmed mean | 167.07ms | 163.54ms | -3.53ms (-2.11%) |
| samply `_platform_memmove` | 11.99% | 8.68% | -3.31% absolute |

### 2. 87MB synthetic 입력 RSS (큰 입력 폭주 가설 검증)

| 빌드 | peak RSS | real time |
| --- | ---: | ---: |
| main (lazy grow) | 2,985 MB | 1.40s |
| pre-warm | **2,321 MB** | **1.31s** |
| Δ | **-663 MB (-22%)** | -0.09s |

`source.len/8` 무한정 의 RSS 폭주 가설 (e.g. 100MB → 300MB pre-alloc OOM) 은 측정으로 반증 — **큰 입력에서도 pre-warm 이 더 적은 RSS**. lazy grow 의 2x peak 가 사라지면서 단일 alloc 으로 수렴. 코드 리뷰의 cap 우려에 대응해 4M cap 도 시도했지만, cap 적용 시 cap 이후 grow round 가 2x peak 부활 → 오히려 RSS +369 MB → cap 제거가 옳음.

## 회귀

- `zig build test` 통과
- `tests/benchmark` bun test: **16 pass / 0 fail**
- `tests/integration` bundle-smoke: **151 pass / 0 fail**
- `tests/integration` bun test 전체: **3,924 pass / 27 fail**. 27 fail 는 main baseline 과 정확히 동일 → PR 회귀 0. (fail 자체는 사전 존재 fixture path 이슈로 PR 와 무관)
- `/code-review max` 1회 → 6 finding (cap 우려, 주석 stale, altitude=Ast.init 으로 이동, 단일 corpus, style, follow-up extra_data) 반영. 가장 큰 변화 = Parser.init → Ast.init 으로 altitude 이동 + cap 측정 후 제거.

## Follow-up (별도 PR)

- `extra_data` / `string_table` 도 같은 패턴으로 pre-warm 검토 (memmove 잔여 8.68% 의 일부 회수 가능성).

Closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)