### PR TITLE
perf(transpile): phase 메모리 계측 + RFC 분포 분석 (RFC #3940 PR-3)

### DIFF
--- a/docs/RFC_TRANSFORMER_OWN_AST.md
+++ b/docs/RFC_TRANSFORMER_OWN_AST.md
@@ -222,6 +222,89 @@ n=30 페어드 교대 실행, ReleaseFast, macOS, `scripts/measure-rss.ts`:
 debug assert (transformed_root/transform_boundary == null) 가 깨진다. PR-3 의 추가 정밀화는
 이 -84 MB 가 ROI 하한임을 전제로 판단.
 
+## 11. PR-3 측정 + 정밀화 (phase 별 분포)
+
+`ZNTC_MEM_PROFILE=1` 계측 (`transpile.zig` 의 `MemProfile`, phase 경계마다
+`arena.queryCapacity()` 스냅샷) 으로 87MB synthetic 의 phase 별 arena 누적 분포 측정
+(instrumented ReleaseFast build, single run):
+
+| phase | arena 누적 cap | Δ (증분) |
+| --- | ---: | ---: |
+| start | 0 MB | — |
+| parse | 2049 MB | +2049 MB |
+| semantic | 4303 MB | +2254 MB |
+| transform | 4303 MB | +0 MB |
+| generate | 4303 MB | +0 MB |
+| emit | 4303 MB | +0 MB |
+
+### 11.1 clone 의 peak RSS 기여 ≈ 80 MB (직접 증거는 RSS, capacity 아님)
+
+`initFromOwnedAst` (own) 와 `init` (clone) 을 동일 fixture 로 비교 (둘 다 instrumented,
+single run):
+
+| 버전 | arena 누적 cap | peak RSS |
+| --- | ---: | ---: |
+| init (clone) | 4303 MB | ~3415 MB |
+| initFromOwnedAst (own) | 4303 MB | ~3337 MB |
+| **Δ** | **0 MB** | **~-78 MB** |
+
+**arena capacity 동일 (4303 MB) 은 clone 비용을 증명하지 못한다 — measurement 한계의
+귀결일 뿐이다.** `arena.queryCapacity()` 는 모든 BufNode backing 의 *합* 이고, arena alloc
+은 가장 최근 BufNode 의 tail 만 사용한다 (이전 node 의 tail 은 backfill 안 함). semantic
+단계가 마지막에 큰 BufNode (+2254 MB) 를 만들면서 그 node 에 큰 미사용 tail 이 남고 →
+이후 transform 의 clone / generate output / emit 가 모두 그 tail 에 fit → 새 BufNode 가
+안 생겨 capacity 의 합이 불변. 즉 **capacity 가 clone/own 동일한 것은 clone 이 싸든 비싸든
+*예상되는* 결과** 이며 (§11.3 의 과소측정 한계), clone 비용에 대해 아무 정보도 주지 않는다.
+
+clone 의 실제 비용을 측정하는 유일한 직접 지표는 **peak RSS 차이 (~-78 MB)** 다. clone 이
+tail 페이지를 touch 하는 만큼만 RSS 가 늘기 때문. §1.1 의 "transformer.ast cloned 581 MB"
+는 *논리적 복제 크기* 일 뿐, arena+mimalloc 환경에서 *touch 되어 RSS 에 기여하는 부분은
+~80 MB*. 따라서 §5.5 의 -300 MB 게이트는 clone 의 실제 RSS 비용 자체가 ~80 MB 라
+**도달 불가** 였다.
+
+### 11.1.1 §10 (prewarm) 과 §11 은 같은 root cause
+
+§10 의 "clone 배열 prewarm (#3928, -553 MB 선반영)" 과 §11 의 "clone 이 arena tail/page
+reuse 에 흡수" 는 *독립 확증이 아니라 동일 현상의 두 각도* 다. clone 의 marginal RSS 비용이
+~80 MB 로 작은 근본 이유는 prewarm 이 clone 대상 배열의 capacity 를 미리 키워 둔 것 +
+arena/mimalloc 의 page reuse — 둘은 같은 메커니즘을 allocator 층위와 array 층위에서 본 것.
+"두 개의 독립 증거" 로 읽으면 안 된다.
+
+### 11.2 잔여 dominant 영역 (이 fixture 기준, 일반화 주의)
+
+clone 영역 소진 후 **이 87MB synthetic 에서** arena 의 capacity high-water 는 거의 전부
+parse (2049 MB) + semantic (2254 MB). 단 이 fixture 는 244K decl 의 **TS-type-heavy**
+synthetic 이라 semantic (scope/symbol/reference) 비중이 과대 — §1.1 의 이전 baseline 은
+analyzer 13% / codegen 6% 였다. **일반 JS corpus 는 분포가 크게 다를 수 있으므로**, parse/
+semantic 을 "다음 레버" 로 단정하지 말고 *후보* 로만 본다. 실제 착수 전 대표 corpus 로 재측정
+필수. 후보 영역:
+
+- **semantic (analyzer)**: scopes / symbols / references 배열.
+- **parse (parser.ast)**: nodes / extra_data / string_table.
+
+둘 다 본 RFC 범위 밖 — `RFC_LIFECYCLE_SCOPE_REDESIGN` (cross-build memory ownership)
+또는 별도 analyzer/parser 메모리 RFC 후보.
+
+### 11.3 측정 인프라 한계 (중요)
+
+- `arena.queryCapacity()` 는 모든 BufNode backing 의 합 = *reserved high-water mark*
+  이지 *used* 가 아니다. arena 는 최근 BufNode tail 만 쓰므로, 그 tail 에 fit 하는 alloc
+  (clone / generate output / emit) 은 새 node 를 안 만들어 **증분 0 으로 과소측정**.
+  위 phase 표의 transform/generate/emit +0 은 "메모리를 안 썼다" 가 아니라 "queryCapacity
+  가 못 본다" 는 뜻. 실제 phase 비용은 peak RSS 로만 봐야 한다 (§11.1).
+- §11 의 절대 peak RSS (own 3337 / clone 3415 MB) 는 §10 의 n=30 측정 (3182 / 3266 MB)
+  보다 ~150 MB 높다 — instrumented build (계측 + single run) 의 오버헤드. Δ 도 §11
+  은 single-run -78 MB, §10 은 n=30 median -84 MB 로 *측정 방법이 다르다*. 둘 다 "~80 MB
+  영역" 으로 정합하나 ±수 MB 정밀 일치를 주장하지 않는다 (single-run 은 분산 큼).
+- `ZNTC_MEM_PROFILE` 계측 자체는 enabled=false 시 즉시 return + `env_flag.Once` (std.once
+  프로세스 1회 캐시) — production hot path 영향 0.
+
+### 11.4 RFC 종결
+
+clone 회피 (PR-1 API + PR-2 적용) 로 transformer 영역의 RSS 기여 (~80 MB) 소진.
+잔여는 parse/semantic 으로 본 RFC 범위 밖. **추가 정밀화는 별도 epic** (analyzer/parser
+메모리 또는 lifecycle redesign) 으로 분리. 본 RFC 의 transformer-ownership 레버는 종결.
+
 ## 8. 박제 (재시도 금지)
 
 - **PR #3941 의 arena 분리만으로는 RSS 절약 0** — clone 회피 필수

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1133,6 +1133,42 @@ fn isDeclarationFile(file_path: []const u8) bool {
         std.mem.endsWith(u8, file_path, ".d.cts");
 }
 
+/// `ZNTC_MEM_PROFILE` 존재 여부 — 프로세스 1회 캐시 (std.once, WASI/Windows 포터블).
+/// 직접 std.posix.getenv 는 WASI 에서 @compileError 라 env_flag.Once 사용.
+const mem_profile_env = @import("env_flag.zig").Once("ZNTC_MEM_PROFILE");
+
+/// transpile phase 별 arena 누적 capacity 스냅샷 (RFC_TRANSFORMER_OWN_AST PR-3 측정).
+/// `ZNTC_MEM_PROFILE=1` 일 때만 stderr 로 phase 경계 증분 출력 — 단일 arena 라 phase 별
+/// alloc 의 직접 분리는 불가하나, queryCapacity 증분이 각 phase 가 추가한 메모리의 proxy.
+/// 평소엔 enabled=false 라 snap() 이 즉시 return (hot path 영향 0).
+/// ⚠️ queryCapacity 는 reserved high-water mark — 마지막 arena BufNode 의 미사용 tail 에
+/// fit 하는 alloc (clone, codegen output) 은 증분 0 으로 *과소측정*. 실제 phase 비용은
+/// peak RSS 로 봐야 한다 (RFC §11.3 참조).
+const MemProfile = struct {
+    enabled: bool,
+    prev: usize = 0,
+
+    fn init() MemProfile {
+        return .{ .enabled = mem_profile_env.enabled() };
+    }
+
+    fn snap(self: *MemProfile, arena: *std.heap.ArenaAllocator, label: []const u8) void {
+        if (!self.enabled) return;
+        const cap = arena.queryCapacity();
+        const delta = cap -| self.prev;
+        const to_mb = struct {
+            fn f(b: usize) f64 {
+                return @as(f64, @floatFromInt(b)) / (1024.0 * 1024.0);
+            }
+        }.f;
+        std.debug.print(
+            "[mem] {s:<10} arena={d:>11} B ({d:>8.1} MB)  Δ +{d:>8.1} MB\n",
+            .{ label, cap, to_mb(cap), to_mb(delta) },
+        );
+        self.prev = cap;
+    }
+};
+
 fn transpileWithCallbackInternal(
     allocator: std.mem.Allocator,
     source: []const u8,
@@ -1150,6 +1186,9 @@ fn transpileWithCallbackInternal(
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const arena_alloc = arena.allocator();
+
+    var mem_profile = MemProfile.init();
+    mem_profile.snap(&arena, "start");
 
     // 1. 파싱
     var scanner = Scanner.init(arena_alloc, source) catch return error.OutOfMemory;
@@ -1185,6 +1224,7 @@ fn transpileWithCallbackInternal(
         parser.is_jsx = true;
     }
     _ = parser.parse() catch return error.ParseError;
+    mem_profile.snap(&arena, "parse");
     // Ast 가 arena 안에 살아 Ast.deinit() 가 호출되지 않으므로, intern stats dump 를
     // arena 해제 직전(LIFO) 에 명시 호출. ZNTC_STRING_INTERN_STATS=1 일 때만 출력.
     defer parser.ast.dumpStringInternStatsIfEnabled();
@@ -1238,6 +1278,7 @@ fn transpileWithCallbackInternal(
     } else if (transform_plan.semantic == .bindings) {
         binding_lite_storage = try collectBindingLite(arena_alloc, &parser.ast);
     }
+    mem_profile.snap(&arena, "semantic");
 
     if (options.stop_after == .semantic) {
         return .{ .code = try allocator.dupe(u8, "") };
@@ -1304,6 +1345,7 @@ fn transpileWithCallbackInternal(
     }
     transformer.line_offsets = scanner.line_offsets.items;
     const root = transformer.transform() catch return error.TransformError;
+    mem_profile.snap(&arena, "transform");
 
     if (options.stop_after == .transform) {
         return .{ .code = try allocator.dupe(u8, "") };
@@ -1371,6 +1413,7 @@ fn transpileWithCallbackInternal(
         cg.line_offsets = scanner.line_offsets.items;
     }
     const raw_output = cg.generate(root) catch return error.CodegenError;
+    mem_profile.snap(&arena, "generate");
 
     // 6.5. JSX import prepend (transformer가 JSX lowering 수행한 경우).
     // transformer.options 는 per-file pragma (#D026) 가 적용된 effective 설정 — 원본
@@ -1448,6 +1491,8 @@ fn transpileWithCallbackInternal(
         }
         break :blk buf.items;
     } else output;
+    // emit = generate 이후 jsx/css/runtime-helper prepend + sourcemap footer 까지 포함.
+    mem_profile.snap(&arena, "emit");
 
     // Arena 밖으로 복제 (arena는 함수 종료 시 defer로 해제 — line 167).
     // mangle_metadata.skip_nodes는 arena-owned이므로 별도 deinit 불필요.


### PR DESCRIPTION
## Summary
- PR-2 (clone 회피) 후 87MB synthetic 의 phase 별 메모리 분포를 측정해 **clone 영역 소진을 확정**하고 잔여 dominant 영역을 식별.
- `ZNTC_MEM_PROFILE` env-gated 계측 추가 (phase 경계마다 `arena.queryCapacity()` 스냅샷). enabled=false 시 즉시 return — production hot path 영향 0.
- RFC §11 에 측정 결과 + 결론 기록. transformer-ownership 레버 **종결**.

RFC: `docs/RFC_TRANSFORMER_OWN_AST.md` §11

## 측정 결과 (87MB synthetic, instrumented)
| phase | arena 누적 cap | Δ |
| --- | ---: | ---: |
| parse | 2049 MB | +2049 MB |
| semantic | 4303 MB | +2254 MB |
| transform / generate / emit | 4303 MB | +0 MB |

clone(init) vs own(initFromOwnedAst): arena capacity **동일** (4303 MB), peak RSS **3415 vs 3337 MB (Δ −78 MB)**.

## 핵심 결론
1. **clone 의 peak RSS 기여 ≈ 80 MB** (논리적 581 MB 와 무관) — `−300 MB` 게이트는 애초 도달 불가.
2. **capacity 동일은 clone 비용을 증명하지 못함** — `queryCapacity` 가 마지막 arena BufNode tail 에 fit 하는 alloc 을 과소측정하는 한계의 귀결. 직접 증거는 peak RSS −78 MB 뿐 (리뷰 지적 반영).
3. §10 (prewarm) 과 §11 (arena tail/page reuse) 은 독립 확증이 아니라 **동일 현상의 두 각도**.
4. parse/semantic 이 잔여 dominant 이나 **TS-heavy synthetic 특성** — 일반 corpus 는 분포 다름. 다음 레버 "후보" 로만 (별도 epic).

## 변경 내용
- `transpile.zig`: `MemProfile` + 6 phase snap. `env_flag.Once` 사용 (직접 `std.posix.getenv` 는 WASI `@compileError` → `zig build wasm` 깨짐).
- RFC §11: 측정 결과 + 측정 인프라 한계 + 종결.

## Test plan
- [x] `zig build test` 통과
- [x] `zig build wasm` 통과 (WASI fix 검증)
- [x] `ZNTC_MEM_PROFILE=1` phase 분포 측정 (87MB synthetic)
- [x] `/code-review max` — WASI build break (실측 확인) + RFC 논리 결함 (capacity 논증 self-undermining) 적발 → 모두 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)