### PR TITLE
fix(bundler): ambiguous export* 충돌을 spec 대로 거부/undefined 처리 (#3982)

### DIFF
--- a/src/bundler/bundler_test/exports_name_dedup.zig
+++ b/src/bundler/bundler_test/exports_name_dedup.zig
@@ -91,3 +91,92 @@ test "exports name dedup: 단일 사본은 suffix 없이 base 이름" {
     // suffix 가 붙은 인스턴스가 있으면 안 됨
     try testing.expect(std.mem.indexOf(u8, code, "exports_lonely$") == null);
 }
+
+// ============================================================
+// #3982: ambiguous export* (한 이름이 2+ distinct 소스에서 export *)
+// ESM spec ResolveExport ambiguity — named import = error, namespace 멤버 = undefined.
+// diamond(같은 underlying 모듈 2경로)는 ambiguous 아님.
+// ============================================================
+
+fn hasAmbiguousDiag(r: *const helpers.Bundled) bool {
+    const diags = r.result.diagnostics orelse return false;
+    for (diags) |d| {
+        if (d.code == .ambiguous_export) return true;
+    }
+    return false;
+}
+
+test "ambiguous export*: 2개 distinct 소스의 같은 이름 named import 는 build error (#3982)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.js", "export const shared = 'from-a';");
+    try writeFile(tmp.dir, "b.js", "export const shared = 'from-b';");
+    try writeFile(tmp.dir, "barrel.js", "export * from './a.js';\nexport * from './b.js';");
+    try writeFile(tmp.dir, "entry.js",
+        \\import { shared } from './barrel.js';
+        \\globalThis.z = shared;
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    // ESM spec: ambiguous → esbuild/rolldown/Node 처럼 build error 로 surface.
+    try testing.expect(r.result.hasErrors());
+    try testing.expect(hasAmbiguousDiag(&r));
+}
+
+test "ambiguous export*: 한 소스에만 있는 이름은 정상 해석 (#3982)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.js", "export const only_a = 1;\nexport const shared = 'from-a';");
+    try writeFile(tmp.dir, "b.js", "export const only_b = 2;\nexport const shared = 'from-b';");
+    try writeFile(tmp.dir, "barrel.js", "export * from './a.js';\nexport * from './b.js';");
+    try writeFile(tmp.dir, "entry.js",
+        \\import { only_a } from './barrel.js';
+        \\globalThis.z = only_a;
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    // only_a 는 a.js 에만 있음 → 모호하지 않음 → 정상.
+    try testing.expect(!r.result.hasErrors());
+    try testing.expect(!hasAmbiguousDiag(&r));
+}
+
+test "ambiguous export*: diamond(같은 underlying 2경로)는 ambiguous 아님 (#3982)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "real.js", "export const shared = 'real';");
+    try writeFile(tmp.dir, "p1.js", "export * from './real.js';");
+    try writeFile(tmp.dir, "p2.js", "export * from './real.js';");
+    try writeFile(tmp.dir, "barrel.js", "export * from './p1.js';\nexport * from './p2.js';");
+    try writeFile(tmp.dir, "entry.js",
+        \\import { shared } from './barrel.js';
+        \\globalThis.z = shared;
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    // shared 가 두 경로로 도달하지만 같은 canonical(real.js) → 모호하지 않음.
+    try testing.expect(!r.result.hasErrors());
+    try testing.expect(!hasAmbiguousDiag(&r));
+}
+
+test "ambiguous export*: namespace 멤버는 undefined — 객체서 제외 + void 0 rewrite (#3982)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.js", "export const a = 1;\nexport const shared = 'from-a';");
+    try writeFile(tmp.dir, "b.js", "export const b = 2;\nexport const shared = 'from-b';");
+    try writeFile(tmp.dir, "barrel.js", "export * from './a.js';\nexport * from './b.js';");
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ns from './barrel.js';
+        \\globalThis.z = [ns.a, ns.b, ns.shared];
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+    // namespace 멤버 접근은 에러가 아님(undefined).
+    try testing.expect(!r.result.hasErrors());
+    // materialize 된 ns 객체에 ambiguous `shared` getter 가 없어야 한다(undefined).
+    try testing.expect(std.mem.indexOf(u8, code, "get shared") == null);
+}

