### PR TITLE
chore(profile): @setEvalBranchQuota num_categories 기반 derived 표현

### DIFF
--- a/src/profile.zig
+++ b/src/profile.zig
@@ -355,7 +355,7 @@ pub const Category = enum {
     pub fn displayName(cat: Category) []const u8 {
         return switch (cat) {
             inline else => |c| comptime blk: {
-                @setEvalBranchQuota(20000);
+                @setEvalBranchQuota(num_categories * 200);
                 const name = @tagName(c);
                 var buf: [name.len]u8 = undefined;
                 for (name, 0..) |ch, i| {
@@ -741,7 +741,7 @@ pub fn takeSnapshot() ProfileSnapshot {
 /// `min_ms_threshold` 미만의 category 는 skip — JSON 크기 줄이고 중요 phase 만.
 /// 0 이면 모든 active category 출력.
 pub fn snapshotToJson(snap: ProfileSnapshot, writer: anytype, min_ms_threshold: f64) !void {
-    @setEvalBranchQuota(20000);
+    @setEvalBranchQuota(num_categories * 200);
     try writer.writeByte('{');
     var first = true;
     inline for (@typeInfo(Category).@"enum".fields) |field| {
@@ -767,7 +767,7 @@ pub fn snapshotToJson(snap: ProfileSnapshot, writer: anytype, min_ms_threshold: 
 
 /// 지정한 format 으로 리포트 출력.
 pub fn report(writer: anytype, format: Format) !void {
-    @setEvalBranchQuota(20000);
+    @setEvalBranchQuota(num_categories * 200);
     switch (format) {
         .table => try reportTable(writer),
         .tree => try reportTree(writer),


### PR DESCRIPTION
## Summary
Sub-PR-L.0 통합 사후 `/code-review max` 의 MED finding #5 cleanup.

`src/profile.zig` 의 `@setEvalBranchQuota(20000)` 하드코드 3곳을 `num_categories * 200` 으로 변경.

**문제**: Category enum 은 RFC #3940 진행 중 계속 늘어남 (이번 Sub-PR-L.0e 에서도 link sub-phase 6 개 추가). enum 이 quota 임계를 넘으면 compile 이 *다른 파일에 cryptic 에러*로 silent fail → 디버깅 시간 낭비.

**Fix**: `num_categories` (= `@typeInfo(Category).@"enum".fields.len`) 기반 derived 표현. enum 이 늘어나도 자동 비례.
- 현재 `num_categories ≈ 209` → derived ≈ 41,800 (기존 20,000 대비 여유)
- 200/cat 은 display / JSON serialize / report 각 inline-unroll path 의 comptime branch 안전 margin

3곳:
- `displayName` (struct method, inline else switch)
- `snapshotToJson` (inline for over enum.fields)
- `report` (switch dispatch)

**Zig 초보자 노트**: file-scope `const` 는 forward reference 가능해서 `displayName` 이 `num_categories` 정의보다 위(line 358 vs 418)에 있어도 정상 작동합니다. comptime 값이라 `@setEvalBranchQuota` 인자로 그대로 사용 가능.

## Test plan
- [x] `zig build install` (no errors)
- [x] `zig build test` 전체 통과 (snapshotToJson / displayName 유닛 포함)

## 비고
- 순수 robustness cleanup. 런타임 동작 변화 0.
- review max 의 다른 LOW finding (#8 snapshot by-value copy, #9 wire format snake/camel) 은 perf refactor / RFC-level 결정이라 본 PR scope 밖 — RFC #3940 본작업에서 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)