### PR TITLE
fix(bundler): export*-as-ns inner 이름이 plain export* 와 false-ambiguous 충돌하던 회귀 수정 (zod z.string===undefined)

### DIFF
--- a/src/bundler/bundler_test/exports_name_dedup.zig
+++ b/src/bundler/bundler_test/exports_name_dedup.zig
@@ -261,3 +261,82 @@ test "ambiguous export*: default 는 export * 비전파라 ambiguous 아님 (#39
     // default 충돌은 ambiguous 진단을 내지 않는다(애초에 namespace 에 포함 안 됨).
     try testing.expect(!hasAmbiguousDiag(&r));
 }
+
+// ============================================================
+// 회귀: `export * as ns` 의 내부 이름이 plain `export *` 의 동명 export 와
+// false-ambiguous 충돌 → 정상 export 가 사라지던 버그 (zod `z.string`===undefined).
+// `export * as ns from` 은 top-level 에 단일 named export `ns` 만 기여하므로,
+// 그 내부 이름은 ambiguity 판정/star resolve 에 절대 참여하면 안 된다.
+// ============================================================
+
+test "namespaced star: inner 이름이 plain star 와 false-ambiguous 아님 — named import 정상 (zod z.string)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // coerce 와 schemas 가 같은 이름 `string` 을 export. coerce 는 `export * as`,
+    // schemas 는 plain `export *` → top-level `string` 은 schemas 것만 유일.
+    try writeFile(tmp.dir, "coerce.js", "export function string() { return 'coerce'; }");
+    try writeFile(tmp.dir, "schemas.js", "export function string() { return 'schema'; }");
+    try writeFile(tmp.dir, "core.js", "export * as coerce from './coerce.js';\nexport * from './schemas.js';");
+    try writeFile(tmp.dir, "entry.js",
+        \\import { string } from './core.js';
+        \\globalThis.z = string();
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    // `string` 은 schemas 단일 소스 → 모호하지 않음. pre-fix 에선 coerce(namespaced)와
+    // false-ambiguous → named import `{ string }` 이 build error → hasErrors/ambiguous diag.
+    // 이 두 단언이 회귀를 가른다(둘 다 pre-fix 에서 실패).
+    try testing.expect(!r.result.hasErrors());
+    try testing.expect(!hasAmbiguousDiag(&r));
+}
+
+test "namespaced star: namespace 멤버가 plain star 정의로 해석 (drop 안 됨, production)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "coerce.js", "export function string() { return 'coerce'; }");
+    try writeFile(tmp.dir, "schemas.js", "export function string() { return 'schema'; }");
+    try writeFile(tmp.dir, "core.js", "export * as coerce from './coerce.js';\nexport * from './schemas.js';");
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ns from './core.js';
+        \\globalThis.z = [typeof ns.string, ns.coerce.string()];
+    );
+
+    // 실제 zod 회귀는 production scope-hoist(tree-shake) 경로에서만 재현된다 — dev 번들의
+    // `__export` map 은 버그와 무관하게 멤버를 그대로 emit 하므로 가드가 되지 못한다.
+    // production 에선 `ns.string` 이 schemas 로 정확히 해석돼야 그 factory(`"schema"`)가
+    // live 로 유지된다. pre-fix 는 false-ambiguous 로 멤버 해석이 깨져 schemas 본체가
+    // tree-shake 로 사라지므로 `"schema"` 부재 → 이 단언이 회귀를 가른다.
+    var r = try helpers.bundleEntry(testing.allocator, &tmp, "entry.js", .{
+        .scope_hoist = true,
+        .tree_shaking = true,
+    });
+    defer r.deinit();
+    const code = r.code();
+    try testing.expect(!r.result.hasErrors());
+    try testing.expect(!hasAmbiguousDiag(&r));
+    // schemas factory body 가 live (top-level `ns.string` → schemas 해석 증거).
+    try testing.expect(std.mem.indexOf(u8, code, "\"schema\"") != null);
+    // 중첩 `coerce` namespace 도 별도로 보존(coerce factory live).
+    try testing.expect(std.mem.indexOf(u8, code, "\"coerce\"") != null);
+}
+
+test "namespaced star: 2 plain star 동명은 export * as 가 있어도 ambiguous 유지 (over-correction 가드)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // schemas + extra 두 plain star 가 같은 `string` → genuine ambiguous.
+    // `export * as coerce` 가 함께 있어도 ambiguity 는 그대로여야 한다.
+    try writeFile(tmp.dir, "coerce.js", "export function string() { return 'coerce'; }");
+    try writeFile(tmp.dir, "schemas.js", "export function string() { return 'schema'; }");
+    try writeFile(tmp.dir, "extra.js", "export function string() { return 'extra'; }");
+    try writeFile(tmp.dir, "core.js", "export * as coerce from './coerce.js';\nexport * from './schemas.js';\nexport * from './extra.js';");
+    try writeFile(tmp.dir, "entry.js",
+        \\import { string } from './core.js';
+        \\globalThis.z = string();
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(r.result.hasErrors());
+    try testing.expect(hasAmbiguousDiag(&r));
+}

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1850,12 +1850,19 @@ pub const Linker = struct {
     /// 첫 매칭에서 멈추지 않고 전 소스를 확인 — 2+ distinct canonical 이면 ambiguous.
     /// resolveExportChainInner step2(named/re-export/tree-shake 경로)와 ambiguity
     /// 진단(resolveImports)이 공유해 스캔 로직 drift 를 방지한다.
+    ///
+    /// plain `export * from`(exported_name=="*")만 따른다. `export * as ns from`
+    /// (re_export_namespace)은 단일 named export `ns`만 기여하고 소스의 *임의* 이름을
+    /// 현재 namespace 로 끌어오지 않는다 — 따라가면 그 inner 이름(예: coerce.string)이
+    /// plain star 소스의 동명 export(schemas.string)와 false-ambiguous 충돌해 정상
+    /// export 가 사라진다(zod `z.string`===undefined 회귀). isReExportAll() 단독은
+    /// 두 종류를 모두 포함하므로 exported_name=="*" 게이트를 함께 적용한다.
     fn resolveStarExport(self: *const Linker, module_idx: ModuleIndex, name: []const u8, depth: u32) StarResolve {
         const m = self.graph.getModule(module_idx) orelse return .none;
         var found: ?SymbolRef = null;
         var found_is_cjs = false;
         for (m.export_bindings) |eb| {
-            if (!eb.kind.isReExportAll()) continue;
+            if (!(eb.kind.isReExportAll() and std.mem.eql(u8, eb.exported_name, "*"))) continue;
             const rec_idx = eb.import_record_index orelse continue;
             if (rec_idx >= m.import_records.len) continue;
             const source_mod = m.import_records[rec_idx].resolved;

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -13,6 +13,18 @@ fn dirPath(tmp: *std.testing.TmpDir) ![:0]u8 {
     return try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
 }
 
+/// 주어진 basename 과 정확히 일치하는 모듈의 인덱스를 찾는다. 테스트에서 graph
+/// 빌드 순서에 의존하지 않고 특정 소스 파일의 모듈을 지목하기 위한 헬퍼.
+/// `std.fs.path.basename` 으로 경로 마지막 컴포넌트를 비교 — suffix 매칭(`endsWith`)이
+/// 아니라 정확 일치라, 예컨대 "core.ts" 질의가 "my-core.ts" 모듈을 잘못 잡지 않는다.
+fn findModuleIdx(graph: *ModuleGraph, basename: []const u8) ?ModuleIndex {
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
+        if (std.mem.eql(u8, std.fs.path.basename(m.path), basename)) return m.index;
+    }
+    return null;
+}
+
 fn buildAndLink(allocator: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !TestResult {
     const dp = try tmp.dir.realPathFileAlloc(std.testing.io, ".", allocator);
     defer allocator.free(dp);
@@ -1077,6 +1089,78 @@ test "export * as: does not pollute parent seen (name collision)" {
     const entry = r.graph.getModule(ModuleIndex.fromUsize(0)).?;
     try std.testing.expect(entry.import_bindings.len > 0);
     try std.testing.expectEqual(ImportBinding.Kind.namespace, entry.import_bindings[0].kind);
+
+    // 회귀 가드(zod `z.string`===undefined): `export * as regexes` 의 내부 `string` 이
+    // plain `export *`(schemas)의 `string` 과 false-ambiguous 충돌하면 안 된다.
+    // `export * as ns` 는 top-level 에 `ns` 한 이름만 기여하므로 ambiguity 판정 비참여.
+    const core_idx = findModuleIdx(r.graph, "core.ts").?;
+    const schemas_idx = findModuleIdx(r.graph, "schemas.ts").?;
+    try std.testing.expect(!r.linker.isAmbiguousStarExport(core_idx, "string"));
+    const resolved = r.linker.resolveExportChain(core_idx, "string", 0);
+    try std.testing.expect(resolved != null);
+    // schemas(plain star)의 factory 로 해석되어야 한다 — regexes(namespaced)가 아님.
+    try std.testing.expectEqual(@intFromEnum(schemas_idx), @intFromEnum(resolved.?.module_index));
+}
+
+test "export * as: namespaced inner name does not leak to top-level (no false resolve)" {
+    // `export * as regexes` 만 있고 plain `export *` 가 없으면, regexes 의 내부 `string`
+    // 은 core 의 top-level export 가 아니다(ESM: namespaced star 는 `regexes` 한 이름만
+    // 기여). top-level `string` resolve 는 null 이어야 하고 ambiguous 도 아니다.
+    // 회귀 가드: resolveStarExport 가 namespaced re-export 를 따라가면 `string` 을
+    // regexes.string 으로 잘못 해석(leak)했었다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "regexes.ts", "export const string = /^.*$/;");
+    try writeFile(tmp.dir, "core.ts", "export * as regexes from './regexes';\nexport const marker = 1;");
+    try writeFile(tmp.dir, "entry.ts", "import { string } from './core';\nconsole.log(string);");
+
+    var r = try buildLinkAndRename(std.testing.allocator, &tmp, "entry.ts");
+    defer r.linker.deinit();
+    defer r.destroyGraph();
+    defer r.cache.deinit();
+
+    const core_idx = findModuleIdx(r.graph, "core.ts").?;
+    // top-level `string` 은 존재하지 않음 → resolve null, ambiguous 아님.
+    try std.testing.expect(r.linker.resolveExportChain(core_idx, "string", 0) == null);
+    try std.testing.expect(!r.linker.isAmbiguousStarExport(core_idx, "string"));
+    // `regexes` 자체는 정상 named export 로 해석.
+    try std.testing.expect(r.linker.resolveExportChain(core_idx, "regexes", 0) != null);
+    // named import { string } 는 진짜 missing → 진단.
+    var has_missing = false;
+    for (r.linker.diagnostics.items) |d| {
+        if (d.code == .missing_export) has_missing = true;
+    }
+    try std.testing.expect(has_missing);
+}
+
+test "export * as: genuine 2-plain-star ambiguity preserved despite namespaced star" {
+    // over-correction 가드: plain `export *` 2개(schemas, extra)가 같은 `string` 을
+    // 내보내면 `export * as regexes` 가 함께 있어도 여전히 ESM-ambiguous 여야 한다.
+    // (namespaced star 는 ambiguity 에 영향 없음 — 추가도 제거도 하지 않음.)
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "regexes.ts", "export const string = /^.*$/;");
+    try writeFile(tmp.dir, "schemas.ts", "export function string() { return 'schema'; }");
+    try writeFile(tmp.dir, "extra.ts", "export function string() { return 'extra'; }");
+    try writeFile(tmp.dir, "core.ts", "export * as regexes from './regexes';\nexport * from './schemas';\nexport * from './extra';");
+    try writeFile(tmp.dir, "entry.ts", "import { string } from './core';\nconsole.log(string);");
+
+    var r = try buildLinkAndRename(std.testing.allocator, &tmp, "entry.ts");
+    defer r.linker.deinit();
+    defer r.destroyGraph();
+    defer r.cache.deinit();
+
+    const core_idx = findModuleIdx(r.graph, "core.ts").?;
+    // schemas + extra 두 plain star 가 distinct canonical → ambiguous → resolve null.
+    try std.testing.expect(r.linker.isAmbiguousStarExport(core_idx, "string"));
+    try std.testing.expect(r.linker.resolveExportChain(core_idx, "string", 0) == null);
+    // ambiguous named import → 사용자 노출(fatal) 진단. (missing_export 와 달리
+    // ambiguous_export 는 fatal_diagnostics 에만 기록된다.)
+    var has_ambiguous = false;
+    for (r.linker.fatal_diagnostics.items) |d| {
+        if (d.code == .ambiguous_export) has_ambiguous = true;
+    }
+    try std.testing.expect(has_ambiguous);
 }
 
 // ============================================================


### PR DESCRIPTION
## 문제

`zod` 번들 시 `typeof z.string` 이 `undefined` → e2e 2건 실패:
- `browser-smoke.test.ts › browser: zod`
- `lib-scenario-e2e.test.ts › D1_validation_serialize_combo`

## 루트커즈

zod `external.js` 는 plain `export * from "./schemas.js"` 와 `export * as coerce from "./coerce.js"` 등을 함께 가집니다.

`resolveStarExport` 가 `if (!eb.kind.isReExportAll()) continue;` 로 star 소스를 스캔했는데, `isReExportAll()` 은 `re_export_star`(plain `export *`) **와** `re_export_namespace`(`export * as ns`) 를 **둘 다** true 로 반환합니다.

→ top-level `string` 해석이 `schemas.string`(plain) + `coerce.string`(namespaced) 두 canonical 을 찾아 **false-ambiguous → drop**. 누락 이름은 정확히 `{plain star} ∩ {namespaced star}` 교집합인 `string/number/boolean/bigint/date` (= `coerce.js` export 5개).

`export * as coerce` 는 top-level 에 `coerce` 한 이름만 기여해야 하는데 그 내부 이름이 ambiguity 판정에 잘못 참여했습니다. #3982(ambiguous export*) 도입 회귀.

## 수정

```diff
-            if (!eb.kind.isReExportAll()) continue;
+            if (!(eb.kind.isReExportAll() and std.mem.eql(u8, eb.exported_name, "*"))) continue;
```

`resolveStarExport` 가 plain `export *`(`exported_name=="*"`) 만 따르도록 보강. 이 관용구는 다른 4곳(linker.zig 1635/1844/2391, metadata.zig)에서 이미 쓰는 표준 패턴인데 `resolveStarExport` 만 누락돼 있었습니다.

## 회귀 테스트 (6건, 전부 pre-fix 에서 실패 확인 — 게이트 일시 되돌려 검증)

| 파일 | 테스트 | 가른 단언 |
|---|---|---|
| `linker_test.zig` | `does not pollute parent seen` (강화) | `!isAmbiguousStarExport` + `resolveExportChain → schemas` |
| `linker_test.zig` | `namespaced inner name does not leak` | `resolveExportChain == null` + missing_export |
| `linker_test.zig` | `genuine 2-plain-star ambiguity preserved` (over-correction 가드) | ambiguous 유지 |
| `exports_name_dedup.zig` | `inner 이름 false-ambiguous 아님 (named)` | `!hasErrors` |
| `exports_name_dedup.zig` | `namespace 멤버 plain star 해석 (production)` | schemas factory `"schema"` live |
| `exports_name_dedup.zig` | `2 plain star ambiguous 유지` (over-correction 가드) | ambiguous diag |

> **dev 모드는 런타임 재-export 간접화(`__export` getter)라 버그 미재현** — namespace 가드는 production scope-hoist 모드여야 진짜로 동작합니다. (리뷰에서 dev 버전이 vacuous 임이 적발되어 production 으로 교정.)

## 검증

- `typeof z.string` → `function`, `z.object().safeParse()` → `ok`
- `browser: zod` / `D1_validation_serialize_combo` e2e ✅ pass
- 전체 유닛 테스트 `zig build test` ✅ (cascade 회귀 없음)
- lib-scenario-e2e 19건 ✅ / browser-smoke 95건(zod·effect 등 실제 라이브러리) ✅
- `/code-review max` (23 에이전트) → 프로덕션 수정 CONFIRMED 정확, 테스트 품질 findings 반영 완료

## 참고 (범위 밖)

namespace 가 멤버-rewrite 로 미materialize 된 상태에서 **존재하지 않는** 멤버 접근(`ns.nope`)이 dangling 참조 → ReferenceError 가 되는 별개 latent codegen 버그를 발견했습니다(ESM 은 undefined). `export *` 무관하게 재현되며 별도 이슈로 다룰 예정입니다.

Closes #4011

🤖 Generated with [Claude Code](https://claude.com/claude-code)