### PR TITLE
perf(mangler): 식별자 slot 할당을 esbuild 식 scope-nesting(O(N))으로 교체

### DIFF
--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -1,12 +1,12 @@
-//! ZNTC Identifier Mangler — Liveness-based Slot Reuse (oxc 방식)
+//! ZNTC Identifier Mangler — esbuild 식 scope-nesting slot 할당
 //!
-//! 스코프 분석 + liveness BitSet를 기반으로 로컬 변수 이름을 짧은 이름으로 교체한다.
-//! 번들 크기를 ~70% 절감하는 핵심 최적화.
+//! 스코프 트리를 따라 로컬 변수 이름을 짧은 이름으로 교체한다. 번들 크기를 ~70% 절감하는 핵심 최적화.
 //!
-//! 알고리즘 (oxc/esbuild 기반, 그래프 컬러링):
+//! 알고리즘 (esbuild renamer.go / oxc 기반, O(N)):
 //!   1. parent 배열에서 children 역산 (O(n), 2-pass)
-//!   2. references로 per-symbol liveness BitSet 계산
-//!   3. DFS로 scope tree 순회, alive하지 않은 slot 재사용 (그래프 컬러링)
+//!   2~3. scope tree DFS — 자식 scope 가 부모의 현재 slot 카운트를 상속해 시작. 형제는 같은 slot
+//!        번호를 구성적으로 재사용(동시 live 불가 → 충돌 0), 자식 binding 은 부모 slot 이후만 받아
+//!        closure-shadow 불가. liveness BitSet/graph-coloring first-fit 스캔 없음 → 선형.
 //!   4. 빈도순 이름 할당 (Base54, 고빈도 심볼이 짧은 이름)
 //!
 //! 규칙:
@@ -16,8 +16,8 @@
 //!   - 함수 파라미터도 mangling 대상
 //!
 //! 참고:
-//!   - oxc: crates/oxc_mangler/src/lib.rs (liveness + graph coloring)
-//!   - esbuild: internal/renamer/renamer.go (DFS slot assignment)
+//!   - esbuild: internal/renamer/renamer.go (assignNestedScopeSlots)
+//!   - oxc: crates/oxc_mangler/src/lib.rs
 
 const std = @import("std");
 const Scope = @import("../semantic/scope.zig").Scope;
@@ -93,12 +93,11 @@ pub const MangleInput = struct {
     external_reserved_global: ?*const std.StringHashMap(void) = null,
 };
 
-/// Liveness 기반 mangling.
+/// scope-nesting 기반 mangling.
 pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
     const scopes = input.scopes;
     const symbols = input.symbols;
     const scope_maps = input.scope_maps;
-    const references = input.references;
     const source = input.source;
     const skip_symbols = input.skip_symbols;
 
@@ -120,209 +119,34 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
     defer allocator.free(children.list);
 
     // ================================================================
-    // Phase 2: per-symbol liveness BitSet 계산
+    // Phase 2+3: slot 할당 (symbol_idx → slot_id + slot 별 ref 합)
     // ================================================================
-    // 각 symbol이 어느 scope에서 alive한지 추적.
-    // alive = 선언 scope에서 참조 scope까지의 ancestor 경로 전체.
-    //
-    // 벌크 할당: symbol_count개의 mask 배열을 단일 버퍼로 할당하여
-    // 개별 DynamicBitSet.initEmpty 대신 O(1) 할당.
-    const MaskInt = std.DynamicBitSetUnmanaged.MaskInt;
-    const masks_per_symbol = (scope_count + @bitSizeOf(MaskInt) - 1) / @bitSizeOf(MaskInt);
-    const all_masks = try allocator.alloc(MaskInt, symbol_count * masks_per_symbol);
-    defer allocator.free(all_masks);
-    @memset(all_masks, 0);
-
-    var symbol_liveness = try allocator.alloc(std.DynamicBitSet, symbol_count);
-    defer allocator.free(symbol_liveness);
-    for (symbol_liveness, 0..) |*bs, i| {
-        const start = i * masks_per_symbol;
-        bs.* = .{
-            .unmanaged = .{
-                .masks = @ptrCast(all_masks[start..].ptr),
-                .bit_length = scope_count,
-            },
-            .allocator = allocator,
-        };
-    }
-
-    // 선언 scope 자체 + 모든 후손 scope 를 alive 로 표시 (#2956 shadowing 방지).
-    //
-    // outer binding 은 모든 후손 scope 에서 reference 가능 (closure). 후손 scope 의
-    // declaration 이 ancestor 와 같은 slot 을 받으면 mangle 후 자기참조가 됨:
-    //   function e(t,n) { ... }
-    //   function p(n,t) { const e = e(n); ... }   // const e 가 outer e 를 shadow → ReferenceError
-    // declaration scope 의 subtree 전체를 alive 로 표시하면 이 binding 과 후손
-    // declaration 이 graph coloring 에서 다른 slot 을 받게 됨. sibling 은 declaration
-    // scope 가 같아 이미 충돌 (intersect) 처리되므로 영향 없음.
-    for (symbols, 0..) |sym, i| {
-        if (!sym.scope_id.isNone() and sym.scope_id.toIndex() < scope_count) {
-            markScopeSubtree(&symbol_liveness[i], children, sym.scope_id.toIndex());
-        }
-    }
-
-    // references: 참조 scope에서 선언 scope까지 ancestor 경로를 모두 set
-    for (references) |r| {
-        const sym_idx: u32 = @intFromEnum(r.symbol_id);
-        if (sym_idx >= symbol_count) continue;
-        const decl_scope = symbols[sym_idx].scope_id;
-        if (decl_scope.isNone()) continue;
-        markAncestorPath(&symbol_liveness[sym_idx], scopes, r.scope_id, decl_scope);
-    }
-
-    // ================================================================
-    // Phase 3: Slot 할당 (DFS + 그래프 컬러링)
-    // ================================================================
-    const Slot = struct {
-        liveness: std.DynamicBitSet,
-        total_refs: u32,
-    };
-
-    var slots: std.ArrayListUnmanaged(Slot) = .empty;
-    defer {
-        for (slots.items) |*s| s.liveness.deinit();
-        slots.deinit(allocator);
-    }
-
     // symbol_idx -> slot_id (null이면 미할당)
