### PR TITLE
feat(bundler): emitter canonical read 를 rename_table lookup 으로 전환 (RFC #3940 Sub-PR-L.4b)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1394,8 +1394,11 @@ pub const Linker = struct {
 
     fn lookupSymbolCanonical(self: *const Linker, module_index: u32, name: []const u8) ?[]const u8 {
         const found = self.findSymbolMutable(module_index, name) orelse return null;
-        if (!found.sym.hasCanonicalName()) return null;
-        return found.sym.canonical_name;
+        // RFC #3940 Sub-PR-L.4b — emit 경로가 `Symbol.canonical_name` field 대신 build-scope
+        // `rename_table` 을 읽는다. parity (L.3 병행작성 + L.4a carry-over sync) 로 결과 동일:
+        // canonical write 단일 sink 가 둘에 같은 slice 를 기록하므로 byte-identical. miss → null
+        // (기존 `!hasCanonicalName()` 분기와 동치).
+        return self.rename_table.get(bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(module_index)), found.idx));
     }
 
     /// ExportBinding의 canonical local name을 kind별 safe한 방법으로 조회.
@@ -1413,9 +1416,9 @@ pub const Linker = struct {
     }
 
     /// SymbolRef 기반 canonical name 조회 facade. #1328 Phase 4c-3.
-    /// - alias: AliasTable이 canonical_name 소유 → 직접 반환.
-    /// - semantic: Symbol.canonical_name 직접 조회. 미설정 시 string map fallback
-    ///   (synthetic 심볼 등 mirror 안 된 케이스).
+    /// - alias: AliasTable이 canonical_name 소유 → 직접 반환 (L.5 분리 대상).
+    /// - semantic: build-scope `rename_table` 조회 (RFC #3940 L.4b — `Symbol.canonical_name`
+    ///   field 대신). parity 로 결과 동일. bounds 밖이면 null.
     /// 리네임 안 됐으면 null — caller가 원본 이름으로 fallback.
     pub fn getCanonicalByRef(self: *const Linker, ref: bundler_symbol.SymbolRef) ?[]const u8 {
         if (!ref.isValid()) return null;
@@ -1429,9 +1432,7 @@ pub const Linker = struct {
                 const sem = m.semantic orelse break :blk null;
                 const idx: u32 = @intFromEnum(s.symbol);
                 if (idx >= sem.symbols.items.len) break :blk null;
-                const sym = &sem.symbols.items[idx];
-                if (sym.hasCanonicalName()) break :blk sym.canonical_name;
-                break :blk null;
+                break :blk self.rename_table.get(bundler_symbol.SymbolID.make(s.module, idx));
             },
         };
     }


### PR DESCRIPTION
## Summary
RFC #3940 (lifecycle scope redesign) **Sub-PR-L.4b**. emit 경로가 `Symbol.canonical_name` field 대신 build-scope `Linker.rename_table` 를 읽도록 전환한다. parity (L.3 병행작성 + L.4a carry-over sync) 로 `rename_table == canonical_name` 이라 결과물이 **byte-identical**. L.5 (`canonical_name` field 제거) 의 직전 단계.

## 변경 (linker.zig 2곳)
emitter 의 모든 canonical read 경로가 두 facade 를 경유하므로, 이 둘만 바꾸면 chunks/esm_wrap/metadata 가 자동 전환됨:
1. **`lookupSymbolCanonical`**: `found.sym.canonical_name` → `rename_table.get(SymbolID.make(module_index, found.idx))`. `getCanonicalName` → `getCanonicalForExport`/chunks.zig/esm_wrap.zig/metadata.zig 자동 전환.
2. **`getCanonicalByRef.semantic`**: `sym.canonical_name` → `rename_table.get(SymbolID.make(s.module, idx))`. bounds check 유지. `.alias` variant 는 AliasTable 유지 (L.5 분리).

codegen hot path 의 `LinkingMetadata.renames` 는 *별개 map* 이라 무관 (안 건드림).

## 검증 (byte-identical critical)
emitter 가 `rename_table` 의 첫 production reader 가 되므로 출력 동일성이 핵심:
- **cross-revision byte-identical**: main baseline binary 와 L.4b 로 5 determinism fixture 를 각각 빌드해 SHA256 대조 — **전부 동일**
  - name-collision (`--minify-identifiers`, rename 집중)
  - barrel (export* 체인)
  - small / dynamic-only (file 모드)
  - code-splitting (`--outdir --splitting`, worker_linker 경로)
- integration `determinism.test.ts` 5 pass
- `zig build test` 전체 통과

## /code-review max — no findings
- **write-site parity**: 모든 canonical write 가 `assignSymbolCanonical` sink 경유. 우회 2곳(graph carry-over → L.4a `syncRenameTableFromCanonical`, cache-hit reset → 다음 build 의 fresh Linker 재계산)도 emit 전 동기 보장
- **idx 공간 일관성**: mangler `cand.symbol_id` / `findSymbolMutable.idx` / `@intFromEnum(s.symbol)` 모두 `sem.symbols.items` 인덱스 공간 = sink 가 넣은 키와 동일
- alias 미전환(AliasTable 유지), splitting/per-chunk reemit 동기, bounds check 보존, doc 갱신 모두 확인

## ⚠️ L.5 checklist
`module.zig` 의 `syntheticName`/`getInitName` 등이 아직 `canonical_name` 직접 read (graph/finalize.zig 의 used_names 수집). Module 메서드라 Linker 핸들이 없어 본 PR 범위 밖. parity 하에 현재 동등하나 **L.5 field 제거 시 함께 변환 필요** (rename_table 핸들 주입 또는 SymbolID 기반 재설계).

## Test plan
- [x] cross-revision byte-identical (5 fixture)
- [x] integration determinism 5 pass
- [x] `zig build test` + `zig fmt --check`
- [x] `/code-review max` no findings

## 다음
Sub-PR-L.5 (big-bang): `Symbol.canonical_name` field 제거 + alias canonical 외부화 + reachable_stmts/symbol_to_stmt build-scope 분류 + module.zig syntheticName 전환. 모든 corpus byte-identical 회귀 가드.

🤖 Generated with [Claude Code](https://claude.com/claude-code)