### PR TITLE
test: make test262 suite deterministic

### DIFF
--- a/src/bundler/bundler_test/incremental_bench_v4.zig
+++ b/src/bundler/bundler_test/incremental_bench_v4.zig
@@ -6,7 +6,7 @@
 //! case B: changed_files = {entry.ts}      — watcher 가 1 file 변경 보고 (single-file edit)
 //! case C: changed_files = null            — watcher 미통합 (=v3 baseline)
 //!
-//! lodash-es 641 module fixture 로 측정.
+//! CI dependency install 여부와 무관하도록 테스트 안에서 synthetic lodash-es fixture 를 만든다.
 
 const std = @import("std");
 const Bundler = @import("../bundler.zig").Bundler;
@@ -29,6 +29,61 @@ const LODASH_ENTRY =
     \\console.log([uniq, chunk, compact].map(f => typeof f).join(','));
     \\
 ;
+
+const LODASH_NAMES = [_][]const u8{
+    "uniq",
+    "chunk",
+    "compact",
+    "drop",
+    "dropRight",
+    "fill",
+    "findIndex",
+    "flatten",
+    "flattenDeep",
+    "head",
+    "indexOf",
+    "initial",
+    "intersection",
+    "last",
+    "nth",
+    "pull",
+    "pullAll",
+    "remove",
+    "slice",
+    "sortedIndex",
+    "take",
+    "takeRight",
+    "union",
+    "uniqBy",
+    "without",
+    "xor",
+    "zip",
+    "zipObject",
+    "countBy",
+    "every",
+    "filter",
+    "find",
+    "forEach",
+    "groupBy",
+    "includes",
+    "keyBy",
+    "map",
+    "orderBy",
+    "partition",
+    "reduce",
+    "reject",
+    "sample",
+    "shuffle",
+    "size",
+    "some",
+    "sortBy",
+    "debounce",
+    "throttle",
+    "memoize",
+    "once",
+    "defer",
+    "delay",
+};
 
 const Case = enum { empty, single_entry, null_changed };
 
@@ -242,6 +297,37 @@ fn printSubPhase(label: []const u8, r: WarmResult) void {
     });
 }
 
+fn writeSyntheticLodashFixture(
+    allocator: std.mem.Allocator,
+    dir: std.fs.Dir,
+) !void {
+    try writeFile(dir, "node_modules/lodash-es/package.json",
+        \\{"type":"module","module":"index.js","main":"index.js"}
+    );
+
+    var index: std.ArrayList(u8) = .empty;
+    defer index.deinit(allocator);
+    const w = index.writer(allocator);
+    for (LODASH_NAMES) |name| {
+        const module_path = try std.fmt.allocPrint(
+            allocator,
+            "node_modules/lodash-es/{s}.js",
+            .{name},
+        );
+        defer allocator.free(module_path);
+        const module_source = try std.fmt.allocPrint(
+            allocator,
+            "export function {s}(value) {{ return value; }}\n",
+            .{name},
+        );
+        defer allocator.free(module_source);
+
+        try writeFile(dir, module_path, module_source);
+        try w.print("export {{ {s} }} from './{s}.js';\n", .{ name, name });
+    }
+    try writeFile(dir, "node_modules/lodash-es/index.js", index.items);
+}
+
 test "incremental bench v4: changed_files null/empty/single comparison" {
     profile.resetForTest();
     profile.setLevel(.summary);
@@ -285,24 +371,10 @@ test "incremental bench v4: changed_files null/empty/single comparison" {
     defer tmp.cleanup();
 
     try writeFile(tmp.dir, "entry.ts", LODASH_ENTRY);
-
-    // node_modules symlink — lodash-es resolve 가능하게.
-    // cwd 가 repo root (zig build 의 실행 위치) → 그 안의 node_modules 를 symlink target.
-    const real_nm = std.fs.cwd().realpathAlloc(allocator, "node_modules") catch |err| {
-        std.debug.print("[bench v4] cwd node_modules absent ({}), skip\n", .{err});
-        return error.SkipZigTest;
-    };
-    defer allocator.free(real_nm);
+    try writeSyntheticLodashFixture(allocator, tmp.dir);
 
     const tmp_real = try tmp.dir.realpathAlloc(allocator, ".");
     defer allocator.free(tmp_real);
-    const tmp_nm = try std.fs.path.join(allocator, &.{ tmp_real, "node_modules" });
-    defer allocator.free(tmp_nm);
-    std.posix.symlink(real_nm, tmp_nm) catch |err| {
-        std.debug.print("[bench v4] symlink skip: {}\n", .{err});
-        return error.SkipZigTest;
-    };
-
     const entry = try std.fs.path.join(allocator, &.{ tmp_real, "entry.ts" });
     defer allocator.free(entry);
 
@@ -317,10 +389,7 @@ test "incremental bench v4: changed_files null/empty/single comparison" {
             .module_store = &store,
         });
         defer b.deinit();
-        const r = b.bundle() catch |err| {
-            std.debug.print("[bench v4] cold bundle fail: {}\n", .{err});
-            return error.SkipZigTest;
-        };
+        const r = try b.bundle();
         defer r.deinit(allocator);
         cold_module_count = if (r.module_paths) |paths| paths.len else 0;
     }
