### PR TITLE
fix(bundler): plugin-failure 진단의 owned_diagnostic_strings data race 수정 (#3977)

### DIFF
--- a/src/bundler/graph/diagnostics.zig
+++ b/src/bundler/graph/diagnostics.zig
@@ -88,9 +88,20 @@ fn tryAddPluginFailureDiag(
     const file_path = try self.allocator.dupe(u8, file_src);
     errdefer self.allocator.free(file_path);
 
-    try self.owned_diagnostic_strings.ensureUnusedCapacity(self.allocator, 2);
-    self.owned_diagnostic_strings.appendAssumeCapacity(message);
-    self.owned_diagnostic_strings.appendAssumeCapacity(file_path);
+    // (#3977) owned_diagnostic_strings 는 ModuleGraph 공유 ArrayList. discovery 가
+    // 멀티스레드(기본 std.Thread.Pool)로 돌 때 여러 worker 가 plugin hook 실패로
+    // (scanWorker→parseModule→runLoad/Transform, discovery_scan→resolveId 등) 동시에
+    // 이 경로에 진입하면 무락 ensureUnusedCapacity/appendAssumeCapacity 가 realloc
+    // race → use-after-free/double-free/힙 손상. 같은 파일 addDiag 가 self.diagnostics
+    // 를 diag_mutex 로 보호하듯 이 공유 리스트도 동일 mutex 로 보호한다. addDiag(아래)
+    // 가 같은 mutex 를 다시 잡으므로(비재귀) 별도 블록으로 분리해 재진입 데드락을 피한다.
+    {
+        self.diag_mutex.lock();
+        defer self.diag_mutex.unlock();
+        try self.owned_diagnostic_strings.ensureUnusedCapacity(self.allocator, 2);
+        self.owned_diagnostic_strings.appendAssumeCapacity(message);
+        self.owned_diagnostic_strings.appendAssumeCapacity(file_path);
+    }
 
     addDiag(self, .plugin_error, .@"error", file_path, span, step, message, null);
 }


### PR DESCRIPTION
## 요약
`tryAddPluginFailureDiag` 가 ModuleGraph 공유 `owned_diagnostic_strings` ArrayList 를 **락 없이** 변경해, discovery 멀티스레드 worker 가 plugin hook 실패 시 동시에 append → realloc race(use-after-free/double-free/힙 손상)가 나던 버그 수정.

## 루트 코즈
`diagnostics.zig` 의 `ensureUnusedCapacity` + `appendAssumeCapacity` x2 가 무락. discovery 는 기본 `std.Thread.Pool` 로 멀티스레드(`scanWorker→parseModule→runLoad/Transform`, `discovery_scan→resolveId` 등 worker 경로). 같은 파일 `addDiag` 는 `self.diagnostics` 를 `diag_mutex` 로 보호하는데 이 공유 리스트만 누락.

## 변경
append 3줄을 `diag_mutex` 보호 블록으로 감쌈. 직후 `addDiag` 가 같은 mutex 를 다시 잡으므로(비재귀 mutex) **별도 블록으로 분리**해 재진입 데드락 회피. lifecycle reset/deinit 의 read 는 pool join 후 single-thread 라 무관.

## 검증
- `/code-review max` 통과: 재진입 데드락 없음(블록 `}`에서 unlock 후 addDiag 가 재취득), errdefer-lock 누수/double-free 없음, 소유권 전이 일관 — 전 angle clean
- 유닛 green(데드락 없음)
- ⚠️ **동적 race 재현은 타이밍 의존**이라 harness(400모듈 + onLoad throw plugin, 20회)에서 pre/post 모두 미발생 → 정적 분석 + 코드베이스 자체 `addDiag` 의 기존 `diag_mutex` 패턴 일관성으로 판단. 결정적 race 회귀 테스트는 본질상 불가(ThreadSanitizer 필요).

원 발견: 멀티에이전트 버그헌트의 concurrency finder 가 정적 분석 + bun 크래시 백트레이스(worker 스레드 `array_list.ensureTotalCapacityPrecise → addPluginFailureDiag`)로 보고.

Closes #3977

🤖 Generated with [Claude Code](https://claude.com/claude-code)