### PR TITLE
feat(bundler): syntheticName canonical read 를 rename_table 로 — non-esm_wrap (RFC #3940 Sub-PR-L.4c-2a-i)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -59,6 +59,7 @@ const tla_warning_comment = "/* [" ++ error_codes.Code.tla_requires_esm_format.f
 const linker_mod = @import("linker.zig");
 const Linker = linker_mod.Linker;
 const LinkingMetadata = linker_mod.LinkingMetadata;
+const RenameTable = @import("symbol.zig").RenameTable;
 const TreeShaker = @import("tree_shaker.zig").TreeShaker;
 const statement_shaker = @import("statement_shaker.zig");
 const stmt_info_mod = @import("stmt_info.zig");
@@ -764,7 +765,7 @@ pub fn emitWithTreeShaking(
         // 동시에 user entry body 는 setup 이후 실행된다.
         if (emit_top_level_rbm and !rbm_calls_emitted and shouldInsertRunBeforeMainBefore(i, rbm_insert_after_pos)) {
             const before_len = module_output.items.len;
-            try appendRunBeforeMainCalls(&module_output, allocator, graph, options.run_before_main, options);
+            try appendRunBeforeMainCalls(&module_output, allocator, graph, options.run_before_main, options, if (linker) |l| &l.rename_table else null);
             module_line += @intCast(std.mem.count(u8, module_output.items[before_len..], "\n"));
             rbm_calls_emitted = true;
         }
@@ -917,7 +918,7 @@ pub fn emitWithTreeShaking(
     }
     if (emit_top_level_rbm and !rbm_calls_emitted) {
         const before_len = module_output.items.len;
-        try appendRunBeforeMainCalls(&module_output, allocator, graph, options.run_before_main, options);
+        try appendRunBeforeMainCalls(&module_output, allocator, graph, options.run_before_main, options, if (linker) |l| &l.rename_table else null);
         module_line += @intCast(std.mem.count(u8, module_output.items[before_len..], "\n"));
         rbm_calls_emitted = true;
     }
@@ -982,7 +983,7 @@ pub fn emitWithTreeShaking(
                         try output.appendSlice(allocator, chain);
                     }
                 }
-                try appendGuardedModuleCall(&output, allocator, em, options);
+                try appendGuardedModuleCall(&output, allocator, em, options, if (linker) |l| &l.rename_table else null);
                 break;
             }
         }
