### PR TITLE
feat(build): WASM 최적화 모드 오버라이드(-Dwasm-optimize) + 배포 LTO opt-in(-Denable-lto)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,6 +27,24 @@ pub fn build(b: *std.Build) void {
     ) orelse false;
     const strip_setting: ?bool = if (keep_debug) false else null;
 
+    // `-Dwasm-optimize` 로 WASM 빌드의 최적화 모드를 덮어쓴다 (기본 ReleaseSmall — 배포 사이즈
+    // 우선). wasm 전용 버그 디버깅 시 Debug/ReleaseSafe 로 빌드하기 위한 것으로, NAPI 의
+    // `-Dnapi-optimize` 와 동일한 패리티. CLI/네이티브 빌드의 `-Doptimize` 와는 독립이다.
+    const wasm_optimize = b.option(
+        std.builtin.OptimizeMode,
+        "wasm-optimize",
+        "WASM 모듈 최적화 모드 (기본: ReleaseSmall, 디버깅 시 Debug/ReleaseSafe)",
+    ) orelse .ReleaseSmall;
+
+    // `-Denable-lto=true` 로 WASM 배포 아티팩트에 LTO(full)를 켠다 (기본 off). 컴파일 시간이
+    // 늘지만 코드 사이즈가 줄 수 있어 배포 빌드에서 opt-in 한다. 일반 빌드엔 영향이 없다.
+    const enable_lto = b.option(
+        bool,
+        "enable-lto",
+        "WASM 배포 빌드에 LTO(full) 적용 (기본: false, 사이즈↓·빌드시간↑)",
+    ) orelse false;
+    const wasm_lto: ?std.zig.LtoMode = if (enable_lto) .full else null;
+
     // This creates a "module", which represents a collection of source files alongside
     // some compilation options, such as optimization mode and linked system libraries.
     // Every executable or library we compile will be based on one or more modules.
@@ -195,13 +213,13 @@ pub fn build(b: *std.Build) void {
         const wasm_lib_mod = b.createModule(.{
             .root_source_file = b.path("src/root.zig"),
             .target = wasm_target,
-            .optimize = .ReleaseSmall,
+            .optimize = wasm_optimize,
         });
 
         const wasm_mod = b.createModule(.{
             .root_source_file = b.path("packages/wasm/src/wasm_entry.zig"),
             .target = wasm_target,
-            .optimize = .ReleaseSmall,
+            .optimize = wasm_optimize,
         });
         wasm_mod.addImport("zntc_lib", wasm_lib_mod);
 
@@ -213,6 +231,7 @@ pub fn build(b: *std.Build) void {
         wasm_exe.rdynamic = true;
         // 라이브러리 모드: 엔트리포인트 없이 export 함수만 노출
         wasm_exe.entry = .disabled;
+        wasm_exe.lto = wasm_lto; // -Denable-lto (기본 null = off)
 
         const wasm_install = b.addInstallArtifact(wasm_exe, .{});
         const wasm_step = b.step("wasm", "Build WASM module (wasm32-wasi)");
@@ -241,14 +260,14 @@ pub fn build(b: *std.Build) void {
         const wasm_bundler_lib_mod = b.createModule(.{
             .root_source_file = b.path("src/root.zig"),
             .target = wasm_bundler_target,
-            .optimize = .ReleaseSmall,
+            .optimize = wasm_optimize,
             .single_threaded = true,
         });
 
         const wasm_bundler_mod = b.createModule(.{
             .root_source_file = b.path("packages/wasm/src/wasm_bundler_entry.zig"),
             .target = wasm_bundler_target,
-            .optimize = .ReleaseSmall,
+            .optimize = wasm_optimize,
             .single_threaded = true,
         });
         wasm_bundler_mod.addImport("zntc_lib", wasm_bundler_lib_mod);
@@ -259,6 +278,7 @@ pub fn build(b: *std.Build) void {
         });
         wasm_bundler_exe.rdynamic = true;
         wasm_bundler_exe.entry = .disabled;
+        wasm_bundler_exe.lto = wasm_lto; // -Denable-lto (기본 null = off)
         // 0.16: single-threaded → std.heap.wasm_allocator(BrkAllocator) 사용 가능
         // (멀티스레드 c_allocator 우회 불필요). shared_memory 제거.
         wasm_bundler_mod.link_libc = true;


### PR DESCRIPTION
## 배경

WASM 모듈(transpile `wasm`, bundler `wasm-bundler`)이 `.ReleaseSmall` 로 **하드코딩**돼 있어, wasm 전용 버그를 Debug/ReleaseSafe 로 빌드해 디버깅할 방법이 없었습니다. NAPI 는 이미 `-Dnapi-optimize` 로 가능한데 wasm 만 빠져 있었습니다. 또 배포 아티팩트에 LTO 를 켜는 손쉬운 스위치가 없었습니다.

## 변경 내용 (둘 다 기본 동작 불변)

- **`-Dwasm-optimize`** (기본 `ReleaseSmall`): `wasm`/`wasm-bundler` 의 최적화 모드를 덮어씀. `-Dnapi-optimize` 와 동일 패리티. CLI 의 `-Doptimize` 와는 독립.
- **`-Denable-lto`** (기본 `false`, opt-in): `wasm_exe`/`wasm_bundler_exe` 에 `lto = .full` 적용. 기본값은 `null`(off)이라 일반 빌드엔 영향 없음.

## 검증 (Zig 0.16.0, 실측)

| 빌드 | 기본 | `-Denable-lto=true` | Δ |
|---|---|---|---|
| `wasm` | 1,395,354 B | 1,367,658 B | **−1.98%** (−27.7 KB) |
| `wasm-bundler` | 2,793,032 B | 2,750,805 B | **−1.51%** (−42.2 KB) |

- `zig build wasm -Dwasm-optimize=ReleaseSafe` → 빌드 성공(옵션 동작 확인)
- `zig build install`(CLI 기본) · `wasm-bundler` 기본 · `zig build test` 모두 **green**(무파손)
- `/code-review max`(9앵글+sweep) → 버그 **0건**

## Zig 초보자 설명

- `b.option(std.builtin.OptimizeMode, "wasm-optimize", ...) orelse .ReleaseSmall` — CLI 에서 `-Dwasm-optimize=...` 를 주면 그 값을, 안 주면 `.ReleaseSmall`(기존 하드코딩과 동일)을 씁니다. 그래서 **아무 플래그도 안 주면 동작이 똑같습니다**.
- `lto: ?std.zig.LtoMode`(`Step.Compile` 필드)에 `.full`/`.thin`/`null` 을 줄 수 있습니다. `null` = LTO 끔(기본). LTO 는 링크 시 전체 모듈을 함께 최적화해 코드 사이즈를 줄이지만 빌드 시간이 늘어 배포 빌드에서만 opt-in 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)