### PR TITLE
fix(bundler): shared namespace var 이름을 module_index rank 로 결정화 (#3966)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -281,6 +281,13 @@ pub const Linker = struct {
     ns_shared_inline_cache: std.AutoHashMapUnmanaged(u32, SharedNsInline) = .{},
     ns_shared_inline_order: std.ArrayListUnmanaged(u32) = .empty,
     ns_shared_var_names: std.StringHashMapUnmanaged(void) = .{},
+    /// (#3966) shared namespace var 이름의 결정적 충돌 해소. 같은 sanitized
+    /// base (예: 서로 다른 디렉터리의 `core.js`) 를 갖는 모듈들 중 module_index
+    /// (renumber 후 path-sorted, 결정적) 순서의 rank. rank>0 인 모듈만 저장
+    /// (충돌 희소) — 부재 시 rank 0. 병렬 emit 의 first-come-first-served
+    /// 이름 claim 이 `core_ns`/`core_ns_2` 를 run 마다 뒤바꾸던 비결정 제거.
+    ns_base_rank: std.AutoHashMapUnmanaged(u32, u32) = .{},
+    ns_base_rank_built: bool = false,
     /// computeCrossChunkLinks(메타데이터 前 실행, chunk graph 보유)가 채우는
     /// "정의자 청크가 다른" namespace re-export target 집합. registerNamespace
     /// Rewrites 는 metadata 시점에 chunk 정보가 없으므로 이 집합으로 shared
@@ -425,6 +432,7 @@ pub const Linker = struct {
         self.ns_shared_inline_cache.deinit(self.allocator);
         self.ns_shared_inline_order.deinit(self.allocator);
         self.ns_shared_var_names.deinit(self.allocator);
+        self.ns_base_rank.deinit(self.allocator);
         self.ns_cross_chunk_targets.deinit(self.allocator);
         // #1791 fatal diag message 해제 (allocPrint owned)
         for (self.fatal_diagnostics.items) |d| self.allocator.free(d.message);

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -341,7 +341,9 @@ fn getOrCreateSharedNamespaceVar(
         return raced.var_name;
     }
 
-    const fresh = try makeUniqueSharedNsVarNameLocked(mutable_self, base_name, seen_exports);
+    try ensureNsBaseRank(mutable_self);
+    const rank = mutable_self.ns_base_rank.get(target_mod_idx) orelse 0;
+    const fresh = try makeUniqueSharedNsVarNameLocked(mutable_self, base_name, rank, seen_exports);
     errdefer self.allocator.free(fresh);
     try mutable_self.ns_shared_inline_order.append(self.allocator, target_mod_idx);
     errdefer _ = mutable_self.ns_shared_inline_order.pop();
@@ -644,15 +646,56 @@ fn makeSharedNamespaceBaseName(self: *const Linker, target_mod_idx: u32) std.mem
     return buf.toOwnedSlice(self.allocator);
 }
 
+/// (#3966) sanitized base 가 같은 모듈들의 결정적 rank 를 1회 계산해 캐싱.
+/// renumber(#3564) 후 module_index 는 path-sorted 라 0..moduleCount 순회가
+/// 결정적. rank>0 (충돌) 인 모듈만 map 에 저장 — 부재 시 rank 0.
+/// 호출처(getOrCreateSharedNamespaceVar)가 `ns_cache_mutex` 를 보유한 상태에서
+/// 부르므로 별도 락 불필요.
+fn ensureNsBaseRank(self: *Linker) std.mem.Allocator.Error!void {
+    if (self.ns_base_rank_built) return;
+    self.ns_base_rank_built = true;
+
+    var counts = std.StringHashMap(u32).init(self.allocator);
+    defer {
+        var it = counts.keyIterator();
+        while (it.next()) |k| self.allocator.free(k.*);
+        counts.deinit();
+    }
+
+    const n: u32 = @intCast(self.graph.moduleCount());
+    var idx: u32 = 0;
+    while (idx < n) : (idx += 1) {
+        const base = try makeSharedNamespaceBaseName(self, idx);
+        defer self.allocator.free(base);
+        const gop = try counts.getOrPut(base);
+        if (!gop.found_existing) {
+            gop.key_ptr.* = try self.allocator.dupe(u8, base);
+            gop.value_ptr.* = 0;
+        }
+        const rank = gop.value_ptr.*;
+        gop.value_ptr.* = rank + 1;
+        if (rank > 0) {
+            try self.ns_base_rank.put(self.allocator, idx, rank);
+        }
+    }
+}
+
+/// rank 0 → `{base}_ns`, rank N>0 → `{base}_ns_{N+1}` (예: `core_ns`, `core_ns_2`).
+/// rank 가 target 의 module_index 로 결정되므로 병렬 materialize 순서와 무관 (#3966).
+/// 잔여 충돌(target 자체 export 와 동명 등 희소 케이스)은 결정적으로 증가.
 fn makeUniqueSharedNsVarNameLocked(
     self: *Linker,
     base: []const u8,
+    rank: u32,
     seen_exports: *std.StringHashMap(void),
 ) std.mem.Allocator.Error![]const u8 {
-    var candidate = try std.fmt.allocPrint(self.allocator, "{s}_ns", .{base});
+    var candidate = if (rank == 0)
+        try std.fmt.allocPrint(self.allocator, "{s}_ns", .{base})
+    else
+        try std.fmt.allocPrint(self.allocator, "{s}_ns_{d}", .{ base, rank + 1 });
     if (!seen_exports.contains(candidate) and !self.ns_shared_var_names.contains(candidate)) return candidate;
 
-    var i: usize = 2;
+    var i: usize = if (rank == 0) 2 else rank + 2;
     while (true) : (i += 1) {
         self.allocator.free(candidate);
         candidate = try std.fmt.allocPrint(self.allocator, "{s}_ns_{d}", .{ base, i });
@@ -971,4 +1014,65 @@ test "G1-step2: 복잡 VAL (call/string/depth) depth-track 보존" {
             "f:()=>t,g:()=>u,h:()=>v,\"q-x\":()=>w}",
         got,
     );
+}
+
+// ================================================================
+// #3966: shared namespace var 이름의 rank 기반 결정성 회귀 가드.
+// rank 는 target 의 module_index(path-sorted) 로 결정되므로 병렬 emit
+// materialize 순서와 무관하게 같은 base 의 충돌이 항상 같은 suffix 로 풀린다.
+// ================================================================
+
+fn testEmptyLinker(a: std.mem.Allocator, cache: *@import("../resolve_cache.zig").ResolveCache, graph: *@import("../graph.zig").ModuleGraph) Linker {
+    cache.* = @import("../resolve_cache.zig").ResolveCache.init(a, .{});
+    graph.* = @import("../graph.zig").ModuleGraph.init(a, cache);
+    return Linker.init(a, graph, .esm);
+}
+
+test "#3966: rank → 결정적 ns var 이름 (rank 0 base_ns, rank N base_ns_{N+1})" {
+    const a = std.testing.allocator;
+    var cache: @import("../resolve_cache.zig").ResolveCache = undefined;
+    var graph: @import("../graph.zig").ModuleGraph = undefined;
+    var linker = testEmptyLinker(a, &cache, &graph);
+    defer linker.deinit();
+    defer graph.deinit();
+    defer cache.deinit();
+
+    var seen = std.StringHashMap(void).init(a);
+    defer seen.deinit();
+
+    // 같은 base("core") 의 rank 0/1/2 → core_ns / core_ns_2 / core_ns_3.
+    // 발급 순서를 일부러 rank 역순(2→0→1)으로 호출해도 rank 만으로 이름이
+    // 결정됨을 검증 (materialize 순서 무관성 = #3966 핵심).
+    const n2 = try makeUniqueSharedNsVarNameLocked(&linker, "core", 2, &seen);
+    defer a.free(n2);
+    try std.testing.expectEqualStrings("core_ns_3", n2);
+    try linker.ns_shared_var_names.put(a, n2, {});
+
+    const n0 = try makeUniqueSharedNsVarNameLocked(&linker, "core", 0, &seen);
+    defer a.free(n0);
+    try std.testing.expectEqualStrings("core_ns", n0);
+    try linker.ns_shared_var_names.put(a, n0, {});
+
+    const n1 = try makeUniqueSharedNsVarNameLocked(&linker, "core", 1, &seen);
+    defer a.free(n1);
+    try std.testing.expectEqualStrings("core_ns_2", n1);
+}
+
+test "#3966: target 자체 export 와 동명 충돌 시 결정적 증가" {
+    const a = std.testing.allocator;
+    var cache: @import("../resolve_cache.zig").ResolveCache = undefined;
+    var graph: @import("../graph.zig").ModuleGraph = undefined;
+    var linker = testEmptyLinker(a, &cache, &graph);
+    defer linker.deinit();
+    defer graph.deinit();
+    defer cache.deinit();
+
+    var seen = std.StringHashMap(void).init(a);
+    defer seen.deinit();
+    // 모듈이 `x_ns` 라는 이름을 직접 export → rank 0 후보(x_ns) 충돌 → x_ns_2 로 증가.
+    try seen.put("x_ns", {});
+
+    const got = try makeUniqueSharedNsVarNameLocked(&linker, "x", 0, &seen);
+    defer a.free(got);
+    try std.testing.expectEqualStrings("x_ns_2", got);
 }

--- a/tests/integration/tests/determinism.test.ts
+++ b/tests/integration/tests/determinism.test.ts
@@ -95,4 +95,12 @@ describe('build determinism (#3564)', () => {
   test('code-splitting — manualChunks + dynamic', async () => {
     await expectDeterministic('code-splitting', 'index.js', ['--splitting'], 'outdir');
   });
+
+  // #3966: 서로 다른 디렉터리의 동일 basename(core/patch) 모듈을 namespace 로
+  // import + 값 사용 → shared-ns 객체 변수(core_ns/core_ns_2/...) 발급. 병렬
+  // emit 에서 이 이름의 base/suffix 배정이 first-come 비결정이었음. rank(=path-
+  // sorted module_index) 기반 배정으로 결정화.
+  test('ns-base-collision — 동일 basename namespace 값 사용 (#3966)', async () => {
+    await expectDeterministic('ns-base-collision', 'index.js');
+  });
 });

--- a/tests/integration/tests/fixtures/determinism/ns-base-collision/a/core.js
+++ b/tests/integration/tests/fixtures/determinism/ns-base-collision/a/core.js
@@ -1,0 +1,4 @@
+export const id = 'a-core';
+export function make(x) {
+  return { tag: id, value: x };
+}

--- a/tests/integration/tests/fixtures/determinism/ns-base-collision/a/patch.js
+++ b/tests/integration/tests/fixtures/determinism/ns-base-collision/a/patch.js
@@ -1,0 +1,4 @@
+export const name = 'a-patch';
+export function apply(o) {
+  return { ...o, patched: name };
+}

--- a/tests/integration/tests/fixtures/determinism/ns-base-collision/b/core.js
+++ b/tests/integration/tests/fixtures/determinism/ns-base-collision/b/core.js
@@ -1,0 +1,4 @@
+export const id = 'b-core';
+export function make(x) {
+  return { tag: id, value: x * 2 };
+}

--- a/tests/integration/tests/fixtures/determinism/ns-base-collision/b/patch.js
+++ b/tests/integration/tests/fixtures/determinism/ns-base-collision/b/patch.js
@@ -1,0 +1,4 @@
+export const name = 'b-patch';
+export function apply(o) {
+  return { ...o, patched: name, extra: true };
+}

--- a/tests/integration/tests/fixtures/determinism/ns-base-collision/c/core.js
+++ b/tests/integration/tests/fixtures/determinism/ns-base-collision/c/core.js
@@ -1,0 +1,4 @@
+export const id = 'c-core';
+export function make(x) {
+  return { tag: id, value: x + 100 };
+}

--- a/tests/integration/tests/fixtures/determinism/ns-base-collision/index.js
+++ b/tests/integration/tests/fixtures/determinism/ns-base-collision/index.js
@@ -1,0 +1,19 @@
+// #3966 회귀: 서로 다른 디렉터리의 동일 basename(`core`/`patch`) 모듈을
+// namespace 로 import 하고 *값으로* 사용한다. 값 사용이 shared-ns inline
+// 객체 materialize 를 강제(force_inline) → `core_ns`/`core_ns_2`/... 변수명이
+// 발급된다. 병렬 emit 에서 이 이름의 base/suffix 배정이 비결정이었음(#3966).
+import * as coreA from './a/core.js';
+import * as coreB from './b/core.js';
+import * as coreC from './c/core.js';
+import * as patchA from './a/patch.js';
+import * as patchB from './b/patch.js';
+
+// namespace 객체를 값으로 노출 → inline materialize 강제.
+const registry = [coreA, coreB, coreC, patchA, patchB];
+
+export function run(x) {
+  let acc = coreA.make(x);
+  acc = patchA.apply(acc);
+  acc = patchB.apply(coreB.make(x));
+  return { acc, c: coreC.make(x), n: registry.length };
+}


### PR DESCRIPTION
## 요약
`zntc --bundle`(non-minify) 로 **effect** 를 번들하면 출력이 비결정적이던 버그(#3966)를 수정합니다. 동일 바이너리·입력 10회에 3개 해시(size ~262B 변동)가 나오던 문제입니다.

## 루트 코즈
- shared namespace 객체 변수명(`core_ns`)이 병렬 emit 의 `buildMetadataForAst`(`emitModuleThread`) 에서 `ns_cache_mutex` 하 **first-come-first-served** 로 claim 됩니다.
- 서로 다른 디렉터리의 동일 basename 모듈(effect 의 `core`/`patch` 2쌍)이 base 이름을 두고 경쟁 → 어느 스레드가 먼저 닿느냐에 따라 `core_ns` ↔ `core_ns_2` 가 run 마다 뒤바뀜.
- emit 단계의 `std.Thread.Pool` 은 `--jobs` 로 제어되지 않아(기본 CPU 수) `--jobs=1` 에서도 재현됩니다. worker race 로 오인하기 쉬운 함정.
- `#3564` determinism epic 이 mangler / bundleOrder / graph renumber 는 tie-break 했으나 **shared-ns 변수 네이밍은 누락**했습니다.

## 변경
같은 sanitized base 를 가진 모듈들에 `module_index`(renumber 후 path-sorted = 결정적) 순서의 **rank** 를 1회 계산(`ensureNsBaseRank`)해서:
- rank 0 → `{base}_ns`
- rank N>0 → `{base}_ns_{N+1}`

로 배정합니다. materialize 순서와 무관하게 이름이 고정됩니다. **충돌이 없는 lib 은 rank 0 → 기존 `{base}_ns` 이름 그대로**라 byte-identical 이 유지됩니다.

## 검증
- effect: **12/12 동일** (multi-thread + `--jobs=1`, 이전 3 해시)
- 결정적 lib **byte-identical vs main**: lodash-es / zod / rxjs / three / @reduxjs-toolkit ✅
- effect ESM 런타임: 크래시·ReferenceError 없음, 구문 OK
- `zig build test` exit 0, determinism 통합 6/6(신규 fixture 포함), export-star/cross-chunk 25/25, bundle-smoke 151/151

## Test plan
- [x] effect 10회+ 해시 단일화 (multi/single thread)
- [x] 5개 결정적 lib byte-identical vs main
- [x] rank→name 결정성 유닛테스트 2개 (`shared_namespace.zig`)
- [x] `ns-base-collision` determinism 통합 fixture
- [x] 전체 유닛 + bundle-smoke 회귀 0

Closes #3966

🤖 Generated with [Claude Code](https://claude.com/claude-code)