### PR TITLE
feat(bundler): --jobs(max_threads) 를 io async_limit 에 연결 (#4004)

### DIFF
--- a/packages/core/src/napi/build_async_entry.zig
+++ b/packages/core/src/napi/build_async_entry.zig
@@ -48,6 +48,7 @@ const BuildAsyncData = struct {
 
 /// 독립 스레드에서 번들링 실행 (libuv 워커 미사용 → TSFN 데드락 방지)
 fn buildWorkerThread(async_data: *BuildAsyncData) void {
+    common.setJobs(async_data.options.max_threads); // #4004: --jobs → io async_limit
     var bundler = Bundler.init(native_alloc, async_data.options);
     defer bundler.deinit();
     async_data.result = bundler.bundle(common.io()) catch |err| {

--- a/packages/core/src/napi/build_sync_entry.zig
+++ b/packages/core/src/napi/build_sync_entry.zig
@@ -78,6 +78,7 @@ pub fn napiBuildSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c
         bundle_opts.plugins = sync_plugin_storage[0..1];
     }
 
+    common.setJobs(bundle_opts.max_threads); // #4004: --jobs → io async_limit
     var bundler = Bundler.init(native_alloc, bundle_opts);
     defer bundler.deinit();
     var result = bundler.bundle(common.io()) catch |err| {

--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -64,6 +64,17 @@ pub fn io() std.Io {
     return g_threaded.?.io();
 }
 
+/// #4004: 빌드 직전 --jobs(JS `options.jobs`)를 공유 io 의 async_limit 에 반영.
+/// g_threaded 가 *Threaded 를 소유하므로 setAsyncLimit(Threaded.mutex 보호) 가능.
+/// ⚠️ 공유 전역 io 라 동시 in-flight 빌드가 서로 다른 jobs 면 마지막 setter 값을
+/// 공유한다(메모리 안전 — mutex 보호, determinism #3564 무관 — byte-identical).
+/// null(jobs=0)=기본 async_limit(cpu-1) 유지.
+pub fn setJobs(max_threads: u32) void {
+    if (@import("zntc_lib").bundler.asyncLimitForJobs(max_threads)) |lim| {
+        if (g_threaded) |*t| t.setAsyncLimit(lim);
+    }
+}
+
 // ── NAPI 환경변수 스냅샷 (0.16) ───────────────────────────────────────────
 // std.process.getEnvVarOwned 제거 → libc environ(std.c.environ) 으로 Map 을
 // 만들어 env_flag 에 등록. Map 은 프로세스 수명 동안 유지(deinit 안 함).

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -94,6 +94,16 @@ pub const OutputExports = enum {
 /// (federation.zig ↔ bundler.zig circular import 회피, types 는 양쪽 공통).
 pub const MfBundleConfig = types.MfBundleConfig;
 
+/// `--jobs`(max_threads) → io 의 `async_limit` 매핑 (#4004). `bundle(io)` 는 io 를
+/// 인터페이스로만 받아 동시성을 못 바꾸므로, io 를 *소유* 한 진입점(CLI main / NAPI
+/// common)에서 빌드 전 `Threaded.setAsyncLimit` 으로 적용한다. `null` 이면 기본값
+/// (생성 시 cpu-1) 유지. async_limit 은 "메인 스레드 제외 최대 풀 크기"라:
+///   0 → 기본 유지 / 1 → `.nothing`(=0, inline 순차, 디버깅) / N → `.limited(N-1)`.
+pub fn asyncLimitForJobs(max_threads: u32) ?std.Io.Limit {
+    if (max_threads == 0) return null;
+    return .limited(max_threads - 1);
+}
+
 pub const BundleOptions = struct {
     entry_points: []const []const u8,
     format: EmitOptions.Format = .esm,

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -630,8 +630,9 @@ pub fn emitWithTreeShaking(
     // 결정(async_limit=0 이면 inline = 단일스레드). results[i] 가 인덱스별 독립 슬롯이라
     // worker 순서 무관(determinism 불변). pool.init 실패 분기 불필요 — group.async 는
     // 실패하지 않고 자원 부족 시 inline fallback.
-    // 참고: emit 은 0.15 의 Thread.Pool 도 --jobs 미반영(항상 병렬, #3966)이었고, 0.16
-    // 도 io 기본 async_limit(cpu-1)을 쓴다 — --jobs 연결은 build_flow 주석의 follow-up 참조.
+    // 참고: 0.15 의 Thread.Pool 은 --jobs 미반영(항상 병렬, #3966)이었으나, 0.16 은 io 의
+    // async_limit 을 따르고 진입점이 --jobs 를 거기에 반영하므로(#4004) emit 도 --jobs=1
+    // (.nothing)이면 inline=순차가 된다. determinism 은 index 슬롯으로 무관(#3564).
     const use_pool = sorted.items.len >= 2;
     if (use_pool) {
         var group: std.Io.Group = .init;

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -92,10 +92,10 @@ pub fn build(self: *ModuleGraph, io: std.Io, entry_points: []const []const u8) !
         // 결정(async_limit=0 이면 io.async 가 inline 실행 = 순차). work-stealing
         // (recv 후 신규 모듈 즉시 dispatch) 패턴은 그대로. group.async 는 실패하지 않으므로
         // pool_ok fallback 불필요.
-        // ⚠️ 현재 --jobs(self.max_threads)는 async_limit 로 연결돼 있지 않다 — io 는 진입점
-        // (CLI=init.io / NAPI=common.io())의 기본값(cpu-1)을 쓴다. 출력은 renumber/path-sort
-        // (#3564)로 worker 수와 무관하게 byte-identical → determinism 영향 0. --jobs→async_limit
-        // 연결(특히 --jobs=1 순차 디버깅)은 per-build io 구성이 필요한 별도 작업(#1514 follow-up).
+        // --jobs(self.max_threads)는 진입점(CLI main / NAPI common.setJobs)에서 io 의
+        // async_limit 으로 반영된다(#4004, bundler.asyncLimitForJobs). --jobs=1 → .nothing
+        // 이면 아래 group.async 가 inline 실행 = 순차(디버깅/재현). 출력은 renumber/path-sort
+        // (#3564)로 worker 수와 무관하게 byte-identical → async_limit 변화에도 determinism 불변.
         var channel = MpscChannel(graph_discovery_scan.ScanResult).init(self.allocator);
         defer channel.deinit();
 

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -69,6 +69,7 @@ pub const ChunkKind = chunk.ChunkKind;
 pub const ChunkGraph = chunk.ChunkGraph;
 pub const Bundler = bundler_core.Bundler;
 pub const BundleOptions = bundler_core.BundleOptions;
+pub const asyncLimitForJobs = bundler_core.asyncLimitForJobs;
 pub const MfBundleConfig = types.MfBundleConfig; // #3318 P1-1
 pub const federation = @import("federation.zig"); // #3318 (mfSharedGlobalName 단일 소스)
 pub const mf_options = @import("mf_options.zig"); // #3318 mf DTO→Bundle + seam 단일 소스(CLI·NAPI 공용)

--- a/src/main.zig
+++ b/src/main.zig
@@ -304,7 +304,22 @@ pub fn main(init: std.process.Init) !void {
     // Zig 0.16: juicy main — io / args / environ 을 Init 에서 받는다 (libc-free,
     // Zig start 가 채움). args 는 argsAlloc 제거로 Init.minimal.args 이터레이터
     // 수집, env 는 std.process.getEnvVarOwned 제거로 environ Map 스냅샷 캡처로 대체.
-    const io = init.io;
+    //
+    // #4004: --jobs(max_threads)로 io 의 async_limit(Io.Group 병렬도)을 제어하려면
+    // io 를 *소유* 해야 한다 — init.io 는 std 가 소유해 setAsyncLimit 불가. init.gpa
+    // (threadsafe 명시)로 Threaded 를 직접 만들어 쓰고, opts 파싱 후 setAsyncLimit 으로
+    // --jobs 를 반영한다(아래). 기본 async_limit(cpu-1)은 init.io 와 동일.
+    //
+    // ⚠️ environ/argv0 을 init.minimal 에서 그대로 전달해야 한다 — std start 는 init.io
+    // 의 Threaded 에 process environ 을 넣지만(start.zig), `.{}` 로 만들면 environ 이
+    // .empty 가 돼 std.process.spawn(io, ...) 의 자식이 빈 환경을 받는다(예: --serve
+    // --open 의 xdg-open 이 PATH/DISPLAY 없이 실행돼 브라우저가 안 열림).
+    var threaded = std.Io.Threaded.init(init.gpa, .{
+        .argv0 = .init(init.minimal.args),
+        .environ = init.minimal.environ,
+    });
+    defer threaded.deinit();
+    const io = threaded.io();
     // env 스냅샷을 가장 먼저 등록 — env_flag.Once 가 첫 조회 결과를 캐시하므로
     // 어떤 env 조회보다 앞서야 한다.
     env_flag.captureEnviron(init.environ_map);
@@ -364,6 +379,10 @@ pub fn main(init: std.process.Init) !void {
 
     var opts = try cli_options.parseCliArguments(args, allocator, io) orelse return;
     defer opts.deinit(allocator);
+
+    // #4004: --jobs → io async_limit. 여기부터의 bundle/transpile(graph discover·emit
+    // 의 Io.Group)이 반영받는다. --jobs=1 → .nothing(inline 순차, 디버깅/재현).
+    if (lib.bundler.asyncLimitForJobs(opts.max_threads)) |lim| threaded.setAsyncLimit(lim);
 
     // --profile / --profile-level / --profile-format 반영 (env 와 합집합).
     if (opts.profile_csv) |csv| lib.profile.addFromCsv(csv);


### PR DESCRIPTION
## 배경 — 왜 0.16 부터 이런 대응이 필요한가

이건 **0.15 엔 없던 작업**이라 "왜 이렇게 해야 하나"를 먼저 정리합니다.

0.15 까지 **스레드도 파일시스템도 전역(ambient)** 이었습니다 — 어디서든 `std.fs.cwd()...`, `std.Thread.Pool` 을 원하는 스레드 수로 직접 생성. 0.16 은 이를 전부 **명시적 capability(`io: std.Io` 토큰)** 로 바꿨습니다("숨은 전역 I/O 금지"). 그 결과:

- **동시성의 소유권이 이동**했습니다. 0.15 는 bundler 가 `std.Thread.Pool(max_threads)` 을 **직접 생성**해 스레드 수를 소유했습니다. 0.16 은 풀이 사라지고 동시성 = **`io` 인스턴스의 `async_limit`** 이며, `Io.Group.async(io, …)` 가 그 io 의 limit 을 따릅니다. bundler 는 풀을 안 만들고 **호출자의 io 를 빌려 씁니다** → 스레드 수 제어권이 **io 소유자(진입점)** 로 넘어갔습니다.

(같은 뿌리에서 이번 마이그레이션이 캐시들에 `io` 필드를 추가한 것도 설명됩니다 — fs 가 이제 `io` 인자를 요구하는데 오래 사는 캐시에 매 호출 io 를 넘기긴 침투적이라 init 시 1회 캡처. 즉 "동시성 capability 를 누가 소유/구성하나"(--jobs) 와 "fs capability 를 오래 사는 객체가 어떻게 드나"(캐시 io 필드) 는 **같은 동전의 양면**입니다.)

## 루트커즈 (검증 완료)

`max_threads` 는 파싱 → `BundleOptions` → `graph.max_threads`(bundler.zig:867/1130) 까지 흐르지만:

1. 프로덕션에서 `graph.max_threads` 를 읽는 곳은 **단 하나** — `build_flow.zig:79` 의 `if (self.max_threads == 0 and modules.count() == 1)` (단일모듈 tiny-graph 휴리스틱, 동시성 제어 아님).
2. `setAsyncLimit` 호출은 프로덕션 코드에 **0 건** (grep 확인).
3. 실제 `Io.Group.async` 병렬도를 정하는 io 의 `async_limit` 은 **진입점에서 기본값(cpu-1)으로 1회 구성된 뒤 절대 재설정 안 됨** (CLI `init.io` / NAPI `common` 의 `Threaded.init(…, .{})`).

→ **`--jobs` 는 병렬도에 사실상 no-op** (단일모듈 pre-scan 휴리스틱만 토글).

## 변경 — io 를 *소유* 한 진입점에서 빌드 전 적용

`bundle(io)` 는 io 를 **인터페이스로만** 받아 동시성을 못 바꿉니다(setAsyncLimit 불가). 따라서 io 를 *소유* 한 곳에서만 설정 가능 (= 주석이 말하던 "per-build io 구성"):

- **`bundler.asyncLimitForJobs(max_threads) ?Io.Limit`**: `0 → null`(기본 cpu-1 유지) / `1 → .nothing`(inline 순차, 디버깅·재현) / `N → .limited(N-1)`.
- **CLI (`main.zig`)**: `init.io` 는 std 소유라 setAsyncLimit 불가 → `init.gpa`(threadsafe 명시)로 `Threaded` 를 직접 소유하고 opts 파싱 후 적용.
- **NAPI (`common.setJobs`)**: 전역 `g_threaded`(*Threaded 소유)에 빌드 직전 적용 (sync/async 엔트리).
- **`build_flow`/`emitter` 는 무수정** — 이미 `io.async_limit` 을 존중. 주석만 현행화.

## 성능은 유지됩니다 — `0 → null` 이 핵심

`--jobs` **미지정(기본, 대부분의 경우)** → `max_threads=0` → `null` → **`setAsyncLimit` 미호출** → async_limit 이 생성 시 기본값 `cpu-1` 그대로 = `init.io`/0.15 `Thread.Pool(cpu)` 와 **동일 병렬도**. **핫패스(기본 빌드)는 전혀 안 건드립니다.** 동작이 바뀌는 건 사용자가 `--jobs` 를 명시할 때뿐 — `--jobs=1` 순차(의도적), `--jobs=N` 상한. (`0 → .nothing` 으로 잘못 매핑했다면 기본이 순차가 돼 성능이 박살났을 것.)

## code-review max 적발 — environ 회귀 수정

CLI 가 `init.io` → 자체 `Threaded` 로 바뀌며, std start 가 `init.io` 에 넣어주던 **process environ 을 잃는** 버그를 적발. `.{}` 로 만들면 `environ=.empty` → `std.process.spawn(io, …)` 자식이 빈 환경 (예: `--serve --open` 의 `xdg-open` 이 PATH/DISPLAY 없이 실행 → 브라우저 안 열림). **`environ`/`argv0` 을 `init.minimal` 에서 그대로 전달**해 start.zig 의 init.io 구성과 동일하게 복원.

## 알려진 제약 (주석 명시)

NAPI 는 공유 전역 io 라, 동시 in-flight 빌드가 서로 다른 `jobs` 면 **last-writer-wins** — 메모리 안전(`setAsyncLimit` mutex 보호)하고 determinism(#3564) 무관(byte-identical)이나 per-build 병렬도 의미만 비결정.

## 검증

- `zig build` / `zig build napi` / `zig build test` 전부 GREEN.
- `--jobs=1` / `=0` / `=8` 번들 출력 **byte-identical (179B)** — determinism #3564 보존, async_limit 변화에도 출력 불변.
- `--jobs=1 → .limited(0) → .nothing` = inline 순차 (std 계약).

Closes #4004