### PR TITLE
fix(parser): new-callee optional-chain 거부의 진단 품질 + computed subscript [+In] 누락

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1166,6 +1166,8 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
             try self.addErrorCode(self.ast.getNode(expr).span, "'import' cannot be used with 'new'", .import_cannot_new);
         }
     }
+    // new callee 에 optional chain(`a?.b`)이 있으면 SyntaxError — 진단은 callee 당 1회만.
+    var reported_optional_new = false;
     while (true) {
         const expr_start = self.ast.getNode(expr).span.start;
         switch (self.current()) {
@@ -1189,7 +1191,12 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
             },
             .l_bracket => {
                 try self.advance();
+                // computed-member subscript 는 항상 [+In] (ECMAScript MemberExpression
+                // `[ Expression ]`). for-init 등 allow_in=false 컨텍스트에서도 `new a[b in c]`
+                // 의 `in` 을 허용해야 한다 — postfix `.l_bracket` 경로와 동일.
+                const cm_saved = self.enterAllowInContext(true);
                 const prop = try parseExpression(self);
+                self.restoreContext(cm_saved);
                 try self.expect(.r_bracket);
                 {
                     const me = try self.ast.addExtras(&.{ @intFromEnum(expr), @intFromEnum(prop), 0 });
@@ -1202,24 +1209,21 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
             },
             .question_dot => {
                 // ECMAScript: new 의 callee(MemberExpression)는 OptionalExpression 일 수 없다
-                // (`new a?.b()` / `new a.b?.c()` = SyntaxError). 진단만 내고 `?.`를 일반 `.`
-                // 처럼 소비해 recovery — 이후 postfix 루프가 `(new ...)?.x` 로 잘못 재해석하는
-                // 것을 막는다. paren 으로 감싼 `new (a?.b)()` 는 `?.`가 paren 내부라 이 루프에
-                // 도달하지 않아 유효하게 통과한다.
-                try self.addErrorCode(self.currentSpan(), "Invalid optional chain in 'new' expression", .optional_chain_new);
-                try self.advance(); // consume `?.`
-                // `?.(` (optional call) / `?.\`tpl\`` 는 멤버명이 없다 — break 하면 상위가
-                // `(`/template 을 args/tagged 로 소비해 단일 진단으로 끝난다. 여기서
-                // parseIdentifierName 을 부르면 "Identifier expected" 2차 에러가 덧붙어 노이즈.
-                if (self.current() == .l_paren or self.current() == .no_substitution_template or
-                    self.current() == .template_head)
-                {
-                    break;
+                // (`new a?.b()` / `new a.b?.c()` = SyntaxError). 진단은 callee 당 1회만 내고
+                // (`reported_optional_new`), `?.`와 뒤따르는 멤버를 일반 멤버처럼 소비해 postfix
+                // 루프가 `(new ...)?.x` 로 잘못 재해석하는 것을 막는다. paren 으로 감싼
+                // `new (a?.b)()` 는 `?.`가 paren 내부라 이 루프에 도달하지 않아 유효 통과.
+                if (!reported_optional_new) {
+                    try self.addErrorCode(self.currentSpan(), "Invalid optional chain in 'new' expression", .optional_chain_new);
+                    reported_optional_new = true;
                 }
-                // `?.[` → computed, 그 외 → 일반 멤버 접근으로 recovery.
+                try self.advance(); // consume `?.`
                 if (self.current() == .l_bracket) {
+                    // `?.[expr]` → computed (subscript 는 [+In]).
                     try self.advance();
+                    const cm_saved = self.enterAllowInContext(true);
                     const prop = try parseExpression(self);
+                    self.restoreContext(cm_saved);
                     try self.expect(.r_bracket);
                     const me = try self.ast.addExtras(&.{ @intFromEnum(expr), @intFromEnum(prop), 0 });
                     expr = try self.ast.addNode(.{
@@ -1227,7 +1231,12 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
                         .span = .{ .start = expr_start, .end = self.currentSpan().start },
                         .data = .{ .extra = me },
                     });
-                } else {
+                } else if (self.current() == .identifier or self.current() == .escaped_keyword or
+                    self.current() == .escaped_strict_reserved or self.current() == .private_identifier or
+                    self.current().isKeyword())
+                {
+                    // `?.name` → 일반 멤버명으로 소비. parseIdentifierName 이 멤버명을 받을 때만
+                    // 호출하므로 "Identifier expected" 2차 에러(노이즈)가 안 붙는다.
                     const prop = try parseIdentifierName(self);
                     const prop_end = if (!prop.isNone()) self.ast.getNode(prop).span.end else self.currentSpan().start;
                     const me = try self.ast.addExtras(&.{ @intFromEnum(expr), @intFromEnum(prop), 0 });
@@ -1239,6 +1248,11 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
                         .span = .{ .start = expr_start, .end = prop_end },
                         .data = .{ .extra = me },
                     });
+                } else {
+                    // 멤버명 없음(`?.(` optional call / `?.\`tpl\`` / `?.<T>` / EOF / `;` 등) →
+                    // break. 상위가 `(`/template/type-args 를 소비하거나 `new <callee>` 로
+                    // 종료한다. 단일 623 진단 유지(2차 에러·dangling `.invalid` prop 없음).
+                    break;
                 }
             },
             else => break,

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2113,6 +2113,20 @@ fn expectNoParseError(source: []const u8) !void {
     try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
 }
 
+/// 소스를 파싱하고 에러가 *정확히 1개*이며 그 메시지가 일치하는지 검증한다.
+/// 중복/cascade 진단(같은 에러 N회, 2차 "Identifier expected" 노이즈)을 가드 — V8 처럼
+/// 한 SyntaxError 로 끝나는지 확인.
+fn expectSingleParseError(source: []const u8, message: []const u8) !void {
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    try std.testing.expectEqual(@as(usize, 1), parser.errors.items.len);
+    try std.testing.expectEqualStrings(message, parser.errors.items[0].message);
+}
+
 test "new + optional chain: callee 의 optional chain 은 SyntaxError" {
     // ECMAScript: new 의 MemberExpression callee 는 OptionalExpression 일 수 없다.
     // V8/esbuild 와 동일하게 거부. (이전엔 수용하고 `(new obj)?.fn()` 로 오파싱했다.)
@@ -2128,6 +2142,19 @@ test "new + optional chain: callee 의 optional chain 은 SyntaxError" {
     try expectParseError("new new a?.b()()", .{ .message = "Invalid optional chain in 'new' expression" });
 }
 
+test "new + optional chain: 진단은 callee 당 정확히 1개 (중복/cascade 노이즈 없음)" {
+    // 체인(`?.b?.c`)이어도 callee 당 623 1개 (V8 동형). 이전엔 `?.` 마다 중복 발생.
+    try expectSingleParseError("new a?.b?.c()", "Invalid optional chain in 'new' expression");
+    try expectSingleParseError("new a.b?.c?.d()", "Invalid optional chain in 'new' expression");
+    try expectSingleParseError("new a?.[0]?.[1]()", "Invalid optional chain in 'new' expression");
+    // 멤버명 없는 후속 토큰(optional call/EOF/`;`/연산자)이어도 2차 "Identifier expected"
+    // 노이즈가 안 붙고 623 단일.
+    try expectSingleParseError("new a?.()", "Invalid optional chain in 'new' expression");
+    try expectSingleParseError("new a?.", "Invalid optional chain in 'new' expression");
+    try expectSingleParseError("new a?.;", "Invalid optional chain in 'new' expression");
+    try expectSingleParseError("new a?.+b", "Invalid optional chain in 'new' expression");
+}
+
 test "new + optional chain: 유효 형태는 통과" {
     // paren 으로 감싼 optional chain 은 new 의 피연산자로 유효.
     try expectNoParseError("new (a?.b)()");
@@ -2139,6 +2166,10 @@ test "new + optional chain: 유효 형태는 통과" {
     // new 표현식 *뒤*의 optional 접근은 유효(`(new a()).b?.c`).
     try expectNoParseError("new a().b?.c");
     try expectNoParseError("(new a())?.b");
+    // computed-member subscript 는 [+In] — for-init(allow_in=false) 안에서도 `in` 허용.
+    // `new a[k in a]()` 가 오거부되던 pre-existing 버그(F1) 가드.
+    try expectNoParseError("for (var x = new a[(\"k\" in a)]();;) { break; }");
+    try expectNoParseError("for (var x = a[(\"k\" in a)];;) { break; }");
 }
 
 test "ErrorMsg: expect() shows 'found' token" {


### PR DESCRIPTION
#4019/#4022(`new a?.b()` SyntaxError 거부) 머지 후 **정식 `/code-review max`(37 에이전트, 2.4M 토큰)** 가 적발한 follow-up. 잘못된 출력/crash/hang 은 없으나, 진단 품질 회귀 + 1건 pre-existing correctness.

## F1 (correctness, pre-existing)
`parseNewCallee` 의 `.l_bracket` 가 computed subscript 를 `enterAllowInContext(true)` 없이 파싱 → for-init(allow_in=false)에서 `new a[("k" in a)]()` (valid ES)를 `Expected ']' but found 'in'` 으로 **오거부**. postfix `.l_bracket`(line 879)은 이미 wrap 하는데 new-callee 경로만 누락. canonical + #4022 의 `?.[` recovery 둘 다 wrap 추가.

## F2/F3 (진단 품질 — #4022 가 도입)
- **F2**: 체인 `new a?.b?.c()` 가 623 을 `?.` 마다 **N회** 보고 (V8 은 1개).
- **F3**: break-guard 가 `(`/template 만 커버 → `new a?.;`/`new a?.`(EOF)/`new a?.<T>()`/`new a?.+b` 가 623 + 2차 "Identifier expected"(ZNTC0500) 노이즈. #4022 주석이 "2차 에러 방지"라 했는데 미달.

## 수정
| 항목 | 변경 |
|---|---|
| 623 중복(F2) | `reported_optional_new` 플래그 → callee 당 1회 |
| 2차 500(F3) | recovery 를 **멤버명 시작 토큰일 때만** `parseIdentifierName`, 아니면 break |
| `.invalid` prop(F4) | F3 break 로 자연 해소 |
| `[+In]`(F1) | canonical `.l_bracket` + `?.[` recovery 의 `parseExpression` 를 `enterAllowInContext(true)` 로 wrap |
| 테스트 갭(F5) | `expectSingleParseError`(에러 정확히 1개) + for-init `[+In]` 통과 케이스 |

## 검증 (node parity)
- 거부 9 케이스 모두 **errors=1** (이전 2~7개): `new a?.b?.c()`/`a?.()`/`a?.;`/`a?.`/`a?.+b`/`a?.[0]?.[1]()`/`a.b?.c?.d()` …
- `new a[("k" in a)]()` for-init → **0 errors** (이전 5개), node OK 일치
- 유효 형태(`new (a?.b)()`/`a.b()`/`Error(e?.msg)`/`a().b?.c`) 0 errors 유지
- 전체 유닛 `zig build test` ✅ / lib-scenario 19 ✅ / browser-smoke 95 ✅
- 신규 단일-진단 테스트는 #4022 버전에서 실패(진짜 가드)

## 메타
정식 max 리뷰가 이전 가벼운 포그라운드 리뷰들이 놓친 recovery 진단 품질을 exhaustive 테스트로 적발 — max 리뷰의 가치 입증. 잔여 `new new a()?.b`(argless new 뒤 trailing `?.`)는 별도 규칙·별도 경로라 여전히 분리(이 PR 범위 밖).

Closes #4024

🤖 Generated with [Claude Code](https://claude.com/claude-code)