### PR TITLE
feat(bundler): transform_prepass carry-over rename_table 동기화 (RFC #3940 Sub-PR-L.4a)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1378,6 +1378,12 @@ pub const Bundler = struct {
                     const l = &(linker.?);
                     l.populateReExportAliases();
                     l.populateImportSymbols();
+                    // RFC #3940 Sub-PR-L.4a — 이 분기는 canonical 을 재계산하지 않고 graph
+                    // carry-over (preserveCanonicalNamesAfterSemanticResync) 가 보존한
+                    // canonical_name 을 그대로 쓴다. carry-over 는 assignSymbolCanonical 단일
+                    // sink 를 우회하므로 rename_table 이 stale → canonical_name 으로부터 재동기화해
+                    // emit (L.4b 의 rename_table lookup) 이 정확하도록 보장.
+                    try l.syncRenameTableFromCanonical();
                 }
             }
             break :blk s;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2280,6 +2280,30 @@ pub const Linker = struct {
         return true;
     }
 
+    /// RFC #3940 Sub-PR-L.4a — `rename_table` 을 현재 `Symbol.canonical_name` 으로부터 전체 재구성.
+    ///
+    /// graph carry-over (`transform_prepass.preserveCanonicalNamesAfterSemanticResync`) 가
+    /// tree-shake 단계 (link 후, `minify_identifiers=false` + const-materialization AST mutation)
+    /// 에서 `assignSymbolCanonical` 단일 sink 를 우회해 `canonical_name` 을 직접 복사하면
+    /// rename_table 이 stale/누락된다. 이 분기는 canonical 을 재계산하지 않으므로, emit 전에
+    /// canonical_name (이 단계의 ground truth) 으로부터 rename_table 을 재구성해 동기화한다.
+    /// `clear` 후 전 모듈 순회 — semantic resync 로 바뀐 symbol idx 의 stale entry 도 제거된다.
+    ///
+    /// (graph 단계 carry-over 는 link 전이라 canonical_name 이 비어 preserve 가 no-op → 무관.
+    /// L.5 에서 canonical_name field 제거 시엔 carry-over 를 SymbolID 기반으로 재설계 — 이 메서드 폐기.)
+    pub fn syncRenameTableFromCanonical(self: *Linker) !void {
+        self.rename_table.clear();
+        for (0..self.graph.moduleCount()) |mi| {
+            const m = self.getModule(@intCast(mi)) orelse continue;
+            const sem = m.semantic orelse continue;
+            for (sem.symbols.items, 0..) |*sym, si| {
+                if (sym.canonical_name.len == 0) continue;
+                const id = bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(mi)), si);
+                try self.rename_table.put(self.allocator, id, sym.canonical_name);
+            }
+        }
+    }
+
     /// unified mangling 산출물을 초기화한다. AST mutation 후 semantic을 재생성한 경우
     /// old symbol id 기준 mangling 결과를 emit에 재사용하면 잘못된 rename이 적용된다.
     pub fn clearMangling(self: *Linker) void {

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1527,6 +1527,34 @@ test "RenameTable 병행: clearCanonicalNames 가 rename_table 도 비움 (RFC #
     try std.testing.expect(r.linker.renameTableParityHolds()); // canonical_name 도 "" → 자명하게 true
 }
 
