### PR TITLE
fix(test): 범위초과 \u{} 이스케이프 통합 테스트를 expectError 로 교정 (#3980)

### DIFF
--- a/tests/integration/tests/tsc/__snapshots__/es6-unicodeExtendedEscapes.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-unicodeExtendedEscapes.test.ts.snap
@@ -138,14 +138,6 @@ var x = "\\u{10FFFF}";
 "
 `;
 
-exports[`TSC: es6/unicodeExtendedEscapes unicodeExtendedEscapesInStrings07 1`] = `
-"// @target: es5,es6
-// ES6 Spec - 10.1.1 Static Semantics: UTF16Encoding (cp)
-//  1. Assert: 0 ≤ cp ≤ 0x10FFFF.
-var x = "\\u{110000}";
-"
-`;
-
 exports[`TSC: es6/unicodeExtendedEscapes unicodeExtendedEscapesInStrings08 1`] = `
 "// @target: es5,es6
 // ES6 Spec - 10.1.1 Static Semantics: UTF16Encoding (cp)
@@ -181,12 +173,6 @@ exports[`TSC: es6/unicodeExtendedEscapes unicodeExtendedEscapesInStrings11 1`] =
 // Although we should just get back a single code point value of 0xDC00,
 // this is a useful edge-case test.
 var x = "\\u{DC00}";
-"
-`;
-
-exports[`TSC: es6/unicodeExtendedEscapes unicodeExtendedEscapesInStrings12 1`] = `
-"// @target: es5,es6
-var x = "\\u{FFFFFFFF}";
 "
 `;
 

--- a/tests/integration/tests/tsc/es6-unicodeExtendedEscapes.test.ts
+++ b/tests/integration/tests/tsc/es6-unicodeExtendedEscapes.test.ts
@@ -249,7 +249,8 @@ var x = "\\u{10FFFF}";
     );
   });
   test('unicodeExtendedEscapesInStrings07', async () => {
-    await expectPass(
+    // 0x110000 > 0x10FFFF → 범위 초과. ES/TSC(TS1198) 처럼 에러로 거부 (#3980).
+    await expectError(
       `// @target: es5,es6
 
 // ES6 Spec - 10.1.1 Static Semantics: UTF16Encoding (cp)
@@ -310,7 +311,8 @@ var x = "\\u{DC00}";
     );
   });
   test('unicodeExtendedEscapesInStrings12', async () => {
-    await expectPass(
+    // 0xFFFFFFFF > 0x10FFFF → 범위 초과. ES/TSC(TS1198) 처럼 에러로 거부 (#3980).
+    await expectError(
       `// @target: es5,es6
 
 var x = "\\u{FFFFFFFF}";


### PR DESCRIPTION
## 문제 (CI 회귀)

`#3980`(string literal `\u{}` 범위초과 검사 추가)가 머지된 뒤, 통합 테스트가 빨갛게 깨져 있었습니다.

- `unicodeExtendedEscapesInStrings07` (`\u{110000}`)
- `unicodeExtendedEscapesInStrings12` (`\u{FFFFFFFF}`)

두 테스트는 **#3980 이전의 passthrough 출력**(`var x = "\u{110000}";`)을 `expectPass` + 스냅샷으로 박제하고 있었습니다. #3980 이 이제 범위초과(>0x10FFFF)를 올바르게 **에러로 거부**(exit 1, stdout 비어 stale 스냅샷과 불일치)하면서 깨졌습니다.

## 수정

0x10FFFF 초과 코드포인트는 ES 명세 + TSC(TS1198 *"An extended Unicode escape value must be between 0x0 and 0x10FFFF inclusive"*)에서 **에러**입니다. 같은 파일의 **RegExp 변형**(`unicodeExtendedEscapesInRegularExpressions07/12`)은 이미 `expectError` 였으므로, String 변형도 동일하게 `expectError` 로 교정하고 stale 스냅샷 2개를 제거했습니다.

런타임 동작(#3980 의 거부)은 정당하며 변경하지 않았습니다 — **테스트 기대만 정정**.

## 검증

로컬에서 CI 동등 전부 재실행:

- `zig build` / `zig build test` / `zig build -Doptimize=ReleaseFast` / `zig build test262` ✅
- `zig fmt --check src/`, audit(addnode/sourcemap), oxlint, oxfmt:check ✅
- NAPI(Bun 501 / Node 19) ✅
- **Integration 3954 pass / 0 fail** ✅ (본 수정으로 회복)

🤖 Generated with [Claude Code](https://claude.com/claude-code)