--- a/src/bundler/bundler_test/jsx.zig
+++ b/src/bundler/bundler_test/jsx.zig
@@ -619,7 +619,19 @@ test "Re-export: overlapping export * names" {
     const result = try b.bundle();
     defer result.deinit(std.testing.allocator);
 
-    try std.testing.expect(!result.hasErrors());
+    // (#3982) x 는 a/b 양쪽에서 export * 로 도달 → ESM spec 상 ambiguous → named
+    // import 는 build error(esbuild/rolldown/Node 동형). y(a만)·z(b만)는 정상.
+    try std.testing.expect(result.hasErrors());
+    var found_ambiguous = false;
+    if (result.diagnostics) |diags| {
+        for (diags) |d| {
+            if (d.code == .ambiguous_export) {
+                found_ambiguous = true;
+                break;
+            }
+        }
+    }
+    try std.testing.expect(found_ambiguous);
 }
 
 // ============================================================

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1534,6 +1534,27 @@ pub const Linker = struct {
                             }
                         }
                     }
+                    // (#3982) ambiguous export*: 같은 이름이 2+ distinct star 소스에서
+                    // 도달하면 resolveExportChain 이 null 을 주지만 이는 *누락*이 아니라
+                    // *모호*다(ESM spec). named import 는 esbuild/rolldown/Node 처럼 build
+                    // error 로 surface. 값으로 쓰는 import 만(미사용/type-only 제외).
+                    if (value_used and !ib.is_helper and
+                        self.resolveStarExport(source_record.resolved, ib.imported_name, 0) == .ambiguous)
+                    {
+                        const msg = std.fmt.allocPrint(self.allocator, "Ambiguous import \"{s}\" — exported by multiple modules via \"export *\"", .{ib.imported_name}) catch {
+                            continue;
+                        };
+                        self.fatal_diagnostics.append(self.allocator, .{
+                            .code = .ambiguous_export,
+                            .severity = .@"error",
+                            .message = msg,
+                            .file_path = m.path,
+                            .span = ib.local_span,
+                            .step = .link,
+                            .suggestion = ib.imported_name,
+                        }) catch self.allocator.free(msg);
+                        continue;
+                    }
                     const genuine = value_used and !ib.is_helper and !tgt_cjs and !type_only and
                         !self.shim_missing_exports and
                         !self.moduleHasExportName(source_record.resolved, ib.imported_name, 0);
@@ -1734,23 +1755,14 @@ pub const Linker = struct {
             };
         }
 
-        // 2. export * 확인 (re_export_all)
+        // 2. export * 확인 (re_export_all). 모든 star 소스를 스캔해 동일 이름이
+        // 2개 이상의 서로 다른 canonical 에서 도달하면 ESM spec 상 ambiguous(접근 불가)
+        // → null 반환(#3982). diamond(같은 underlying 2경로)는 ambiguous 아님.
         const m = m_any;
