### PR TITLE
perf(bundler): graph/emit dispatch 를 range-task 로 배치 — 0.16 Io.Group per-task 오버헤드 amortize (#4007)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -27,6 +27,7 @@ const Chunk = chunk_mod.Chunk;
 const ChunkIndex = types.ChunkIndex;
 const Module = @import("module.zig").Module;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
+const util = @import("../util/mod.zig");
 const ast_mod = @import("../parser/ast.zig");
 const Ast = ast_mod.Ast;
 const NodeIndex = ast_mod.NodeIndex;
@@ -635,12 +636,22 @@ pub fn emitWithTreeShaking(
     // (.nothing)이면 inline=순차가 된다. determinism 은 index 슬롯으로 무관(#3564).
     const use_pool = sorted.items.len >= 2;
     if (use_pool) {
+        // #4007: 모듈당 group.async 는 0.16 std.Io.Group 의 per-task dispatch 비용을 모듈 수만큼
+        // 치러 다모듈 그래프에서 emit wall 회귀(0.15 Thread.Pool 대비, synthreal +0.7ms)를 만든다.
+        // 모듈을 ~parallelism*4 청크의 range-task 로 묶어 dispatch 횟수를 N→~chunks 로 amortize.
+        // hit_mask 는 read-only, results[i] 는 인덱스별 독립 슬롯 → worker race 없음, 출력 순서는
+        // exec_index 합류로 worker 수·dispatch 단위와 무관(determinism #3564 불변).
         var group: std.Io.Group = .init;
-        for (sorted.items, 0..) |m, i| {
-            if (hit_mask[i]) continue;
-            const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
-            const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
-            group.async(io, emitModuleThread, .{ allocator, m, options, linker, is_entry, used_names, shaker, &results[i] });
+        const total = sorted.items.len;
+        // graph 와 동일하게 --jobs(graph.max_threads) 우선 — chunk granularity 만 정하고
+        // 실제 병렬도는 io.async_limit(#4004)이 결정. 0 이면 CPU 코어 수 fallback.
+        const parallelism: usize = if (graph.max_threads != 0) graph.max_threads else (std.Thread.getCpuCount() catch 8);
+        const chunk = util.chunkSize(total, parallelism);
+        var s: usize = 0;
+        while (s < total) {
+            const e = @min(s + chunk, total);
+            group.async(io, emitRangeThread, .{ allocator, sorted.items, options, linker, entry_idx, used_names_list, hit_mask, shaker, results, s, e });
+            s = e;
         }
         group.await(io) catch {};
     } else {
@@ -1353,17 +1364,31 @@ pub fn shouldInsertRunBeforeMainBefore(position: usize, insert_after_pos: ?usize
     return if (insert_after_pos) |last| position > last else true;
 }
 
-fn emitModuleThread(
+/// 한 워커가 sorted_items[lo..hi) 모듈을 순차 emit 해 각자의 results[i] 슬롯에 쓴다(#4007 —
+/// 0.16 Io.Group per-task dispatch 비용 amortize). hit_mask 는 read-only, results 슬롯은
+/// 인덱스별 독립 → 호출자(emitWithTreeShaking)가 [0,total) 를 청크로 나눠 호출해도 race 없음.
+/// 출력 순서는 이후 exec_index 합류라 dispatch 단위와 무관(determinism #3564 불변).
+fn emitRangeThread(
     allocator: std.mem.Allocator,
-    module: *const Module,
+    sorted_items: []const *const Module,
     options: *const EmitOptions,
     linker: ?*const Linker,
-    is_entry: bool,
-    used_names: ?[]const []const u8,
+    entry_idx: ?u32,
+    used_names_list: []const chunks.UsedNamesEntry,
+    hit_mask: []const bool,
     shaker: ?*const TreeShaker,
-    result: *CompiledModule,
+    results: []CompiledModule,
+    lo: usize,
+    hi: usize,
 ) void {
-    result.code = emitModule(allocator, module, options, linker, is_entry, used_names, shaker, &result.helpers, &result.mappings, &result.names, &result.preamble_lines, &result.fn_map_json, &result.entry_chain, &result.shared_ns_decls) catch null;
+    var i = lo;
+    while (i < hi) : (i += 1) {
+        if (hit_mask[i]) continue;
+        const m = sorted_items[i];
+        const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
+        const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
+        results[i].code = emitModule(allocator, m, options, linker, is_entry, used_names, shaker, &results[i].helpers, &results[i].mappings, &results[i].names, &results[i].preamble_lines, &results[i].fn_map_json, &results[i].entry_chain, &results[i].shared_ns_decls) catch null;
+    }
 }
 
 /// 단일 모듈을 Transformer → Codegen 파이프라인으로 처리.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -2115,7 +2115,7 @@ pub fn applyNamingPatternWithDir(
 }
 
 /// used_names 사전 계산 결과.
-const UsedNamesEntry = struct {
+pub const UsedNamesEntry = struct {
     names: []const []const u8,
     all_used: bool, // true이면 emitModule에 null 전달 (모든 export 사용)
 };

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -16,6 +16,7 @@ const graph_requested_exports = @import("requested_exports.zig");
 const graph_runtime_polyfills = @import("runtime_polyfills.zig");
 const graph_discovery_scan = @import("discovery_scan.zig");
 const renumber = @import("renumber.zig");
+const util = @import("../../util/mod.zig");
 const graph_resolve_imports = @import("resolve_imports.zig");
 const graph_cycles = @import("cycles.zig");
 const graph_finalize = @import("finalize.zig");
@@ -102,29 +103,22 @@ pub fn build(self: *ModuleGraph, io: std.Io, entry_points: []const []const u8) !
         var group: std.Io.Group = .init;
         var inflight: usize = 0;
 
-        // Spawn the initial modules: entries, inject files, and run-before-main files.
-        while (spawned_up_to < self.modules.count()) : (spawned_up_to += 1) {
-            const m = self.modules.at(spawned_up_to);
-            if (m.state == .ready) continue; // Skip disabled modules.
-            const idx: ModuleIndex = @enumFromInt(@as(u32, @intCast(spawned_up_to)));
-            group.async(io, graph_discovery_scan.scanWorker, .{ self, io, idx, &channel });
-            inflight += 1;
-        }
+        // #4007: 모듈당 group.async 는 0.16 std.Io.Group 의 per-task dispatch 비용(태스크당
+        // 힙alloc + 전역 t.mutex lock + condSignal)을 모듈 수만큼 치러 다모듈 그래프에서 wall
+        // 회귀(0.15 Thread.Pool 대비, synthreal 500모듈 +8.6% 실측)를 만든다. pending 비-ready
+        // 모듈을 ~parallelism*4 청크의 range-task 로 묶어 dispatch 횟수를 N→~chunks 로 줄여
+        // amortize 한다. work-stealing(recv 후 신규 모듈 즉시 dispatch)은 청크 단위로 유지.
+        const parallelism: usize = if (self.max_threads != 0) self.max_threads else (std.Thread.getCpuCount() catch 8);
 
-        // Apply each worker result, then immediately dispatch newly discovered modules.
+        // 초기 알려진 모듈(entries/inject/run-before-main) 청크 dispatch.
+        dispatchPendingChunked(self, io, &group, &channel, &spawned_up_to, &inflight, parallelism);
+
+        // Apply each worker result, then dispatch newly discovered modules (chunked).
         while (inflight > 0) {
             const result = channel.recv(io);
             inflight -= 1;
             try graph_discovery_scan.applyScanResult(self, io, result);
-
-            // Dispatch newly discovered modules without waiting for a batch boundary.
-            while (spawned_up_to < self.modules.count()) : (spawned_up_to += 1) {
-                const m = self.modules.at(spawned_up_to);
-                if (m.state == .ready) continue;
-                const idx: ModuleIndex = @enumFromInt(@as(u32, @intCast(spawned_up_to)));
-                group.async(io, graph_discovery_scan.scanWorker, .{ self, io, idx, &channel });
-                inflight += 1;
-            }
+            dispatchPendingChunked(self, io, &group, &channel, &spawned_up_to, &inflight, parallelism);
         }
 
         // 모든 결과 수신 완료 — worker 함수가 완전히 반환하고 group 리소스 해제될 때까지 대기.
@@ -139,6 +133,45 @@ pub fn build(self: *ModuleGraph, io: std.Io, entry_points: []const []const u8) !
     discover_scope.end();
 
     try finalizeGraph(self, entry_points);
+}
+
+/// 현재 pending(=spawned_up_to..modules.count()) 비-ready 모듈을 ~parallelism*4 청크의
+/// range-task 로 묶어 group.async dispatch 한다(#4007 — 0.16 Io.Group per-task dispatch
+/// 비용 amortize). disabled(.ready) 모듈은 메인 스레드가 단일스레드로 건너뛰며 *연속 비-ready
+/// 구간* 만 워커에 넘긴다 → scanRangeWorker 가 .state 를 안 읽어 applyScanResult(메인) 와 race
+/// 없음(#1779 worker race-safety 불변식 유지). inflight 는 per-module 누적(워커가 모듈당 결과
+/// 개별 send) → recv/applyScanResult 회계 불변. determinism(#3564)은 dispatch 단위와 무관.
+fn dispatchPendingChunked(
+    self: *ModuleGraph,
+    io: std.Io,
+    group: *std.Io.Group,
+    channel: *MpscChannel(graph_discovery_scan.ScanResult),
+    spawned_up_to: *usize,
+    inflight: *usize,
+    parallelism: usize,
+) void {
+    const count = self.modules.count();
+    while (spawned_up_to.* < count) {
+        // disabled(.ready) 모듈 스킵 — 메인 스레드 단독 .state 읽기.
+        if (self.modules.at(spawned_up_to.*).state == .ready) {
+            spawned_up_to.* += 1;
+            continue;
+        }
+        // 연속 비-ready 구간 [lo, hi).
+        const lo = spawned_up_to.*;
+        var hi = lo + 1;
+        while (hi < count and self.modules.at(hi).state != .ready) hi += 1;
+        // ~parallelism*4 청크로 분할 (dispatch amortize ↔ load-balance 균형).
+        const chunk = util.chunkSize(hi - lo, parallelism);
+        var s = lo;
+        while (s < hi) {
+            const e = @min(s + chunk, hi);
+            group.async(io, graph_discovery_scan.scanRangeWorker, .{ self, io, s, e, channel });
+            inflight.* += (e - s);
+            s = e;
+        }
+        spawned_up_to.* = hi;
+    }
 }
 
 /// PR7-2b (#1880): plugin `this.emitFile({ type: 'chunk', id })` 로 별도 chunk 요청된 모듈을

--- a/src/bundler/graph/discovery_scan.zig
+++ b/src/bundler/graph/discovery_scan.zig
@@ -33,6 +33,19 @@ pub fn scanWorker(self: *ModuleGraph, io: std.Io, idx: ModuleIndex, channel: *Mp
     channel.send(io, self.scanModule(io, idx));
 }
 
+/// 한 워커가 연속 인덱스 구간 [lo, hi) 를 순차 scan 해 모듈당 ScanResult 를 send 한다.
+/// 0.16 std.Io.Group 의 per-task dispatch 비용(태스크당 힙alloc + 전역 mutex + condSignal)
+/// 을 amortize 하기 위해 build_flow 가 모듈당 group.async 대신 청크 단위로 호출한다(#4007).
+/// **불변식**: [lo, hi) 는 호출자(메인 스레드)가 단일스레드로 .state!=.ready 임을 검증한
+/// 연속 구간이다 — 워커는 .state 를 읽지 않으므로 applyScanResult(메인) 와 race 없음.
+/// 모듈당 결과를 개별 send 하므로 recv/applyScanResult/inflight 회계는 per-module 그대로.
+pub fn scanRangeWorker(self: *ModuleGraph, io: std.Io, lo: usize, hi: usize, channel: *MpscChannel(ScanResult)) void {
+    var i = lo;
+    while (i < hi) : (i += 1) {
+        channel.send(io, self.scanModule(io, .fromUsize(i)));
+    }
+}
+
 pub fn scanModuleRangeSequential(self: *ModuleGraph, io: std.Io, start: usize, end: usize) !usize {
     var i = start;
     while (i < end) : (i += 1) {

--- a/src/util/mod.zig
+++ b/src/util/mod.zig
@@ -5,3 +5,24 @@ pub const string_list = @import("string_list.zig");
 pub const spin_lock = @import("spin_lock.zig");
 pub const SpinLock = spin_lock.SpinLock;
 pub const SpinRwLock = spin_lock.SpinRwLock;
+
+/// 병렬 dispatch 청크 크기 계산 (#4007). `total` 개 작업을 ~`parallelism`*4 청크로 나눌 때
+/// 청크당 작업 수(ceil). target_chunks 를 `total` 로 캡해 oversubscribe 방지 + `total / target
+/// + remainder` 형태로 계산해 32-bit usize 에서 `total + target - 1` 류 오버플로를 회피한다
+/// (`parallelism` 이 --jobs 로 비정상적으로 커도 안전 — 캡 후 chunk=1 로 degrade).
+pub fn chunkSize(total: usize, parallelism: usize) usize {
+    if (total == 0) return 1;
+    const target_chunks = @max(@as(usize, 1), @min(total, parallelism *| 4));
+    const base = total / target_chunks;
+    return if (total % target_chunks != 0) base + 1 else base;
+}
+
+test chunkSize {
+    const std = @import("std");
+    try std.testing.expectEqual(@as(usize, 1), chunkSize(0, 8)); // 빈 입력 → 1 (무한루프 방지)
+    try std.testing.expectEqual(@as(usize, 1), chunkSize(1, 8));
+    try std.testing.expectEqual(@as(usize, 1), chunkSize(5, 8)); // total < parallelism*4 → 청크당 1
+    try std.testing.expectEqual(@as(usize, 16), chunkSize(500, 8)); // ceil(500/32)
+    try std.testing.expectEqual(@as(usize, 63), chunkSize(2000, 8)); // ceil(2000/32)
+    try std.testing.expectEqual(@as(usize, 1), chunkSize(100, std.math.maxInt(usize))); // 비정상 parallelism → 오버플로 없이 chunk=1
+}


### PR DESCRIPTION
## 배경 — Zig 0.16 마이그레이션이 만든 다모듈 wall 회귀

마이그레이션(#1514) 후 0.15.2 ReleaseFast 대비 측정(n=60 interleaved):
- **synthreal**(500 모듈, 실질 TS): **+8.6%** (60/60 느림)
- **synth-2000**(trivial): +4.3% (60/60)
- 단일 대용량 파일(compute-heavy): +0.3% (노이즈) — 회귀는 **모듈 수에 비례, 내용 무관**

## 루트커즈 (5각도 워크플로 + 교차검증)

지배 원인 = **`io_group_per_task`**: graph discover(`build_flow.zig`)와 emit(`emitter.zig`)이 **모듈당 `group.async`** 호출 → 0.16 `std.Io.Threaded.groupAsync` 가 태스크당 (힙 alloc + 전역 `t.mutex` + Group status atomic + condSignal) 을 치름. 0.15 `std.Thread.Pool` 대비 전역-락 dispatch 의 병렬 확장성 손실(파일수 비례).

결정적 근거:
- **jobs=1(dispatch 없음)에선 0.16이 오히려 빠름** (vtable/per-syscall 가설 반증)
- worker fs self-CPU는 0.16이 **−27%** (op당 비용 증가 아님)
- 회귀는 병렬에서만(wall↑인데 worker CPU↓ = 병렬효율 손실)
- fs op 카운트 0.15==0.16, 출력 byte-identical (중복 fs 반증)

## fix — 모듈당 → ~parallelism*4 청크의 range-task

dispatch 횟수를 N→~chunks 로 줄여 per-task 비용 amortize:
- `discovery_scan.scanRangeWorker`: 연속 `[lo,hi)` 순차 scan + 모듈당 결과 send.
- `build_flow.dispatchPendingChunked`: pending 비-ready 모듈을 청크 dispatch. **메인 스레드가 단일스레드로 `.ready` 스킵 → 워커는 `.state` 미참조**(#1779 worker race-safety 불변 유지).
- `emitter.emitRangeThread`: `[lo,hi)` emit. `hit_mask` read-only + `results[i]` 인덱스별 독립 슬롯 → race 없음. `emitModuleThread` 대체.
- `util.chunkSize`: 청크 계산 공용 헬퍼(graph/emit 공유).

**determinism(#3564 renumber/path-sort)은 dispatch 단위·worker 수 무관 → byte-identical 불변.**

## `/code-review max` 결과 반영

다중에이전트 리뷰(concurrency/determinism/엣지/cross-file) — race·#3564·deadlock·inflight 회계 모두 clean. **1건 correctness 적발·수정**: 32-bit 타겟(zntc는 x86-win/ia32 출하)에서 `--jobs` 가 비정상적으로 크면 `(total + target_chunks - 1)` usize 오버플로 가능 → `util.chunkSize` 가 target_chunks 를 total 로 캡 + 나눗셈-우선 형태로 회피(유닛테스트 포함). 더불어 chunk-math 복붙 제거 + emit parallelism 을 graph 와 동일하게 `--jobs` 우선으로 일관화.

## 검증 (n=60 interleaved, ReleaseFast)

| 워크로드 | 회귀(전) | **fix 후 vs 0.15** |
|---|---|---|
| synthreal (500) | +8.6% | **−2.4%** (0.16이 더 빠름) |
| synth-2000 | +4.3% | **−7.3%** (0/60) |

- byte-identical: synth/synthreal/synth200 == 0.15, `--jobs` 1/2/4/8 동일, **동등성 매트릭스 19/19** (esm/cjs/iife/umd · minify · sourcemap · splitting · dynamic · CSS · tree-shake)
- `zig build test` 전체 통과 + `util.chunkSize` 유닛테스트

> note: `mpsc_channel.send` OOM 시 inflight 누수(이론상 deadlock)는 **pre-existing**(per-module 경로에도 동일), 본 PR 범위 밖 — 별도 추적.