### PR TITLE
feat(transformer): Transformer.initFromOwnedAst API 추가 (RFC #3940 PR-1)

### DIFF
--- a/src/transformer/state.zig
+++ b/src/transformer/state.zig
@@ -2,7 +2,13 @@ const Span = @import("../lexer/token.zig").Span;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const es_helpers = @import("es_helpers.zig");
 
-pub const AstOwnership = enum { owned, borrowed };
+/// transformer 가 보유한 AST 의 소유 관계.
+/// - `.owned`: `init` (clone 후 transformer 가 deinit + destroy)
+/// - `.borrowed`: `initBorrow` (외부 owner 가 ast 를 mutate-free, transformer 는 cache hit 분기만)
+/// - `.owned_from_caller`: `initFromOwnedAst` (호출자가 ast 인스턴스의 lifetime 보유,
+///    transformer 는 *직접 mutate* 하나 deinit/destroy 는 호출자 책임). transpile path
+///    에서 cloneForTransformer 회피용 — RFC_TRANSFORMER_OWN_AST 참조.
+pub const AstOwnership = enum { owned, borrowed, owned_from_caller };
 
 pub const BlockRenameEntry = struct {
     old_name: []const u8,

--- a/src/transformer/state.zig
+++ b/src/transformer/state.zig
@@ -8,7 +8,21 @@ const es_helpers = @import("es_helpers.zig");
 /// - `.owned_from_caller`: `initFromOwnedAst` (호출자가 ast 인스턴스의 lifetime 보유,
 ///    transformer 는 *직접 mutate* 하나 deinit/destroy 는 호출자 책임). transpile path
 ///    에서 cloneForTransformer 회피용 — RFC_TRANSFORMER_OWN_AST 참조.
-pub const AstOwnership = enum { owned, borrowed, owned_from_caller };
+pub const AstOwnership = enum {
+    owned,
+    borrowed,
+    owned_from_caller,
+
+    /// transformer 의 deinit 이 ast.deinit() + allocator.destroy(ast) 를 수행해야 하는지.
+    /// `.owned` 만 true — 그 외엔 외부 owner (borrowed) 또는 caller (owned_from_caller) 책임.
+    /// exhaustive switch 로 미래 variant 추가 시 컴파일 에러로 누락 방지.
+    pub fn transformerFreesAst(self: AstOwnership) bool {
+        return switch (self) {
+            .owned => true,
+            .borrowed, .owned_from_caller => false,
+        };
+    }
+};
 
 pub const BlockRenameEntry = struct {
     old_name: []const u8,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -308,6 +308,7 @@ pub const Transformer = struct {
     const lifecycle_mod = @import("transformer/lifecycle.zig");
     pub const init = lifecycle_mod.init;
     pub const initBorrow = lifecycle_mod.initBorrow;
+    pub const initFromOwnedAst = lifecycle_mod.initFromOwnedAst;
     pub const deinit = lifecycle_mod.deinit;
     pub const deinitExceptAst = lifecycle_mod.deinitExceptAst;
     pub const initSymbolIds = lifecycle_mod.initSymbolIds;

--- a/src/transformer/transformer/lifecycle.zig
+++ b/src/transformer/transformer/lifecycle.zig
@@ -36,6 +36,28 @@ pub fn initBorrow(allocator: std.mem.Allocator, ast: *const Ast, options: Transf
     return finishInit(allocator, @constCast(ast), opts, .borrowed);
 }
 
+/// Transformer 가 `source_ast` 의 *mutation 권한* 만 양도받아 직접 transform 한다.
+/// `cloneForTransformer` 의 deep copy 를 회피해 peak RSS 절감 — RFC_TRANSFORMER_OWN_AST.
+///
+/// 호출 후 `source_ast` 는 *transformer.ast 와 동일 instance* (dangling 아님).
+/// `Transformer.deinit` 은 ast 를 건드리지 않는다 — 호출자가 `source_ast.deinit()` 책임.
+/// `init` (clone 후 owned) 과 달리, `source_ast` 의 후속 사용도 동일 instance 라 안전.
+///
+/// `transpile path` 전용. bundler 의 graph cache / HMR re-process 는 원본 보존 의무 →
+/// 기존 `init` (clone) 사용 유지.
+pub fn initFromOwnedAst(
+    allocator: std.mem.Allocator,
+    source_ast: *Ast,
+    options: TransformOptions,
+) Error!Transformer {
+    var opts = options;
+    if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
+    // D1 (RFC #1672): parser/transformer 영역 경계 스냅샷.
+    // `init` 의 clone 직후와 동일 시점 = 호출 시점의 nodes.items.len.
+    source_ast.transform_boundary = @intCast(source_ast.nodes.items.len);
+    return finishInit(allocator, source_ast, opts, .owned_from_caller);
+}
+
 fn finishInit(
     allocator: std.mem.Allocator,
     ast_ptr: *Ast,
@@ -43,7 +65,9 @@ fn finishInit(
     ownership: AstOwnership,
 ) Error!Transformer {
     const parser_count: u32 = switch (ownership) {
-        .owned => @intCast(ast_ptr.nodes.items.len),
+        // `.owned` 는 clone 직후 → nodes.items.len 이 parser 영역 끝.
+        // `.owned_from_caller` 는 source_ast 자체가 parser 결과 → 동일.
+        .owned, .owned_from_caller => @intCast(ast_ptr.nodes.items.len),
         .borrowed => ast_ptr.transform_boundary orelse @intCast(ast_ptr.nodes.items.len),
     };
     var self: Transformer = .{
@@ -61,7 +85,9 @@ fn finishInit(
 }
 
 pub fn deinit(self: *Transformer) void {
-    // borrow 모드는 외부 owner (보통 module.parse_arena) 가 ast 를 free.
+    // `.borrowed` 는 외부 owner (보통 module.parse_arena) 가 ast 를 free.
+    // `.owned_from_caller` 는 호출자가 ast 인스턴스의 lifetime 보유 (transpile path
+    // 에서 `parser.ast.deinit()` 으로 free). transformer 는 ast 를 건드리지 않는다.
     if (self.ast_ownership == .owned) {
         self.ast.deinit();
         self.allocator.destroy(self.ast);

--- a/src/transformer/transformer/lifecycle.zig
+++ b/src/transformer/transformer/lifecycle.zig
@@ -10,9 +10,17 @@ const TransformOptions = transformer_mod.TransformOptions;
 const Error = Transformer.Error;
 const AstOwnership = state_mod.AstOwnership;
 
-pub fn init(allocator: std.mem.Allocator, source_ast: *const Ast, options: TransformOptions) Error!Transformer {
+/// 3-constructor 공통: experimental_decorators 가 true 면 use_define_for_class_fields 가 false 여야 한다.
+/// stage2 decorator 가 instance field 의 initializer 를 가로채야 하는데, useDefineForClassFields
+/// true 는 ECMA-스펙 `[[Define]]` semantics 라 가로챌 곳이 없음. 둘 다 enable 은 모순이라 강제 정정.
+fn normalizeOptions(options: TransformOptions) TransformOptions {
     var opts = options;
     if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
+    return opts;
+}
+
+pub fn init(allocator: std.mem.Allocator, source_ast: *const Ast, options: TransformOptions) Error!Transformer {
+    const opts = normalizeOptions(options);
 
     const ast_ptr = try allocator.create(Ast);
     errdefer allocator.destroy(ast_ptr);
@@ -31,9 +39,7 @@ pub fn init(allocator: std.mem.Allocator, source_ast: *const Ast, options: Trans
 /// `*const Ast` 받음 — transform() cache hit 분기는 ast mutation 없음. 단, ast 필드는
 /// `*Ast` 라 내부적으로 `@constCast` (caller 가 mut 의도면 별도 borrow 함수 미래에).
 pub fn initBorrow(allocator: std.mem.Allocator, ast: *const Ast, options: TransformOptions) Error!Transformer {
-    var opts = options;
-    if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
-    return finishInit(allocator, @constCast(ast), opts, .borrowed);
+    return finishInit(allocator, @constCast(ast), normalizeOptions(options), .borrowed);
 }
 
 /// Transformer 가 `source_ast` 의 *mutation 권한* 만 양도받아 직접 transform 한다.
@@ -45,15 +51,27 @@ pub fn initBorrow(allocator: std.mem.Allocator, ast: *const Ast, options: Transf
 ///
 /// `transpile path` 전용. bundler 의 graph cache / HMR re-process 는 원본 보존 의무 →
 /// 기존 `init` (clone) 사용 유지.
+///
+/// **사전조건**: caller 의 `source_ast` 는 *pristine parser 결과* 여야 한다.
+/// - `transformed_root == null` — 이미 transform 된 ast 면 driver.zig 의 cache-hit 분기가
+///   stale root 를 반환하고 transformer 내부 state (symbol_ids/runtime_helpers/refresh registrations)
+///   는 비어 emit 시 helper import 가 누락 (silent miscompile).
+/// - `transform_boundary == null` — parser 가 아직 boundary 를 세운 적 없어야 한다. 이미
+///   세워진 boundary 를 silent overwrite 하면 D1 invariant (boundary 위는 transformer append)
+///   가 깨져 resync analyzer 가 transformer 노드를 parser 노드로 오분류한다.
+/// debug 빌드에서 assert 로 강제. release 빌드는 doc-contract 만.
 pub fn initFromOwnedAst(
     allocator: std.mem.Allocator,
     source_ast: *Ast,
     options: TransformOptions,
 ) Error!Transformer {
-    var opts = options;
-    if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
+    std.debug.assert(source_ast.transformed_root == null);
+    std.debug.assert(source_ast.transform_boundary == null);
+
+    const opts = normalizeOptions(options);
     // D1 (RFC #1672): parser/transformer 영역 경계 스냅샷.
     // `init` 의 clone 직후와 동일 시점 = 호출 시점의 nodes.items.len.
+    // assert 통과 후이므로 caller-visible 부작용은 contract 의 일부.
     source_ast.transform_boundary = @intCast(source_ast.nodes.items.len);
     return finishInit(allocator, source_ast, opts, .owned_from_caller);
 }
@@ -88,7 +106,8 @@ pub fn deinit(self: *Transformer) void {
     // `.borrowed` 는 외부 owner (보통 module.parse_arena) 가 ast 를 free.
     // `.owned_from_caller` 는 호출자가 ast 인스턴스의 lifetime 보유 (transpile path
     // 에서 `parser.ast.deinit()` 으로 free). transformer 는 ast 를 건드리지 않는다.
-    if (self.ast_ownership == .owned) {
+    // method 호출 = exhaustive switch → 미래 variant 추가 시 컴파일 에러로 누락 방지.
+    if (self.ast_ownership.transformerFreesAst()) {
         self.ast.deinit();
         self.allocator.destroy(self.ast);
     }

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -3069,3 +3069,130 @@ test "experimentalDecorators + private: @dec field 가 private 동반에도 emit
     defer std.testing.allocator.free(code);
     try std.testing.expect(std.mem.indexOf(u8, code, "__decorateClass") != null);
 }
+
+// ============================================================
+// RFC_TRANSFORMER_OWN_AST PR-1: Transformer.initFromOwnedAst
+// cloneForTransformer 회피 — caller 가 ast 인스턴스의 lifetime 보유, transformer 가
+// *동일 instance* 를 직접 mutate. transpile path 전용 (bundler 는 원본 보존 의무라 init 유지).
+// ============================================================
+
+test "initFromOwnedAst: transformer.ast 가 source_ast 와 동일 instance" {
+    // clone 하지 않으므로 transformer.ast 의 포인터가 호출자가 넘긴 ast 와 같아야 한다.
+    var src_ast = Ast.init(std.testing.allocator, "");
+    defer src_ast.deinit();
+
+    const empty_list = try src_ast.addNodeList(&.{});
+    _ = try src_ast.addNode(.{
+        .tag = .program,
+        .span = .{ .start = 0, .end = 0 },
+        .data = .{ .list = empty_list },
+    });
+
+    var t = try Transformer.initFromOwnedAst(std.testing.allocator, &src_ast, .{});
+    defer t.deinit();
+
+    // 핵심 invariant: clone 안 함 → 동일 인스턴스.
+    try std.testing.expectEqual(@as(*Ast, &src_ast), t.ast);
+    // boundary 가 호출 시점 nodes.items.len 으로 스냅샷 (init 의 clone-after 와 동일 의미).
+    try std.testing.expectEqual(
+        @as(u32, @intCast(src_ast.nodes.items.len)),
+        src_ast.transform_boundary.?,
+    );
+}
+
+test "initFromOwnedAst: empty program → init 과 동일한 결과" {
+    // init (clone path) 와 initFromOwnedAst (own path) 가 동일 입력에 동일 transform 결과를 내야 한다.
+
+    // init (clone) 경로
+    var ast_a = Ast.init(std.testing.allocator, "");
+    defer ast_a.deinit();
+    const list_a = try ast_a.addNodeList(&.{});
+    _ = try ast_a.addNode(.{
+        .tag = .program,
+        .span = .{ .start = 0, .end = 0 },
+        .data = .{ .list = list_a },
+    });
+    var t_a = try Transformer.init(std.testing.allocator, &ast_a, .{});
+    defer t_a.deinit();
+    const root_a = try t_a.transform();
+    const res_a = t_a.ast.getNode(root_a);
+
+    // initFromOwnedAst (own) 경로
+    var ast_b = Ast.init(std.testing.allocator, "");
+    defer ast_b.deinit();
+    const list_b = try ast_b.addNodeList(&.{});
+    _ = try ast_b.addNode(.{
+        .tag = .program,
+        .span = .{ .start = 0, .end = 0 },
+        .data = .{ .list = list_b },
+    });
+    var t_b = try Transformer.initFromOwnedAst(std.testing.allocator, &ast_b, .{});
+    defer t_b.deinit();
+    const root_b = try t_b.transform();
+    const res_b = t_b.ast.getNode(root_b);
+
+    try std.testing.expectEqual(res_a.tag, res_b.tag);
+    try std.testing.expectEqual(res_a.data.list.len, res_b.data.list.len);
+}
+
+test "initFromOwnedAst: type_alias_declaration strip → init 과 동일" {
+    // strip 동작이 own path 에서도 정확히 작동하는지 검증.
+
+    // init (clone) 경로
+    var ast_a = Ast.init(std.testing.allocator, "type Foo = string;");
+    defer ast_a.deinit();
+    const ta_a = try ast_a.addEmptyExtraNode(.ts_type_alias_declaration, .{ .start = 0, .end = 18 });
+    const list_a = try ast_a.addNodeList(&.{ta_a});
+    _ = try ast_a.addNode(.{
+        .tag = .program,
+        .span = .{ .start = 0, .end = 18 },
+        .data = .{ .list = list_a },
+    });
+    var t_a = try Transformer.init(std.testing.allocator, &ast_a, .{});
+    defer t_a.deinit();
+    const root_a = try t_a.transform();
+    const res_a = t_a.ast.getNode(root_a);
+
+    // initFromOwnedAst (own) 경로
+    var ast_b = Ast.init(std.testing.allocator, "type Foo = string;");
+    defer ast_b.deinit();
+    const ta_b = try ast_b.addEmptyExtraNode(.ts_type_alias_declaration, .{ .start = 0, .end = 18 });
+    const list_b = try ast_b.addNodeList(&.{ta_b});
+    _ = try ast_b.addNode(.{
+        .tag = .program,
+        .span = .{ .start = 0, .end = 18 },
+        .data = .{ .list = list_b },
+    });
+    var t_b = try Transformer.initFromOwnedAst(std.testing.allocator, &ast_b, .{});
+    defer t_b.deinit();
+    const root_b = try t_b.transform();
+    const res_b = t_b.ast.getNode(root_b);
+
+    // 둘 다 program 이고 list 가 비어야 (type alias 제거).
+    try std.testing.expectEqual(Tag.program, res_a.tag);
+    try std.testing.expectEqual(Tag.program, res_b.tag);
+    try std.testing.expectEqual(@as(u32, 0), res_a.data.list.len);
+    try std.testing.expectEqual(@as(u32, 0), res_b.data.list.len);
+}
+
+test "initFromOwnedAst: deinit 후에도 caller 의 ast.deinit() 정상 동작" {
+    // ownership 이 호출자에 있으므로 transformer.deinit 은 ast 를 건드리지 않아야 한다.
+    // defer LIFO 순서: t.deinit() → src_ast.deinit().
+    var src_ast = Ast.init(std.testing.allocator, "");
+    defer src_ast.deinit();
+
+    const empty_list = try src_ast.addNodeList(&.{});
+    _ = try src_ast.addNode(.{
+        .tag = .program,
+        .span = .{ .start = 0, .end = 0 },
+        .data = .{ .list = empty_list },
+    });
+
+    {
+        var t = try Transformer.initFromOwnedAst(std.testing.allocator, &src_ast, .{});
+        _ = try t.transform();
+        t.deinit();
+        // t.deinit 후 src_ast 가 살아있어야 — node 접근으로 use-after-free 검출.
+        try std.testing.expect(src_ast.nodes.items.len > 0);
+    }
+}

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -3076,17 +3076,37 @@ test "experimentalDecorators + private: @dec field 가 private 동반에도 emit
 // *동일 instance* 를 직접 mutate. transpile path 전용 (bundler 는 원본 보존 의무라 init 유지).
 // ============================================================
 
-test "initFromOwnedAst: transformer.ast 가 source_ast 와 동일 instance" {
-    // clone 하지 않으므로 transformer.ast 의 포인터가 호출자가 넘긴 ast 와 같아야 한다.
-    var src_ast = Ast.init(std.testing.allocator, "");
-    defer src_ast.deinit();
-
-    const empty_list = try src_ast.addNodeList(&.{});
-    _ = try src_ast.addNode(.{
+/// helper — 빈 program 노드 한 개를 가진 pristine parser AST 를 만든다.
+fn buildEmptyProgramAst(allocator: std.mem.Allocator) !Ast {
+    var ast = Ast.init(allocator, "");
+    errdefer ast.deinit();
+    const empty_list = try ast.addNodeList(&.{});
+    _ = try ast.addNode(.{
         .tag = .program,
         .span = .{ .start = 0, .end = 0 },
         .data = .{ .list = empty_list },
     });
+    return ast;
+}
+
+/// helper — type alias 한 개만 있는 program (strip 검증용 fixture).
+fn buildTypeAliasProgramAst(allocator: std.mem.Allocator) !Ast {
+    var ast = Ast.init(allocator, "type Foo = string;");
+    errdefer ast.deinit();
+    const ta = try ast.addEmptyExtraNode(.ts_type_alias_declaration, .{ .start = 0, .end = 18 });
+    const list = try ast.addNodeList(&.{ta});
+    _ = try ast.addNode(.{
+        .tag = .program,
+        .span = .{ .start = 0, .end = 18 },
+        .data = .{ .list = list },
+    });
+    return ast;
+}
+
+test "initFromOwnedAst: transformer.ast 가 source_ast 와 동일 instance" {
+    // clone 하지 않으므로 transformer.ast 의 포인터가 호출자가 넘긴 ast 와 같아야 한다.
+    var src_ast = try buildEmptyProgramAst(std.testing.allocator);
+    defer src_ast.deinit();
 
     var t = try Transformer.initFromOwnedAst(std.testing.allocator, &src_ast, .{});
     defer t.deinit();
@@ -3100,99 +3120,45 @@ test "initFromOwnedAst: transformer.ast 가 source_ast 와 동일 instance" {
     );
 }
 
-test "initFromOwnedAst: empty program → init 과 동일한 결과" {
-    // init (clone path) 와 initFromOwnedAst (own path) 가 동일 입력에 동일 transform 결과를 내야 한다.
+test "initFromOwnedAst: type_alias_declaration strip → init 과 동일 결과" {
+    // strip 동작이 own path 에서도 정확히 작동하는지 init (clone) 과 cross-check.
 
-    // init (clone) 경로
-    var ast_a = Ast.init(std.testing.allocator, "");
+    var ast_a = try buildTypeAliasProgramAst(std.testing.allocator);
     defer ast_a.deinit();
-    const list_a = try ast_a.addNodeList(&.{});
-    _ = try ast_a.addNode(.{
-        .tag = .program,
-        .span = .{ .start = 0, .end = 0 },
-        .data = .{ .list = list_a },
-    });
     var t_a = try Transformer.init(std.testing.allocator, &ast_a, .{});
     defer t_a.deinit();
     const root_a = try t_a.transform();
     const res_a = t_a.ast.getNode(root_a);
 
-    // initFromOwnedAst (own) 경로
-    var ast_b = Ast.init(std.testing.allocator, "");
+    var ast_b = try buildTypeAliasProgramAst(std.testing.allocator);
     defer ast_b.deinit();
-    const list_b = try ast_b.addNodeList(&.{});
-    _ = try ast_b.addNode(.{
-        .tag = .program,
-        .span = .{ .start = 0, .end = 0 },
-        .data = .{ .list = list_b },
-    });
     var t_b = try Transformer.initFromOwnedAst(std.testing.allocator, &ast_b, .{});
     defer t_b.deinit();
     const root_b = try t_b.transform();
     const res_b = t_b.ast.getNode(root_b);
 
+    // 둘 다 program 이고 list 가 비어야 (type alias 제거) + 동등성.
+    try std.testing.expectEqual(Tag.program, res_a.tag);
     try std.testing.expectEqual(res_a.tag, res_b.tag);
+    try std.testing.expectEqual(@as(u32, 0), res_a.data.list.len);
     try std.testing.expectEqual(res_a.data.list.len, res_b.data.list.len);
 }
 
-test "initFromOwnedAst: type_alias_declaration strip → init 과 동일" {
-    // strip 동작이 own path 에서도 정확히 작동하는지 검증.
-
-    // init (clone) 경로
-    var ast_a = Ast.init(std.testing.allocator, "type Foo = string;");
-    defer ast_a.deinit();
-    const ta_a = try ast_a.addEmptyExtraNode(.ts_type_alias_declaration, .{ .start = 0, .end = 18 });
-    const list_a = try ast_a.addNodeList(&.{ta_a});
-    _ = try ast_a.addNode(.{
-        .tag = .program,
-        .span = .{ .start = 0, .end = 18 },
-        .data = .{ .list = list_a },
-    });
-    var t_a = try Transformer.init(std.testing.allocator, &ast_a, .{});
-    defer t_a.deinit();
-    const root_a = try t_a.transform();
-    const res_a = t_a.ast.getNode(root_a);
-
-    // initFromOwnedAst (own) 경로
-    var ast_b = Ast.init(std.testing.allocator, "type Foo = string;");
-    defer ast_b.deinit();
-    const ta_b = try ast_b.addEmptyExtraNode(.ts_type_alias_declaration, .{ .start = 0, .end = 18 });
-    const list_b = try ast_b.addNodeList(&.{ta_b});
-    _ = try ast_b.addNode(.{
-        .tag = .program,
-        .span = .{ .start = 0, .end = 18 },
-        .data = .{ .list = list_b },
-    });
-    var t_b = try Transformer.initFromOwnedAst(std.testing.allocator, &ast_b, .{});
-    defer t_b.deinit();
-    const root_b = try t_b.transform();
-    const res_b = t_b.ast.getNode(root_b);
-
-    // 둘 다 program 이고 list 가 비어야 (type alias 제거).
-    try std.testing.expectEqual(Tag.program, res_a.tag);
-    try std.testing.expectEqual(Tag.program, res_b.tag);
-    try std.testing.expectEqual(@as(u32, 0), res_a.data.list.len);
-    try std.testing.expectEqual(@as(u32, 0), res_b.data.list.len);
-}
-
-test "initFromOwnedAst: deinit 후에도 caller 의 ast.deinit() 정상 동작" {
-    // ownership 이 호출자에 있으므로 transformer.deinit 은 ast 를 건드리지 않아야 한다.
-    // defer LIFO 순서: t.deinit() → src_ast.deinit().
-    var src_ast = Ast.init(std.testing.allocator, "");
+test "initFromOwnedAst: deinit 이 caller 의 ast 를 건드리지 않는다" {
+    // ownership 이 호출자에 있으므로 transformer.deinit 후에도 src_ast 가 valid.
+    // src_ast.deinit() 가 호출되기 *전* 에 t.deinit() 만 실행한 시점에서 src_ast 가
+    // 살아있어야 하므로, defer 가 아닌 명시적 t.deinit() 로 호출 순서를 통제한다.
+    // (Transformer.deinit 이 self.ast 에 손대면 다음 ast 접근에서 testing.allocator
+    // 가 use-after-free 또는 stale data 로 검출.)
+    var src_ast = try buildEmptyProgramAst(std.testing.allocator);
     defer src_ast.deinit();
 
-    const empty_list = try src_ast.addNodeList(&.{});
-    _ = try src_ast.addNode(.{
-        .tag = .program,
-        .span = .{ .start = 0, .end = 0 },
-        .data = .{ .list = empty_list },
-    });
+    var t = try Transformer.initFromOwnedAst(std.testing.allocator, &src_ast, .{});
+    _ = try t.transform();
+    t.deinit();
 
-    {
-        var t = try Transformer.initFromOwnedAst(std.testing.allocator, &src_ast, .{});
-        _ = try t.transform();
-        t.deinit();
-        // t.deinit 후 src_ast 가 살아있어야 — node 접근으로 use-after-free 검출.
-        try std.testing.expect(src_ast.nodes.items.len > 0);
-    }
+    // t.deinit 후 src_ast.nodes 접근 — testing.allocator 가 free 된 메모리 read 를 감지.
+    try std.testing.expect(src_ast.nodes.items.len > 0);
+    const root_node = src_ast.getNode(@enumFromInt(src_ast.nodes.items.len - 1));
+    try std.testing.expectEqual(Tag.program, root_node.tag);
 }


### PR DESCRIPTION
## Summary
- `Transformer.initFromOwnedAst` API 추가 — caller 가 ast 인스턴스의 lifetime 보유, transformer 가 *동일 instance* 를 직접 mutate (`cloneForTransformer` 회피). 87MB synthetic 기준 peak RSS −580 MB / −33% 절감을 위한 인프라. transpile path 전용이고 bundler 의 graph cache / HMR re-process 는 원본 보존 의무라 기존 `init` (clone) 유지.
- 본 PR 은 **인프라만** — 호출자 없음. PR-2 에서 `transpile.zig:1295` 의 `Transformer.init` → `initFromOwnedAst` 로 swap + 측정 (RFC 게이트 −300 MB) 예정.

자세한 배경: `docs/RFC_TRANSFORMER_OWN_AST.md`

## 변경 내용
- `AstOwnership.owned_from_caller` enum variant + `transformerFreesAst()` method (state.zig)
- `Transformer.initFromOwnedAst` 추가 (lifecycle.zig)
- `finishInit` parser_count 분기: `.owned, .owned_from_caller` 같은 시점 — clone 직후 == source_ast 자체가 parser 결과
- `deinit` 분기: caller 가 ast lifetime 보유 → noop. `transformerFreesAst()` exhaustive switch 로 미래 variant 누락 방지
- 사전조건 assert (debug): `source_ast.transformed_root == null && source_ast.transform_boundary == null`
  - 이미 transform 된 ast 면 `driver.zig` cache-hit 분기가 stale root 반환 + transformer state 미 hydrate → silent miscompile
  - 기존 boundary 를 silent overwrite 하면 D1 invariant 깨짐
- 3-constructor 의 `experimental_decorators` 처리 중복 → `normalizeOptions` helper 추출
- 단위 테스트 3 (instance identity / strip 동등성 / use-after-free 없음) + 헬퍼 2

## 위험
- 호출자 없음 → behavior 회귀 위험 0. 잠재 위험은 PR-2 (transpile.zig swap) 에서 측정-게이트로 검증.
- 잘못된 호출은 debug build 의 assert 로 즉시 차단됨 (release 는 doc-contract).

## Test plan
- [x] `zig build test` 통과
- [x] `/code-review max` 1회 — findings 6 개 모두 반영 (F1+F2+F3 가드, F4 exhaustive, F5 test 주석 정정 + cleanup)
- [ ] PR-2 에서 87MB synthetic peak RSS −300 MB 이상 측정 후 실제 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)