### PR TITLE
fix(bundler): dev HMR 의 export*-from-CJS namespace 멤버 누락 수정 (#3975)

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -199,6 +199,50 @@ test "CJS: namespace with export*-as-inner from CJS (#3975)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib())") != null);
 }
 
+test "CJS: dev mode namespace of export*-from-CJS — wrapped exports 에 __copyProps (#3975)" {
+    // dev 모드는 mid 가 __esm 으로 wrap 된다. `export * from <CJS>` 의 동적 멤버를
+    // wrapped exports 객체에 __copyProps 로 복사해야 namespace/named import 가 본다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.cjs", "exports.alpha = 1;");
+    try writeFile(tmp.dir, "mid.ts", "export const local = 42;\nexport * from './lib.cjs';");
+    try writeFile(tmp.dir, "entry.ts", "import * as ns from './mid.ts';\nglobalThis.z = [ns.local, ns.alpha];");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // wrapped exports 객체에 CJS 멤버를 런타임 복사.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__copyProps(exports_mid, require_lib())") != null);
+}
+
+test "CJS: dev mode namespace of export*-as-inner from CJS — __toESM 표현식 (#3975)" {
+    // dev 모드 `export * as inner from <CJS>`: 빈 cjs_ns={} 대신 멤버 rewrite 가
+    // __toESM(require_lib()) 표현식이어야(접근 시점 평가, ordering 안전).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.cjs", "exports.alpha = 1;");
+    try writeFile(tmp.dir, "mid.ts", "export * as inner from './lib.cjs';");
+    try writeFile(tmp.dir, "entry.ts", "import * as ns from './mid.ts';\nglobalThis.z = ns.inner.alpha;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 빈 객체 namespace 가 아니라 __toESM(require_lib()) 표현식으로 접근.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib())") != null);
+}
+
 test "CJS: RN strict order defers named CJS import with inlineRequires" {
     // RN inlineRequires 에서는 named CJS import 도 Metro 처럼 값 사용 지점에서 평가된다.
     // side-effect import 순서는 유지하지만, named binding 의 require 는 본문 실행 전

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -684,6 +684,32 @@ pub fn emitEsmWrappedModule(
 
             try wrapped.appendSlice(allocator, "});\n");
         }
+
+        // (#3975) `export * from <CJS>`: CJS 는 정적 export_bindings 가 없어 위 getter
+        // 열거로 안 잡힌다. wrapped 모듈의 exports 객체에 CJS 동적 멤버를 런타임 복사
+        // (`__copyProps(exports_x, require_cjs())`) → `import * as ns`(__toESM(exports))·
+        // named re-import 모두 CJS 멤버를 본다. esbuild __reExport 대응. plain CJS 는
+        // default 키가 없어 default 누출 없음(`export *` 는 default 비전파, spec 일치).
+        if (linker) |l| {
+            for (module.export_bindings) |eb| {
+                if (!(eb.kind.isReExportAll() and std.mem.eql(u8, eb.exported_name, "*"))) continue;
+                const rec_idx = eb.import_record_index orelse continue;
+                if (rec_idx >= module.import_records.len) continue;
+                const src_idx = module.import_records[rec_idx].resolved;
+                if (src_idx.isNone()) continue;
+                const src_mod = l.graph.getModule(src_idx) orelse continue;
+                if (src_mod.wrap_kind != .cjs) continue;
+                const rv = try src_mod.allocRequireName(allocator, rename_tbl);
+                defer allocator.free(rv);
+                const copy_props: []const u8 = if (options.minify_whitespace) rt.NAMES.COPY_PROPS_MIN else "__copyProps";
+                try wrapped.appendSlice(allocator, copy_props);
+                try wrapped.appendSlice(allocator, "(");
+                try wrapped.appendSlice(allocator, exports_name);
+                try wrapped.appendSlice(allocator, ", ");
+                try wrapped.appendSlice(allocator, rv);
+                try wrapped.appendSlice(allocator, "());\n");
+            }
+        }
     }
 
     // 5. body codegen (variable_declaration/class → 할당문만)

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -203,6 +203,24 @@ pub fn registerNamespaceRewrites(
             continue;
         }
         if (exp.ns_target_mod) |target| {
+            // (#3975) target 이 CJS 면 정적 ns-object(buildInlineObjectStr=빈 {})로는
+            // 동적 멤버를 못 담는다. 멤버를 `__toESM(require_cjs())` 표현식으로 재작성 →
+            // `ns.inner` → `__toESM(require_cjs())`, 접근 시점 평가(CJS wrapper 정의 후)라
+            // ordering 안전(var cjs_ns={} 빈객체 + shared-preamble ordering 버그 회피).
+            // require_cjs 는 dev/production 양쪽에서 정의됨. production 의 inner 는
+            // metadata.zig namespaceHasCjsStar 분기가 먼저 처리하므로 이 경로는 주로 dev.
+            if (self.getModule(target)) |tm| {
+                if (tm.wrap_kind == .cjs) {
+                    const req = try tm.allocRequireName(self.allocator, &self.rename_table);
+                    defer self.allocator.free(req);
+                    const toesm: []const u8 = if (self.minify_whitespace) rt.NAMES.TOESM_MIN else "__toESM";
+                    const expr = try std.fmt.allocPrint(self.allocator, "{s}({s}())", .{ toesm, req });
+                    errdefer self.allocator.free(expr);
+                    try owned_rewrite_values.append(self.allocator, expr);
+                    try inner_map.put(exp.exported, expr);
+                    continue;
+                }
+            }
             const ns_var = if (ns_target_to_var.get(target)) |cached|
                 cached
             else blk: {


### PR DESCRIPTION
## 배경

#3975 의 production 케이스(pure/mixed/multi/inner/named)는 PR #4001 에서 해결했습니다. 본 PR 은 마지막 남은 **dev-server HMR(`--dev`)** 경로를 해결해 #3975 를 완전히 닫습니다.

dev 는 모듈이 `__esm` 으로 **wrap** 되어 production(scope-hoist)과 emit 경로가 다릅니다 — wrapped 모듈의 자체 exports 객체(`exports_mid`)에 CJS 동적 멤버가 누락됐습니다.

## 수정

1. **`esm_wrap.zig`** — wrapped 모듈의 `export * from <CJS>` 는 CJS 가 정적 export_bindings 가 없어 getter 열거에서 빠졌습니다. `__export(exports_x, {...})` 뒤에 CJS star 마다 `__copyProps(exports_x, require_cjs());` 를 emit → wrapped exports 객체에 동적 멤버를 런타임 복사. `import * as ns`(= `__toESM(exports)`)·named re-import 모두 CJS 멤버를 봅니다. `__copyProps` 가 기존 키를 보존(`!__hasOwn`)해 정적 getter 와 안전하게 공존.

2. **`shared_namespace.zig`** `registerNamespaceRewrites` — `export * as inner from <CJS>` 의 `ns_target_mod` 가 CJS 면 빈 `var cjs_ns = {}` 대신 멤버 rewrite 를 `__toESM(require_cjs())` **표현식**으로 매핑. 접근 시점(`ns.inner.alpha`)에 평가되므로 CJS wrapper 정의 뒤 — **ordering 안전**. production inner 는 metadata `namespaceHasCjsStar` 분기가 선처리하므로 dev 전용 경로 → 무충돌.

## 검증 (Node 실행, production + dev 양쪽)

| 케이스 | production | dev |
|---|---|---|
| pure `export * from cjs` | `1` | `1` |
| mixed (local + cjs star) | `42 1` | `42 1` |
| multiple cjs star | `1 2` | `1 2` |
| `export * as inner from cjs` | `1` | `1` |
| named re-import | `1` | `1` |

- 회귀 테스트 2종(dev mixed copyProps / dev inner __toESM)
- `zig build test` 전체 + `bundle-smoke` 151/151 + `es5-rn` 30/30 + `export-star-emit`/`ns-shadow-runtime` 통합 green
- `/code-review` (정확성/ordering/메모리/double-fire): 실 결함 0 — require_cjs ordering(DFS post-order), 헬퍼 가용성, expr 소유권, production 무충돌 모두 clear

Closes #3975

🤖 Generated with [Claude Code](https://claude.com/claude-code)