### PR TITLE
feat(bundler): syntheticName rt 필수화 (canonical 이중경로 제거) + single-file dynamic import rt (RFC #3940 Sub-PR-L.5b)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -811,7 +811,7 @@ pub fn emitWithTreeShaking(
         // 우회하는 single-file 전용 헬퍼 사용. wrap_kind=.esm 인 dynamic target 의
         // `import("./x")` 를 `Promise.resolve().then(() => (init_x(), exports_x))`
         // 로 변환 → bundle self-contained (외부 sibling 파일 fallback 제거).
-        const rewritten = chunks.rewriteDynamicImportsSingleFile(allocator, code, m, graph, options.platform == .react_native) catch null;
+        const rewritten = chunks.rewriteDynamicImportsSingleFile(allocator, code, m, graph, options.platform == .react_native, if (linker) |l| &l.rename_table else null) catch null;
         defer if (rewritten) |r| allocator.free(r);
         const code_after_rewrite = rewritten orelse code;
 

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -1591,6 +1591,7 @@ pub fn rewriteDynamicImportsSingleFile(
     module: *const Module,
     graph: *const ModuleGraph,
     lower_unresolved_dynamic_imports: bool,
+    rename_tbl: ?*const RenameTable,
 ) ![]const u8 {
     if (module.import_records.len == 0) return try allocator.dupe(u8, code);
     if (!graph.inline_dynamic_imports) return try allocator.dupe(u8, code);
@@ -1627,15 +1628,15 @@ pub fn rewriteDynamicImportsSingleFile(
         const target_mod = graph.getModule(rec.resolved) orelse continue;
         const replacement_expr = switch (target_mod.wrap_kind) {
             .esm => blk: {
-                // single-file 경로 (linker 파라미터 없음) → rt null, canonical field (parity 로 동치).
-                const init_name = try target_mod.allocInitName(allocator, null);
+                // RFC #3940 L.5b: caller(emitWithTreeShaking)가 linker 보유 → rt 전달.
+                const init_name = try target_mod.allocInitName(allocator, rename_tbl);
                 defer allocator.free(init_name);
-                const exports_name = try target_mod.allocExportsName(allocator, null);
+                const exports_name = try target_mod.allocExportsName(allocator, rename_tbl);
                 defer allocator.free(exports_name);
                 break :blk try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>({s}(),{s}))", .{ init_name, exports_name });
             },
             .cjs => blk: {
-                const require_name = try target_mod.allocRequireName(allocator, null);
+                const require_name = try target_mod.allocRequireName(allocator, rename_tbl);
                 defer allocator.free(require_name);
                 break :blk try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>{s}())", .{require_name});
             },

--- a/src/bundler/emitter/cjs_wrap.zig
+++ b/src/bundler/emitter/cjs_wrap.zig
@@ -13,7 +13,7 @@ const EmitOptions = @import("../emitter.zig").EmitOptions;
 /// Disabled 모듈: platform=browser에서 Node 빌트인 모듈을 빈 __commonJS wrapper로 출력.
 /// wrapper key는 dev/HMR registry 조회와 일치해야 하므로 module.wrapperId()를 쓴다.
 pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, minify: bool) !?[]const u8 {
-    // RFC #3940 L.4c-2a-i: free fn (linker 없음) → rt null, canonical field 경로 (parity 로 동치).
+    // RFC #3940 L.5b: disabled/asset 모듈은 semantic 없어 syntheticName 이 즉시 fallback (rt 무관).
     const var_name = try module.allocRequireName(allocator, null);
     defer allocator.free(var_name);
     const wrapper_id = module.wrapperId();
@@ -106,7 +106,7 @@ pub fn emitAssetModule(allocator: std.mem.Allocator, module: *const Module, opti
 /// `var require_X = __commonJS({ "filename"(exports, module) { module.exports = <source>; } });`
 /// 형태의 __commonJS wrapper를 생성.
 pub fn emitCjsWrapper(allocator: std.mem.Allocator, module: *const Module, source: []const u8, minify: bool) !?[]const u8 {
-    // RFC #3940 L.4c-2a-i: free fn (linker 없음) → rt null, canonical field 경로 (parity 로 동치).
+    // RFC #3940 L.5b: disabled/asset 모듈은 semantic 없어 syntheticName 이 즉시 fallback (rt 무관).
     const var_name = try module.allocRequireName(allocator, null);
     defer allocator.free(var_name);
 

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -469,10 +469,10 @@ pub const Module = struct {
     /// 주입한 경우 릴리즈/압축 출력에서는 그 이름을 우선 사용한다.
     /// 미등록이면 null.
     /// 반환 slice는 parse_arena가 소유 — 모듈 수명 내 유효.
-    /// RFC #3940 L.4c-2: rename 출처를 build-scope `rename_table` 로 전환 (Module 은 graph-scope
-    /// 라 Linker 직접 참조 불가 → caller 가 `rt` 전달). `rt` 가 null 이면 기존 `canonical_name`
-    /// field 경로 (parity 로 동일 값 — L.3 sink + L.4a sync). i 단계: non-esm_wrap caller 는 실제
-    /// rt, esm_wrap/finalize/cjs_wrap 은 null. L.5 에서 field 경로 제거 + rt 필수화.
+    /// RFC #3940 L.5b: rename 출처는 build-scope `rename_table` (Module 은 graph-scope 라 Linker
+    /// 직접 참조 불가 → caller 가 `rt` 전달). `rt == null` 은 rename 이 아직/원래 없는 컨텍스트
+    /// (finalize: mangle 전 / cjs_wrap: semantic 없음) — synthetic_name fallback. (L.4c-2 의
+    /// `canonical_name` field 이중 경로는 L.5b 에서 제거 — rename_table 단일 출처.)
     fn syntheticName(self: *const Module, maybe_id: ?SemanticSymbolId, rt: ?*const RenameTable) ?[]const u8 {
         const id = maybe_id orelse return null;
         const sem = self.semantic orelse return null;
@@ -480,9 +480,6 @@ pub const Module = struct {
         if (idx >= sem.symbols.items.len) return null;
         if (rt) |t| {
             if (t.get(SymbolID.make(self.index, idx))) |n| if (n.len > 0) return n;
-        } else {
-            const canon = sem.symbols.items[idx].canonical_name;
-            if (canon.len > 0) return canon;
         }
         const name = sem.symbols.items[idx].synthetic_name;
         return if (name.len > 0) name else null;


### PR DESCRIPTION
## Summary
- L.4c-2a 의 `syntheticName` 이중 경로(`rt ? rename_table : canonical_name field`)에서 **canonical fallback 제거 → rename_table 단일 출처**. L.5c (canonical field 제거)의 선결. byte-identical.
- single-file dynamic import(`rewriteDynamicImportsSingleFile`)에 `rename_table` 전파 — else 제거 후 rt 없으면 wrapper 이름 mangle 누락되므로 필수 (caller emitWithTreeShaking 가 linker 보유).

RFC: `docs/RFC_LIFECYCLE_SCOPE_REDESIGN.md`, 이슈 #3957. L.5 3분할 중 **L.5b**.

## 변경
- `module.zig syntheticName`: `else { canonical_name field }` 분기 제거. rt==null 은 rename 없는 컨텍스트(finalize=mangle 전 / cjs_wrap=semantic 없음)라 synthetic_name fallback (기존 else 도 canonical 비어 동치).
- `chunks.zig rewriteDynamicImportsSingleFile`: `rename_tbl` 파라미터 + caller(emitter.zig) `if (linker) |l| &l.rename_table else null`. wrapper 선언부(esm_wrap)와 동일 패턴 → 호출↔선언 rt 출처 일치.

## 검증 (byte-identical critical, 사용자 강조)
- [x] zig build test
- [x] main vs PR `--bundle` (non-min + min) diff: **lodash-es/zod/rxjs/three/@reduxjs-toolkit 5 lib IDENTICAL**
- [x] single-file dynamic import fixture (init_/exports_/require_): non-min + min **IDENTICAL** + node 실행 정확 (`{"r":45,"l":"dep"}`)
- [x] bundle-smoke 151/0, benchmark 3953/0 (snapshot 1768 = wrapper-name emit, main 기준 동일)
- [x] `/code-review high` — correctness 0 findings (else 제거 null caller 안전: finalize=mangle 전/cjs_wrap=semantic 없음; single-file rt 가 선언부와 동일 패턴). cleanup: cjs_wrap stale 주석 정정.

## 범위 조정
plan 의 **mangler.zig:596 canonical reserve 삭제는 L.5c 로 미룸**. eval/with(blocksMangling) 경로에서 canonical reserve 가 no-op 인지 검증하려던 fixture 가 `with`-in-ESM **parse error** 라 결론 불가 — canonical field 제거(L.5c)와 함께 rename_table 전환으로 안전하게 처리.

## 후속
- **L.5c**: `Symbol.canonical_name` field + hasCanonicalName 삭제(big bang) + assignSymbolCanonical/clearCanonicalNames/canonical_symbols/build_flow reset/renameTableParityHolds 정리 + **mangler.zig:596 canonical reserve → rename_table 전환** (eval/with 정확성 검증 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)