@@ -340,7 +409,7 @@ test "incremental bench v4: changed_files null/empty/single comparison" {
         \\
         \\[incremental-bench v4] lodash-es {d} module, 3 case warm:
         \\  cold        : parse={d}us semantic={d}us discover={d}us total={d}us
-        \\  warm null   : parse={d}us semantic={d}us discover={d}us total={d}us  (v3 baseline, 641 stat)
+        \\  warm null   : parse={d}us semantic={d}us discover={d}us total={d}us  (v3 baseline, full stat)
         \\  warm empty  : parse={d}us semantic={d}us discover={d}us total={d}us  (no-change watcher)
         \\  warm single : parse={d}us semantic={d}us discover={d}us total={d}us  (1-file watcher)
         \\

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -38,6 +38,16 @@ fn formatLazyMarker(
     );
 }
 
+fn countOccurrences(haystack: []const u8, needle: []const u8) usize {
+    var count: usize = 0;
+    var search_from: usize = 0;
+    while (std.mem.indexOfPos(u8, haystack, search_from, needle)) |pos| {
+        count += 1;
+        search_from = pos + needle.len;
+    }
+    return count;
+}
+
 // ============================================================
 // Batch D: metafile, analyze, legal-comments, inject, keepNames
 // ============================================================
@@ -1436,15 +1446,34 @@ test "JSX automatic: ESM-wrapped module with CJS jsx-runtime — synthetic bindi
 }
 
 test "JSX automatic-dev: #1209 — _jsxDEV must be assigned per module (HMR safety)" {
-    // #3062 이후 synthetic JSX 우회 제거 + transformer 가 정식 import 노드 추가. 새
-    // 방식에선 `_jsxDEV` 식별자가 source 의 canonical 로 rename 되어 substring
-    // assertion 부적용. brittle substring 보다 더 robust 한 e2e DOM 검증으로 대체:
-    //   - tests/e2e/tests/lib-scenario-e2e.test.ts 의 H1/H4/H5/H6 시나리오가
-    //     preact JSX automatic 의 빌드 → 브라우저 실행 → DOM 검증까지 다룸.
-    //     H4: 사용자 `_jsx` 식별자 충돌 (#3068 helper scope 격리)
-    //     H5: 멀티 모듈 jsx-runtime 공유
-    //     H6: barrel re-export JSX
-    return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app.tsx",
+        \\export function App() { return <div>Hello</div>; }
+        \\export function Other() { return <span>Other</span>; }
+    );
+    try writeFile(tmp.dir, "entry.ts",
+        \\const app = require('./app.tsx');
+        \\console.log(app.App(), app.Other());
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .jsx_runtime = .automatic_dev,
+        .external = &.{"react/jsx-dev-runtime"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    const out = result.output;
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, out, "__esm(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "_jsxDEV") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "var _jsxDEV = ") == null);
 }
 
 test "JSX automatic-dev: #1209 — browser platform also affected" {
@@ -1480,10 +1509,37 @@ test "JSX automatic-dev: #1209 — browser platform also affected" {
 }
 
 test "JSX automatic: multiple modules sharing same jsx-runtime" {
-    // #3062 이후 substring assertion 부적용. e2e 대체:
-    //   tests/e2e/tests/lib-scenario-e2e.test.ts 의 H5_preact_jsx_multi_module
-    //   (CompA / CompB / entry 가 동시에 JSX 사용 + 브라우저 DOM 검증).
-    return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.tsx",
+        \\export function A() { return <span>A</span>; }
+    );
+    try writeFile(tmp.dir, "b.tsx",
+        \\export function B() { return <span>B</span>; }
+    );
+    try writeFile(tmp.dir, "entry.tsx",
+        \\import { A } from './a.tsx';
+        \\import { B } from './b.tsx';
+        \\export function App() { return <><A /><B /></>; }
+    );
+
+    const entry = try absPath(&tmp, "entry.tsx");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .jsx_runtime = .automatic,
+        .external = &.{"react/jsx-runtime"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    const out = result.output;
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, out, "_jsx") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "_jsxs") != null);
+    try std.testing.expectEqual(@as(usize, 1), countOccurrences(out, "from \"react/jsx-runtime\""));
 }
 
 test "JSX automatic: fragment syntax uses _Fragment" {
@@ -1571,18 +1627,68 @@ test "JSX automatic: mixed JSX and non-JSX modules" {
 }
 
 test "JSX automatic: re-export of JSX component" {
-    // #3062 이후 substring assertion 부적용. e2e 대체:
-    //   tests/e2e/tests/lib-scenario-e2e.test.ts 의 H6_preact_jsx_re_export
-    //   (barrel 파일 통과 후 Button 컴포넌트 → 브라우저 DOM 검증).
-    return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "button.tsx",
+        \\export function Button() { return <button>OK</button>; }
+    );
+    try writeFile(tmp.dir, "barrel.ts",
+        \\export { Button } from './button.tsx';
+    );
+    try writeFile(tmp.dir, "entry.tsx",
+        \\import { Button } from './barrel.ts';
+        \\export const node = <Button />;
+    );
+
+    const entry = try absPath(&tmp, "entry.tsx");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .jsx_runtime = .automatic,
+        .external = &.{"react/jsx-runtime"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    const out = result.output;
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, out, "function Button") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "_jsx") != null);
+    try std.testing.expectEqual(@as(usize, 1), countOccurrences(out, "from \"react/jsx-runtime\""));
 }
 
 test "JSX automatic: ESM-wrapped hoisted function can access _jsxDEV (scope test)" {
-    // #3062 이후 substring assertion 부적용. e2e 대체:
-    //   tests/e2e/tests/lib-scenario-e2e.test.ts 의 H1/H4/H5/H6 가 preact JSX
-    //   automatic 의 빌드/렌더 정상성을 브라우저 동작까지 검증. 별도 ESM-wrapped
-    //   require 소비 fixture 가 필요하면 후속 시나리오로 추가 가능.
-    return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "comp.tsx",
+        \\export function App() { return <div>hi</div>; }
+        \\export const make = () => <App />;
+    );
+    try writeFile(tmp.dir, "entry.ts",
+        \\const c = require('./comp.tsx');
+        \\console.log(c.App(), c.make());
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .jsx_runtime = .automatic_dev,
+        .external = &.{"react/jsx-dev-runtime"},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    const out = result.output;
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, out, "__esm(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "function App") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "_jsxDEV") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "var _jsxDEV = ") == null);
 }
 
 test "JSX automatic: ESM-wrapped with multiple JSX functions (_jsx, _jsxs, _Fragment)" {

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -1397,14 +1397,13 @@ test "snapshotToJson: 활성 phase 만 JSON 출력" {
     defer resetForTest();
     addFromCsv("parse,emit");
 
-    var s1 = begin(.parse);
-    std.Thread.sleep(2_000_000); // 2ms
-    s1.end();
-    var s2 = begin(.emit);
-    std.Thread.sleep(1_000_000); // 1ms
-    s2.end();
-
-    const snap = takeSnapshot();
+    var snap: ProfileSnapshot = .{
+        .totals_ns = [_]u64{0} ** num_categories,
+        .self_totals_ns = [_]u64{0} ** num_categories,
+        .counts = [_]u32{0} ** num_categories,
+    };
+    snap.totals_ns[@intFromEnum(Category.parse)] = 2 * std.time.ns_per_ms;
+    snap.totals_ns[@intFromEnum(Category.emit)] = 1 * std.time.ns_per_ms;
     var buf: [512]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     try snapshotToJson(snap, fbs.writer(), 0);
@@ -1423,14 +1422,13 @@ test "snapshotToJson: min_ms_threshold 이상만 포함" {
     defer resetForTest();
     addFromCsv("parse,emit");
 
-    var s1 = begin(.parse);
-    std.Thread.sleep(5_000_000); // 5ms
-    s1.end();
-    var s2 = begin(.emit);
-    std.Thread.sleep(100_000); // 0.1ms
-    s2.end();
-
-    const snap = takeSnapshot();
+    var snap: ProfileSnapshot = .{
+        .totals_ns = [_]u64{0} ** num_categories,
+        .self_totals_ns = [_]u64{0} ** num_categories,
+        .counts = [_]u32{0} ** num_categories,
+    };
+    snap.totals_ns[@intFromEnum(Category.parse)] = 5 * std.time.ns_per_ms;
+    snap.totals_ns[@intFromEnum(Category.emit)] = std.time.ns_per_ms / 10;
     var buf: [512]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     try snapshotToJson(snap, fbs.writer(), 1.0); // 1ms threshold


### PR DESCRIPTION
## 요약
- `snapshotToJson` threshold 테스트를 wall-clock sleep 대신 고정 `ProfileSnapshot` 기반 검증으로 변경했습니다.
- JSX automatic 관련 unconditional skip 4개를 실제 bundler 출력 검증으로 복구했습니다.
- incremental bench v4가 repo `node_modules`에 의존하지 않도록 synthetic `lodash-es` fixture를 테스트 안에서 생성하게 했습니다.

## 검증
- `git diff --check`
- `zig build test262 --summary all` (5637/5637 passed)
- `zig build test --summary all` (5638/5638 passed)
- pre-push hook 통과: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`