@@ -1233,12 +1234,12 @@ pub fn appendIndented(wrapped: *std.ArrayList(u8), allocator: std.mem.Allocator,
 
 /// 모듈의 wrap_kind에 따라 require_xxx() 또는 init_xxx() 호출 코드를 생성한다.
 /// run-before-main, 엔트리 자동 호출, star export init 등에서 공용.
-pub fn appendModuleCall(output: *std.ArrayList(u8), allocator: std.mem.Allocator, mod: anytype) !void {
+pub fn appendModuleCall(output: *std.ArrayList(u8), allocator: std.mem.Allocator, mod: anytype, rename_tbl: ?*const RenameTable) !void {
     if (!mod.wrap_kind.isWrapped()) return;
     const call_name = if (mod.wrap_kind == .cjs)
-        try mod.allocRequireName(allocator)
+        try mod.allocRequireName(allocator, rename_tbl)
     else
-        try mod.allocInitName(allocator);
+        try mod.allocInitName(allocator, rename_tbl);
     defer allocator.free(call_name);
     if (mod.wrap_kind != .cjs and mod.uses_top_level_await) {
         try output.appendSlice(allocator, "await ");
@@ -1256,15 +1257,16 @@ pub fn appendGuardedModuleCall(
     allocator: std.mem.Allocator,
     mod: anytype,
     options: *const EmitOptions,
+    rename_tbl: ?*const RenameTable,
 ) !void {
     if (!mod.shouldGuard(options.entry_error_guard)) {
-        try appendModuleCall(output, allocator, mod);
+        try appendModuleCall(output, allocator, mod, rename_tbl);
         return;
     }
     const call_name = if (mod.wrap_kind == .cjs)
-        try mod.allocRequireName(allocator)
+        try mod.allocRequireName(allocator, rename_tbl)
     else
-        try mod.allocInitName(allocator);
+        try mod.allocInitName(allocator, rename_tbl);
     defer allocator.free(call_name);
     // guard helper 에 함수 식별자만 전달. helper 가 fn() 호출.
     try output.appendSlice(allocator, if (options.minify_whitespace) rt.GUARD_FN_NAME_MIN else rt.GUARD_FN_NAME);
@@ -1277,10 +1279,10 @@ pub fn appendGuardedModuleCall(
 /// `entry_error_guard` 활성 시 각 rbm 호출도 `__zntc_guarded(...)` 로 wrap —
 /// Metro `getAppendScripts` 가 `runBeforeMainModule` 의 각 path 마다 별도
 /// `__r(N);` (= guardedLoadModule outer 호출) 을 emit 하는 것과 동등.
-pub fn appendRunBeforeMainCalls(output: *std.ArrayList(u8), allocator: std.mem.Allocator, graph: *const @import("graph.zig").ModuleGraph, run_before_main: []const []const u8, options: *const EmitOptions) !void {
+pub fn appendRunBeforeMainCalls(output: *std.ArrayList(u8), allocator: std.mem.Allocator, graph: *const @import("graph.zig").ModuleGraph, run_before_main: []const []const u8, options: *const EmitOptions, rename_tbl: ?*const RenameTable) !void {
     for (run_before_main) |rbm_path| {
         const rbm = graph.findModuleByPath(rbm_path) orelse continue;
-        try appendGuardedModuleCall(output, allocator, rbm, options);
+        try appendGuardedModuleCall(output, allocator, rbm, options, rename_tbl);
     }
 }
 
@@ -1932,7 +1934,7 @@ pub fn emitModule(
     if (module.wrap_kind == .cjs) {
         const preamble_code = if (metadata) |md| md.cjs_import_preamble else null;
 
-        const var_name = try module.allocRequireName(allocator);
+        const var_name = try module.allocRequireName(allocator, if (linker) |l| &l.rename_table else null);
         defer allocator.free(var_name);
 
         var wrapped: std.ArrayList(u8) = .empty;

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -22,6 +22,7 @@ const Codegen = @import("../../codegen/codegen.zig").Codegen;
 const CodegenOptions = @import("../../codegen/codegen.zig").CodegenOptions;
 const SourceMap = @import("../../codegen/sourcemap.zig");
 const Linker = @import("../linker.zig").Linker;
+const RenameTable = @import("../symbol.zig").RenameTable;
 const LinkingMetadata = @import("../linker.zig").LinkingMetadata;
 const tree_shaker_mod = @import("../tree_shaker.zig");
 const TreeShaker = tree_shaker_mod.TreeShaker;
@@ -366,6 +367,7 @@ pub fn emitChunks(
                 chunk_graph,
                 chunk,
                 options.run_before_main,
+                if (linker) |l| &l.rename_table else null,
             );
             try emitRunBeforeMainCrossImports(
                 &chunk_output,
@@ -650,7 +652,7 @@ pub fn emitChunks(
 
             if (emit_top_level_rbm and !rbm_calls_emitted and shouldInsertRunBeforeMainBefore(sorted_pos, rbm_insert_after_pos)) {
                 const before_len = chunk_output.items.len;
-                try appendRunBeforeMainCalls(&chunk_output, allocator, graph, options.run_before_main, options);
+                try appendRunBeforeMainCalls(&chunk_output, allocator, graph, options.run_before_main, options, if (linker) |l| &l.rename_table else null);
                 if (module_line) |*ml| ml.* += @intCast(std.mem.count(u8, chunk_output.items[before_len..], "\n"));
                 rbm_calls_emitted = true;
             }
@@ -696,7 +698,7 @@ pub fn emitChunks(
         }
         if (emit_top_level_rbm and !rbm_calls_emitted) {
             const before_len = chunk_output.items.len;
-            try appendRunBeforeMainCalls(&chunk_output, allocator, graph, options.run_before_main, options);
+            try appendRunBeforeMainCalls(&chunk_output, allocator, graph, options.run_before_main, options, if (linker) |l| &l.rename_table else null);
             if (module_line) |*ml| ml.* += @intCast(std.mem.count(u8, chunk_output.items[before_len..], "\n"));
             rbm_calls_emitted = true;
         }
@@ -717,6 +719,7 @@ pub fn emitChunks(
                 chunk_graph,
                 chunk,
                 options.run_before_main,
+                if (linker) |l| &l.rename_table else null,
             );
         }
 
@@ -1085,12 +1088,13 @@ fn collectRunBeforeMainCrossImports(
     chunk_graph: *const ChunkGraph,
     current_chunk: *const Chunk,
     run_before_main: []const []const u8,
+    rename_tbl: ?*const RenameTable,
 ) !void {
     for (run_before_main) |rbm_path| {
         const rbm = graph.findModuleByPath(rbm_path) orelse continue;
         const source_chunk = chunk_graph.getModuleChunk(rbm.index);
         if (source_chunk == .none or source_chunk == current_chunk.index) continue;
-        const name = try runBeforeMainCallName(allocator, rbm) orelse continue;
+        const name = try runBeforeMainCallName(allocator, rbm, rename_tbl) orelse continue;
 
         var duplicate = false;
         for (out.items) |existing| {
@@ -1170,12 +1174,13 @@ fn collectRunBeforeMainExportNames(
     chunk_graph: *const ChunkGraph,
     current_chunk: *const Chunk,
     run_before_main: []const []const u8,
+    rename_tbl: ?*const RenameTable,
 ) !void {
     for (run_before_main) |rbm_path| {
         const rbm = graph.findModuleByPath(rbm_path) orelse continue;
         const source_chunk = chunk_graph.getModuleChunk(rbm.index);
         if (source_chunk == .none or source_chunk != current_chunk.index) continue;
-        const name = try runBeforeMainCallName(allocator, rbm) orelse continue;
+        const name = try runBeforeMainCallName(allocator, rbm, rename_tbl) orelse continue;
         errdefer allocator.free(name);
         if (containsName(out.items, name)) {
             allocator.free(name);
@@ -1185,12 +1190,12 @@ fn collectRunBeforeMainExportNames(
     }
 }
 
-fn runBeforeMainCallName(allocator: std.mem.Allocator, module: *const Module) !?[]const u8 {
+fn runBeforeMainCallName(allocator: std.mem.Allocator, module: *const Module, rename_tbl: ?*const RenameTable) !?[]const u8 {
     if (!module.wrap_kind.isWrapped()) return null;
     return if (module.wrap_kind == .cjs)
-        try module.allocRequireName(allocator)
+        try module.allocRequireName(allocator, rename_tbl)
     else
-        try module.allocInitName(allocator);
+        try module.allocInitName(allocator, rename_tbl);
 }
 
 fn appendUniqueName(list: *std.ArrayList([]const u8), allocator: std.mem.Allocator, name: []const u8) !void {
@@ -1443,14 +1448,14 @@ fn rewriteDynamicImports(
             const tmi: u32 = rec.resolved.toU32();
             const replacement_expr = switch (target_mod.wrap_kind) {
                 .esm => blk: {
-                    const init_name = try target_mod.allocInitName(allocator);
+                    const init_name = try target_mod.allocInitName(allocator, if (linker) |l| &l.rename_table else null);
                     defer allocator.free(init_name);
-                    const exports_name = try target_mod.allocExportsName(allocator);
+                    const exports_name = try target_mod.allocExportsName(allocator, if (linker) |l| &l.rename_table else null);
                     defer allocator.free(exports_name);
                     break :blk try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>({s}(),{s}))", .{ init_name, exports_name });
                 },
                 .cjs => blk: {
-                    const require_name = try target_mod.allocRequireName(allocator);
+                    const require_name = try target_mod.allocRequireName(allocator, if (linker) |l| &l.rename_table else null);
                     defer allocator.free(require_name);
                     break :blk try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>{s}())", .{require_name});
                 },
@@ -1622,14 +1627,15 @@ pub fn rewriteDynamicImportsSingleFile(
         const target_mod = graph.getModule(rec.resolved) orelse continue;
         const replacement_expr = switch (target_mod.wrap_kind) {
             .esm => blk: {
-                const init_name = try target_mod.allocInitName(allocator);
+                // single-file 경로 (linker 파라미터 없음) → rt null, canonical field (parity 로 동치).
+                const init_name = try target_mod.allocInitName(allocator, null);
                 defer allocator.free(init_name);
-                const exports_name = try target_mod.allocExportsName(allocator);
+                const exports_name = try target_mod.allocExportsName(allocator, null);
                 defer allocator.free(exports_name);
                 break :blk try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>({s}(),{s}))", .{ init_name, exports_name });
             },
             .cjs => blk: {
-                const require_name = try target_mod.allocRequireName(allocator);
+                const require_name = try target_mod.allocRequireName(allocator, null);
                 defer allocator.free(require_name);
                 break :blk try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>{s}())", .{require_name});
             },

--- a/src/bundler/emitter/cjs_wrap.zig
+++ b/src/bundler/emitter/cjs_wrap.zig
@@ -13,7 +13,8 @@ const EmitOptions = @import("../emitter.zig").EmitOptions;
 /// Disabled 모듈: platform=browser에서 Node 빌트인 모듈을 빈 __commonJS wrapper로 출력.
 /// wrapper key는 dev/HMR registry 조회와 일치해야 하므로 module.wrapperId()를 쓴다.
 pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, minify: bool) !?[]const u8 {
-    const var_name = try module.allocRequireName(allocator);
+    // RFC #3940 L.4c-2a-i: free fn (linker 없음) → rt null, canonical field 경로 (parity 로 동치).
+    const var_name = try module.allocRequireName(allocator, null);
     defer allocator.free(var_name);
     const wrapper_id = module.wrapperId();
 
@@ -105,7 +106,8 @@ pub fn emitAssetModule(allocator: std.mem.Allocator, module: *const Module, opti
 /// `var require_X = __commonJS({ "filename"(exports, module) { module.exports = <source>; } });`
 /// 형태의 __commonJS wrapper를 생성.
 pub fn emitCjsWrapper(allocator: std.mem.Allocator, module: *const Module, source: []const u8, minify: bool) !?[]const u8 {
-    const var_name = try module.allocRequireName(allocator);
+    // RFC #3940 L.4c-2a-i: free fn (linker 없음) → rt null, canonical field 경로 (parity 로 동치).
+    const var_name = try module.allocRequireName(allocator, null);
     defer allocator.free(var_name);
 
     var buf: std.ArrayList(u8) = .empty;

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -171,9 +171,9 @@ pub fn emitEsmWrappedModule(
 ) !EsmEmitResult {
     const basename = module.wrapperId();
 
-    const init_name = try module.allocInitName(allocator);
+    const init_name = try module.allocInitName(allocator, null);
     defer allocator.free(init_name);
-    const exports_name = try module.allocExportsName(allocator);
+    const exports_name = try module.allocExportsName(allocator, null);
     defer allocator.free(exports_name);
 
     // AST top-level 문장을 분류
@@ -532,7 +532,7 @@ pub fn emitEsmWrappedModule(
                     const getter_val = switch (src_mod.wrap_kind) {
                         .esm, .none => try makeNamespaceGetterValue(allocator, src_mod, options),
                         .cjs => blk: {
-                            const rv = try src_mod.allocRequireName(allocator);
+                            const rv = try src_mod.allocRequireName(allocator, null);
                             defer allocator.free(rv);
                             break :blk try std.fmt.allocPrint(allocator, "{s}()", .{rv});
                         },
@@ -813,9 +813,9 @@ pub fn emitEsmWrappedModule(
                             try reexport_buf.appendSlice(allocator, source_mod.dev_id);
                             try reexport_buf.appendSlice(allocator, "\"].exports))");
                         } else {
-                            const iv = try source_mod.allocInitName(allocator);
+                            const iv = try source_mod.allocInitName(allocator, null);
                             defer allocator.free(iv);
-                            const ev = try source_mod.allocExportsName(allocator);
+                            const ev = try source_mod.allocExportsName(allocator, null);
                             defer allocator.free(ev);
                             // #1621: minify 시 __toCommonJS → $tC 축약.
                             const to_cjs_name: []const u8 = if (options.minify_whitespace) rt.NAMES.TOCOMMONJS_MIN else "__toCommonJS";
@@ -841,7 +841,7 @@ pub fn emitEsmWrappedModule(
                         if (found_preamble_var) |pv| {
                             try reexport_buf.appendSlice(allocator, pv);
                         } else {
-                            const rv = try source_mod.allocRequireName(allocator);
+                            const rv = try source_mod.allocRequireName(allocator, null);
                             defer allocator.free(rv);
                             const interop_mode = cjsInteropMode(options, module);
                             // #1621: minify 시 __toESM → $tE 축약.
@@ -1171,7 +1171,7 @@ fn appendWrappedInitCall(
                 try buf.appendSlice(allocator, src_mod.dev_id);
                 try buf.appendSlice(allocator, "\"].fn()");
             } else {
-                const iv = try src_mod.allocInitName(allocator);
+                const iv = try src_mod.allocInitName(allocator, null);
                 defer allocator.free(iv);
                 try buf.appendSlice(allocator, iv);
                 try buf.appendSlice(allocator, "()");
@@ -1179,7 +1179,7 @@ fn appendWrappedInitCall(
             try buf.appendSlice(allocator, if (guard) rt.GUARD_LAMBDA_CLOSE else rt.INIT_CALL_END);
         },
         .cjs => {
-            const rv = try src_mod.allocRequireName(allocator);
+            const rv = try src_mod.allocRequireName(allocator, null);
             defer allocator.free(rv);
             if (guard) try buf.appendSlice(allocator, if (options.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
             try buf.appendSlice(allocator, rv);
@@ -1273,7 +1273,7 @@ fn makeLazyEsmGetterValue(
     const init_call = if (options.dev_mode) blk: {
         break :blk try std.fmt.allocPrint(allocator, "__zntc_modules[\"{s}\"].fn()", .{src_mod.dev_id});
     } else blk: {
-        const iv = try src_mod.allocInitName(allocator);
+        const iv = try src_mod.allocInitName(allocator, null);
         defer allocator.free(iv);
         break :blk try std.fmt.allocPrint(allocator, "{s}()", .{iv});
     };
@@ -1294,7 +1294,7 @@ fn makeEsmExportGetterValue(
     name: []const u8,
     options: *const EmitOptions,
 ) ![]const u8 {
-    const ev = try src_mod.allocExportsName(allocator);
+    const ev = try src_mod.allocExportsName(allocator, null);
     defer allocator.free(ev);
     const target = try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ev, name });
     defer allocator.free(target);
@@ -1306,7 +1306,7 @@ fn makeNamespaceGetterValue(
     src_mod: *const Module,
     options: *const EmitOptions,
 ) ![]const u8 {
-    const ev = try src_mod.allocExportsName(allocator);
+    const ev = try src_mod.allocExportsName(allocator, null);
     defer allocator.free(ev);
     return makeLazyEsmGetterValue(allocator, src_mod, ev, options);
 }
@@ -1345,12 +1345,12 @@ fn makeStarGetterValue(
                 if (l.tree_shaker_active and !canonical_mod.is_included) return null;
                 // canonical 모듈이 래핑되어 있으면 exports_xxx.name 형태
                 if (canonical_mod.wrap_kind == .esm) {
-                    const ev = try canonical_mod.allocExportsName(allocator);
+                    const ev = try canonical_mod.allocExportsName(allocator, null);
                     defer allocator.free(ev);
                     return try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ev, resolved.export_name });
                 }
                 if (canonical_mod.wrap_kind == .cjs) {
-                    const rv = try canonical_mod.allocRequireName(allocator);
+                    const rv = try canonical_mod.allocRequireName(allocator, null);
                     defer allocator.free(rv);
                     return try std.fmt.allocPrint(allocator, "{s}().{s}", .{ rv, resolved.export_name });
                 }
@@ -1369,7 +1369,7 @@ fn makeStarGetterValue(
             return try makeEsmExportGetterValue(allocator, src_mod, name, options);
         },
         .cjs => {
-            const rv = try src_mod.allocRequireName(allocator);
+            const rv = try src_mod.allocRequireName(allocator, null);
             defer allocator.free(rv);
             return try std.fmt.allocPrint(allocator, "{s}().{s}", .{ rv, name });
         },

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -187,9 +187,10 @@ pub fn registerWrapperSymbols(self: *ModuleGraph) void {
     var seed_it = self.modules.iterator(0);
     while (seed_it.next()) |m| {
         if (m.wrap_kind == .none) continue;
-        if (m.getInitName()) |n| _ = used_names.put(n, 1) catch {};
-        if (m.getExportsName()) |n| _ = used_names.put(n, 1) catch {};
-        if (m.getRequireName()) |n| _ = used_names.put(n, 1) catch {};
+        // RFC #3940 L.4c-2a-i: mangle 전 단계 (canonical 미설정) → rt null, synthetic_name 조회.
+        if (m.getInitName(null)) |n| _ = used_names.put(n, 1) catch {};
+        if (m.getExportsName(null)) |n| _ = used_names.put(n, 1) catch {};
+        if (m.getRequireName(null)) |n| _ = used_names.put(n, 1) catch {};
     }
 
     var it = self.modules.iterator(0);

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2089,7 +2089,7 @@ pub const Linker = struct {
         if (target.wrap_kind != .cjs) return null;
         if (std.mem.eql(u8, ref.export_name, "default")) return null;
 
-        const req_var = try target.allocRequireName(self.allocator);
+        const req_var = try target.allocRequireName(self.allocator, &self.rename_table);
         defer self.allocator.free(req_var);
         return try std.fmt.allocPrint(self.allocator, "{s}().{s}", .{ req_var, ref.export_name });
     }
@@ -2432,7 +2432,7 @@ pub fn getOrCreateRequireVar(
 ) ![]const u8 {
     if (cache.get(mod_idx)) |cached| return cached;
     const target_mod = self.getModule(mod_idx).?;
-    const name = try target_mod.allocRequireName(self.allocator);
+    const name = try target_mod.allocRequireName(self.allocator, &self.rename_table);
     try cache.put(mod_idx, name);
     return name;
 }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -1131,7 +1131,7 @@ pub fn buildMetadataForAst(
                         try preamble.write(target_mod.dev_id);
                         try preamble.write("\"].fn()");
                     } else {
-                        const init_name = try target_mod.allocInitName(self.allocator);
+                        const init_name = try target_mod.allocInitName(self.allocator, &self.rename_table);
                         defer self.allocator.free(init_name);
                         try preamble.write(init_name);
                         try preamble.write("()");
@@ -1257,7 +1257,7 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module, format: types
                 if (require_rewrites.get(rec.specifier)) |old| {
                     self.allocator.free(old);
                 }
-                const exports_name = try m.allocExportsName(self.allocator);
+                const exports_name = try m.allocExportsName(self.allocator, &self.rename_table);
                 defer self.allocator.free(exports_name);
                 // #1621: minify 시 __toCommonJS → $tC 축약.
                 const to_cjs_name: []const u8 = if (self.minify_whitespace) rt.NAMES.TOCOMMONJS_MIN else "__toCommonJS";
@@ -1281,7 +1281,7 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module, format: types
             const req_ref = if (self.dev_mode)
                 try types.fmtDevRequireCallExpr(self.allocator, target_mod.dev_id)
             else
-                try target_mod.allocRequireName(self.allocator);
+                try target_mod.allocRequireName(self.allocator, &self.rename_table);
             try require_rewrites.put(self.allocator, rec.specifier, req_ref);
         } else if (target_mod.wrap_kind == .esm) {
             // ESM 타겟: require("spec") → (init_xxx(), __toCommonJS(exports_xxx))
@@ -1292,9 +1292,9 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module, format: types
                 const call_expr = try types.fmtDevRequireExpr(self.allocator, target_mod.dev_id);
                 try require_rewrites.put(self.allocator, rec.specifier, call_expr);
             } else {
-                const init_name = try target_mod.allocInitName(self.allocator);
+                const init_name = try target_mod.allocInitName(self.allocator, &self.rename_table);
                 defer self.allocator.free(init_name);
-                const exports_name = try target_mod.allocExportsName(self.allocator);
+                const exports_name = try target_mod.allocExportsName(self.allocator, &self.rename_table);
                 defer self.allocator.free(exports_name);
                 // #1621: minify 시 __toCommonJS → $tC 축약.
                 const to_cjs_name: []const u8 = if (self.minify_whitespace) rt.NAMES.TOCOMMONJS_MIN else "__toCommonJS";

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -887,7 +887,7 @@ pub fn writeEsmInitExprBody(
         try writer.write(target_mod.dev_id);
         try writer.write("\"].fn()");
     } else {
-        const init_name = try target_mod.allocInitName(self.allocator);
+        const init_name = try target_mod.allocInitName(self.allocator, &self.rename_table);
         defer self.allocator.free(init_name);
         try writer.write(init_name);
         try writer.write("()");

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -26,6 +26,8 @@ pub const ExportBinding = binding_scanner.ExportBinding;
 const stmt_info_mod = @import("stmt_info.zig");
 const symbol_mod = @import("symbol.zig");
 pub const AliasTable = symbol_mod.AliasTable;
+const RenameTable = symbol_mod.RenameTable;
+const SymbolID = symbol_mod.SymbolID;
 const RuntimeHelpers = @import("../transformer/runtime_helper_bits.zig").RuntimeHelpers;
 
 pub const DISABLED_MODULE_PREFIX = "(disabled):";
@@ -460,19 +462,27 @@ pub const Module = struct {
     /// 주입한 경우 릴리즈/압축 출력에서는 그 이름을 우선 사용한다.
     /// 미등록이면 null.
     /// 반환 slice는 parse_arena가 소유 — 모듈 수명 내 유효.
-    fn syntheticName(self: *const Module, maybe_id: ?SemanticSymbolId) ?[]const u8 {
+    /// RFC #3940 L.4c-2: rename 출처를 build-scope `rename_table` 로 전환 (Module 은 graph-scope
+    /// 라 Linker 직접 참조 불가 → caller 가 `rt` 전달). `rt` 가 null 이면 기존 `canonical_name`
+    /// field 경로 (parity 로 동일 값 — L.3 sink + L.4a sync). i 단계: non-esm_wrap caller 는 실제
+    /// rt, esm_wrap/finalize/cjs_wrap 은 null. L.5 에서 field 경로 제거 + rt 필수화.
+    fn syntheticName(self: *const Module, maybe_id: ?SemanticSymbolId, rt: ?*const RenameTable) ?[]const u8 {
         const id = maybe_id orelse return null;
         const sem = self.semantic orelse return null;
         const idx: u32 = @intFromEnum(id);
         if (idx >= sem.symbols.items.len) return null;
-        const sym = sem.symbols.items[idx];
-        if (sym.canonical_name.len > 0) return sym.canonical_name;
-        const name = sym.synthetic_name;
+        if (rt) |t| {
+            if (t.get(SymbolID.make(self.index, idx))) |n| if (n.len > 0) return n;
+        } else {
+            const canon = sem.symbols.items[idx].canonical_name;
+            if (canon.len > 0) return canon;
+        }
+        const name = sem.symbols.items[idx].synthetic_name;
         return if (name.len > 0) name else null;
     }
 
-    pub fn getInitName(self: *const Module) ?[]const u8 {
-        return self.syntheticName(self.init_symbol);
+    pub fn getInitName(self: *const Module, rt: ?*const RenameTable) ?[]const u8 {
+        return self.syntheticName(self.init_symbol, rt);
     }
 
     /// 이 모듈이 ESM 순환 그룹의 일원인지. 0 = 순환 없음 (D065).
@@ -511,28 +521,28 @@ pub const Module = struct {
         return true;
     }
 
-    pub fn getExportsName(self: *const Module) ?[]const u8 {
-        return self.syntheticName(self.exports_symbol);
+    pub fn getExportsName(self: *const Module, rt: ?*const RenameTable) ?[]const u8 {
+        return self.syntheticName(self.exports_symbol, rt);
     }
 
-    pub fn getRequireName(self: *const Module) ?[]const u8 {
-        return self.syntheticName(self.require_symbol);
+    pub fn getRequireName(self: *const Module, rt: ?*const RenameTable) ?[]const u8 {
+        return self.syntheticName(self.require_symbol, rt);
     }
 
     /// `getInitName()`의 할당 버전 — 등록된 경우 dupe, 아니면 fresh 생성.
     /// 기존 `types.makeInitVarName(alloc, path)` 호출지의 drop-in 대체.
-    pub fn allocInitName(self: *const Module, allocator: std.mem.Allocator) ![]const u8 {
-        if (self.getInitName()) |n| return allocator.dupe(u8, n);
+    pub fn allocInitName(self: *const Module, allocator: std.mem.Allocator, rt: ?*const RenameTable) ![]const u8 {
+        if (self.getInitName(rt)) |n| return allocator.dupe(u8, n);
         return types.makeInitVarName(allocator, self.path);
     }
 
-    pub fn allocExportsName(self: *const Module, allocator: std.mem.Allocator) ![]const u8 {
-        if (self.getExportsName()) |n| return allocator.dupe(u8, n);
+    pub fn allocExportsName(self: *const Module, allocator: std.mem.Allocator, rt: ?*const RenameTable) ![]const u8 {
+        if (self.getExportsName(rt)) |n| return allocator.dupe(u8, n);
         return types.makeExportsVarName(allocator, self.path);
     }
 
-    pub fn allocRequireName(self: *const Module, allocator: std.mem.Allocator) ![]const u8 {
-        if (self.getRequireName()) |n| return allocator.dupe(u8, n);
+    pub fn allocRequireName(self: *const Module, allocator: std.mem.Allocator, rt: ?*const RenameTable) ![]const u8 {
+        if (self.getRequireName(rt)) |n| return allocator.dupe(u8, n);
         return types.makeRequireVarName(allocator, self.path);
     }
 


### PR DESCRIPTION
## Summary
- `module.zig` 의 wrapper-name getter (`syntheticName`/`getInit·Exports·Require`/`allocInit·Exports·Require`) 가 `Symbol.canonical_name` 을 직접 read 하던 것을 build-scope `rename_table` 경유로 전환. L.4b(emit facade)·L.4c-1(computeMangling dedup) 에 이은 facade-우회 read 정리. **byte-identical 순수 리팩토링** (L.5 canonical_name field 제거의 선결).
- 사용자 결정 2단계 분할 중 **i (non-esm_wrap 호출처)**. ii = esm_wrap helper layer.

RFC: `docs/RFC_LIFECYCLE_SCOPE_REDESIGN.md`, 이슈 #3957

## 분할 장치 — syntheticName 이중 경로
6 메서드 시그니처에 `rt` 추가가 모든 호출처를 동시 강제하므로, `syntheticName` 에 이중 경로:
```zig
if (rt) |t| { if (t.get(SymbolID.make(self.index, idx))) |n| if (n.len > 0) return n; }
else        { const canon = sym.canonical_name; if (canon.len > 0) return canon; }
// 그 외 synthetic_name
```
parity (L.3 sink lockstep + L.4a carry-over sync) 로 두 경로 **동일 값** → byte-identical.
- 실제 `&l.rename_table`: linker / metadata / shared_namespace / emitter / chunks
- `null`(canonical field): esm_wrap(ii 예정) / finalize(mangle 전) / cjs_wrap(semantic 없음) / single-file
- Module 은 graph-scope → Linker 직접 참조 불가(import cycle) → RenameTable 만 주입.

## 검증 (byte-identical critical)
- [x] `zig build test` (cjs_esm / exports_name_dedup / mangle_edge_cases / linker_test parity)
- [x] origin/main(b2892062) vs PR `--bundle --minify` diff: **axios/express/superjson/immer(CJS) + effect/rxjs/@reduxjs-toolkit(ESM) + lodash-es(barrel) 8 lib 전부 IDENTICAL**
- [x] `--minify --splitting` (dynamic import + chunk cross-import + run-before-main) IDENTICAL
- [x] CJS+ESM mixed fixture **node 실행 `{"cjs":42,"esm":42}`** (main 동일, ReferenceError 없음)
- [x] bundle-smoke 151/0, benchmark 16/0
- [x] `/code-review high` — correctness 0 findings (parity 동치성 airtight + 실측 byte-identical 추가 확인)

## 후속 추적 (이 PR 범위 밖)
- **ii**: esm_wrap.zig helper layer (`appendWrappedInitCall`/`make*GetterValue` + 14 호출처) rt threading.
- **L.5**: `canonical_name` field 제거 + 이중 경로 `else` 분기 제거 + rt 필수화.
  - ⚠️ **L.5 체크리스트**: `chunks.zig rewriteDynamicImportsSingleFile` 는 `linker` 파라미터 자체가 없어 현재 null(canonical) — field 제거 시 새 `rename_table` 파라미터 추가 필요 (single-file 경로가 chunked twin 과 달라 누락 위험). 리뷰 finding #4.
  - cleanup: `if (linker) |l| &l.rename_table else null` 11회 반복 → 함수당 1 binding 추출 (L.5 에서 어차피 동일 코드 수정하므로 함께). 리뷰 finding #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)