### PR TITLE
feat(transpile): cloneForTransformer 회피 — initFromOwnedAst 사용 (RFC #3940 PR-2)

### DIFF
--- a/docs/RFC_TRANSFORMER_OWN_AST.md
+++ b/docs/RFC_TRANSFORMER_OWN_AST.md
@@ -186,10 +186,41 @@ PR-2 머지 후 samply 재측정:
 
 ## 7. 다음 세션 시작점
 
-1. PR-1: `Transformer.initFromOwnedAst` API 추가 (작은 PR, infra)
-2. PR-2: transpile.zig 가 새 API 사용 + arena 분리 원복 + 측정
+1. PR-1: `Transformer.initFromOwnedAst` API 추가 (작은 PR, infra) — **완료**
+2. PR-2: transpile.zig 가 새 API 사용 + arena 분리 원복 + 측정 — **완료**
 
-PR-1 머지 후 PR-2 의 측정 결과 따라 GO/NO-GO 결정.
+PR-1 머지 후 PR-2 의 측정 결과 따라 GO/NO-GO 결정. → §10 참조.
+
+## 10. PR-2 측정 결과 + GO 판단 (실측)
+
+87MB synthetic (`scripts/gen-synthetic-87mb.ts`, seed 0x1234abcd, 244K decls),
+n=30 페어드 교대 실행, ReleaseFast, macOS, `scripts/measure-rss.ts`:
+
+| | median peak RSS |
+| --- | ---: |
+| main (clone) | ~3266 MB |
+| PR-2 (initFromOwnedAst) | ~3182 MB |
+| **Δ** | **~-84 MB (-2.6%)** |
+
+- sign-test: 30/30 b<a, two-sided p < 0.0001 — 통계적으로 명백히 유의
+- correctness: main vs PR-2 output **byte-identical** (37.5 MB), bundle-smoke 151/0, bench 16/0
+
+**RFC §5.5 게이트 (-300 MB) 미충족, §5.6 NO-GO 임계 (-100 MB) 도 미달.**
+그러나:
+- 추정 -580 MB 와 실측 -84 MB 의 격차 원인 = **clone 되는 `nodes`/`extra_data` 배열이
+  이미 pre-warm 됨** (`project_arraylist_prewarm_session_2026_05_28.md` / #3928 에서
+  -553 MB 선반영). 즉 §1.1 의 581 MB 분포는 prewarm 이전 stale 수치.
+- mimalloc 의 page reuse 가 clone buffer 를 즉시 재사용 → peak 영향 제한적 (RFC §5.6
+  에서 예견한 시나리오).
+
+**GO 판단 (사용자 결정)**: 작은 절감이나 (1) 통계적으로 명백 (p<0.0001), (2) correctness
+회귀 0 (byte-identical), (3) clone 제거로 코드도 단순화 (단일 arena) — 머지 진행.
+대신 §5.5 의 -300 MB 게이트는 prewarm 선반영으로 *애초에 도달 불가* 였음을 기록.
+
+**박제**: transpile path 의 *immutable parser.ast 안전성* 을 in-place mutation 과
+맞바꾼 대가가 -2.6% 라는 점 — 이후 transpile path 에 parser.ast 재사용 코드를 추가하면
+debug assert (transformed_root/transform_boundary == null) 가 깨진다. PR-3 의 추가 정밀화는
+이 -84 MB 가 ROI 하한임을 전제로 판단.
 
 ## 8. 박제 (재시도 금지)
 
@@ -200,7 +231,8 @@ PR-1 머지 후 PR-2 의 측정 결과 따라 GO/NO-GO 결정.
 ## 9. References
 
 - `src/parser/ast.zig:1147` cloneForTransformer
-- `src/transformer/transformer/lifecycle.zig:13-37` Transformer.init / initBorrow
-- `src/transpile.zig:1295` transpile path 의 Transformer.init 호출
+- `src/transformer/transformer/lifecycle.zig` Transformer.init / initBorrow / initFromOwnedAst
+- `src/transpile.zig` transpile path 의 `initFromOwnedAst` 호출 (PR-2)
 - `src/bundler/emitter.zig:1431-1432` bundler path (clone 유지)
+- `scripts/gen-synthetic-87mb.ts` / `scripts/measure-rss.ts` — 측정 재현 도구 (PR-3 재사용)
 - 메모리 박제: `project_arraylist_prewarm_session_2026_05_28.md` 의 Step 2 NO-GO 분석

--- a/scripts/gen-synthetic-87mb.ts
+++ b/scripts/gen-synthetic-87mb.ts
@@ -9,7 +9,8 @@
  * 사용:
  *   bun scripts/gen-synthetic-87mb.ts <output_path> [target_mb=87]
  *
- * fixture 는 gitignore — 빌드 머신에서 1 회 생성 후 측정용으로 사용.
+ * 생성된 fixture (수십 MB) 는 commit 하지 말 것 — /tmp 등 repo 밖에 출력하거나
+ * .gitignore 에 추가. 빌드 머신에서 1 회 생성 후 측정용으로 사용.
  */
 
 const path = require("node:path");
@@ -24,7 +25,9 @@ if (!out) {
 
 const targetBytes = targetMb * 1024 * 1024;
 
-// 결정성: 동일 generator 가 동일 결과 — 측정 재현성 확보.
+// 결정성: 동일 JS 엔진 내에서 동일 generator 가 동일 결과 — 측정 재현성 확보.
+// (float64 LCG: seed*1103515245 가 2^53 를 넘어 하위 비트가 반올림되므로 glibc LCG 와
+//  비트 동일하진 않으나, 한 머신에서 fixture 1 회 생성용이라 충분. 분포 uniform 검증됨.)
 let seed = 0x1234abcd;
 function rand(): number {
   seed = (seed * 1103515245 + 12345) & 0x7fffffff;

--- a/scripts/gen-synthetic-87mb.ts
+++ b/scripts/gen-synthetic-87mb.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+/**
+ * 87MB synthetic .ts fixture generator — RFC_TRANSFORMER_OWN_AST 측정용.
+ *
+ * 생성: 함수 / 클래스 / 인터페이스 / type-alias / re-export 가 섞인 N 개 모듈을
+ *      단일 파일에 concat. ECMA/TS 구문 다양성을 살려 parser/transformer 경로의
+ *      대표성 확보 (단순 string 반복은 intern 으로 메모리 왜곡).
+ *
+ * 사용:
+ *   bun scripts/gen-synthetic-87mb.ts <output_path> [target_mb=87]
+ *
+ * fixture 는 gitignore — 빌드 머신에서 1 회 생성 후 측정용으로 사용.
+ */
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+const out = process.argv[2];
+const targetMb = Number(process.argv[3] ?? 87);
+if (!out) {
+  console.error("usage: bun gen-synthetic-87mb.ts <output_path> [target_mb=87]");
+  process.exit(1);
+}
+
+const targetBytes = targetMb * 1024 * 1024;
+
+// 결정성: 동일 generator 가 동일 결과 — 측정 재현성 확보.
+let seed = 0x1234abcd;
+function rand(): number {
+  seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+  return seed / 0x80000000;
+}
+function pick<T>(xs: T[]): T {
+  return xs[Math.floor(rand() * xs.length)] ?? xs[0]!;
+}
+
+const types = ["string", "number", "boolean", "Date", "T", "U", "K", "V"];
+const verbs = ["compute", "process", "handle", "format", "parse", "build", "render", "emit"];
+const nouns = ["user", "order", "item", "node", "edge", "query", "result", "context"];
+
+function genFunction(id: number): string {
+  const v = pick(verbs);
+  const n = pick(nouns);
+  const t1 = pick(types);
+  const t2 = pick(types);
+  const t3 = pick(types);
+  const body: string[] = [];
+  const k = 8 + Math.floor(rand() * 8);
+  for (let i = 0; i < k; i++) {
+    body.push(`  const x_${i}: ${t3} = ${rand() < 0.5 ? Math.floor(rand() * 1000) : `"v_${i}"`} as ${t3};`);
+  }
+  body.push(`  return { id: ${id}, value: x_0 };`);
+  return `export function ${v}${n}_${id}<${t2} extends ${t1}>(arg: ${t1}): { id: number; value: ${t3} } {\n${body.join("\n")}\n}`;
+}
+
+function genClass(id: number): string {
+  const n = pick(nouns);
+  const t1 = pick(types);
+  const methods: string[] = [];
+  const k = 4 + Math.floor(rand() * 4);
+  for (let i = 0; i < k; i++) {
+    const v = pick(verbs);
+    methods.push(`  ${v}_${i}<U>(arg: U, opts: { flag?: boolean } = {}): ${t1} {\n    return arg as unknown as ${t1};\n  }`);
+  }
+  return `export class ${n.charAt(0).toUpperCase()}${n.slice(1)}_${id}<${t1}> {\n  private _id: number = ${id};\n  constructor(public name: string) {}\n${methods.join("\n")}\n}`;
+}
+
+function genInterface(id: number): string {
+  const fields: string[] = [];
+  const k = 5 + Math.floor(rand() * 5);
+  for (let i = 0; i < k; i++) {
+    fields.push(`  field_${i}?: ${pick(types)} | null;`);
+  }
+  return `export interface IShape_${id}<T> {\n${fields.join("\n")}\n  meta: { count: number; items: T[] };\n}`;
+}
+
+function genTypeAlias(id: number): string {
+  return `export type Alias_${id}<T extends ${pick(types)}> = T extends ${pick(types)} ? Array<T> : Record<string, T>;`;
+}
+
+const generators = [genFunction, genClass, genInterface, genTypeAlias];
+
+const fd = fs.openSync(out, "w");
+let bytes = 0;
+let id = 0;
+const HEADER = `// 87MB synthetic — RFC_TRANSFORMER_OWN_AST measurement fixture (seed 0x1234abcd).\n// Do not edit; regenerate with: bun scripts/gen-synthetic-87mb.ts ${out} ${targetMb}\n\n`;
+fs.writeSync(fd, HEADER);
+bytes += HEADER.length;
+
+while (bytes < targetBytes) {
+  const block = generators[id % generators.length]!(id);
+  const chunk = block + "\n\n";
+  fs.writeSync(fd, chunk);
+  bytes += chunk.length;
+  id++;
+}
+
+fs.closeSync(fd);
+console.error(`generated ${out}: ${(bytes / 1024 / 1024).toFixed(2)} MB, ${id} top-level decls`);

--- a/scripts/measure-rss.ts
+++ b/scripts/measure-rss.ts
@@ -3,7 +3,7 @@
  * Peak RSS 측정 + 페어드 통계 — RFC_TRANSFORMER_OWN_AST PR-2 검증용.
  *
  * 두 zntc 바이너리 (main / PR) 를 같은 fixture 로 N 회 교대 실행해 RSS 분포 비교.
- * Mann-Whitney U + Wilcoxon signed-rank + binomial sign-test 3 중으로 p-value 산출.
+ * 페어드 binomial sign-test (two-sided) 로 p-value 산출 + median Δ 게이트로 GO/NO-GO.
  *
  * macOS: /usr/bin/time -l 의 "maximum resident set size" (bytes) 파싱.
  * Linux: /usr/bin/time -v 의 "Maximum resident set size (kbytes)" 파싱.
@@ -60,10 +60,16 @@ type Sample = { a: number; b: number };
 function sample(): Sample[] {
   const xs: Sample[] = [];
   for (let i = 0; i < n; i++) {
-    // 교대 실행으로 OS-level caching/jitter 균등화.
-    const first = i % 2 === 0;
-    const va = first ? measure(a, fixture) : measure(a, fixture);
-    const vb = first ? measure(b, fixture) : measure(b, fixture);
+    // 실제 교대 실행으로 warm-cache/jitter 순서 편향 제거: 짝수 iter 는 a→b, 홀수는 b→a.
+    let va: number;
+    let vb: number;
+    if (i % 2 === 0) {
+      va = measure(a, fixture);
+      vb = measure(b, fixture);
+    } else {
+      vb = measure(b, fixture);
+      va = measure(a, fixture);
+    }
     xs.push({ a: va, b: vb });
     process.stderr.write(`  [${i + 1}/${n}] a=${(va / 1024 / 1024).toFixed(1)}MB b=${(vb / 1024 / 1024).toFixed(1)}MB Δ=${((vb - va) / 1024 / 1024).toFixed(1)}MB\n`);
   }
@@ -87,18 +93,13 @@ function stddev(xs: number[]): number {
 }
 
 // Binomial sign-test (two-sided): k = #(b < a), n = trials.
-// CDF via direct sum (n=30 충분히 작음).
+// p = 2 * min-tail CDF (direct sum; n=30 충분히 작음).
 function binomialP(k: number, n: number): number {
   function logBinom(n: number, k: number): number {
     let r = 0;
     for (let i = 1; i <= k; i++) r += Math.log(n - k + i) - Math.log(i);
     return r;
   }
-  let p = 0;
-  for (let i = 0; i <= Math.min(k, n - k); i++) {
-    p += Math.exp(logBinom(n, i)) * Math.pow(0.5, n);
-  }
-  // two-sided: 2 * min-tail
   const minK = Math.min(k, n - k);
   let pTail = 0;
   for (let i = 0; i <= minK; i++) {
@@ -125,8 +126,9 @@ function binomialP(k: number, n: number): number {
   console.error(`a (main):    median=${(median(as) / 1024 / 1024).toFixed(2)} MB  mean=${(mean(as) / 1024 / 1024).toFixed(2)} ± ${(stddev(as) / 1024 / 1024).toFixed(2)} MB`);
   console.error(`b (PR-2):    median=${(median(bs) / 1024 / 1024).toFixed(2)} MB  mean=${(mean(bs) / 1024 / 1024).toFixed(2)} ± ${(stddev(bs) / 1024 / 1024).toFixed(2)} MB`);
   console.error(`Δ (b - a):   median=${(median(diffs) / 1024 / 1024).toFixed(2)} MB  mean=${(mean(diffs) / 1024 / 1024).toFixed(2)} ± ${(stddev(diffs) / 1024 / 1024).toFixed(2)} MB`);
-  console.error(`sign-test:   ${k}/${effN} samples with b < a (ties=${ties}), two-sided p = ${p.toFixed(4)}`);
-  console.error(`gate:        Δ ≤ -300 MB ? ${median(diffs) <= -300 * 1024 * 1024 ? "GO" : "NO-GO"}    p < 0.05 ? ${p < 0.05 ? "OK" : "NS"}`);
+  const dir = median(diffs) < 0 ? "b<a (PR smaller)" : median(diffs) > 0 ? "b>a (PR larger)" : "tie";
+  console.error(`sign-test:   ${k}/${effN} samples with b < a (ties=${ties}), two-sided p = ${p.toFixed(6)} — direction: ${dir}`);
+  console.error(`gate:        Δ ≤ -300 MB ? ${median(diffs) <= -300 * 1024 * 1024 ? "GO" : "NO-GO"}    significant improvement ? ${p < 0.05 && median(diffs) < 0 ? "YES" : "NO"}`);
 
   process.stdout.write(JSON.stringify({
     n,

--- a/scripts/measure-rss.ts
+++ b/scripts/measure-rss.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env bun
+/**
+ * Peak RSS 측정 + 페어드 통계 — RFC_TRANSFORMER_OWN_AST PR-2 검증용.
+ *
+ * 두 zntc 바이너리 (main / PR) 를 같은 fixture 로 N 회 교대 실행해 RSS 분포 비교.
+ * Mann-Whitney U + Wilcoxon signed-rank + binomial sign-test 3 중으로 p-value 산출.
+ *
+ * macOS: /usr/bin/time -l 의 "maximum resident set size" (bytes) 파싱.
+ * Linux: /usr/bin/time -v 의 "Maximum resident set size (kbytes)" 파싱.
+ *
+ * 사용:
+ *   bun scripts/measure-rss.ts <zntc_a> <zntc_b> <fixture> [n=30]
+ */
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+
+const a = process.argv[2];
+const b = process.argv[3];
+const fixture = process.argv[4];
+const n = Number(process.argv[5] ?? 30);
+
+if (!a || !b || !fixture) {
+  console.error("usage: bun measure-rss.ts <zntc_a> <zntc_b> <fixture> [n=30]");
+  process.exit(1);
+}
+
+function isMac(): boolean {
+  return process.platform === "darwin";
+}
+
+/** RSS (bytes) of a single zntc run. */
+function measure(zntc: string, fixture: string): number {
+  // /usr/bin/time -l (mac) | -v (linux). -o 파일 출력 후 파싱.
+  const tmp = `/tmp/zntc-rss-${process.pid}-${Math.random().toString(36).slice(2)}.txt`;
+  const cmd = isMac()
+    ? ["/usr/bin/time", "-l", "-o", tmp, zntc, fixture, "-o", "/dev/null"]
+    : ["/usr/bin/time", "-v", "-o", tmp, zntc, fixture, "-o", "/dev/null"];
+  const r = spawnSync(cmd[0]!, cmd.slice(1), { stdio: ["ignore", "ignore", "pipe"] });
+  if (r.status !== 0) {
+    const stderr = r.stderr?.toString() ?? "";
+    throw new Error(`zntc failed (${r.status}): ${stderr.slice(0, 500)}`);
+  }
+  const out = fs.readFileSync(tmp, "utf8");
+  fs.unlinkSync(tmp);
+  if (isMac()) {
+    // macOS: "<bytes> maximum resident set size"
+    const m = out.match(/(\d+)\s+maximum resident set size/);
+    if (!m) throw new Error(`no RSS line in macOS time -l output:\n${out}`);
+    return Number(m[1]);
+  }
+  // Linux: "Maximum resident set size (kbytes): <kb>"
+  const m = out.match(/Maximum resident set size \(kbytes\):\s+(\d+)/);
+  if (!m) throw new Error(`no RSS line in linux time -v output:\n${out}`);
+  return Number(m[1]) * 1024;
+}
+
+type Sample = { a: number; b: number };
+
+function sample(): Sample[] {
+  const xs: Sample[] = [];
+  for (let i = 0; i < n; i++) {
+    // 교대 실행으로 OS-level caching/jitter 균등화.
+    const first = i % 2 === 0;
+    const va = first ? measure(a, fixture) : measure(a, fixture);
+    const vb = first ? measure(b, fixture) : measure(b, fixture);
+    xs.push({ a: va, b: vb });
+    process.stderr.write(`  [${i + 1}/${n}] a=${(va / 1024 / 1024).toFixed(1)}MB b=${(vb / 1024 / 1024).toFixed(1)}MB Δ=${((vb - va) / 1024 / 1024).toFixed(1)}MB\n`);
+  }
+  return xs;
+}
+
+function median(xs: number[]): number {
+  const ys = [...xs].sort((p, q) => p - q);
+  const mid = Math.floor(ys.length / 2);
+  return ys.length % 2 === 1 ? ys[mid]! : (ys[mid - 1]! + ys[mid]!) / 2;
+}
+
+function mean(xs: number[]): number {
+  return xs.reduce((s, v) => s + v, 0) / xs.length;
+}
+
+function stddev(xs: number[]): number {
+  const m = mean(xs);
+  const ss = xs.reduce((s, v) => s + (v - m) ** 2, 0);
+  return Math.sqrt(ss / Math.max(1, xs.length - 1));
+}
+
+// Binomial sign-test (two-sided): k = #(b < a), n = trials.
+// CDF via direct sum (n=30 충분히 작음).
+function binomialP(k: number, n: number): number {
+  function logBinom(n: number, k: number): number {
+    let r = 0;
+    for (let i = 1; i <= k; i++) r += Math.log(n - k + i) - Math.log(i);
+    return r;
+  }
+  let p = 0;
+  for (let i = 0; i <= Math.min(k, n - k); i++) {
+    p += Math.exp(logBinom(n, i)) * Math.pow(0.5, n);
+  }
+  // two-sided: 2 * min-tail
+  const minK = Math.min(k, n - k);
+  let pTail = 0;
+  for (let i = 0; i <= minK; i++) {
+    pTail += Math.exp(logBinom(n, i)) * Math.pow(0.5, n);
+  }
+  return Math.min(1, 2 * pTail);
+}
+
+(async () => {
+  console.error(`measuring n=${n} samples per binary against ${fixture}...`);
+  const xs = sample();
+  const as = xs.map((x) => x.a);
+  const bs = xs.map((x) => x.b);
+  const diffs = xs.map((x) => x.b - x.a);
+  const k = diffs.filter((d) => d < 0).length;
+  const ties = diffs.filter((d) => d === 0).length;
+
+  // paired sign-test on non-ties.
+  const effN = n - ties;
+  const p = effN > 0 ? binomialP(k, effN) : 1;
+
+  console.error("");
+  console.error("===== summary =====");
+  console.error(`a (main):    median=${(median(as) / 1024 / 1024).toFixed(2)} MB  mean=${(mean(as) / 1024 / 1024).toFixed(2)} ± ${(stddev(as) / 1024 / 1024).toFixed(2)} MB`);
+  console.error(`b (PR-2):    median=${(median(bs) / 1024 / 1024).toFixed(2)} MB  mean=${(mean(bs) / 1024 / 1024).toFixed(2)} ± ${(stddev(bs) / 1024 / 1024).toFixed(2)} MB`);
+  console.error(`Δ (b - a):   median=${(median(diffs) / 1024 / 1024).toFixed(2)} MB  mean=${(mean(diffs) / 1024 / 1024).toFixed(2)} ± ${(stddev(diffs) / 1024 / 1024).toFixed(2)} MB`);
+  console.error(`sign-test:   ${k}/${effN} samples with b < a (ties=${ties}), two-sided p = ${p.toFixed(4)}`);
+  console.error(`gate:        Δ ≤ -300 MB ? ${median(diffs) <= -300 * 1024 * 1024 ? "GO" : "NO-GO"}    p < 0.05 ? ${p < 0.05 ? "OK" : "NS"}`);
+
+  process.stdout.write(JSON.stringify({
+    n,
+    a_median_bytes: median(as),
+    b_median_bytes: median(bs),
+    delta_median_bytes: median(diffs),
+    delta_mean_bytes: mean(diffs),
+    delta_stddev_bytes: stddev(diffs),
+    sign_test_k: k,
+    sign_test_n: effN,
+    sign_test_p: p,
+    samples: xs,
+  }, null, 2));
+})();

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3,14 +3,17 @@
 //! 단일 AST를 append-only로 변환한다.
 //!
 //! 작동 원리:
-//!   1. 파서 AST를 cloneForTransformer()로 복제
+//!   1. 파서 AST 를 확보 — 두 경로:
+//!      - `init`: cloneForTransformer() 로 복제 (bundler/HMR — 원본 보존 의무).
+//!      - `initFromOwnedAst`: 복제 없이 parser.ast 의 ownership 양도받아 in-place mutate
+//!        (transpile path — RFC_TRANSFORMER_OWN_AST, clone deep copy 회피).
 //!   2. 파서 노드(0..parser_node_count-1)를 읽기 전용으로 탐색
 //!   3. 변환된 노드를 같은 AST 끝에 append
 //!   4. string_table이 하나이므로 파서에서 만든 합성 이름도 codegen에서 읽을 수 있음
 //!
 //! 메모리:
-//!   - ast는 트랜스포머 allocator로 복제됨 (원본 module.ast 보존)
-//!   - 변환 완료 후 원본 AST는 해제 가능
+//!   - `init`: ast 는 트랜스포머 allocator 로 복제됨 (원본 module.ast 보존).
+//!   - `initFromOwnedAst`: ast 는 caller (parser.ast) 와 동일 instance — 복제 없음.
 //!   - source는 원본과 같은 슬라이스를 참조 (zero-copy)
 
 const std = @import("std");

--- a/src/transformer/transformer/lifecycle.zig
+++ b/src/transformer/transformer/lifecycle.zig
@@ -105,7 +105,8 @@ fn finishInit(
 pub fn deinit(self: *Transformer) void {
     // `.borrowed` 는 외부 owner (보통 module.parse_arena) 가 ast 를 free.
     // `.owned_from_caller` 는 호출자가 ast 인스턴스의 lifetime 보유 (transpile path
-    // 에서 `parser.ast.deinit()` 으로 free). transformer 는 ast 를 건드리지 않는다.
+    // 에서는 ast 가 arena 안에 있어 arena.deinit() 으로 일괄 회수). transformer 는
+    // ast 를 건드리지 않는다.
     // method 호출 = exhaustive switch → 미래 variant 추가 시 컴파일 에러로 누락 방지.
     if (self.ast_ownership.transformerFreesAst()) {
         self.ast.deinit();

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1144,20 +1144,15 @@ fn transpileWithCallbackInternal(
     // `.d.ts` declaration 파일: 전체 type-only → 빈 출력 (D12.5).
     if (isDeclarationFile(file_path)) return .{ .code = try allocator.dupe(u8, "") };
 
-    // arena 분리 (Step 1 — RFC 메모리 절약 part 1, 동작 무변경):
-    // - parser_arena: scanner + parser-time 데이터 (parser.ast / scratch / bracket_stack).
-    //   현재는 transpile 끝 defer 로 deinit → 단일 arena 와 RSS 동일. Step 2 (다음 PR)
-    //   에서 transformer.transform 전 이른 deinit 으로 RSS 회수 예정.
-    // - transformer_arena: analyzer / transformer / codegen / 결과 dupe 모두.
-    var parser_arena = std.heap.ArenaAllocator.init(allocator);
-    defer parser_arena.deinit();
-    const parser_alloc = parser_arena.allocator();
-    var transformer_arena = std.heap.ArenaAllocator.init(allocator);
-    defer transformer_arena.deinit();
-    const arena_alloc = transformer_arena.allocator();
+    // 단일 arena (RFC_TRANSFORMER_OWN_AST PR-2 후): clone 회피로 parser.ast 가 transformer.ast
+    // 와 동일 instance — 이른 deinit 으로 회수할 영역 자체가 없어 PR #3941 의 parser_arena/
+    // transformer_arena 2-arena 구조는 의미 없음. 단일 arena 로 환원.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
 
-    // 1. 파싱 (parser_arena)
-    var scanner = Scanner.init(parser_alloc, source) catch return error.OutOfMemory;
+    // 1. 파싱
+    var scanner = Scanner.init(arena_alloc, source) catch return error.OutOfMemory;
 
     // --stop-after=scan: 파서 호출 없이 토큰 drain 만 수행 (profile/debug 용).
     // Scanner 가 lazy 이므로 next() 로 EOF 까지 소비해야 실제 tokenization 비용이 발생.
@@ -1169,7 +1164,7 @@ fn transpileWithCallbackInternal(
         return .{ .code = try allocator.dupe(u8, "") };
     }
 
-    var parser = Parser.init(parser_alloc, &scanner);
+    var parser = Parser.init(arena_alloc, &scanner);
     parser.configureFromExtension(std.fs.path.extension(file_path));
     parser.configureAmbientFromPath(file_path);
 
@@ -1292,9 +1287,11 @@ fn transpileWithCallbackInternal(
     if (effective_opts.jsxClassicPragmaIgnoredUnderAutomatic(&parser.ast)) {
         std.log.warn("zntc: {s}: {s}", .{ file_path, TransformOptions.jsx_pragma_ignored_msg });
     }
-    var transformer = try Transformer.init(arena_alloc, &parser.ast, effective_opts);
-    // transformer.ast 도 arena owned (cloneForTransformer 결과). parser.ast 와 동일 이유.
-    defer transformer.ast.dumpStringInternStatsIfEnabled();
+    // RFC_TRANSFORMER_OWN_AST PR-2: clone 회피 — transformer 가 parser.ast 의 ownership 을
+    // 양도받아 *동일 instance* 를 직접 mutate. cloneForTransformer (87MB synthetic 기준 -581 MB)
+    // 회피. transpile path 전용 (bundler 의 graph cache / HMR re-process 는 init 유지).
+    // line 1195 의 defer 가 stats 를 dump 하므로 여기서 별도 defer 불필요 — 같은 instance.
+    var transformer = try Transformer.initFromOwnedAst(arena_alloc, &parser.ast, effective_opts);
     if (analyzer_storage) |*analyzer| {
         transformer.initSymbolIds(analyzer.symbol_ids.items) catch return error.TransformError;
         transformer.symbols = analyzer.symbols.items;

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1288,9 +1288,12 @@ fn transpileWithCallbackInternal(
         std.log.warn("zntc: {s}: {s}", .{ file_path, TransformOptions.jsx_pragma_ignored_msg });
     }
     // RFC_TRANSFORMER_OWN_AST PR-2: clone 회피 — transformer 가 parser.ast 의 ownership 을
-    // 양도받아 *동일 instance* 를 직접 mutate. cloneForTransformer (87MB synthetic 기준 -581 MB)
-    // 회피. transpile path 전용 (bundler 의 graph cache / HMR re-process 는 init 유지).
-    // line 1195 의 defer 가 stats 를 dump 하므로 여기서 별도 defer 불필요 — 같은 instance.
+    // 양도받아 *동일 instance* 를 직접 mutate. cloneForTransformer 의 deep copy 회피로
+    // 87MB synthetic 기준 peak RSS -84 MB (-2.6%, n=30 p<0.0001) 절감 (clone 배열이
+    // 이미 pre-warm 된 상태라 RFC 초기 추정 -580 MB 보다 작음). transpile path 전용 —
+    // bundler 의 graph cache / HMR re-process 는 원본 보존 의무라 init 유지.
+    // 위 `defer parser.ast.dumpStringInternStatsIfEnabled()` 가 stats 를 dump 하므로
+    // 여기서 별도 defer 불필요 — parser.ast 와 transformer.ast 가 같은 instance.
     var transformer = try Transformer.initFromOwnedAst(arena_alloc, &parser.ast, effective_opts);
     if (analyzer_storage) |*analyzer| {
         transformer.initSymbolIds(analyzer.symbol_ids.items) catch return error.TransformError;


### PR DESCRIPTION
## Summary
- transpile path 가 `Transformer.init` (clone) → `Transformer.initFromOwnedAst` (ownership 양도) 로 전환. parser.ast 가 transformer.ast 와 **동일 instance** 가 되어 `cloneForTransformer` 의 deep copy 회피.
- 단일 arena 환원 — clone 회피로 PR #3941 의 parser_arena/transformer_arena 2-arena 구조가 의미 소멸.
- PR-1 (#3948, 머지됨) 의 `initFromOwnedAst` API 를 실제 사용하는 첫 호출처.

RFC: `docs/RFC_TRANSFORMER_OWN_AST.md` (§10 에 측정 결과 + GO 판단 기록)

## 측정 (87MB synthetic, n=30, ReleaseFast, macOS)
| | median peak RSS |
| --- | ---: |
| main (clone) | ~3266 MB |
| PR-2 (initFromOwnedAst) | ~3182 MB |
| **Δ** | **−84 MB (−2.6%)** |

- sign-test 30/30 b<a, two-sided **p < 0.0001** — 통계적으로 명백히 유의
- 교대 실행 (a→b / b→a) 로 순서 편향 제거 후 재측정 동일 결과

**RFC §5.5 게이트 (−300 MB) 미충족.** 추정 −580 MB 와 격차 원인 = clone 되는 `nodes`/`extra_data` 배열이 이미 pre-warm 됨 (#3928 에서 −553 MB 선반영) → §1.1 의 581 MB 분포가 prewarm 이전 stale. 게이트는 애초 도달 불가였음.

## GO 판단
작은 절감이나 (1) 통계 명백 (p<0.0001), (2) **correctness 회귀 0** (output byte-identical 37.5 MB), (3) clone 제거로 코드 단순화 (단일 arena) — 머지.

## 변경 내용
- `transpile.zig`: `init` → `initFromOwnedAst` swap + 2-arena → 단일 arena + dumpStringInternStatsIfEnabled 중복 dump 제거 (동일 instance)
- `transformer.zig` / `lifecycle.zig`: module doc / deinit 주석 정정 (transpile 은 clone 안 함)
- `scripts/gen-synthetic-87mb.ts` + `scripts/measure-rss.ts`: 측정 재현 도구 (PR-3 재사용)
- RFC §10: 측정 결과 + GO 판단

## Test plan
- [x] `zig build test` 통과 (debug assert 포함 — transpile path 의 pristine 사전조건 검증)
- [x] tests/integration bundle-smoke 151/0
- [x] tests/benchmark 16/0
- [x] main vs PR-2 87MB output **byte-identical**
- [x] `/code-review max` — 측정 방법론 버그 (no-op alternation) 적발 → 수정 + 재측정, comment rot 정정
- [ ] PR-3: 측정 정밀화 (잔여 영역 식별)

🤖 Generated with [Claude Code](https://claude.com/claude-code)