### PR TITLE
fix(bundler): namespace import 의 export*-from-CJS 멤버를 런타임 구성 (#3975)

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -126,6 +126,79 @@ test "CJS: import * as ns of ESM-that-export*-from-CJS → __toESM(require()) af
     try std.testing.expect(wrapper_pos < use_pos);
 }
 
+test "CJS: namespace of mixed barrel (local export + export*-from-CJS) (#3975)" {
+    // mid 가 자체 ESM export + `export * from <CJS>` 혼합. ns 는 per-module preamble 에서
+    // `var ns = {get local...}; __copyProps(ns, require_lib());` 로 런타임 구성돼야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.cjs", "exports.alpha = 1;");
+    try writeFile(tmp.dir, "mid.ts", "export const local = 42;\nexport * from './lib.cjs';");
+    try writeFile(tmp.dir, "entry.ts", "import * as ns from './mid.ts';\nglobalThis.z = [ns.local, ns.alpha];");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // CJS 멤버는 __copyProps(ns, require_lib()) 로 런타임 복사 (헬퍼 정의가 아닌 호출부).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__copyProps(ns, require_lib())") != null);
+    // require wrapper 정의가 __copyProps(ns, require_lib()) 호출보다 먼저 와야 함(ordering).
+    const wrapper_pos = std.mem.indexOf(u8, result.output, "require_lib = __commonJS").?;
+    const use_pos = std.mem.indexOf(u8, result.output, "__copyProps(ns, require_lib())").?;
+    try std.testing.expect(wrapper_pos < use_pos);
+    // ESM-local 멤버는 getter 로 유지.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "get local()") != null);
+}
+
+test "CJS: namespace of multiple export*-from-CJS barrels (#3975)" {
+    // 2개의 `export * from <CJS>` → 각 CJS 마다 __copyProps. 다중 CJS star 가
+    // resolveStarExport 를 거짓-ambiguous 로 만들어 tree-shake 되던 회귀 가드.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "c1.cjs", "exports.alpha = 1;");
+    try writeFile(tmp.dir, "c2.cjs", "exports.beta = 2;");
+    try writeFile(tmp.dir, "mid.ts", "export * from './c1.cjs';\nexport * from './c2.cjs';");
+    try writeFile(tmp.dir, "entry.ts", "import * as ns from './mid.ts';\nglobalThis.z = [ns.alpha, ns.beta];");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 두 CJS 소스가 모두 번들에 남아 namespace 로 복사돼야 한다(tree-shake 거짓제거 방지).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_c1 = __commonJS") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_c2 = __commonJS") != null);
+}
+
+test "CJS: namespace with export*-as-inner from CJS (#3975)" {
+    // `export * as inner from <CJS>` → ns.inner 는 빈 {} 가 아니라 __toESM(require()) 여야.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.cjs", "exports.alpha = 1;");
+    try writeFile(tmp.dir, "mid.ts", "export * as inner from './lib.cjs';");
+    try writeFile(tmp.dir, "entry.ts", "import * as ns from './mid.ts';\nglobalThis.z = ns.inner.alpha;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // inner 멤버가 __toESM(require_lib()) 로 materialize 돼야 한다(빈 {} 아님).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib())") != null);
+}
+
 test "CJS: RN strict order defers named CJS import with inlineRequires" {
     // RN inlineRequires 에서는 named CJS import 도 Metro 처럼 값 사용 지점에서 평가된다.
     // side-effect import 순서는 유지하지만, named binding 의 require 는 본문 실행 전

--- a/src/bundler/emitter/runtime_helpers.zig
+++ b/src/bundler/emitter/runtime_helpers.zig
@@ -107,6 +107,27 @@ fn isPureCjsStarReExport(target: *const Module, graph: *const ModuleGraph) bool 
     return found_cjs_star;
 }
 
