### PR TITLE
refactor(linker): linker 서브시스템 HashMap 을 0.16 unmanaged 로 전환

### DIFF
--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -1349,13 +1349,13 @@ fn fanOutModuleExports(
     // collectExportsRecursive 는 lnk.allocator 로 append. OOM 은 named 루프와
     // 일관되게 전파(silent partial-link 방지).
     var exps: std.ArrayList(Linker.NsExportPair) = .empty;
-    var seen_e = std.StringHashMap(void).init(lnk.allocator);
-    var visited_e = std.AutoHashMap(u32, void).init(lnk.allocator);
+    var seen_e: std.StringHashMapUnmanaged(void) = .empty;
+    var visited_e: std.AutoHashMapUnmanaged(u32, void) = .empty;
     defer {
         for (exps.items) |e| if (e.owned) lnk.allocator.free(e.local);
         exps.deinit(lnk.allocator);
-        seen_e.deinit();
-        visited_e.deinit();
+        seen_e.deinit(lnk.allocator);
+        visited_e.deinit(lnk.allocator);
     }
     try lnk.collectExportsRecursive(&exps, &seen_e, &visited_e, src_mod, 0);
     for (exps.items) |e|

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -146,10 +146,10 @@ pub const Linker = struct {
     format: types.Format,
 
     /// 모듈별 export 맵: "module_index\x00exported_name" → ExportEntry
-    export_map: std.StringHashMap(ExportEntry),
+    export_map: std.StringHashMapUnmanaged(ExportEntry) = .empty,
 
     /// import→export 바인딩 결과: (module_index, local_span_key) → ResolvedBinding
-    resolved_bindings: std.AutoHashMap(BindingKey, ResolvedBinding),
+    resolved_bindings: std.AutoHashMapUnmanaged(BindingKey, ResolvedBinding) = .empty,
 
     diagnostics: std.ArrayList(BundlerDiagnostic),
     /// #1791 사용자 노출용 치명 진단 (예: IIFE 포맷에서 unresolved import).
@@ -166,7 +166,7 @@ pub const Linker = struct {
     canonical_strings: std.ArrayList([]const u8) = .empty,
     /// 충돌 검사용 set. 리네임 후보가 기존 canonical로 사용 중인지 O(1) 확인.
     /// 키는 canonical_strings가 소유 — 이 맵은 borrowed.
-    canonical_names_used: std.StringHashMap(void),
+    canonical_names_used: std.StringHashMapUnmanaged(void) = .empty,
 
     /// RFC #3940 — build-scope `SymbolID → 최종 이름` 테이블. canonical write 단일 sink
     /// (`assignSymbolCanonical`) 가 기록한다. 값 string 은 borrow (canonical_strings 소유, 같은
@@ -176,7 +176,7 @@ pub const Linker = struct {
 
     /// 자동 수집된 예약 글로벌 이름. 모든 모듈의 unresolved references를 합친 것.
     /// scope hoisting 시 모듈 top-level 변수가 이 이름을 shadowing하면 리네임.
-    reserved_globals: std.StringHashMap(void),
+    reserved_globals: std.StringHashMapUnmanaged(void) = .empty,
 
     /// 외부에서 전달된 예약 전역 식별자 (--global-identifier).
     /// RN의 polyfillGlobal()로 등록되는 이름(Performance, EventCounts 등)을
@@ -357,11 +357,11 @@ pub const Linker = struct {
             .allocator = allocator,
             .graph = graph,
             .format = format,
-            .export_map = std.StringHashMap(ExportEntry).init(allocator),
-            .resolved_bindings = std.AutoHashMap(BindingKey, ResolvedBinding).init(allocator),
+            .export_map = .empty,
+            .resolved_bindings = .empty,
             .diagnostics = .empty,
-            .canonical_names_used = std.StringHashMap(void).init(allocator),
-            .reserved_globals = std.StringHashMap(void).init(allocator),
+            .canonical_names_used = .empty,
+            .reserved_globals = .empty,
             .global_identifiers = global_identifiers,
         };
     }
@@ -401,13 +401,13 @@ pub const Linker = struct {
         while (eit.next()) |key| {
             self.allocator.free(key.*);
         }
-        self.export_map.deinit();
-        self.resolved_bindings.deinit();
+        self.export_map.deinit(self.allocator);
+        self.resolved_bindings.deinit(self.allocator);
         for (self.canonical_strings.items) |s| self.allocator.free(s);
         self.canonical_strings.deinit(self.allocator);
-        self.canonical_names_used.deinit();
+        self.canonical_names_used.deinit(self.allocator);
         self.rename_table.deinit(self.allocator);
-        self.reserved_globals.deinit();
+        self.reserved_globals.deinit(self.allocator);
         // chain_cache: 키는 allocator로 dupe됨
         var cc_it = self.chain_cache.keyIterator();
         while (cc_it.next()) |key| self.allocator.free(key.*);
@@ -523,7 +523,7 @@ pub const Linker = struct {
     };
 
     /// name_to_owners HashMap의 타입 별칭.
-    pub const NameToOwnersMap = std.StringHashMap(std.ArrayList(NameOwner));
+    pub const NameToOwnersMap = std.StringHashMapUnmanaged(std.ArrayList(NameOwner));
 
     /// name_to_owners에 (name, owner) 항목을 추가한다.
     fn addNameOwner(
@@ -532,7 +532,7 @@ pub const Linker = struct {
         name: []const u8,
         owner: NameOwner,
     ) !void {
-        const entry = try name_to_owners.getOrPut(name);
+        const entry = try name_to_owners.getOrPut(self.allocator, name);
         if (!entry.found_existing) {
             entry.value_ptr.* = .empty;
         }
@@ -746,12 +746,12 @@ pub const Linker = struct {
             const sem = m.semantic orelse continue;
             var it = sem.unresolved_references.iterator();
             while (it.next()) |entry| {
-                try self.reserved_globals.put(entry.key_ptr.*, {});
+                try self.reserved_globals.put(self.allocator, entry.key_ptr.*, {});
             }
         }
         // 외부 전달된 전역 식별자도 예약 (--global-identifier, RN polyfillGlobal 등)
         for (self.global_identifiers) |name| {
-            try self.reserved_globals.put(name, {});
+            try self.reserved_globals.put(self.allocator, name, {});
         }
     }
 
@@ -765,11 +765,11 @@ pub const Linker = struct {
         try self.collectReservedGlobals();
 
         // 1. 모든 모듈의 top-level export 이름 수집
-        var name_to_owners = NameToOwnersMap.init(self.allocator);
+        var name_to_owners: NameToOwnersMap = .empty;
         defer {
             var vit = name_to_owners.valueIterator();
             while (vit.next()) |list| list.deinit(self.allocator);
-            name_to_owners.deinit();
+            name_to_owners.deinit(self.allocator);
         }
 
         for (0..self.graph.moduleCount()) |i| {
@@ -869,10 +869,10 @@ pub const Linker = struct {
         // inline 처리되어 var 가 안 만들어지더라도 entry source 의 reference 식별자는
         // 그대로 emit 되므로 mangler 가 같은 이름을 다른 binding 의 short name 으로
         // 부여하면 SyntaxError. is_external 무관하게 reserved 에 등록.
-        var exported = std.StringHashMap(void).init(self.allocator);
-        defer exported.deinit();
-        var reserved = std.StringHashMap(void).init(self.allocator);
-        defer reserved.deinit();
+        var exported: std.StringHashMapUnmanaged(void) = .empty;
+        defer exported.deinit(self.allocator);
+        var reserved: std.StringHashMapUnmanaged(void) = .empty;
+        defer reserved.deinit(self.allocator);
 
         // Scope-hoisted output shares one top-level lexical environment. If a
         // minified top-level declaration reuses an unresolved global name
@@ -880,7 +880,7 @@ pub const Linker = struct {
         // hoisted and shadows that global even in modules evaluated earlier.
         var global_it = self.reserved_globals.keyIterator();
         while (global_it.next()) |name| {
-            try reserved.put(name.*, {});
+            try reserved.put(self.allocator, name.*, {});
         }
 
         var mit = self.graph.modulesIterator();
@@ -889,10 +889,10 @@ pub const Linker = struct {
                 for (m.export_bindings) |eb| {
                     const exported_name = eb.exported_name;
                     const local_name = m.exportBindingLocalName(eb);
-                    try exported.put(exported_name, {});
-                    try exported.put(local_name, {});
-                    try reserved.put(exported_name, {});
-                    try reserved.put(local_name, {});
+                    try exported.put(self.allocator, exported_name, {});
+                    try exported.put(self.allocator, local_name, {});
+                    try reserved.put(self.allocator, exported_name, {});
+                    try reserved.put(self.allocator, local_name, {});
                 }
             }
             for (m.import_bindings) |ib| {
@@ -901,9 +901,9 @@ pub const Linker = struct {
                 // import is only preserved for output syntax. In that case the scanner
                 // local name is the external contract we must not mangle.
                 const local_name = if (ib.local_symbol.isValid()) m.importBindingLocalName(ib) else ib.local_name;
-                try reserved.put(local_name, {});
+                try reserved.put(self.allocator, local_name, {});
                 if (m.import_records[ib.import_record_index].is_external) {
-                    try exported.put(local_name, {});
+                    try exported.put(self.allocator, local_name, {});
                 }
             }
             // Phase B 는 1-char binding 을 literal 로 보존한다 (mangler.zig
@@ -920,7 +920,7 @@ pub const Linker = struct {
                 for (sem.scope_maps) |smap| {
                     var sm_it = smap.iterator();
                     while (sm_it.next()) |e| {
-                        if (e.key_ptr.len <= 1) try reserved.put(e.key_ptr.*, {});
+                        if (e.key_ptr.len <= 1) try reserved.put(self.allocator, e.key_ptr.*, {});
                     }
                 }
             }
@@ -996,7 +996,7 @@ pub const Linker = struct {
                             // mangle 안 되고 source 그대로 emit 되므로 internal binding 의
                             // mangle 결과로 동일 이름 부여 시 충돌 — three 의 \`class e\` ↔
                             // entry \`const e = new Euler(...)\` 가 그 케이스.
-                            try reserved.put(sym_name, {});
+                            try reserved.put(self.allocator, sym_name, {});
                             continue;
                         }
                         if (std.mem.eql(u8, sym_name, "default")) continue;
@@ -1018,7 +1018,7 @@ pub const Linker = struct {
                         if (key.len <= 1) {
                             // canonical_name 이 sym_name 과 다른 1-char 케이스도 reserve
                             // (위 sym_name 분기와 대칭 — #2965).
-                            try reserved.put(key, {});
+                            try reserved.put(self.allocator, key, {});
                             continue;
                         }
                         if (exported.contains(key)) continue;
@@ -1285,7 +1285,7 @@ pub const Linker = struct {
             if (self.rename_table.get(id)) |prior| _ = self.canonical_names_used.fetchRemove(prior);
         }
         try self.canonical_strings.append(self.allocator, value);
-        try self.canonical_names_used.put(value, {});
+        try self.canonical_names_used.put(self.allocator, value, {});
         if (id.isValid()) try self.rename_table.put(self.allocator, id, value);
     }
 
@@ -1465,7 +1465,7 @@ pub const Linker = struct {
                 if (self.export_map.fetchRemove(key)) |old| {
                     self.allocator.free(old.key);
                 }
-                try self.export_map.put(key, .{
+                try self.export_map.put(self.allocator, key, .{
                     .binding = eb,
                     .module_index = mod_idx,
                 });
@@ -1580,7 +1580,7 @@ pub const Linker = struct {
                     .module_index = @intCast(i),
                     .span_key = types.spanKey(ib.local_span),
                 };
-                try self.resolved_bindings.put(bk, .{
+                try self.resolved_bindings.put(self.allocator, bk, .{
                     .local_name = ib.local_name,
                     .local_span = ib.local_span,
                     .canonical = canonical,
@@ -2293,8 +2293,8 @@ pub const Linker = struct {
     pub fn collectExportsRecursive(
         self: *const Linker,
         exports: *std.ArrayList(NsExportPair),
-        seen: *std.StringHashMap(void),
-        visited: *std.AutoHashMap(u32, void),
+        seen: *std.StringHashMapUnmanaged(void),
+        visited: *std.AutoHashMapUnmanaged(u32, void),
         module_idx: ModuleIndex,
         depth: u32,
     ) std.mem.Allocator.Error!void {
@@ -2303,14 +2303,14 @@ pub const Linker = struct {
         const m = self.graph.getModule(module_idx) orelse return;
         // diamond export * 패턴에서 동일 모듈 재방문 방지
         if (visited.contains(mod_i)) return;
-        try visited.put(mod_i, {});
+        try visited.put(self.allocator, mod_i, {});
 
         // namespace import를 O(1) 조회용 맵으로 수집 (local_name → import_record_index)
-        var ns_imports = std.StringHashMap(u32).init(self.allocator);
-        defer ns_imports.deinit();
+        var ns_imports: std.StringHashMapUnmanaged(u32) = .empty;
+        defer ns_imports.deinit(self.allocator);
         for (m.import_bindings) |mib| {
             if (mib.kind == .namespace) {
-                try ns_imports.put(mib.local_name, mib.import_record_index);
+                try ns_imports.put(self.allocator, mib.local_name, mib.import_record_index);
             }
         }
 
@@ -2319,7 +2319,7 @@ pub const Linker = struct {
             // export * as ns (exported_name != "*") → named export로 포함
             if (eb.kind == .re_export_star) continue;
             if (seen.contains(eb.exported_name)) continue;
-            try seen.put(eb.exported_name, {});
+            try seen.put(self.allocator, eb.exported_name, {});
 
             const eb_local = m.exportBindingLocalName(eb);
             // ns_target_mod: hoisted ns_var 가 필요한 source 모듈 (registerNamespaceRewrites
@@ -2385,7 +2385,7 @@ pub const Linker = struct {
         // ESM 스펙: export *는 "default"를 제외 (ECMAScript 15.2.3.5).
         // seen에 "default"를 추가하여 하위 모듈의 default export가 수집되지 않도록 함.
         // 직접 선언된 export { default }는 위 첫 루프에서 이미 수집됨.
-        try seen.put("default", {});
+        try seen.put(self.allocator, "default", {});
         for (m.export_bindings) |eb| {
             if (!eb.kind.isReExportAll()) continue;
             if (!std.mem.eql(u8, eb.exported_name, "*")) continue; // export * as ns는 skip
@@ -2537,23 +2537,23 @@ pub const Linker = struct {
             const sem = m.semantic orelse continue;
             var urit = sem.unresolved_references.iterator();
             while (urit.next()) |entry| {
-                try self.reserved_globals.put(entry.key_ptr.*, {});
+                try self.reserved_globals.put(self.allocator, entry.key_ptr.*, {});
             }
         }
 
         // 1. 지정된 모듈의 top-level 심볼 이름 수집
-        var name_to_owners = NameToOwnersMap.init(self.allocator);
+        var name_to_owners: NameToOwnersMap = .empty;
         defer {
             var vit = name_to_owners.valueIterator();
             while (vit.next()) |list| list.deinit(self.allocator);
-            name_to_owners.deinit();
+            name_to_owners.deinit(self.allocator);
         }
 
         // cross-chunk import 이름을 "점유"로 등록 — exec_index=0 (가장 낮음)으로
         // 등록하여 충돌 시 로컬 심볼이 rename됨 (import 이름이 우선 유지)
         for (occupied_names) |name| {
             if (std.mem.eql(u8, name, "default")) continue;
-            const entry = try name_to_owners.getOrPut(name);
+            const entry = try name_to_owners.getOrPut(self.allocator, name);
             if (!entry.found_existing) {
                 entry.value_ptr.* = .empty;
             }
@@ -2580,12 +2580,12 @@ pub const Linker = struct {
 /// CJS 모듈의 require_xxx 변수명을 캐시에서 가져오거나 새로 생성.
 pub fn getOrCreateRequireVar(
     self: *const Linker,
-    cache: *std.AutoHashMap(u32, []const u8),
+    cache: *std.AutoHashMapUnmanaged(u32, []const u8),
     mod_idx: u32,
 ) ![]const u8 {
     if (cache.get(mod_idx)) |cached| return cached;
     const target_mod = self.getModule(mod_idx).?;
     const name = try target_mod.allocRequireName(self.allocator, &self.rename_table);
-    try cache.put(mod_idx, name);
+    try cache.put(self.allocator, mod_idx, name);
     return name;
 }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -44,7 +44,7 @@ fn canDeferStaticImportForInlineRequires(
     m: *const Module,
     rec_index: u32,
     target_mod: *const Module,
-    exported_locals: *const std.StringHashMap(void),
+    exported_locals: *const std.StringHashMapUnmanaged(void),
 ) bool {
     if (target_mod.uses_top_level_await) return false;
     if (target_mod.isUserDeclaredSideEffectful()) return false;
@@ -64,7 +64,7 @@ fn canDeferStaticImportForInlineRequires(
 
 fn getOrCreateCjsRequireRef(
     self: *const Linker,
-    cache: *std.AutoHashMap(u32, []const u8),
+    cache: *std.AutoHashMapUnmanaged(u32, []const u8),
     mod_idx: u32,
 ) ![]const u8 {
     if (!self.dev_mode) return getOrCreateRequireVar(self, cache, mod_idx);
@@ -72,7 +72,7 @@ fn getOrCreateCjsRequireRef(
 
     const target_mod = self.getModule(mod_idx).?;
     const ref = try types.fmtDevRequireRef(self.allocator, target_mod.dev_id);
-    try cache.put(mod_idx, ref);
+    try cache.put(self.allocator, mod_idx, ref);
     return ref;
 }
 
@@ -274,10 +274,10 @@ fn markReactNativeWrappedBindingImports(
     if (self.graph.resolve_cache.platform != .react_native) return;
     if (!module.wrap_kind.isWrapped()) return;
 
-    var linked_specifiers = std.StringHashMap(void).init(self.allocator);
-    defer linked_specifiers.deinit();
+    var linked_specifiers: std.StringHashMapUnmanaged(void) = .empty;
+    defer linked_specifiers.deinit(self.allocator);
     for (module.import_records) |rec| {
-        try linked_specifiers.put(rec.specifier, {});
+        try linked_specifiers.put(self.allocator, rec.specifier, {});
     }
     if (linked_specifiers.count() == 0) return;
 
@@ -306,14 +306,14 @@ fn markReactNativeWrappedBindingImports(
 /// 0xAA UAF 발생. dupe + owned 추적으로 회피.
 fn putOwnedRename(
     self: *const Linker,
-    renames: *std.AutoHashMap(u32, []const u8),
+    renames: *std.AutoHashMapUnmanaged(u32, []const u8),
     owned: *std.ArrayListUnmanaged([]const u8),
     sid: u32,
     src: []const u8,
 ) !void {
     const v = try self.allocator.dupe(u8, src);
     try owned.append(self.allocator, v);
-    try renames.put(sid, v);
+    try renames.put(self.allocator, sid, v);
 }
 
 /// identifier 의 첫 byte 가 정상 ASCII (0x21-0x7F) 인지. UAF 시 채워지는 0xAA / 0 등
@@ -328,7 +328,7 @@ fn isValidIdentStartByte(b: u8) bool {
 fn mergeUnifiedPhaseB(
     self: *const Linker,
     module_index: u32,
-    renames: *std.AutoHashMap(u32, []const u8),
+    renames: *std.AutoHashMapUnmanaged(u32, []const u8),
     owned: *std.ArrayListUnmanaged([]const u8),
 ) !void {
     const ur = &(self.unified_result orelse return);
@@ -362,7 +362,7 @@ pub fn buildMetadataForAst(
     if (m_opt == null) {
         return .{
             .skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, 0),
-            .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
+            .renames = .empty,
             .final_exports = null,
             .symbol_ids = &.{},
             .allocator = self.allocator,
@@ -381,7 +381,7 @@ pub fn buildMetadataForAst(
         try markReactNativeWrappedBindingImports(self, ast, &m, &skip_nodes);
         return .{
             .skip_nodes = skip_nodes,
-            .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
+            .renames = .empty,
             .final_exports = null,
             .symbol_ids = &.{},
             .cjs_import_preamble = null,
@@ -406,8 +406,8 @@ pub fn buildMetadataForAst(
     // 가 같은 노드를 idempotent 하게 set 하므로 RN 헬퍼 호출은 early-return path
     // (semantic == null) 에서만 필요하다.
 
-    var renames = std.AutoHashMap(u32, []const u8).init(self.allocator);
-    errdefer renames.deinit();
+    var renames: std.AutoHashMapUnmanaged(u32, []const u8) = .empty;
+    errdefer renames.deinit(self.allocator);
 
     // nested mangling에서 소유권을 이전받은 문자열 추적 (deinit에서 해제)
     var owned_nested_renames: std.ArrayListUnmanaged([]const u8) = .empty;
@@ -434,14 +434,14 @@ pub fn buildMetadataForAst(
     preamble.minify = self.minify_whitespace;
 
     // __esm 모듈의 init_xxx() 호출 중복 방지 (같은 모듈을 여러 binding이 참조할 때)
-    var esm_init_set = std.AutoHashMap(u32, void).init(self.allocator);
-    defer esm_init_set.deinit();
+    var esm_init_set: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer esm_init_set.deinit(self.allocator);
     defer preamble.deinit();
 
     // namespace member rewrite 엔트리 수집 (esbuild 방식)
     var ns_rewrite_list: std.ArrayList(LinkingMetadata.NsMemberRewrites.Entry) = .empty;
     errdefer {
-        for (ns_rewrite_list.items) |*e| e.map.deinit();
+        for (ns_rewrite_list.items) |*e| e.map.deinit(self.allocator);
         ns_rewrite_list.deinit(self.allocator);
     }
     // namespace 인라인 객체 수집 (값 사용 시)
@@ -457,26 +457,26 @@ pub fn buildMetadataForAst(
     // 같은 importer 안에서 여러 namespace import 가 같은 source 의 hoisted ns_var 를
     // 공유하도록 caller-owned cache. registerNamespaceRewrites 가 source mod_idx 별로
     // ns_var_name 을 dedup. 값 (var_name) 의 owner 는 ns_inline_list — 중복 free 안 함.
-    var ns_target_to_var = std.AutoHashMap(u32, []const u8).init(self.allocator);
-    defer ns_target_to_var.deinit();
+    var ns_target_to_var: std.AutoHashMapUnmanaged(u32, []const u8) = .empty;
+    defer ns_target_to_var.deinit(self.allocator);
 
     // PR #3742 (C7 F3 follow-up): nested bindings set 도 caller-owned cache.
     // 같은 importer 안 N 개 ns import → per-importer 1회 build (lazy init).
-    var nested_bindings_cache: ?std.StringHashMap(void) = null;
-    defer if (nested_bindings_cache) |*c| c.deinit();
+    var nested_bindings_cache: ?std.StringHashMapUnmanaged(void) = null;
+    defer if (nested_bindings_cache) |*c| c.deinit(self.allocator);
 
     // CJS 모듈별 require_xxx 변수명 캐시 (같은 모듈에서 여러 named import 시 중복 생성 방지)
-    var cjs_var_cache = std.AutoHashMap(u32, []const u8).init(self.allocator);
+    var cjs_var_cache: std.AutoHashMapUnmanaged(u32, []const u8) = .empty;
     defer {
         var vit = cjs_var_cache.valueIterator();
         while (vit.next()) |v| self.allocator.free(v.*);
-        cjs_var_cache.deinit();
+        cjs_var_cache.deinit(self.allocator);
     }
 
     // CJS named import는 값 접근을 direct expression으로 유지해도, 정적 import의
     // 평가 효과는 importer 본문 전에 한 번 발생해야 한다.
-    var cjs_static_init_set = std.AutoHashMap(u32, void).init(self.allocator);
-    defer cjs_static_init_set.deinit();
+    var cjs_static_init_set: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer cjs_static_init_set.deinit(self.allocator);
 
     var ns_var_list: std.ArrayListUnmanaged([]const u8) = .empty;
     // ns_var_list 소유권은 metadata.dev_ns_vars로 이전됨 (정상 경로)
@@ -495,8 +495,8 @@ pub fn buildMetadataForAst(
     }
     // IIFE dedupe 맵은 실제 IIFE 포맷 + unresolved 발생 시에만 lazy init — ESM/CJS
     // 빌드 (실측 99%+ 모듈) 에서 해시맵 backing alloc 비용을 피한다.
-    var iife_diag_seen: ?std.StringHashMap(void) = null;
-    defer if (iife_diag_seen) |*seen_map| seen_map.deinit();
+    var iife_diag_seen: ?std.StringHashMapUnmanaged(void) = null;
+    defer if (iife_diag_seen) |*seen_map| seen_map.deinit(self.allocator);
 
     // namespace import / inline object 캐시는 linker 전역 필드(`self.ns_export_cache`,
     // `self.ns_inline_cache`) 로 이동 — 같은 target 을 여러 모듈이 namespace import 해도
@@ -511,10 +511,10 @@ pub fn buildMetadataForAst(
         const module_scope = sem.scope_maps[0];
 
         // export된 local name을 미리 수집 — namespace import가 re-export되는지 O(1) 확인용
-        var exported_locals = std.StringHashMap(void).init(self.allocator);
-        defer exported_locals.deinit();
+        var exported_locals: std.StringHashMapUnmanaged(void) = .empty;
+        defer exported_locals.deinit(self.allocator);
         for (m.export_bindings) |eb| {
-            if (eb.kind == .local) try exported_locals.put(m.exportBindingLocalName(eb), {});
+            if (eb.kind == .local) try exported_locals.put(self.allocator, m.exportBindingLocalName(eb), {});
         }
 
         if (self.strict_execution_order and m.wrap_kind == .esm) {
@@ -546,14 +546,14 @@ pub fn buildMetadataForAst(
                     .none => {},
                     .cjs => {
                         if (cjs_static_init_set.contains(target_idx)) continue;
-                        try cjs_static_init_set.put(target_idx, {});
+                        try cjs_static_init_set.put(self.allocator, target_idx, {});
                         const req_var = try getOrCreateCjsRequireRef(self, &cjs_var_cache, target_idx);
                         try preamble.write(req_var);
                         try preamble.write("();\n");
                     },
                     .esm => {
                         if (esm_init_set.contains(target_idx)) continue;
-                        try esm_init_set.put(target_idx, {});
+                        try esm_init_set.put(self.allocator, target_idx, {});
                         try appendEsmInitCall(self, &preamble, target_mod);
                     },
                 }
@@ -657,8 +657,8 @@ pub fn buildMetadataForAst(
                         // #1824: --globals 로 매핑된 external 은 위 `is_iife_mapped` 브랜치에서 처리됨.
                         // build-time 에러로 pending_diagnostics 에 쌓고 emitter 가 flush.
                         // specifier 단위로 dedupe — 같은 spec 의 binding 여러 개에 대해 한 번만.
-                        if (iife_diag_seen == null) iife_diag_seen = std.StringHashMap(void).init(self.allocator);
-                        const seen_gop = try iife_diag_seen.?.getOrPut(rec.specifier);
+                        if (iife_diag_seen == null) iife_diag_seen = .empty;
+                        const seen_gop = try iife_diag_seen.?.getOrPut(self.allocator, rec.specifier);
                         if (!seen_gop.found_existing) {
                             const msg = try std.fmt.allocPrint(
                                 self.allocator,
@@ -731,7 +731,7 @@ pub fn buildMetadataForAst(
                             const direct_access = try std.fmt.allocPrint(self.allocator, "{s}" ++ EXPR_RENAME_MARKER ++ "{s}", .{ req_var, ib.imported_name });
                             errdefer self.allocator.free(direct_access);
                             try owned_nested_renames.append(self.allocator, direct_access);
-                            try renames.put(sym_idx, direct_access);
+                            try renames.put(self.allocator, sym_idx, direct_access);
                         }
                     } else {
                         const interop_mode = cjsInteropMode(self, &m);
@@ -854,11 +854,11 @@ pub fn buildMetadataForAst(
                     lazy_esm_import_mod = value_init_mod;
                 }
                 if (!lazy_esm_import and !esm_init_set.contains(@intCast(canonical_mod))) {
-                    try esm_init_set.put(@intCast(canonical_mod), {});
+                    try esm_init_set.put(self.allocator, @intCast(canonical_mod), {});
                     try appendEsmInitCall(self, &preamble, target_mod);
                 }
                 if (!lazy_esm_import and value_init_mod_idx != canonical_mod and !esm_init_set.contains(@intCast(value_init_mod_idx))) {
-                    try esm_init_set.put(@intCast(value_init_mod_idx), {});
+                    try esm_init_set.put(self.allocator, @intCast(value_init_mod_idx), {});
                     try appendEsmInitCall(self, &preamble, value_init_mod);
                 }
                 // import binding은 아래의 rename 경로로 처리 (continue하지 않음)
@@ -1063,7 +1063,7 @@ pub fn buildMetadataForAst(
                         errdefer if (!rename_owned_by_list) self.allocator.free(rename_value);
                         try owned_nested_renames.append(self.allocator, rename_value);
                         rename_owned_by_list = true;
-                        try renames.put(sym_idx, rename_value);
+                        try renames.put(self.allocator, sym_idx, rename_value);
                     } else {
                         try putOwnedRename(self, &renames, &owned_nested_renames, sym_idx, rename_value);
                     }
@@ -1083,12 +1083,12 @@ pub fn buildMetadataForAst(
         // - scope hoisted 타겟: rename으로 직접 참조 → import 불필요
         // - __esm 모듈: preamble이 init 호출 + CJS require를 처리 → body에서 중복 방지
         if (m.wrap_kind.isWrapped()) {
-            var hoisted_specifiers = std.StringHashMap(void).init(self.allocator);
-            defer hoisted_specifiers.deinit();
-            var linked_specifiers = std.StringHashMap(void).init(self.allocator);
-            defer linked_specifiers.deinit();
+            var hoisted_specifiers: std.StringHashMapUnmanaged(void) = .empty;
+            defer hoisted_specifiers.deinit(self.allocator);
+            var linked_specifiers: std.StringHashMapUnmanaged(void) = .empty;
+            defer linked_specifiers.deinit(self.allocator);
             for (m.import_records, 0..) |rec, rec_i| {
-                try linked_specifiers.put(rec.specifier, {});
+                try linked_specifiers.put(self.allocator, rec.specifier, {});
                 if (rec.resolved.isNone()) {
                     // Lazy barrel tree-shaking can intentionally leave unrequested
                     // static import records unresolved. The source AST still has
@@ -1098,14 +1098,14 @@ pub fn buildMetadataForAst(
                     // original import node when graph linking also decided not to
                     // resolve this record.
                     if (!self.graph.shouldLinkResolvedRecordForModule(module_index, rec_i, rec)) {
-                        try hoisted_specifiers.put(rec.specifier, {});
+                        try hoisted_specifiers.put(self.allocator, rec.specifier, {});
                     }
                     continue;
                 }
                 const tidx = @intFromEnum(rec.resolved);
                 const tmod = self.graph.getModule(rec.resolved) orelse continue;
                 if (tmod.wrap_kind == .none) {
-                    try hoisted_specifiers.put(rec.specifier, {});
+                    try hoisted_specifiers.put(self.allocator, rec.specifier, {});
                 } else if (tmod.wrap_kind == .cjs) {
                     // CJS target의 value import는 metadata rename 또는 preamble에서
                     // 처리한다. 원본 import_declaration을 남기면 body에서 raw
@@ -1115,7 +1115,7 @@ pub fn buildMetadataForAst(
                         if (ib.import_record_index == rec_i) break true;
                     } else false;
                     if (has_binding) {
-                        try hoisted_specifiers.put(rec.specifier, {});
+                        try hoisted_specifiers.put(self.allocator, rec.specifier, {});
                     }
                 } else if (tmod.wrap_kind == .esm and tidx != module_index) {
                     // __esm → __esm live binding: named import만 skip.
@@ -1130,7 +1130,7 @@ pub fn buildMetadataForAst(
                             break true;
                     } else false;
                     if (!has_namespace or (self.tree_shaker_active and !tmod.is_included)) {
-                        try hoisted_specifiers.put(rec.specifier, {});
+                        try hoisted_specifiers.put(self.allocator, rec.specifier, {});
                     }
                 }
             }
@@ -1211,7 +1211,7 @@ pub fn buildMetadataForAst(
                 .cjs => {
                     const target = @intFromEnum(rec.resolved);
                     if (cjs_static_init_set.contains(@intCast(target))) continue;
-                    try cjs_static_init_set.put(@intCast(target), {});
+                    try cjs_static_init_set.put(self.allocator, @intCast(target), {});
                     const req_var = try getOrCreateCjsRequireRef(self, &cjs_var_cache, @intCast(@intFromEnum(rec.resolved)));
                     try preamble.write(req_var);
                     try preamble.write("();\n");
@@ -1219,7 +1219,7 @@ pub fn buildMetadataForAst(
                 .esm => {
                     const target = @intFromEnum(rec.resolved);
                     if (esm_init_set.contains(@intCast(target))) continue;
-                    try esm_init_set.put(@intCast(target), {});
+                    try esm_init_set.put(self.allocator, @intCast(target), {});
                     const is_tla = target_mod.uses_top_level_await;
                     const guard = target_mod.shouldGuard(self.entry_error_guard);
                     if (is_tla) try preamble.write("await ");
@@ -1434,10 +1434,10 @@ pub fn buildFinalExports(
         for (pairs.items) |p| if (p.owned) self.allocator.free(p.local);
         pairs.deinit(self.allocator);
     }
-    var seen = std.StringHashMap(void).init(self.allocator);
-    defer seen.deinit();
-    var visited = std.AutoHashMap(u32, void).init(self.allocator);
-    defer visited.deinit();
+    var seen: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen.deinit(self.allocator);
+    var visited: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer visited.deinit(self.allocator);
 
     try self.collectExportsRecursive(
         &pairs,
@@ -1646,7 +1646,7 @@ pub fn buildDevMetadataForAst(
     if (m_opt == null) {
         return .{
             .skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, 0),
-            .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
+            .renames = .empty,
             .final_exports = null,
             .symbol_ids = &.{},
             .allocator = self.allocator,
@@ -1660,7 +1660,7 @@ pub fn buildDevMetadataForAst(
         const node_count = ast.nodes.items.len;
         return .{
             .skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, node_count),
-            .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
+            .renames = .empty,
             .final_exports = null,
             .symbol_ids = if (m.semantic) |sem| sem.symbol_ids else &.{},
             .cjs_import_preamble = null,
@@ -1757,8 +1757,8 @@ pub fn buildDevMetadataForAst(
     };
 
     // named binding의 symbol_id → "ns_var.imported_name" renames 등록
-    var renames = std.AutoHashMap(u32, []const u8).init(self.allocator);
-    errdefer renames.deinit();
+    var renames: std.AutoHashMapUnmanaged(u32, []const u8) = .empty;
+    errdefer renames.deinit(self.allocator);
     var owned_rename_values: std.ArrayListUnmanaged([]const u8) = .empty;
     errdefer {
         for (owned_rename_values.items) |v| self.allocator.free(v);
@@ -1775,7 +1775,7 @@ pub fn buildDevMetadataForAst(
                 const sym_id = findSymbolIdBySpan(sem.symbol_ids, ast, ib.local_span) orelse continue;
                 const rename = try std.fmt.allocPrint(self.allocator, "{s}.{s}", .{ ns_var, ib.imported_name });
                 try owned_rename_values.append(self.allocator, rename);
-                try renames.put(sym_id, rename);
+                try renames.put(self.allocator, sym_id, rename);
             }
         }
     }
@@ -1882,7 +1882,7 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
     if (m_opt == null) {
         return .{
             .skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, 0),
-            .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
+            .renames = .empty,
             .final_exports = null,
             .symbol_ids = &.{},
             .allocator = self.allocator,
@@ -1893,7 +1893,7 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
     const ast = m.ast orelse {
         return .{
             .skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, 0),
-            .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
+            .renames = .empty,
             .final_exports = null,
             .symbol_ids = &.{},
             .allocator = self.allocator,
@@ -1902,7 +1902,7 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
 
     const node_count = ast.nodes.items.len;
     var skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, node_count);
-    var renames = std.AutoHashMap(u32, []const u8).init(self.allocator);
+    var renames: std.AutoHashMapUnmanaged(u32, []const u8) = .empty;
 
     // 1. import_declaration → 전체 스킵
     for (ast.nodes.items, 0..) |node, node_idx| {
@@ -1973,7 +1973,7 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
             const local_name = m.importBindingLocalName(ib);
 
             if (!std.mem.eql(u8, local_name, target_name)) {
-                try renames.put(sym_idx, target_name);
+                try renames.put(self.allocator, sym_idx, target_name);
             }
         }
     }
@@ -1986,7 +1986,7 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
             const sym_name = scope_entry.key_ptr.*;
             if (self.getCanonicalName(module_index, sym_name)) |renamed| {
                 const sym_idx = scope_entry.value_ptr.*;
-                try renames.put(@intCast(sym_idx), renamed);
+                try renames.put(self.allocator, @intCast(sym_idx), renamed);
             }
         }
     }

--- a/src/bundler/linker/metadata_types.zig
+++ b/src/bundler/linker/metadata_types.zig
@@ -11,7 +11,7 @@ pub const LinkingMetadata = struct {
     /// 스킵할 AST 노드 인덱스 (import_declaration, export 키워드 등)
     skip_nodes: std.DynamicBitSet,
     /// symbol_id → 새 이름. codegen이 식별자 출력 시 symbol_ids[node_idx]로 조회.
-    renames: std.AutoHashMap(u32, []const u8),
+    renames: std.AutoHashMapUnmanaged(u32, []const u8) = .empty,
     /// dev 모드(`buildDevMetadata`) 가 채우는 모듈 단위 `exports.x = x;` 문자열.
     /// scope-hoisted 번들(`buildMetadataForAst`/`buildMetadata`) 은 `final_export_entries`
     /// 를 채우고 이 필드는 null.
@@ -69,11 +69,11 @@ pub const LinkingMetadata = struct {
 
         pub const Entry = struct {
             symbol_id: u32,
-            map: std.StringHashMap([]const u8),
+            map: std.StringHashMapUnmanaged([]const u8),
         };
 
         /// symbol_id로 매핑 조회.
-        pub fn get(self: *const NsMemberRewrites, sym_id: u32) ?*const std.StringHashMap([]const u8) {
+        pub fn get(self: *const NsMemberRewrites, sym_id: u32) ?*const std.StringHashMapUnmanaged([]const u8) {
             for (self.entries) |*e| {
                 if (e.symbol_id == sym_id) return &e.map;
             }
@@ -120,7 +120,7 @@ pub const LinkingMetadata = struct {
         // nested mangling에서 소유권을 이전받은 문자열 해제
         for (self.owned_rename_values.items) |v| self.allocator.free(v);
         self.owned_rename_values.deinit(self.allocator);
-        self.renames.deinit();
+        self.renames.deinit(self.allocator);
         if (self.final_exports) |fe| self.allocator.free(fe);
         if (self.final_export_entries) |entries| self.allocator.free(entries);
         if (self.cjs_import_preamble) |p| self.allocator.free(p);
@@ -140,7 +140,7 @@ pub const LinkingMetadata = struct {
                 while (vit.next()) |v| {
                     if (v.*.len > 0 and v.*[0] == '{') self.allocator.free(v.*);
                 }
-                m.deinit();
+                m.deinit(self.allocator);
             }
             self.allocator.free(self.ns_member_rewrites.entries);
         }

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -49,12 +49,12 @@ pub fn registerNamespaceRewrites(
     owned_rewrite_values: *std.ArrayListUnmanaged([]const u8),
     /// 같은 importer 안에서 여러 namespace import 가 같은 target source 의 inline ns_var
     /// 를 공유하도록 caller 가 owned. `cjs_var_cache` 와 같은 패턴 (`metadata.zig`).
-    ns_target_to_var: *std.AutoHashMap(u32, []const u8),
+    ns_target_to_var: *std.AutoHashMapUnmanaged(u32, []const u8),
     /// PR #3742 (C7 F3 follow-up): nested bindings set 도 caller-owned cache.
     /// 같은 importer 안 N 개 ns import 가 동일한 set 재build 회피 (per-importer 1회).
     /// null 으로 시작, 첫 호출에서 lazy build. caller 가 `defer if (cache) |*c| c.deinit()`.
     /// per-thread — emit thread 마다 별도 buildMetadataForAst → 별도 cache (caller stack frame).
-    nested_bindings_cache: *?std.StringHashMap(void),
+    nested_bindings_cache: *?std.StringHashMapUnmanaged(void),
     force_inline: bool,
     force_target_init: bool,
     importer_mod_idx: u32,
@@ -83,10 +83,10 @@ pub fn registerNamespaceRewrites(
             }
             exports.deinit(self.allocator);
         }
-        var seen = std.StringHashMap(void).init(self.allocator);
-        defer seen.deinit();
-        var visited = std.AutoHashMap(u32, void).init(self.allocator);
-        defer visited.deinit();
+        var seen: std.StringHashMapUnmanaged(void) = .empty;
+        defer seen.deinit(self.allocator);
+        var visited: std.AutoHashMapUnmanaged(u32, void) = .empty;
+        defer visited.deinit(self.allocator);
         try self.collectExportsRecursive(&exports, &seen, &visited, @enumFromInt(target_mod_idx), 0);
 
         mutable_self.ns_cache_mutex.lock();
@@ -105,12 +105,12 @@ pub fn registerNamespaceRewrites(
         break :blk owned_slice;
     };
 
-    var seen_exports = std.StringHashMap(void).init(self.allocator);
-    defer seen_exports.deinit();
+    var seen_exports: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen_exports.deinit(self.allocator);
     // PR #3741 (C7 perf): capacity hint — cached_exports.len 만큼 미리 알loc 해서 rehash 회피.
-    try seen_exports.ensureTotalCapacity(@intCast(cached_exports.len));
+    try seen_exports.ensureTotalCapacity(self.allocator, @intCast(cached_exports.len));
     for (cached_exports) |exp| {
-        try seen_exports.put(exp.exported, {});
+        try seen_exports.put(self.allocator, exp.exported, {});
     }
 
     // importer 의 nested binding 과 충돌하는 export 는 inline 시 self-shadow 무한
@@ -121,11 +121,11 @@ pub fn registerNamespaceRewrites(
     // 또한 ns_target_mod 가 있는 export (re_export_namespace 등) 는 target_mod 별
     // hoisted ns_var 를 만들고 inner_map 매핑은 그 변수명으로 둔다 — emitStaticMember
     // 가 access site 마다 객체 literal 을 inline emit 하는 회귀 방지 (#1928).
-    var inner_map = std.StringHashMap([]const u8).init(self.allocator);
+    var inner_map: std.StringHashMapUnmanaged([]const u8) = .empty;
     var inner_map_transferred = false;
-    errdefer if (!inner_map_transferred) inner_map.deinit();
+    errdefer if (!inner_map_transferred) inner_map.deinit(self.allocator);
     // PR #3741 (C7 perf): capacity hint — cached_exports.len entries 예상.
-    try inner_map.ensureTotalCapacity(@intCast(cached_exports.len));
+    try inner_map.ensureTotalCapacity(self.allocator, @intCast(cached_exports.len));
     var has_shadow = false;
     // target_init 은 target_mod_idx 에만 의존하므로 export 마다 재계산할 필요가 없다.
     // dev lazy runtime 에서는 access site 가 package entry 도 깨워야 하므로 target init 을
@@ -140,13 +140,13 @@ pub fn registerNamespaceRewrites(
     // export 마다 반복 → 매번 `allocEsmInitExprForModuleIndex` 가 동일한 init 식을 새로
     // alloc. 호출자가 owned 한 캐시로 1회 alloc + 재사용. null 결과 (source.wrap_kind
     // != .esm) 도 캐시해 이중 lookup 회피. 같은 패턴: `cjs_var_cache` (metadata.zig).
-    var source_init_cache = std.AutoHashMap(u32, ?[]const u8).init(self.allocator);
+    var source_init_cache: std.AutoHashMapUnmanaged(u32, ?[]const u8) = .empty;
     defer {
         var it = source_init_cache.valueIterator();
         while (it.next()) |value_ptr| {
             if (value_ptr.*) |expr| self.allocator.free(expr);
         }
-        source_init_cache.deinit();
+        source_init_cache.deinit(self.allocator);
     }
     // RFC PR-2 (#3399): mangle-safe 경로면 shadow-skip 을 끄고 멤버를 inner_map
     // 에 등록 → `emitStaticMember` 가 `X.member`→exp.local 직접 재작성 →
@@ -161,20 +161,20 @@ pub fn registerNamespaceRewrites(
     if (!ns_rewrite and nested_bindings_cache.* == null) {
         if (self.getModule(importer_mod_idx)) |importer_mod| {
             if (importer_mod.semantic) |sem| {
-                var nb = std.StringHashMap(void).init(self.allocator);
-                errdefer nb.deinit();
+                var nb: std.StringHashMapUnmanaged(void) = .empty;
+                errdefer nb.deinit(self.allocator);
                 // F2: capacity hint — non-module-scope 의 entry 합 추정.
                 var est: usize = 0;
                 for (sem.scope_maps, 0..) |scope_map, scope_idx| {
                     if (scope_idx == 0) continue;
                     est += scope_map.count();
                 }
-                try nb.ensureTotalCapacity(@intCast(est));
+                try nb.ensureTotalCapacity(self.allocator, @intCast(est));
                 for (sem.scope_maps, 0..) |scope_map, scope_idx| {
                     if (scope_idx == 0) continue;
                     var it = scope_map.iterator();
                     while (it.next()) |entry| {
-                        try nb.put(entry.key_ptr.*, {});
+                        try nb.put(self.allocator, entry.key_ptr.*, {});
                     }
                 }
                 nested_bindings_cache.* = nb;
@@ -199,7 +199,7 @@ pub fn registerNamespaceRewrites(
         // namespace 멤버는 undefined. `void 0` 으로 매핑하면 emitStaticMember 가 access
         // 를 `void 0` 으로 재작성(materialize 안 된 inline ns 의 dangling 참조 방지).
         if (ambiguity_possible and self.isAmbiguousStarExport(@enumFromInt(target_mod_idx), exp.exported)) {
-            try inner_map.put(exp.exported, "void 0");
+            try inner_map.put(self.allocator, exp.exported, "void 0");
             continue;
         }
         if (exp.ns_target_mod) |target| {
@@ -217,7 +217,7 @@ pub fn registerNamespaceRewrites(
                     const expr = try std.fmt.allocPrint(self.allocator, "{s}({s}())", .{ toesm, req });
                     errdefer self.allocator.free(expr);
                     try owned_rewrite_values.append(self.allocator, expr);
-                    try inner_map.put(exp.exported, expr);
+                    try inner_map.put(self.allocator, exp.exported, expr);
                     continue;
                 }
             }
@@ -226,11 +226,11 @@ pub fn registerNamespaceRewrites(
             else blk: {
                 if (self.useSharedNsInline(target)) {
                     const ns_var_name = try appendSharedNsInlineEntry(self, ns_inline_list, null, target, &seen_exports);
-                    try ns_target_to_var.put(target, ns_var_name);
+                    try ns_target_to_var.put(self.allocator, target, ns_var_name);
                     break :blk ns_var_name;
                 }
                 const fresh = try makeUniqueNsVarName(self, exp.exported, &seen_exports);
-                try ns_target_to_var.put(target, fresh);
+                try ns_target_to_var.put(self.allocator, target, fresh);
                 const obj_str = try buildInlineObjectStr(self, target, 0);
                 try ns_inline_list.append(self.allocator, .{
                     .symbol_id = null,
@@ -242,7 +242,7 @@ pub fn registerNamespaceRewrites(
             // inner_map 은 ns_inline_list.entry.var_name pointer 를 borrow — ns_inline
             // 이 owner. inner_map.deinit 은 backing 만 해제, value pointer 는 안 건드림 →
             // 같은 메모리 double-free 없음.
-            try inner_map.put(exp.exported, ns_var);
+            try inner_map.put(self.allocator, exp.exported, ns_var);
             continue;
         }
         if (try allocNamespaceMemberRewriteValue(self, target_init, target_mod_idx, exp, &source_init_cache)) |rewrite_value| {
@@ -252,12 +252,12 @@ pub fn registerNamespaceRewrites(
             // LinkingMetadata.owned_rename_values 로 이전해 metadata deinit 에서 해제한다.
             try owned_rewrite_values.append(self.allocator, rewrite_value);
             owned_by_list = true;
-            try inner_map.put(exp.exported, rewrite_value);
+            try inner_map.put(self.allocator, exp.exported, rewrite_value);
             continue;
         }
         // exp.local 은 owned=true 면 ns_export_cache 가, 아니면 target module 이 소유한다.
         // metadata map 은 값 포인터만 빌린다.
-        try inner_map.put(exp.exported, exp.local);
+        try inner_map.put(self.allocator, exp.exported, exp.local);
     }
     try ns_rewrite_list.append(self.allocator, .{
         .symbol_id = symbol_id,
@@ -306,18 +306,18 @@ pub fn ensureSharedNsVar(
         if (self.ns_shared_inline_cache.get(target_mod_idx)) |cached| return cached.var_name;
     }
     var exports: std.ArrayList(NsExportPair) = .empty;
-    var seen = std.StringHashMap(void).init(self.allocator);
-    var visited = std.AutoHashMap(u32, void).init(self.allocator);
+    var seen: std.StringHashMapUnmanaged(void) = .empty;
+    var visited: std.AutoHashMapUnmanaged(u32, void) = .empty;
     defer {
         for (exports.items) |e| if (e.owned) self.allocator.free(e.local);
         exports.deinit(self.allocator);
-        seen.deinit();
-        visited.deinit();
+        seen.deinit(self.allocator);
+        visited.deinit(self.allocator);
     }
     try self.collectExportsRecursive(&exports, &seen, &visited, target, 0);
-    var seen_exports = std.StringHashMap(void).init(self.allocator);
-    defer seen_exports.deinit();
-    for (exports.items) |e| try seen_exports.put(e.exported, {});
+    var seen_exports: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen_exports.deinit(self.allocator);
+    for (exports.items) |e| try seen_exports.put(self.allocator, e.exported, {});
     return getOrCreateSharedNamespaceVar(self, target_mod_idx, &seen_exports);
 }
 
@@ -330,7 +330,7 @@ fn appendSharedNsInlineEntry(
     ns_inline_list: *std.ArrayList(LinkingMetadata.NsInlineObjects.Entry),
     symbol_id: ?u32,
     target_mod_idx: u32,
-    seen_exports: *std.StringHashMap(void),
+    seen_exports: *std.StringHashMapUnmanaged(void),
 ) std.mem.Allocator.Error![]const u8 {
     const ns_var_name = try getOrCreateSharedNamespaceVar(self, target_mod_idx, seen_exports);
     try ns_inline_list.append(self.allocator, .{
@@ -345,7 +345,7 @@ fn appendSharedNsInlineEntry(
 fn getOrCreateSharedNamespaceVar(
     self: *const Linker,
     target_mod_idx: u32,
-    seen_exports: *std.StringHashMap(void),
+    seen_exports: *std.StringHashMapUnmanaged(void),
 ) std.mem.Allocator.Error![]const u8 {
     const mutable_self = @constCast(self);
 
@@ -620,13 +620,13 @@ pub fn collectSharedNamespaceDecls(
         decls.deinit(allocator);
     }
 
-    var seen = std.AutoHashMap(u32, void).init(allocator);
-    defer seen.deinit();
+    var seen: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer seen.deinit(allocator);
 
     for (md.ns_inline_objects.entries) |entry| {
         const target_mod_idx = entry.shared_target_mod_idx orelse continue;
         if (seen.contains(target_mod_idx)) continue;
-        try seen.put(target_mod_idx, {});
+        try seen.put(allocator, target_mod_idx, {});
 
         const target = self.getModule(target_mod_idx) orelse continue;
         @constCast(self).ns_cache_mutex.lock();
@@ -683,11 +683,11 @@ fn ensureNsBaseRank(self: *Linker) std.mem.Allocator.Error!void {
     if (self.ns_base_rank_built) return;
     self.ns_base_rank_built = true;
 
-    var counts = std.StringHashMap(u32).init(self.allocator);
+    var counts: std.StringHashMapUnmanaged(u32) = .empty;
     defer {
         var it = counts.keyIterator();
         while (it.next()) |k| self.allocator.free(k.*);
-        counts.deinit();
+        counts.deinit(self.allocator);
     }
 
     const n: u32 = @intCast(self.graph.moduleCount());
@@ -695,7 +695,7 @@ fn ensureNsBaseRank(self: *Linker) std.mem.Allocator.Error!void {
     while (idx < n) : (idx += 1) {
         const base = try makeSharedNamespaceBaseName(self, idx);
         defer self.allocator.free(base);
-        const gop = try counts.getOrPut(base);
+        const gop = try counts.getOrPut(self.allocator, base);
         if (!gop.found_existing) {
             gop.key_ptr.* = try self.allocator.dupe(u8, base);
             gop.value_ptr.* = 0;
@@ -715,7 +715,7 @@ fn makeUniqueSharedNsVarNameLocked(
     self: *Linker,
     base: []const u8,
     rank: u32,
-    seen_exports: *std.StringHashMap(void),
+    seen_exports: *std.StringHashMapUnmanaged(void),
 ) std.mem.Allocator.Error![]const u8 {
     var candidate = if (rank == 0)
         try std.fmt.allocPrint(self.allocator, "{s}_ns", .{base})
@@ -733,7 +733,7 @@ fn makeUniqueSharedNsVarNameLocked(
 
 /// namespace preamble 변수명을 export 이름과 충돌하지 않도록 생성.
 /// "z" → "z_ns", 충돌 시 "z_ns2", "z_ns3", ...
-fn makeUniqueNsVarName(self: *const Linker, base: []const u8, exports: *const std.StringHashMap(void)) std.mem.Allocator.Error![]const u8 {
+fn makeUniqueNsVarName(self: *const Linker, base: []const u8, exports: *const std.StringHashMapUnmanaged(void)) std.mem.Allocator.Error![]const u8 {
     // 첫 시도: base_ns
     const first = try std.mem.concat(self.allocator, u8, &.{ base, "_ns" });
     if (!exports.contains(first)) return first;
@@ -780,23 +780,23 @@ pub fn buildInlineObjectStr(
         }
         exports.deinit(self.allocator);
     }
-    var seen = std.StringHashMap(void).init(self.allocator);
-    defer seen.deinit();
-    var visited = std.AutoHashMap(u32, void).init(self.allocator);
-    defer visited.deinit();
+    var seen: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen.deinit(self.allocator);
+    var visited: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer visited.deinit(self.allocator);
     try self.collectExportsRecursive(&exports, &seen, &visited, @enumFromInt(target_mod_idx), 0);
 
     // export * as ns 패턴 수집 (별도 처리 — 재귀 인라인 필요)
     const target = target_any;
-    var ns_re_exports = std.StringHashMap(u32).init(self.allocator); // exported_name → source_mod
-    defer ns_re_exports.deinit();
+    var ns_re_exports: std.StringHashMapUnmanaged(u32) = .empty; // exported_name → source_mod
+    defer ns_re_exports.deinit(self.allocator);
     for (target.export_bindings) |eb| {
         if (eb.kind == .re_export_namespace) {
             if (eb.import_record_index) |rec_idx| {
                 if (rec_idx < target.import_records.len) {
                     const src = target.import_records[rec_idx].resolved;
                     if (!src.isNone()) {
-                        try ns_re_exports.put(eb.exported_name, @intFromEnum(src));
+                        try ns_re_exports.put(self.allocator, eb.exported_name, @intFromEnum(src));
                     }
                 }
             }
@@ -919,11 +919,11 @@ fn allocNamespaceMemberRewriteValue(
     target_init: ?[]const u8,
     target_mod_idx: u32,
     exp: NsExportPair,
-    source_init_cache: *std.AutoHashMap(u32, ?[]const u8),
+    source_init_cache: *std.AutoHashMapUnmanaged(u32, ?[]const u8),
 ) std.mem.Allocator.Error!?[]const u8 {
     const source_init: ?[]const u8 = if (exp.init_mod) |source_mod_idx| blk: {
         if (source_mod_idx == target_mod_idx) break :blk null;
-        const gop = try source_init_cache.getOrPut(source_mod_idx);
+        const gop = try source_init_cache.getOrPut(self.allocator, source_mod_idx);
         if (!gop.found_existing) {
             // alloc 실패 시 entry 의 value_ptr.* 가 undefined 로 남아 defer 가
             // 잘못 dereference. 미초기화 entry 제거 후 에러 전파.
@@ -1086,8 +1086,8 @@ test "#3966: rank → 결정적 ns var 이름 (rank 0 base_ns, rank N base_ns_{N
     defer graph.deinit();
     defer cache.deinit();
 
-    var seen = std.StringHashMap(void).init(a);
-    defer seen.deinit();
+    var seen: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen.deinit(a);
 
     // 같은 base("core") 의 rank 0/1/2 → core_ns / core_ns_2 / core_ns_3.
     // 발급 순서를 일부러 rank 역순(2→0→1)으로 호출해도 rank 만으로 이름이
@@ -1116,10 +1116,10 @@ test "#3966: target 자체 export 와 동명 충돌 시 결정적 증가" {
     defer graph.deinit();
     defer cache.deinit();
 
-    var seen = std.StringHashMap(void).init(a);
-    defer seen.deinit();
+    var seen: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen.deinit(a);
     // 모듈이 `x_ns` 라는 이름을 직접 export → rank 0 후보(x_ns) 충돌 → x_ns_2 로 증가.
-    try seen.put("x_ns", {});
+    try seen.put(a, "x_ns", {});
 
     const got = try makeUniqueSharedNsVarNameLocked(&linker, "x", 0, &seen);
     defer a.free(got);

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -484,18 +484,18 @@ test "isCandidateAvailable: 예약어/글로벌/nested 통합 확인" {
     var linker = Linker.init(std.testing.allocator, &graph, .esm);
     defer linker.deinit();
 
-    var name_to_owners = Linker.NameToOwnersMap.init(std.testing.allocator);
-    defer name_to_owners.deinit();
+    var name_to_owners: Linker.NameToOwnersMap = .empty;
+    defer name_to_owners.deinit(std.testing.allocator);
 
     // 예약어는 불가
     try std.testing.expect(!linker.isCandidateAvailable("class", 0, &name_to_owners));
     // 일반 이름은 가능
     try std.testing.expect(linker.isCandidateAvailable("foo", 0, &name_to_owners));
     // name_to_owners에 있는 이름은 불가
-    try name_to_owners.put("bar", .empty);
+    try name_to_owners.put(std.testing.allocator, "bar", .empty);
     try std.testing.expect(!linker.isCandidateAvailable("bar", 0, &name_to_owners));
     // reserved_globals에 있는 이름은 불가
-    try linker.reserved_globals.put("console", {});
+    try linker.reserved_globals.put(std.testing.allocator, "console", {});
     try std.testing.expect(!linker.isCandidateAvailable("console", 0, &name_to_owners));
 }
 

--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -195,8 +195,8 @@ fn e2eEnumWithRename(backing_allocator: std.mem.Allocator, source: []const u8, r
     const enum_symbol_id = transformer.symbol_ids.items[@intFromEnum(enum_name_idx)] orelse return error.MissingEnumSymbol;
 
     const skip = try std.DynamicBitSet.initEmpty(allocator, transformer.ast.nodes.items.len);
-    var renames = std.AutoHashMap(u32, []const u8).init(allocator);
-    try renames.put(enum_symbol_id, renamed);
+    var renames: std.AutoHashMapUnmanaged(u32, []const u8) = .empty;
+    try renames.put(allocator, enum_symbol_id, renamed);
     var md: LinkingMetadata = .{
         .skip_nodes = skip,
         .renames = renames,

--- a/src/codegen/codegen_test/skip_nodes_blank.zig
+++ b/src/codegen/codegen_test/skip_nodes_blank.zig
@@ -44,7 +44,7 @@ fn codegenWithSkippedStatements(
 
     var md: LinkingMetadata = .{
         .skip_nodes = skip,
-        .renames = std.AutoHashMap(u32, []const u8).init(a),
+        .renames = .empty,
         .final_exports = null,
         .symbol_ids = &.{},
         .allocator = a,

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1379,7 +1379,10 @@ fn transpileWithCallbackInternal(
         const node_count = transformer.ast.nodes.items.len;
         mangle_metadata = .{
             .skip_nodes = std.DynamicBitSet.initEmpty(arena_alloc, node_count) catch return error.OutOfMemory,
-            .renames = mr.renames,
+            // mr.renames 는 managed map. LinkingMetadata.renames 는 unmanaged 라
+            // backing handle (.unmanaged) 만 빌린다. 소유권은 mr 에 남아 mr.deinit()
+            // 이 해제 — mangle_metadata 는 deinit 되지 않으므로 double-free 없음.
+            .renames = mr.renames.unmanaged,
             .final_exports = null,
             .symbol_ids = if (transformer.symbol_ids.items.len > 0)
                 transformer.symbol_ids.items


### PR DESCRIPTION
## 배경

[#4021](https://github.com/ohah/zntc/pull/4021)(함수-로컬 맵) 후속. **linker 서브시스템**(가장 churn 큰 영역)의 managed HashMap 을 0.16 unmanaged 로 전환합니다. 순수 컨벤션 일관성 — 측정 perf/메모리 이득은 없습니다.

> **왜 안전한가:** `managed → unmanaged` 는 **의미상 중립**입니다. 맵이 내부에 저장하던 allocator 를 호출부가 인자로 넘길 뿐, 수명·deinit 타이밍·소유권은 불변. 원본 `.init(X)` 의 X 를 그대로 쓰고, 누락 사이트는 컴파일러가 전부 잡습니다(`zig build` green = 모든 mutator 가 allocator 를 받음).

## 변경

`linker.zig` / `linker/metadata.zig` / `linker/shared_namespace.zig` / `linker/metadata_types.zig` 의 **약 42개 맵**(로컬 + 구조체 FIELD).

FIELD 타입 변경이 consumer 로 캐스케이드됐지만, **reader(`.get`/`.iterator`)는 무변경**이고 타입 경계만 갱신:
- `chunk.zig` (`collectExportsRecursive` 의 seen/visited), `transpile.zig`, `linker_test.zig`, `codegen_test/{basic,skip_nodes_blank}.zig`

## 소유권 보존 (비기계적 2곳 정밀 검증)

1. **`transpile.zig`**: `.renames = mr.renames` → `mr.renames.unmanaged` (borrow). 원본도 borrow 였고 `mangle_metadata` 는 deinit 되지 않음(`skip_nodes`=arena, `renames`=mr 소유 → `mr.deinit()` 가 해제). 이중 해제·UAF 없음, 동치 변환.
2. **`metadata.zig`**: `ns_rewrite_list` 의 `e.map.deinit(self.allocator)` 는 **errdefer(에러 경로)** 뿐. 성공 시 `dupe` 로 소유권 이전 후 `LinkingMetadata.deinit` 이 해제 → UAF 없음.

## 검증 (Zig 0.16.0)

- `zig build install` · `zig build test` **exit 0** (독립 재검증)
- 새 라인에 managed `.init(` **0건**
- 제거 라인 전수 스캔 → `free`/`errdefer`/제어흐름 **로직 드롭 0건** (전부 타입스왑 + allocator 인자)
- `/code-review max` → 버그 **0건** (두 소유권 브릿지는 원본과 의미 동일 확인)

남은 FIELD 맵(bundler 캐시·codegen·semantic·transformer·server)은 후속 PR 에서 마저 전환합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)