### PR TITLE
docs(rfc): graph persistence CLOSED (PoC NO-GO) + emit incremental RFC

### DIFF
--- a/docs/RFC_EMIT_INCREMENTAL.md
+++ b/docs/RFC_EMIT_INCREMENTAL.md
@@ -1,0 +1,181 @@
+# RFC: Emit Incremental — emit_module_pass Chunk-Level Dirty Marking
+
+상태: **DRAFT · 측정 기반 epic** · 분류: dev UX / emit 모델 재설계
+부모 RFC: [RFC_EMIT_INCREMENTAL_DEV_SERVER.md](./RFC_EMIT_INCREMENTAL_DEV_SERVER.md) PR-C 영역
+관련: `src/bundler/emitter.zig:563` (emit_module_pass), `:670` (skip_bundle_concat), `src/bundler/compiled_cache.zig`
+선행: [RFC_GRAPH_PERSISTENCE](./RFC_GRAPH_PERSISTENCE.md) NO-GO (graph 영역 종결, emit 영역 별개)
+
+## 1. 배경
+
+dev_server lodash HMR latency 분해 (post Sub-PR-B.2):
+
+```
+scan      ~38ms
+parse     ~54ms
+semantic  ~10ms
+resolve   ~3ms
+graph    ~146ms   ← RFC_GRAPH_PERSISTENCE CLOSED, NO-GO
+link      ~61ms
+emit      ~80ms   ← PR-A 후 (skip_bundle_output 으로 172→80)
+```
+
+esbuild lodash in-process rebuild = 50ms. graph 영역이 architecture lock 으로 막힘.
+
+**emit 영역은 graph 와 *독립* — graph 안 건드리고 fix 가능**:
+- `emit_module_pass` (`emitter.zig:563`) 가 매 빌드 mod 단위 emit
+- `compiled_cache` (PR-A 의 hash 분리 fix 로 작동) — cache hit/miss 모듈 단위 검사
+- *모듈 단위* cache 는 있지만, *chunk 전체* re-emit 은 매번 발생
+
+### 1.1 emit_module_pass 의 현재 동작
+
+`emitter.zig:563-660` (요약):
+1. `Phase 1.5`: compiled_cache lookup per module → hit/miss bitmap
+2. `Phase 2`: parallel emit per module (miss 만)
+3. `Phase 2.5`: cache put per module (miss 만)
+4. `Phase 3 (emit_concat)`: 모든 모듈을 chunk 단위 concat (현재는 skip_bundle_output 로 dev mode 시 skip)
+
+**PR-A 후 dev mode 의 emit_concat 은 이미 skip**. 남은 비용 = `emit_module_pass` 의 *모듈 단위 emit per chunk*.
+
+### 1.2 진짜 병목 = 모듈 단위 emit 의 parallel 처리
+
+incremental 의 emit ~80ms (PR-A 후) wall 중:
+- cache hit ratio = 640/641 (PR-A 의 hash 분리 효과)
+- 즉 *변경 모듈 1개만 진짜 emit*, 나머지 640 모듈은 cache hit (Phase 1.5 의 `cache.tryHit`)
+- 그러나 cache hit 자체 비용 (`computeInputHash` per module + `tryHit` + `dupe`) = ~80ms wall 의 큰 부분
+
+esbuild 가 50ms 인 이유:
+- chunk-level incremental — 변경 모듈이 포함된 *chunk 하나* 만 re-emit
+- 다른 chunk 는 *이전 빌드의 byte stream 그대로 재사용*
+- 즉 *cache lookup per module* 도 발생 안 함
+
+## 2. 제안 — Chunk-Level Dirty Marking
+
+### 2.1 핵심 원칙
+
+1. **Chunk-level cache** — chunk 단위 emit byte stream 캐시 (모듈 단위 아닌)
+2. **Dirty marking** — 변경 모듈이 속한 chunk 만 dirty 마킹
+3. **Non-dirty chunk skip** — emit_module_pass 자체 skip, 이전 byte stream 재사용
+
+### 2.2 graph 영역과의 분리
+
+본 RFC 는 **`ModuleGraph` 인스턴스 lifecycle 안 건드림** (RFC_GRAPH_PERSISTENCE CLOSED 영역). emit 단계의 *결과* (chunk byte stream) 만 cache. graph 가 매 빌드 fresh init 돼도 emit cache 는 graph 외부 (예: IncrementalBundler 또는 emit_store) 에 보존.
+
+cache key = `chunk_id` + `included module hashes`. 변경 모듈의 hash 변경 → 해당 chunk 의 cache miss.
+
+### 2.3 측정 목표
+
+| Phase | 현재 (PR-A 후) | 목표 (PR-C) | 회수치 |
+|---|---|---|---|
+| emit | ~80ms | ~10ms | -70ms |
+| WALL | 307ms | ~240ms | -67ms |
+| esbuild 격차 | 6× | ~5× | (graph 가 막혀 한계) |
+
+esbuild 50ms 까지 closer 가지만 graph 146ms 가 architectural lock 이라 *graph + emit fix 합치면 ~30-50ms 가능 (graph 가 lifecycle redesign 후)*. 본 RFC 만으로는 ~240ms 가 한계.
+
+### 2.4 변경 영역
+
+**A) `ChunkEmitCache` 신규**
+- 위치: `src/bundler/chunk_emit_cache.zig` (신규)
+- key = `(chunk_id, sorted modules hash)`, value = `EmittedChunk { bytes, sourcemap_segments, modules: []ModuleEmitInfo }`
+- `tryHit(chunk_id, modules)` / `put(chunk_id, modules, emitted)`
+- `IncrementalBundler` 가 owner (graph 외부)
+
+**B) `emit_module_pass` 단계 분기**
+- chunk_id 시점에 `ChunkEmitCache.tryHit` 호출
+- hit 면 *모든 module emit skip*, cached bytes 직접 chunk output 으로
+- miss 면 현재 path (per-module emit + cache put 후 chunk 도 cache put)
+
+**C) Chunk membership 결정의 안정성**
+- chunk 분배가 *deterministic* 필요 — 같은 입력 → 같은 chunk id + modules
+- dev 모드의 single chunk 는 trivial (모든 모듈이 chunk 0)
+- production splitting 시 chunk hash 가 변경 모듈 영향 받음 — 그 chunk 만 cache miss
+
+**D) Dev mode 우선**
+- production splitting 시 chunk hash 변경 추적 복잡 — 별도 PR
+- 본 RFC scope = dev mode (single chunk) 만 우선 적용
+
+### 2.5 단계별 PR 분할
+
+**Sub-PR-C.1: `ChunkEmitCache` API skeleton (S)**
+- 신규 struct + init/deinit/tryHit/put. 호출자 없음.
+- 단위 테스트.
+- 영향 0.
+
+**Sub-PR-C.2: Dev mode single-chunk wire-up + PoC 측정 (M, GO/NO-GO)**
+- `emit_module_pass` 시작 시 ChunkEmitCache.tryHit
+- single chunk + dev mode 케이스 한정
+- ZNTC_EMIT_INCREMENTAL=1 env opt-in (kill-switch)
+- lodash dev_server HMR 측정 — emit 80→? (목표 ≤30ms)
+- **GO/NO-GO 결정**
+
+**Sub-PR-C.3: 정확성 가드 + production opt-in (M)**
+- HMR client 가 받는 dev_codes / sourcemap segments 의 wire form 회귀 가드
+- chunk dirty marking 의 false negative (변경 안 잡힘) 검증
+- ZNTC_EMIT_INCREMENTAL default true 전환
+
+**Sub-PR-C.4: Production splitting 지원 (L, 후속)**
+- 여러 chunk 환경에서 dirty chunk 만 re-emit
+- chunk hash 변경 추적
+- RN 회귀 가드
+
+## 3. PoC 계획
+
+### Step 1 — emit_module_pass 의 *진짜* sub-phase 분포 측정 (이번 RFC 작성 전제)
+
+PR-A 후 emit ~80ms 의 분해:
+- compiled_cache.tryHit per module: ?
+- emitModule per module (miss 만): ?
+- compiled_cache.put per module: ?
+- dev_codes collection: ?
+- sourcemap segment 누적: ?
+
+incremental 측정 + ZNTC_PROFILE detailed 로 확인 필요. PoC step 2 의 prerequisite.
+
+### Step 2 — `ChunkEmitCache.tryHit` PoC 시뮬레이션
+
+미구현 시 측정 — emit 단계 *전체 skip* 시 wall 의 이론적 하한 확인:
+- `emit_module_pass` 시작점에서 즉시 *cached output* 반환 (dummy)
+- 측정: wall = scan + parse + semantic + resolve + graph + link = ? ms
+- 이 값이 *graph fix 없이 도달 가능한 하한*
+
+### Step 3 — Sub-PR-C.1 (next session)
+
+API skeleton + 단위 테스트.
+
+### Step 4 — Sub-PR-C.2 (PoC GO/NO-GO)
+
+본격 wire-up + lodash 측정.
+
+## 4. 회귀 가드
+
+- `tests/benchmark/devserver-hmr.ts` — dev_server WS HMR latency (bench follow-up PR)
+- 내장 `incremental_bench_v4` — emit sub-phases timing
+- 새 fixture: HMR client 의 dev_codes wire form 정확성
+
+## 5. RN 영향
+
+| Sub-PR | RN 영향 |
+|---|---|
+| C.1 (API skeleton) | 0 (호출자 없음) |
+| C.2 (dev mode wire-up) | 0 (RN HMR 은 NAPI watch path, 본 RFC scope 외) |
+| C.3 (정확성 가드) | 0 |
+| **C.4 (production splitting)** | **잠재 risk** — RN bundle (single IIFE) 의 emit 영향. 회귀 가드 (RN bare/large/expo) 필수 |
+
+NAPI watch.zig 의 RN HMR 은 별도 incremental loop — 본 RFC 와 무관.
+
+## 6. 정책 / 결정
+
+### GO/NO-GO 기준 (Sub-PR-C.2)
+
+- ✅ GO: lodash emit 80→≤30ms (~60% 절약). PR-C.3/C.4 진행.
+- ❌ NO-GO: 절약 <30ms 또는 정확성 회귀 → RFC_EMIT_INCREMENTAL_CLOSED.md 종결.
+
+### Out of scope
+
+- **Graph persistence** — RFC_GRAPH_PERSISTENCE CLOSED. 본 RFC 는 graph 안 건드림.
+- **Lifecycle scope redesign** — 별도 epic, mid-term.
+- **mangler size gap** — RFC_MANGLER_SIZE_GAP_CLOSED 영역.
+
+### 진짜 의의
+
+RFC_GRAPH_PERSISTENCE 가 NO-GO 라 graph 146ms 는 architectural lock. 그러나 *emit 80ms 영역은 graph 와 독립* — 안전하게 fix 가능. dev_server HMR 307ms → ~240ms (~22% 절약) 의 단기 win. 진짜 esbuild parity (~50ms) 는 lifecycle redesign 후.

