### PR TITLE
fix(bundler): namespace import of pure-CJS-star ESM → __toESM(require()) (#3975)

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -97,6 +97,35 @@ test "CJS: ESM imports named from CJS" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, ".value") != null);
 }
 
+test "CJS: import * as ns of ESM-that-export*-from-CJS → __toESM(require()) after wrapper (#3975)" {
+    // mid 가 `export * from <CJS>` 인 pure-CJS-star 인 경우, `import * as ns from mid`
+    // 의 namespace 는 정적 열거 불가(CJS 동적 exports)라 직접 `import * as ns from cjs`
+    // 와 동형으로 per-module preamble 의 `var ns = __toESM(require_lib())` 로 처리돼야 한다.
+    // 이전엔 정적 ns-object 가 shared-ns preamble(CJS wrapper 정의 전)에 emit 돼
+    // ReferenceError(또는 빈 ns) 였다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.cjs", "exports.alpha = 1;\nexports.beta = 2;");
+    try writeFile(tmp.dir, "mid.ts", "export * from './lib.cjs';");
+    try writeFile(tmp.dir, "entry.ts", "import * as ns from './mid.ts';\nconsole.log(ns.alpha, ns.beta);");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // __toESM(require_lib()) 형태로 ns 가 materialize 돼야 함.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib())") != null);
+    // require_lib wrapper 정의가 __toESM(require_lib()) 사용보다 *먼저* 와야 함(ordering).
+    const wrapper_pos = std.mem.indexOf(u8, result.output, "require_lib = __commonJS").?;
+    const use_pos = std.mem.indexOf(u8, result.output, "__toESM(require_lib())").?;
+    try std.testing.expect(wrapper_pos < use_pos);
+}
+
 test "CJS: RN strict order defers named CJS import with inlineRequires" {
     // RN inlineRequires 에서는 named CJS import 도 Metro 처럼 값 사용 지점에서 평가된다.
     // side-effect import 순서는 유지하지만, named binding 의 require 는 본문 실행 전

--- a/src/bundler/emitter/runtime_helpers.zig
+++ b/src/bundler/emitter/runtime_helpers.zig
@@ -83,6 +83,30 @@ pub fn emitBundleRuntimeHelpers(
 /// linker 가 있으면 `getResolvedBinding` 의 chain 끝까지 따라가 ESM re-export
 /// (`export { default } from "./cjs"`) 와 다단계 re-export 도 캐치. linker 가 없으면
 /// (linker_test 단독 등) importer 의 직접 target 만 검사하는 보수적 fallback.
+/// (#3975) 모듈이 *순수* CJS star re-export(ESM 이 단일 `export * from <CJS>` 만,
+/// 자체 named/default export·다른 star 없음)인지. metadata.zig 의 pureCjsStarTarget
+/// 와 동일 조건 — namespace import 가 이 모듈을 가리키면 underlying CJS 로 redirect 되어
+/// `__toESM(require())` 가 emit 되므로 헬퍼 필요 판정에 쓴다.
+fn isPureCjsStarReExport(target: *const Module, graph: *const ModuleGraph) bool {
+    if (target.wrap_kind == .cjs) return false;
+    var found_cjs_star = false;
+    for (target.export_bindings) |eb| {
+        if (eb.kind.isReExportAll() and std.mem.eql(u8, eb.exported_name, "*")) {
+            const ri = eb.import_record_index orelse return false;
+            if (ri >= target.import_records.len) return false;
+            const src = target.import_records[ri].resolved;
+            if (src.isNone()) return false;
+            const sm = graph.getModule(src) orelse return false;
+            if (sm.wrap_kind != .cjs) return false;
+            if (found_cjs_star) return false; // 다중 star → 순수 아님
+            found_cjs_star = true;
+        } else {
+            return false; // 자체 export 또는 export * as ns
+        }
+    }
+    return found_cjs_star;
+}
+
 fn moduleNeedsToEsmInterop(module: *const Module, graph: *const ModuleGraph, linker: ?*const Linker) bool {
     for (module.import_bindings) |ib| {
         if (ib.import_record_index >= module.import_records.len) continue;
@@ -94,6 +118,11 @@ fn moduleNeedsToEsmInterop(module: *const Module, graph: *const ModuleGraph, lin
             if (record.resolved.isNone()) continue;
             const target = graph.getModule(record.resolved) orelse continue;
             if (target.wrap_kind == .cjs) return true;
+            // (#3975) target 이 ESM 이라도 *pure* CJS-star re-export(단일 `export * from
+            // <CJS>`, 자체 export 없음)면 metadata 가 underlying CJS 로 redirect 해 per-module
+            // preamble 이 `var ns = __toESM(require())` 를 emit → __toESM 헬퍼 필요. redirect
+            // 조건(metadata.zig pureCjsStarTarget)과 동일하게 감지한다.
+            if (isPureCjsStarReExport(target, graph)) return true;
             continue;
         }
 

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -150,6 +150,34 @@ fn nsForceInline(
         self.isNamespaceExportConsumed(module_index, local_name);
 }
 
+/// (#3975) namespace import target 이 *순수* CJS star re-export — ESM 모듈이 단일
+/// `export * from <CJS>` 만 가지고 자체 named/default export·다른 star 가 없는 경우 —
+/// 면 underlying CJS 모듈 인덱스를 반환한다. 이 경우 `import * as ns from mid` 는
+/// `import * as ns from cjs`(직접) 와 의미가 동일하므로, namespace 를 정적 ns-object
+/// (shared-ns preamble, CJS wrapper 정의 *전* emit → ReferenceError) 대신 직접 CJS
+/// interop preamble(`var ns = __toESM(require())`, per-module = CJS region 후) 로
+/// 처리하도록 canonical 을 redirect 한다(#3975 emit-ordering 근본 수정).
+fn pureCjsStarTarget(self: *const Linker, mod_idx: u32) ?u32 {
+    const m = self.getModule(mod_idx) orelse return null;
+    if (m.wrap_kind == .cjs) return null; // 이미 CJS — redirect 불필요
+    var cjs_src: ?u32 = null;
+    for (m.export_bindings) |eb| {
+        if (eb.kind.isReExportAll() and std.mem.eql(u8, eb.exported_name, "*")) {
+            const rec_idx = eb.import_record_index orelse return null;
+            if (rec_idx >= m.import_records.len) return null;
+            const src = m.import_records[rec_idx].resolved;
+            if (src.isNone()) return null;
+            const sm = self.graph.getModule(src) orelse return null;
+            if (sm.wrap_kind != .cjs) return null; // ESM star 는 정적 ns-object 로 처리 가능
+            if (cjs_src != null) return null; // 다중 star → 순수 단일 아님
+            cjs_src = @intFromEnum(src);
+        } else {
+            return null; // 자체 named/default export 또는 `export * as ns` 존재 → 순수 아님
+        }
+    }
+    return cjs_src;
+}
+
 fn allocLazyEsmImportExpr(self: *const Linker, import_mod: *const Module, value_mod: *const Module, target_name: []const u8) ![]const u8 {
     const sep = if (self.minify_whitespace) "," else ", ";
     const import_init = try allocEsmInitExpr(self, import_mod);
@@ -646,7 +674,16 @@ pub fn buildMetadataForAst(
                 continue;
             }
 
-            const canonical_mod = @intFromEnum(rec.resolved);
+            var canonical_mod = @intFromEnum(rec.resolved);
+
+            // (#3975) namespace import 가 pure-CJS-star ESM(단일 `export * from <CJS>`,
+            // 자체 export 없음)을 가리키면 underlying CJS 로 redirect → 아래 CJS-interop
+            // preamble 경로(`var ns = __toESM(require())`, per-module = CJS region 후, 올바른
+            // ordering)로 처리. 정적 ns-object 경로는 shared-ns preamble 이 CJS wrapper 정의
+            // *전* emit 돼 `require_x is not a function` 이 됐다(직접 import * as ns from cjs 와 동형화).
+            if (ib.kind == .namespace) {
+                if (pureCjsStarTarget(self, canonical_mod)) |cjs_idx| canonical_mod = cjs_idx;
+            }
 
             // __esm 모듈에서 CJS 타겟 또는 self-import: body의 require_rewrites가
             // 할당문 + init 호출을 처리하므로 preamble 생성 skip.


### PR DESCRIPTION
## 요약
`import * as ns from mid` 에서 `mid` 가 **pure CJS-star re-export**(ESM 이 단일 `export * from <CJS>` 만 가지고 자체 export 없음)일 때 ns 멤버가 누락(ns 미선언 → `ReferenceError`, 또는 빈 객체)되던 버그의 **헤드라인 케이스**를 수정합니다.

## 루트 원인 — emit ordering
namespace 가 정적 ns-object(shared-ns preamble)로 처리되는데, 그 preamble 은 모듈 본문(CJS wrapper `var require_x = __commonJS(...)`)보다 **먼저** emit 된다. 그래서 `var ns = __toESM(require_x())` 가 `require_x` 정의 전에 평가 → 실패. 또한 CJS exports 는 동적이라 정적 getter 로 열거 불가.

직접 `import * as ns from cjs` 는 작동하는데, 이는 namespace 를 **per-module CJS-interop preamble**(CJS region *후*)에 `var ns = __toESM(require_x())` 로 emit 하기 때문.

## 변경
namespace import 의 `canonical_mod` 을 `pureCjsStarTarget()` 으로 underlying CJS 로 **redirect** → 직접 import 과 동일한 per-module 경로(올바른 ordering)로 처리. `moduleNeedsToEsmInterop` 도 동일 조건(`isPureCjsStarReExport`)으로 `__toESM` 헬퍼를 emit 하도록 확장. **redirect 는 `ib.kind==.namespace` + pure-CJS-star 에만** — 다른 모든 import 는 불변.

## 검증
- `export * from cjs` + `import * as ns; ns.alpha,ns.beta` → **`1 2`**(이전 ReferenceError)
- 직접 `import * as ns from cjs` 불변(`1`), `require_x` wrapper 가 `__toESM(require_x())` 사용 *전* 정의됨(ordering 가드 테스트)
- unit exit 0, **bundle-smoke + cjs-code-splitting 156/156** 회귀 0
- `/code-review max` 통과: pure 판정(다중/mixed/ESM-star/`export * as ns` 제외)·헬퍼 동기화·tree-shake 가드·named/default 무영향 검증

## 미해결 (문서화 — pre-existing, 본 fix 가 악화 안 함, main 과 byte-identical)
별도 후속으로 분리:
- **dev 모드** — body require_rewrites 가 mid 로 재대입(redirect 의 첫 대입을 clobber). dev 는 별도 emit 경로.
- **--splitting** 청크 경계
- **다중/mixed CJS-star** (`export * from cjs1; export * from cjs2`, `export const x; export * from cjs`)
- **`export * as inner from cjs`** (nested namespace, re_export_namespace 경로 — shared-ns preamble ordering 동일 이슈)

→ 헤드라인(pure-CJS-star, prod)만 수정하므로 `Closes` 대신 `Refs`. #3975 는 잔여 sub-case 용으로 open 유지.

Refs #3975

🤖 Generated with [Claude Code](https://claude.com/claude-code)