+test "syncRenameTableFromCanonical: carry-over 우회분을 canonical_name 으로부터 복구 (RFC #3940 L.4a)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "export { x as a } from './m1'; export { x as b } from './m2';");
+    try writeFile(tmp.dir, "m1.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "m2.ts", "export const x = 2;");
+
+    var r = try buildAndLink(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.destroyGraph();
+    defer r.cache.deinit();
+
+    try r.linker.computeRenames();
+    const before = r.linker.rename_table.count();
+    try std.testing.expect(before >= 1);
+    try std.testing.expect(r.linker.renameTableParityHolds());
+
+    // carry-over (transform_prepass) 가 assignSymbolCanonical sink 를 우회해 canonical_name 만
+    // 갱신하고 rename_table 은 stale 인 상태를 모사: rename_table 만 비운다 (canonical_name 유지).
+    r.linker.rename_table.clear();
+    try std.testing.expect(!r.linker.renameTableParityHolds()); // 이제 깨짐 (blocker 재현)
+
+    // sync 가 canonical_name (ground truth) 으로부터 rename_table 을 재구성 → parity 회복.
+    try r.linker.syncRenameTableFromCanonical();
+    try std.testing.expectEqual(before, r.linker.rename_table.count());
+    try std.testing.expect(r.linker.renameTableParityHolds());
+}
+
 // Regression: HMR rebuild 에서 소스가 재파싱된 모듈의 `alias_table` 이 줄어들
 // 수 있어 (e.g. re_export 엔트리가 없어진 경우), 캐시된 import_binding 의
 // `.symbol.alias` 가 old-build AliasId 를 stale 로 들고 있으면


### PR DESCRIPTION
## Summary
RFC #3940 (lifecycle scope redesign) **Sub-PR-L.4a** — L.4 의 선행. L.3 review 가 발견한 **L.4 blocker** 를 해소한다. `graph/transform_prepass.zig` 의 carry-over (`preserveCanonicalNamesAfterSemanticResync`) 가 canonical write 단일 sink (`assignSymbolCanonical`) 를 우회해 `canonical_name` 을 직접 복사하는 경로에서, `rename_table` 이 stale 해지는 문제를 emit 전 재동기화로 해결.

## 조사로 확정한 유일한 blocker 경로
carry-over 가 일어나는 시점을 코드로 추적해 진짜 blocker 를 좁혔습니다:
- **graph 단계** (`transform_prepass.run`, link **전**): canonical_name 이 아직 비어있어(link 전) preserve loop (`if (old_sym.canonical_name.len == 0) continue`)가 전부 skip → **no-op, 무관**
- **tree-shake 단계** (`resyncAfterConstMaterialization`, link **후**) + `minify_identifiers=false` + `ast_mutated_after_link` → canonical 재계산 없이 carry-over preserve 값 그대로 emit → **진짜 blocker**. 정확히 `bundler.zig` 의 `else if (s.ast_mutated_after_link)` 분기.
- `minify_identifiers=true` 분기는 `finalize(clear_first=true)` 가 sink 통해 동기 → 불필요

## 변경
- **`linker.zig`** — `syncRenameTableFromCanonical()`: `rename_table.clear()` 후 전 모듈 순회하며 `canonical_name` (이 단계의 ground truth) 으로부터 재구성. `clear` 가 semantic resync 로 바뀐 idx 의 stale entry 도 제거.
- **`bundler.zig`** — 위 blocker 분기에서 `populateReExportAliases`+`populateImportSymbols` 후 `try l.syncRenameTableFromCanonical()` 추가.
- **`linker_test.zig`** — `rename_table.clear()` (carry-over 우회 모사) → `!renameTableParityHolds()` (blocker 재현) → `syncRenameTableFromCanonical()` → parity+count 회복 입증.

## /code-review max — no findings
- **위치 정확성**: bundler.zig:1374 가 유일한 blocker 경로 확정 (minify=true·graph 단계·tree-shake-only 경로는 sync 불필요 모두 검증)
- **borrow 안전성**: `ast_mutated_after_link` 분기는 `clear_first` 안 하므로 `canonical_strings` 가 살아있어 borrow slice 유효
- **stale entry**: `clear()` 가 전체 비우니 idx 변경분도 정리
- **alias 분리**: sync 는 semantic canonical 만 재구성, alias 는 AliasTable 경유 유지 (L.5 분리)
- **notable**: L.4a 자체는 `rename_table` production reader 가 없어(get 은 parity 함수뿐) output 위험 0 — 순수 준비 단계

## Test plan
- [x] `zig build test` 전체 통과 (sync test 가 blocker 재현·복구 입증)
- [x] `zig fmt --check` 통과
- [x] `/code-review max` no findings

## 다음
Sub-PR-L.4b: emitter 가 `rename_table.get` 으로 전환 (audit §6.1 의 직접 read 3곳: chunks/esm_wrap/syntheticName). corpus byte-identical 회귀 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)