### PR TITLE
fix(bundler): non-literal dynamic import 진단을 reason 메시지로 통일 + #3973 회귀 수정 (#3984)

### DIFF
--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -227,6 +227,24 @@ pub fn applyResolveResult(
     is_error: bool,
 ) !void {
     const mod_index = ModuleIndex.fromUsize(mod_idx);
+    // (#3984) 비-literal dynamic import(`import(x)`)는 parser 가 dynamic_invalid_reason
+    // 을 설정해 둔 *의도된 비해석* 레코드다. worker scan 은 빈 specifier("") 로
+    // resolve 를 시도하는데, 그 결과가 (a) native resolve 실패 → is_error, (b)
+    // `--packages=external`/`--external` 에서 isExternal("")=true → is_error=false 인데
+    // phantom external 로 link, (c) resolveId plugin 이 ""를 resolve → 잘못된 모듈 link
+    // 로 갈라진다. 어느 경우든 generic "Cannot resolve module" 나 잘못된 link 대신 그
+    // reason 을 warning 으로 emit + passthrough 해야 한다. 따라서 is_error 분기 *이전*
+    // 에 일괄 처리한다(altitude: 세 경로를 한 곳으로 수렴). resolved 를 채우지 않고
+    // return → codegen 이 원본 import() 를 native passthrough. resolve_failed 마킹으로
+    // resolveModuleImports 의 동형 분기가 중복 emit 하지 않게 한다(단일 경고).
+    if (record.dynamic_invalid_reason) |reason| {
+        const rec_ptr = &self.modules.at(mod_idx).import_records[rec_i];
+        if (!rec_ptr.resolve_failed) {
+            self.addDiag(.unresolved_import, .warning, self.modules.at(mod_idx).path, record.span, .resolve, reason, null);
+            rec_ptr.resolve_failed = true;
+        }
+        return;
+    }
     if (is_error) {
         // Worker resolve 실패 → 경고만 (메인 빌드 중단하지 않음)
         if (record.kind == .worker) {
@@ -448,7 +466,15 @@ pub fn resolveModuleImports(self: *ModuleGraph, idx: ModuleIndex) !void {
             if (record.dynamic_invalid_reason) |reason| {
                 // 비-literal dynamic import: warning 후 resolved=.none 유지 →
                 // chunk/codegen 무시(원본 import() 네이티브 passthrough).
-                self.addDiag(.unresolved_import, .warning, module_path, record.span, .resolve, reason, null);
+                // (#3984) worker-scan 경로(applyResolveResult)가 이미 진단했으면
+                // resolve_failed 가 set 되어 있다 → 중복 emit 방지. worker scan 을
+                // 거치지 않고 직접 도달한 fallback 경로만 여기서 emit 하되, 여기서도
+                // resolve_failed 를 set 해 (applyResolveResult 와 대칭) resolveModuleImports
+                // 재진입(lazy re-export barrel 타깃이 ready 후 재방문)에서 중복 emit 을 막는다.
+                if (!record.resolve_failed) {
+                    self.addDiag(.unresolved_import, .warning, module_path, record.span, .resolve, reason, null);
+                    mod_ptr.import_records[rec_i].resolve_failed = true;
+                }
                 continue;
             }
         }

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -283,6 +283,40 @@ test "graph: unresolved import — 진단 1회만 (중복 방지 회귀)" {
     try std.testing.expectEqual(@as(usize, 1), unresolved_errors);
 }
 
+test "graph: non-literal dynamic import — string-literal reason warning 1회 (#3984)" {
+    // 비-literal `import(name)` 은 generic "Cannot resolve module" 가 아니라
+    // dynamic_invalid_reason("...string literal specifier...") warning 을 정확히
+    // 1회 emit 해야 한다. (#3973 의 resolve_failed 마킹이 worker-scan 경로에서
+    // 올바른 메시지를 죽이던 회귀 가드.)
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "const name = './mod';\nexport const p = import(name);\nconsole.log('entry');");
+    try writeFile(tmp.dir, "mod.ts", "export default 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "a.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    try graph.build(&.{entry});
+
+    var reason_warnings: usize = 0;
+    var generic_cannot_resolve: usize = 0;
+    for (graph.diagnostics.items) |d| {
+        if (d.code != .unresolved_import) continue;
+        if (std.mem.indexOf(u8, d.message, "string literal") != null) reason_warnings += 1;
+        if (std.mem.eql(u8, d.message, "Cannot resolve module")) generic_cannot_resolve += 1;
+    }
+    // 정확히 1회의 reason warning, generic 메시지는 0회.
+    try std.testing.expectEqual(@as(usize, 1), reason_warnings);
+    try std.testing.expectEqual(@as(usize, 0), generic_cannot_resolve);
+}
+
 test "graph: unresolved type-only import — soft fail with warning (#2466)" {
     // react-native-screens/types 패턴: subpath 가 .d.ts 만 export 하므로 resolve 실패하지만
     // X 가 type position 에서만 쓰이면 babel typescript preset 처럼 statement 통째 elide


### PR DESCRIPTION
## 요약
비-literal `import(x)` 의 진단을 `applyResolveResult` 최상단에서 일괄 처리해 **단일 reason 경고 + native passthrough** 로 통일합니다. 더불어 **CI 회귀(#3973 가 유발)** 를 함께 수정합니다.

## 배경 — CI 회귀의 진짜 원인
`tests/dynamic-import-non-literal.test.ts` 2건이 CI(fresh 빌드)에서 실패했습니다. 조사 결과:
- 비-literal dynamic import 의 올바른 경고("...string literal specifier...")는 `resolveModuleImports` 가 emit.
- **#3973 가 추가한 `resolve_failed` 마킹**이 worker-scan 의 `applyResolveResult` 에서 dynamic 레코드에도 찍혀 → `shouldResolveRecordForModule`=false → `hasDeferredRequestedImports`=false → `resolveModuleImports` 미호출 → 올바른 메시지 소실, generic `Cannot resolve module (did you mean ''?)` 만 남음.
- 로컬 `packages/core/zntc.node` 가 stale(#3973 이전)이라 미검출, CI fresh 빌드서 발현. main(60b48597)에서 NAPI 재빌드로 동일 재현 확인 → **#3980(직전 PR) 회귀 아님**.

## 루트 코즈 (버그 #10)
worker scan 이 빈 specifier `""` 로 resolve 를 시도해 세 갈래로 분기:
- (a) native 실패 → `is_error` → generic "Cannot resolve module" (버그)
- (b) `--packages=external`/`--external` → `isExternal("")=true` → phantom external link + **경고 완전 소실**
- (c) resolveId plugin 이 `""` resolve → 잘못된 모듈 link

## 변경
`applyResolveResult` 의 `is_error` 분기 **이전**에 `dynamic_invalid_reason` 을 일괄 처리(reason warning 1회 + `resolve_failed` 마킹 + early return, resolved 안 채움 → codegen native passthrough). 세 경로를 한 곳으로 수렴(altitude). `resolveModuleImports` 의 동형 분기도 emit 후 `resolve_failed` 를 set 해 대칭화(재진입 중복 방지).

## 검증
- 일반 / `--packages=external` / `--external='*'` 3경로 모두 **reason warning 1회 + `import()` passthrough**, generic 메시지 0
- #3973 dedup(unresolved module 단일) 유지
- `zig build test` exit 0, `dynamic-import-non-literal` 통합 **3/3**(이전 1/3), resolve/bundle-dynamic 통합 29/29
- graph_test 에 reason-warning 1회 회귀 가드 추가

## 리뷰
`/code-review max` + deep 적대적 재검증(2 에이전트) 수행. altitude 발견(external/plugin 엣지) → 상단-이동으로 해소, 비대칭 발견(resolveModuleImports `resolve_failed` 미설정) → 대칭화로 해소.

Closes #3984

🤖 Generated with [Claude Code](https://claude.com/claude-code)