### PR TITLE
feat(parser): pre-warm ast.extra_data capacity by source length

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1080,16 +1080,23 @@ pub const Ast = struct {
 
     pub fn init(allocator: std.mem.Allocator, source: []const u8) Ast {
         var nodes: std.ArrayList(Node) = .empty;
-        // typescript.js 9MB 측정에서 노드 1 개당 약 8 source 바이트의 밀도. 한 번에
-        // capacity 를 잡아 lazy realloc 의 2x peak (이전 buffer + 새 buffer 공존)를
-        // 회피한다. 87MB synthetic 입력 실측: pre-warm RSS 2.32 GB vs lazy 2.99 GB
-        // (-22%). 큰 입력 폭주 가설은 측정으로 반증돼 별도 cap 은 두지 않는다.
-        // 시그니처가 error union 이 아니므로 OOM 은 `catch {}` 후 기존 lazy grow
-        // 경로로 fallback.
+        var extra_data: std.ArrayList(u32) = .empty;
+        // 핫 ArrayList 두 곳을 source 길이 기반 평균 밀도로 한 번에 capacity 를 잡아
+        // lazy realloc 의 2x peak (이전 buffer + 새 buffer 공존) 를 회피한다. 87MB
+        // synthetic 입력 실측: nodes 만 적용 시 RSS 2.99 GB → 2.32 GB (-22%, PR
+        // #3926), extra_data 까지 적용 시 RSS 2.32 → 2.23 GB (-98 MB / -4.2% 추가).
+        // 측정 fixture = typescript.js / _tsc.js / mobx / date-fns/cdn / vue / svelte.
+        //   nodes:      source.len / 8  (range 3.60–9.76 byte/node, mean 7.44)
+        //   extra_data: source.len / 6  (range 3.19–8.07 byte/entry, mean 6.43)
+        // svelte 처럼 밀도 높은 corpus 는 평균 ratio 로 ~50% cover 돼 1 라운드 lazy
+        // grow 가 남지만, 평균 corpus 의 RSS 절감을 우선 (cap 가설은 87MB 측정으로
+        // 반증 — pre-warm 이 lazy 보다 항상 RSS 작거나 같음). 시그니처가 error union
+        // 이 아니므로 OOM 은 `catch {}` 후 기존 lazy grow 경로로 fallback.
         nodes.ensureTotalCapacity(allocator, source.len / 8) catch {};
+        extra_data.ensureTotalCapacity(allocator, source.len / 6) catch {};
         return .{
             .nodes = nodes,
-            .extra_data = .empty,
+            .extra_data = extra_data,
             .string_table = .empty,
             .string_interns = .empty,
             .allocator = allocator,


### PR DESCRIPTION
## 배경

[PR #3926](https://github.com/ohah/zntc/pull/3926) 의 follow-up. `ast.nodes` 외 AST 의 두 번째 핫 ArrayList `extra_data` (변형 데이터 overflow, `ArrayList(u32)`) 도 같은 lazy grow 2x peak 문제를 가진다.

6 corpus fixture 측정 결과:

| Fixture | source | extra_data | byte/entry |
| --- | ---: | ---: | ---: |
| typescript.js | 9.1M | 1,172,880 | 7.77 |
| _tsc.js | 6.2M | 770,185 | 8.07 |
| mobx | 205K | 27,776 | 7.40 |
| date-fns/cdn | 237K | 40,302 | 5.88 |
| vue | 380K | 60,695 | 6.26 |
| svelte | 838K | 262,365 | **3.19** |
| **mean** | — | — | **6.43** |

`source.len / 6` 을 평균 밀도로 한 번에 잡아 [PR #3926](https://github.com/ohah/zntc/pull/3926) 와 동일 패턴.

## 변경

```diff
 pub fn init(allocator: std.mem.Allocator, source: []const u8) Ast {
     var nodes: std.ArrayList(Node) = .empty;
+    var extra_data: std.ArrayList(u32) = .empty;
     // ... 측정 근거 주석 (consolidate) ...
     nodes.ensureTotalCapacity(allocator, source.len / 8) catch {};
+    extra_data.ensureTotalCapacity(allocator, source.len / 6) catch {};
     return .{
         .nodes = nodes,
-        .extra_data = .empty,
+        .extra_data = extra_data,
```

## 측정

### typescript.js 9MB (12 회 인터리브, ReleaseFast)

| 지표 | main (post PR #3926) | + extra_data | Δ |
| --- | ---: | ---: | ---: |
| wall median | 164.38ms | 165.49ms | +1.1ms (noise floor 내) |
| samply `_platform_memmove` | 9.58% | 9.78% | noise |

9MB 의 extra_data 는 4.7 MB 라 단일 alloc 영향 미미.

### 87MB synthetic (RSS 3회 안정, wall n=1 directional)

| 지표 | main (post PR #3926) | + extra_data | Δ |
| --- | ---: | ---: | ---: |
| peak RSS | 2,321 MB | **2,223 MB** | **-98 MB (-4.2%)** |
| wall | 1.43s | 1.21s | -15% (single run, directional) |

87MB 같은 generated bundle 의 worker pool 동시 파싱 시 RSS profile 개선이 본 PR 의 헤드라인.

## 회귀

- `zig build test` ✅
- `tests/benchmark` bun test: 16 pass / 0 fail
- `tests/integration` bundle-smoke: 151 pass / 0 fail
- `tests/integration` 전체: **3,924 pass / 27 fail** (main baseline 정확히 동일 — PR 회귀 0)
- `/code-review max` 3 finding 반영 (주석 consolidation, ratio trade-off 명시, 87MB wall n=1 directional 명시)

## Follow-up

svelte 처럼 entry 밀도 3.19 B/entry 인 dense corpus 는 평균 ratio 로 ~50% 만 cover. ratio 4 로 끌어올리면 svelte 까지 fully cover 되지만 sparse corpus 가 2x oversized — RSS net win 검증 후 별도 PR.

string_table 은 transpile path 에서 final length = 0 (bundler/transformer 의 일부 경로만 채움) — pre-warm 불필요 / 측정 부족으로 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)