### PR TITLE
fix(bundler): unresolved import 진단 중복 출력 제거 (#3973)

### DIFF
--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -166,7 +166,7 @@ pub fn shouldLinkResolvedRecordForModule(self: anytype, mod_idx: usize, rec_i: u
 }
 
 pub fn shouldResolveRecordForModule(self: anytype, mod_idx: usize, rec_i: usize, record: ImportRecord) bool {
-    if (record.resolved != .none or record.is_external) return false;
+    if (record.resolved != .none or record.is_external or record.resolve_failed) return false;
     return shouldLinkResolvedRecordForModule(self, mod_idx, rec_i, record);
 }
 

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -282,6 +282,10 @@ pub fn applyResolveResult(
         }
         const sev: types.BundlerDiagnostic.Severity = if (record.kind == .dynamic_import) .warning else .@"error";
         self.addDiag(.unresolved_import, sev, self.modules.at(mod_idx).path, record.span, .resolve, "Cannot resolve module", record.specifier);
+        // 실패 확정 마킹 — 성공(recordResolvedDep 가 resolved 설정)·external 과 동일하게
+        // "재resolve 불필요" 상태로 둬야 shouldResolveRecordForModule/resolveModuleImports
+        // 가 이 record 를 다시 resolve(+ 중복 진단)하지 않는다.
+        self.modules.at(mod_idx).import_records[rec_i].resolve_failed = true;
         return;
     }
 
@@ -448,7 +452,7 @@ pub fn resolveModuleImports(self: *ModuleGraph, idx: ModuleIndex) !void {
                 continue;
             }
         }
-        if (record.resolved != .none or record.is_external) continue;
+        if (record.resolved != .none or record.is_external or record.resolve_failed) continue;
         const should_link = graph_requested_exports.shouldLinkResolvedRecordForModule(self, mod_idx, rec_i, record);
 
         // Plugin: resolveId 훅 — 기본 resolver 전에 플러그인에게 경로 해석 기회를 줌

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -255,6 +255,34 @@ test "graph: unresolved import — error diagnostic" {
     try std.testing.expect(has_unresolved);
 }
 
+test "graph: unresolved import — 진단 1회만 (중복 방지 회귀)" {
+    // #3966 후속: hard-error 로 실패한 record 는 resolve_failed 로 마킹되어
+    // applyScanResult 의 직접 호출 + 후속 resolveModuleImports 양쪽에서 재처리되지
+    // 않는다. value usage 가 있어 hard-error 경로(soft-fail 아님)를 타게 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import x from './nonexistent';\nconsole.log(x);");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "a.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{entry});
+
+    // 같은 unresolved import 에 대한 error 진단은 정확히 1개여야 한다 (중복 출력 버그 가드).
+    var unresolved_errors: usize = 0;
+    for (graph.diagnostics.items) |d| {
+        if (d.code == .unresolved_import and d.severity == .@"error") unresolved_errors += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), unresolved_errors);
+}
+
 test "graph: unresolved type-only import — soft fail with warning (#2466)" {
     // react-native-screens/types 패턴: subpath 가 .d.ts 만 export 하므로 resolve 실패하지만
     // X 가 type position 에서만 쓰이면 babel typescript preset 처럼 statement 통째 elide

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -678,6 +678,11 @@ pub const ImportRecord = struct {
     is_lazy_resolved: bool = false,
     /// --external로 명시적으로 제외된 모듈 (resolve 실패와 구분)
     is_external: bool = false,
+    /// resolve 가 hard-error 로 확정 실패한 record. 성공(resolved 설정)·external·
+    /// lazy 와 마찬가지로 "재resolve 불필요" 상태 마커. 이게 없으면
+    /// shouldResolveRecordForModule / resolveModuleImports 가 resolved==.none 만 보고
+    /// 이미 실패 처리된 record 를 미처리로 오판해 재resolve → 진단 중복 출력 (#3966 후속).
+    resolve_failed: bool = false,
     /// try-block 안의 `require("xxx")` 또는 동적 `import("xxx")` —
     /// resolve 실패 시 hard error 가 아니라 warning 으로 격하하고 stub 으로 대체.
     /// follow-redirects/debug.js 같은 Metro 식 optional dep 패턴 지원


### PR DESCRIPTION
## 요약
해석 불가능한 모듈을 import 하면 `[error] Cannot resolve module` 진단이 **2번 중복 출력**되던 버그를 수정합니다 (ESM/CJS/IIFE 공통).

## 루트 코즈
`applyResolveResult` 가 같은 (mod, rec) 에 **2번** 호출됩니다 (임시 계측으로 확정):
1. `applyScanResult` 가 worker resolve 결과를 적용 → `applyResolveResult(is_error=true)` → `addDiag` #1. 단 hard-error 분기는 record 를 갱신 없이 `return`.
2. 이어 `resolveModuleImports` 호출 → `shouldResolveRecordForModule`(requested_exports.zig:169) / `resolveModuleImports`(resolve_imports.zig:455) 의 게이트가 `record.resolved != .none or record.is_external` 만 봅니다. hard-error record 는 `resolved==.none` 이라 "미처리" 로 오판 → 재resolve → `addDiag` #2.

성공(`recordResolvedDep` 가 `resolved` 설정)·external·lazy 케이스는 record 가 마킹되어 재처리를 피하는데, **hard-error 만 마킹이 누락된 비대칭**입니다.

## 변경
`ImportRecord.resolve_failed` 플래그를 추가해 hard-error 를 `is_external`/`is_lazy_resolved` 와 동일하게 "재resolve 불필요" 상태로 마킹하고, 두 게이트에서 함께 skip 합니다.

- `is_external` 같은 기존 마커 패턴과 일관 (default false → 새 record 안전)
- `resolved` 를 건드리지 않으므로 IIFE 의 "cannot be emitted in IIFE format" 후속 진단 등 기존 동작 보존

## 검증
- ESM / CJS / IIFE 모두 `Cannot resolve module` **1회**
- 다중 unresolved → 각 1회, optional dep → warning 1회
- 정상 빌드 회귀 0 (semver/lodash-es/zod/rxjs byte 안정), exit code(1) 유지
- `zig build test` exit 0, resolve/determinism 통합 22/22, bundle-smoke 151/151
- `graph_test.zig` 에 진단 count==1 회귀 가드 추가

## Test plan
- [x] 포맷별(ESM/CJS/IIFE) 진단 1회 확인
- [x] 다중 unresolved / optional / 정상 빌드 회귀
- [x] graph_test 진단 count==1 유닛 가드
- [x] 통합 + bundle-smoke 회귀 0

Closes #3973

🤖 Generated with [Claude Code](https://claude.com/claude-code)