### PR TITLE
fix(bundler): multi-pass capture stale-idx 근본 수정 (RFC #3940 L.5c review)

### DIFF
--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -227,7 +227,15 @@ pub fn run(self: anytype, module: *Module, arena_alloc: std.mem.Allocator) void 
 /// 반영한다 (tree_shaker.linker 는 *const 라 put 불가 — capture=read, apply=write 분리).
 /// `rename_table == null` (graph pre-pass, link 전) 이면 rename 미설정이라 no-op.
 ///
-/// SymbolID 정합: renumber 가 inner idx 불변 → resync 전후 `(module.index, idx)→name` 동일.
+/// **Multi-pass 정합 (RFC #3940 L.5c review fix)**: 같은 모듈이 한 build 에서 2회 이상 resync
+/// 되면 (pre-shake `applyNodeBufferCapabilityFacts` markAst + numeric post-pass markConst 등)
+/// `rename_table` (link 시점 = pass0 idx) 만으로는 2차 capture 의 old_idx (= 1차 resync 후 idx)
+/// 와 어긋나 stale lookup 이 된다. 그러나 **직전 resync 가 이미 old_sem(=현재) idx 기준으로
+/// `pending_renames` 에 stash** 했으므로, rename source 를 `pending_renames` (직전 결과) 우선 +
+/// `rename_table` (link 시점) 폴백으로 잡으면 idx-shift 와 무관하게 정합한다. 또 매 resync 마다
+/// old_sem 기준으로 **새 맵을 rebuild(교체)** 해 이전 idx 의 stale entry 를 제거 — 다른 심볼이
+/// 잘못된 rename 으로 오염되는 것을 막는다. 단일 resync (대부분) 는 pending 이 비어 폴백만 타므로
+/// 기존과 byte-identical.
 fn captureRenamesToPending(
     module: *Module,
     rename_table: *const bundler_symbol.RenameTable,
@@ -237,16 +245,26 @@ fn captureRenamesToPending(
     arena: std.mem.Allocator,
 ) !void {
     const module_scope: ?*const std.StringHashMap(usize) = if (new_sem.scope_maps.len > 0) &new_sem.scope_maps[0] else null;
+    // old_sem 기준 새 맵을 만들어 교체 — 이전 idx 의 stale entry 누적/오염 방지 (multi-pass).
+    var rebuilt: bundler_symbol.RenameTable = .{};
+    // `rename_table` (link 시점 = pass0 idx) 폴백은 **첫 capture (pending 비어있음)** 에서만
+    // 허용한다. 2차+ resync 는 old_sem idx 가 pass1+ 라, pass0 키 폴백 시 그 슬롯의 *다른* 심볼
+    // rename 을 오인해 잘못 적용할 수 있다 (idx-space mismatch). 직전 resync 가 old_sem idx 로
+    // stash 한 `pending_renames` 가 2차+ 의 유일한 정합 source 다. apply 가 build 끝에 pending 을
+    // clear 하므로 다음 build 의 첫 capture 는 다시 count==0 — cross-build 안전.
+    const allow_table_fallback = module.pending_renames.count() == 0;
     for (old_sem.symbols.items, 0..) |old_sym, old_idx| {
         const old_id = bundler_symbol.SymbolID.make(module.index, old_idx);
-        const rename = rename_table.get(old_id) orelse continue;
+        // 직전 resync 결과(pending) 우선; 첫 capture 만 link 시점 rename_table 폴백.
+        const rename = module.pending_renames.get(old_id) orelse
+            (if (allow_table_fallback) rename_table.get(old_id) else null) orelse continue;
 
         if (old_sym.synthetic_kind == null) {
             const name = old_sym.nameText(source);
             const new_idx = if (module_scope) |scope| scope.get(name) else null;
             if (new_idx) |idx| {
                 if (idx < new_sem.symbols.items.len and new_sem.symbols.items[idx].synthetic_kind == null) {
-                    try module.pending_renames.put(arena, bundler_symbol.SymbolID.make(module.index, idx), rename);
+                    try rebuilt.put(arena, bundler_symbol.SymbolID.make(module.index, idx), rename);
                 }
             }
             continue;
@@ -255,10 +273,11 @@ fn captureRenamesToPending(
         for (new_sem.symbols.items, 0..) |new_sym, new_idx| {
             if (new_sym.synthetic_kind != old_sym.synthetic_kind) continue;
             if (!std.mem.eql(u8, new_sym.synthetic_name, old_sym.synthetic_name)) continue;
-            try module.pending_renames.put(arena, bundler_symbol.SymbolID.make(module.index, new_idx), rename);
+            try rebuilt.put(arena, bundler_symbol.SymbolID.make(module.index, new_idx), rename);
             break;
         }
     }
+    module.pending_renames = rebuilt;
 }
 
 fn refreshSemanticAndStmtInfoAfterAstMutation(

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -288,6 +288,7 @@ pub const Module = struct {
     /// new idx 로 채우고, bundler 의 post-shake finalize 가 `applyPendingRenames` 로 mutable
     /// `rename_table` 에 반영 후 비운다. value 는 `Linker.canonical_strings` borrow (같은 build
     /// finalize 내 소비). build-scope 라 store round-trip 전 반드시 clear (cross-build dangling 방지).
+    /// 맵 backing 은 `parse_arena` 소유 — 개별 `deinit` 금지 (`arena.deinit` 가 일괄 해제, #1287).
     pending_renames: RenameTable = .{},
 
     /// 내가 import하는 모듈들 (순방향)


### PR DESCRIPTION
## Summary
RFC #3940 L.5c 의 통합 사후 `/code-review max` 가 발견한 **multi-pass stale-idx (잠재 miscompile)** 를 근본 수정한다.

## 버그
`Symbol.canonical_name` field 제거(L.5c) 후 rename 은 build-scope `rename_table: AutoHashMap<SymbolID{module, inner}, name>` 에만 산다. post-link tree-shake 에서 **같은 모듈이 한 build 에서 2회 이상 resync** 되면 (pre-shake `applyNodeBufferCapabilityFacts` markAst + numeric post-pass markConst), 2차 capture 의 `old_idx` 는 1차 resync 후(pass1) idx 인데, 기존 `captureRenamesToPending` 은 `rename_table.get(SymbolID(module, old_idx))` 만 봤다. `rename_table` 은 link 시점(pass0) idx 키라 **mismatch → stale rename 조회/누락 → 잘못된 식별자 emit**.

## Fix (`captureRenamesToPending`)
1. **rename source = `pending_renames`(직전 resync 결과) 우선 + `rename_table` 폴백** — 1차 capture 가 이미 pass1 idx 로 pending 에 stash 했으므로 2차의 `old_idx=pass1` 과 정합.
2. **매 호출 `old_sem` 기준 새 맵 rebuild → 교체** — 이전 idx 의 stale entry 제거 (다른 심볼 오염 방지).
3. **`rename_table` 폴백을 첫 capture(`pending.count()==0`)에만 허용** — 2차+ 폴백 시 pass-N idx 로 pass0 키를 조회해 다른 심볼 rename 을 오인하는 것을 차단 (review finding #1 대응). `applyPendingRenames` 가 build 끝에 pending 을 clear → cross-build 안전.

## 검증
- **byte-identical**: 단일 resync 5 fixture(small/barrel/name-collision[minify]/dynamic-only/code-splitting) fix 전후 SHA256 **동일** (회귀 0).
- `zig build test` 전체 통과, `zig fmt` 통과.
- **`/code-review max` 2회**:
  - 1차: multi-pass 논리(pass0→pass1→pass2) + pending 키 정합 **VERIFIED CORRECT**. finding #1(2차+ 폴백 idx-mismatch) 제기 → 이 PR 의 #3 gate 로 대응.
  - 2차(PR-final): gate 가 finding#1 일반 케이스 정확 차단(A), **cross-build UAF clear 안전 확인(C)** — `applyPendingRenames` 가 `pending.clear()` + capture/apply 가 `!minify_identifiers` 로 대칭 게이트. byte-identical(D)·arena churn benign(E, parse_arena bulk-free)·synthetic 정합(F) 모두 confirmed.

## 잔여 (L.6 stable-id 영역, regression 아님)
review 2차가 확정: "첫 capture 가 **전부** drop → pending 재-empty → 2차 폴백 재무장" 극단이 남는다. 단 이는 **모든 rename 심볼 제거 + freed inner-idx slot 재사용 + 그 idx 충돌** 3중 동시 충족이 필요해, `ModuleIndex`/inner-idx 를 path-stable id 로 전환하는 **graph persistence(L.6)** 에서만 완전 제거 가능. 이 PR 의 gate 는 일반 multi-pass 를 정확히 막고, 극단은 L.6 으로 정당히 위임.

## 추가
- `Module.pending_renames` 필드 주석에 "맵 backing 은 `parse_arena` 소유 — 개별 deinit 금지(#1287)" 보강 (미래 maintainer 가드).

## Test plan
- [x] byte-identical 5 fixture (단일 resync 회귀 0)
- [x] `zig build test` + `zig fmt`
- [x] `/code-review max` 2회 (논리 트레이스 + gate 엣지 + cross-build UAF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)