### PR TITLE
fix(cli): unresolved-import suggestion 을 'did you mean' 대신 hint 로 렌더 (#3986)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -736,9 +736,12 @@ pub fn main() !void {
                     .warning => "warning",
                     .info => "info",
                 };
-                try stderr.print("[{s}] {s}: {s}", .{ sev_str, d.file_path, d.message });
-                if (d.suggestion) |s| try stderr.print(" (did you mean '{s}'?)", .{s});
-                try stderr.print("\n", .{});
+                try stderr.print("[{s}] {s}: {s}\n", .{ sev_str, d.file_path, d.message });
+                // (#3986) suggestion 은 *교정된 이름*이 아니라 unresolved specifier 또는
+                // 조언 문장(producer 가 record.specifier / 전체 문장을 넣음)이다. ZNTC 엔
+                // typo-detector 가 없어 'did you mean' 프레이밍은 항상 오도였다. app
+                // bundle 진단(app/build.zig:719 `hint:`)과 동일하게 중립 hint 로 렌더.
+                if (d.suggestion) |s| try stderr.print("  hint: {s}\n", .{s});
             }
         }
 

--- a/tests/integration/tests/resolve-fallback.test.ts
+++ b/tests/integration/tests/resolve-fallback.test.ts
@@ -133,4 +133,28 @@ describe('--fallback', () => {
       await cleanup();
     }
   });
+
+  // #3986: unresolved import 진단 suggestion 이 'did you mean <원본-specifier>' 로
+  // 오도되던 것을 중립 'hint:' 로 교체. (suggestion 은 교정된 이름이 아니라 specifier)
+  test('unresolved import 진단은 misleading "did you mean" 대신 hint 로 렌더 (#3986)', async () => {
+    const { dir, cleanup } = await createFixture({
+      'entry.ts': `import { foo } from "./does-not-exist.js";\nconsole.log(foo);`,
+    });
+    try {
+      const { stderr, exitCode } = await runZntc([
+        '--bundle',
+        join(dir, 'entry.ts'),
+        '--format=esm',
+        '-o',
+        join(dir, 'out.js'),
+      ]);
+      expect(exitCode).toBe(1); // hard error
+      expect(stderr).toContain('Cannot resolve module');
+      expect(stderr).not.toContain('did you mean'); // 오도 프레이밍 제거
+      expect(stderr).toContain('hint:'); // 중립 hint 로 specifier 표시
+      expect(stderr).toContain('./does-not-exist.js');
+    } finally {
+      await cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## 요약
unresolved import 진단의 suggestion 이 `(did you mean '<원본-specifier>'?)` 로 렌더돼 **사용자가 입력한 경로를 그대로 "혹시 이거?" 로 제안**하는 오도 출력이 되던 버그 수정.

## 루트 코즈
`main.zig:740` 이 non-null `d.suggestion` 을 무조건 `(did you mean '{s}'?)` 로 감쌌다. 그러나 모든 producer 가 **원본 문자열**을 넘긴다: `resolve_imports.zig`/`discovery_scan.zig` = `record.specifier`, `linker.zig:1508` = `ib.imported_name`, `loaders.zig` = CSS modules 조언 문장. bundler 에 typo-detector 가 0개(grep)라 'did you mean' 에 들어갈 교정된 이름이 존재하지 않음. CSS 문장 suggestion 은 `(did you mean 'Use plain CSS...'?)` 로 문법까지 깨졌다.

## 변경
`app/build.zig:719` 의 `  hint: {s}` 와 동일하게 중립 hint 로 렌더(message 줄 + 별도 hint 줄). suggestion=null 진단은 message+newline 만(이전과 byte-identical).

## 검증
- `import { foo } from "./does-not-exist.js"` → `Cannot resolve module` + `  hint: ./does-not-exist.js` (did you mean 0)
- CSS modules 조언 문장도 `hint:` 로 정상 렌더(이전 문법 파괴 해소)
- resolve-fallback 통합에 회귀 가드 추가(did-you-mean 부재 + hint 존재 + specifier)
- `/code-review max` 통과: 모든 suggestion producer 가 hint 프레이밍 적합, null 경로 byte-identical, rich/NAPI 경로 무영향 확인

Closes #3986

🤖 Generated with [Claude Code](https://claude.com/claude-code)