-        for (m.export_bindings) |eb| {
-            if (!eb.kind.isReExportAll()) continue;
-            if (eb.import_record_index) |rec_idx| {
-                if (rec_idx < m.import_records.len) {
-                    const source_mod = m.import_records[rec_idx].resolved;
-                    if (!source_mod.isNone()) {
-                        // CJS fallback은 실제 `module.exports`/`exports.*` 소스에만 유효하다.
-                        // 런타임 값이 비어 있는 type barrel이 임의의 이름을 소유하면 안 된다.
-                        // synthetic 도 같은 이유로 star 전파 금지(allow_synthetic=false) — Rollup 동일.
-                        if (self.resolveOrCjsFallback(source_mod, name, depth + 1, false)) |result| {
-                            return result;
-                        }
-                    }
-                }
-            }
+        switch (self.resolveStarExport(module_idx, name, depth)) {
+            .resolved => |result| return result,
+            .ambiguous => return null,
+            .none => {},
         }
 
         // 3. #3664 P2: synthetic_named_exports — 정적/re-export/export* 어디서도 못 찾으면 fallback
@@ -1787,6 +1799,75 @@ pub const Linker = struct {
             if (sm.wrap_kind == .cjs and sm.has_cjs_export_signal) return .{ .module_index = source_mod, .export_name = name };
         }
         return null;
+    }
+
+    /// 두 SymbolRef 가 같은 canonical(동일 정의)을 가리키는지. diamond(같은 underlying
+    /// 모듈이 여러 경로로 re-export)는 ambiguous 가 아니므로 이 비교로 구별한다. #3982
+    fn sameCanonical(a: SymbolRef, b: SymbolRef) bool {
+        if (@intFromEnum(a.module_index) != @intFromEnum(b.module_index)) return false;
+        if (!std.mem.eql(u8, a.export_name, b.export_name)) return false;
+        const am = a.synthetic_member;
+        const bm = b.synthetic_member;
+        if (am == null and bm == null) return true;
+        if (am == null or bm == null) return false;
+        return std.mem.eql(u8, am.?, bm.?);
+    }
+
+    const StarResolve = union(enum) {
+        /// star 소스 어디에서도 못 찾음
+        none,
+        /// 정확히 하나의 canonical 로 해석(또는 diamond — 모두 같은 canonical)
+        resolved: SymbolRef,
+        /// 2개 이상의 서로 다른 canonical 에서 도달 — ESM spec ambiguous
+        ambiguous,
+    };
+
+    /// 모듈이 직접 export 하지 않으면서 2+ distinct `export *` 소스에서 같은 이름이
+    /// 도달하는지(ESM ambiguous). namespace 멤버 rewrite(shared_namespace.zig)가
+    /// ambiguous 멤버를 `void 0` 으로 매핑하기 위해 호출 — named 경로와 동일한
+    /// resolveStarExport 판정을 공유해 drift 를 막는다. #3982
+    /// 직접 export(또는 named re-export)면 그 정의가 우선이라 ambiguous 아님.
+    pub fn isAmbiguousStarExport(self: *const Linker, module_idx: ModuleIndex, name: []const u8) bool {
+        var key_buf: [4096]u8 = undefined;
+        const dk = makeExportKeyBuf(&key_buf, module_idx.toU32(), name);
+        if (self.export_map.contains(dk)) return false;
+        return self.resolveStarExport(module_idx, name, 0) == .ambiguous;
+    }
+
+    /// `export * from` (exported_name=="*") re-export 개수. ambiguity 는 2+ star
+    /// 소스에서만 가능하므로, 흔한 0~1 star 모듈에서 ambiguity 스캔을 건너뛰는 게이트.
+    pub fn starReExportCount(self: *const Linker, module_idx: ModuleIndex) usize {
+        const m = self.graph.getModule(module_idx) orelse return 0;
+        var n: usize = 0;
+        for (m.export_bindings) |eb| {
+            if (eb.kind.isReExportAll() and std.mem.eql(u8, eb.exported_name, "*")) n += 1;
+        }
+        return n;
+    }
+
+    /// 모듈의 모든 `export *` 소스를 스캔해 `name` 의 해석 결과를 반환(#3982).
+    /// 첫 매칭에서 멈추지 않고 전 소스를 확인 — 2+ distinct canonical 이면 ambiguous.
+    /// resolveExportChainInner step2(named/re-export/tree-shake 경로)와 ambiguity
+    /// 진단(resolveImports)이 공유해 스캔 로직 drift 를 방지한다.
+    fn resolveStarExport(self: *const Linker, module_idx: ModuleIndex, name: []const u8, depth: u32) StarResolve {
+        const m = self.graph.getModule(module_idx) orelse return .none;
+        var found: ?SymbolRef = null;
+        for (m.export_bindings) |eb| {
+            if (!eb.kind.isReExportAll()) continue;
+            const rec_idx = eb.import_record_index orelse continue;
+            if (rec_idx >= m.import_records.len) continue;
+            const source_mod = m.import_records[rec_idx].resolved;
+            if (source_mod.isNone()) continue;
+            // CJS fallback은 실제 `module.exports`/`exports.*` 소스에만 유효. synthetic 은
+            // star 전파 금지(allow_synthetic=false) — Rollup 동일.
+            const result = self.resolveOrCjsFallback(source_mod, name, depth + 1, false) orelse continue;
+            if (found) |f| {
+                if (!sameCanonical(f, result)) return .ambiguous;
+            } else {
+                found = result;
+            }
+        }
+        return if (found) |f| .{ .resolved = f } else .none;
     }
 
     /// namespace 식별자가 member access 이외의 위치에서 사용되는지 판별.

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -182,6 +182,9 @@ pub fn registerNamespaceRewrites(
         }
     }
 