-    var symbol_to_slot = try allocator.alloc(?u32, symbol_count);
+    const symbol_to_slot = try allocator.alloc(?u32, symbol_count);
     defer allocator.free(symbol_to_slot);
     @memset(symbol_to_slot, null);
 
-    // scope별 bindings를 symbol_idx 기준으로 정렬하기 위한 임시 버퍼
-    var binding_buf: std.ArrayListUnmanaged(SymBinding) = .empty;
-    defer binding_buf.deinit(allocator);
-
-    // mangling에서 제외된 심볼의 원본 이름은 그대로 출력에 남거나(shouldSkip,
-    // blocksMangling) 번들러가 별도로 canonicalize하므로(skip_symbols), base54가
-    // 해당 이름을 다른 slot에 재할당하면 동일 스코프 중복 선언(#1609: 9-param
-    // pipe의 1글자 param) 또는 shadowing 오염으로 이어진다. 이들 이름을 Phase 4
-    // 이름 할당에서 reserved로 취급한다.
+    // mangling 제외 심볼의 원본 이름(shouldSkip/blocksMangling)은 출력에 그대로 남으므로
+    // base54 가 같은 이름을 다른 slot 에 재할당하면 중복 선언(#1609)/shadow 오염 → Phase 4
+    // 발급에서 reserved 로 회피. #1760: Phase A 누적 예약어(external_reserved)도 seed.
     var reserved_names = std.StringHashMap(void).init(allocator);
     defer reserved_names.deinit();
-
-    // #1760: Phase A 에서 누적된 예약어를 Phase B 가 물려받음.
     if (input.external_reserved) |ext| {
         var it = ext.keyIterator();
         while (it.next()) |k| try reserved_names.put(k.*, {});
     }
 