--- a/docs/RFC_GRAPH_PERSISTENCE.md
+++ b/docs/RFC_GRAPH_PERSISTENCE.md
@@ -1,8 +1,47 @@
 # RFC: Graph Persistence — Incremental Build 의 ModuleGraph Instance 재사용
 
-상태: **DRAFT · 측정 기반 epic** · 분류: dev UX / core 재설계
+상태: **CLOSED · NO-GO (정확성 회귀, 재시도 금지)** · 분류: 결정 문서
 부모 RFC: [RFC_EMIT_INCREMENTAL_DEV_SERVER.md](./RFC_EMIT_INCREMENTAL_DEV_SERVER.md) PR-B 영역
 관련: `src/bundler/bundler.zig:1073`, `src/bundler/incremental.zig`, `src/bundler/graph.zig`, `src/bundler/graph/build_flow.zig`, `src/bundler/graph/resolve_imports.zig`
+
+## 0. 종결 (Sub-PR-B.3 PoC 결과)
+
+본 RFC 의 Sub-PR-B.3 PoC 가 **정확성 회귀로 NO-GO 확정** (2026-05-28).
+
+**측정 데이터:**
+- Sub-PR-B.3 의 selective invalidate path 적용 + ZNTC_INCREMENTAL_PERSIST=1
+- lodash dev_server 의 첫 incremental rebuild → **segfault**
+- 위치: `Linker.assignSymbolCanonical` → `HashMap StringContext.hash` → string pointer access
+- 진짜 root: 이전 빌드 `Linker` 가 alloc 한 `canonical_name` 메모리 가 `Linker.deinit` 후 freed. 다음 빌드의 `Linker` 가 graph 의 stale slice 접근 → segfault
+
+**RFC §6 의 NO-GO 기준 정확히 부합:** "정확성 회귀 → RFC_GRAPH_PERSISTENCE_CLOSED.md 종결".
+
+**진짜 fix 는 stale pointer 추적이 아님:**
+- canonical_name 만이 아니라 *전체 cross-build memory* (parse_arena ownership, alias_table, export_index_by_name, namespace_access_index, requested_exports 내부 strings 등) 모두
+- 그때그때 정리는 *implicit invariant* — 새 PR 마다 회귀 risk 영구 증가, 유지보수 폭탄
+
+**진짜 graph persistence 의 architecture 영역 = `RFC_LIFECYCLE_SCOPE_REDESIGN`** (별도 epic 후보):
+- build-scope (매 빌드 free) vs graph-scope (persistent) 메모리 영역 명확 분리
+- canonical_name 등 cross-build 데이터는 graph allocator 가 own
+- esbuild SymbolID 패턴 양도 (path/ID-based references)
+- ZNTC 의 1-2 quarter 작업, mid-term roadmap 영역
+
+**Sub-PR-B.3 변경 revert.** Sub-PR-B.1 (#3934 reset/invalidateModule API) + Sub-PR-B.2 (#3936 initWithGraph + enable_persistence opt-in flag) 는 main 에 머지된 상태로 보존 — 호출자 없어 영향 0, 향후 lifecycle redesign 시 활용 가능.
+
+**재시도 금지 영역:**
+- selective invalidate + persistent_graph 만으로 graph reuse
+- stale pointer 그때그때 정리 (보안성 없음)
+- 본 RFC §3 의 Sub-PR-B.3 ~ B.5 영역
+
+**대안 진행 영역:**
+- emit_module_pass incremental (별개 RFC, graph 안 건드림) — RFC_EMIT_INCREMENTAL
+- requested_exports 자료구조 부분 fix (HashSet 등, graph state 변경 없이 가능) — 후속 fix
+- RFC_LIFECYCLE_SCOPE_REDESIGN 큰 epic — mid-term
+
+---
+
+(이하 원래 RFC 본문 — 측정 데이터 + design 영역. 종결됐으나 history 보존을 위해 유지.)
+
 
 ## 1. 배경
 


### PR DESCRIPTION
## Summary

Sub-PR-B.3 PoC 측정 결과 **graph persistence NO-GO** 확정. RFC #3933 을 CLOSED 종결. 대안 영역으로 **RFC_EMIT_INCREMENTAL (PR-C)** 작성 — graph 안 건드리고 emit 영역만 fix.

## Sub-PR-B.3 PoC 결과

- `persistent_graph + selective invalidate path` 적용
- `ZNTC_INCREMENTAL_PERSIST=1`, lodash dev_server 첫 incremental rebuild
- → **segfault**: `Linker.assignSymbolCanonical` → `HashMap StringContext.hash` → string ptr access
- 진짜 root: 이전 빌드 Linker 가 alloc 한 canonical_name 메모리가 deinit 후 freed. 다음 빌드 Linker 가 graph 의 stale slice 접근

RFC §6 의 NO-GO 기준 정확히 부합 (정확성 회귀).

## 진짜 fix 는 무엇인가

stale pointer 그때그때 추적은 *유지보수 폭탄*:
- canonical_name 만이 아니라 *전체 cross-build memory* (parse_arena ownership, alias_table, export_index_by_name, namespace_access_index 등) 모두
- *implicit invariant* — 새 PR 마다 회귀 risk 영구 증가
- 컴파일러가 못 잡고 runtime segfault 로만 발견

진짜 fix = **`RFC_LIFECYCLE_SCOPE_REDESIGN`** (별도 epic, mid-term):
- build-scope (매 빌드 free) vs graph-scope (persistent) 메모리 영역 명확 분리
- canonical_name 등 cross-build 데이터는 graph allocator 가 own
- esbuild SymbolID 패턴 양도 (path/ID-based references)
- 1-2 quarter 작업

## 대안: RFC_EMIT_INCREMENTAL (PR-C)

graph 영역이 lock 됐어도 **emit 80ms (post-PR-A) 는 graph 와 독립** — 안전하게 fix 가능:
- `ChunkEmitCache` — chunk 단위 byte stream 캐시 (모듈 단위 아닌)
- 변경 모듈이 속한 chunk 만 dirty 마킹 → 다른 chunk 의 emit 자체 skip
- 측정 목표: emit 80→≤30ms, dev_server lodash 307→~240ms

Sub-PR-C.1~C.4 분할, C.2 의 lodash 측정에서 GO/NO-GO.

## 변경

| 파일 | 변경 |
|---|---|
| `docs/RFC_GRAPH_PERSISTENCE.md` | status DRAFT → **CLOSED (NO-GO, 재시도 금지)**, §0 추가 — segfault detail + 진짜 fix 영역 (lifecycle redesign) |
| `docs/RFC_EMIT_INCREMENTAL.md` (신규) | PR-C 영역 RFC — chunk-level dirty marking |

Sub-PR-B.1 (#3934) / B.2 (#3936) 의 API skeleton 은 main 에 보존 — 호출자 없어 영향 0.

## Test plan

- [x] PoC 측정 데이터 (RFC 본문)
- [x] RFC #3933 CLOSED status 명시 + 재시도 금지 영역
- [x] PR-C RFC scope + GO/NO-GO 기준 명시
- [ ] Sub-PR-C.1 (다음 세션): ChunkEmitCache API skeleton

## Related

- 부모 RFC: #3931 (dev_server HMR)
- CLOSED: #3933 (graph persistence)
- 선행 PRs: #3932 (PR-A wire-up), #3934 (Sub-PR-B.1 reset API), #3936 (Sub-PR-B.2 initWithGraph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)