### PR TITLE
fix(transformer): es5 다운레벨에서 default 있는 중첩 destructuring lowering (#3979)

### DIFF
--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -560,13 +560,33 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 } else {
                     const value_node = self.ast.getNode(value_idx);
                     if (value_node.tag == .assignment_pattern) {
-                        // default: { a = 1 } → var a = _ref.a === void 0 ? 1 : _ref.a
-                        const binding = try self.visitNode(value_node.data.binary.left);
-                        const default_val = try self.visitNode(value_node.data.binary.right);
-                        try rewritePatternDefaultTDZ(self, default_val, pattern, i_loop);
-                        const defaulted = try buildDefaulted(self, member_access, default_val, ref_span, key_idx, key_node.tag, span);
-                        const decl = try es_helpers.makeDeclarator(self, binding, defaulted, span);
-                        try self.scratch.append(self.allocator, decl);
+                        const left_node = self.ast.getNode(value_node.data.binary.left);
+                        if (left_node.tag == .object_pattern or left_node.tag == .array_pattern) {
+                            // (#3979) default 가 있는 *중첩* 패턴: { a: { c = 2 } = {} }
+                            //   → var _ref2 = _ref.a === void 0 ? {} : _ref.a; var c = _ref2.c ...
+                            // left 가 패턴이면 visitNode 로 verbatim 방출(invalid ES5)하지 말고
+                            // defaulted 값을 임시변수에 담아 재귀(non-default 중첩 분기와 동일 lowering).
+                            const default_val = try self.visitNode(value_node.data.binary.right);
+                            try rewritePatternDefaultTDZ(self, default_val, pattern, i_loop);
+                            const defaulted = try buildDefaulted(self, member_access, default_val, ref_span, key_idx, key_node.tag, span);
+                            const nested_span = try es_helpers.makeTempVarSpan(self);
+                            const nested_binding = try es_helpers.makeBindingIdentifier(self, nested_span);
+                            const nested_init = if (left_node.tag == .array_pattern)
+                                try buildArrayRead(self, defaulted, left_node, span)
+                            else
+                                defaulted;
+                            const nested_decl = try es_helpers.makeDeclarator(self, nested_binding, nested_init, span);
+                            try self.scratch.append(self.allocator, nested_decl);
+                            try emitPatternDeclarators(self, left_node, nested_span, span);
+                        } else {
+                            // default: { a = 1 } → var a = _ref.a === void 0 ? 1 : _ref.a
+                            const binding = try self.visitNode(value_node.data.binary.left);
+                            const default_val = try self.visitNode(value_node.data.binary.right);
+                            try rewritePatternDefaultTDZ(self, default_val, pattern, i_loop);
+                            const defaulted = try buildDefaulted(self, member_access, default_val, ref_span, key_idx, key_node.tag, span);
+                            const decl = try es_helpers.makeDeclarator(self, binding, defaulted, span);
+                            try self.scratch.append(self.allocator, decl);
+                        }
                     } else if (value_node.tag == .object_pattern or value_node.tag == .array_pattern) {
                         // nested: { a: { b } } → var _ref2 = _ref.a; var b = _ref2.b
                         const nested_span = try es_helpers.makeTempVarSpan(self);
@@ -614,24 +634,54 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 const elem_access = try makeArrayAccess(self, ref_span, idx, span);
 
                 if (elem.tag == .assignment_pattern) {
-                    // default: [x = 1] → var x = _ref[0] === void 0 ? 1 : _ref[0]
-                    const binding = try self.visitNode(elem.data.binary.left);
-                    const default_val = try self.visitNode(elem.data.binary.right);
-                    try rewritePatternDefaultTDZ(self, default_val, pattern, idx);
-                    const void_zero = try es_helpers.makeVoidZero(self, span);
-                    const elem_access2 = try makeArrayAccess(self, ref_span, idx, span);
-                    const eq_check = try self.ast.addNode(.{
-                        .tag = .binary_expression,
-                        .span = span,
-                        .data = .{ .binary = .{ .left = elem_access, .right = void_zero, .flags = @intFromEnum(token_mod.Kind.eq3) } },
-                    });
-                    const conditional = try self.ast.addNode(.{
-                        .tag = .conditional_expression,
-                        .span = span,
-                        .data = .{ .ternary = .{ .a = eq_check, .b = default_val, .c = elem_access2 } },
-                    });
-                    const decl = try es_helpers.makeDeclarator(self, binding, conditional, span);
-                    try self.scratch.append(self.allocator, decl);
+                    const left_node = self.ast.getNode(elem.data.binary.left);
+                    if (left_node.tag == .object_pattern or left_node.tag == .array_pattern) {
+                        // (#3979) default 가 있는 *중첩* 패턴: [ { a = 1 } = {} ] / [ [c=2] = [] ]
+                        // left 가 패턴이면 verbatim 방출(invalid ES5)하지 말고 defaulted 값을
+                        // 임시변수에 담아 재귀(non-default 중첩 분기와 동일 lowering).
+                        const default_val = try self.visitNode(elem.data.binary.right);
+                        try rewritePatternDefaultTDZ(self, default_val, pattern, idx);
+                        const void_zero = try es_helpers.makeVoidZero(self, span);
+                        const elem_access2 = try makeArrayAccess(self, ref_span, idx, span);
+                        const eq_check = try self.ast.addNode(.{
+                            .tag = .binary_expression,
+                            .span = span,
+                            .data = .{ .binary = .{ .left = elem_access, .right = void_zero, .flags = @intFromEnum(token_mod.Kind.eq3) } },
+                        });
+                        const conditional = try self.ast.addNode(.{
+                            .tag = .conditional_expression,
+                            .span = span,
+                            .data = .{ .ternary = .{ .a = eq_check, .b = default_val, .c = elem_access2 } },
+                        });
+                        const nested_span = try es_helpers.makeTempVarSpan(self);
+                        const nested_binding = try es_helpers.makeBindingIdentifier(self, nested_span);
+                        const nested_init = if (left_node.tag == .array_pattern)
+                            try buildArrayRead(self, conditional, left_node, span)
+                        else
+                            conditional;
+                        const nested_decl = try es_helpers.makeDeclarator(self, nested_binding, nested_init, span);
+                        try self.scratch.append(self.allocator, nested_decl);
+                        try emitPatternDeclarators(self, left_node, nested_span, span);
+                    } else {
+                        // default: [x = 1] → var x = _ref[0] === void 0 ? 1 : _ref[0]
+                        const binding = try self.visitNode(elem.data.binary.left);
+                        const default_val = try self.visitNode(elem.data.binary.right);
+                        try rewritePatternDefaultTDZ(self, default_val, pattern, idx);
+                        const void_zero = try es_helpers.makeVoidZero(self, span);
+                        const elem_access2 = try makeArrayAccess(self, ref_span, idx, span);
+                        const eq_check = try self.ast.addNode(.{
+                            .tag = .binary_expression,
+                            .span = span,
+                            .data = .{ .binary = .{ .left = elem_access, .right = void_zero, .flags = @intFromEnum(token_mod.Kind.eq3) } },
+                        });
+                        const conditional = try self.ast.addNode(.{
+                            .tag = .conditional_expression,
+                            .span = span,
+                            .data = .{ .ternary = .{ .a = eq_check, .b = default_val, .c = elem_access2 } },
+                        });
+                        const decl = try es_helpers.makeDeclarator(self, binding, conditional, span);
+                        try self.scratch.append(self.allocator, decl);
+                    }
                 } else if (elem.tag == .object_pattern or elem.tag == .array_pattern) {
                     // nested: [[a, b]] → var _ref2 = _ref[0]; var a = _ref2[0]; ...
                     const nested_span = try es_helpers.makeTempVarSpan(self);

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { bundleAndRun, createFixture, runZntc, transpileAndRun } from './helpers';
+import { bundleAndRun, createFixture, runNode, runZntc, transpileAndRun } from './helpers';
 
 describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
   let cleanup: (() => Promise<void>) | undefined;
@@ -161,6 +161,41 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(conditionalGuard).toBeGreaterThanOrEqual(0);
       expect(thenBranch).toBeGreaterThan(conditionalGuard);
       expect(elseBranch).toBeGreaterThan(thenBranch);
+    });
+
+    test('default 있는 중첩 destructuring 은 verbatim 잔존 없이 valid ES5 lowering (#3979)', async () => {
+      // 이전: declarator 의 assignment_pattern 분기가 left 가 중첩 패턴인지 검사 안 해
+      // `var { c:c=2 } = ...` / `[c=2]` 리터럴 destructuring 이 ES5 출력에 잔존(invalid).
+      const fixture = await createFixture({
+        'index.ts': `
+          const o = { b: { c: 5 }, d: [7] };
+          const { b: { c = 2 } = {} } = o;       // object-in-object + default
+          const { d: [e = 9] = [] } = o;          // array-in-object + default
+          const [ { a = 1 } = {} ] = [{ a: 8 }];  // object-in-array + default
+          console.log(c, e, a);
+        `,
+      });
+      cleanup = fixture.cleanup;
+
+      const outFile = join(fixture.dir, 'out.js');
+      const transpile = await runZntc([
+        join(fixture.dir, 'index.ts'),
+        '-o',
+        outFile,
+        '--target=es5',
+      ]);
+      expect(transpile.exitCode).toBe(0);
+
+      const output = readFileSync(outFile, 'utf8');
+      // ES5 에 없는 destructuring binding 패턴이 남으면 안 된다. 소스 객체 리터럴
+      // (`var o = { b: { c: 5 } }`) 은 binding 이름이 `var` 와 `{` 사이에 있어 매칭 안 됨.
+      // 잘못된 잔존(`var { c:c=2 } = ...`, `[c=2]`)은 `var`/`,` 직후 `{`/`[` 형태.
+      expect(/(?:var|,)\s*\{[^=]*=/.test(output)).toBe(false); // var { x = ... }
+      expect(/(?:var|,)\s*\[[^\]]*=/.test(output)).toBe(false); // var [ x = ... ]
+
+      // 런타임 값 정확성 (es5 출력을 node 로 실행)
+      const { stdout } = await runNode(outFile);
+      expect(stdout).toBe('5 7 8');
     });
 
     test('logical nullish assignment reads member value only once', async () => {


### PR DESCRIPTION
## 요약
`--target=es5` 다운레벨 시 **default value 가 있는 중첩 destructuring 패턴**이 변환되지 않고 리터럴 그대로 남아 **invalid ES5** 가 emit 되던 버그 수정.

## 루트 코즈
`emitObjectPatternDeclarators`(:562) / `emitArrayPatternDeclarators`(:616) 의 `assignment_pattern` 분기가 `default` 의 `left` 가 **중첩 패턴**(`.object_pattern`/`.array_pattern`)인지 검사하지 않고 `visitNode(left)` 결과를 declarator binding 으로 verbatim emit → `var { c:c=2 } = _ref.a === void 0 ? {} : _ref.a` 처럼 ES5 에 없는 destructuring 문법이 잔존. 같은 파일의 **non-default 중첩 분기**(570/635)는 temp var + 재귀로 올바르게 처리하던 비대칭.

## 변경
`left` 가 패턴이면 defaulted 값(`_ref.a === void 0 ? {} : _ref.a`)을 임시변수에 담고 `emitPatternDeclarators` 로 재귀(non-default 분기와 동일 lowering). **scalar(비-중첩) default 경로는 `else` 에 원본 그대로 보존** → byte-identical.

## 검증
- `{ b:{c=2}={} }`(obj-in-obj), `{ d:[e=9]=[] }`(arr-in-obj), `[ {a=1}={} ]`(obj-in-arr): 모두 acorn `ecmaVersion:5` 파싱 OK + 런타임 정답(`5 7 8`)
- scalar `[x=1]`/`{a=2}` 출력 불변, downlevel 통합 **417/417** + 신규 회귀 가드(ES5 패턴 부재 + 런타임)
- const/let/var 선언 + destructuring 파라미터 경로 공통 적용

## 리뷰
`/code-review max` 통과: scalar byte-identical 확인, 깊은 중첩(8단)·rest·computed key·param 경로 전부 ES5-valid + 런타임 MATCH. (별개 발견: `buildDefaulted` 의 멤버 getter/computed-key 이중평가는 scalar 포함 **선재 버그** — 본 fix 이전엔 invalid ES5 였어 순개선이며 별도 추적 권장.)

Closes #3979

🤖 Generated with [Claude Code](https://claude.com/claude-code)