### PR TITLE
fix(lexer): line_offsets prewarm follow-up — best-effort + comment fix

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -129,13 +129,11 @@ pub const Scanner = struct {
         var line_offsets: std.ArrayList(u32) = .empty;
         // 8 corpus 직접 계측 (typescript.js / _tsc.js / svelte / mobx / vue /
         // date-fns / pako / 87MB synthetic): bytes/line 범위 29.65 (vue, dense) ~
-        // 46.43 (_tsc, sparse). svelte 는 minified single-line outlier.
-        // source.len/20 으로 prewarm 하면 모든 corpus 에서 final lines < prewarm
-        // requested (vue 47% 마진, typescript.js 9MB 56% 마진) — 한 round 도 lazy
-        // grow 발생 안 함. typescript.js 9MB: 200K lines 가 1→212K capacity 까지
-        // 22 round grow 했던 부분을 단일 alloc 으로 흡수. ratio 20 은 vue 의
-        // 29.65 보다 33% 더 dense 한 hypothetical bundle 까지 cover.
-        try line_offsets.ensureTotalCapacity(allocator, source.len / 20);
+        // 46.43 (_tsc, sparse). source.len/20 prewarm 으로 모든 corpus 에서 final
+        // lines < requested (vue 32.6% 마진, typescript.js 9MB 56% 마진) — 한
+        // round 도 lazy grow 발생 안 함. best-effort: OOM 시 lazy grow 로 fallback
+        // (Ast.init 의 nodes / extra_data prewarm 과 동일 패턴).
+        line_offsets.ensureTotalCapacity(allocator, source.len / 20) catch {};
         // 첫 번째 줄의 시작 offset은 항상 0. 이 append가 실패하면 getLineColumn()이 동작 불가.
         try line_offsets.append(allocator, 0);
 


### PR DESCRIPTION
## 배경

PR #3929 (`Scanner.line_offsets` prewarm) 는 머지 전 `/code-review max` 가 누락된 채 머지됐다. post-merge `/code-review max` 결과 2 finding 발견:

1. **(HIGH)** 주석 stale 숫자 — "vue **47%** 마진" 인데 실제 verify printout 은 **32.6%**. ratio 변경 (28 → 24 → 20) 과정에서 갱신 누락.
2. **(HIGH/MEDIUM)** `try ensureTotalCapacity` 가 형제 PR (#3926/#3927/#3928) 의 `catch {}` 패턴과 불일치 — prewarm 은 best-effort 성능 최적화여야 하나 본 PR 는 `try` 로 hard-fail.

## 변경

### A. 주석 stale 숫자 수정

```diff
- // requested (vue 47% 마진, typescript.js 9MB 56% 마진) — 한 round 도 lazy
+ // lines < requested (vue 32.6% 마진, typescript.js 9MB 56% 마진) — 한
```

verify printout 재확인 (`(19000 - 12815) / 19000 = 32.55% → 32.6%`).

### B. `try` → `catch {}` (best-effort 일관성)

```diff
- try line_offsets.ensureTotalCapacity(allocator, source.len / 20);
+ line_offsets.ensureTotalCapacity(allocator, source.len / 20) catch {};
```

`Ast.init` (PR #3926) / `Ast.init` extra_data (PR #3927) 모두 같은 `catch {}` 패턴.

**OOM 안전성**: ArrayList `ensureTotalCapacity` 실패 시 ArrayList 는 `.empty` 상태 유지. 직후 `try line_offsets.append(allocator, 0)` 가 lazy alloc 으로 실 OOM 을 정확히 catch (4-byte alloc 도 실패할 만큼 진짜 OOM 이면 거기서 `error.OutOfMemory` propagate).

### C. 주석 트림 + "PR #3926" anchor 제거

- "ratio 20 은 vue 의 29.65 보다 33% 더 dense 한 hypothetical bundle 까지 cover" / "22 round grow 했던 부분을 단일 alloc 으로 흡수" 문장 제거 — `32.6% 마진` + `best-effort` 로 함의 충분
- `PR #3926` anchor → `Ast.init 의 nodes / extra_data prewarm 과 동일 패턴` ([[feedback_no_reference_comments]])

## 회귀

- `zig build test` ✅
- `tests/benchmark`: 16 pass / 0 fail
- `tests/integration` bundle-smoke: 151 pass / 0 fail
- 동작 변화 없음 — typescript.js / 87MB synthetic 모두 prewarm 성공 → `catch {}` 분기 미발동 → `try` 와 동일 코드 경로.

## /code-review

- post-merge max 1회 (PR #3929 누락 보완)
- 본 follow-up pre-merge max 1회

PR #3929 머지 워크플로우 위반 (max 사전 누락) 의 책임은 본 follow-up 으로 최소화. 다음 PR 부터는 사전 max 절차 엄수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)