### PR TITLE
feat(napi): WatchHandle phaseDurations 에 link sub-phase 추가 (RFC #3940 Sub-PR-L.0e)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1420,6 +1420,24 @@ export interface WatchRebuildEvent {
     emitConcat: number;
     /** Source map V3 JSON generation (VLQ encode + sources content + debugId). */
     emitSourcemapFinalize: number;
+
+    // Link sub-phase (RFC #3940 Sub-PR-L.0e — Lifecycle redesign 의 link 영역 측정).
+
+    /** Link: per-module export map build. */
+    linkBuildExportMap: number;
+    /** Link: import resolution (binding cross-reference). */
+    linkResolveImports: number;
+    /**
+     * Link: canonical_name 계산. lodash 측정에서 ~50ms — RFC #3940 의 RenameTable
+     * 도입 (Phase 2) 후 baseline 으로 활용.
+     */
+    linkComputeRenames: number;
+    /** Link: re-export alias 채우기 (cross-module export name 매핑). */
+    linkPopulateReExportAliases: number;
+    /** Link: import symbol 채우기. */
+    linkPopulateImportSymbols: number;
+    /** Link: namespace access 채우기 (namespace import 사용처). */
+    linkPopulateNamespaceAccesses: number;
   };
   /** Number of modules reparsed in the incremental graph. Counts cache-missed
    * modules only. Not exposed for full builds. */

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -295,6 +295,16 @@ const PhaseDurations = struct {
     emit_module_pass_ms: f64 = 0,
     emit_concat_ms: f64 = 0,
     emit_sourcemap_finalize_ms: f64 = 0,
+
+    // ── Link sub-phase (RFC #3940 Sub-PR-L.0e — Lifecycle redesign 의 link 영역 측정) ──
+    // link_compute_renames 가 lodash 측정에서 50ms — RFC #3940 의 SymbolID 패턴 적용 후
+    // RenameTable 측정 baseline.
+    link_build_export_map_ms: f64 = 0,
+    link_resolve_imports_ms: f64 = 0,
+    link_compute_renames_ms: f64 = 0,
+    link_populate_re_export_aliases_ms: f64 = 0,
+    link_populate_import_symbols_ms: f64 = 0,
+    link_populate_namespace_accesses_ms: f64 = 0,
 };
 
 /// onRebuild 콜백에 전달할 이벤트 데이터
@@ -517,6 +527,13 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
                 .{ .name = "emitModulePass", .value = pd.emit_module_pass_ms },
                 .{ .name = "emitConcat", .value = pd.emit_concat_ms },
                 .{ .name = "emitSourcemapFinalize", .value = pd.emit_sourcemap_finalize_ms },
+                // RFC #3940 Sub-PR-L.0e — Link sub-phase (lifecycle redesign 의 link 영역 측정).
+                .{ .name = "linkBuildExportMap", .value = pd.link_build_export_map_ms },
+                .{ .name = "linkResolveImports", .value = pd.link_resolve_imports_ms },
+                .{ .name = "linkComputeRenames", .value = pd.link_compute_renames_ms },
+                .{ .name = "linkPopulateReExportAliases", .value = pd.link_populate_re_export_aliases_ms },
+                .{ .name = "linkPopulateImportSymbols", .value = pd.link_populate_import_symbols_ms },
+                .{ .name = "linkPopulateNamespaceAccesses", .value = pd.link_populate_namespace_accesses_ms },
             };
             for (fields) |f| {
                 var js_num: c.napi_value = undefined;
@@ -1361,6 +1378,15 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             .emit_module_pass_ms = nsToMs(profile_mod.totalNs(.emit_module_pass)),
             .emit_concat_ms = nsToMs(profile_mod.totalNs(.emit_concat)),
             .emit_sourcemap_finalize_ms = nsToMs(profile_mod.totalNs(.emit_sourcemap_finalize)),
+
+            // RFC #3940 Sub-PR-L.0e — Link sub-phase. lifecycle redesign 의 RenameTable
+            // 도입 (Phase 2) 후 link_compute_renames 측정 baseline 으로 활용.
+            .link_build_export_map_ms = nsToMs(profile_mod.totalNs(.link_build_export_map)),
+            .link_resolve_imports_ms = nsToMs(profile_mod.totalNs(.link_resolve_imports)),
+            .link_compute_renames_ms = nsToMs(profile_mod.totalNs(.link_compute_renames)),
+            .link_populate_re_export_aliases_ms = nsToMs(profile_mod.totalNs(.link_populate_re_export_aliases)),
+            .link_populate_import_symbols_ms = nsToMs(profile_mod.totalNs(.link_populate_import_symbols)),
+            .link_populate_namespace_accesses_ms = nsToMs(profile_mod.totalNs(.link_populate_namespace_accesses)),
         };
         event.reparsed_modules = rebuild_result.reparsed_modules;
 


### PR DESCRIPTION
## Summary

`RFC_RELEASE_PROFILING_HARNESS` Sub-PR-L.0e. NAPI watch 의 `onRebuild` callback `phaseDurations` 가 이미 emit/graph sub-phase 완전 지원. RFC #3940 의 link 영역 측정 위해 **link sub-phase 6개** 추가.

## 발견 — NAPI 는 이미 구현됨

```ts
event.phaseDurations = {
  detect, graph, link, shake, emit, delta, total,
  scan, parse, resolve, semantic, transform, codegen, metadata,
  graphBuild, graphWorker, graphDiscover, graphFinalize,
  emitPolyfill, emitRefresh, emitOutput, emitMetafile, emitCss,
  emitPrelude, emitModulePass, emitConcat, emitSourcemapFinalize,
};
```

Sub-PR-L.0e 의 실제 작업 = link sub-phase 보강만.

## 변경

| 영역 | 변경 |
|---|---|
| `watch.zig` `PhaseDurations` struct | link sub-phase 6 field 추가 |
| `watch.zig` JS payload `fields[]` | mapping 6 entry |
| `watch.zig` `event.phase_durations` 초기화 | `profile_mod.totalNs(.link_*)` 6 호출 |
| `index.ts` TS type | TypeScript field 6 추가 + JSDoc |

## RFC #3940 활용

- `linkComputeRenames` — lodash 측정 ~50ms. RFC #3940 Phase 2 의 RenameTable 도입 후 baseline 비교
- 다른 link sub-phase — link 단계의 어느 부분이 graph-scope memory 의존하는지 정밀 측정

## Test plan

- [x] `zig build install` 성공
- [x] `zig build napi` 성공
- [x] `zig build test` 통과 (exit=0)
- [ ] RN HMR (NAPI watch path) 측정 — link sub-phase 출력 확인 (follow-up)

## Related

- 부모 RFC: #3940 (lifecycle redesign)
- 선행: #3942 (L.0a), #3943 (L.0b), #3944 (L.0c), #3945 (L.0d)
- Sub-PR-L.0 epic 완료 — RFC #3940 Phase 1 (audit + measurement baseline) 시작 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)