### PR TITLE
refactor: 함수-로컬 managed HashMap 을 0.16 unmanaged 로 전환 (컨벤션 통일)

### DIFF
--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -193,8 +193,8 @@ pub fn buildApp(allocator: std.mem.Allocator, io: std.Io, opts: AppBuildOptions)
         return error.BundleFailed;
     }
 
-    var reserved = std.StringHashMap(void).init(allocator);
-    defer reserved.deinit();
+    var reserved: std.StringHashMapUnmanaged(void) = .empty;
+    defer reserved.deinit(allocator);
     var reserved_keys: std.ArrayList([]const u8) = .empty;
     defer {
         for (reserved_keys.items) |key| allocator.free(key);
@@ -375,8 +375,8 @@ pub fn prepareDev(allocator: std.mem.Allocator, io: std.Io, opts: AppDevPrepareO
     defer app_env.deinitMap(&env_map, allocator);
 
     try std.Io.Dir.cwd().createDirPath(io, outdir);
-    var reserved = std.StringHashMap(void).init(allocator);
-    defer reserved.deinit();
+    var reserved: std.StringHashMapUnmanaged(void) = .empty;
+    defer reserved.deinit(allocator);
     var reserved_keys: std.ArrayList([]const u8) = .empty;
     defer {
         for (reserved_keys.items) |key| allocator.free(key);
@@ -436,9 +436,9 @@ pub fn prepareDev(allocator: std.mem.Allocator, io: std.Io, opts: AppDevPrepareO
 }
 
 fn mergeDefines(allocator: std.mem.Allocator, env_defines: []const app_env.DefineEntry, user_defines: []const DefineEntry) ![]DefineEntry {
-    var user_keys = std.StringHashMap(void).init(allocator);
-    defer user_keys.deinit();
-    try user_keys.ensureTotalCapacity(@intCast(user_defines.len));
+    var user_keys: std.StringHashMapUnmanaged(void) = .empty;
+    defer user_keys.deinit(allocator);
+    try user_keys.ensureTotalCapacity(allocator, @intCast(user_defines.len));
     for (user_defines) |entry| user_keys.putAssumeCapacity(entry.key, {});
 
     var list: std.ArrayList(DefineEntry) = .empty;
@@ -646,13 +646,13 @@ fn injectModulePreloads(
 
     // path → outputs index 를 한 번만 빌드. 이전엔 recursive walker 가 매 import 마다
     // outputs 를 선형 스캔 (O(N²)) 했음. outputs 자체에 대한 alias 라 owned key 불필요.
-    var by_path = std.StringHashMap(usize).init(allocator);
-    defer by_path.deinit();
-    try by_path.ensureTotalCapacity(@intCast(outputs.len));
+    var by_path: std.StringHashMapUnmanaged(usize) = .empty;
+    defer by_path.deinit(allocator);
+    try by_path.ensureTotalCapacity(allocator, @intCast(outputs.len));
     for (outputs, 0..) |out, i| by_path.putAssumeCapacity(out.path, i);
 
-    var seen = std.StringHashMap(void).init(allocator);
-    defer seen.deinit();
+    var seen: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen.deinit(allocator);
     var seen_keys: std.ArrayList([]const u8) = .empty;
     defer {
         for (seen_keys.items) |key| allocator.free(key);
@@ -672,10 +672,10 @@ fn injectModulePreloads(
 fn appendModulePreloadImports(
     allocator: std.mem.Allocator,
     outputs: []const bundler_mod.emitter.OutputFile,
-    by_path: *const std.StringHashMap(usize),
+    by_path: *const std.StringHashMapUnmanaged(usize),
     imports: []const []const u8,
     base: []const u8,
-    seen: *std.StringHashMap(void),
+    seen: *std.StringHashMapUnmanaged(void),
     seen_keys: *std.ArrayList([]const u8),
     tags: *std.ArrayList(u8),
 ) !void {
@@ -732,14 +732,14 @@ fn joinBaseUrlWithSuffix(allocator: std.mem.Allocator, base: []const u8, rel: []
 
 fn addReserved(
     allocator: std.mem.Allocator,
-    reserved: *std.StringHashMap(void),
+    reserved: *std.StringHashMapUnmanaged(void),
     reserved_keys: *std.ArrayList([]const u8),
     key: []const u8,
 ) !void {
     if (reserved.contains(key)) return;
     const owned = try allocator.dupe(u8, key);
     errdefer allocator.free(owned);
-    try reserved.put(owned, {});
+    try reserved.put(allocator, owned, {});
     try reserved_keys.append(allocator, owned);
 }
 
@@ -748,7 +748,7 @@ fn copyAssetFile(
     io: std.Io,
     asset_path: []const u8,
     outdir: []const u8,
-    reserved: *std.StringHashMap(void),
+    reserved: *std.StringHashMapUnmanaged(void),
     reserved_keys: *std.ArrayList([]const u8),
     output_count: *usize,
 ) ![]const u8 {
@@ -770,7 +770,7 @@ fn rewriteCssUrls(
     style_path: []const u8,
     outdir: []const u8,
     base: []const u8,
-    reserved: *std.StringHashMap(void),
+    reserved: *std.StringHashMapUnmanaged(void),
     reserved_keys: *std.ArrayList([]const u8),
     output_count: *usize,
 ) ![]const u8 {
@@ -818,7 +818,7 @@ fn copyPublicDir(
     io: std.Io,
     public_dir: []const u8,
     outdir: []const u8,
-    reserved: *std.StringHashMap(void),
+    reserved: *std.StringHashMapUnmanaged(void),
     output_count: *usize,
 ) !void {
     var dir = std.Io.Dir.cwd().openDir(io, public_dir, .{ .iterate = true }) catch |err| switch (err) {
@@ -835,7 +835,7 @@ fn copyPublicDirInner(
     public_dir: []const u8,
     rel_dir: []const u8,
     outdir: []const u8,
-    reserved: *std.StringHashMap(void),
+    reserved: *std.StringHashMapUnmanaged(void),
     output_count: *usize,
 ) !void {
     const abs_dir = if (rel_dir.len == 0) try allocator.dupe(u8, public_dir) else try std.fs.path.join(allocator, &.{ public_dir, rel_dir });

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -591,8 +591,8 @@ fn dumpModuleStats(graph: *ModuleGraph) void {
     var plain_esm_nm: usize = 0;
     var plain_none_nm: usize = 0;
     var plain_nm_has_sem: usize = 0;
-    var type_hist = std.StringHashMap(usize).init(graph.allocator);
-    defer type_hist.deinit();
+    var type_hist: std.StringHashMapUnmanaged(usize) = .empty;
+    defer type_hist.deinit(graph.allocator);
 
     var it = graph.modulesIterator();
     while (it.next()) |m| {
@@ -626,7 +626,7 @@ fn dumpModuleStats(graph: *ModuleGraph) void {
             }
             if (m.semantic != null) plain_nm_has_sem += 1;
         }
-        const e = type_hist.getOrPut(@tagName(m.module_type)) catch continue;
+        const e = type_hist.getOrPut(graph.allocator, @tagName(m.module_type)) catch continue;
         if (!e.found_existing) e.value_ptr.* = 0;
         e.value_ptr.* += 1;
     }
@@ -1245,11 +1245,11 @@ pub const Bundler = struct {
         }
 
         // Worker 별도 빌드: new Worker(new URL(...)) 패턴에서 수집된 worker 경로를 독립 IIFE로 빌드
-        var worker_output_map = std.StringHashMap([]const u8).init(self.allocator);
+        var worker_output_map: std.StringHashMapUnmanaged([]const u8) = .empty;
         defer {
             var it = worker_output_map.valueIterator();
             while (it.next()) |v| self.allocator.free(v.*);
-            worker_output_map.deinit();
+            worker_output_map.deinit(self.allocator);
         }
         var worker_output_files: std.ArrayList(OutputFile) = .empty;
         defer worker_output_files.deinit(self.allocator);
@@ -1273,7 +1273,7 @@ pub const Bundler = struct {
                     const worker_result = self.buildWorker(io, we.resolved_path) catch {
                         continue;
                     };
-                    try worker_output_map.put(we.resolved_path, worker_result.filename);
+                    try worker_output_map.put(self.allocator, we.resolved_path, worker_result.filename);
                     try worker_output_files.append(self.allocator, .{
                         .path = try self.allocator.dupe(u8, worker_result.filename),
                         .contents = worker_result.contents,

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -500,12 +500,12 @@ const EntryInfo = struct {
 /// manual chunk 이름을 slot index 로 매핑. 이미 있으면 기존 slot 반환, 없으면 새 slot 생성.
 /// record entries + resolver 동적 결과의 dedup 통합 지점.
 fn ensureNameSlot(
-    name_to_slot: *std.StringHashMap(usize),
+    name_to_slot: *std.StringHashMapUnmanaged(usize),
     effective_names: *std.ArrayList([]const u8),
     allocator: std.mem.Allocator,
     name: []const u8,
 ) !usize {
-    const gop = try name_to_slot.getOrPut(name);
+    const gop = try name_to_slot.getOrPut(allocator, name);
     if (!gop.found_existing) {
         gop.value_ptr.* = effective_names.items.len;
         try effective_names.append(allocator, name);
@@ -705,8 +705,8 @@ pub fn generateChunks(
     // 결과를 순서대로 병합. resolver 가 반환한 name 이 record 와 겹치면 동일 slot.
     var effective_names: std.ArrayList([]const u8) = .empty;
     defer effective_names.deinit(allocator);
-    var name_to_slot = std.StringHashMap(usize).init(allocator);
-    defer name_to_slot.deinit();
+    var name_to_slot: std.StringHashMapUnmanaged(usize) = .empty;
+    defer name_to_slot.deinit(allocator);
     for (manual_chunks) |mc| {
         _ = try ensureNameSlot(&name_to_slot, &effective_names, allocator, mc.name);
     }

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -464,11 +464,11 @@ pub fn emitEsmWrappedModule(
     //   ESM 스펙에 따라 "default"는 제외.
     {
         // star re-export 중복 방지용
-        var direct_exports = std.StringHashMap(void).init(allocator);
-        defer direct_exports.deinit();
+        var direct_exports: std.StringHashMapUnmanaged(void) = .empty;
+        defer direct_exports.deinit(allocator);
         for (module.export_bindings) |eb| {
             if (eb.kind == .local or eb.kind == .re_export) {
-                try direct_exports.put(eb.exported_name, {});
+                try direct_exports.put(allocator, eb.exported_name, {});
             }
         }
 
@@ -488,10 +488,10 @@ pub fn emitEsmWrappedModule(
 
         if (linker) |l| {
             // seen/visited는 루프 밖에서 할당하여 재사용 (export * from이 여러 개일 때 할당 절약)
-            var seen = std.StringHashMap(void).init(allocator);
-            defer seen.deinit();
-            var visited = std.AutoHashMap(u32, void).init(allocator);
-            defer visited.deinit();
+            var seen: std.StringHashMapUnmanaged(void) = .empty;
+            defer seen.deinit(allocator);
+            var visited: std.AutoHashMapUnmanaged(u32, void) = .empty;
+            defer visited.deinit(allocator);
             var sorted_names: std.ArrayList([]const u8) = .empty;
             defer sorted_names.deinit(allocator);
 
@@ -507,7 +507,7 @@ pub fn emitEsmWrappedModule(
                 if (std.mem.eql(u8, eb.exported_name, "*")) {
                     seen.clearRetainingCapacity();
                     visited.clearRetainingCapacity();
-                    try collectStarExportNames(l, src_i, &seen, &visited);
+                    try collectStarExportNames(allocator, l, src_i, &seen, &visited);
 
                     // hashmap 순회는 비결정 — 사전순 정렬 후 emit 해 namespace getter 출현 순서 결정.
                     sorted_names.clearRetainingCapacity();
@@ -527,7 +527,7 @@ pub fn emitEsmWrappedModule(
                             .name = name,
                             .getter_value = getter_val,
                         });
-                        try direct_exports.put(name, {});
+                        try direct_exports.put(allocator, name, {});
                     }
                 } else {
                     // export * as ns from './dep' → namespace re-export
@@ -546,7 +546,7 @@ pub fn emitEsmWrappedModule(
                             .name = eb.exported_name,
                             .getter_value = getter_val,
                         });
-                        try direct_exports.put(eb.exported_name, {});
+                        try direct_exports.put(allocator, eb.exported_name, {});
                     }
                 }
             }
@@ -900,8 +900,8 @@ pub fn emitEsmWrappedModule(
     defer star_init_buf.deinit(allocator);
     if (linker) |l| {
         // 중복 init 방지 (같은 소스 모듈에 대해 여러 re-export가 있을 수 있음)
-        var re_export_inited = std.AutoHashMap(u32, void).init(allocator);
-        defer re_export_inited.deinit();
+        var re_export_inited: std.AutoHashMapUnmanaged(u32, void) = .empty;
+        defer re_export_inited.deinit(allocator);
 
         for (module.export_bindings) |eb| {
             if (!eb.kind.isReExportAll() and eb.kind != .re_export) continue;
@@ -916,7 +916,7 @@ pub fn emitEsmWrappedModule(
             // dev_mode 등 tree-shaker 미동작 환경은 is_included 비트 신뢰 불가라
             // tree_shaker_active 게이트 (metadata.zig:408,438 동일 정책).
             if (l.tree_shaker_active and !src_mod_ptr.is_included) continue;
-            re_export_inited.put(src_i, {}) catch {};
+            re_export_inited.put(allocator, src_i, {}) catch {};
             if (shouldLazyReExportInit(options, src_mod_ptr)) continue;
 
             try appendWrappedInitCall(&star_init_buf, allocator, src_mod_ptr, options, rename_tbl);
@@ -935,7 +935,7 @@ pub fn emitEsmWrappedModule(
             const src_mod = l.graph.getModule(rec.resolved) orelse continue;
             if (re_export_inited.contains(src_i)) continue;
             if (src_mod.wrap_kind != .esm) continue;
-            re_export_inited.put(src_i, {}) catch {};
+            re_export_inited.put(allocator, src_i, {}) catch {};
 
             try appendWrappedInitCall(&star_init_buf, allocator, src_mod, options, rename_tbl);
         }
@@ -1255,20 +1255,21 @@ fn appendExportGetter(
 /// ESM 스펙: export *는 "default"를 제외한 모든 named export를 전파한다.
 /// diamond export * 패턴(A→B,C / B,C→D)에서 무한 재귀를 방지하기 위해 visited로 모듈 추적.
 fn collectStarExportNames(
+    allocator: std.mem.Allocator,
     l: *const Linker,
     mod_idx: u32,
-    seen: *std.StringHashMap(void),
-    visited: *std.AutoHashMap(u32, void),
+    seen: *std.StringHashMapUnmanaged(void),
+    visited: *std.AutoHashMapUnmanaged(u32, void),
 ) !void {
     const m = l.graph.getModule(ModuleIndex.fromUsize(mod_idx)) orelse return;
     if (visited.contains(mod_idx)) return;
-    try visited.put(mod_idx, {});
+    try visited.put(allocator, mod_idx, {});
 
     // 직접 선언된 export 수집 (local + re_export + named re_export_all)
     for (m.export_bindings) |eb| {
         if (eb.kind == .re_export_star) continue;
         if (!seen.contains(eb.exported_name)) {
-            try seen.put(eb.exported_name, {});
+            try seen.put(allocator, eb.exported_name, {});
         }
     }
 
@@ -1280,7 +1281,7 @@ fn collectStarExportNames(
         if (rec_idx >= m.import_records.len) continue;
         const source_mod_idx = m.import_records[rec_idx].resolved;
         if (source_mod_idx.isNone()) continue;
-        try collectStarExportNames(l, @intFromEnum(source_mod_idx), seen, visited);
+        try collectStarExportNames(allocator, l, @intFromEnum(source_mod_idx), seen, visited);
     }
 }
 

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -354,9 +354,9 @@ pub const IncrementalBundler = struct {
         if (old_paths.len != new_paths.len) return false;
 
         // old_paths를 해시셋에 넣고 new_paths 전부가 존재하는지 확인
-        var set = std.StringHashMap(void).init(self.allocator);
-        defer set.deinit();
-        set.ensureTotalCapacity(@intCast(old_paths.len)) catch return false;
+        var set: std.StringHashMapUnmanaged(void) = .empty;
+        defer set.deinit(self.allocator);
+        set.ensureTotalCapacity(self.allocator, @intCast(old_paths.len)) catch return false;
         for (old_paths) |p| {
             set.putAssumeCapacity(p, {});
         }

--- a/src/cli/watch.zig
+++ b/src/cli/watch.zig
@@ -56,13 +56,13 @@ pub fn watchDirectory(
     const stdout = &stdout_state.interface;
 
     // mtime 맵: 파일 경로(소유) -> mtime
-    var mtime_map = std.StringHashMap(i128).init(allocator);
+    var mtime_map: std.StringHashMapUnmanaged(i128) = .empty;
     defer {
         var it = mtime_map.iterator();
         while (it.next()) |entry| {
             allocator.free(entry.key_ptr.*);
         }
-        mtime_map.deinit();
+        mtime_map.deinit(allocator);
     }
 
     // 초기 mtime 수집
@@ -74,13 +74,13 @@ pub fn watchDirectory(
         io.sleep(std.Io.Duration.fromMilliseconds(500), .awake) catch {};
 
         // 현재 파일 상태 수집
-        var current_mtimes = std.StringHashMap(i128).init(allocator);
+        var current_mtimes: std.StringHashMapUnmanaged(i128) = .empty;
         defer {
             var it = current_mtimes.iterator();
             while (it.next()) |entry| {
                 allocator.free(entry.key_ptr.*);
             }
-            current_mtimes.deinit();
+            current_mtimes.deinit(allocator);
         }
 
         collectMtimes(allocator, io, input_dir, &current_mtimes) catch continue;
@@ -118,7 +118,7 @@ pub fn watchDirectory(
 
                 // mtime 맵 업데이트 - 키를 복제하여 저장
                 const owned_key = try allocator.dupe(u8, path);
-                if (mtime_map.fetchPut(owned_key, current_mtime) catch null) |old| {
+                if (mtime_map.fetchPut(allocator, owned_key, current_mtime) catch null) |old| {
                     allocator.free(old.key);
                 }
             }
@@ -160,7 +160,7 @@ pub fn getFileMtime(io: std.Io, path: []const u8) !i128 {
 pub fn upsertMtimePath(
     allocator: std.mem.Allocator,
     io: std.Io,
-    map: *std.StringHashMap(i128),
+    map: *std.StringHashMapUnmanaged(i128),
     path: []const u8,
 ) void {
     const mt = getFileMtime(io, path) catch return;
@@ -169,7 +169,7 @@ pub fn upsertMtimePath(
         return;
     }
     const duped = allocator.dupe(u8, path) catch return;
-    map.put(duped, mt) catch allocator.free(duped);
+    map.put(allocator, duped, mt) catch allocator.free(duped);
 }
 
 /// 디렉토리를 순회하며 .ts/.tsx 파일의 mtime을 수집한다.
@@ -178,7 +178,7 @@ pub fn collectMtimes(
     allocator: std.mem.Allocator,
     io: std.Io,
     input_dir: []const u8,
-    mtime_map: *std.StringHashMap(i128),
+    mtime_map: *std.StringHashMapUnmanaged(i128),
 ) !void {
     var dir = try std.Io.Dir.cwd().openDir(io, input_dir, .{ .iterate = true });
     defer dir.close(io);
@@ -206,7 +206,7 @@ pub fn collectMtimes(
         };
 
         // full_path를 키로 소유권 이전
-        mtime_map.put(full_path, mtime) catch {
+        mtime_map.put(allocator, full_path, mtime) catch {
             allocator.free(full_path);
             continue;
         };
@@ -221,13 +221,13 @@ pub fn collectWatchRootMtimes(
     root: []const u8,
     include: []const []const u8,
     exclude: []const []const u8,
-    mtime_map: *std.StringHashMap(i128),
+    mtime_map: *std.StringHashMapUnmanaged(i128),
 ) !void {
     // 0.16: statFile 가 io 를 요구하므로 visitor closure 가 ctx 로 io 를 받는다.
-    const Ctx = struct { map: *std.StringHashMap(i128), io: std.Io };
+    const Ctx = struct { map: *std.StringHashMapUnmanaged(i128), allocator: std.mem.Allocator, io: std.Io };
     const visit = struct {
         fn f(ctx: Ctx, full_path: []const u8) bool {
-            const gop = ctx.map.getOrPut(full_path) catch return false;
+            const gop = ctx.map.getOrPut(ctx.allocator, full_path) catch return false;
             if (gop.found_existing) return false;
             gop.value_ptr.* = getFileMtime(ctx.io, full_path) catch {
                 _ = ctx.map.remove(full_path);
@@ -241,7 +241,7 @@ pub fn collectWatchRootMtimes(
         io,
         root,
         .{ .include = include, .exclude = exclude },
-        Ctx{ .map = mtime_map, .io = io },
+        Ctx{ .map = mtime_map, .allocator = allocator, .io = io },
         visit,
     );
 }

--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -173,12 +173,12 @@ pub fn mangleAll(
     // mangle_audit 비활성 시 set build + per-candidate lookup 전부 skip
     // (production hot path 낭비 회피).
     const audit_enabled = debug_log.enabled(.mangle_audit);
-    var cross_module_ref_set = std.AutoHashMap(ModuleSymKey, void).init(allocator);
-    defer cross_module_ref_set.deinit();
+    var cross_module_ref_set: std.AutoHashMapUnmanaged(ModuleSymKey, void) = .empty;
+    defer cross_module_ref_set.deinit(allocator);
     if (audit_enabled) {
         for (input.modules) |m| {
             for (m.cross_module_imports) |ref| {
-                try cross_module_ref_set.put(.{
+                try cross_module_ref_set.put(allocator, .{
                     .module_index = ref.source_module_index,
                     .symbol_id = ref.source_symbol_id,
                 }, {});

--- a/src/main.zig
+++ b/src/main.zig
@@ -926,14 +926,14 @@ pub fn main(init: std.process.Init) !void {
             defer persistent_store.deinit();
 
             // dev mode: per-module code 캐시 (HMR diff용)
-            var module_code_cache = std.StringHashMap([]const u8).init(allocator);
+            var module_code_cache: std.StringHashMapUnmanaged([]const u8) = .empty;
             defer {
                 var it = module_code_cache.iterator();
                 while (it.next()) |entry| {
                     allocator.free(entry.key_ptr.*);
                     allocator.free(entry.value_ptr.*);
                 }
-                module_code_cache.deinit();
+                module_code_cache.deinit(allocator);
             }
 
             // 초기 빌드의 module_dev_codes로 캐시 초기화 (첫 rebuild부터 HMR diff 가능)
@@ -944,7 +944,7 @@ pub fn main(init: std.process.Init) !void {
                         allocator.free(id_copy);
                         continue;
                     };
-                    module_code_cache.put(id_copy, code_copy) catch {
+                    module_code_cache.put(allocator, id_copy, code_copy) catch {
                         allocator.free(id_copy);
                         allocator.free(code_copy);
                     };
@@ -957,17 +957,17 @@ pub fn main(init: std.process.Init) !void {
             // 첫 빌드는 module_store 없이 실행되었으므로 두 번째 빌드부터 캐시가 유효함.
 
             // 초기 module_paths에서 mtime 수집
-            var mtime_map = std.StringHashMap(i128).init(allocator);
+            var mtime_map: std.StringHashMapUnmanaged(i128) = .empty;
             defer {
                 var it = mtime_map.keyIterator();
                 while (it.next()) |k| allocator.free(k.*);
-                mtime_map.deinit();
+                mtime_map.deinit(allocator);
             }
 
             // 엔트리 파일도 감시 대상에 추가
             const entry_dupe = try allocator.dupe(u8, abs_entry);
             const entry_mtime = watch_cli.getFileMtime(io, abs_entry) catch 0;
-            try mtime_map.put(entry_dupe, entry_mtime);
+            try mtime_map.put(allocator, entry_dupe, entry_mtime);
 
             if (result.module_paths) |paths| {
                 for (paths) |p| watch_cli.upsertMtimePath(allocator, io, &mtime_map, p);
@@ -1143,7 +1143,7 @@ pub fn main(init: std.process.Init) !void {
                                 allocator.free(id_copy);
                                 continue;
                             };
-                            module_code_cache.put(id_copy, code_copy) catch {
+                            module_code_cache.put(allocator, id_copy, code_copy) catch {
                                 allocator.free(id_copy);
                                 allocator.free(code_copy);
                             };

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -154,8 +154,8 @@ pub fn checkPrivateNameStaticConflict(
 
     // private name → (is_static, span) 매핑
     // 같은 이름이 다른 static 상태로 등장하면 에러
-    var declared = std.StringHashMap(PrivateStaticEntry).init(allocator);
-    defer declared.deinit();
+    var declared: std.StringHashMapUnmanaged(PrivateStaticEntry) = .empty;
+    defer declared.deinit(allocator);
 
     for (indices) |raw_idx| {
         const idx: NodeIndex = @enumFromInt(raw_idx);
@@ -197,7 +197,7 @@ fn checkPrivateKeyStaticConflict(
     ast: *const Ast,
     key_idx: NodeIndex,
     is_static: bool,
-    declared: *std.StringHashMap(PrivateStaticEntry),
+    declared: *std.StringHashMapUnmanaged(PrivateStaticEntry),
     errors: *std.ArrayList(Diagnostic),
     allocator: std.mem.Allocator,
 ) AllocError!void {
@@ -214,7 +214,7 @@ fn checkPrivateKeyStaticConflict(
             try addErrorCodeWithPrevious(errors, allocator, key_node.span, msg, .private_redeclared, existing.span);
         }
     } else {
-        try declared.put(name, .{ .is_static = is_static, .span = key_node.span });
+        try declared.put(allocator, name, .{ .is_static = is_static, .span = key_node.span });
     }
 }
 
@@ -333,8 +333,8 @@ pub fn checkDuplicateParams(
     if (params.start + params.len > ast.extra_data.items.len) return;
 
     // 파라미터 이름 → 첫 선언 위치 매핑
-    var seen = std.StringHashMap(Span).init(allocator);
-    defer seen.deinit();
+    var seen: std.StringHashMapUnmanaged(Span) = .empty;
+    defer seen.deinit(allocator);
 
     const param_indices = ast.extra_data.items[params.start .. params.start + params.len];
     for (param_indices) |raw_idx| {
@@ -346,7 +346,7 @@ pub fn checkDuplicateParams(
 fn recordSeenName(
     name: []const u8,
     span: Span,
-    seen: *std.StringHashMap(Span),
+    seen: *std.StringHashMapUnmanaged(Span),
     errors: *std.ArrayList(Diagnostic),
     allocator: std.mem.Allocator,
 ) AllocError!void {
@@ -354,7 +354,7 @@ fn recordSeenName(
         const msg = try std.fmt.allocPrint(allocator, "Duplicate parameter name '{s}'", .{name});
         try addErrorCodeWithPrevious(errors, allocator, span, msg, .duplicate_parameter, previous_span);
     } else {
-        try seen.put(name, span);
+        try seen.put(allocator, name, span);
     }
 }
 
@@ -366,7 +366,7 @@ fn recordSeenName(
 fn collectBindingNames(
     ast: *const Ast,
     idx: NodeIndex,
-    seen: *std.StringHashMap(Span),
+    seen: *std.StringHashMapUnmanaged(Span),
     errors: *std.ArrayList(Diagnostic),
     allocator: std.mem.Allocator,
 ) AllocError!void {
@@ -395,8 +395,8 @@ pub fn checkDuplicateArrowParams(
     if (node.tag == .binding_identifier or node.tag == .identifier_reference or node.tag == .assignment_target_identifier) return;
     if (node.tag == .formal_parameters and node.data.list.len <= 1) return;
 
-    var seen = std.StringHashMap(Span).init(allocator);
-    defer seen.deinit();
+    var seen: std.StringHashMapUnmanaged(Span) = .empty;
+    defer seen.deinit(allocator);
 
     try collectArrowParamNames(ast, param_idx, &seen, errors, allocator);
 }
@@ -405,7 +405,7 @@ pub fn checkDuplicateArrowParams(
 fn collectArrowParamNames(
     ast: *const Ast,
     idx: NodeIndex,
-    seen: *std.StringHashMap(Span),
+    seen: *std.StringHashMapUnmanaged(Span),
     errors: *std.ArrayList(Diagnostic),
     allocator: std.mem.Allocator,
 ) AllocError!void {

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -769,9 +769,9 @@ pub const DevServer = struct {
 
         // issue #3858 — rescan 시 빠른 중복 체크용 set. css_paths 의 path 와 동일
         // 인스턴스 참조 (소유 X — css_paths 가 owner).
-        var css_path_set = std.StringHashMap(void).init(self.allocator);
-        defer css_path_set.deinit();
-        for (css_paths.items) |p| css_path_set.put(p, {}) catch {};
+        var css_path_set: std.StringHashMapUnmanaged(void) = .empty;
+        defer css_path_set.deinit(self.allocator);
+        for (css_paths.items) |p| css_path_set.put(self.allocator, p, {}) catch {};
 
         self.routineLog("  [watch] watching {d} files for changes...\n", .{watcher.watchCount()});
 
@@ -840,9 +840,9 @@ pub const DevServer = struct {
                 collectCssFiles(self.allocator, self.io, self.root_dir, root, &new_css_paths);
 
                 // new_css_paths set 으로 빠른 lookup
-                var new_set = std.StringHashMap(void).init(self.allocator);
-                defer new_set.deinit();
-                for (new_css_paths.items) |p| new_set.put(p, {}) catch {};
+                var new_set: std.StringHashMapUnmanaged(void) = .empty;
+                defer new_set.deinit(self.allocator);
+                for (new_css_paths.items) |p| new_set.put(self.allocator, p, {}) catch {};
 
                 // (a) 신규 path detect — new_set 에 있으나 css_path_set 에 없음
                 for (new_css_paths.items) |p| {
@@ -852,7 +852,7 @@ pub const DevServer = struct {
                         self.allocator.free(path_owned);
                         continue;
                     };
-                    css_path_set.put(path_owned, {}) catch {};
+                    css_path_set.put(self.allocator, path_owned, {}) catch {};
                     watcher.addPath(path_owned) catch {};
                     // synthetic event — caller 가 css-update broadcast 트리거하도록
                     if (changed_set.getOrPut(path_owned) catch null) |gop| {

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -167,16 +167,16 @@ pub fn collectClosureVars(
     params: ast_mod.NodeList,
     func_name: ?[]const u8,
 ) Error![]const ClosureVar {
-    var locals = std.StringHashMap(void).init(self.allocator);
-    defer locals.deinit();
-    var refs = std.StringHashMap(NodeIndex).init(self.allocator);
-    defer refs.deinit();
-    var new_classes = std.StringHashMap(NodeIndex).init(self.allocator);
-    defer new_classes.deinit();
+    var locals: std.StringHashMapUnmanaged(void) = .empty;
+    defer locals.deinit(self.allocator);
+    var refs: std.StringHashMapUnmanaged(NodeIndex) = .empty;
+    defer refs.deinit(self.allocator);
+    var new_classes: std.StringHashMapUnmanaged(NodeIndex) = .empty;
+    defer new_classes.deinit(self.allocator);
 
     // 0. 함수 이름 → locals (자기 참조 제외: JS 스펙상 함수 이름은 body 내에서 접근 가능)
     if (func_name) |name| {
-        if (name.len > 0) locals.put(name, {}) catch return error.OutOfMemory;
+        if (name.len > 0) locals.put(self.allocator, name, {}) catch return error.OutOfMemory;
     }
 
     // 1. 파라미터 이름 수집 (parser가 formal_parameters로 정규화 보장)
@@ -243,12 +243,12 @@ pub fn collectClosureVars(
 /// arrow params without type annotations 는 expression 으로 파싱된 뒤
 /// coverExpressionToAssignmentTarget 로 변환되므로 cover-grammar 결과 (identifier_reference,
 /// assignment_target_identifier, assignment_expression) 도 binding 으로 본다.
-fn collectBindingNames(self: *Transformer, idx: NodeIndex, locals: *std.StringHashMap(void)) Error!void {
+fn collectBindingNames(self: *Transformer, idx: NodeIndex, locals: *std.StringHashMapUnmanaged(void)) Error!void {
     var it = try ast_walk.bindingIdentifiers(self.allocator, self.ast, idx, .{ .cover_grammar_assignment = true });
     defer it.deinit();
     while (try it.next()) |leaf_idx| {
         const name = self.ast.getText(self.ast.getNode(leaf_idx).data.string_ref);
-        if (name.len > 0) locals.put(name, {}) catch return error.OutOfMemory;
+        if (name.len > 0) locals.put(self.allocator, name, {}) catch return error.OutOfMemory;
     }
 }
 
@@ -259,24 +259,24 @@ fn walkScopedBody(
     self: *Transformer,
     body_idx: NodeIndex,
     param_nodes: []const u32,
-    outer_locals: *std.StringHashMap(void),
-    outer_refs: *std.StringHashMap(NodeIndex),
+    outer_locals: *std.StringHashMapUnmanaged(void),
+    outer_refs: *std.StringHashMapUnmanaged(NodeIndex),
 ) Error!void {
-    var inner_locals = std.StringHashMap(void).init(self.allocator);
-    defer inner_locals.deinit();
+    var inner_locals: std.StringHashMapUnmanaged(void) = .empty;
+    defer inner_locals.deinit(self.allocator);
 
     for (param_nodes) |raw| {
         try collectAllIdentifiers(self, @enumFromInt(raw), &inner_locals);
     }
 
-    var inner_refs = std.StringHashMap(NodeIndex).init(self.allocator);
-    defer inner_refs.deinit();
+    var inner_refs: std.StringHashMapUnmanaged(NodeIndex) = .empty;
+    defer inner_refs.deinit(self.allocator);
     try walkBodyForClosureAnalysis(self, body_idx, &inner_locals, &inner_refs);
 
     var iter = inner_refs.iterator();
     while (iter.next()) |entry| {
         if (!inner_locals.contains(entry.key_ptr.*) and !outer_locals.contains(entry.key_ptr.*)) {
-            outer_refs.put(entry.key_ptr.*, entry.value_ptr.*) catch return error.OutOfMemory;
+            outer_refs.put(self.allocator, entry.key_ptr.*, entry.value_ptr.*) catch return error.OutOfMemory;
         }
     }
 }
@@ -284,7 +284,7 @@ fn walkScopedBody(
 /// 노드 트리에서 모든 identifier (identifier_reference, binding_identifier 등)를 수집.
 /// params에서 binding names를 추출하는 용도. generic pre-order 순회 — 명시 stack 사용으로
 /// 깊이 한도 없음 (#2484: 이전 depth>32 silent return 이 깊은 패턴에서 leaf 누락).
-fn collectAllIdentifiers(self: *Transformer, idx: NodeIndex, locals: *std.StringHashMap(void)) Error!void {
+fn collectAllIdentifiers(self: *Transformer, idx: NodeIndex, locals: *std.StringHashMapUnmanaged(void)) Error!void {
     var stack: std.ArrayList(NodeIndex) = .empty;
     defer stack.deinit(self.allocator);
     if (!idx.isNone() and @intFromEnum(idx) < self.ast.nodes.items.len) {
@@ -297,7 +297,7 @@ fn collectAllIdentifiers(self: *Transformer, idx: NodeIndex, locals: *std.String
         switch (node.tag) {
             .identifier_reference, .binding_identifier, .assignment_target_identifier => {
                 const name = self.ast.getText(node.data.string_ref);
-                if (name.len > 0) locals.put(name, {}) catch return error.OutOfMemory;
+                if (name.len > 0) locals.put(self.allocator, name, {}) catch return error.OutOfMemory;
                 continue;
             },
             else => {},
@@ -320,9 +320,9 @@ fn collectAllIdentifiers(self: *Transformer, idx: NodeIndex, locals: *std.String
 fn walkBodyForClosureAnalysisWithNew(
     self: *Transformer,
     idx: NodeIndex,
-    locals: *std.StringHashMap(void),
-    refs: *std.StringHashMap(NodeIndex),
-    new_classes: *std.StringHashMap(NodeIndex),
+    locals: *std.StringHashMapUnmanaged(void),
+    refs: *std.StringHashMapUnmanaged(NodeIndex),
+    new_classes: *std.StringHashMapUnmanaged(NodeIndex),
 ) Error!void {
     try collectNewExpressionCallees(self, idx, new_classes);
     try walkBodyForClosureAnalysis(self, idx, locals, refs);
@@ -333,7 +333,7 @@ fn walkBodyForClosureAnalysisWithNew(
 fn collectNewExpressionCallees(
     self: *Transformer,
     idx: NodeIndex,
-    new_classes: *std.StringHashMap(NodeIndex),
+    new_classes: *std.StringHashMapUnmanaged(NodeIndex),
 ) Error!void {
     var stack: std.ArrayList(NodeIndex) = .empty;
     defer stack.deinit(self.allocator);
@@ -353,7 +353,7 @@ fn collectNewExpressionCallees(
                     if (callee.tag == .identifier_reference) {
                         const name = self.ast.getText(callee.data.string_ref);
                         if (name.len > 0) {
-                            new_classes.put(name, callee_idx) catch return error.OutOfMemory;
+                            new_classes.put(self.allocator, name, callee_idx) catch return error.OutOfMemory;
                         }
                     }
                 }
@@ -373,8 +373,8 @@ fn collectNewExpressionCallees(
 fn walkBodyForClosureAnalysis(
     self: *Transformer,
     idx: NodeIndex,
-    locals: *std.StringHashMap(void),
-    refs: *std.StringHashMap(NodeIndex),
+    locals: *std.StringHashMapUnmanaged(void),
+    refs: *std.StringHashMapUnmanaged(NodeIndex),
 ) Error!void {
     var stack: std.ArrayList(NodeIndex) = .empty;
     defer stack.deinit(self.allocator);
@@ -393,7 +393,7 @@ fn walkBodyForClosureAnalysis(
             .identifier_reference => {
                 const name = self.ast.getText(node.data.string_ref);
                 if (name.len > 0) {
-                    refs.put(name, cur) catch return error.OutOfMemory;
+                    refs.put(self.allocator, name, cur) catch return error.OutOfMemory;
                 }
                 continue;
             },
@@ -412,8 +412,8 @@ fn walkBodyForClosureAnalysis(
                 const plist = self.ast.functionParamsList(node);
                 const p_start = plist.start;
                 const p_len = plist.len;
-                var fn_locals = std.StringHashMap(void).init(self.allocator);
-                defer fn_locals.deinit();
+                var fn_locals: std.StringHashMapUnmanaged(void) = .empty;
+                defer fn_locals.deinit(self.allocator);
                 // name + params → param_nodes (extra_data 슬라이스 + name 앞에 추가)
                 try collectAllIdentifiers(self, @enumFromInt(self.ast.extra_data.items[e]), &fn_locals);
                 var fpi: u32 = 0;
@@ -421,13 +421,13 @@ fn walkBodyForClosureAnalysis(
                     if (p_start + fpi < self.ast.extra_data.items.len)
                         try collectAllIdentifiers(self, @enumFromInt(self.ast.extra_data.items[p_start + fpi]), &fn_locals);
                 }
-                var fn_refs = std.StringHashMap(NodeIndex).init(self.allocator);
-                defer fn_refs.deinit();
+                var fn_refs: std.StringHashMapUnmanaged(NodeIndex) = .empty;
+                defer fn_refs.deinit(self.allocator);
                 try walkBodyForClosureAnalysis(self, body_idx, &fn_locals, &fn_refs);
                 var fr_iter = fn_refs.iterator();
                 while (fr_iter.next()) |entry| {
                     if (!fn_locals.contains(entry.key_ptr.*) and !locals.contains(entry.key_ptr.*)) {
-                        refs.put(entry.key_ptr.*, entry.value_ptr.*) catch return error.OutOfMemory;
+                        refs.put(self.allocator, entry.key_ptr.*, entry.value_ptr.*) catch return error.OutOfMemory;
                     }
                 }
                 continue;


### PR DESCRIPTION
## 배경

이 repo 는 ArrayList 를 **이미 100% unmanaged** 로 migrate 했는데(`.append(alloc, x)`), HashMap 만 managed 가 남아 자료구조 스타일이 혼재했습니다. 0.16 릴리스 노트가 *"allocator 필드 없는 unmanaged 가 더 범용적이고 managed 는 제거되어야 한다"* 고 명시하므로, **future-proofing + 일관성** 목적으로 정리합니다.

> ⚠️ **측정 가능한 perf/메모리 이득은 없습니다.** 인스턴스당 allocator 포인터 8B, 연산당 필드 1회 read 절약 수준. 0.16 에서 managed 가 deprecated 도 아니라 긴급성도 없습니다. 순수 컨벤션 통일입니다.

## 범위 (이번 PR = 함수-로컬 맵만)

`var m = std.XxxHashMap(T).init(alloc); defer m.deinit();` 형태로 **함수 안에서 선언·사용·해제**되는 로컬 맵만 전환했습니다. allocator 가 같은 스코프에 있고 deinit 도 같은 함수라 **escape 위험 없이 안전**합니다. **25개 로컬 맵 / 11개 파일.**

- `semantic/checker.zig`, `app/build.zig`, `transformer/worklet.zig`, `codegen/unified_mangler.zig`, `bundler/{chunk,bundler,incremental,emitter/esm_wrap}.zig`, `server/dev_server.zig`, `cli/watch.zig`, `main.zig`
- 로컬 맵을 받는 헬퍼 시그니처(`*HashMap` → `*HashMapUnmanaged` + `allocator` 파라미터)도 함께 갱신.

### 의도적 제외 (follow-up)
- **구조체 FIELD 맵** — 메서드 간 allocator 전파가 필요해 별도 작업. (`module_store`, `resolver`, `compiled_cache`, `mangler.renames` 등)
- **테스트 맵** (`std.testing.allocator`), **linker 서브시스템** (`linker.zig` 121 호출부 등 churn 과다).
- `dev_server.changed_set` 은 컴파일러가 `BundleOptions.changed_files` FIELD 와 결합됨을 잡아내 전환 **철회**(안전망 사례).

## 전환 패턴 (Zig 초보자 설명)

managed HashMap 은 `init(allocator)` 때 allocator 를 내부에 저장하고 모든 연산이 그걸 씁니다. unmanaged 는 그 필드가 없고 **연산마다 allocator 를 인자로 받습니다**.

```zig
// before (managed)
var m = std.StringHashMap(T).init(allocator);
defer m.deinit();
try m.put(k, v);

// after (unmanaged)
var m: std.StringHashMapUnmanaged(T) = .empty;
defer m.deinit(allocator);
try m.put(allocator, k, v);
```

`get`/`contains`/`count`/`iterator` 등 **할당이 없는 연산은 그대로**(allocator 불필요), `put`/`getOrPut`/`fetchPut`/`ensureTotalCapacity`/`deinit` 등 **할당하는 연산만 첫 인자로 allocator 추가**. 넘기는 allocator 는 원래 `.init(X)` 의 X 를 그대로 써서 **동작은 완전히 동일**합니다.

## 검증 (Zig 0.16.0)

- `zig build install` · `zig build test` 모두 **exit 0** (독립 재검증). 컴파일러가 allocator 누락 사이트를 전부 잡음.
- 새로 추가된 라인에 managed `.init(` **0건**.
- blast-radius 큰 맵(`main.zig`×2, `bundler.zig`×2, `watch`/`esm_wrap`/`worklet` 헬퍼 캐스케이드)을 직접 리뷰 → **미반환·미저장·원본 allocator 보존**(escape→UAF 위험 없음) 확인.
- `/code-review max`(9앵글+sweep) → 버그 **0건**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)