### PR TITLE
feat(graph): ModuleGraph.reset / invalidateModule API (RFC #3933 Sub-PR-B.1)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -251,6 +251,12 @@ pub const ModuleGraph = struct {
     const graph_lifecycle = @import("graph/lifecycle.zig");
     pub const init = graph_lifecycle.init;
     pub const deinit = graph_lifecycle.deinit;
+    /// RFC_GRAPH_PERSISTENCE Sub-PR-B.1 — graph-global state reset (modules 보존).
+    /// 호출자 없음 (Sub-PR-B.3 에서 wire-up).
+    pub const reset = graph_lifecycle.reset;
+    /// RFC_GRAPH_PERSISTENCE Sub-PR-B.1 — 단일 모듈 invalidate (path 보존).
+    /// 호출자 없음 (Sub-PR-B.3 에서 wire-up).
+    pub const invalidateModule = graph_lifecycle.invalidateModule;
 
     const ensureBuiltinPlugins = graph_plugins.ensureBuiltinPlugins;
     pub const pluginRunnerWithBuiltins = graph_plugins.pluginRunnerWithBuiltins;

--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -19,6 +19,77 @@ pub fn init(allocator: std.mem.Allocator, resolve_cache: *ResolveCache) ModuleGr
     };
 }
 
+/// graph-global state 만 reset — modules / path_to_module / path_arena / pkg_info_cache 는
+/// 보존. RFC_GRAPH_PERSISTENCE Sub-PR-B.1 의 API skeleton — 호출자 없음 (테스트 only).
+///
+/// Reset 영역:
+///   - diagnostics + owned_diagnostic_strings (매 빌드마다 새 diag)
+///   - worker_entries (매 빌드마다 새로 수집, resolved_path 는 graph allocator 소유)
+///   - rn_asset_metadata (매 빌드마다 새로 수집)
+///   - runtime_polyfill_roots (매 빌드마다 새로 수집)
+///   - requested_exports (graph-level state, ancestor 추적 어려워 일괄 reset)
+///   - source_read_cache (다음 빌드에서 fresh read 강제)
+///   - exec_counter / cycle_counter (DFS state)
+///
+/// **보존 영역 (persistence 의 핵심):**
+///   - modules SegmentedList — module 인스턴스 그대로
+///   - path_to_module — path → idx 인덱스
+///   - path_arena — path/resolve_dir 메모리
+///   - pkg_info_cache — package.json 정보 (재 parse 회피)
+///   - 옵션들 (dev_mode, jsx_runtime, defines, plugins 등)
+///
+/// 사용 가정: caller 가 변경 모듈에 대해 invalidateModule(idx) 를 추가로 호출해
+/// 모듈 단위 state 도 reset. reset() 만 호출하면 modules 의 stale ast/semantic 이
+/// 그대로 남음 — Sub-PR-B.3 의 wire-up 에서 invalidateModule 와 함께 사용.
+pub fn reset(self: *ModuleGraph) void {
+    for (self.owned_diagnostic_strings.items) |s| self.allocator.free(s);
+    self.owned_diagnostic_strings.clearRetainingCapacity();
+    self.diagnostics.clearRetainingCapacity();
+
+    for (self.worker_entries.items) |we| self.allocator.free(we.resolved_path);
+    self.worker_entries.clearRetainingCapacity();
+
+    const graph_assets = @import("assets.zig");
+    for (self.rn_asset_metadata.items) |meta| {
+        graph_assets.freeRnAssetMetadata(self.allocator, meta);
+    }
+    self.rn_asset_metadata.clearRetainingCapacity();
+
+    self.runtime_polyfill_roots.clearRetainingCapacity();
+
+    var req_it = self.requested_exports.valueIterator();
+    while (req_it.next()) |req| req.deinit(self.allocator);
+    self.requested_exports.clearRetainingCapacity();
+
+    self.source_read_cache.deinit(self.allocator);
+    self.source_read_cache = .{};
+
+    self.exec_counter = 0;
+    self.cycle_counter = 0;
+}
+
+/// 단일 모듈의 state 부분 reset (path 보존, graph slot 유지). 변경 감지된 모듈을
+/// re-parse/re-analyze 하기 전 호출. 인덱스 자체는 path_to_module 에서 유지되어
+/// 다른 모듈의 dependencies/importers 가 가리키는 ModuleIndex 가 그대로 유효.
+///
+/// 동작: module.deinit() 으로 ast/semantic/resolved_deps 등 모든 resource 해제 →
+/// 동일 index/path 로 빈 Module 새로 init (state = .reserved). 이후 caller 가
+/// 정상 build flow (read → parse → semantic → resolve) 로 다시 채움.
+///
+/// **importers / dynamic_importers 보존**: 다른 모듈이 이 모듈을 import 하는 정보는
+/// 이번 변경과 무관 — caller (정상 build flow) 가 같은 importers 를 다시 채움.
+/// 실제로는 module.deinit 가 importers/dependencies 둘 다 해제하지만, init 후 caller
+/// 가 build flow 에서 importers 재기록함.
+pub fn invalidateModule(self: *ModuleGraph, idx: ModuleIndex) void {
+    const idx_usize = @intFromEnum(idx);
+    std.debug.assert(idx_usize < self.modules.count());
+    const mod_ptr = self.modules.at(idx_usize);
+    const saved_path = mod_ptr.path;
+    const saved_index = mod_ptr.index;
+    mod_ptr.deinit(self.allocator);
+    mod_ptr.* = @import("../module.zig").Module.init(saved_index, saved_path);
+}
+
 pub fn deinit(self: *ModuleGraph) void {
     var mod_it = self.modules.iterator(0);
     while (mod_it.next()) |m| {

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -1470,3 +1470,102 @@ test "F4 follow-up: buildIncremental 는 user-set project_root 를 보존" {
     // RN/Metro asset httpServerLocation 어긋남.
     try std.testing.expectEqualStrings(user_project_root, graph.project_root);
 }
+
+// ============================================================
+// Sub-PR-B.1: ModuleGraph.reset / invalidateModule API tests
+// RFC_GRAPH_PERSISTENCE — 호출자 없음 (Sub-PR-B.3 에서 wire-up). 본 단위 테스트는
+// API 의 부분 정확성만 — graph-global state clear + module-local state reset.
+// ============================================================
+
+test "graph.reset: modules + path_to_module 보존, diagnostics/worker_entries clear" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './b';");
+    try writeFile(tmp.dir, "b.ts", "export const x = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "a.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{entry});
+
+    const mod_count_before = graph.moduleCount();
+    const path_count_before = graph.path_to_module.count();
+    try std.testing.expect(mod_count_before >= 2);
+
+    // 인위적으로 graph-global state 채우기 — diagnostics + worker_entries
+    const Span = @import("../lexer/token.zig").Span;
+    try graph.diagnostics.append(graph.allocator, .{
+        .code = .parse_error,
+        .severity = .warning,
+        .message = "synthetic diag",
+        .file_path = "synthetic.ts",
+        .span = Span.EMPTY,
+        .step = .parse,
+    });
+    const synthetic_path = try graph.allocator.dupe(u8, "/tmp/worker.ts");
+    try graph.worker_entries.append(graph.allocator, .{
+        .resolved_path = synthetic_path,
+        .source_module = ModuleIndex.fromUsize(0),
+        .record_index = 0,
+    });
+    graph.exec_counter = 42;
+    graph.cycle_counter = 7;
+
+    // reset 호출
+    graph.reset();
+
+    // modules 보존
+    try std.testing.expectEqual(mod_count_before, graph.moduleCount());
+    try std.testing.expectEqual(path_count_before, graph.path_to_module.count());
+    // graph-global state cleared
+    try std.testing.expectEqual(@as(usize, 0), graph.diagnostics.items.len);
+    try std.testing.expectEqual(@as(usize, 0), graph.worker_entries.items.len);
+    try std.testing.expectEqual(@as(u32, 0), graph.exec_counter);
+    try std.testing.expectEqual(@as(u32, 0), graph.cycle_counter);
+}
+
+test "graph.invalidateModule: path 보존, ast/semantic/resolved_deps clear" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './b';");
+    try writeFile(tmp.dir, "b.ts", "export const x = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "a.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{entry});
+
+    const target_idx = ModuleIndex.fromUsize(0);
+    const path_before = graph.getModule(target_idx).?.path;
+    const path_dupe = try std.testing.allocator.dupe(u8, path_before);
+    defer std.testing.allocator.free(path_dupe);
+
+    // build 후엔 ast / semantic 채워져 있음
+    try std.testing.expect(graph.getModule(target_idx).?.state == .ready);
+
+    graph.invalidateModule(target_idx);
+
+    // path 보존 (path_arena 가 소유)
+    try std.testing.expectEqualStrings(path_dupe, graph.getModule(target_idx).?.path);
+    // module state 가 reserved (build 시작 상태) 로 reset
+    try std.testing.expectEqual(Module.State.reserved, graph.getModule(target_idx).?.state);
+    // ast / semantic null
+    try std.testing.expect(graph.getModule(target_idx).?.ast == null);
+    try std.testing.expect(graph.getModule(target_idx).?.semantic == null);
+    // resolved_deps clear
+    try std.testing.expectEqual(@as(usize, 0), graph.getModule(target_idx).?.resolved_deps.items.len);
+}