-    // DFS로 scope tree 순회
-    var dfs_stack: std.ArrayListUnmanaged(u32) = .empty;
-    defer dfs_stack.deinit(allocator);
-    try dfs_stack.append(allocator, 0); // root scope
-
-    while (dfs_stack.items.len > 0) {
-        const scope_idx = dfs_stack.pop().?;
-
-        // 이 scope의 bindings 수집 (결정론적 순서를 위해 symbol_idx 정렬)
-        binding_buf.items.len = 0;
-        if (scope_idx < scope_maps.len) {
-            var sit = scope_maps[@intCast(scope_idx)].iterator();
-            while (sit.next()) |entry| {
-                const sym_idx: u32 = @intCast(entry.value_ptr.*);
-                if (sym_idx >= symbol_count) continue;
-
-                const sym = symbols[sym_idx];
-                const name = entry.key_ptr.*;
-
-                // skip 판정 — 아래 세 경로는 원본 이름이 출력에 살아남으므로 reserved.
-                if (shouldSkip(sym, name)) {
-                    // shouldSkip 의 5 case 분류:
-                    //   1. is_exported            → renames 로 ref, 원본 안 emit → reserve 불필요
-                    //   2. is_import              → mangled source 로 ref, 원본 안 emit → 불필요
-                    //   3. is_class_expr_name     → self-ref 도 mangled → 불필요
-                    //   4. "arguments"            → literal 그대로 emit → reserve 필수
-                    //   5. name.len <= 1          → literal 그대로 emit → base54 충돌 회피 reserve
-                    // 1-3 은 외부 `external_reserved` 가 mangled name 으로 이미 보유 — 추가 안 함.
-                    // (blocksMangling path 는 별도 — direct eval/with 는 모든 이름이 동적 lookup
-                    // 대상이라 full reserve 필요 — 의도적으로 단순화 안 함.)
-                    if (name.len <= 1 or std.mem.eql(u8, name, "arguments")) {
-                        try reserved_names.put(name, {});
-                    }
-                    continue;
-                }
-                // direct eval / with 스코프의 바인딩은 mangling 차단 (#1258) — 원본 이름이
-                // 동적 lookup 대상으로 출력에 그대로 남으므로 reserve.
-                if (!sym.scope_id.isNone()) {
-                    const s_idx = sym.scope_id.toIndex();
-                    if (s_idx < scopes.len and scopes[s_idx].blocksMangling()) {
-                        try reserved_names.put(name, {});
-                        continue;
-                    }
-                }
-                if (skip_symbols) |ss| {
-                    if (sym_idx < ss.capacity() and ss.isSet(sym_idx)) {
-                        // skip_symbols (module_scope_symbols) path: 이 binding 은 nested
-                        // mangler 가 다루지 않는다 — Phase A 가 mangle 했거나 import binding
-                        // (mangled source name 으로 inline). 양쪽 모두 *원본 이름은 출력에
-                        // 안 남고* mangled name 만 emit 된다. mangled name 은 외부
-                        // `external_reserved` 가 보유 → 여기서 *추가 reserve 불필요*.
-                        // 원본 이름 reserve 를 유지하면 1-char 풀 잠식 (J scope-local mangle
-                        // epic 의 핵심 root cause — mobx 52 skips_1char 의 직접 원인).
-                        continue;
-                    }
-                }
-
-                try binding_buf.append(allocator, .{ .sym_idx = sym_idx, .name = name });
-            }
-        }
-
-        // 결정론적 순서: symbol_idx 오름차순
-        std.mem.sortUnstable(SymBinding, binding_buf.items, {}, struct {
-            fn cmp(_: void, a: SymBinding, b: SymBinding) bool {
-                return a.sym_idx < b.sym_idx;
-            }
-        }.cmp);
-
-        // 각 binding에 slot 할당
-        for (binding_buf.items) |binding| {
-            const sym_idx = binding.sym_idx;
-            if (symbol_to_slot[sym_idx] != null) continue; // 이미 할당됨 (var 호이스팅 등)
-
-            // 기존 slot 중 재사용 가능한 것 찾기:
-            // slot의 liveness가 이 symbol의 liveness와 겹치지 않으면 재사용 가능
-            var reused_slot: ?u32 = null;
-            for (slots.items, 0..) |*slot, slot_idx| {
-                // slot.liveness와 symbol_liveness[sym_idx]가 교집합이 없으면 재사용 가능
-                if (!bitsetIntersects(slot.liveness, symbol_liveness[sym_idx])) {
-                    reused_slot = @intCast(slot_idx);
-                    break;
-                }
-            }
-
-            if (reused_slot) |slot_id| {
-                symbol_to_slot[sym_idx] = slot_id;
-                // slot의 liveness 확장 (합집합)
-                slots.items[slot_id].liveness.setUnion(symbol_liveness[sym_idx]);
-                slots.items[slot_id].total_refs += symbols[sym_idx].reference_count;
-            } else {
-                // 새 slot 생성
-                const new_slot_id: u32 = @intCast(slots.items.len);
-                var new_liveness = try std.DynamicBitSet.initEmpty(allocator, scope_count);
-                new_liveness.setUnion(symbol_liveness[sym_idx]);
-                try slots.append(allocator, .{
-                    .liveness = new_liveness,
-                    .total_refs = symbols[sym_idx].reference_count,
-                });
-                symbol_to_slot[sym_idx] = new_slot_id;
-            }
-        }
-
-        // children을 DFS stack에 push (역순으로 넣어서 작은 인덱스부터 처리)
-        const start = children.offsets[scope_idx];
-        const end = if (scope_idx + 1 < children.offsets.len) children.offsets[scope_idx + 1] else @as(u32, @intCast(children.list.len));
-        var ci = end;
-        while (ci > start) {
-            ci -= 1;
-            try dfs_stack.append(allocator, children.list[ci]);
-        }
-    }
+    // slot_refs[slot_id] = 그 slot 을 공유하는 심볼들의 reference_count 합 (Phase 4 빈도 naming).
+    // esbuild/oxc 식 scope-nesting (O(N)): 자식 scope 가 부모 slot 카운트를 상속 → 형제는 같은
+    // slot 번호를 구성적으로 재사용(동시 live 불가 → 충돌 0), 자식 binding 은 부모 slot 번호
+    // 이후만 받아 closure-shadow 불가. liveness graph-coloring 과 동일 출력을 O(N²)→O(N) 으로 계산.
+    var slot_refs = try assignSlotsScopeNesting(allocator, scopes, symbols, scope_maps, skip_symbols, symbol_count, children, symbol_to_slot, &reserved_names);
+    defer slot_refs.deinit(allocator);
 
     // ================================================================
     // Phase 4: 빈도순 이름 할당 (Base54)
     // ================================================================
