### PR TITLE
fix(bundler): 진짜 누락 export 만 missing_export 진단으로 surface (#3978)

### DIFF
--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2307,9 +2307,213 @@ test "shimMissingExports: 플래그 꺼져있으면 shim 미생성" {
     const result = try b.bundle();
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expect(!result.hasErrors());
     // shim 없으면 void 0 선언이 없어야 함
     try std.testing.expect(std.mem.indexOf(u8, result.output, "void 0") == null);
+    // shim 이 꺼져 있고 실제로 없는 export 를 값으로 쓰면 esbuild 처럼 진단을 surface 한다
+    try std.testing.expect(result.hasErrors());
+}
+
+test "missing export: 값으로 쓰는 실제 누락 export 는 missing_export 진단을 surface (#3978)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { doesNotExist } from './lib';
+        \\globalThis.z = doesNotExist;
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export const existing = 42;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.hasErrors());
+    var found = false;
+    if (result.diagnostics) |diags| {
+        for (diags) |d| {
+            if (d.code == .missing_export) {
+                found = true;
+                break;
+            }
+        }
+    }
+    try std.testing.expect(found);
+}
+
+test "missing export: type-only import 는 stripped 이므로 진단을 내지 않는다 (#3978)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import type { Missing } from './lib';
+        \\const x: Missing = null;
+        \\globalThis.z = x;
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\export const existing = 42;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // 타입은 strip 되어 런타임 값 참조가 아니므로 missing_export 진단을 내지 않는다
+    var found = false;
+    if (result.diagnostics) |diags| {
+        for (diags) |d| {
+            if (d.code == .missing_export) {
+                found = true;
+                break;
+            }
+        }
+    }
+    try std.testing.expect(!found);
+}
+
+test "missing export: CJS 모듈 import 는 동적 exports 라 진단 보수적으로 억제 (#3978)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { maybe } from './lib.cjs';
+        \\globalThis.z = maybe;
+    );
+    try writeFile(tmp.dir, "lib.cjs",
+        \\module.exports.existing = 42;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // CJS exports 는 정적으로 열거 불가 → 거짓 양성을 피하려 missing_export 를 surface 하지 않는다
+    var found = false;
+    if (result.diagnostics) |diags| {
+        for (diags) |d| {
+            if (d.code == .missing_export) {
+                found = true;
+                break;
+            }
+        }
+    }
+    try std.testing.expect(!found);
+}
+
+/// (#3978) missing_export 게이트의 각 차원을 독립적으로 고정하는 표.
+/// `bundle_src`: entry.ts/lib.ts/extra 파일들. `expect_error`: missing_export
+/// 진단이 surface 되어야 하는가.
+const MissingExportCase = struct {
+    name: []const u8,
+    entry: []const u8,
+    files: []const [2][]const u8, // {파일명, 내용}
+    expect_error: bool,
+};
+
+test "missing export 게이트: export*/named-reexport/unused/default 차원별 동작 (#3978)" {
+    const cases = [_]MissingExportCase{
+        // A. export * 배럴을 통해 *존재하는* 이름 → 재귀로 찾으므로 진단 없음
+        .{
+            .name = "export*-present",
+            .entry = "import { found } from './barrel';\nglobalThis.z = found;",
+            .files = &.{
+                .{ "barrel.ts", "export * from './real';" },
+                .{ "real.ts", "export const found = 1;" },
+            },
+            .expect_error = false,
+        },
+        // B. export * 배럴을 통해 *진짜 없는* 이름 → 현재는 진단 안 함(보수적 한계).
+        //    순수 re-export 배럴은 자신의 exported_names 가 비어 있어(count==0)
+        //    모델-불완전으로 간주, false-positive 를 피하려 억제한다. 배럴은 매우
+        //    흔하므로 의도된 트레이드오프 — 이 동작이 바뀌면 의식적 결정이어야 한다.
+        .{
+            .name = "export*-missing(conservative)",
+            .entry = "import { nope } from './barrel';\nglobalThis.z = nope;",
+            .files = &.{
+                .{ "barrel.ts", "export * from './real';" },
+                .{ "real.ts", "export const found = 1;" },
+            },
+            .expect_error = false,
+        },
+        // C. named re-export(`export { x } from`)로 존재하는 이름 → exported_names 에
+        //    잡히므로 진단 없음
+        .{
+            .name = "named-reexport-present",
+            .entry = "import { x } from './barrel';\nglobalThis.z = x;",
+            .files = &.{
+                .{ "barrel.ts", "export { x } from './real';" },
+                .{ "real.ts", "export const x = 1;" },
+            },
+            .expect_error = false,
+        },
+        // D. import 했으나 값으로 *참조 안 한* 누락 이름 → value_used=false → 진단 없음
+        //    (런타임에 식별자가 emit 되지 않아 ReferenceError 가 없음)
+        .{
+            .name = "unused-missing",
+            .entry = "import { a, ghost } from './lib';\nglobalThis.z = a;",
+            .files = &.{
+                .{ "lib.ts", "export const a = 1;" },
+            },
+            .expect_error = false,
+        },
+        // E. ESM 모듈에 default 가 없는데 default 를 값으로 사용 → 진짜 누락(esbuild parity)
+        .{
+            .name = "esm-default-missing",
+            .entry = "import D from './lib';\nglobalThis.z = D;",
+            .files = &.{
+                .{ "lib.ts", "export const a = 1;" },
+            },
+            .expect_error = true,
+        },
+        // F. CJS 모듈 default → CJS 는 default 를 synthesize 하므로 누락이 아님 → 진단 없음
+        .{
+            .name = "cjs-default",
+            .entry = "import D from './lib.cjs';\nglobalThis.z = D;",
+            .files = &.{
+                .{ "lib.cjs", "module.exports.a = 1;" },
+            },
+            .expect_error = false,
+        },
+    };
+
+    for (cases) |c| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        try writeFile(tmp.dir, "entry.ts", c.entry);
+        for (c.files) |f| try writeFile(tmp.dir, f[0], f[1]);
+
+        const entry = try absPath(&tmp, "entry.ts");
+        defer std.testing.allocator.free(entry);
+
+        var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+        defer b.deinit();
+        const result = try b.bundle();
+        defer result.deinit(std.testing.allocator);
+
+        var found = false;
+        if (result.diagnostics) |diags| {
+            for (diags) |d| {
+                if (d.code == .missing_export) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        if (found != c.expect_error) {
+            std.debug.print("[missing export 게이트] case '{s}': expect_error={} but found={}\n", .{ c.name, c.expect_error, found });
+            return error.MissingExportGateMismatch;
+        }
+    }
 }
 
 test "Self-re-export: default re-export가 자기 자신을 가리킬 때 skip" {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1497,7 +1497,7 @@ pub const Linker = struct {
                     ib.imported_name,
                     0,
                 ) orelse {
-                    // export를 찾을 수 없음
+                    // export를 찾을 수 없음 — 내부 진단(self.diagnostics, 테스트/디버그용) 유지.
                     self.addDiag(
                         .missing_export,
                         .@"error",
@@ -1507,6 +1507,50 @@ pub const Linker = struct {
                         "Imported name not found in module",
                         ib.imported_name,
                     );
+                    // (#3978) 사용자 노출(BundleResult)은 *진짜 누락*만. resolveExportChain
+                    // null 은 CJS 동적 exports / TS namespace·interface·const-enum / default-fn /
+                    // handled-elsewhere 등 false-null 이 대부분(계측: unit 137 중 ~133 false).
+                    // semantic.exported_names(analyzer 가 type-space 포함 *모든* export 이름 기록)를
+                    // chain-aware 로 조회해 진짜 누락만 가려낸다. CJS/helper/type-only/shim 은 제외.
+                    // esbuild/rolldown parity. (export_bindings 는 TS 구문 미기록이라 사용 불가.)
+                    const tgt_cjs = if (self.graph.getModule(source_record.resolved)) |t| t.wrap_kind == .cjs else true;
+                    var type_only = false;
+                    // value_used: importer 의 로컬 바인딩이 *값* 위치에서 참조되는가. 미해결
+                    // import 는 local_symbol 이 invalid 라 isImportBindingTypeOnly 가 판정 못 하므로
+                    // module scope(scope_maps[0])에서 local_name → symbol 을 찾아 references 의
+                    // value-use 를 직접 확인한다. type-only(타입 위치만 사용, strip)·미사용 import 는
+                    // false → 진단 surface 안 함(런타임에 식별자가 emit 되지 않아 ReferenceError 없음).
+                    var value_used = false;
+                    if (m.semantic) |*sem| {
+                        type_only = metadata_mod.isImportBindingTypeOnly(sem, ib);
+                        if (sem.scope_maps.len > 0) {
+                            if (sem.scope_maps[0].get(ib.local_name)) |sym_idx| {
+                                for (sem.references) |r| {
+                                    if (@intFromEnum(r.symbol_id) == sym_idx and r.isValueUse()) {
+                                        value_used = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    const genuine = value_used and !ib.is_helper and !tgt_cjs and !type_only and
+                        !self.shim_missing_exports and
+                        !self.moduleHasExportName(source_record.resolved, ib.imported_name, 0);
+                    if (genuine) {
+                        const msg = std.fmt.allocPrint(self.allocator, "No matching export \"{s}\" in module", .{ib.imported_name}) catch {
+                            continue;
+                        };
+                        self.fatal_diagnostics.append(self.allocator, .{
+                            .code = .missing_export,
+                            .severity = .@"error",
+                            .message = msg,
+                            .file_path = m.path,
+                            .span = ib.local_span,
+                            .step = .link,
+                            .suggestion = ib.imported_name,
+                        }) catch self.allocator.free(msg);
+                    }
                     continue;
                 };
 
@@ -1539,6 +1583,47 @@ pub const Linker = struct {
             }
         }
         return null;
+    }
+
+    /// (#3978) scanner-level export 존재 여부(chain-aware). resolveExportChain 은
+    /// 해석(rename/symbol) 까지 모델하느라 CJS 동적 exports·TS namespace/interface/
+    /// const-enum·default-function 등을 false-null 로 떨군다. 이 함수는 semantic
+    /// analyzer 가 기록한 *완전한* export-name 집합(exported_names — type-space 포함)을
+    /// 조회해 "export 가 선언돼 있는가" 만 본다. missing_export 진단을 진짜 누락에만
+    /// surface 하기 위한 보수적 게이트 — 불확실(모듈/semantic 부재·깊이초과·CJS)하면
+    /// "있음"(true)으로 처리해 false-positive 진단을 피한다.
+    pub fn moduleHasExportName(self: *const Linker, module_idx: ModuleIndex, name: []const u8, depth: u32) bool {
+        if (depth > max_chain_depth) return true; // 불확실 → 보수적
+        const m = self.graph.getModule(module_idx) orelse return true;
+        if (m.wrap_kind == .cjs) return true; // CJS: 동적 exports, 정적 확인 불가 → 있다고 가정
+        const sem = if (m.semantic) |*s| s else return true; // semantic 부재 → 보수적
+        // exported_names: analyzer 가 기록한 named/default/re-export 이름 집합.
+        if (sem.exported_names.contains(name)) return true;
+        // namespace / const-enum 등 exported_names 에 안 잡히는 export 는 module-scope
+        // 심볼의 is_exported 플래그로 추가 확인.
+        if (sem.scope_maps.len > 0) {
+            if (sem.scope_maps[0].get(name)) |sym_idx| {
+                if (sym_idx < sem.symbols.items.len and sem.symbols.items[sym_idx].decl_flags.is_exported) return true;
+            }
+        }
+        // export * from <src>: 구체 이름은 exported_names 에 없으므로 소스로 재귀
+        // (ESM spec: export * 는 default 제외).
+        if (!std.mem.eql(u8, name, "default")) {
+            for (m.export_bindings) |eb| {
+                if (eb.kind.isReExportAll() and std.mem.eql(u8, eb.exported_name, "*")) {
+                    const rec_idx = eb.import_record_index orelse continue;
+                    if (rec_idx >= m.import_records.len) continue;
+                    const src = m.import_records[rec_idx].resolved;
+                    if (!src.isNone() and self.moduleHasExportName(src, name, depth + 1)) return true;
+                }
+            }
+        }
+        // 여기 도달 = 이름 미발견. exported_names 가 *비어있으면* 이 모듈의 export 가
+        // semantic 에 캡처되지 않은 형태(TS namespace/const-enum, ESM-wrap/scope-hoist 등)
+        // → 모델 불완전이므로 보수적으로 "있음"(true) 처리해 false-positive 진단을 피한다.
+        // 비어있지 않으면(실제 export 가 캡처됨) 진짜 미발견 → false(genuine missing).
+        if (sem.exported_names.count() == 0) return true;
+        return false;
     }
 
     pub fn resolveExportChain(


### PR DESCRIPTION
## 문제 (#3978)

번들러 `resolveImports` 루프는 `resolveExportChain` 이 `null` 이면 **무조건** `missing_export` 진단을 `self.diagnostics` 에만 기록했습니다. 그런데 `self.diagnostics` 는 **내부/테스트 전용**이라 `BundleResult` 로 wire 되지 않아 — 사용자는 실제로 존재하지 않는 export 를 import 해도 빌드 에러를 보지 못하고 런타임에 `ReferenceError` 를 맞았습니다 (esbuild/rolldown 은 빌드 시점에 `No matching export` 로 거부).

## 단순 라우팅이 안 되는 이유

그 `null` 의 대부분은 **진짜 누락이 아닙니다**. `resolveExportChain` 은 해석(rename/symbol)까지 모델하느라 다음을 false-null 로 떨굽니다:

- CJS 동적 exports (`module.exports.x = ...`)
- TS namespace / interface / const-enum (strip 되어 semantic 에 값으로 안 잡힘)
- default-function, handled-elsewhere

단순히 `fatal_diagnostics` 로 라우팅하면 **137개 유닛 회귀** (smoke=JS 는 0건이었으나 TS 픽스처에서 폭발)가 발생합니다.

## 해결 — 정밀 게이트

`semantic.exported_names`(analyzer 가 **type-space 포함 모든** export 이름을 기록)를 chain-aware 로 조회하는 `moduleHasExportName` 게이트를 추가했습니다. 다음을 **모두** 만족하는 *진짜 누락*만 `fatal_diagnostics` 로 surface 합니다:

- `value_used` — importer 로컬 바인딩이 **값** 위치에서 참조됨 (module scope + references 직접 확인)
- `!is_helper` · `!target_cjs` · `!type_only` · `!shim_missing_exports`
- `!moduleHasExportName(...)` — `exported_names` + module-scope `is_exported` + `export *` 재귀

`exported_names.count()==0`(모델 불완전: TS namespace/const-enum, ESM-wrap 등)은 **보수적으로 억제**해 false-positive 를 피합니다. esbuild/rolldown parity.

## 회귀 테스트

- 기본 3건: genuine(값사용 ESM)→error / type-only→no-error / CJS→no-error
- 차원별 표 6건: `export*`-present/-missing(보수적 한계 문서화) / named-reexport / unused / ESM-default-missing→error / CJS-default→no-error
- 기존 `shimMissingExports` ON/OFF 테스트도 정합 갱신 (OFF + 진짜 누락 = 이제 에러 surface)

## 알려진 보수적 한계

순수 `export *` 배럴(자신의 `exported_names` 가 빈)을 통한 진짜 누락은 진단하지 않습니다 — 배럴은 매우 흔하고 false-positive 회피가 우선이라 의도된 트레이드오프입니다 (테스트로 박제).

## 검증

- `zig build test` 전체 통과 (신규 9 테스트 포함)
- `bundle-smoke` 151/151
- `/code-review max` (9-angle + sweep) — 메모리 소유권/재귀 종료/게이트 로직/중복 진단 전부 clear

Closes #3978

🤖 Generated with [Claude Code](https://claude.com/claude-code)