+/// (#3975) namespace target(ESM)이 CJS 를 `export *`/`export * as` 로 재노출하는지
+/// (혼합·다중·inner 포함, pure-single 상위집합). metadata.zig 의 namespaceHasCjsStar 와
+/// 동일 조건 — 이 경로는 per-module preamble 이 `__copyProps(ns, require())`/`__toESM`
+/// 을 emit 하므로 두 헬퍼가 필요하다. 두 함수는 lockstep 유지 (어긋나면 헬퍼 미정의 →
+/// ReferenceError).
+fn namespaceTargetHasCjsStar(target: *const Module, graph: *const ModuleGraph) bool {
+    if (target.wrap_kind == .cjs) return false;
+    for (target.export_bindings) |eb| {
+        const is_star = eb.kind.isReExportAll() and std.mem.eql(u8, eb.exported_name, "*");
+        const is_star_as = eb.kind == .re_export_namespace;
+        if (!is_star and !is_star_as) continue;
+        const ri = eb.import_record_index orelse continue;
+        if (ri >= target.import_records.len) continue;
+        const src = target.import_records[ri].resolved;
+        if (src.isNone()) continue;
+        const sm = graph.getModule(src) orelse continue;
+        if (sm.wrap_kind == .cjs) return true;
+    }
+    return false;
+}
+
 fn moduleNeedsToEsmInterop(module: *const Module, graph: *const ModuleGraph, linker: ?*const Linker) bool {
     for (module.import_bindings) |ib| {
         if (ib.import_record_index >= module.import_records.len) continue;
@@ -123,6 +144,9 @@ fn moduleNeedsToEsmInterop(module: *const Module, graph: *const ModuleGraph, lin
             // preamble 이 `var ns = __toESM(require())` 를 emit → __toESM 헬퍼 필요. redirect
             // 조건(metadata.zig pureCjsStarTarget)과 동일하게 감지한다.
             if (isPureCjsStarReExport(target, graph)) return true;
+            // (#3975) 혼합/다중/inner: per-module preamble 이 `__copyProps(ns, require())`
+            // (+ inner 는 __toESM) 를 emit → 헬퍼 필요.
+            if (namespaceTargetHasCjsStar(target, graph)) return true;
             continue;
         }
 

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1852,6 +1852,7 @@ pub const Linker = struct {
     fn resolveStarExport(self: *const Linker, module_idx: ModuleIndex, name: []const u8, depth: u32) StarResolve {
         const m = self.graph.getModule(module_idx) orelse return .none;
         var found: ?SymbolRef = null;
+        var found_is_cjs = false;
         for (m.export_bindings) |eb| {
             if (!eb.kind.isReExportAll()) continue;
             const rec_idx = eb.import_record_index orelse continue;
@@ -1861,10 +1862,22 @@ pub const Linker = struct {
             // CJS fallback은 실제 `module.exports`/`exports.*` 소스에만 유효. synthetic 은
             // star 전파 금지(allow_synthetic=false) — Rollup 동일.
             const result = self.resolveOrCjsFallback(source_mod, name, depth + 1, false) orelse continue;
+            // resolveOrCjsFallback 은 CJS 소스에 대해 *임의의* 이름을 매칭(동적 exports)으로
+            // 반환한다. 따라서 CJS 결과는 그 이름을 정적으로 *정의한다고 증명할 수 없으므로*
+            // ambiguity 판정에서 제외한다 — 2+ CJS star 가 모든 이름을 거짓-ambiguous 로
+            // 만드는 것을 방지(#3975 다중 CJS star). 런타임에 __copyProps first-wins 로 병합.
+            // ESM 정적 export 끼리의 충돌만 진짜 ambiguous(#3982).
+            const result_is_cjs = if (self.graph.getModule(result.module_index)) |rm| rm.wrap_kind == .cjs else false;
             if (found) |f| {
-                if (!sameCanonical(f, result)) return .ambiguous;
+                if (!result_is_cjs and !found_is_cjs and !sameCanonical(f, result)) return .ambiguous;
+                // 정적(ESM) 결과를 CJS 동적 결과보다 우선.
+                if (found_is_cjs and !result_is_cjs) {
+                    found = result;
+                    found_is_cjs = false;
+                }
             } else {
                 found = result;
+                found_is_cjs = result_is_cjs;
             }
         }
         return if (found) |f| .{ .resolved = f } else .none;
@@ -2210,6 +2223,9 @@ pub const Linker = struct {
 
     pub const registerNamespaceRewrites = shared_namespace.registerNamespaceRewrites;
     pub const ensureSharedNsVar = shared_namespace.ensureSharedNsVar;
+    /// (#3975) namespace 객체의 ESM-local getter literal 생성 (CJS star/inner 혼합 케이스의
+    /// per-module 런타임 구성에서 사용). buildInlineObjectStr 노출.
+    pub const buildNamespaceInlineObject = shared_namespace.buildInlineObjectStr;
 
     /// computeCrossChunkLinks 가 cross-chunk namespace re-export target 마킹
     /// (#3367). metadata 시점엔 chunk 정보 부재 — registerNamespaceRewrites 가

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -178,6 +178,28 @@ fn pureCjsStarTarget(self: *const Linker, mod_idx: u32) ?u32 {
     return cjs_src;
 }
 
+/// (#3975) namespace target(ESM)이 CJS 모듈을 `export *` 또는 `export * as ns` 로
+/// 재노출하는지. pureCjsStarTarget 의 일반화 — 혼합(local export + CJS star)·다중 CJS
+/// star·inner(`export * as`)를 모두 포함한다. true 면 정적 ns-object 가 CJS 동적 멤버를
+/// 못 담으므로 per-module preamble 에서 `var ns={...}; __copyProps(ns, require())` 로
+/// 런타임 구성한다. (pure-single 케이스는 pureCjsStarTarget redirect 가 먼저 처리.)
+fn namespaceHasCjsStar(self: *const Linker, mod_idx: u32) bool {
+    const m = self.getModule(mod_idx) orelse return false;
+    if (m.wrap_kind == .cjs) return false; // 직접 CJS namespace 는 별도 경로
+    for (m.export_bindings) |eb| {
+        const is_star = eb.kind.isReExportAll() and std.mem.eql(u8, eb.exported_name, "*");
+        const is_star_as = eb.kind == .re_export_namespace;
+        if (!is_star and !is_star_as) continue;
+        const rec_idx = eb.import_record_index orelse continue;
+        if (rec_idx >= m.import_records.len) continue;
+        const src = m.import_records[rec_idx].resolved;
+        if (src.isNone()) continue;
+        const sm = self.graph.getModule(src) orelse continue;
+        if (sm.wrap_kind == .cjs) return true;
+    }
+    return false;
+}
+
 fn allocLazyEsmImportExpr(self: *const Linker, import_mod: *const Module, value_mod: *const Module, target_name: []const u8) ![]const u8 {
     const sep = if (self.minify_whitespace) "," else ", ";
     const import_init = try allocEsmInitExpr(self, import_mod);
@@ -848,6 +870,45 @@ pub fn buildMetadataForAst(
             if (ib.kind == .namespace) {
                 const ns_sym_id = ib.local_symbol.semanticIndex() orelse continue;
                 const local_name = m.importBindingLocalName(ib);
+
+                // (#3975) target 이 CJS 를 export*/export*-as 로 재노출하면(혼합·다중·inner),
+                // 정적 ns-object 가 CJS 동적 멤버를 못 담는다. per-module preamble(CJS region
+                // 후, 올바른 ordering)에 `var ns = <ESM-local getters>;` + 각 CJS star 마다
+                // `__copyProps(ns, require_cjs())` 를 emit 해 런타임 구성한다. pure-single 케이스는
+                // 위 pureCjsStarTarget redirect 가 이미 처리하므로 여기 도달하지 않는다.
+                // dev_mode 는 별도 dev-metadata 경로(buildDevMetadata)가 namespace 를
+                // 처리하므로 여기서 중복 emit 하지 않는다 — 그쪽에 CJS-star copyProps 추가.
+                const cjs_star_target = self.getModule(canonical_mod);
+                const target_included = if (cjs_star_target) |cm| cm.is_included else true;
+                if (!self.dev_mode and namespaceHasCjsStar(self, canonical_mod) and
+                    !(self.tree_shaker_active and !target_included))
+                {
+                    const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse local_name;
+                    // ESM-local getter 객체 (CJS plain-star 멤버는 부재, inner-CJS 는 __toESM).
+                    const obj = try self.buildNamespaceInlineObject(@intCast(canonical_mod), 0);
+                    defer self.allocator.free(obj);
+                    try preamble.writeNamespaceObject(preamble_name, obj);
+                    // 각 `export * from <CJS>` 의 동적 멤버를 런타임 복사.
+                    const cm = cjs_star_target.?;
+                    for (cm.export_bindings) |eb| {
+                        if (!(eb.kind.isReExportAll() and std.mem.eql(u8, eb.exported_name, "*"))) continue;
+                        const rec_idx = eb.import_record_index orelse continue;
+                        if (rec_idx >= cm.import_records.len) continue;
+                        const src = cm.import_records[rec_idx].resolved;
+                        if (src.isNone()) continue;
+                        const sm = self.graph.getModule(src) orelse continue;
+                        if (sm.wrap_kind != .cjs) continue;
+                        if (self.tree_shaker_active and !sm.is_included) continue;
+                        const req_var = try getOrCreateCjsRequireRef(self, &cjs_var_cache, src.toU32());
+                        try preamble.writeNamespaceCopyProps(preamble_name, req_var);
+                    }
+                    const hoisted = try self.allocator.dupe(u8, preamble_name);
+                    errdefer self.allocator.free(hoisted);
+                    try ns_var_list.append(self.allocator, hoisted);
+                    try putOwnedRename(self, &renames, &owned_nested_renames, ns_sym_id, preamble_name);
+                    continue;
+                }
+
                 const effective_syms = override_symbol_ids orelse sem.symbol_ids;
 
                 // esbuild 방식: ns.prop → 직접 치환, ns 값 사용 → 변수 선언 + 참조.

--- a/src/bundler/linker/preamble_writer.zig
+++ b/src/bundler/linker/preamble_writer.zig
@@ -216,4 +216,18 @@ pub const PreambleWriter = struct {
         try self.write(object_literal);
         try self.write(";\n");
     }
+
+    /// (#3975) `export * from <CJS>` 의 동적 멤버를 런타임에 namespace 객체로 복사.
+    /// `__copyProps(<ns>, <req>());` — esbuild `__reExport(ns, __toESM(require()))` 대응.
+    /// plain CJS(`exports.x=`)는 module.exports 에 `default` 키가 없어 raw require() 복사로
+    /// 충분하며 default 누출이 없다(`export *` 는 default 비전파 — spec 일치).
+    pub fn writeNamespaceCopyProps(self: *PreambleWriter, ns_name: []const u8, req_var: []const u8) !void {
+        const copy_props_name: []const u8 = if (self.minify) rt.NAMES.COPY_PROPS_MIN else "__copyProps";
+        try self.write(copy_props_name);
+        try self.write("(");
+        try self.write(ns_name);
+        try self.write(", ");
+        try self.write(req_var);
+        try self.write("());\n");
+    }
 };

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -736,7 +736,7 @@ fn makeUniqueNsVarName(self: *const Linker, base: []const u8, exports: *const st
 /// 모듈의 모든 export를 인라인 객체 문자열로 생성 (재귀적).
 /// `export * as ns` export는 소스 모듈의 인라인 객체로 중첩.
 /// 결과는 `self.ns_inline_cache` 에 target_mod_idx 별로 캐싱 — linker 전역 공유.
-fn buildInlineObjectStr(
+pub fn buildInlineObjectStr(
     self: *const Linker,
     target_mod_idx: u32,
     depth: u32,
@@ -826,6 +826,22 @@ fn buildInlineObjectStr(
                 try buf.appendSlice(self.allocator, exp.exported);
             }
             try buf.appendSlice(self.allocator, colon_sep);
+            // (#3975) `export * as inner from <CJS>`: CJS 멤버는 정적 열거 불가 →
+            // 빈 `{}` 대신 `__toESM(require())` 로 런타임 namespace 를 만든다. 이 literal 은
+            // namespaceHasCjsStar 경로(per-module preamble, CJS region 후)에서만 emit 되므로
+            // require_x ordering 안전.
+            if (self.getModule(src_mod)) |src_m| {
+                if (src_m.wrap_kind == .cjs) {
+                    const req = try src_m.allocRequireName(self.allocator, &self.rename_table);
+                    defer self.allocator.free(req);
+                    const toesm: []const u8 = if (self.minify_whitespace) rt.NAMES.TOESM_MIN else "__toESM";
+                    try buf.appendSlice(self.allocator, toesm);
+                    try buf.appendSlice(self.allocator, "(");
+                    try buf.appendSlice(self.allocator, req);
+                    try buf.appendSlice(self.allocator, "())");
+                    continue;
+                }
+            }
             const nested = try buildInlineObjectStr(self, src_mod, depth + 1);
             defer self.allocator.free(nested);
             try buf.appendSlice(self.allocator, nested);


### PR DESCRIPTION
## 문제 (#3975)

`import * as ns from './mid'` 에서 `mid` 가 CJS 모듈을 `export *` / `export * as` 로 재노출하면, CJS 의 **동적 멤버가 namespace 객체에서 통째로 누락**돼 `ReferenceError` 또는 `undefined`(무진단)가 됐습니다. headline 단일-순수-star 케이스는 PR #3996(`pureCjsStarTarget` redirect)에서 해결됐고, 본 PR 은 나머지 production 케이스를 모두 해결합니다.

## 수정 (런타임 namespace 구성, esbuild `__reExport` 대응)

namespace 객체는 정적 literal 이라 CJS 동적 멤버를 못 담습니다. **per-module CJS-interop preamble**(CJS region 후 — emit ordering 안전)에 런타임 구성을 emit 합니다:

- **`namespaceHasCjsStar`** — target(ESM)이 CJS 를 `export *`/`export * as` 로 재노출하는지(혼합·다중·inner 포함, `pureCjsStarTarget` 의 일반화).
- **혼합 / 다중** (`export const local; export * from <cjs>` / 2+ CJS star):
  `var ns = {get local(){return local}}; __copyProps(ns, require_cjs());` (CJS star 마다). plain CJS 는 `module.exports` 에 `default` 키가 없어 raw `require()` 복사로 default 누출 없이 `export *` 의미(default 비전파) 일치.
- **inner** (`export * as inner from <cjs>`): `buildInlineObjectStr` 가 빈 `{}` 대신 `__toESM(require())` 로 inner namespace materialize.
- **resolveStarExport (#3982 ambiguity 스캐너) 수정**: `resolveOrCjsFallback` 은 CJS 소스에 대해 *임의의* 이름을 매칭으로 반환(동적 exports)하므로, 2+ CJS star 가 모든 이름을 **거짓-ambiguous** 로 만들어 모듈을 tree-shake 하던 회귀를 수정. CJS 동적 결과는 ambiguity 판정에서 제외(런타임 `__copyProps` first-wins 병합), **ESM 정적 충돌만 ambiguous(#3982 보존)**.
- **moduleNeedsToEsmInterop** 가 `namespaceTargetHasCjsStar` 도 감지 → `__toESM`/`__copyProps` 헬퍼 emit.

## 동작 검증 (Node 실행)

| 케이스 | production | code-splitting |
|---|---|---|
| pure `export * from cjs` | `1` ✅ | ✅ |
| mixed (local + cjs star) | `42 1` ✅ | ✅ |
| multiple cjs star | `1 2` ✅ | ✅ |
| `export * as inner from cjs` | `1` ✅ | ✅ |
| 다중 importer (캐시 안전성) | `1 1` ✅ | |

#3982 회귀: ESM-ambiguous named import → 여전히 build error(exit 1), diamond → 정상(`real`).

## 테스트

- 회귀 3종 추가(`cjs_esm.zig`): 혼합 barrel / 다중 CJS star / `export * as inner`.
- `zig build test` 전체 통과, `bundle-smoke` 151/151, `export-star-emit` 7/7.
- `/code-review` (정확성/메모리/ordering): 캐시 우려 1건 → require 변수명 전역 결정적 + 다중 importer 실증으로 REFUTED.

## 남은 부분

**dev-server HMR 경로**(`--dev`)는 별도의 dev 모듈 시스템(`__zntc_modules` 레지스트리 + 자체 namespace 처리)을 사용하며, 이슈의 repro(production `zntc --bundle`)와 다른 코드 경로입니다. production 빌드는 정상이므로 dev HMR + CJS-star-namespace 조합(niche)은 후속으로 둡니다. 그래서 `Refs`(미-close).

Refs #3975

🤖 Generated with [Claude Code](https://claude.com/claude-code)