### PR TITLE
fix(diagnostic): expect()/jsx 진단을 'Expected X but found Y' 로 렌더 (#3985)

### DIFF
--- a/src/diagnostic_renderer.zig
+++ b/src/diagnostic_renderer.zig
@@ -246,7 +246,19 @@ fn renderHeader(writer: anytype, diag: RichDiagnostic, color: bool, unicode: boo
     try writer.writeAll("  ");
     try ansi.styled(writer, style, icon, color);
     try writer.writeByte(' ');
-    try ansi.styled(writer, style, diag.message, color);
+    if (diag.found) |found_tok| {
+        // (#3985) "기대 토큰" 진단: message 는 기대 심볼, found 는 실제 심볼.
+        // "Expected '<message>' but found '<found>'" 로 렌더(이전엔 message 만 →
+        // 컨텍스트 없는 bare 심볼 `× )`). found 가 set 되는 곳은 expect()/
+        // expectSemicolon()/jsx 뿐이며 거기선 message 가 항상 토큰 심볼이다.
+        try ansi.styled(writer, style, "Expected '", color);
+        try ansi.styled(writer, style, diag.message, color);
+        try ansi.styled(writer, style, "' but found '", color);
+        try ansi.styled(writer, style, found_tok, color);
+        try ansi.styled(writer, style, "'", color);
+    } else {
+        try ansi.styled(writer, style, diag.message, color);
+    }
 
     // 에러 코드
     if (diag.code) |code_str| {
@@ -434,6 +446,50 @@ test "render: basic error with code frame" {
     try std.testing.expect(std.mem.indexOf(u8, out, "^^^^^^^^^^^^^^^^") != null);
     // help
     try std.testing.expect(std.mem.indexOf(u8, out, "help: Set target to 'es2022'") != null);
+}
+
+test "render: found 토큰 → 'Expected X but found Y' 헤더 (#3985)" {
+    // expect()/expectSemicolon()/jsx 진단: message=기대 심볼, found=실제 심볼.
+    // 이전엔 message 만 렌더(bare `× )`) → found 가 dead 였음. 렌더 문자열을 직접 검사.
+    const source = "f(a, b ;";
+    const offsets = [_]u32{0};
+    const diag = RichDiagnostic{
+        .severity = .@"error",
+        .message = ")",
+        .found = ";",
+        .span = .{ .start = 7, .end = 8 },
+        .file_path = "t.ts",
+    };
+    const info = SourceInfo{ .source = source, .line_offsets = &offsets };
+
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try render(fbs.writer(), diag, info, .{ .color = false, .unicode = true });
+    const out = fbs.getWritten();
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "Expected ')' but found ';'") != null);
+    // bare 심볼만 있던 회귀 방지: 헤더 라인이 `× )` 로 끝나지 않아야 함.
+    try std.testing.expect(std.mem.indexOf(u8, out, "but found") != null);
+}
+
+test "render: found 없으면 message 그대로 (회귀 가드 #3985)" {
+    const source = "x";
+    const offsets = [_]u32{0};
+    const diag = RichDiagnostic{
+        .severity = .@"error",
+        .message = "Some plain message",
+        .span = .{ .start = 0, .end = 1 },
+        .file_path = "t.ts",
+    };
+    const info = SourceInfo{ .source = source, .line_offsets = &offsets };
+
+    var buf: [4096]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try render(fbs.writer(), diag, info, .{ .color = false, .unicode = true });
+    const out = fbs.getWritten();
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "Some plain message") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Expected '") == null);
 }
 
 test "render: multi-line source with context" {

--- a/src/rich_diagnostic.zig
+++ b/src/rich_diagnostic.zig
@@ -29,6 +29,10 @@ pub const RichDiagnostic = struct {
     code: ?[]const u8 = null,
     /// 주 메시지 (예: "Top-level await is not available in the configured target environment")
     message: []const u8,
+    /// (#3985) expect()/expectSemicolon()/jsx 처럼 "기대 토큰" 진단일 때 실제로 만난
+    /// 토큰 심볼. non-null 이면 렌더러가 `Expected '<message>' but found '<found>'` 로
+    /// 출력한다(이때 message 는 기대 토큰 심볼). null 이면 message 를 그대로 출력.
+    found: ?[]const u8 = null,
     /// 주 에러 위치 (소스에서의 바이트 범위)
     span: Span,
     /// 에러가 발생한 파일 경로
@@ -124,6 +128,7 @@ pub fn fromDiagnostic(d: Diagnostic, file_path: []const u8) RichDiagnostic {
         .severity = .@"error",
         .code = if (d.code) |c| c.format() else null,
         .message = d.message,
+        .found = d.found,
         .span = d.span,
         .file_path = file_path,
         .labels = d.labels,


### PR DESCRIPTION
## 요약
`expect()`/`expectSemicolon()`/jsx 가 내는 가장 흔한 구문 에러가 CLI 에서 컨텍스트 없는 **bare 심볼**(`× )`, `× ;`)로 렌더되던 버그 수정. `found` 토큰이 수집·저장되지만 렌더 시점에 dead 였다.

## 루트 코즈
`Diagnostic.found`(실제 만난 토큰)는 채워지나, `RichDiagnostic` 에 `found` 필드 자체가 없어 `fromDiagnostic`(rich_diagnostic.zig:126)이 버리고 `renderHeader`(diagnostic_renderer.zig:249)는 `message` 만 출력. 주석/유닛테스트(parser.zig:518/600, parser_test.zig)가 명시한 'Expected X but found Y' 의도와 모순. 유닛테스트는 저장 필드만 검사해 격차를 못 잡음(false confidence).

## 변경
- `RichDiagnostic` 에 `found: ?[]const u8` 추가
- `fromDiagnostic` 이 `.found = d.found` 전파
- `renderHeader` 가 `found` non-null 이면 `Expected '<message>' but found '<found>'` 조립(else 는 기존 message 그대로 → byte-identical)

`found` 를 set 하는 6개 producer(expect/expectSemicolon/jsx 4곳) 전부 `message=토큰심볼` 이라 프레이밍 일관.

## 검증
- `f(a, b ;` → `Expected ')' but found ';'`, `let x=1 let y=2` → `Expected ';' but found 'let'`
- 비-found 진단 전부 렌더 불변(기존 렌더 테스트 통과), `fromBundlerDiagnostic` 무영향
- **렌더-문자열 검사** 테스트 2개 추가(found 케이스 + 회귀 가드) — 기존 테스트가 저장 필드만 봐서 못 잡던 격차를 출력으로 가드
- `/code-review max` 통과

Closes #3985

🤖 Generated with [Claude Code](https://claude.com/claude-code)