### PR TITLE
feat(bundler): computeMangling dedup key 를 rename_table lookup 으로 전환 (RFC #3940 Sub-PR-L.4c-1)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -952,7 +952,9 @@ pub const Linker = struct {
                                 .cjs_exports, .cjs_require, .esm_init => {},
                                 else => continue,
                             }
-                            const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym.synthetic_name;
+                            // RFC #3940 L.4c: dedup key 도 build-scope rename_table 경유.
+                            // parity (L.3 sink + L.4a carry-over sync) 로 canonical_name 과 동치.
+                            const key = self.rename_table.get(bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(mi)), si)) orelse sym.synthetic_name;
                             if (key.len <= 1) continue;
                             if (exported.contains(key)) continue;
                             try candidates.append(self.allocator, .{
@@ -1007,7 +1009,8 @@ pub const Linker = struct {
                         // getter dead-export skip 과 같은 진실의 원천.
                         if (self.tree_shaker_active and !m.isStatementAliveBySym(sym_idx_usize)) continue;
 
-                        const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym_name;
+                        // RFC #3940 L.4c: dedup key 를 build-scope rename_table 경유 (parity 로 동치).
+                        const key = self.rename_table.get(bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(mi)), sym_idx)) orelse sym_name;
                         if (key.len <= 1) {
                             // canonical_name 이 sym_name 과 다른 1-char 케이스도 reserve
                             // (위 sym_name 분기와 대칭 — #2965).
@@ -1036,7 +1039,8 @@ pub const Linker = struct {
                         // ref=0 이면 어디서도 import 하지 않아 codegen 이 binding 을 emit
                         // 하지 않는다. 그런 candidate 는 mangle 풀에서 제외.
                         if (sk == .default_export and sym.reference_count == 0) continue;
-                        const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym.synthetic_name;
+                        // RFC #3940 L.4c: dedup key 를 build-scope rename_table 경유 (parity 로 동치).
+                        const key = self.rename_table.get(bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(mi)), si)) orelse sym.synthetic_name;
                         if (key.len <= 1) continue;
                         if (exported.contains(key)) continue;
 


### PR DESCRIPTION
## Summary
- `collectUnifiedInput`/`computeMangling` 의 candidate dedup key 3곳 (helper-module / module-scope / synthetic-default 루프) 이 `Symbol.canonical_name` 을 **직접 read** 하던 것을 build-scope `rename_table.get(SymbolID)` 경유로 전환.
- L.4b 가 emit-path facade(`getCanonicalName`/`getCanonicalByRef`) 를 전환한 데 이어, facade 를 거치지 않는 **link-scope 직접 read** 를 정리하는 단계. cross-build dangling 제거(L.5)의 선행.

RFC: `docs/RFC_LIFECYCLE_SCOPE_REDESIGN.md`, 추적 이슈 #3957

## 동치성 (byte-identical 근거)
parity (L.3 단일 sink 병행작성 + L.4a carry-over sync) 로 `canonical_name.len>0 ⟺ rename_table.get(id)!=null` 이고 값 동일 → `rename_table.get(id) orelse fallback` 이 기존 `if (canonical.len>0) canonical else fallback` 과 동치.
- 단일 sink `assignSymbolCanonical` 가 canonical_name + rename_table 를 lockstep 기록/clear.
- sink 우회 write (carry-over `preserveCanonicalNamesAfterSemanticResync`) 는 `!minify_identifiers` gate → computeMangling(minify_identifiers 경로)와 **상호배타** = dedup read 시점엔 미동기 canonical 존재 불가.
- `mi`/`si`/`sym_idx` 가 candidate `.module_index`/`.symbol_id` 및 `renameTableParityHolds` 와 **동일 SymbolID 패턴**.

## 검증
- [x] `zig build test` 통과 (L.3/L.4 parity test 포함)
- [x] **byte-identical**: origin/main(L.4b) vs L.4c `--bundle --minify` diff — effect/zod/rxjs/three/lodash-es/date-fns **6 lib 전부 IDENTICAL**
- [x] tests/integration bundle-smoke **151/0**
- [x] tests/benchmark **3951 pass / 0 fail**
- [x] `/code-review high` — correctness 0 findings (동치성 airtight 입증)

## 후속 추적 (이 PR 범위 밖)
- **L.4c-2**: `module.zig:469 syntheticName` (Module→build-scope layering) + `mangler.zig reserveNameFor` (byValue Symbol 시그니처) — 별도 PR.
- **facade 수렴 (L.4c-2/L.5)**: 본 PR 의 inline `rename_table.get(SymbolID.make(mi,idx))` 와 `getCanonicalByRef.semantic` arm(linker.zig:1439)이 중복 로직 — 후속에서 `renamedBySymbolId(SymbolID, fallback)` 단일 primitive 로 수렴해 facade 와 inline 사이트가 같은 sink 공유 (L.3 "단일 sink" 정신의 연장). 본 mechanical PR 에선 blast radius 제한 위해 inline 유지.
- **L.5**: `Symbol.canonical_name` field 제거 (big bang).
- 성능: dedup hot loop 에 hashmap get 추가 — link 단계 one-shot pass 라 sub-1% 추정 (L-series perf budget 추적 시 lodash/three `--timing` A/B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)