### PR TITLE
fix(build): lib/exe 테스트 바이너리 직렬 실행으로 CI flaky 제거

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -168,6 +168,12 @@ pub fn build(b: *std.Build) void {
 
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
 
+    // lib/exe 테스트 바이너리를 직렬 실행. 둘을 병렬로 돌리면 CI runner 자원 경합 +
+    // `.zig-cache/tmp` 임시파일 race 로 무관 테스트가 seed-랜덤하게 spurious fail 한다
+    // (예: profile.snapshotToJson, parser.ast_walk_test). exe 가 lib 완료 후 돌게 해
+    // 한 번에 한 테스트 프로세스만 실행되도록 강제한다.
+    run_exe_unit_tests.step.dependOn(&run_lib_unit_tests.step);
+
     // Similar to creating the run step earlier, this exposes a `test` step to
     // the `zig build --help` menu, providing a way for the user to request
     // running the unit tests.


### PR DESCRIPTION
## 배경

CI `Debug Test` job 의 `zig build test` 에서 `profile.test.snapshotToJson: min_ms_threshold` 가 1건 실패하고 `parser.ast_walk_test.bindingIdentifiers` 가 동반 실패하는 현상이 보고됨.

조사 결과:
- 최신 main 기준 `zig build test` **로컬 3회 연속 통과**, 해당 테스트 `-Dtest-filter` 단독도 통과
- `snapshotToJson` 테스트는 고정값(`parse=5ms`, `emit=0.1ms`, threshold=`1.0ms`) 사용 → timing 의존 없는 **결정적 로직**. `emit` 은 `0.1 < 1.0` 으로 정확히 skip 됨
- 즉 코드 버그가 아니라 **flaky CI 실패**. seed(`0x18ec5de5`) 랜덤 순서 탓에 victim 테스트가 매번 바뀜

## 원인

`build.zig` 의 `test` 스텝이 `run_lib_unit_tests` 와 `run_exe_unit_tests` 두 테스트 바이너리에 모두 의존하지만 둘 사이엔 의존이 없어, Zig 빌드 러너가 **두 프로세스를 동시 실행**한다. CI runner 자원 경합 + `.zig-cache/tmp` 임시파일 race 로 무관 테스트가 spurious fail 한다.

## 변경

`run_exe_unit_tests` 가 `run_lib_unit_tests` 완료 후 실행되도록 의존 edge 추가 → 한 번에 테스트 프로세스 1개만 실행.

## Trade-off

- 두 바이너리가 직렬로 돌아 약간 느려짐 (수용 가능)
- `run_lib` 가 fail 하면 `run_exe` 는 skip — 단 false-pass 는 없음(실패를 숨기지 않음). flake 제거 대비 수용 가능

## Test plan

- [x] `zig build test` 로컬 통과 (직렬화 적용 후 EXIT=0)
- [x] `zig build test -Dtest-filter="snapshotToJson"` 단독 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)