### PR TITLE
fix(profile-harness): dev_server watchLoop break + incremental fatal reset

### DIFF
--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -249,13 +249,21 @@ pub const IncrementalBundler = struct {
         // RFC #3940 Sub-PR-L.0b — bundle 직후 profile snapshot 캡처 (ZNTC_PROFILE 활성 시).
         // caller (dev_server) 가 SSE event payload 또는 NAPI watch callback 에 포함.
         // counter reset 은 다음 build 측정 위해 즉시. snapshot 은 cheap (atomic load N회).
+        //
+        // /code-review max followup #2 fix: bundle() catch return .fatal 이 reset 을 skip
+        // 하면 다음 성공 build snapshot 이 실패 build 의 partial 누적값과 섞여 측정 오염.
+        // anyEnabled() 를 한 번 캐싱 후 fatal/success 모든 경로에서 reset 보장.
         const _profile = @import("../profile.zig");
-        var result = bundler.bundle() catch return .fatal;
-        const profile_snapshot: ?_profile.ProfileSnapshot = if (_profile.anyEnabled())
+        const profile_was_enabled = _profile.anyEnabled();
+        var result = bundler.bundle() catch {
+            if (profile_was_enabled) _profile.resetCounters();
+            return .fatal;
+        };
+        const profile_snapshot: ?_profile.ProfileSnapshot = if (profile_was_enabled)
             _profile.takeSnapshot()
         else
             null;
-        if (profile_snapshot != null) _profile.resetCounters();
+        if (profile_was_enabled) _profile.resetCounters();
 
         if (result.hasErrors()) {
             const err_json = buildErrorJson(self.allocator, &result) orelse {

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -890,18 +890,26 @@ pub const DevServer = struct {
                     // bundle_build_done 이벤트. RFC #3940 Sub-PR-L.0c — ZNTC_PROFILE
                     // 활성 시 profile snapshot 을 별도 JSON 으로 dump. profile 비활성 (default)
                     // 이면 result.profile_snapshot 가 null → 기존 짧은 JSON 그대로.
-                    if (result.profile_snapshot) |snap| {
+                    //
+                    // /code-review max followup #1 (CRITICAL) fix: profile JSON 작성 실패 시
+                    // unlabeled `break` 가 가장 가까운 loop (`while (true)` watchLoop) 로
+                    // 빠져나가 watch thread 가 silent 종료되는 버그. labeled block + bool 반환
+                    // 으로 emit 실패 시 short JSON fallback 사용, loop 는 그대로 유지.
+                    const emit_ok: bool = if (result.profile_snapshot) |snap| blk: {
                         // profile 활성 path — 큰 JSON 가능. ArrayList 동적 할당.
                         var profile_buf: std.ArrayList(u8) = .empty;
                         defer profile_buf.deinit(self.allocator);
                         const w = profile_buf.writer(self.allocator);
-                        w.print("{{\"type\":\"bundle_build_done\",\"id\":\"{d}\",\"totalModules\":{d},\"duration\":{d:.2},\"profile\":", .{ build_id, result.paths.len, build_duration_ms }) catch break;
+                        w.print("{{\"type\":\"bundle_build_done\",\"id\":\"{d}\",\"totalModules\":{d},\"duration\":{d:.2},\"profile\":", .{ build_id, result.paths.len, build_duration_ms }) catch break :blk false;
                         const _profile = @import("../profile.zig");
-                        _profile.snapshotToJson(snap, w, 0.1) catch break; // 0.1ms threshold — sub-100us noise skip
-                        w.writeByte('}') catch break;
+                        _profile.snapshotToJson(snap, w, 0.1) catch break :blk false; // 0.1ms threshold — sub-100us noise skip
+                        w.writeByte('}') catch break :blk false;
                         self.publishEvent(EventType.bundle_build_done, profile_buf.items);
-                    } else {
-                        // profile 비활성 default — 기존 짧은 JSON path
+                        break :blk true;
+                    } else false;
+
+                    if (!emit_ok) {
+                        // profile 비활성 default 또는 profile JSON emit 실패 → 기존 짧은 JSON path
                         var done_buf: [256]u8 = undefined;
                         if (std.fmt.bufPrint(&done_buf, "{{\"type\":\"bundle_build_done\",\"id\":\"{d}\",\"totalModules\":{d},\"duration\":{d:.2}}}", .{ build_id, result.paths.len, build_duration_ms })) |json| {
                             self.publishEvent(EventType.bundle_build_done, json);


### PR DESCRIPTION
## Summary
Sub-PR-L.0 (#3942/3943/3944/3945/3947) 통합 사후 `/code-review max` 에서 발견된 **CRITICAL #1 + HIGH #2** fix.

### #1 (CRITICAL) — `src/server/dev_server.zig:898/900/901`
profile path 의 세 `catch break` 가 **unlabeled** 라 가장 가까운 loop (`while (true)` watchLoop) 로 빠져나가는 버그. `ArrayList` 동적 할당 실패 (OOM 등) 시 watch thread 가 silent 종료 → 데브 서버 좀비화 (HMR 응답 안 함, 재시작 필요).

**Zig 초보자 노트**: Zig 의 `break` 는 label 없이 쓰면 `switch` 가 아닌 가장 가까운 **loop** (`while`/`for`) 로 빠져나갑니다. `switch` prong 안의 `if` 안에서 쓴 `break` 도 그래서 outer loop 까지 빠져나갑니다. 이 코드 다른 위치 (line 854, 906) 는 `catch continue` / `else |_| {}` 패턴이라 OK 였는데 새 profile path 만 실수로 break 였습니다.

Fix: `if (...) |snap| blk: { ... break :blk false; ... break :blk true; } else false` labeled block + bool 반환 패턴. emit 실패 시 short JSON path fallback. loop 는 그대로 유지.

### #2 (HIGH) — `src/bundler/incremental.zig:253`
`bundler.bundle() catch return .fatal` 가 `resetCounters()` 를 skip 하여 다음 성공 build 의 snapshot 이 *실패 build 의 partial 누적값 + 새 build* 의 혼합 → SSE consumer / benchmark median 오염.

Fix: `anyEnabled()` 를 한 번 캐싱 (`profile_was_enabled`) 후 fatal/success 모든 경로에서 reset.

## Test plan
- [x] `zig build install` (no errors)
- [x] `zig build test` 전체 통과
- [x] `/code-review max` no findings (A break scope, B defer ordering, C cross-file, D removed behavior, E catch path, F simplification, G race, H test coverage)
- [ ] dev server smoke (ZNTC_PROFILE=all + 의도적 file change × N) — reviewer 가 가능하면 확인

## 비고
- PR2 (bench update-start 필터 + warmup 강화) 는 별도 PR.
- 본 fix 의 범위는 좁고 (2 파일 25 line) defer ordering / labeled break / ?ProfileSnapshot 값 의미만 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)