### PR TITLE
fix(bundler): MpscChannel send OOM 시 graceful 실패 (hang/UAF 제거) (#4009)

### DIFF
--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -101,6 +101,15 @@ pub fn build(self: *ModuleGraph, io: std.Io, entry_points: []const []const u8) !
         defer channel.deinit();
 
         var group: std.Io.Group = .init;
+        // #4009: discovery 가 어떤 경로로 빠져나가도(정상 / recv 의 error.SendFailed /
+        // applyScanResult error) 워커를 먼저 reap 한 뒤 channel.deinit(아래 defer, LIFO 로
+        // 이 await 뒤에 실행)되도록 defer await. recv 가 OOM 시 error 를 던질 때 워커가 떠도는
+        // 채 채널이 teardown 되는 UAF + 기존 `try applyScanResult` 에러 경로의 await 누락을 함께
+        // 막는다(정상 경로의 명시 await 를 이 defer 로 대체).
+        // (알려진 한계: 에러-abort 시 워커가 await 직전 send 한 미소비 ScanResult 의
+        // resolve_outputs 는 channel.deinit 가 item-단위로 못 풀어 해제 안 됨 — 이미 OOM 으로
+        // 빌드를 접는 rare 경로라 수용. leak-clean 종료가 필요하면 별도 drain follow-up.)
+        defer group.await(io) catch {};
         var inflight: usize = 0;
 
         // #4007: 모듈당 group.async 는 0.16 std.Io.Group 의 per-task dispatch 비용(태스크당
@@ -115,14 +124,14 @@ pub fn build(self: *ModuleGraph, io: std.Io, entry_points: []const []const u8) !
 
         // Apply each worker result, then dispatch newly discovered modules (chunked).
         while (inflight > 0) {
-            const result = channel.recv(io);
+            // #4009: 워커 send 가 OOM 으로 결과를 drop 하면 error.SendFailed — 무한 대기 대신
+            // 빌드를 실패시킨다(상단 defer group.await 가 워커 reap 보장).
+            const result = try channel.recv(io);
             inflight -= 1;
             try graph_discovery_scan.applyScanResult(self, io, result);
             dispatchPendingChunked(self, io, &group, &channel, &spawned_up_to, &inflight, parallelism);
         }
-
-        // 모든 결과 수신 완료 — worker 함수가 완전히 반환하고 group 리소스 해제될 때까지 대기.
-        group.await(io) catch {};
+        // (정상 종료 시 group reap 은 상단 `defer group.await` 가 처리)
     }
 
     var runtime_indices: std.ArrayList(types.ModuleIndex) = .empty;

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -99,6 +99,7 @@ test {
     _ = package_json;
     _ = resolve_cache;
     _ = module;
+    _ = mpsc_channel; // #4009 send OOM → recv error.SendFailed 회귀 가드
     _ = graph;
     _ = emitter;
     _ = binding_scanner;

--- a/src/bundler/mpsc_channel.zig
+++ b/src/bundler/mpsc_channel.zig
@@ -15,6 +15,12 @@ pub fn MpscChannel(comptime T: type) type {
         /// 큐 저장소. send()가 뒤에 append, recv()가 앞에서 꺼냄.
         queue: std.ArrayListUnmanaged(T) = .empty,
         allocator: std.mem.Allocator,
+        /// #4009: send 의 큐 append 가 OOM 으로 결과를 drop 했음을 메인(recv)에 알리는 플래그.
+        /// 예전엔 `append catch return` 으로 결과를 조용히 버려, recv 가 안 오는 결과를 무한
+        /// 대기(deadlock/hang)했다. recv 가 이 플래그를 보고 error.SendFailed 를 반환해 빌드가
+        /// graceful 하게 실패하도록 한다(panic 은 NAPI in-process 에서 호스트 프로세스 abort 라
+        /// 부적합 — 빌드 OOM 은 JS throw/CLI 에러 종료로 전파돼야 함). set/read 모두 mutex 보호.
+        send_failed: bool = false,
 
         pub fn init(allocator: std.mem.Allocator) Self {
             return .{ .allocator = allocator };
@@ -28,18 +34,51 @@ pub fn MpscChannel(comptime T: type) type {
         pub fn send(self: *Self, io: std.Io, item: T) void {
             self.mutex.lockUncancelable(io);
             defer self.mutex.unlock(io);
-            self.queue.append(self.allocator, item) catch return;
-            self.cond.signal(io);
+            // append OOM 시 item 은 drop 되지만 send_failed 로 표시(아래 field doc 참조, #4009).
+            self.queue.append(self.allocator, item) catch {
+                self.send_failed = true;
+            };
+            self.cond.signal(io); // 성공/실패 모두 발행 — recv 를 깨워 소비 or send_failed 확인.
         }
 
+        pub const RecvError = error{
+            /// 워커의 send 가 OOM 으로 결과를 drop 함 — 이 결과는 영영 오지 않으므로 hang
+            /// 대신 호출자가 빌드를 실패시켜야 한다(#4009).
+            SendFailed,
+        };
+
         /// 메인 스레드에서 호출. 큐가 비어있으면 워커가 send할 때까지 블로킹 대기.
-        pub fn recv(self: *Self, io: std.Io) T {
+        /// send 가 OOM 으로 결과를 drop 한 뒤 큐가 비면 error.SendFailed 반환(무한 대기 방지).
+        pub fn recv(self: *Self, io: std.Io) RecvError!T {
             self.mutex.lockUncancelable(io);
             defer self.mutex.unlock(io);
             while (self.queue.items.len == 0) {
+                if (self.send_failed) return error.SendFailed;
                 self.cond.waitUncancelable(io, &self.mutex);
             }
             return self.queue.swapRemove(0);
         }
     };
+}
+
+test "MpscChannel: 정상 send 후 전부 recv (소비 순서는 비보장 — recv 는 swapRemove)" {
+    // recv 는 swapRemove(0) 라 3개 이상서 FIFO 가 아니다(소비처 applyScanResult 가 result.module_idx
+    // 로 적용 + determinism 은 renumber/#3564 라 채널 순서 무관). 2개라 우연히 7,8 순.
+    const io = std.testing.io;
+    var ch = MpscChannel(u32).init(std.testing.allocator);
+    defer ch.deinit();
+    ch.send(io, 7);
+    ch.send(io, 8);
+    try std.testing.expectEqual(@as(u32, 7), try ch.recv(io));
+    try std.testing.expectEqual(@as(u32, 8), try ch.recv(io));
+}
+
+test "MpscChannel: send OOM 시 recv 가 error.SendFailed 반환 (무한 hang 방지, #4009)" {
+    const io = std.testing.io;
+    // 첫 alloc(큐 성장)을 실패시켜 send 가 결과를 drop 하게 한다.
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    var ch = MpscChannel(u32).init(failing.allocator());
+    defer ch.deinit();
+    ch.send(io, 42); // append OOM → send_failed=true (예전엔 silent drop → recv 무한 대기)
+    try std.testing.expectError(error.SendFailed, ch.recv(io));
 }


### PR DESCRIPTION
## 문제
graph discovery 의 `MpscChannel.send` 가 큐 append OOM 시 `catch return` 으로 결과를 **조용히 drop + signal 누락** → 메인 `recv` 가 안 오는 결과를 무한 대기(**deadlock/hang**). recv 시그니처가 `T`(에러 불가)라 실패를 알릴 길이 없었음.

**pre-existing**: MpscChannel 최초 생성 커밋 `1aeb96e1` 부터의 패턴 — 0.16 마이그레이션·dispatch 배치(#4008) 무관. 정상 빌드선 append 가 성공해 미도달(런타임 재현 불가) → #4008 `/code-review max` 정적 분석에서 발견.

## fix (정상 경로 byte-identical, OOM 경로만 동작 변경)
- **mpsc_channel**: `send_failed: bool`(무할당) 추가 — append OOM 시 set + signal 은 항상 발행. `recv` 가 `error{SendFailed}!T` 반환(큐 비고 플래그면 error) → hang 대신 빌드 graceful 실패.
- **panic 대신 error 선택**: NAPI in-process 에서 panic 은 **호스트 프로세스 abort**. 빌드 OOM 은 JS throw/CLI 에러로 전파돼야 함 → dev server/watch/Vite plugin 이 살아남아 다음 빌드 계속.
- **build_flow**: `try channel.recv` + `defer group.await`. 후자는 recv/applyScanResult 에러 경로에서도 워커를 reap 한 뒤 channel.deinit(LIFO) 되게 해, 워커가 떠도는 채 채널 teardown 되는 **잠재 UAF**(기존 `try applyScanResult` 가 await 건너뛰던 경로)도 함께 해소.
- **mod.zig**: `_ = mpsc_channel;` 로 인라인 회귀 테스트 suite 수집.

## 이득 (정직하게)
correctness/안정성 fix이며 **성능과 무관**(정상 경로 불변). 가장 구체적 가치는 **in-process 장수 호스트**(dev server/watch/플러그인)에서 일시적 빌드 OOM 이 전체를 hang/죽이지 않고 **그 빌드만 graceful 실패**. CLI 1회 빌드엔 미미(rare). 부수로 **에러 경로 잠재 UAF** 해소.

## `/code-review max` 결과
2개 멀티에이전트 finder — **correctness/concurrency 버그 0건**(condvar lost-wakeup·defer UAF·error 전파·동기화·부분성공 모두 SOUND, 잠재 UAF 해소 확인). 품질 노트 반영: 테스트명 정정(swapRemove 비-FIFO 명시), 중복 주석 경감, OOM-abort 시 미소비 결과 resolve_outputs leak 을 known-acceptable(rare·failing-path)로 주석 명시.

## 검증
mpsc 유닛테스트 2/2(정상 + FailingAllocator OOM→error.SendFailed), `zig build test` 전체 통과, 번들 정상경로 출력 불변.

Closes #4009