### PR TITLE
fix(bundler): CompiledModule.dupe shared_ns_decls 부분-채움 누수 가드 (#3983)

### DIFF
--- a/src/bundler/compiled_module.zig
+++ b/src/bundler/compiled_module.zig
@@ -75,6 +75,15 @@ pub const CompiledModule = struct {
         errdefer if (ec) |c| allocator.free(c);
         const shared = try allocator.alloc(SharedNsDecl, self.shared_ns_decls.len);
         errdefer allocator.free(shared);
+        // (#3983) names 루프와 동일한 부분-채움 누수 가드. 완료된 iteration 의
+        // per-iteration errdefer 는 discharge 되므로, 이후 iteration 의 dupe 가 OOM
+        // 으로 실패하면 shared[0..shared_filled] 에 이미 저장된 문자열 3종이 누수된다.
+        var shared_filled: usize = 0;
+        errdefer for (shared[0..shared_filled]) |d| {
+            allocator.free(d.target_path);
+            allocator.free(d.var_name);
+            allocator.free(d.object_literal);
+        };
         for (self.shared_ns_decls, 0..) |decl, i| {
             const target_path = try allocator.dupe(u8, decl.target_path);
             errdefer allocator.free(target_path);
@@ -87,6 +96,7 @@ pub const CompiledModule = struct {
                 .var_name = var_name,
                 .object_literal = object_literal,
             };
+            shared_filled = i + 1;
         }
         return .{
             .code = code,
@@ -100,3 +110,28 @@ pub const CompiledModule = struct {
         };
     }
 };
+
+test "CompiledModule.dupe: 모든 할당 지점 OOM 에서 누수 없음 (#3983)" {
+    // shared_ns_decls 가 여러 개일 때, iteration 사이 OOM 시 이미 dupe 된
+    // 문자열이 누수되던 버그(shared_filled 가드 부재) 회귀. checkAllAllocationFailures
+    // 가 각 할당 인덱스에서 실패시켜 leak 을 검출한다 — names/shared 루프 둘 다 커버.
+    const src = CompiledModule{
+        .code = "out",
+        .mappings = null,
+        .names = &.{ "alpha", "beta" },
+        .fn_map_json = "fm",
+        .entry_chain = "ec",
+        .shared_ns_decls = &.{
+            .{ .target_path = "p0", .var_name = "v0", .object_literal = "{a:0}" },
+            .{ .target_path = "p1", .var_name = "v1", .object_literal = "{a:1}" },
+            .{ .target_path = "p2", .var_name = "v2", .object_literal = "{a:2}" },
+        },
+    };
+    const Runner = struct {
+        fn run(alloc: std.mem.Allocator, s: CompiledModule) !void {
+            var d = try s.dupe(alloc);
+            d.deinit(alloc);
+        }
+    };
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, Runner.run, .{src});
+}


### PR DESCRIPTION
## 요약
`CompiledModule.dupe()` 의 `shared_ns_decls` 복제 루프에서, 이미 완료된 iteration 의 dupe 문자열이 이후 iteration 의 OOM 실패 시 누수되던 버그 수정(errdefer 미보호). double-free/UAF 아닌 **OOM 경로 누수**.

## 루트 코즈
같은 함수의 `names` 루프(line 64-71)는 `names_filled` 카운터 + `errdefer for (names[0..names_filled]) free` 로 부분-채움 누수를 방어하나, `shared` 루프(line 76-90)는 동일 가드가 **누락**. iteration i 가 `shared[i] = .{...}` 까지 성공하면 per-iteration errdefer 들이 discharge → 이후 iteration OOM 시 `shared[0..i]` 의 3*i 문자열 누수. HMR/watch compiled output cache ownership 전이(`compiled_cache.zig:390`, `emitter.zig:614`)에서 도달.

## 변경
`names` 루프와 동형으로 `shared_filled` 카운터 + outer errdefer 추가. 현재 iteration 의 partial dupe 는 per-iteration errdefer, 완료된 iteration 은 outer errdefer 가 책임(분리 → double-free 없음).

## 검증
- `std.testing.checkAllAllocationFailures` inline 회귀 테스트 추가: **가드 제거 시 `1 leaked` FAIL, 가드 있으면 pass** (revert 로 테스트가 실제 버그를 검출함을 확인 — no-op 아님)
- `/code-review max` 통과: errdefer LIFO + `shared_filled=i+1`(대입 후) 책임 분리로 double-free 없음, 성공 경로 동작 불변, deinit 정합, 호출처 부분정리 불필요 확인

Closes #3983

🤖 Generated with [Claude Code](https://claude.com/claude-code)