### PR TITLE
feat(lexer): pre-warm Scanner.line_offsets capacity by source length

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -127,6 +127,15 @@ pub const Scanner = struct {
         std.debug.assert(source.len <= std.math.maxInt(u32));
 
         var line_offsets: std.ArrayList(u32) = .empty;
+        // 8 corpus 직접 계측 (typescript.js / _tsc.js / svelte / mobx / vue /
+        // date-fns / pako / 87MB synthetic): bytes/line 범위 29.65 (vue, dense) ~
+        // 46.43 (_tsc, sparse). svelte 는 minified single-line outlier.
+        // source.len/20 으로 prewarm 하면 모든 corpus 에서 final lines < prewarm
+        // requested (vue 47% 마진, typescript.js 9MB 56% 마진) — 한 round 도 lazy
+        // grow 발생 안 함. typescript.js 9MB: 200K lines 가 1→212K capacity 까지
+        // 22 round grow 했던 부분을 단일 alloc 으로 흡수. ratio 20 은 vue 의
+        // 29.65 보다 33% 더 dense 한 hypothetical bundle 까지 cover.
+        try line_offsets.ensureTotalCapacity(allocator, source.len / 20);
         // 첫 번째 줄의 시작 offset은 항상 0. 이 append가 실패하면 getLineColumn()이 동작 불가.
         try line_offsets.append(allocator, 0);
 


### PR DESCRIPTION
## 배경

PR #3925 / #3926 / #3927 / #3928 의 ArrayList prewarm 패턴 마지막 untreated site. samply Top 13 = `ArrayList(parser.ast.Node).ensureTotalCapacity` 1.74% 와 14 = `ArrayList(ModuleIndex)` 1.67% 의 caller chain 추적 결과 후자가 **Scanner.handleNewline → skipWhitespace**. 즉 `Scanner.line_offsets: ArrayList(u32)` 의 lazy grow.

LLVM 가 `enum(u32)` backing 의 ArrayList 를 같은 instance 로 dedup 해서 samply 라벨이 `ModuleIndex` 로 표시됐지만 실제 caller 는 line_offsets.

## Root cause

`Scanner.init` 에서 `line_offsets: ArrayList(u32) = .empty` 시작 → 매 newline 시 append. prewarm 없어서 typescript.js 9MB 의 200K lines 가 capacity `1 → 212K` 까지 **22 round 의 doubling grow + 2x peak**.

## 변경

```diff
 var line_offsets: std.ArrayList(u32) = .empty;
+try line_offsets.ensureTotalCapacity(allocator, source.len / 20);
 try line_offsets.append(allocator, 0);
```

## Ratio 선택 — 8 corpus 직접 계측

| corpus | source | lines | bytes/line |
| --- | ---: | ---: | ---: |
| typescript.js | 9.1M | 200,277 | 45.50 |
| _tsc.js | 6.2M | 133,819 | 46.43 |
| svelte | 838K | 2 | 419,036 (minified outlier) |
| mobx | 205K | 6,012 | 34.20 |
| **vue** | 380K | 12,815 | **29.65** (가장 dense) |
| date-fns | 237K | 5,487 | 43.20 |
| pako | 238K | 6,897 | 34.62 |
| 87MB synthetic | 91M | 2,002,761 | 45.50 |

ratio 20 = vue 의 29.65 bytes/line 보다 **33% 더 dense 한 hypothetical bundle 까지 cover** → fallback (lazy grow) 시나리오 회피.

## 의도 검증 (instrumented)

| corpus | final lines | prewarm requested | margin |
| --- | ---: | ---: | ---: |
| typescript.js 9MB | 200,277 | 455,628 | 56.0% |
| _tsc.js | 133,819 | 310,654 | 56.9% |
| mobx | 6,012 | 10,281 | 41.5% |
| **vue** | 12,815 | 19,000 | **32.6%** |
| date-fns | 5,487 | 11,852 | 53.7% |
| pako | 6,897 | 11,940 | 42.2% |
| 87MB synthetic | 2,002,761 | 4,556,286 | 56.0% |

**모든 corpus 에서 final < prewarm requested** → **한 round 도 lazy grow 발생 안 함** (grow_safe=yes 직접 확인).

## 측정 결과

### 87MB synthetic peak RSS (3회 안정)

| 빌드 | RSS | Δ |
| --- | ---: | ---: |
| main (post PR #3928) | 1,768,308,736 B | — |
| + line_offsets prewarm | **1,748,877,312 B** | **-19,431,424 B = -19.5 MB (-1.1%)** |

### typescript.js 9MB wall median (10회 인터리브)

| 빌드 | wall | Δ |
| --- | ---: | ---: |
| main HEAD | 165.57ms | — |
| + line_offsets prewarm | 166.06ms | +0.49ms (noise floor) |

작은 incremental win — line_offsets ArrayList 자체가 (8 MB 정도, 87MB 입력 기준) ast.nodes (270 MB) 보다 훨씬 작기 때문. 그러나 root cause 명확 + 의도 검증 완료 + 정확성 회귀 0.

## 회귀

- `zig build test` ✅
- `tests/benchmark` bun test: 16 pass / 0 fail
- `tests/integration` bundle-smoke: 151 pass / 0 fail
- `tests/integration` 전체: **3,951 pass / 0 fail** (.node 갱신 후 main baseline 과 동일)

## 메모리 박제 충돌

[[project_lexer_perf_backlog_no_roi]] 의 #24 (line_offsets prealloc) **"ROI 0 (scan 80ms 의 0.1% 미만)"** 박제는 ZNTC 자체 profile (timer artifact 영향 받음) 기반 측정. 본 PR 의 sampling 기반 caller chain 추적으로 **진짜 root cause 식별** + 87MB RSS 측정으로 -19.5 MB win 확인. 메모리 박제는 *timer 기반 측정의 한계* 박제로 재해석.

🤖 Generated with [Claude Code](https://claude.com/claude-code)