### PR TITLE
fix(lexer): string literal \u{} 이스케이프 범위초과 검사 추가 (#3980)

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -1680,19 +1680,30 @@ pub const Scanner = struct {
                     'u' => {
                         self.current += 1;
                         if (self.peek() == '{') {
-                            // \u{H...H} — 가변 길이, 각 문자가 hex digit이어야 함
+                            // \u{H...H} — 가변 길이, 각 문자가 hex digit이어야 하고 값 ≤ 0x10FFFF.
+                            // (#3980) 범위초과 검사가 빠져 "\u{110000}" 같은 invalid escape 가
+                            // 통과하던 버그 수정 — template 경로(scanTemplateContent)와 동일 검증.
                             self.current += 1;
                             var has_hex = false;
+                            var code_point: u32 = 0;
+                            var overflow = false;
                             while (!self.isAtEnd() and self.peek() != '}') {
                                 const hc = self.peek();
-                                if ((hc >= '0' and hc <= '9') or (hc >= 'a' and hc <= 'f') or (hc >= 'A' and hc <= 'F')) {
-                                    has_hex = true;
-                                    self.current += 1;
-                                } else {
+                                const digit: u32 = if (hc >= '0' and hc <= '9')
+                                    hc - '0'
+                                else if (hc >= 'a' and hc <= 'f')
+                                    hc - 'a' + 10
+                                else if (hc >= 'A' and hc <= 'F')
+                                    hc - 'A' + 10
+                                else
                                     return .syntax_error; // non-hex (예: '_' numeric separator)
-                                }
+                                has_hex = true;
+                                if (code_point > 0x10FFFF) overflow = true;
+                                code_point = (code_point << 4) | digit;
+                                self.current += 1;
                             }
                             if (!has_hex) return .syntax_error;
+                            if (overflow or code_point > 0x10FFFF) return .syntax_error; // 범위초과 (#3980)
                             if (!self.isAtEnd()) self.current += 1; // consume '}'
                         } else {
                             // \uHHHH — 고정 4자리

--- a/src/lexer/scanner_test.zig
+++ b/src/lexer/scanner_test.zig
@@ -715,6 +715,25 @@ test "Scanner: string with unicode escape \\u{}" {
     try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
 }
 
+test "Scanner: string \\u{10FFFF} (유효 max codepoint) → string_literal (#3980)" {
+    const source = "'\\u{10FFFF}'";
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+
+    try scanner.next();
+    try std.testing.expectEqual(Kind.string_literal, scanner.token.kind);
+}
+
+test "Scanner: string \\u{110000} (범위초과) → syntax_error (#3980)" {
+    // 0x110000 > 0x10FFFF. 이전엔 has_hex 만 검사해 silent 통과 → invalid JS emit.
+    const source = "'\\u{110000}'";
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+
+    try scanner.next();
+    try std.testing.expectEqual(Kind.syntax_error, scanner.token.kind);
+}
+
 test "Scanner: string with escaped quote" {
     const source = "'it\\'s'";
     var scanner = try Scanner.init(std.testing.allocator, source);


### PR DESCRIPTION
## 요약
문자열 리터럴의 범위초과 유니코드 이스케이프(`"\u{110000}"`, > 0x10FFFF)가 **진단 없이 통과(exit 0)**해 invalid JS 가 emit 되던 버그 수정.

## 루트 코즈
`scanStringLiteral` 의 `\u{...}` 분기(src/lexer/scanner.zig)가 `has_hex`(최소 1 hex)만 검사하고 code point ≤ 0x10FFFF 범위를 검사하지 않았다. 동일 파일 template 경로(`scanTemplateContent`)는 code_point 누적+overflow+범위검사를 하던 **비대칭**.

## 변경
string 경로에 template 경로와 동일하게 code_point 누적 + overflow 추적 + `overflow or code_point > 0x10FFFF` 시 `.syntax_error` 반환. non-hex/빈 `\u{}`/미완성은 기존 동작 유지.

## 검증
- `"\u{110000}"`/`"\u{FFFFFFF}"` → 거부(exit 1, 출력 없음), `"\u{10FFFF}"`(유효 max)·`"\u{1F600}"` → 통과 + codepoint 값 보존(10ffff)
- 동일 ZNTC 가 template `\u{110000}` 에는 ZNTC0908 발행하던 자기모순 해소
- scanner_test 에 유효 max / 범위초과 회귀 가드 2개 추가
- `/code-review max` 통과: 브루트포스 0..0x2000000 전수 검증 0 mismatch, u32 shift overflow panic 없음, 4-digit `\uHHHH`/regex/식별자 이스케이프 경로는 이미 범위검사 보유(비대칭 해소 완결)

Closes #3980

🤖 Generated with [Claude Code](https://claude.com/claude-code)