### PR TITLE
test(browser-field): disabled 모듈 namespace 기대값을 esbuild-parity 로 교정

### DIFF
--- a/tests/integration/tests/browser-field.test.ts
+++ b/tests/integration/tests/browser-field.test.ts
@@ -71,8 +71,12 @@ describe('package.json browser 필드', () => {
     );
     try {
       expect(result.exitCode).toBe(0);
-      // false → 빈 모듈 — namespace import 는 빈 object (혹은 undefined-like).
-      expect(result.runOutput).toBe('{}');
+      // false → 빈 모듈. esbuild parity: disabled 모듈은 빈 CJS 라 `export * as` 가
+      // __toESM 으로 감싸지며 CJS-interop default 가 붙어 `{"default":{}}` 가 된다.
+      // 4-tool 실측: esbuild==zntc==`{"default":{}}` / rolldown==rspack==`{}`.
+      // default-import(`import x from`)는 esbuild/rspack/zntc 모두 `{}`(truthy)로 일치
+      // (rolldown 만 undefined) — 그 truthy no-op 의미가 더 보편적이라 esbuild-parity 유지.
+      expect(result.runOutput).toBe('{"default":{}}');
     } finally {
       await result.cleanup();
     }
@@ -156,7 +160,9 @@ describe('package.json browser 필드', () => {
     );
     try {
       expect(result.exitCode).toBe(0);
-      expect(result.runOutput).toBe('{}');
+      // esbuild parity: disabled 모듈 namespace re-export 는 `{"default":{}}` (위 회귀
+      // 테스트 주석 참조 — 빈 CJS + __toESM CJS-interop default).
+      expect(result.runOutput).toBe('{"default":{}}');
     } finally {
       await result.cleanup();
     }


### PR DESCRIPTION
## 문제

`Integration & E2E` 의 `Integration Tests (ubuntu/macos)` 가 browser-field 2건으로 실패:
- `ignoring-module — \`./file.js\`: false 는 빈 모듈 (회귀)`
- `bare module disable — \`wrong-module\`: false 는 빈 모듈`

`browser: { "...": false }` 로 비활성화된 모듈을 `export * as ns from "..."` 로 namespace 재export 시, 테스트는 `{}` 를 기대했으나 실제(및 esbuild)는 `{"default":{}}`.

## 마이그레이션과 무관 (pre-existing)

테스트 파일이 0.16 마이그레이션 전후 **무변경**(`git diff f5bcaff8 HEAD` 공백)이고, 마이그레이션 직전 바이너리(0.15.2)와 현재(0.16.0) 번들 출력이 **byte-identical** → 이 테스트는 마이그레이션 전부터 실패하던 오기대값. (실행 자체는 정상 — 런타임 크래시 없음, 관측 값만 다름.)

## 루트커즈

disabled 모듈은 빈 **CJS** 로 대체되고(`fs.zig:37` "esbuild (disabled) 호환"), `export * as` 가 `__toESM` 으로 감싸지며 CJS-interop `default` 가 붙어 `{"default":{}}` 가 된다.

## 4-tool 실측 (compare-three 규약)

| | `import * as ns` | `import x` (default) |
|---|---|---|
| esbuild | `{"default":{}}` | `{}` (truthy) |
| **zntc** | `{"default":{}}` | `{}` (truthy) |
| rspack | `{}` | `{}` (truthy) |
| rolldown | `{}` | `undefined` (falsy) |

## esbuild-parity 유지 결정 (구현 무변경, 테스트만 교정)

- **보편성**: disabled 모듈 default-import 가 truthy `{}` 인 모델을 **4개 중 3개**(esbuild/rspack/zntc)가 따름. 실코드의 `if (mod)` no-op 가드에 안전 — rolldown 의 `undefined`(falsy)는 그 가드를 다르게 타 회귀 유발.
- **유지보수**: zntc 는 esbuild 와 양쪽 케이스 정확 일치 = **단일 레퍼런스 불변식**(`fs.zig:37` 문서화). namespace 만 `{}` 로 바꾸려면 ① rolldown식(default→undefined, 런타임 회귀) 또는 ② rspack식 하이브리드(어느 번들러와도 불일치하는 bespoke) 뿐 — 둘 다 유지보수·위험 열위.

→ 구현은 esbuild-parity 그대로 두고, 테스트 기대값을 실제 동작(`{"default":{}}`)으로 교정 + 근거를 테스트 주석에 명시.

## 검증

`cd tests/integration && bun test tests/browser-field.test.ts` → **8 pass / 0 fail**.

테스트-only 변경(번들러 코드 무수정, 파일 간 상호작용 없음)이라 4-tool 실측 + 로컬 통과로 검증 완결.