### PR DESCRIPTION
## Summary

RFC #3933 (graph persistence) 의 prerequisite. graph instance 를 빌드 간 재사용하기 위한 API skeleton 만 추가 — **호출자 없음, production 동작 변화 0**. Sub-PR-B.3 (replay short-circuit) 에서 wire-up.

## 변경

| API | 동작 |
|---|---|
| `ModuleGraph.reset()` | graph-global state clear (diagnostics, worker_entries, rn_asset_metadata, runtime_polyfill_roots, requested_exports, source_read_cache, DFS counters). **modules / path_to_module / path_arena / pkg_info_cache 는 보존** |
| `ModuleGraph.invalidateModule(idx)` | 단일 모듈 in-place reset. `module.deinit()` 후 같은 index/path 로 빈 Module 재 init. path_to_module 의 idx 보존 → 다른 모듈의 ModuleIndex 참조 그대로 유효 |

## 단위 테스트

- `graph.reset: modules + path_to_module 보존, diagnostics/worker_entries clear`
- `graph.invalidateModule: path 보존, ast/semantic/resolved_deps clear`

## 영향

- 호출자 없음 → production 빌드 영향 0
- 5607 tests + Pipeline Profile + incremental-bench 전부 통과
- 다음 Sub-PR (B.2: Bundler.initWithGraph) 의 prerequisite

## Test plan

- [x] `zig build test` 통과 (exit=0)
- [x] 새 단위 테스트 2건 통과
- [ ] Sub-PR-B.3 wire-up 시 정확성 invariant 확장 검증 (follow-up)

## Related

- RFC: #3933 (graph persistence)
- 부모 epic: #3931 (dev_server HMR latency)
- 선행 PR: #3932 (PR-A wire-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)