+    // (#3982) 2+ `export *` 소스가 있는 barrel 만 ambiguity 검사(흔한 0~1 star 는 비용 0).
+    const ambiguity_possible = self.starReExportCount(@enumFromInt(target_mod_idx)) >= 2;
+
     for (cached_exports) |exp| {
         const is_shadow = blk: {
             if (ns_rewrite) break :blk false;
@@ -190,6 +193,13 @@ pub fn registerNamespaceRewrites(
         };
         if (is_shadow) {
             has_shadow = true;
+            continue;
+        }
+        // (#3982) 같은 이름이 2+ distinct star 소스에서 도달하면 ESM spec 상 ambiguous —
+        // namespace 멤버는 undefined. `void 0` 으로 매핑하면 emitStaticMember 가 access
+        // 를 `void 0` 으로 재작성(materialize 안 된 inline ns 의 dangling 참조 방지).
+        if (ambiguity_possible and self.isAmbiguousStarExport(@enumFromInt(target_mod_idx), exp.exported)) {
+            try inner_map.put(exp.exported, "void 0");
             continue;
         }
         if (exp.ns_target_mod) |target| {
@@ -788,9 +798,14 @@ fn buildInlineObjectStr(
     const colon_sep: []const u8 = if (min_ws) ":" else ": ";
     const get_open: []const u8 = if (min_ws) "(){return " else "() { return ";
     const get_close: []const u8 = if (min_ws) "}" else "; }";
+    // (#3982) 2+ `export *` 소스 barrel 만 ambiguity 검사.
+    const ambiguity_possible = self.starReExportCount(@enumFromInt(target_mod_idx)) >= 2;
     try buf.appendSlice(self.allocator, "{");
     var first = true;
     for (exports.items) |exp| {
+        // (#3982) 같은 이름이 2+ distinct star 소스에서 도달하면 ESM spec 상 ambiguous —
+        // namespace 객체에서 제외 → `ns.x`===undefined, `"x" in ns`===false (Node 동형).
+        if (ambiguity_possible and self.isAmbiguousStarExport(@enumFromInt(target_mod_idx), exp.exported)) continue;
         // declaration 이 tree-shaken 되어 emit 안 되면 namespace getter 도 skip —
         // dangling reference 방지. declaration 모듈은 init_mod (lazy init) 있으면
         // 그쪽, 없으면 target (정적 export).

--- a/src/bundler/tree_shaker_test.zig
+++ b/src/bundler/tree_shaker_test.zig
@@ -1735,13 +1735,15 @@ test "ref: export * name collision — both sources have same export" {
     var r = try buildAndShake(std.testing.allocator, &tmp, "entry.ts");
     defer r.deinit();
 
-    // x가 사용됨 — 어느 소스에서 왔든 하나는 마킹
-    // (충돌 해결은 linker의 역할, tree-shaker는 사용 여부만 추적)
+    // (#3982) x 는 src1/src2 양쪽에서 export * 로 도달 → ESM spec 상 ambiguous →
+    // resolveExportChain 이 어느 canonical 로도 해석하지 않는다(named import 는 linker
+    // 가 build error 로 surface). 따라서 tree-shaker 도 x 를 어느 소스에서도 used 로
+    // 마킹하지 않는다(이전엔 first-wins 로 한쪽을 마킹하던 lenient 동작 — 폐기).
     const src1 = r.findModule("src1.ts");
     const src2 = r.findModule("src2.ts");
     const x_used_in_src1 = if (src1) |i| r.shaker.isExportUsed(i, "x") else false;
     const x_used_in_src2 = if (src2) |i| r.shaker.isExportUsed(i, "x") else false;
-    try std.testing.expect(x_used_in_src1 or x_used_in_src2);
+    try std.testing.expect(!x_used_in_src1 and !x_used_in_src2);
     // only1, only2는 사용되지 않음
     if (src1) |i| try std.testing.expect(!r.shaker.isExportUsed(i, "only1"));
     if (src2) |i| try std.testing.expect(!r.shaker.isExportUsed(i, "only2"));

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -763,6 +763,9 @@ pub const BundlerDiagnostic = struct {
         unresolved_import,
         /// export 이름을 찾을 수 없음
         missing_export,
+        /// 한 이름이 2개 이상의 서로 다른 `export *` 소스에서 도달 — ESM spec(ResolveExport
+        /// ambiguity)상 접근 불가. named import = error, namespace 멤버 = undefined. #3982
+        ambiguous_export,
         /// 순환 참조 감지
         circular_dependency,
         /// re-export source가 자기 자신으로 resolve (alias/plugin 잘못)


### PR DESCRIPTION
## 문제 (#3982)

한 이름이 **서로 다른 2개 이상의 모듈**에서 `export *` 로 도달하면, ESM spec(16.2.1.5.2 ResolveExport ambiguity)상 그 이름은 ambiguous 라 접근 불가여야 합니다 — namespace 멤버는 `undefined`, 직접 named import 는 binding error. ZNTC 는 **첫 `export *` 소스로 해석**해 정의된-잘못된 값을 **무진단**으로 산출했습니다.

```js
// barrel.js: export * from './a'; export * from './b';  (둘 다 shared export)
import { shared } from './barrel';        // ZNTC=from-a / esbuild·rolldown·Node=ERROR
import * as ns from './barrel'; ns.shared // ZNTC=from-a / Node=undefined
```

## 루트커즈 수정

기존 `resolveExportChainInner` step2 가 첫 `export *` 매칭에서 즉시 return(first-wins)한 게 근본 원인이었습니다.

- **`resolveStarExport`**: 모든 star 소스를 스캔해 동일 이름이 **2+ distinct canonical** 에서 도달하면 `.ambiguous`. **diamond**(같은 underlying 모듈이 여러 경로로 re-export)는 `sameCanonical` 비교로 구별(ambiguous 아님). `resolveExportChainInner` step2 가 이를 사용 — named import / re-export forwarding / tree-shake 가 **일관된 판정**을 공유(스캔 로직 drift 방지).
- **named import**: ambiguous → #3978 에서 만든 `fatal_diagnostics` 경로로 `.ambiguous_export` **build error** surface(esbuild/rolldown/Node 동형). 값으로 쓰는 import 만(미사용/type-only 제외).
- **namespace 멤버**: `registerNamespaceRewrites` 가 ambiguous 멤버를 `void 0` 으로 매핑 → `emitStaticMember` 가 `ns.x`→`void 0` 재작성. `buildInlineObjectStr` 는 materialize 객체에서 제외 → `ns.x`===`undefined`, `"x" in ns`===`false`. 흔한 0~1 star 모듈은 `starReExportCount>=2` 게이트로 검사 비용 0.

## 동작 검증 (Node 실행)

| 케이스 | 결과 |
|---|---|
| `ns.a, ns.b, ns.shared` | `1 2 undefined` ✓ |
| `import {shared}` (ambiguous) | build error `Ambiguous import "shared"` (exit 1) ✓ |
| `import {a}` (a만) | 정상 ✓ |
| diamond (`p1`/`p2` 모두 `export * from real`) | `real`, 정상 ✓ |
| `globalThis.NS=ns; NS.shared; "shared" in NS` | `undefined false` (객체서 제외) ✓ |

## 테스트

- 기존 `tree_shaker_test` "export * name collision"(first-wins lenient 단언) + `jsx` "overlapping export *"(no-error 단언)을 **spec-strict** 동작으로 갱신
- 회귀 4종 추가(`exports_name_dedup.zig`): named error / 비-ambiguous / diamond / namespace undefined
- 변수명 dedup(`exports_name_dedup` 세 사본) **보존** 확인 — 별개 namespace import 라 무관

## 검증

- `zig build test` 전체 통과 (회귀 4종 포함)
- `bundle-smoke` 151/151 (measure: ambiguous-star 히트 0건 — blast radius 안전, direct export 는 step1 에서 여전히 우선)
- `/code-review max` (2-angle, 정확성 + 메모리/엣지) — first-wins→full-scan blast radius, `void 0` 수명, diamond null-safety, 테스트 non-vacuous 전부 clear

#3978(missing_export surfacing) 의 fatal_diagnostics 경로에 의존 — 머지되어 해소됨.

Closes #3982

🤖 Generated with [Claude Code](https://claude.com/claude-code)