-    const slot_count = slots.items.len;
+    const slot_count = slot_refs.items.len;
     if (slot_count == 0) {
         return .{
             .renames = std.AutoHashMap(u32, []const u8).init(allocator),
@@ -336,7 +160,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
     for (sorted_slots, 0..) |*entry, i| {
         entry.* = .{
             .slot_id = @intCast(i),
-            .total_refs = slots.items[i].total_refs,
+            .total_refs = slot_refs.items[i],
         };
     }
     std.mem.sortUnstable(SlotSortEntry, sorted_slots, {}, struct {
@@ -422,55 +246,121 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
 }
 
 // ============================================================
-// Liveness 헬퍼
+// Slot 할당 (Phase 2+3) — 공유 binding 수집 + 두 알고리즘
 // ============================================================
 
-/// ref_scope에서 decl_scope까지 ancestor 경로의 모든 scope를 liveness에 set.
-fn markAncestorPath(
-    liveness: *std.DynamicBitSet,
+/// 한 scope 의 binding 을 수집해 `binding_buf` 에 채운다(sym_idx 오름차순 정렬).
+/// shouldSkip/blocksMangling/skip_symbols 로 mangle 제외 심볼은 제외하고, 출력에 남는
+/// 원본 이름은 `reserved_names` 에 등록. 신/구 slot 알고리즘이 공유 (동일 분류 보장).
+fn collectScopeBindings(
+    scope_idx: u32,
+    scope_maps: []const std.StringHashMap(usize),
+    symbols: []const Symbol,
     scopes: []const Scope,
-    ref_scope: ScopeId,
-    decl_scope: ScopeId,
-) void {
-    var cur = ref_scope;
-    while (!cur.isNone()) {
-        const idx = cur.toIndex();
-        if (idx >= scopes.len) break;
-        liveness.set(idx);
-        if (cur.toIndex() == decl_scope.toIndex()) break;
-        cur = scopes[idx].parent;
+    skip_symbols: ?std.DynamicBitSet,
+    symbol_count: usize,
+    binding_buf: *std.ArrayListUnmanaged(SymBinding),
+    reserved_names: *std.StringHashMap(void),
+    allocator: std.mem.Allocator,
+) !void {
+    binding_buf.items.len = 0;
+    if (scope_idx < scope_maps.len) {
+        var sit = scope_maps[@intCast(scope_idx)].iterator();
+        while (sit.next()) |entry| {
+            const sym_idx: u32 = @intCast(entry.value_ptr.*);
+            if (sym_idx >= symbol_count) continue;
+
+            const sym = symbols[sym_idx];
+            const name = entry.key_ptr.*;
+
+            // skip 판정 — 원본 이름이 출력에 살아남는 1글자/arguments 만 reserved.
+            if (shouldSkip(sym, name)) {
+                if (name.len <= 1 or std.mem.eql(u8, name, "arguments")) {
+                    try reserved_names.put(name, {});
+                }
+                continue;
+            }
+            // direct eval / with 스코프 바인딩(#1258): 동적 lookup 대상이라 원본 이름 reserve.
+            if (!sym.scope_id.isNone()) {
+                const s_idx = sym.scope_id.toIndex();
+                if (s_idx < scopes.len and scopes[s_idx].blocksMangling()) {
+                    try reserved_names.put(name, {});
+                    continue;
+                }
+            }
+            // skip_symbols (번들 module-scope): nested mangler 미관리, reserve 안 함
+            // (mangled name 은 external_reserved 보유, 원본 reserve 시 1-char 풀 잠식).
+            if (skip_symbols) |ss| {
+                if (sym_idx < ss.capacity() and ss.isSet(sym_idx)) continue;
+            }
+
+            try binding_buf.append(allocator, .{ .sym_idx = sym_idx, .name = name });
+        }
     }
+
+    // 결정론적 순서: symbol_idx 오름차순.
+    std.mem.sortUnstable(SymBinding, binding_buf.items, {}, struct {
+        fn cmp(_: void, a: SymBinding, b: SymBinding) bool {
+            return a.sym_idx < b.sym_idx;
+        }
+    }.cmp);
 }
 
-/// scope_root 와 그 모든 후손 scope 를 liveness 에 set (#2956 shadowing 방지).
-/// children list 를 따라 재귀 DFS. scope tree depth 는 보통 < 100 으로 stack 안전.
-fn markScopeSubtree(
-    liveness: *std.DynamicBitSet,
+/// esbuild/oxc 식 scope-nesting slot 할당 (O(N)). 자식 scope 가 부모의 현재 slot 카운트를
+/// 상속받아 시작 → 형제 scope 는 같은 slot 번호를 구성적으로 재사용(동시 live 불가 → 충돌 0),
+/// 자식 binding 은 부모 slot 번호 이후만 받아 closure-shadow 불가(#2956 subtree-liveness 동치).
+/// liveness BitSet/graph-coloring first-fit 스캔 없음 → 대용량 단일 모듈도 선형.
+/// `symbol_to_slot`/`reserved_names` 를 채우고 `slot_refs`(slot_id→ref 합)를 반환.
+fn assignSlotsScopeNesting(
+    allocator: std.mem.Allocator,
+    scopes: []const Scope,
+    symbols: []const Symbol,
+    scope_maps: []const std.StringHashMap(usize),
+    skip_symbols: ?std.DynamicBitSet,
+    symbol_count: usize,
     children: ChildrenList,
-    scope_root: u32,
-) void {
-    liveness.set(scope_root);
-    if (scope_root + 1 >= children.offsets.len) return;
-    const start = children.offsets[scope_root];
-    const end = children.offsets[scope_root + 1];
-    var ci = start;
-    while (ci < end) : (ci += 1) {
-        markScopeSubtree(liveness, children, children.list[ci]);
-    }
-}
+    symbol_to_slot: []?u32,
+    reserved_names: *std.StringHashMap(void),
+) !std.ArrayListUnmanaged(u32) {
+    var slot_refs: std.ArrayListUnmanaged(u32) = .empty;
+    errdefer slot_refs.deinit(allocator);
 
-/// 두 BitSet이 교집합을 가지는지 검사 (하나라도 겹치면 true).
-/// std.DynamicBitSet에는 non-destructive 교집합 검사가 없으므로 직접 구현.
-fn bitsetIntersects(a: std.DynamicBitSet, b: std.DynamicBitSet) bool {
-    const MaskInt = std.DynamicBitSetUnmanaged.MaskInt;
-    const bits_per_mask = @bitSizeOf(MaskInt);
-    const na = (a.unmanaged.bit_length + bits_per_mask - 1) / bits_per_mask;
-    const nb = (b.unmanaged.bit_length + bits_per_mask - 1) / bits_per_mask;
-    const len = @min(na, nb);
-    for (a.unmanaged.masks[0..len], b.unmanaged.masks[0..len]) |ma, mb| {
-        if (ma & mb != 0) return true;
+    var binding_buf: std.ArrayListUnmanaged(SymBinding) = .empty;
+    defer binding_buf.deinit(allocator);
+
+    const Frame = struct { scope_idx: u32, start_slot: u32 };
+    var stack: std.ArrayListUnmanaged(Frame) = .empty;
+    defer stack.deinit(allocator);
+    try stack.append(allocator, .{ .scope_idx = 0, .start_slot = 0 });
+
+    while (stack.items.len > 0) {
+        const frame = stack.pop().?;
+        const scope_idx = frame.scope_idx;
+        var local_slot = frame.start_slot;
+
+        try collectScopeBindings(scope_idx, scope_maps, symbols, scopes, skip_symbols, symbol_count, &binding_buf, reserved_names, allocator);
+
+        for (binding_buf.items) |binding| {
+            const sym_idx = binding.sym_idx;
+            if (symbol_to_slot[sym_idx] != null) continue; // 이미 할당됨 (var 호이스팅 등)
+            const slot_id = local_slot;
+            local_slot += 1;
+            symbol_to_slot[sym_idx] = slot_id;
+            while (slot_refs.items.len <= slot_id) try slot_refs.append(allocator, 0);
+            slot_refs.items[slot_id] += symbols[sym_idx].reference_count;
+        }
+
+        // 자식은 부모의 현재 slot 카운트(local_slot)를 start 로 상속. 역순 push(결정성).
+        const start = children.offsets[scope_idx];
+        const end = if (scope_idx + 1 < children.offsets.len) children.offsets[scope_idx + 1] else @as(u32, @intCast(children.list.len));
+        var ci = end;
+        while (ci > start) {
+            ci -= 1;
+            try stack.append(allocator, .{ .scope_idx = children.list[ci], .start_slot = local_slot });
+        }
     }
-    return false;
+
+    return slot_refs;
 }
 
 // ============================================================
@@ -721,52 +611,114 @@ test "mangle: string_table 기반 생성 심볼도 rename 결과에 포함" {
     try std.testing.expectEqualStrings("t", result.renames.get(0).?);
 }
 
-test "markScopeSubtree: declaration scope + 모든 후손 set, sibling/ancestor 는 제외 (#2956)" {
+test "mangle: scope-nesting 형제 scope 가 같은 slot 재사용 (충돌 0)" {
     const allocator = std.testing.allocator;
 
-    // scope tree:
-    //   0 (root)
-    //     ├─ 1
-    //     │   └─ 3
-    //     └─ 2
+    // scope tree: 0(root) → 1(func), 2(func) — 형제.
     const scopes = [_]Scope{
         .{ .parent = .none, .kind = .global, .is_strict = false, .symbol_count = 0 },
-        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 0 },
-        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 0 },
-        .{ .parent = @enumFromInt(1), .kind = .block, .is_strict = false, .symbol_count = 0 },
+        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 1 },
+        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 1 },
     };
+    const symbols = [_]Symbol{
+        .{
+            .name = .{ .start = 0, .end = 0 },
+            .scope_id = @enumFromInt(1),
+            .origin_scope = @enumFromInt(1),
+            .kind = .variable_var,
+            .decl_flags = SymbolKind.variable_var.declFlags(),
+            .declaration_span = Span{ .start = 0, .end = 0 },
+            .reference_count = 5,
+            .synthetic_name = "alpha",
+        },
+        .{
+            .name = .{ .start = 0, .end = 0 },
+            .scope_id = @enumFromInt(2),
+            .origin_scope = @enumFromInt(2),
+            .kind = .variable_var,
+            .decl_flags = SymbolKind.variable_var.declFlags(),
+            .declaration_span = Span{ .start = 0, .end = 0 },
+            .reference_count = 3,
+            .synthetic_name = "beta",
+        },
+    };
+    var s_root = std.StringHashMap(usize).init(allocator);
+    defer s_root.deinit();
+    var s1 = std.StringHashMap(usize).init(allocator);
+    defer s1.deinit();
+    try s1.put("alpha", 0);
+    var s2 = std.StringHashMap(usize).init(allocator);
+    defer s2.deinit();
+    try s2.put("beta", 1);
+    const scope_maps = [_]std.StringHashMap(usize){ s_root, s1, s2 };
 
-    const children = try buildChildrenList(allocator, &scopes);
-    defer allocator.free(children.offsets);
-    defer allocator.free(children.list);
+    var result = try mangle(allocator, .{
+        .scopes = &scopes,
+        .symbols = &symbols,
+        .scope_maps = &scope_maps,
+        .references = &.{},
+        .source = "",
+    });
+    defer result.deinit();
 
-    var liveness = try std.DynamicBitSet.initEmpty(allocator, scopes.len);
-    defer liveness.deinit();
-
-    // scope 1 의 subtree (1, 3) 만 set 되어야 한다.
-    markScopeSubtree(&liveness, children, 1);
-    try std.testing.expect(liveness.isSet(1));
-    try std.testing.expect(liveness.isSet(3));
-    try std.testing.expect(!liveness.isSet(0)); // ancestor 는 제외
-    try std.testing.expect(!liveness.isSet(2)); // sibling 은 제외
+    // 형제 scope 의 두 binding 은 동시 live 불가 → 같은 slot → 같은 mangled 이름.
+    const a = result.renames.get(0) orelse return error.NoRename0;
+    const b = result.renames.get(1) orelse return error.NoRename1;
+    try std.testing.expectEqualStrings(a, b);
 }
 
-test "markScopeSubtree: leaf scope 은 자기 자신만 set" {
+test "mangle: scope-nesting 자식 binding 은 부모 slot 을 안 받음 (shadow 방지 #2956)" {
     const allocator = std.testing.allocator;
 
+    // scope tree: 0(root) → 1(func) → 2(block). outer=scope1, inner=scope2(자식).
     const scopes = [_]Scope{
         .{ .parent = .none, .kind = .global, .is_strict = false, .symbol_count = 0 },
-        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 0 },
+        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 1 },
+        .{ .parent = @enumFromInt(1), .kind = .block, .is_strict = false, .symbol_count = 1 },
     };
+    const symbols = [_]Symbol{
+        .{
+            .name = .{ .start = 0, .end = 0 },
+            .scope_id = @enumFromInt(1),
+            .origin_scope = @enumFromInt(1),
+            .kind = .variable_var,
+            .decl_flags = SymbolKind.variable_var.declFlags(),
+            .declaration_span = Span{ .start = 0, .end = 0 },
+            .reference_count = 5,
+            .synthetic_name = "outer",
+        },
+        .{
+            .name = .{ .start = 0, .end = 0 },
+            .scope_id = @enumFromInt(2),
+            .origin_scope = @enumFromInt(2),
+            .kind = .variable_let,
+            .decl_flags = SymbolKind.variable_let.declFlags(),
+            .declaration_span = Span{ .start = 0, .end = 0 },
+            .reference_count = 3,
+            .synthetic_name = "inner",
+        },
+    };
+    var s_root = std.StringHashMap(usize).init(allocator);
+    defer s_root.deinit();
+    var s1 = std.StringHashMap(usize).init(allocator);
+    defer s1.deinit();
+    try s1.put("outer", 0);
+    var s2 = std.StringHashMap(usize).init(allocator);
+    defer s2.deinit();
+    try s2.put("inner", 1);
+    const scope_maps = [_]std.StringHashMap(usize){ s_root, s1, s2 };
 
-    const children = try buildChildrenList(allocator, &scopes);
-    defer allocator.free(children.offsets);
-    defer allocator.free(children.list);
+    var result = try mangle(allocator, .{
+        .scopes = &scopes,
+        .symbols = &symbols,
+        .scope_maps = &scope_maps,
+        .references = &.{},
+        .source = "",
+    });
+    defer result.deinit();
 
-    var liveness = try std.DynamicBitSet.initEmpty(allocator, scopes.len);
-    defer liveness.deinit();
-
-    markScopeSubtree(&liveness, children, 1);
-    try std.testing.expect(liveness.isSet(1));
-    try std.testing.expect(!liveness.isSet(0));
+    // 자식 scope 의 inner 가 부모 outer 와 다른 slot → 다른 이름 (shadow 시 ReferenceError 방지).
+    const o = result.renames.get(0) orelse return error.NoRenameOuter;
+    const i = result.renames.get(1) orelse return error.NoRenameInner;
+    try std.testing.expect(!std.mem.eql(u8, o, i));
 }

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -52,13 +52,13 @@ pub const ManglerResult = struct {
 /// Mangler 호출 1회의 측정값. Unified mangler 로 마이그레이션 전/후의
 /// property 검증 (번들 크기 ± 1%, 이름 길이 총합 등) 에 사용.
 pub const ManglerStats = struct {
-    /// Phase 3 에서 생성된 고유 slot 수 (= 고유 base54 이름 수).
+    /// slot 할당(Phase 2+3)에서 생성된 고유 slot 수 (= 고유 base54 이름 수).
     slot_count: usize = 0,
     /// Phase 4 에서 할당된 slot 이름 길이의 합.
     slot_name_length_sum: usize = 0,
     /// Phase 4 종료 시점의 base54 name_counter 값 (예약어 스킵 포함 소비).
     name_counter_final: u32 = 0,
-    /// Phase 3 종료 시점의 reserved_names set 크기.
+    /// slot 할당 종료 시점의 reserved_names set 크기.
     reserved_size: usize = 0,
     /// Phase 5 후 renames 에 기록된 심볼 수 (원본과 동일하면 skip 되므로 slot_count 와 다를 수 있음).
     renamed_symbol_count: usize = 0,
@@ -73,8 +73,9 @@ pub const MangleInput = struct {
     scopes: []const Scope,
     symbols: []const Symbol,
     scope_maps: []const std.StringHashMap(usize),
-    /// Mangler 는 (symbol_id, scope_id) 만 소비. node_index/kind 필드는
-    /// dead store / property mangle 등 다른 consumer 용.
+    /// **scope-nesting 전환 후 mangle() 미사용** (과거 liveness graph-coloring 의 per-symbol
+    /// liveness 계산 입력이었음). slot 할당은 scope_maps + scope tree 만으로 결정. 호출처 호환
+    /// 및 다른 consumer(dead store / property mangle) 용으로 필드는 유지.
     references: []const Reference,
     source: []const u8,
     /// 번들 모드에서 mangling 제외할 symbol indices (null이면 없음)
@@ -246,12 +247,12 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
 }
 
 // ============================================================
-// Slot 할당 (Phase 2+3) — 공유 binding 수집 + 두 알고리즘
+// Slot 할당 (Phase 2+3) — binding 수집 + scope-nesting
 // ============================================================
 
 /// 한 scope 의 binding 을 수집해 `binding_buf` 에 채운다(sym_idx 오름차순 정렬).
 /// shouldSkip/blocksMangling/skip_symbols 로 mangle 제외 심볼은 제외하고, 출력에 남는
-/// 원본 이름은 `reserved_names` 에 등록. 신/구 slot 알고리즘이 공유 (동일 분류 보장).
+/// 원본 이름은 `reserved_names` 에 등록.
 fn collectScopeBindings(
     scope_idx: u32,
     scope_maps: []const std.StringHashMap(usize),
@@ -346,6 +347,10 @@ fn assignSlotsScopeNesting(
             const slot_id = local_slot;
             local_slot += 1;
             symbol_to_slot[sym_idx] = slot_id;
+            // slot_id 는 항상 0..N 연속 (start_slot ≤ slot_refs.len 상속 + 1 씩 증가) → 아래
+            // while 은 0/1 개만 append. gap 이 생기면 phantom slot 이 base54 이름을 낭비하므로
+            // 불변식을 assert 로 명문화 (start_slot 상속 로직 변경 시 회귀 가드).
+            std.debug.assert(slot_id <= slot_refs.items.len);
             while (slot_refs.items.len <= slot_id) try slot_refs.append(allocator, 0);
             slot_refs.items[slot_id] += symbols[sym_idx].reference_count;
         }
@@ -721,4 +726,64 @@ test "mangle: scope-nesting 자식 binding 은 부모 slot 을 안 받음 (shado
     const o = result.renames.get(0) orelse return error.NoRenameOuter;
     const i = result.renames.get(1) orelse return error.NoRenameInner;
     try std.testing.expect(!std.mem.eql(u8, o, i));
+}
+
+test "mangle: scope-nesting 깊이 3 — grandchild ≠ grandparent, cousin 은 재사용" {
+    const allocator = std.testing.allocator;
+
+    // scope tree: 0(root) → 1(func) → {2(block), 3(block)} ; 2 → 4(block).
+    //   gp@1, alpha@2, beta@3(=alpha 의 cousin), deepv@4(=gp 의 grandchild).
+    const scopes = [_]Scope{
+        .{ .parent = .none, .kind = .global, .is_strict = false, .symbol_count = 0 },
+        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 1 },
+        .{ .parent = @enumFromInt(1), .kind = .block, .is_strict = false, .symbol_count = 1 },
+        .{ .parent = @enumFromInt(1), .kind = .block, .is_strict = false, .symbol_count = 1 },
+        .{ .parent = @enumFromInt(2), .kind = .block, .is_strict = false, .symbol_count = 1 },
+    };
+    const names = [_][]const u8{ "gpvar", "alpha", "beta", "deepv" };
+    const decl_scopes = [_]u32{ 1, 2, 3, 4 };
+    var symbols: [4]Symbol = undefined;
+    for (&symbols, 0..) |*s, idx| {
+        s.* = .{
+            .name = .{ .start = 0, .end = 0 },
+            .scope_id = @enumFromInt(decl_scopes[idx]),
+            .origin_scope = @enumFromInt(decl_scopes[idx]),
+            .kind = .variable_var,
+            .decl_flags = SymbolKind.variable_var.declFlags(),
+            .declaration_span = Span{ .start = 0, .end = 0 },
+            .reference_count = 1,
+            .synthetic_name = names[idx],
+        };
+    }
+
+    var maps: [5]std.StringHashMap(usize) = undefined;
+    for (&maps) |*m| m.* = std.StringHashMap(usize).init(allocator);
+    defer for (&maps) |*m| m.deinit();
+    try maps[1].put("gpvar", 0);
+    try maps[2].put("alpha", 1);
+    try maps[3].put("beta", 2);
+    try maps[4].put("deepv", 3);
+
+    var result = try mangle(allocator, .{
+        .scopes = &scopes,
+        .symbols = &symbols,
+        .scope_maps = &maps,
+        .references = &.{},
+        .source = "",
+    });
+    defer result.deinit();
+
+    const gp = result.renames.get(0) orelse return error.NoGp;
+    const alpha = result.renames.get(1) orelse return error.NoAlpha;
+    const beta = result.renames.get(2) orelse return error.NoBeta;
+    const deepv = result.renames.get(3) orelse return error.NoDeep;
+
+    // cousin (alpha@2, beta@3): 같은 부모 slot 카운트 상속 → 같은 slot/이름.
+    try std.testing.expectEqualStrings(alpha, beta);
+    // grandchild(deepv@4) ≠ grandparent(gp@1): 부모 slot 이후 상속 → 다른 이름.
+    try std.testing.expect(!std.mem.eql(u8, deepv, gp));
+    // grandchild ≠ 자기 부모(alpha@2): deepv 는 alpha slot 이후.
+    try std.testing.expect(!std.mem.eql(u8, deepv, alpha));
+    // 부모(gp) ≠ 자식(alpha).
+    try std.testing.expect(!std.mem.eql(u8, gp, alpha));
 }

--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -103,7 +103,7 @@ pub const UnifiedMangleResult = struct {
     }
 };
 
-/// 단일 호출 mangler. Phase A (빈도순 base54) + Phase B (per-module liveness)
+/// 단일 호출 mangler. Phase A (빈도순 base54) + Phase B (per-module scope-nesting)
 /// 를 counter/reserved 공유 상태로 순차 실행.
 pub fn mangleAll(
     allocator: std.mem.Allocator,
@@ -252,7 +252,7 @@ pub fn mangleAll(
     };
 
     // ================================================================
-    // Phase B — per-module scope liveness
+    // Phase B — per-module scope-nesting slot 할당
     // ================================================================
     const phase_b_stats = try allocator.alloc(mangler.ManglerStats, input.modules.len);
     errdefer allocator.free(phase_b_stats);


### PR DESCRIPTION
## 요약

식별자 mangler 의 slot 할당이 **대용량 단일 모듈에서 O(N²)** 라 esbuild 대비 minify 가 170배 느렸습니다. esbuild/oxc 식 **scope-nesting slot 할당(O(N))** 으로 교체합니다.

esbuild head-to-head 실측 (typescript.js 9MB):
| 작업 | 교체 전 | esbuild | 교체 후 |
|---|---|---|---|
| `--minify-identifiers` | **35,054ms** | 205ms | **128ms** |
| transpile | 120ms | 208ms | 120ms |
| bundle / bundle+minify | 20ms | 16ms | 20ms |

→ transpile/bundle 은 원래 esbuild 와 대등/빠름. **대용량 단일파일 minify 만 O(N²) 절벽**이었고, 교체 후 **274배 빨라져 esbuild(205ms)보다도 빠름**.

## 근본 원인

`mangle()` Phase 3 가 per-symbol liveness BitSet graph-coloring first-fit. symbol 마다 기존 slot 전체를 `bitsetIntersects` 로 스캔하는데, slot 재사용 시 `setUnion` 으로 slot liveness 가 누적·광역화 → 새 symbol 마다 수천 broad slot 을 건너뜀. typescript.js 계측: scan_iters **3.5억 회** = 35초.

## 변경

- `mangle()` Phase 2+3 → `assignSlotsScopeNesting` (scope-tree DFS, 자식 scope 가 부모의 현재 slot 카운트를 상속 → 형제는 같은 slot 번호를 구성적으로 재사용(동시 live 불가, 충돌 0), 자식 binding 은 부모 slot 이후만 받아 closure-shadow 불가). liveness BitSet/graph-coloring 스캔 제거 → 선형.
- binding 수집/reserved 분류는 `collectScopeBindings` 로 추출. Phase 1(children) / Phase 4(빈도 naming) / Phase 5(renames) + `MangleInput`/`ManglerResult` API **무변경**.
- 레거시 liveness 경로(`assignSlotsLiveness`/`markScopeSubtree`/`markAncestorPath`/`bitsetIntersects`) **완전 삭제**. markScopeSubtree 단위테스트 → scope-nesting 동작 테스트(형제 재사용 / 부모-자식 shadow 방지 / 깊이-3 grandchild·cousin)로 교체.

net −48 LOC.

## 안전성 (핵심 논거)

scope-nesting 의 "자식 start_slot = 부모 local_slot" 가 기존 `markScopeSubtree`(#2956 closure-shadow 방지)를 **구성적으로 동치 재현** — 자식 binding 이 부모 slot 을 절대 안 받음. lexical scope 상 reference 는 항상 선언 scope 의 subtree 안이므로 삭제된 reference 기반 liveness 는 더 이상 불필요(신 모델이 동일하거나 더 보수적).

## 검증

- **byte-identical** (출력 동일): lodash-es/zod/rxjs/three/@reduxjs-toolkit × bundle/minify/splitting **15/15** (현재 vs origin/main). + code-review 검증에서 9 합성(shadow/closure/var-hoist/annex-B) + **250 실제 lib 파일** + 5 bundle 전부 byte-identical·런타임 정확. #2956 으로 두 알고리즘이 같은 slot 배정에 수렴.
- **smoke** runtime MATCH: 신규 회귀 **0** (기존 d3/typedi/semver@es5 만), corpus size diff **0**, summary 동일(1.07x, 28/84/30).
- Debug + ReleaseFast 유닛 테스트 + `zig build wasm`(WASI) 통과.
- **code-review max**: 확정 correctness 버그 0. 대응으로 stale 주석 정정 + slot 연속성 debug assert + depth-3 테스트 추가.

## 관련

[[project_mangler_largefile_on2_perf]] (esbuild head-to-head 진단). 과거 nested-scope-renamer 이식(PR #3393/#3395)은 *size 감소* 목표였고 +174B 로 NO-GO 됐으나, 본 PR 은 *speed* 목표 + **byte-identical**(size diff 0)이라 그 게이트와 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)