### PR TITLE
refactor: 나머지 managed HashMap 전부 unmanaged 로 전환 (마이그레이션 완료)

### DIFF
--- a/src/app/env.zig
+++ b/src/app/env.zig
@@ -11,10 +11,10 @@ pub const LoadOptions = struct {
     prefixes: []const []const u8 = &.{ "VITE_", "ZNTC_" },
 };
 
-pub const EnvMap = std.StringHashMap([]const u8);
+pub const EnvMap = std.StringHashMapUnmanaged([]const u8);
 
 pub fn loadEnv(allocator: std.mem.Allocator, io: std.Io, opts: LoadOptions) !EnvMap {
-    var merged = EnvMap.init(allocator);
+    var merged: EnvMap = .empty;
     errdefer deinitMap(&merged, allocator);
 
     const mode_file = try std.fmt.allocPrint(allocator, ".env.{s}", .{opts.mode});
@@ -34,12 +34,13 @@ pub fn loadEnv(allocator: std.mem.Allocator, io: std.Io, opts: LoadOptions) !Env
         try parseDotenvInto(allocator, content, &merged);
     }
 
-    var filtered = EnvMap.init(allocator);
+    var filtered: EnvMap = .empty;
     errdefer deinitMap(&filtered, allocator);
     var it = merged.iterator();
     while (it.next()) |entry| {
         if (!hasAllowedPrefix(entry.key_ptr.*, opts.prefixes)) continue;
         try filtered.put(
+            allocator,
             try allocator.dupe(u8, entry.key_ptr.*),
             try allocator.dupe(u8, entry.value_ptr.*),
         );
@@ -54,7 +55,7 @@ pub fn deinitMap(map: *EnvMap, allocator: std.mem.Allocator) void {
         allocator.free(entry.key_ptr.*);
         allocator.free(entry.value_ptr.*);
     }
-    map.deinit();
+    map.deinit(allocator);
 }
 
 pub fn envToDefine(
@@ -170,7 +171,7 @@ fn parseDotenvInto(allocator: std.mem.Allocator, content: []const u8, map: *EnvM
         errdefer allocator.free(owned_key);
         const owned_value = try allocator.dupe(u8, value);
         errdefer allocator.free(owned_value);
-        const gop = try map.getOrPut(owned_key);
+        const gop = try map.getOrPut(allocator, owned_key);
         if (gop.found_existing) {
             allocator.free(owned_key);
             allocator.free(gop.value_ptr.*);

--- a/src/app/env_test.zig
+++ b/src/app/env_test.zig
@@ -22,9 +22,9 @@ test "app env loader honors Vite file priority and prefixes" {
 }
 
 test "app env define includes base and import.meta.env object" {
-    var env_map = env.EnvMap.init(std.testing.allocator);
+    var env_map: env.EnvMap = .empty;
     defer env.deinitMap(&env_map, std.testing.allocator);
-    try env_map.put(try std.testing.allocator.dupe(u8, "VITE_API"), try std.testing.allocator.dupe(u8, "ok"));
+    try env_map.put(std.testing.allocator, try std.testing.allocator.dupe(u8, "VITE_API"), try std.testing.allocator.dupe(u8, "ok"));
 
     const defines = try env.envToDefine(std.testing.allocator, &env_map, "development", "/app/");
     defer env.freeDefines(std.testing.allocator, defines);

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -105,18 +105,19 @@ pub const Baseline = struct {
     iterations: u32 = 0,
     warmup: u32 = 0,
     /// phase name → PhaseStats. Allocator 소유.
-    phases: std.StringHashMap(PhaseStats),
+    phases: std.StringHashMapUnmanaged(PhaseStats) = .empty,
 
     pub fn init(allocator: std.mem.Allocator) Baseline {
+        _ = allocator;
         return .{
-            .phases = std.StringHashMap(PhaseStats).init(allocator),
+            .phases = .empty,
         };
     }
 
     pub fn deinit(self: *Baseline, allocator: std.mem.Allocator) void {
         var it = self.phases.keyIterator();
         while (it.next()) |k| allocator.free(k.*);
-        self.phases.deinit();
+        self.phases.deinit(allocator);
     }
 };
 
@@ -199,7 +200,7 @@ pub fn readBaselineJson(allocator: std.mem.Allocator, json_text: []const u8) !Ba
                 .integer => |i| @as(usize, @intCast(i)),
                 else => 0,
             } else 0;
-            try bl.phases.put(name, .{
+            try bl.phases.put(allocator, name, .{
                 .samples = samples,
                 .mean_ns = mean_ms * 1_000_000.0,
                 .median_ns = @intFromFloat(median_ms * 1_000_000.0),
@@ -399,7 +400,7 @@ test "Baseline JSON round-trip" {
     defer bl.deinit(allocator);
     bl.iterations = 100;
     bl.warmup = 10;
-    try bl.phases.put(try allocator.dupe(u8, "parse"), .{
+    try bl.phases.put(allocator, try allocator.dupe(u8, "parse"), .{
         .samples = 100,
         .mean_ns = 42_300_000.0,
         .median_ns = 41_800_000,

--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -167,11 +167,11 @@ pub fn extractImportBindings(
     errdefer bindings.deinit(allocator);
 
     // import source span → import_record 인덱스 매핑
-    var source_to_record = std.AutoHashMap(u64, u32).init(allocator);
-    defer source_to_record.deinit();
+    var source_to_record: std.AutoHashMapUnmanaged(u64, u32) = .empty;
+    defer source_to_record.deinit(allocator);
     for (import_records, 0..) |rec, i| {
         const key = types.spanKey(rec.span);
-        try source_to_record.put(key, @intCast(i));
+        try source_to_record.put(allocator, key, @intCast(i));
     }
 
     const reachable = try ast_walk.collectReachableNodeIndices(allocator, ast);
@@ -281,11 +281,11 @@ pub fn extractExportBindings(
     errdefer bindings.deinit(allocator);
 
     // import source span → import_record 인덱스 매핑 (re-export용)
-    var source_to_record = std.AutoHashMap(u64, u32).init(allocator);
-    defer source_to_record.deinit();
+    var source_to_record: std.AutoHashMapUnmanaged(u64, u32) = .empty;
+    defer source_to_record.deinit(allocator);
     for (import_records, 0..) |rec, i| {
         const key = types.spanKey(rec.span);
-        try source_to_record.put(key, @intCast(i));
+        try source_to_record.put(allocator, key, @intCast(i));
     }
 
     // import local_name → ImportBinding 매핑 (barrel re-export O(1) 조회)
@@ -656,7 +656,7 @@ pub fn populateSyntheticSymbols(
     /// 모듈 top-level scope (scope_maps[0]). 일반 .local export의 eb.symbol을
     /// scope_maps에서 lookup해 미리 채우는 데 사용. null이면 skip — linker가
     /// 후속 패스에서 fallback 처리.
-    module_scope: ?std.StringHashMap(usize),
+    module_scope: ?std.StringHashMapUnmanaged(usize),
 ) !void {
     for (export_bindings) |*eb| {
         // codegen이 `_default = <expr>` 할당을 emit하는 export만 synthetic_default 등록.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -373,7 +373,7 @@ pub const BundleOptions = struct {
     /// 주입되면 `graph.buildIncremental` 이 set 에 없는 모듈의 mtime stat syscall 을 skip
     /// — cached mtime 을 신뢰. 수백 모듈 규모에서 graphDiscover 주 병목이었음.
     /// null 이면 initial build / CLI / 변경 정보 없음 → 전체 stat (기존 동작).
-    changed_files: ?*const std.StringHashMap(void) = null,
+    changed_files: ?*const std.StringHashMapUnmanaged(void) = null,
     /// Compiled output cache. HMR/watch 에서 변경 안 된 모듈의 emit 을 스킵.
     /// IncrementalBundler 가 소유.
     compiled_cache: ?*@import("compiled_cache.zig").CompiledOutputCache = null,
@@ -1257,11 +1257,11 @@ pub const Bundler = struct {
         // codegen.emitNew lookup 용 per-module map. outer key = module 절대 경로 (graph 소유),
         // inner key = import_record specifier (graph 소유), value = worker chunk filename
         // (worker_output_map 소유). 본 map 은 reference 만 보관 — deinit 시 inner 만 정리.
-        var worker_map_per_module = std.StringHashMap(std.StringHashMap([]const u8)).init(self.allocator);
+        var worker_map_per_module: std.StringHashMapUnmanaged(std.StringHashMapUnmanaged([]const u8)) = .empty;
         defer {
             var oit = worker_map_per_module.valueIterator();
-            while (oit.next()) |inner| inner.deinit();
-            worker_map_per_module.deinit();
+            while (oit.next()) |inner| inner.deinit(self.allocator);
+            worker_map_per_module.deinit(self.allocator);
         }
 
         {
@@ -1285,9 +1285,9 @@ pub const Bundler = struct {
                 if (we.record_index >= mod.import_records.len) continue;
                 const spec = mod.import_records[we.record_index].specifier;
 
-                const entry = try worker_map_per_module.getOrPut(mod.path);
-                if (!entry.found_existing) entry.value_ptr.* = std.StringHashMap([]const u8).init(self.allocator);
-                try entry.value_ptr.put(spec, filename);
+                const entry = try worker_map_per_module.getOrPut(self.allocator, mod.path);
+                if (!entry.found_existing) entry.value_ptr.* = .empty;
+                try entry.value_ptr.put(self.allocator, spec, filename);
             }
         }
 

--- a/src/bundler/bundler_test/incremental_bench_v4.zig
+++ b/src/bundler/bundler_test/incremental_bench_v4.zig
@@ -125,13 +125,13 @@ const WarmResult = struct {
 fn measureWarm(allocator: std.mem.Allocator, store: *PersistentModuleStore, entry: []const u8, case: Case) !WarmResult {
     profile.resetCounters();
 
-    var changed_set: std.StringHashMap(void) = .init(allocator);
-    defer changed_set.deinit();
+    var changed_set: std.StringHashMapUnmanaged(void) = .empty;
+    defer changed_set.deinit(allocator);
     if (case == .single_entry) {
-        try changed_set.put(entry, {});
+        try changed_set.put(allocator, entry, {});
     }
 
-    const changed_ptr: ?*const std.StringHashMap(void) = switch (case) {
+    const changed_ptr: ?*const std.StringHashMapUnmanaged(void) = switch (case) {
         .empty => &changed_set,
         .single_entry => &changed_set,
         .null_changed => null,

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -585,7 +585,7 @@ pub fn mergeSmallChunks(
 fn addDynamicEntry(
     allocator: std.mem.Allocator,
     entries: *std.ArrayList(EntryInfo),
-    dynamic_seen: *std.AutoHashMap(u32, void),
+    dynamic_seen: *std.AutoHashMapUnmanaged(u32, void),
     graph: *const ModuleGraph,
     idx: ModuleIndex,
 ) !void {
@@ -593,7 +593,7 @@ fn addDynamicEntry(
         if (m.is_external) return; // external phantom 은 async chunk 불요(번들 외부)
     }
     const di = @intFromEnum(idx);
-    const gop = try dynamic_seen.getOrPut(di);
+    const gop = try dynamic_seen.getOrPut(allocator, di);
     if (gop.found_existing) return;
     for (entries.items) |e| {
         if (@intFromEnum(e.module_idx) == di and !e.is_dynamic) return; // 이미 user entry
@@ -652,8 +652,8 @@ pub fn generateChunks(
     // dynamic import 대상은 별도의 청크 경계를 형성한다 (code splitting의 핵심).
     // `inline_dynamic_imports` 가 true 면 이 단계 전체를 skip → dynamic target 이
     // 별도 chunk 로 나뉘지 않고 Phase 2 BFS 에서 importer 와 같은 chunk 로 흡수.
-    var dynamic_seen: std.AutoHashMap(u32, void) = .init(allocator);
-    defer dynamic_seen.deinit();
+    var dynamic_seen: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer dynamic_seen.deinit(allocator);
 
     if (!inline_dynamic_imports) {
         var it = graph.modulesIterator();
@@ -1092,15 +1092,15 @@ pub fn generatePreserveModulesChunks(
     errdefer chunk_graph.deinit();
 
     // 엔트리 모듈 인덱스를 미리 수집 (entry_point 청크 판별용)
-    var entry_set: std.AutoHashMap(u32, void) = .init(allocator);
-    defer entry_set.deinit();
+    var entry_set: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer entry_set.deinit(allocator);
     {
         var it = graph.modulesIterator();
         var i: usize = 0;
         while (it.next()) |m| : (i += 1) {
             for (entry_points) |ep| {
                 if (std.mem.eql(u8, m.path, ep)) {
-                    try entry_set.put(@intCast(i), {});
+                    try entry_set.put(allocator, @intCast(i), {});
                     break;
                 }
             }

--- a/src/bundler/chunk_emit_cache.zig
+++ b/src/bundler/chunk_emit_cache.zig
@@ -55,7 +55,7 @@ pub const ChunkEmitCache = struct {
     };
 
     allocator: std.mem.Allocator,
-    entries: std.AutoHashMap(Key, Entry),
+    entries: std.AutoHashMapUnmanaged(Key, Entry) = .empty,
     /// cache hit / miss 카운터 (debug_log.compiled_cache 와 같은 라인). takeStats 가 reset.
     hits: u64 = 0,
     misses: u64 = 0,
@@ -63,13 +63,13 @@ pub const ChunkEmitCache = struct {
     pub fn init(allocator: std.mem.Allocator) ChunkEmitCache {
         return .{
             .allocator = allocator,
-            .entries = std.AutoHashMap(Key, Entry).init(allocator),
+            .entries = .empty,
         };
     }
 
     pub fn deinit(self: *ChunkEmitCache) void {
         self.freeAllEntries();
-        self.entries.deinit();
+        self.entries.deinit(self.allocator);
     }
 
     fn freeAllEntries(self: *ChunkEmitCache) void {
@@ -114,7 +114,7 @@ pub const ChunkEmitCache = struct {
             "";
         errdefer if (sm_dup.len > 0) self.allocator.free(sm_dup);
 
-        const gop = try self.entries.getOrPut(key);
+        const gop = try self.entries.getOrPut(self.allocator, key);
         if (gop.found_existing) {
             self.allocator.free(gop.value_ptr.bytes);
             if (gop.value_ptr.sourcemap_bytes.len > 0) {

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -44,7 +44,7 @@ const TestGraph = struct {
         var it = self.graph.modules.iterator(0);
         while (it.next()) |m| m.deinit(alloc);
         self.graph.modules.deinit(alloc);
-        self.graph.path_to_module.deinit();
+        self.graph.path_to_module.deinit(alloc);
         self.graph.diagnostics.deinit(alloc);
         self.graph.worker_entries.deinit(alloc);
         var pi_it = self.graph.pkg_info_cache.valueIterator();

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -321,7 +321,7 @@ pub fn computeInputHash(
 pub const CompiledOutputCache = struct {
     allocator: std.mem.Allocator,
     /// absolute path → entry. key 는 cache 가 owning.
-    entries: std.StringHashMap(Entry),
+    entries: std.StringHashMapUnmanaged(Entry) = .empty,
     /// 디버그: 실측용 hit/miss 카운터. emit 루프 밖에서 주기적으로 읽어 리셋.
     hits: u64 = 0,
     misses: u64 = 0,
@@ -335,7 +335,7 @@ pub const CompiledOutputCache = struct {
     pub fn init(allocator: std.mem.Allocator) CompiledOutputCache {
         return .{
             .allocator = allocator,
-            .entries = std.StringHashMap(Entry).init(allocator),
+            .entries = .empty,
         };
     }
 
@@ -352,7 +352,7 @@ pub const CompiledOutputCache = struct {
 
     pub fn deinit(self: *CompiledOutputCache) void {
         self.clear();
-        self.entries.deinit();
+        self.entries.deinit(self.allocator);
     }
 
     /// 모든 엔트리 해제 (key + CompiledModule 소유 자원).
@@ -398,7 +398,7 @@ pub const CompiledOutputCache = struct {
 
         const owned_key = try self.allocator.dupe(u8, path);
         errdefer self.allocator.free(owned_key);
-        try self.entries.put(owned_key, .{ .input_hash = input_hash, .compiled = owned });
+        try self.entries.put(self.allocator, owned_key, .{ .input_hash = input_hash, .compiled = owned });
     }
 
     /// 디버그 로그에 hit/miss stats 출력 + 카운터 리셋. `ZNTC_DEBUG=compiled_cache`

--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -29,8 +29,8 @@ pub fn emitCssBundle(
     var css_modules: std.ArrayListUnmanaged(*const Module) = .empty;
     defer css_modules.deinit(allocator);
 
-    var visited = std.AutoHashMap(ModuleIndex, void).init(allocator);
-    defer visited.deinit();
+    var visited: std.AutoHashMapUnmanaged(ModuleIndex, void) = .empty;
+    defer visited.deinit(allocator);
 
     collectCssModules(allocator, graph, entry_idx, &css_modules, &visited);
 
@@ -123,12 +123,13 @@ const ExternalImportEntry = struct {
 const ExternalImportCollector = struct {
     /// key = "<specifier>\x00<condition_tail>" — `\x00` 은 CSS spec 상 합법
     /// URL/condition 에 등장 불가라 안전한 separator.
-    seen: std.StringHashMap(void),
+    seen: std.StringHashMapUnmanaged(void) = .empty,
     list: std.ArrayListUnmanaged(ExternalImportEntry),
 
     fn init(allocator: std.mem.Allocator) ExternalImportCollector {
+        _ = allocator;
         return .{
-            .seen = std.StringHashMap(void).init(allocator),
+            .seen = .empty,
             .list = .empty,
         };
     }
@@ -136,7 +137,7 @@ const ExternalImportCollector = struct {
     fn deinit(self: *ExternalImportCollector, allocator: std.mem.Allocator) void {
         var kit = self.seen.keyIterator();
         while (kit.next()) |k| allocator.free(k.*);
-        self.seen.deinit();
+        self.seen.deinit(allocator);
         self.list.deinit(allocator);
     }
 
@@ -153,7 +154,7 @@ const ExternalImportCollector = struct {
             if (rec.specifier.len == 0) continue;
             const composite_key = try std.fmt.allocPrint(allocator, "{s}\x00{s}", .{ rec.specifier, rec.css_condition_tail });
             errdefer allocator.free(composite_key);
-            const gop = try self.seen.getOrPut(composite_key);
+            const gop = try self.seen.getOrPut(allocator, composite_key);
             if (gop.found_existing) {
                 allocator.free(composite_key);
                 continue;
@@ -273,12 +274,12 @@ fn collectPrefixDeclsTree(
     graph: *const ModuleGraph,
     idx: ModuleIndex,
     collector: *PrefixDeclCollector,
-    visited: *std.AutoHashMap(ModuleIndex, void),
+    visited: *std.AutoHashMapUnmanaged(ModuleIndex, void),
     allocator: std.mem.Allocator,
 ) !void {
     if (idx.isNone()) return;
     if (visited.contains(idx)) return;
-    try visited.put(idx, {});
+    try visited.put(allocator, idx, {});
     const mod = graph.getModule(idx) orelse return;
     if (mod.module_type != .css) return;
     for (mod.dependencies.items) |dep| {
@@ -297,12 +298,12 @@ fn collectExternalImportsTree(
     graph: *const ModuleGraph,
     idx: ModuleIndex,
     collector: *ExternalImportCollector,
-    visited: *std.AutoHashMap(ModuleIndex, void),
+    visited: *std.AutoHashMapUnmanaged(ModuleIndex, void),
     allocator: std.mem.Allocator,
 ) !void {
     if (idx.isNone()) return;
     if (visited.contains(idx)) return;
-    try visited.put(idx, {});
+    try visited.put(allocator, idx, {});
     const mod = graph.getModule(idx) orelse return;
     if (mod.module_type != .css) return;
     for (mod.dependencies.items) |dep| {
@@ -323,13 +324,13 @@ fn emitCssModuleTree(
     graph: *const ModuleGraph,
     idx: ModuleIndex,
     buf: *std.ArrayListUnmanaged(u8),
-    visited: *std.AutoHashMap(ModuleIndex, void),
+    visited: *std.AutoHashMapUnmanaged(ModuleIndex, void),
 ) !void {
     if (idx.isNone()) return;
     if (visited.contains(idx)) return;
     // 함수가 `!void` 라 OOM 은 propagate — `catch return` 으로 삼키면 silent skip 되어
     // @import 서브트리가 emit 누락된다.
-    try visited.put(idx, {});
+    try visited.put(allocator, idx, {});
     const mod = graph.getModule(idx) orelse return;
     if (mod.module_type != .css) return;
     for (mod.dependencies.items) |dep| {
@@ -377,17 +378,17 @@ pub fn planCssChunks(
     // dedup 은 청크 단위로만(같은 청크 내 같은 CSS 가 여러 JS 모듈 경로로
     // 도달해도 1번). 청크 간 복제는 허용 — 동적 청크가 자기 CSS 를
     // <link> 로 가져가도록 `chunk_css_hrefs` 도 자동으로 채워진다.
-    var chunk_mods = std.AutoHashMap(u32, std.ArrayListUnmanaged(*const Module)).init(allocator);
+    var chunk_mods: std.AutoHashMapUnmanaged(u32, std.ArrayListUnmanaged(*const Module)) = .empty;
     defer {
         var vit = chunk_mods.valueIterator();
         while (vit.next()) |list| list.deinit(allocator);
-        chunk_mods.deinit();
+        chunk_mods.deinit(allocator);
     }
     // (chunk_idx, css_module_idx) 쌍 dedup — 한 청크 내 같은 CSS 1회.
-    var chunk_seen = std.AutoHashMap(ChunkCssKey, void).init(allocator);
-    defer chunk_seen.deinit();
-    var visited = std.AutoHashMap(ModuleIndex, void).init(allocator);
-    defer visited.deinit();
+    var chunk_seen: std.AutoHashMapUnmanaged(ChunkCssKey, void) = .empty;
+    defer chunk_seen.deinit(allocator);
+    var visited: std.AutoHashMapUnmanaged(ModuleIndex, void) = .empty;
+    defer visited.deinit(allocator);
 
     var it = graph.modulesIterator();
     while (it.next()) |m| {
@@ -412,8 +413,8 @@ pub fn planCssChunks(
     }
 
     // @import 인라인 dedup 용 — 청크마다 clear (청크 간엔 복제 허용).
-    var emit_visited = std.AutoHashMap(ModuleIndex, void).init(allocator);
-    defer emit_visited.deinit();
+    var emit_visited: std.AutoHashMapUnmanaged(ModuleIndex, void) = .empty;
+    defer emit_visited.deinit(allocator);
 
     // 청크 인덱스 순회 → 출력 순서가 결정적(HashMap 순회 순서와 무관).
     var chunk_idx: usize = 0;
@@ -446,8 +447,8 @@ pub fn planCssChunks(
         // prefix decl / external collect 는 emit 과 동일 dep 트리 순회 —
         // emitCssModuleTree 가 본문 emit 도중 visited 를 마킹해 같은 dep 가
         // 2번 walk 되지 않으므로 별도 일회 순회.
-        var collect_visited = std.AutoHashMap(ModuleIndex, void).init(allocator);
-        defer collect_visited.deinit();
+        var collect_visited: std.AutoHashMapUnmanaged(ModuleIndex, void) = .empty;
+        defer collect_visited.deinit(allocator);
         for (list.items) |mod| {
             try collectPrefixDeclsTree(graph, mod.index, &prefix_decls, &collect_visited, allocator);
         }
@@ -555,14 +556,14 @@ fn disambiguatePathCollisionsGeneric(
     errdefer for (new_paths) |p| if (p) |s| allocator.free(s);
 
     {
-        var groups = std.StringHashMap(std.ArrayListUnmanaged(usize)).init(allocator);
+        var groups: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(usize)) = .empty;
         defer {
             var vit = groups.valueIterator();
             while (vit.next()) |list| list.deinit(allocator);
-            groups.deinit();
+            groups.deinit(allocator);
         }
         for (items, 0..) |e, i| {
-            const gop = try groups.getOrPut(e.path);
+            const gop = try groups.getOrPut(allocator, e.path);
             if (!gop.found_existing) gop.value_ptr.* = .empty;
             try gop.value_ptr.append(allocator, i);
         }
@@ -679,25 +680,25 @@ fn walkCssOwner(
     chunk_graph: *const ChunkGraph,
     idx: ModuleIndex,
     ci: ChunkIndex,
-    chunk_mods: *std.AutoHashMap(u32, std.ArrayListUnmanaged(*const Module)),
-    chunk_seen: *std.AutoHashMap(ChunkCssKey, void),
-    visited: *std.AutoHashMap(ModuleIndex, void),
+    chunk_mods: *std.AutoHashMapUnmanaged(u32, std.ArrayListUnmanaged(*const Module)),
+    chunk_seen: *std.AutoHashMapUnmanaged(ChunkCssKey, void),
+    visited: *std.AutoHashMapUnmanaged(ModuleIndex, void),
 ) !void {
     if (idx.isNone()) return;
     if (visited.contains(idx)) return;
     // 함수가 `!void` 로 바뀌었으니 visited.put OOM 도 try 로 propagate.
     // 옛 `catch return` 은 silent skip → CSS 서브트리 누락 + 호출자가 OOM 도
     // 감지 못함. 같은 함수 내 chunk_seen/chunk_mods 가 try 를 쓰는 것과도 일관.
-    try visited.put(idx, {});
+    try visited.put(allocator, idx, {});
     const mod = graph.getModule(idx) orelse return;
 
     if (mod.module_type == .css) {
         if (mod.css_data == null) return;
         const ci_u32 = @intFromEnum(ci);
         // 청크 단위 dedup — 같은 청크 안에서 여러 JS 모듈이 같은 CSS 도달해도 1회.
-        const seen_gop = try chunk_seen.getOrPut(.{ .chunk = ci_u32, .css = idx });
+        const seen_gop = try chunk_seen.getOrPut(allocator, .{ .chunk = ci_u32, .css = idx });
         if (seen_gop.found_existing) return;
-        const list_gop = try chunk_mods.getOrPut(ci_u32);
+        const list_gop = try chunk_mods.getOrPut(allocator, ci_u32);
         if (!list_gop.found_existing) list_gop.value_ptr.* = .empty;
         try list_gop.value_ptr.append(allocator, mod);
         return;
@@ -839,12 +840,12 @@ fn collectCssModules(
     graph: *const ModuleGraph,
     idx: ModuleIndex,
     result: *std.ArrayListUnmanaged(*const Module),
-    visited: *std.AutoHashMap(ModuleIndex, void),
+    visited: *std.AutoHashMapUnmanaged(ModuleIndex, void),
 ) void {
     if (idx == .none) return;
     if (visited.contains(idx)) return;
     const mod = graph.getModule(idx) orelse return;
-    visited.put(idx, {}) catch return;
+    visited.put(allocator, idx, {}) catch return;
 
     // 의존성 먼저 방문 (DFS)
     for (mod.dependencies.items) |dep_idx| {

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -232,7 +232,7 @@ pub const EmitOptions = struct {
     /// inner key = import_record specifier, value = emit 된 worker chunk filename.
     /// codegen 의 `worker_map` 으로 분배되어 emitNew 가 매칭되면 직접 emit.
     /// null/empty 면 fast-exit — worker 가 없는 빌드에서 추가 비용 0.
-    worker_map_per_module: ?*const std.StringHashMap(std.StringHashMap([]const u8)) = null,
+    worker_map_per_module: ?*const std.StringHashMapUnmanaged(std.StringHashMapUnmanaged([]const u8)) = null,
 
     pub const PolyfillEntry = struct {
         name: []const u8,
@@ -407,8 +407,8 @@ pub fn emitWithTreeShaking(
     const collect_externals = options.format == .umd or options.format == .amd or
         (options.format == .iife and options.globals.len > 0);
     if (collect_externals) {
-        var seen = std.StringHashMap(void).init(allocator);
-        defer seen.deinit();
+        var seen: std.StringHashMapUnmanaged(void) = .empty;
+        defer seen.deinit(allocator);
         for (sorted.items) |m| {
             for (m.import_records) |rec| {
                 if (!rec.is_external or seen.contains(rec.specifier)) continue;
@@ -419,7 +419,7 @@ pub fn emitWithTreeShaking(
                 else
                     try types.specifierToParamName(allocator, rec.specifier);
                 errdefer allocator.free(param);
-                try seen.put(rec.specifier, {});
+                try seen.put(allocator, rec.specifier, {});
                 try ext_specifiers.append(allocator, rec.specifier);
                 try ext_param_names_buf.append(allocator, param);
             }

--- a/src/bundler/emitter/dev.zig
+++ b/src/bundler/emitter/dev.zig
@@ -206,7 +206,7 @@ const TraceResolver = struct {
     module_id: []const u8,
     fallback_source: []const u8,
     parsed_maps: std.ArrayList(source_map_trace.ParsedMap),
-    source_cache: std.StringHashMap(u32),
+    source_cache: std.StringHashMapUnmanaged(u32) = .empty,
     sources_content: bool,
 
     fn init(
@@ -229,7 +229,7 @@ const TraceResolver = struct {
             .module_id = module_id,
             .fallback_source = source,
             .parsed_maps = parsed_maps,
-            .source_cache = std.StringHashMap(u32).init(sm.allocator),
+            .source_cache = .empty,
             .sources_content = sources_content,
         };
     }
@@ -237,7 +237,7 @@ const TraceResolver = struct {
     fn deinit(self: *TraceResolver) void {
         for (self.parsed_maps.items) |*parsed| parsed.deinit();
         self.parsed_maps.deinit(self.sm.allocator);
-        self.source_cache.deinit();
+        self.source_cache.deinit(self.sm.allocator);
     }
 
     fn resolve(self: *TraceResolver, m: SourceMap.Mapping) !ResolvedMapping {
@@ -256,7 +256,7 @@ const TraceResolver = struct {
         if (self.sources_content) {
             try self.sm.addSourceContent(source_content orelse "");
         }
-        try self.source_cache.put(source_name, idx);
+        try self.source_cache.put(self.sm.allocator, source_name, idx);
         return idx;
     }
 };

--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -310,10 +310,10 @@ pub fn verifyHostContract(
     // 제거. expose 검사는 per-spec 유지(서브경로별 존재 확인 필요).
     // 키는 borrow(src/static_specs/mf.remotes — verifyHostContract
     // 수명 내내 유효). map 내부 alloc OOM 만 전파.
-    var seen_specs = std.StringHashMap(void).init(allocator);
-    defer seen_specs.deinit();
-    var seen_remotes = std.StringHashMap(void).init(allocator);
-    defer seen_remotes.deinit();
+    var seen_specs: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen_specs.deinit(allocator);
+    var seen_remotes: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen_remotes.deinit(allocator);
     var i: usize = 0;
     while (nextRemoteImport(src, mf, &i)) |h|
         try verifyOneRemoteSpec(io, allocator, h.spec, mf, cwd, &seen_specs, &seen_remotes);
@@ -334,11 +334,11 @@ fn verifyOneRemoteSpec(
     spec: []const u8,
     mf: *const types.MfBundleConfig,
     cwd: ?[]const u8,
-    seen_specs: *std.StringHashMap(void),
-    seen_remotes: *std.StringHashMap(void),
+    seen_specs: *std.StringHashMapUnmanaged(void),
+    seen_remotes: *std.StringHashMapUnmanaged(void),
 ) !void {
     if (seen_specs.contains(spec)) return; // 동일 spec(다중/정적∩동적) 1회
-    try seen_specs.put(spec, {});
+    try seen_specs.put(allocator, spec, {});
     const kv = for (mf.remotes) |kv| {
         if (federation.matchesRemoteSpec(spec, kv.key)) break kv;
     } else return;
@@ -356,7 +356,7 @@ fn verifyOneRemoteSpec(
     // integrity-before-expose 불변 유지: remote 첫 encounter 에서 무결성
     // → expose → shared 순(기존 의미·fail-fast 메시지 우선순위 보존).
     const remote_first = !seen_remotes.contains(kv.key);
-    if (remote_first) try seen_remotes.put(kv.key, {});
+    if (remote_first) try seen_remotes.put(allocator, kv.key, {});
     if (remote_first) {
         // P3-3: 무결성 — sidecar(P2-2 SHA-256)/`.sig`(P2-3 Ed25519)와
         // manifest 일치. stale/변조면 fail-fast(D3 런타임가드의 빌드타임

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -83,7 +83,7 @@ pub const ModuleGraph = struct {
     /// 않아서 worker race-safety 를 보장한다 (#1779 PR #3). prealloc=0 은 전량
     /// heap chunk — Module 이 수백 바이트라 stack pre-alloc 비효율.
     modules: ModuleList = .{},
-    path_to_module: std.StringHashMap(ModuleIndex),
+    path_to_module: std.StringHashMapUnmanaged(ModuleIndex) = .empty,
     requested_exports: std.AutoHashMapUnmanaged(u32, RequestedExports) = .empty,
     requested_exports_mutex: spin.SpinLock = .{},
     diagnostics: std.ArrayList(BundlerDiagnostic),

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -461,8 +461,8 @@ fn applyRuntimePolyfills(self: *ModuleGraph, io: std.Io, runtime_indices: *std.A
 
     var selected: std.ArrayList(runtime_polyfills.ResolvedModule) = .empty;
     defer selected.deinit(self.allocator);
-    var seen = std.StringHashMap(void).init(self.allocator);
-    defer seen.deinit();
+    var seen: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen.deinit(self.allocator);
 
     switch (plan.mode) {
         .entry => {
@@ -682,7 +682,7 @@ pub fn buildIncremental(
     /// null → 현재 변경 정보 없음 (initial build / CLI 모드). 전체 모듈 stat.
     /// non-null → set 에 없는 path 는 mtime stat 을 skip 하고 store 의 cached mtime 을 그대로 신뢰.
     /// 새로 그래프에 추가된 모듈 (`store.modules.contains(path) == false`) 은 강제로 stat (Issue #1727 §3).
-    changed_files: ?*const std.StringHashMap(void),
+    changed_files: ?*const std.StringHashMapUnmanaged(void),
 ) !IncrementalBuildResult {
     // #1961: builtin runtime helper plugin prepend (build() 와 동일).
     graph_plugins.ensureBuiltinPlugins(self);
@@ -732,8 +732,8 @@ pub fn buildIncremental(
 
     var reparsed: std.ArrayListUnmanaged(types.ModuleIndex) = .empty;
     var graph_changed = false;
-    var cache_hit_modules = std.AutoHashMap(u32, void).init(self.allocator);
-    defer cache_hit_modules.deinit();
+    var cache_hit_modules: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer cache_hit_modules.deinit(self.allocator);
 
     var discover_scope = profile.begin(.graph_discover);
 
@@ -801,7 +801,7 @@ pub fn buildIncremental(
                 // 코스트는 무시 가능. (M8 측정 record_dep link 88%).
                 mod.dependencies.ensureTotalCapacity(self.allocator, 8) catch {};
                 mod.importers.ensureTotalCapacity(self.allocator, 8) catch {};
-                try cache_hit_modules.put(@intCast(i), {});
+                try cache_hit_modules.put(self.allocator, @intCast(i), {});
                 // parse_arena 소유권 이전: store → graph.
                 cached.module.parse_arena = null;
                 cached.module.resolve_dir = null;

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -177,8 +177,8 @@ pub fn registerWrapperSymbols(self: *ModuleGraph) void {
     // key 들은 module 의 parse_arena (graph teardown 까지 살아있음 — `Module.deinit`
     // 까지) 에서 빌리거나 본 함수 안의 arena 에서 새로 할당. used_names 는 이 함수
     // 안에서 defer deinit 되므로 모든 키가 map 보다 오래 산다.
-    var used_names: std.StringHashMap(u32) = std.StringHashMap(u32).init(self.allocator);
-    defer used_names.deinit();
+    var used_names: std.StringHashMapUnmanaged(u32) = .empty;
+    defer used_names.deinit(self.allocator);
 
     // 이미 등록된 모듈 (incremental rebuild) 의 이름을 먼저 seed — 새 모듈이 같은
     // base 를 쓰면 collision 이 재발하므로. seed 후 카운터는 1 (다음 충돌 시 $2 부여).
@@ -188,9 +188,9 @@ pub fn registerWrapperSymbols(self: *ModuleGraph) void {
     while (seed_it.next()) |m| {
         if (m.wrap_kind == .none) continue;
         // RFC #3940 L.4c-2a-i: mangle 전 단계 (canonical 미설정) → rt null, synthetic_name 조회.
-        if (m.getInitName(null)) |n| _ = used_names.put(n, 1) catch {};
-        if (m.getExportsName(null)) |n| _ = used_names.put(n, 1) catch {};
-        if (m.getRequireName(null)) |n| _ = used_names.put(n, 1) catch {};
+        if (m.getInitName(null)) |n| _ = used_names.put(self.allocator, n, 1) catch {};
+        if (m.getExportsName(null)) |n| _ = used_names.put(self.allocator, n, 1) catch {};
+        if (m.getRequireName(null)) |n| _ = used_names.put(self.allocator, n, 1) catch {};
     }
 
     var it = self.modules.iterator(0);
@@ -205,7 +205,7 @@ pub fn registerWrapperSymbols(self: *ModuleGraph) void {
 
         if (needs_init) {
             const init_base = types.makeInitVarName(arena, m.path) catch continue;
-            const init_name = uniqueName(arena, init_base, &used_names) catch continue;
+            const init_name = uniqueName(arena, init_base, &used_names, self.allocator) catch continue;
             m.init_symbol = semantic_symbol.extendSymbol(
                 arena,
                 &sem_ptr.symbols,
@@ -218,7 +218,7 @@ pub fn registerWrapperSymbols(self: *ModuleGraph) void {
 
         if (needs_exports) {
             const exports_base = types.makeExportsVarName(arena, m.path) catch continue;
-            const exports_name = uniqueName(arena, exports_base, &used_names) catch continue;
+            const exports_name = uniqueName(arena, exports_base, &used_names, self.allocator) catch continue;
             m.exports_symbol = semantic_symbol.extendSymbol(
                 arena,
                 &sem_ptr.symbols,
@@ -231,7 +231,7 @@ pub fn registerWrapperSymbols(self: *ModuleGraph) void {
 
         if (needs_require) {
             const require_base = types.makeRequireVarName(arena, m.path) catch continue;
-            const require_name = uniqueName(arena, require_base, &used_names) catch continue;
+            const require_name = uniqueName(arena, require_base, &used_names, self.allocator) catch continue;
             m.require_symbol = semantic_symbol.extendSymbol(
                 arena,
                 &sem_ptr.symbols,
@@ -250,17 +250,18 @@ pub fn registerWrapperSymbols(self: *ModuleGraph) void {
 fn uniqueName(
     name_arena: std.mem.Allocator,
     base: []const u8,
-    used: *std.StringHashMap(u32),
+    used: *std.StringHashMapUnmanaged(u32),
+    map_alloc: std.mem.Allocator,
 ) std.mem.Allocator.Error![]const u8 {
     if (!used.contains(base)) {
-        try used.put(base, 1);
+        try used.put(map_alloc, base, 1);
         return base;
     }
     var n: u32 = 2;
     while (true) : (n += 1) {
         const candidate = try std.fmt.allocPrint(name_arena, "{s}${d}", .{ base, n });
         if (!used.contains(candidate)) {
-            try used.put(candidate, 1);
+            try used.put(map_alloc, candidate, 1);
             return candidate;
         }
     }

--- a/src/bundler/graph/json_module.zig
+++ b/src/bundler/graph/json_module.zig
@@ -95,7 +95,7 @@ pub fn parse(self: *ModuleGraph, io: std.Io, module: *Module) void {
     // Phase 1 (#1328): 합성 심볼 테이블 초기화 + export default 등록.
     module.ensureAliasTable(self.allocator);
     if (module.semantic) |*sem| {
-        const scope0: ?std.StringHashMap(usize) =
+        const scope0: ?std.StringHashMapUnmanaged(usize) =
             if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
         binding_scanner_mod.populateSyntheticSymbols(
             &module.alias_table.?,

--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -13,7 +13,7 @@ pub fn init(allocator: std.mem.Allocator, resolve_cache: *ResolveCache) ModuleGr
         .allocator = allocator,
         .path_arena = std.heap.ArenaAllocator.init(allocator),
         // modules 는 default (.{}) 로 빈 SegmentedList.
-        .path_to_module = std.StringHashMap(ModuleIndex).init(allocator),
+        .path_to_module = .empty,
         .diagnostics = .empty,
         .resolve_cache = resolve_cache,
     };
@@ -102,7 +102,7 @@ pub fn deinit(self: *ModuleGraph) void {
     }
     self.modules.deinit(self.allocator);
     // PR-Z4: path_to_module key 메모리는 path_arena 가 owned — 개별 free 불요, 일괄 해제.
-    self.path_to_module.deinit();
+    self.path_to_module.deinit(self.allocator);
     self.path_arena.deinit();
     var req_it = self.requested_exports.valueIterator();
     while (req_it.next()) |req| req.deinit(self.allocator);

--- a/src/bundler/graph/module_registry.zig
+++ b/src/bundler/graph/module_registry.zig
@@ -107,7 +107,7 @@ pub fn addModuleWithResolveDir(self: *ModuleGraph, io: std.Io, abs_path: []const
     var s_put = profile.begin(.graph_discover_incr_add_module_put);
     try self.modules.append(self.allocator, module);
     ownership_transferred = true;
-    try self.path_to_module.put(path_owned, index);
+    try self.path_to_module.put(self.allocator, path_owned, index);
     // PR-Z3: lodash-es 평균 3-4 dep / module 로 ArrayList default grow (4→8→16) 가 매
     // build 마다 alloc 1-2회. 사전 capacity 8 로 link 의 grow 회피 (M8 측정 link 98%).
     const mod_ref = self.modules.at(@intFromEnum(index));
@@ -169,7 +169,7 @@ fn addDisabledModuleWithMode(
     module.side_effects = false;
     module.state = .ready;
     try self.modules.append(self.allocator, module);
-    try self.path_to_module.put(disabled_path, index);
+    try self.path_to_module.put(self.allocator, disabled_path, index);
 
     return index;
 }
@@ -190,7 +190,7 @@ pub fn addExternalModule(self: *ModuleGraph, specifier: []const u8) !ModuleIndex
     module.side_effects = true;
     module.state = .ready;
     try self.modules.append(self.allocator, module);
-    try self.path_to_module.put(path_owned, index);
+    try self.path_to_module.put(self.allocator, path_owned, index);
     return index;
 }
 

--- a/src/bundler/graph/parser_metadata.zig
+++ b/src/bundler/graph/parser_metadata.zig
@@ -139,7 +139,7 @@ pub fn materialize(
         defer synthetic_scope.end();
         module.ensureAliasTable(self.allocator);
         if (module.semantic) |*sem| {
-            const scope0: ?std.StringHashMap(usize) =
+            const scope0: ?std.StringHashMapUnmanaged(usize) =
                 if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
             binding_scanner.populateSyntheticSymbols(
                 &module.alias_table.?,

--- a/src/bundler/graph/runtime_polyfills.zig
+++ b/src/bundler/graph/runtime_polyfills.zig
@@ -5,7 +5,7 @@ const runtime_polyfills = @import("../runtime_polyfills.zig");
 pub fn selectModule(
     allocator: std.mem.Allocator,
     selected: *std.ArrayList(runtime_polyfills.ResolvedModule),
-    seen: *std.StringHashMap(void),
+    seen: *std.StringHashMapUnmanaged(void),
     plan: runtime_polyfills.Plan,
     module: runtime_polyfills.ResolvedModule,
     reason: []const u8,
@@ -21,7 +21,7 @@ pub fn selectModule(
         return;
     }
     if (seen.contains(module.module)) return;
-    try seen.put(module.module, {});
+    try seen.put(allocator, module.module, {});
     try selected.append(allocator, module);
     if (debug_log.enabled(.runtime_polyfills)) {
         debug_log.print(

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -244,7 +244,7 @@ fn captureRenamesToPending(
     source: []const u8,
     arena: std.mem.Allocator,
 ) !void {
-    const module_scope: ?*const std.StringHashMap(usize) = if (new_sem.scope_maps.len > 0) &new_sem.scope_maps[0] else null;
+    const module_scope: ?*const std.StringHashMapUnmanaged(usize) = if (new_sem.scope_maps.len > 0) &new_sem.scope_maps[0] else null;
     // old_sem 기준 새 맵을 만들어 교체 — 이전 idx 의 stale entry 누적/오염 방지 (multi-pass).
     var rebuilt: bundler_symbol.RenameTable = .{};
     // `rename_table` (link 시점 = pass0 idx) 폴백은 **첫 capture (pending 비어있음)** 에서만
@@ -374,7 +374,7 @@ fn refreshStableBindingRefsAfterSemanticResync(
     defer binding_refs_scope.end();
 
     const sem = if (module.semantic) |*s| s else return;
-    const scope0: ?std.StringHashMap(usize) =
+    const scope0: ?std.StringHashMapUnmanaged(usize) =
         if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
     for (module.import_bindings) |*ib| {
         ib.local_symbol = bundler_symbol.SymbolRef.invalid;

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -909,8 +909,8 @@ test "buildIncremental: changed_files=empty → stat skip → cache hit even aft
     std.testing.io.sleep(std.Io.Duration.fromMilliseconds(20), .awake) catch {};
     try writeFile(tmp.dir, "entry.ts", "export const V = 2;");
 
-    var empty: std.StringHashMap(void) = .init(std.testing.allocator);
-    defer empty.deinit();
+    var empty: std.StringHashMapUnmanaged(void) = .empty;
+    defer empty.deinit(std.testing.allocator);
 
     var graph2 = ModuleGraph.init(std.testing.allocator, &cache);
     defer graph2.deinit();
@@ -941,9 +941,9 @@ test "buildIncremental: changed_files contains entry → stat → cache miss aft
     std.testing.io.sleep(std.Io.Duration.fromMilliseconds(20), .awake) catch {};
     try writeFile(tmp.dir, "entry.ts", "export const V = 2;");
 
-    var changed: std.StringHashMap(void) = .init(std.testing.allocator);
-    defer changed.deinit();
-    try changed.put(entry, {});
+    var changed: std.StringHashMapUnmanaged(void) = .empty;
+    defer changed.deinit(std.testing.allocator);
+    try changed.put(std.testing.allocator, entry, {});
 
     var graph2 = ModuleGraph.init(std.testing.allocator, &cache);
     defer graph2.deinit();
@@ -1014,8 +1014,8 @@ test "buildIncremental: cache-hit modules replay resolved deps without resolver"
     }
 
     counter.count = 0;
-    var empty: std.StringHashMap(void) = .init(std.testing.allocator);
-    defer empty.deinit();
+    var empty: std.StringHashMapUnmanaged(void) = .empty;
+    defer empty.deinit(std.testing.allocator);
 
     var graph2 = ModuleGraph.init(std.testing.allocator, &cache);
     graph2.plugins = &plugins;
@@ -1079,8 +1079,8 @@ test "buildIncremental: changed_files=empty + cache miss (new module) → 강제
     var store = module_store_mod.PersistentModuleStore.init(std.testing.allocator);
     defer store.deinit();
 
-    var empty: std.StringHashMap(void) = .init(std.testing.allocator);
-    defer empty.deinit();
+    var empty: std.StringHashMapUnmanaged(void) = .empty;
+    defer empty.deinit(std.testing.allocator);
 
     var graph = ModuleGraph.init(std.testing.allocator, &cache);
     defer graph.deinit();
@@ -1442,9 +1442,9 @@ test "renumber: orphan modules sorted by path regardless of add order" {
     try graph.modules.append(alloc, Module.init(@enumFromInt(2), "a.ts"));
     // PR-Z4: path_to_module key 는 path_arena 가 owned (graph deinit 시 일괄 해제).
     const arena_alloc = graph.path_arena.allocator();
-    try graph.path_to_module.put(try arena_alloc.dupe(u8, "c.ts"), @enumFromInt(0));
-    try graph.path_to_module.put(try arena_alloc.dupe(u8, "b.ts"), @enumFromInt(1));
-    try graph.path_to_module.put(try arena_alloc.dupe(u8, "a.ts"), @enumFromInt(2));
+    try graph.path_to_module.put(alloc, try arena_alloc.dupe(u8, "c.ts"), @enumFromInt(0));
+    try graph.path_to_module.put(alloc, try arena_alloc.dupe(u8, "b.ts"), @enumFromInt(1));
+    try graph.path_to_module.put(alloc, try arena_alloc.dupe(u8, "a.ts"), @enumFromInt(2));
 
     try renumber_mod.renumberModulesDeterministically(&graph, &.{});
 
@@ -1487,8 +1487,8 @@ test "F4 (#65): buildIncremental 가 stale entry_dir 를 강제 재계산" {
     // 리터럴이 아닌 allocator dupe 로 set 해야 free 가 안전.
     graph.entry_dir = try std.testing.allocator.dupe(u8, "/some/stale/parent/dir");
 
-    var empty: std.StringHashMap(void) = .init(std.testing.allocator);
-    defer empty.deinit();
+    var empty: std.StringHashMapUnmanaged(void) = .empty;
+    defer empty.deinit(std.testing.allocator);
 
     const r = try graph.buildIncremental(std.testing.io, &.{entry}, &store, &empty);
     defer std.testing.allocator.free(r.reparsed_indices);
@@ -1524,8 +1524,8 @@ test "F4 follow-up: buildIncremental 는 user-set project_root 를 보존" {
     const user_project_root = "/repo/monorepo-root";
     graph.project_root = user_project_root;
 
-    var empty: std.StringHashMap(void) = .init(std.testing.allocator);
-    defer empty.deinit();
+    var empty: std.StringHashMapUnmanaged(void) = .empty;
+    defer empty.deinit(std.testing.allocator);
 
     const r = try graph.buildIncremental(std.testing.io, &.{entry}, &store, &empty);
     defer std.testing.allocator.free(r.reparsed_indices);

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -65,7 +65,7 @@ pub const IncrementalBundler = struct {
     options: BundleOptions,
 
     /// 캐시된 모듈별 dev code (module_id → __zntc_register code)
-    module_cache: std.StringHashMap(CachedModule),
+    module_cache: std.StringHashMapUnmanaged(CachedModule) = .empty,
     /// 마지막 번들의 모듈 경로 목록
     last_paths: ?[]const []const u8 = null,
     /// 전체 재빌드가 필요한지 (첫 빌드 또는 그래프 변경)
@@ -112,7 +112,7 @@ pub const IncrementalBundler = struct {
         return .{
             .allocator = allocator,
             .options = options,
-            .module_cache = std.StringHashMap(CachedModule).init(allocator),
+            .module_cache = .empty,
             .persistent_store = module_store.PersistentModuleStore.init(allocator),
             .compiled_cache = CompiledOutputCache.init(allocator),
         };
@@ -120,7 +120,7 @@ pub const IncrementalBundler = struct {
 
     pub fn deinit(self: *IncrementalBundler) void {
         self.clearCache();
-        self.module_cache.deinit();
+        self.module_cache.deinit(self.allocator);
         self.persistent_store.deinit();
         self.compiled_cache.deinit();
         if (self.resolve_cache) |*rc| rc.deinit();
@@ -173,7 +173,7 @@ pub const IncrementalBundler = struct {
     pub fn rebuildWithChanges(
         self: *IncrementalBundler,
         io: std.Io,
-        changed_files: ?*const std.StringHashMap(void),
+        changed_files: ?*const std.StringHashMapUnmanaged(void),
     ) !RebuildResult {
         if (self.needs_full_rebuild) {
             return self.doBuild(io, true, changed_files);
@@ -185,7 +185,7 @@ pub const IncrementalBundler = struct {
         self: *IncrementalBundler,
         io: std.Io,
         is_first: bool,
-        changed_files: ?*const std.StringHashMap(void),
+        changed_files: ?*const std.StringHashMapUnmanaged(void),
     ) !RebuildResult {
         // (#3751) N rebuild 마다 resolve_cache reset — arena monotonic growth 차단.
         // 빌드 *사이* 에서만 실행 (in-flight CachedResolvedDep 가 모두 store 로 owned-clone
@@ -387,7 +387,7 @@ pub const IncrementalBundler = struct {
                     self.allocator.free(id);
                     continue;
                 };
-                self.module_cache.put(id, .{ .id = id, .code = code }) catch {
+                self.module_cache.put(self.allocator, id, .{ .id = id, .code = code }) catch {
                     self.allocator.free(id);
                     self.allocator.free(code);
                 };

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -378,9 +378,9 @@ test "Bundler watch path: changed HMR module rewrites mixed alias imports" {
         \\}
     );
 
-    var touched = std.StringHashMap(void).init(std.testing.allocator);
-    defer touched.deinit();
-    try touched.put(entry, {});
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
 
     var rebuild_opts = initial_opts;
     rebuild_opts.changed_files = &touched;

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -97,14 +97,14 @@ pub const ModuleSemanticData = struct {
     symbols: std.ArrayList(Symbol),
     scopes: []const Scope,
     /// 스코프별 이름→심볼 인덱스 조회. scope_maps[scope_id].get("x") → symbol index.
-    scope_maps: []const std.StringHashMap(usize),
+    scope_maps: []const std.StringHashMapUnmanaged(usize),
     /// export된 이름 목록. exported_names.get("x") → Span.
-    exported_names: std.StringHashMap(Span),
+    exported_names: std.StringHashMapUnmanaged(Span),
     /// 노드 인덱스 → 심볼 인덱스 매핑. 식별자 노드만 유효값.
     symbol_ids: []const ?u32,
     /// 미해결 참조 (unresolved references). 스코프 체인에서 선언을 찾지 못한 이름.
     /// 번들러 linker가 scope hoisting 시 이 이름들을 예약하여 shadowing 방지.
-    unresolved_references: std.StringHashMap(void),
+    unresolved_references: std.StringHashMapUnmanaged(void),
     /// per-reference 배열. 현재 consumer: mangler liveness.
     references: []const Reference = &.{},
     /// `Symbol.const_kind == .number` 인 심볼의 원본 numeric_literal 텍스트 사이드테이블 (#2505).

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -45,7 +45,7 @@ fn clonePathRefIfNeeded(allocator: std.mem.Allocator, ref: PathRef) !PathRef {
 pub const PersistentModuleStore = struct {
     allocator: std.mem.Allocator,
     /// 절대 경로 → 캐시된 모듈. 경로 키는 store allocator 소유.
-    modules: std.StringHashMap(CachedModule),
+    modules: std.StringHashMapUnmanaged(CachedModule) = .empty,
 
     pub const CachedModule = struct {
         /// 캐싱 시점의 파일 mtime (i128 나노초)
@@ -60,7 +60,7 @@ pub const PersistentModuleStore = struct {
     pub fn init(allocator: std.mem.Allocator) PersistentModuleStore {
         return .{
             .allocator = allocator,
-            .modules = std.StringHashMap(CachedModule).init(allocator),
+            .modules = .empty,
         };
     }
 
@@ -70,7 +70,7 @@ pub const PersistentModuleStore = struct {
             self.freeCachedModule(entry.value_ptr);
             self.allocator.free(entry.key_ptr.*);
         }
-        self.modules.deinit();
+        self.modules.deinit(self.allocator);
     }
 
     fn freeCachedModule(self: *PersistentModuleStore, cached: *CachedModule) void {
@@ -199,7 +199,7 @@ pub const PersistentModuleStore = struct {
 
         if (had_existing) {
             // 기존 키 재사용 — put은 값만 업데이트
-            self.modules.put(path, .{
+            self.modules.put(self.allocator, path, .{
                 .mtime = mtime,
                 .module = cached_module,
                 .import_specifiers = specs,
@@ -214,7 +214,7 @@ pub const PersistentModuleStore = struct {
                 return;
             };
 
-            self.modules.put(key, .{
+            self.modules.put(self.allocator, key, .{
                 .mtime = mtime,
                 .module = cached_module,
                 .import_specifiers = specs,

--- a/src/bundler/package_json.zig
+++ b/src/bundler/package_json.zig
@@ -118,7 +118,7 @@ pub const ParsedPackageJson = struct {
 pub const PkgJsonCacheError = error{ FileNotFound, IoError, JsonParseError, OutOfMemory };
 
 pub const PackageJsonCache = struct {
-    cache: std.StringHashMap(Entry),
+    cache: std.StringHashMapUnmanaged(Entry) = .empty,
     rwlock: spin.SpinRwLock = .{},
     allocator: std.mem.Allocator,
 
@@ -139,7 +139,7 @@ pub const PackageJsonCache = struct {
     };
 
     pub fn init(allocator: std.mem.Allocator) PackageJsonCache {
-        return .{ .cache = std.StringHashMap(Entry).init(allocator), .allocator = allocator };
+        return .{ .cache = .empty, .allocator = allocator };
     }
 
     fn freeBuilt(self: *PackageJsonCache, built: ?*ParsedPackageJson) void {
@@ -155,7 +155,7 @@ pub const PackageJsonCache = struct {
             if (entry.value_ptr.* == .ok) self.freeBuilt(entry.value_ptr.ok);
             self.allocator.free(entry.key_ptr.*);
         }
-        self.cache.deinit();
+        self.cache.deinit(self.allocator);
     }
 
     pub fn getOrParse(self: *PackageJsonCache, io: std.Io, pkg_dir_path: []const u8) PkgJsonCacheError!*ParsedPackageJson {
@@ -197,7 +197,7 @@ pub const PackageJsonCache = struct {
             self.freeBuilt(built);
             return error.OutOfMemory;
         };
-        self.cache.put(key, new_entry) catch {
+        self.cache.put(self.allocator, key, new_entry) catch {
             self.allocator.free(key);
             self.freeBuilt(built);
             return error.OutOfMemory;

--- a/src/bundler/purity.zig
+++ b/src/bundler/purity.zig
@@ -28,7 +28,7 @@ const max_depth: u32 = 128;
 /// 모듈별 unresolved 참조 집합 (semantic analyzer 산출).
 /// 이 집합에 속한 이름은 이 모듈 스코프에서 선언/import가 없는 전역 참조.
 /// `new Set()`의 `Set`이 이 집합에 있으면 shadowing 없이 전역 빌트인임이 확정된다.
-pub const GlobalRefSet = std.StringHashMap(void);
+pub const GlobalRefSet = std.StringHashMapUnmanaged(void);
 
 /// 사용자 지정 pure callee hint (`--pure:<callee>` / BuildOptions.pure).
 ///

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -182,7 +182,7 @@ pub const ResolveCache = struct {
 
     /// 패키지 디렉토리별 browser 필드 override 캐시 (disabled + string remap).
     /// pkg_dir_path → BrowserOverrides (null 이면 browser 필드 없음).
-    browser_overrides_cache: std.StringHashMap(?BrowserOverrides),
+    browser_overrides_cache: std.StringHashMapUnmanaged(?BrowserOverrides) = .empty,
     /// `browser_overrides_cache` 접근 보호 — `getBareModuleOverride` 는 어떤 락도 안 쥐고
     /// 호출되므로(`resolveInner` 의 pre-resolve 분기) 두 worker 가 같은 패키지를 처음
     /// 만나면 `.put` 이 동시에 일어나 HashMap 이 깨질 수 있다.
@@ -194,7 +194,7 @@ pub const ResolveCache = struct {
 
     const CacheShard = struct {
         mutex: spin.SpinLock = .{},
-        map: std.StringHashMap(CachedResult),
+        map: std.StringHashMapUnmanaged(CachedResult) = .empty,
     };
 
     fn cacheShardFor(self: *ResolveCache, cache_key: []const u8) *CacheShard {
@@ -207,24 +207,24 @@ pub const ResolveCache = struct {
     /// module_*: 키가 bare name ("fs", "module-a") — specifier 직접 매칭, resolve 전.
     /// [spec: package-browser-field-spec] (#1530).
     const BrowserOverrides = struct {
-        path_disabled: std.StringHashMap(void),
-        path_remap: std.StringHashMap([]const u8),
-        module_disabled: std.StringHashMap(void),
-        module_remap: std.StringHashMap([]const u8),
+        path_disabled: std.StringHashMapUnmanaged(void) = .empty,
+        path_remap: std.StringHashMapUnmanaged([]const u8) = .empty,
+        module_disabled: std.StringHashMapUnmanaged(void) = .empty,
+        module_remap: std.StringHashMapUnmanaged([]const u8) = .empty,
 
         fn deinit(self: *BrowserOverrides, allocator: std.mem.Allocator) void {
-            inline for (&[_]*std.StringHashMap(void){ &self.path_disabled, &self.module_disabled }) |s| {
+            inline for (&[_]*std.StringHashMapUnmanaged(void){ &self.path_disabled, &self.module_disabled }) |s| {
                 var ki = s.keyIterator();
                 while (ki.next()) |k| allocator.free(k.*);
-                s.deinit();
+                s.deinit(allocator);
             }
-            inline for (&[_]*std.StringHashMap([]const u8){ &self.path_remap, &self.module_remap }) |r| {
+            inline for (&[_]*std.StringHashMapUnmanaged([]const u8){ &self.path_remap, &self.module_remap }) |r| {
                 var it = r.iterator();
                 while (it.next()) |e| {
                     allocator.free(e.key_ptr.*);
                     allocator.free(e.value_ptr.*);
                 }
-                r.deinit();
+                r.deinit(allocator);
             }
         }
 
@@ -373,7 +373,7 @@ pub const ResolveCache = struct {
             baseConditionsFor(platform, .require);
         r.conditions = cond_import;
         var cache_shards: [num_resolve_cache_shards]CacheShard = undefined;
-        for (&cache_shards) |*s| s.* = .{ .map = std.StringHashMap(CachedResult).init(allocator) };
+        for (&cache_shards) |*s| s.* = .{ .map = .empty };
         const rc = ResolveCache{
             .allocator = allocator,
             .resolver = r,
@@ -386,7 +386,7 @@ pub const ResolveCache = struct {
             .dir_cache = resolver_mod.DirEntryCache.init(allocator),
             .realpath_cache = resolver_mod.RealpathCache.init(allocator),
             .pkg_json_cache = pkg_json.PackageJsonCache.init(allocator),
-            .browser_overrides_cache = std.StringHashMap(?BrowserOverrides).init(allocator),
+            .browser_overrides_cache = .empty,
             .conditions_import = cond_import,
             .conditions_require = cond_require,
             .conditions_allocated = has_custom,
@@ -405,7 +405,7 @@ pub const ResolveCache = struct {
             while (it.next()) |entry| {
                 self.allocator.free(entry.key_ptr.*);
             }
-            shard.map.deinit();
+            shard.map.deinit(self.allocator);
         }
 
         // PR resolve interning: path pool 일괄 reclaim.
@@ -419,7 +419,7 @@ pub const ResolveCache = struct {
             self.allocator.free(entry.key_ptr.*);
             if (entry.value_ptr.*) |*overrides| overrides.deinit(self.allocator);
         }
-        self.browser_overrides_cache.deinit();
+        self.browser_overrides_cache.deinit(self.allocator);
         if (self.conditions_allocated) {
             self.allocator.free(self.conditions_import);
             self.allocator.free(self.conditions_require);
@@ -713,7 +713,7 @@ pub const ResolveCache = struct {
             self.allocator.free(old.key);
         }
         const key_owned = self.allocator.dupe(u8, cache_key) catch return error.OutOfMemory;
-        map.put(key_owned, value) catch return error.OutOfMemory;
+        map.put(self.allocator, key_owned, value) catch return error.OutOfMemory;
     }
 
     /// 해석된 절대 경로가 package.json "browser" 필드에서 override (disabled / remap) 되었는지 판별.
@@ -805,7 +805,7 @@ pub const ResolveCache = struct {
             if (built) |*b| b.deinit(self.allocator);
             return null;
         };
-        self.browser_overrides_cache.put(key_owned, built) catch {
+        self.browser_overrides_cache.put(self.allocator, key_owned, built) catch {
             self.allocator.free(key_owned);
             if (built) |*b| b.deinit(self.allocator);
             return null;
@@ -822,10 +822,10 @@ pub const ResolveCache = struct {
         const browser_obj = browser_map.object;
 
         var overrides = BrowserOverrides{
-            .path_disabled = std.StringHashMap(void).init(self.allocator),
-            .path_remap = std.StringHashMap([]const u8).init(self.allocator),
-            .module_disabled = std.StringHashMap(void).init(self.allocator),
-            .module_remap = std.StringHashMap([]const u8).init(self.allocator),
+            .path_disabled = .empty,
+            .path_remap = .empty,
+            .module_disabled = .empty,
+            .module_remap = .empty,
         };
 
         var kit = browser_obj.iterator();
@@ -841,7 +841,7 @@ pub const ResolveCache = struct {
                     if (!b) {
                         const owned_key = self.allocator.dupe(u8, normalized_key) catch continue;
                         const target = if (is_relative_path) &overrides.path_disabled else &overrides.module_disabled;
-                        target.put(owned_key, {}) catch self.allocator.free(owned_key);
+                        target.put(self.allocator, owned_key, {}) catch self.allocator.free(owned_key);
                     }
                 },
                 .string => |s| {
@@ -856,7 +856,7 @@ pub const ResolveCache = struct {
                         continue;
                     };
                     const target = if (is_relative_path) &overrides.path_remap else &overrides.module_remap;
-                    target.put(owned_key, owned_val) catch {
+                    target.put(self.allocator, owned_key, owned_val) catch {
                         self.allocator.free(owned_key);
                         self.allocator.free(owned_val);
                     };

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -100,20 +100,20 @@ fn matchTsPathEntry(entry: @import("../config.zig").TsConfig.PathEntry, specifie
 /// 포인터가 이후 다른 스레드의 삽입(map rehash)에도 dangling 되지 않게 한다.
 pub const DirEntryCache = struct {
     /// 디렉토리 절대 경로 → 엔트리 집합. null이면 디렉토리가 존재하지 않음 (negative 캐시).
-    cache: std.StringHashMap(?*EntrySet),
+    cache: std.StringHashMapUnmanaged(?*EntrySet) = .empty,
     rwlock: spin.SpinRwLock = .{},
     allocator: std.mem.Allocator,
     /// 0.16: listDir 가 io 를 요구. Resolver.resolve 진입 시 주입 (per-instance).
     io: std.Io = undefined,
 
     const EntrySet = struct {
-        files: std.StringHashMap(void),
-        dirs: std.StringHashMap(void),
+        files: std.StringHashMapUnmanaged(void) = .empty,
+        dirs: std.StringHashMapUnmanaged(void) = .empty,
     };
 
     pub fn init(allocator: std.mem.Allocator) DirEntryCache {
         return .{
-            .cache = std.StringHashMap(?*EntrySet).init(allocator),
+            .cache = .empty,
             .allocator = allocator,
         };
     }
@@ -124,16 +124,16 @@ pub const DirEntryCache = struct {
             if (entry.value_ptr.*) |set| self.destroyEntrySet(set);
             self.allocator.free(entry.key_ptr.*);
         }
-        self.cache.deinit();
+        self.cache.deinit(self.allocator);
     }
 
     fn destroyEntrySet(self: *DirEntryCache, set: *EntrySet) void {
         var fit = set.files.keyIterator();
         while (fit.next()) |k| self.allocator.free(k.*);
-        set.files.deinit();
+        set.files.deinit(self.allocator);
         var dit = set.dirs.keyIterator();
         while (dit.next()) |k| self.allocator.free(k.*);
-        set.dirs.deinit();
+        set.dirs.deinit(self.allocator);
         self.allocator.destroy(set);
     }
 
@@ -180,7 +180,7 @@ pub const DirEntryCache = struct {
             if (built) |b| self.destroyEntrySet(b);
             return null;
         };
-        self.cache.put(key, built) catch {
+        self.cache.put(self.allocator, key, built) catch {
             self.allocator.free(key);
             if (built) |b| self.destroyEntrySet(b);
             return null;
@@ -200,20 +200,20 @@ pub const DirEntryCache = struct {
             return null;
         };
         set.* = .{
-            .files = std.StringHashMap(void).init(self.allocator),
-            .dirs = std.StringHashMap(void).init(self.allocator),
+            .files = .empty,
+            .dirs = .empty,
         };
 
         for (entries) |entry| {
             switch (entry.kind) {
-                .file => set.files.put(entry.name, {}) catch self.allocator.free(entry.name),
-                .directory => set.dirs.put(entry.name, {}) catch self.allocator.free(entry.name),
+                .file => set.files.put(self.allocator, entry.name, {}) catch self.allocator.free(entry.name),
+                .directory => set.dirs.put(self.allocator, entry.name, {}) catch self.allocator.free(entry.name),
                 .symlink => {
                     // symlink는 대상이 파일인지 디렉토리인지 readdir만으로 알 수 없으므로 양쪽에 등록.
                     // Linux의 bun install이 node_modules에 symlink 디렉토리를 만들기 때문에 필수.
-                    set.files.put(entry.name, {}) catch {};
+                    set.files.put(self.allocator, entry.name, {}) catch {};
                     const name2 = self.allocator.dupe(u8, entry.name) catch continue;
-                    set.dirs.put(name2, {}) catch self.allocator.free(name2);
+                    set.dirs.put(self.allocator, name2, {}) catch self.allocator.free(name2);
                 },
                 else => self.allocator.free(entry.name),
             }
@@ -259,7 +259,7 @@ pub const RealpathCache = struct {
     io: std.Io = undefined,
 
     const Shard = struct {
-        cache: std.StringHashMap([]const u8),
+        cache: std.StringHashMapUnmanaged([]const u8) = .empty,
         mutex: spin.SpinLock = .{},
     };
 
@@ -269,7 +269,7 @@ pub const RealpathCache = struct {
             .allocator = allocator,
         };
         for (&rc.shards) |*s| {
-            s.* = .{ .cache = std.StringHashMap([]const u8).init(allocator) };
+            s.* = .{ .cache = .empty };
         }
         return rc;
     }
@@ -281,7 +281,7 @@ pub const RealpathCache = struct {
                 self.allocator.free(entry.key_ptr.*);
                 self.allocator.free(entry.value_ptr.*);
             }
-            s.cache.deinit();
+            s.cache.deinit(self.allocator);
         }
     }
 
@@ -321,7 +321,7 @@ pub const RealpathCache = struct {
                 self.allocator.free(new_dir);
                 return error.OutOfMemory;
             };
-            shard.cache.put(key, new_dir) catch {
+            shard.cache.put(self.allocator, key, new_dir) catch {
                 self.allocator.free(key);
                 self.allocator.free(new_dir);
                 return error.OutOfMemory;

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -52,7 +52,7 @@ pub const TreeShaker = struct {
     graph: *ModuleGraph,
     linker: *const Linker,
     included: std.DynamicBitSet,
-    used_exports: std.StringHashMap(void),
+    used_exports: std.StringHashMapUnmanaged(void) = .empty,
     entry_set: std.DynamicBitSet,
     /// markAllExportsUsed 의 re-export source 확장 방문 여부.
     /// `*` sentinel 은 다른 경로에서 먼저 찍힐 수 있으므로 recursion guard 와 분리한다.
@@ -146,7 +146,7 @@ pub const TreeShaker = struct {
             .graph = graph,
             .linker = linker,
             .included = included,
-            .used_exports = std.StringHashMap(void).init(allocator),
+            .used_exports = .empty,
             .entry_set = entry_set,
             .all_exports_expanded = all_exports_expanded,
         };
@@ -161,7 +161,7 @@ pub const TreeShaker = struct {
         }
         var kit = self.used_exports.keyIterator();
         while (kit.next()) |key| self.allocator.free(key.*);
-        self.used_exports.deinit();
+        self.used_exports.deinit(self.allocator);
         self.included.deinit();
         self.entry_set.deinit();
         self.all_exports_expanded.deinit();
@@ -2314,7 +2314,7 @@ pub const TreeShaker = struct {
         if (self.used_exports.contains(lookup_key)) return;
 
         const key = try types.makeModuleKey(self.allocator, module_index, export_name);
-        try self.used_exports.put(key, {});
+        try self.used_exports.put(self.allocator, key, {});
 
         // O(1) per-module used export 플래그 갱신
         if (module_index < self.has_direct_used_export.len) {

--- a/src/cli/bench.zig
+++ b/src/cli/bench.zig
@@ -162,7 +162,7 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) !
         bl.source_hint = std.fs.path.basename(input_file);
         for (phase_names.items, phase_stats.items) |name, stats| {
             const name_dup = try allocator.dupe(u8, name);
-            try bl.phases.put(name_dup, stats);
+            try bl.phases.put(allocator, name_dup, stats);
         }
         const file = std.Io.Dir.cwd().createFile(io, save_path, .{}) catch |err| {
             try stderr.print("zntc bench: cannot create '{s}': {}\n", .{ save_path, err });

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -29,7 +29,7 @@ const Span = @import("../lexer/token.zig").Span;
 
 pub const ManglerResult = struct {
     /// symbol_id -> 새 이름. codegen의 linking_metadata.renames에 주입.
-    renames: std.AutoHashMap(u32, []const u8),
+    renames: std.AutoHashMapUnmanaged(u32, []const u8) = .empty,
     allocator: std.mem.Allocator,
     /// 이 호출의 측정값. `--mangle-report` 경로 외엔 무시됨. #1760 property harness.
     stats: ManglerStats = .{},
@@ -37,14 +37,14 @@ pub const ManglerResult = struct {
     pub fn deinit(self: *ManglerResult) void {
         var it = self.renames.valueIterator();
         while (it.next()) |v| self.allocator.free(v.*);
-        self.renames.deinit();
+        self.renames.deinit(self.allocator);
     }
 
     /// renames의 소유권을 이전하고, 이 결과를 안전하게 해제 가능한 상태로 만든다.
     /// 호출 후 renames의 값 문자열은 호출자가 해제 책임을 진다.
-    pub fn takeRenames(self: *ManglerResult) std.AutoHashMap(u32, []const u8) {
+    pub fn takeRenames(self: *ManglerResult) std.AutoHashMapUnmanaged(u32, []const u8) {
         const taken = self.renames;
-        self.renames = std.AutoHashMap(u32, []const u8).init(self.allocator);
+        self.renames = .empty;
         return taken;
     }
 };
@@ -72,7 +72,7 @@ pub const ManglerStats = struct {
 pub const MangleInput = struct {
     scopes: []const Scope,
     symbols: []const Symbol,
-    scope_maps: []const std.StringHashMap(usize),
+    scope_maps: []const std.StringHashMapUnmanaged(usize),
     /// **scope-nesting 전환 후 mangle() 미사용** (과거 liveness graph-coloring 의 per-symbol
     /// liveness 계산 입력이었음). slot 할당은 scope_maps + scope tree 만으로 결정. 호출처 호환
     /// 및 다른 consumer(dead store / property mangle) 용으로 필드는 유지.
@@ -85,13 +85,13 @@ pub const MangleInput = struct {
     starting_name_counter: u32 = 0,
     /// #1760 unified 경로: 외부에서 누적된 reserved set. mangle 시작 시
     /// 내부 reserved_names 에 복사된다. borrowed — caller 소유 유지.
-    external_reserved: ?*const std.StringHashMap(void) = null,
+    external_reserved: ?*const std.StringHashMapUnmanaged(void) = null,
     /// 모든 모듈에 공유되는 reserved (runtime helper 등). 매 모듈마다 복제하면
     /// N×G 알로케이션 — caller 가 한 번만 build 후 borrow 로 share. lookup 시
     /// internal/external_reserved 와 함께 검사하므로 internal copy 안 함.
     /// `external_reserved` 가 *per-module* (예: Phase A 의 이 모듈 mangled 이름)
     /// 라면 본 필드는 *전 모듈 공통* (예: runtime helper 이름) 으로 분리된다.
-    external_reserved_global: ?*const std.StringHashMap(void) = null,
+    external_reserved_global: ?*const std.StringHashMapUnmanaged(void) = null,
 };
 
 /// scope-nesting 기반 mangling.
@@ -107,7 +107,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
 
     if (scope_count == 0 or symbol_count == 0) {
         return .{
-            .renames = std.AutoHashMap(u32, []const u8).init(allocator),
+            .renames = .empty,
             .allocator = allocator,
         };
     }
@@ -130,11 +130,11 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
     // mangling 제외 심볼의 원본 이름(shouldSkip/blocksMangling)은 출력에 그대로 남으므로
     // base54 가 같은 이름을 다른 slot 에 재할당하면 중복 선언(#1609)/shadow 오염 → Phase 4
     // 발급에서 reserved 로 회피. #1760: Phase A 누적 예약어(external_reserved)도 seed.
-    var reserved_names = std.StringHashMap(void).init(allocator);
-    defer reserved_names.deinit();
+    var reserved_names: std.StringHashMapUnmanaged(void) = .empty;
+    defer reserved_names.deinit(allocator);
     if (input.external_reserved) |ext| {
         var it = ext.keyIterator();
-        while (it.next()) |k| try reserved_names.put(k.*, {});
+        while (it.next()) |k| try reserved_names.put(allocator, k.*, {});
     }
 
     // slot_refs[slot_id] = 그 slot 을 공유하는 심볼들의 reference_count 합 (Phase 4 빈도 naming).
@@ -150,7 +150,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
     const slot_count = slot_refs.items.len;
     if (slot_count == 0) {
         return .{
-            .renames = std.AutoHashMap(u32, []const u8).init(allocator),
+            .renames = .empty,
             .allocator = allocator,
         };
     }
@@ -201,11 +201,11 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
     // ================================================================
     // Phase 5: renames 맵 생성
     // ================================================================
-    var renames = std.AutoHashMap(u32, []const u8).init(allocator);
+    var renames: std.AutoHashMapUnmanaged(u32, []const u8) = .empty;
     errdefer {
         var it = renames.valueIterator();
         while (it.next()) |v| allocator.free(v.*);
-        renames.deinit();
+        renames.deinit(allocator);
     }
 
     for (symbol_to_slot, 0..) |maybe_slot, sym_idx| {
@@ -220,7 +220,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
         if (std.mem.eql(u8, orig_name, new_name)) continue;
 
         // 이미 이름이 할당된 slot에서 왔으므로 dupe 필요 (여러 symbol이 같은 slot 공유)
-        try renames.put(@intCast(sym_idx), try allocator.dupe(u8, new_name));
+        try renames.put(allocator, @intCast(sym_idx), try allocator.dupe(u8, new_name));
     }
 
     // slot_names에서 renames로 복사되지 않은 이름 해제
@@ -255,13 +255,13 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
 /// 원본 이름은 `reserved_names` 에 등록.
 fn collectScopeBindings(
     scope_idx: u32,
-    scope_maps: []const std.StringHashMap(usize),
+    scope_maps: []const std.StringHashMapUnmanaged(usize),
     symbols: []const Symbol,
     scopes: []const Scope,
     skip_symbols: ?std.DynamicBitSet,
     symbol_count: usize,
     binding_buf: *std.ArrayListUnmanaged(SymBinding),
-    reserved_names: *std.StringHashMap(void),
+    reserved_names: *std.StringHashMapUnmanaged(void),
     allocator: std.mem.Allocator,
 ) !void {
     binding_buf.items.len = 0;
@@ -277,7 +277,7 @@ fn collectScopeBindings(
             // skip 판정 — 원본 이름이 출력에 살아남는 1글자/arguments 만 reserved.
             if (shouldSkip(sym, name)) {
                 if (name.len <= 1 or std.mem.eql(u8, name, "arguments")) {
-                    try reserved_names.put(name, {});
+                    try reserved_names.put(allocator, name, {});
                 }
                 continue;
             }
@@ -285,7 +285,7 @@ fn collectScopeBindings(
             if (!sym.scope_id.isNone()) {
                 const s_idx = sym.scope_id.toIndex();
                 if (s_idx < scopes.len and scopes[s_idx].blocksMangling()) {
-                    try reserved_names.put(name, {});
+                    try reserved_names.put(allocator, name, {});
                     continue;
                 }
             }
@@ -316,12 +316,12 @@ fn assignSlotsScopeNesting(
     allocator: std.mem.Allocator,
     scopes: []const Scope,
     symbols: []const Symbol,
-    scope_maps: []const std.StringHashMap(usize),
+    scope_maps: []const std.StringHashMapUnmanaged(usize),
     skip_symbols: ?std.DynamicBitSet,
     symbol_count: usize,
     children: ChildrenList,
     symbol_to_slot: []?u32,
-    reserved_names: *std.StringHashMap(void),
+    reserved_names: *std.StringHashMapUnmanaged(void),
 ) !std.ArrayListUnmanaged(u32) {
     var slot_refs: std.ArrayListUnmanaged(u32) = .empty;
     errdefer slot_refs.deinit(allocator);
@@ -541,7 +541,7 @@ pub fn nextBase54Name(counter: *u32, buf: *[8]u8) []const u8 {
 pub fn nextNonReservedBase54Name(
     counter: *u32,
     buf: *[8]u8,
-    reserved: *const std.StringHashMap(void),
+    reserved: *const std.StringHashMapUnmanaged(void),
     skips_1char: *usize,
 ) []const u8 {
     return nextNonReservedBase54NameTwo(counter, buf, reserved, null, skips_1char);
@@ -553,8 +553,8 @@ pub fn nextNonReservedBase54Name(
 pub fn nextNonReservedBase54NameTwo(
     counter: *u32,
     buf: *[8]u8,
-    reserved_a: *const std.StringHashMap(void),
-    reserved_b: ?*const std.StringHashMap(void),
+    reserved_a: *const std.StringHashMapUnmanaged(void),
+    reserved_b: ?*const std.StringHashMapUnmanaged(void),
     skips_1char: *usize,
 ) []const u8 {
     var name = nextBase54Name(counter, buf);
@@ -587,13 +587,13 @@ test "mangle: string_table 기반 생성 심볼도 rename 결과에 포함" {
         },
     };
 
-    var empty_scope = std.StringHashMap(usize).init(allocator);
-    defer empty_scope.deinit();
-    var function_scope = std.StringHashMap(usize).init(allocator);
-    defer function_scope.deinit();
-    try function_scope.put("_this", 0);
+    var empty_scope: std.StringHashMapUnmanaged(usize) = .empty;
+    defer empty_scope.deinit(allocator);
+    var function_scope: std.StringHashMapUnmanaged(usize) = .empty;
+    defer function_scope.deinit(allocator);
+    try function_scope.put(allocator, "_this", 0);
 
-    const scope_maps = [_]std.StringHashMap(usize){ empty_scope, function_scope };
+    const scope_maps = [_]std.StringHashMapUnmanaged(usize){ empty_scope, function_scope };
     const refs = [_]Reference{
         .{
             .node_index = @enumFromInt(0),
@@ -647,15 +647,15 @@ test "mangle: scope-nesting 형제 scope 가 같은 slot 재사용 (충돌 0)" {
             .synthetic_name = "beta",
         },
     };
-    var s_root = std.StringHashMap(usize).init(allocator);
-    defer s_root.deinit();
-    var s1 = std.StringHashMap(usize).init(allocator);
-    defer s1.deinit();
-    try s1.put("alpha", 0);
-    var s2 = std.StringHashMap(usize).init(allocator);
-    defer s2.deinit();
-    try s2.put("beta", 1);
-    const scope_maps = [_]std.StringHashMap(usize){ s_root, s1, s2 };
+    var s_root: std.StringHashMapUnmanaged(usize) = .empty;
+    defer s_root.deinit(allocator);
+    var s1: std.StringHashMapUnmanaged(usize) = .empty;
+    defer s1.deinit(allocator);
+    try s1.put(allocator, "alpha", 0);
+    var s2: std.StringHashMapUnmanaged(usize) = .empty;
+    defer s2.deinit(allocator);
+    try s2.put(allocator, "beta", 1);
+    const scope_maps = [_]std.StringHashMapUnmanaged(usize){ s_root, s1, s2 };
 
     var result = try mangle(allocator, .{
         .scopes = &scopes,
@@ -703,15 +703,15 @@ test "mangle: scope-nesting 자식 binding 은 부모 slot 을 안 받음 (shado
             .synthetic_name = "inner",
         },
     };
-    var s_root = std.StringHashMap(usize).init(allocator);
-    defer s_root.deinit();
-    var s1 = std.StringHashMap(usize).init(allocator);
-    defer s1.deinit();
-    try s1.put("outer", 0);
-    var s2 = std.StringHashMap(usize).init(allocator);
-    defer s2.deinit();
-    try s2.put("inner", 1);
-    const scope_maps = [_]std.StringHashMap(usize){ s_root, s1, s2 };
+    var s_root: std.StringHashMapUnmanaged(usize) = .empty;
+    defer s_root.deinit(allocator);
+    var s1: std.StringHashMapUnmanaged(usize) = .empty;
+    defer s1.deinit(allocator);
+    try s1.put(allocator, "outer", 0);
+    var s2: std.StringHashMapUnmanaged(usize) = .empty;
+    defer s2.deinit(allocator);
+    try s2.put(allocator, "inner", 1);
+    const scope_maps = [_]std.StringHashMapUnmanaged(usize){ s_root, s1, s2 };
 
     var result = try mangle(allocator, .{
         .scopes = &scopes,
@@ -756,13 +756,13 @@ test "mangle: scope-nesting 깊이 3 — grandchild ≠ grandparent, cousin 은 
         };
     }
 
-    var maps: [5]std.StringHashMap(usize) = undefined;
-    for (&maps) |*m| m.* = std.StringHashMap(usize).init(allocator);
-    defer for (&maps) |*m| m.deinit();
-    try maps[1].put("gpvar", 0);
-    try maps[2].put("alpha", 1);
-    try maps[3].put("beta", 2);
-    try maps[4].put("deepv", 3);
+    var maps: [5]std.StringHashMapUnmanaged(usize) = undefined;
+    for (&maps) |*m| m.* = .empty;
+    defer for (&maps) |*m| m.deinit(allocator);
+    try maps[1].put(allocator, "gpvar", 0);
+    try maps[2].put(allocator, "alpha", 1);
+    try maps[3].put(allocator, "beta", 2);
+    try maps[4].put(allocator, "deepv", 3);
 
     var result = try mangle(allocator, .{
         .scopes = &scopes,

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -153,7 +153,7 @@ pub const CodegenOptions = struct {
     /// 매핑 (per-module). emitNew 가 이 맵을 보고 매칭되면 filename + import.meta.url polyfill
     /// 로 직접 emit. bundler 가 모듈별로 sub-map 을 추출해 주입한다 (graph.worker_entries 에서
     /// 도출). null/empty 면 fast-exit - worker 가 없는 모듈에서 추가 비용 0.
-    worker_map: ?*const std.StringHashMap([]const u8) = null,
+    worker_map: ?*const std.StringHashMapUnmanaged([]const u8) = null,
     /// Debug 빌드 전용 내부 invariant. private syntax downlevel 대상인데 transformer 후
     /// raw private AST가 codegen까지 도달하면 사용자 입력 에러가 아니라 transformer 버그다.
     assert_no_raw_private_syntax: bool = false,

--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -43,7 +43,7 @@ pub const ImportRef = struct {
 pub const ModuleMangleInput = struct {
     scopes: []const Scope,
     symbols: []const Symbol,
-    scope_maps: []const std.StringHashMap(usize),
+    scope_maps: []const std.StringHashMapUnmanaged(usize),
     references: []const Reference,
     source: []const u8,
     /// scope_maps[0] 의 모든 symbol_id 를 담은 BitSet. `mangle` 이 skip_symbols
@@ -90,7 +90,7 @@ pub const UnifiedMangleInput = struct {
 };
 
 pub const UnifiedMangleResult = struct {
-    renames: std.AutoHashMap(ModuleSymKey, []const u8),
+    renames: std.AutoHashMapUnmanaged(ModuleSymKey, []const u8) = .empty,
     allocator: std.mem.Allocator,
     phase_a: mangler.ManglerStats = .{},
     phase_b_modules: []mangler.ManglerStats = &.{},
@@ -98,7 +98,7 @@ pub const UnifiedMangleResult = struct {
     pub fn deinit(self: *UnifiedMangleResult) void {
         var it = self.renames.valueIterator();
         while (it.next()) |v| self.allocator.free(v.*);
-        self.renames.deinit();
+        self.renames.deinit(self.allocator);
         self.allocator.free(self.phase_b_modules);
     }
 };
@@ -109,16 +109,16 @@ pub fn mangleAll(
     allocator: std.mem.Allocator,
     input: UnifiedMangleInput,
 ) !UnifiedMangleResult {
-    var renames: std.AutoHashMap(ModuleSymKey, []const u8) = .init(allocator);
+    var renames: std.AutoHashMapUnmanaged(ModuleSymKey, []const u8) = .empty;
     errdefer {
         var vit = renames.valueIterator();
         while (vit.next()) |v| allocator.free(v.*);
-        renames.deinit();
+        renames.deinit(allocator);
     }
 
-    var reserved: std.StringHashMap(void) = .init(allocator);
-    defer reserved.deinit();
-    for (input.global_reserved) |r| try reserved.put(r, {});
+    var reserved: std.StringHashMapUnmanaged(void) = .empty;
+    defer reserved.deinit(allocator);
+    for (input.global_reserved) |r| try reserved.put(allocator, r, {});
 
     // ================================================================
     // Phase A — cross-module frequency
@@ -149,10 +149,10 @@ pub fn mangleAll(
     // init pass 와 seed pass 를 분리 — `StringHashMap.init` 자체는 fail 하지 않으므로
     // 두 번째 seed loop 의 `put` 이 OOM 해도 모든 entries 가 이미 init 되어 defer 의
     // `deinit` 이 안전하게 실행된다 (uninit deinit UB 없음).
-    var per_mod_reserved = try allocator.alloc(std.StringHashMap(void), input.modules.len);
-    for (per_mod_reserved) |*s| s.* = std.StringHashMap(void).init(allocator);
+    var per_mod_reserved = try allocator.alloc(std.StringHashMapUnmanaged(void), input.modules.len);
+    for (per_mod_reserved) |*s| s.* = .empty;
     defer {
-        for (per_mod_reserved) |*s| s.deinit();
+        for (per_mod_reserved) |*s| s.deinit(allocator);
         allocator.free(per_mod_reserved);
     }
     // K2-perf (#46): global_reserved (runtime helper 등) 는 모든 모듈에 동일하므로 N×G
@@ -160,9 +160,9 @@ pub fn mangleAll(
     // `external_reserved_global` 인자로 borrow 로 share. lookup 시 internal/per_mod 와
     // 함께 검사된다 (`nextNonReservedBase54NameTwo`). per_mod_reserved 는 이제 *Phase A
     // mangled this-module names + cross-module imports* 만 보유 — 일반적으로 작음.
-    var global_reserved_set: std.StringHashMap(void) = .init(allocator);
-    defer global_reserved_set.deinit();
-    try global_reserved_set.ensureUnusedCapacity(@intCast(input.global_reserved.len));
+    var global_reserved_set: std.StringHashMapUnmanaged(void) = .empty;
+    defer global_reserved_set.deinit(allocator);
+    try global_reserved_set.ensureUnusedCapacity(allocator, @intCast(input.global_reserved.len));
     for (input.global_reserved) |r| global_reserved_set.putAssumeCapacity(r, {});
 
     // J-step2a (RFC #3288): cross-module ref 인 candidate 분류 — 진단 전용.
@@ -219,14 +219,14 @@ pub fn mangleAll(
         if (!std.mem.eql(u8, cand.name, new_name)) {
             const duped = try allocator.dupe(u8, new_name);
             errdefer allocator.free(duped);
-            try renames.put(.{ .module_index = cand.module_index, .symbol_id = cand.symbol_id }, duped);
-            try reserved.put(duped, {});
-            if (has_mod_slot) try per_mod_reserved[cand.module_index].put(duped, {});
+            try renames.put(allocator, .{ .module_index = cand.module_index, .symbol_id = cand.symbol_id }, duped);
+            try reserved.put(allocator, duped, {});
+            if (has_mod_slot) try per_mod_reserved[cand.module_index].put(allocator, duped, {});
             phase_a_renamed += 1;
         } else {
             // 원본과 동일해도 다음 Phase A 후보가 같은 이름을 집지 못하도록 reserved.
-            try reserved.put(cand.name, {});
-            if (has_mod_slot) try per_mod_reserved[cand.module_index].put(cand.name, {});
+            try reserved.put(allocator, cand.name, {});
+            if (has_mod_slot) try per_mod_reserved[cand.module_index].put(allocator, cand.name, {});
         }
     }
 
@@ -237,7 +237,7 @@ pub fn mangleAll(
         for (m.cross_module_imports) |ref| {
             const key: ModuleSymKey = .{ .module_index = ref.source_module_index, .symbol_id = ref.source_symbol_id };
             if (renames.get(key)) |mangled| {
-                try per_mod_reserved[mi].put(mangled, {});
+                try per_mod_reserved[mi].put(allocator, mangled, {});
             }
         }
     }
@@ -283,9 +283,9 @@ pub fn mangleAll(
         errdefer {
             var eit = take.iterator();
             while (eit.next()) |e| allocator.free(e.value_ptr.*);
-            take.deinit();
+            take.deinit(allocator);
         }
-        try renames.ensureUnusedCapacity(take_count);
+        try renames.ensureUnusedCapacity(allocator, take_count);
 
         var it = take.iterator();
         const mod_idx: u32 = @intCast(i);
@@ -309,7 +309,7 @@ pub fn mangleAll(
             const key: ModuleSymKey = .{ .module_index = mod_idx, .symbol_id = entry.key_ptr.* };
             renames.putAssumeCapacity(key, entry.value_ptr.*);
         }
-        take.deinit();
+        take.deinit(allocator);
     }
 
     if (debug_log.enabled(.mangle_audit)) {
@@ -425,7 +425,7 @@ test "mangleAll: Phase B loop runs with empty module (counter carried through)" 
     // 할당되며, counter 가 Phase A 값부터 출발하는지 검증. 실제 mangler.mangle
     // 은 scope_count=0 에서 early-return 하므로 rename 없음 — 이 테스트의 목적은
     // "Phase B 경로가 컴파일/실행되고 result 구조가 올바른지" 다.
-    const empty_scope_maps: []const std.StringHashMap(usize) = &.{};
+    const empty_scope_maps: []const std.StringHashMapUnmanaged(usize) = &.{};
     var bitset = try std.DynamicBitSet.initEmpty(std.testing.allocator, 0);
     defer bitset.deinit();
 

--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -339,7 +339,7 @@ pub fn isRegisteredHelperBaseName(base_name: []const u8) bool {
 }
 
 /// map 에 들어있는 등록 helper base name 을 제거한다.
-pub fn removeRegisteredHelperBaseNames(map: *std.StringHashMap(void)) void {
+pub fn removeRegisteredHelperBaseNames(map: *std.StringHashMapUnmanaged(void)) void {
     for (MODULES) |m| {
         for (m.helpers) |h| {
             _ = map.remove(h);

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -93,7 +93,7 @@ pub const SemanticAnalyzer = struct {
 
     /// module의 exported name 추적 (중복 export 검사).
     /// key: 내보낸 이름 (default 포함), value: 첫 선언의 span.
-    exported_names: std.StringHashMap(Span),
+    exported_names: std.StringHashMapUnmanaged(Span) = .empty,
 
     /// numeric const symbol 의 원본 텍스트 사이드테이블 (#2505).
     /// Symbol 에 16B slice 를 박지 않으려고 분리. 보통 numeric const 는 전체 심볼의 극소수.
@@ -102,7 +102,7 @@ pub const SemanticAnalyzer = struct {
 
     /// class private name 스택 (중첩 class 지원, oxc 방식).
     /// 각 항목은 해당 class body에서 선언된 private name 집합.
-    class_private_declared: std.ArrayList(std.StringHashMap(PrivateNameInfo)),
+    class_private_declared: std.ArrayList(std.StringHashMapUnmanaged(PrivateNameInfo)),
 
     /// class private name 참조 스택.
     /// 각 항목은 해당 class body에서 참조된 private name 목록 (검증 대기).
@@ -120,13 +120,13 @@ pub const SemanticAnalyzer = struct {
     /// per-scope 심볼 검색용 HashMap 배열 (O(1) 조회).
     /// scopes 배열과 같은 인덱스를 공유: scope_maps.items[scope_id] = 해당 스코프의 이름→심볼인덱스 맵.
     /// key는 소스 코드 슬라이스 (zero-copy), value는 symbols 배열의 인덱스.
-    scope_maps: std.ArrayList(std.StringHashMap(usize)),
+    scope_maps: std.ArrayList(std.StringHashMapUnmanaged(usize)),
 
     /// 미해결 참조 (unresolved references). resolveIdentifier에서 스코프 체인을 다 올라가도
     /// 선언을 찾지 못한 이름. 번들러 linker가 scope hoisting 시 이 이름들을 예약하여
     /// 모듈 top-level 변수가 글로벌을 shadowing하지 않도록 한다 (Rolldown 방식).
     /// key는 소스 코드 슬라이스 (zero-copy).
-    unresolved_references: std.StringHashMap(void),
+    unresolved_references: std.StringHashMapUnmanaged(void) = .empty,
 
     /// Forward reference 지원을 위한 pre-declaration 스코프.
     /// visitProgram에서 첫 번째 패스로 top-level 바인딩 이름을 미리 등록한 후,
@@ -224,13 +224,13 @@ pub const SemanticAnalyzer = struct {
             .ast = ast,
             .scopes = .empty,
             .symbols = .empty,
-            .exported_names = std.StringHashMap(Span).init(allocator),
+            .exported_names = .empty,
             .class_private_declared = .empty,
             .class_private_refs = .empty,
             .labels = .empty,
             .resolved_names = .empty,
             .scope_maps = .empty,
-            .unresolved_references = std.StringHashMap(void).init(allocator),
+            .unresolved_references = .empty,
             .symbol_ids = .empty,
             .references = .empty,
             .errors = .empty,
@@ -247,10 +247,10 @@ pub const SemanticAnalyzer = struct {
         }
         self.scopes.deinit(self.allocator);
         self.symbols.deinit(self.allocator);
-        for (self.scope_maps.items) |*m| m.deinit();
+        for (self.scope_maps.items) |*m| m.deinit(self.allocator);
         self.scope_maps.deinit(self.allocator);
-        self.exported_names.deinit();
-        self.unresolved_references.deinit();
+        self.exported_names.deinit(self.allocator);
+        self.unresolved_references.deinit(self.allocator);
         self.labels.deinit(self.allocator);
         // resolvePrivateName에서 할당된 문자열 해제
         for (self.resolved_names.items) |name| {
@@ -262,7 +262,7 @@ pub const SemanticAnalyzer = struct {
         self.helper_scope_map.deinit(self.allocator);
         self.references.deinit(self.allocator);
         self.numeric_const_texts.deinit(self.allocator);
-        for (self.class_private_declared.items) |*map| map.deinit();
+        for (self.class_private_declared.items) |*map| map.deinit(self.allocator);
         self.class_private_declared.deinit(self.allocator);
         for (self.class_private_refs.items) |*list| list.deinit(self.allocator);
         self.class_private_refs.deinit(self.allocator);
@@ -322,7 +322,7 @@ pub const SemanticAnalyzer = struct {
             .is_strict = is_strict,
         });
         // scope_maps는 scopes와 동일 인덱스를 공유 — 빈 HashMap 추가
-        try self.scope_maps.append(self.allocator, std.StringHashMap(usize).init(self.allocator));
+        try self.scope_maps.append(self.allocator, .empty);
         self.current_scope = new_id;
         return parent;
     }
@@ -406,7 +406,7 @@ pub const SemanticAnalyzer = struct {
 
     /// class body 진입 시 private name 스코프를 push한다.
     fn pushClassScope(self: *SemanticAnalyzer) AllocError!void {
-        try self.class_private_declared.append(self.allocator, std.StringHashMap(PrivateNameInfo).init(self.allocator));
+        try self.class_private_declared.append(self.allocator, .empty);
         try self.class_private_refs.append(self.allocator, .empty);
     }
 
@@ -415,7 +415,7 @@ pub const SemanticAnalyzer = struct {
         if (self.class_private_declared.items.len == 0) return;
 
         var declared = self.class_private_declared.pop() orelse return;
-        defer declared.deinit();
+        defer declared.deinit(self.allocator);
         var refs = self.class_private_refs.pop() orelse return;
         defer refs.deinit(self.allocator);
 
@@ -450,10 +450,10 @@ pub const SemanticAnalyzer = struct {
                 return;
             }
             // getter+setter 쌍 확인됨 → accessor_pair로 업데이트
-            try current.put(name, .{ .span = span, .kind = .accessor_pair });
+            try current.put(self.allocator, name, .{ .span = span, .kind = .accessor_pair });
             return;
         }
-        try current.put(name, .{ .span = span, .kind = kind });
+        try current.put(self.allocator, name, .{ .span = span, .kind = kind });
     }
 
     /// identifier 텍스트에서 unicode escape sequence를 해석하여 StringValue를 반환한다.
@@ -641,7 +641,7 @@ pub const SemanticAnalyzer = struct {
             if (!var_scope_for_alias.isNone() and var_scope_for_alias.toIndex() < self.scope_maps.items.len) {
                 if (self.scope_maps.items[var_scope_for_alias.toIndex()].get(name_text)) |x_idx| {
                     if (self.symbols.items[x_idx].kind.isFunctionLike()) {
-                        try self.scope_maps.items[target_scope.toIndex()].put(name_text, x_idx);
+                        try self.scope_maps.items[target_scope.toIndex()].put(self.allocator, name_text, x_idx);
                         if (node_idx) |ni| {
                             if (ni < self.symbol_ids.items.len) {
                                 self.symbol_ids.items[ni] = @intCast(x_idx);
@@ -676,7 +676,7 @@ pub const SemanticAnalyzer = struct {
         // per-scope HashMap에도 등록 (O(1) 검색용)
         if (!target_scope.isNone()) {
             self.scopes.items[target_scope.toIndex()].symbol_count += 1;
-            try self.scope_maps.items[target_scope.toIndex()].put(name_text, sym_index);
+            try self.scope_maps.items[target_scope.toIndex()].put(self.allocator, name_text, sym_index);
         }
 
         // StmtInfo 사전 수집: 선언 위치를 references 에 declare 플래그로 기록. #1669 부터 모든 scope.
@@ -957,7 +957,7 @@ pub const SemanticAnalyzer = struct {
 
         // 스코프 체인을 전부 올라갔는데 선언을 찾지 못함 → 미해결 참조 (글로벌).
         // 번들러 linker가 이 이름들을 예약하여 scope hoisting 시 shadowing을 방지.
-        self.unresolved_references.put(name, {}) catch {};
+        self.unresolved_references.put(self.allocator, name, {}) catch {};
     }
 
     /// 노드가 식별자 참조이면 resolveIdentifier를 호출하고 true를 반환한다.
@@ -3201,7 +3201,7 @@ pub const SemanticAnalyzer = struct {
             const map = &self.scope_maps.items[target_scope.toIndex()];
             if (map.get(name_text) == null) {
                 self.scopes.items[target_scope.toIndex()].symbol_count += 1;
-                try map.put(name_text, sym_index);
+                try map.put(self.allocator, name_text, sym_index);
             }
         }
 
@@ -3343,7 +3343,7 @@ pub const SemanticAnalyzer = struct {
                     self.symbol_ids.items[ni] = @intCast(sym_index);
                 }
                 // scope_maps[0]에 "_default" 등록 — emitter/StmtInfo가 찾을 수 있도록
-                try self.scope_maps.items[module_scope.toIndex()].put("_default", sym_index);
+                try self.scope_maps.items[module_scope.toIndex()].put(self.allocator, "_default", sym_index);
                 // StmtInfo 사전 수집: facade 심볼을 declared 로 기록 (#1669: scope 무관).
                 self.recordDeclareRef(@intCast(sym_index), module_scope);
                 // export default <literal> → facade 심볼에 const_kind + 사이드테이블 텍스트 설정
@@ -3556,7 +3556,7 @@ pub const SemanticAnalyzer = struct {
                 try self.addErrorMsgCodeWithPrevious(span, msg, .duplicate_export, previous_span);
             }
         } else {
-            try self.exported_names.put(name, span);
+            try self.exported_names.put(self.allocator, name, span);
         }
     }
 

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -792,8 +792,8 @@ pub const DevServer = struct {
             // issue #3858 — event 의 path 가 dir-watch (root_dir) 매치 시 rescan 트리거.
             // PR-1 의 inotify dir-watch 가 file event 와 dir entry event 양쪽 emit 할
             // 수 있어 dedup 가드 (StringHashMap 기반 set).
-            var changed_set = std.StringHashMap(void).init(self.allocator);
-            defer changed_set.deinit();
+            var changed_set: std.StringHashMapUnmanaged(void) = .empty;
+            defer changed_set.deinit(self.allocator);
             var needs_rescan = false;
             for (events) |ev| {
                 self.routineLog("  [watch] changed: {s}\n", .{std.fs.path.basename(ev.path)});
@@ -803,7 +803,7 @@ pub const DevServer = struct {
                         continue; // dir entry event 는 changed_paths 에 넣지 않음 (caller 가 file path 만 처리).
                     }
                 }
-                const gop = changed_set.getOrPut(ev.path) catch continue;
+                const gop = changed_set.getOrPut(self.allocator, ev.path) catch continue;
                 if (gop.found_existing) continue; // dedup
                 changed_paths.append(self.allocator, ev.path) catch {};
 
@@ -855,7 +855,7 @@ pub const DevServer = struct {
                     css_path_set.put(self.allocator, path_owned, {}) catch {};
                     watcher.addPath(path_owned) catch {};
                     // synthetic event — caller 가 css-update broadcast 트리거하도록
-                    if (changed_set.getOrPut(path_owned) catch null) |gop| {
+                    if (changed_set.getOrPut(self.allocator, path_owned) catch null) |gop| {
                         if (!gop.found_existing) changed_paths.append(self.allocator, path_owned) catch {};
                     }
                     self.routineLog("  [watch] new file added: {s}\n", .{std.fs.path.basename(path_owned)});
@@ -878,7 +878,7 @@ pub const DevServer = struct {
                         self.allocator.free(path_dupe);
                         continue;
                     };
-                    if (changed_set.getOrPut(path_dupe) catch null) |gop| {
+                    if (changed_set.getOrPut(self.allocator, path_dupe) catch null) |gop| {
                         if (!gop.found_existing) changed_paths.append(self.allocator, path_dupe) catch {};
                     }
                     _ = css_path_set.remove(p);

--- a/src/server/file_watcher.zig
+++ b/src/server/file_watcher.zig
@@ -93,9 +93,9 @@ const KqueueBackend = struct {
     io: std.Io,
     kq: i32,
     /// 감시 대상: path → fd 매핑
-    watch_fds: std.StringHashMap(WatchEntry),
+    watch_fds: std.StringHashMapUnmanaged(WatchEntry) = .empty,
     /// fd → path 역참조 (kqueue 이벤트에서 O(1) 경로 조회)
-    fd_to_path: std.AutoHashMap(i32, []const u8),
+    fd_to_path: std.AutoHashMapUnmanaged(i32, []const u8) = .empty,
     /// kevent 결과 버퍼. 0.16: posix.Kevent 제거 → std.c.Kevent.
     eventbuf: [64]std.c.Kevent = undefined,
     /// waitForChanges 결과 버퍼
@@ -113,14 +113,15 @@ const KqueueBackend = struct {
     }
 
     fn init(allocator: std.mem.Allocator, io: std.Io) !KqueueBackend {
+        _ = allocator;
         // 0.16: posix.kqueue 제거 → libc kqueue() 직접 호출.
         const kq = std.c.kqueue();
         if (kq < 0) return error.KqueueInitFailed;
         return .{
             .io = io,
             .kq = kq,
-            .watch_fds = std.StringHashMap(WatchEntry).init(allocator),
-            .fd_to_path = std.AutoHashMap(i32, []const u8).init(allocator),
+            .watch_fds = .empty,
+            .fd_to_path = .empty,
             .result_buf = .empty,
         };
     }
@@ -131,8 +132,8 @@ const KqueueBackend = struct {
             self.closeFd(entry.value_ptr.fd);
             allocator.free(entry.key_ptr.*);
         }
-        self.watch_fds.deinit();
-        self.fd_to_path.deinit();
+        self.watch_fds.deinit(allocator);
+        self.fd_to_path.deinit(allocator);
         self.result_buf.deinit(allocator);
         self.closeFd(self.kq);
     }
@@ -164,12 +165,12 @@ const KqueueBackend = struct {
             return;
         }
 
-        self.watch_fds.put(path_owned, .{ .fd = fd }) catch {
+        self.watch_fds.put(allocator, path_owned, .{ .fd = fd }) catch {
             self.closeFd(fd);
             allocator.free(path_owned);
             return;
         };
-        self.fd_to_path.put(fd, path_owned) catch {
+        self.fd_to_path.put(allocator, fd, path_owned) catch {
             _ = self.watch_fds.remove(path_owned);
             self.closeFd(fd);
             allocator.free(path_owned);
@@ -253,16 +254,16 @@ const InotifyBackend = struct {
     io: std.Io,
     inotify_fd: i32,
     /// 감시 대상 파일 경로 (allocator 소유)
-    watched_files: std.StringHashMap(void),
+    watched_files: std.StringHashMapUnmanaged(void) = .empty,
     /// 감시 대상 디렉토리 경로 (allocator 소유). dir 자체가 watch 대상이면
     /// dir entry 변화(IN.CREATE/IN.DELETE/IN.MOVED_*) 시 dir path 의
     /// ChangeEvent emit — caller 가 rescan 으로 신규 file 발견.
     /// issue #3858 — graph 외 .css 파일의 add/delete 감지를 위한 dir-watch.
-    watched_dirs: std.StringHashMap(void),
+    watched_dirs: std.StringHashMapUnmanaged(void) = .empty,
     /// 디렉토리 → wd 매핑
-    dir_wds: std.StringHashMap(i32),
+    dir_wds: std.StringHashMapUnmanaged(i32) = .empty,
     /// wd → 디렉토리 경로 역매핑
-    wd_dirs: std.AutoHashMap(i32, []const u8),
+    wd_dirs: std.AutoHashMapUnmanaged(i32, []const u8) = .empty,
     /// 읽기 버퍼
     read_buf: [8192]u8 = undefined,
     result_buf: std.ArrayList(ChangeEvent),
@@ -292,16 +293,17 @@ const InotifyBackend = struct {
     }
 
     fn init(allocator: std.mem.Allocator, io: std.Io) !InotifyBackend {
+        _ = allocator;
         // 0.16: posix.inotify_init1 제거 → libc inotify_init1.
         const fd = std.c.inotify_init1(std.os.linux.IN.NONBLOCK | std.os.linux.IN.CLOEXEC);
         if (fd < 0) return error.InotifyInitFailed;
         return .{
             .io = io,
             .inotify_fd = fd,
-            .watched_files = std.StringHashMap(void).init(allocator),
-            .watched_dirs = std.StringHashMap(void).init(allocator),
-            .dir_wds = std.StringHashMap(i32).init(allocator),
-            .wd_dirs = std.AutoHashMap(i32, []const u8).init(allocator),
+            .watched_files = .empty,
+            .watched_dirs = .empty,
+            .dir_wds = .empty,
+            .wd_dirs = .empty,
             .result_buf = .empty,
         };
     }
@@ -310,18 +312,18 @@ const InotifyBackend = struct {
         // watched_files 키 해제
         var fit = self.watched_files.keyIterator();
         while (fit.next()) |key| allocator.free(key.*);
-        self.watched_files.deinit();
+        self.watched_files.deinit(allocator);
 
         // watched_dirs 키 해제 (dir_wds 의 키와는 별도 dupe)
         var wdit = self.watched_dirs.keyIterator();
         while (wdit.next()) |key| allocator.free(key.*);
-        self.watched_dirs.deinit();
+        self.watched_dirs.deinit(allocator);
 
         // dir_wds 키 해제 (wd_dirs의 value와 같은 메모리)
         var dit = self.dir_wds.keyIterator();
         while (dit.next()) |key| allocator.free(key.*);
-        self.dir_wds.deinit();
-        self.wd_dirs.deinit();
+        self.dir_wds.deinit(allocator);
+        self.wd_dirs.deinit(allocator);
 
         self.result_buf.deinit(allocator);
         self.closeFd(self.inotify_fd);
@@ -338,11 +340,11 @@ const InotifyBackend = struct {
             if (!self.dir_wds.contains(path)) {
                 const wd = self.addWatch(allocator, path) orelse return;
                 const dir_owned = try allocator.dupe(u8, path);
-                try self.dir_wds.put(dir_owned, wd);
-                try self.wd_dirs.put(wd, dir_owned);
+                try self.dir_wds.put(allocator, dir_owned, wd);
+                try self.wd_dirs.put(allocator, wd, dir_owned);
             }
             const path_owned = try allocator.dupe(u8, path);
-            try self.watched_dirs.put(path_owned, {});
+            try self.watched_dirs.put(allocator, path_owned, {});
             return;
         }
 
@@ -353,12 +355,12 @@ const InotifyBackend = struct {
         if (!self.dir_wds.contains(dir_path)) {
             const wd = self.addWatch(allocator, dir_path) orelse return;
             const dir_owned = try allocator.dupe(u8, dir_path);
-            try self.dir_wds.put(dir_owned, wd);
-            try self.wd_dirs.put(wd, dir_owned);
+            try self.dir_wds.put(allocator, dir_owned, wd);
+            try self.wd_dirs.put(allocator, wd, dir_owned);
         }
 
         const path_owned = try allocator.dupe(u8, path);
-        try self.watched_files.put(path_owned, {});
+        try self.watched_files.put(allocator, path_owned, {});
     }
 
     fn removePath(self: *InotifyBackend, allocator: std.mem.Allocator, path: []const u8) void {
@@ -485,13 +487,14 @@ const InotifyBackend = struct {
 const MtimeBackend = struct {
     /// 0.16: statFile 에 io 필요 (Windows/기타 폴백). init 에서 보관.
     io: std.Io,
-    paths: std.StringHashMap(i128), // path → mtime
+    paths: std.StringHashMapUnmanaged(i128) = .empty, // path → mtime
     result_buf: std.ArrayList(ChangeEvent),
 
     fn init(allocator: std.mem.Allocator, io: std.Io) !MtimeBackend {
+        _ = allocator;
         return .{
             .io = io,
-            .paths = std.StringHashMap(i128).init(allocator),
+            .paths = .empty,
             .result_buf = .empty,
         };
     }
@@ -501,7 +504,7 @@ const MtimeBackend = struct {
         while (it.next()) |entry| {
             allocator.free(entry.key_ptr.*);
         }
-        self.paths.deinit();
+        self.paths.deinit(allocator);
         self.result_buf.deinit(allocator);
     }
 
@@ -509,10 +512,10 @@ const MtimeBackend = struct {
         if (self.paths.contains(path)) return;
         const path_owned = try allocator.dupe(u8, path);
         const stat = std.Io.Dir.cwd().statFile(self.io, path, .{}) catch {
-            try self.paths.put(path_owned, 0);
+            try self.paths.put(allocator, path_owned, 0);
             return;
         };
-        try self.paths.put(path_owned, stat.mtime.toNanoseconds());
+        try self.paths.put(allocator, path_owned, stat.mtime.toNanoseconds());
     }
 
     fn removePath(self: *MtimeBackend, allocator: std.mem.Allocator, path: []const u8) void {

--- a/src/server/tracked_file_set.zig
+++ b/src/server/tracked_file_set.zig
@@ -24,10 +24,10 @@ pub const TrackedFileSet = struct {
     /// 0.16: FileWatcher.init / wyhash.hashFileStreaming 에 io 필요. init 에서 보관.
     io: std.Io,
     watcher: FileWatcher,
-    hashes: std.StringHashMap(u64),
+    hashes: std.StringHashMapUnmanaged(u64) = .empty,
     /// issue #3858 — dir 자체를 watch 대상으로 등록한 path 들. addDirPath 가 set.
     /// caller (watchWorkerThread) 가 isDirPath 로 event dispatch 분기.
-    dir_paths: std.StringHashMap(void),
+    dir_paths: std.StringHashMapUnmanaged(void) = .empty,
     max_bytes: usize,
 
     const Self = @This();
@@ -37,8 +37,8 @@ pub const TrackedFileSet = struct {
             .allocator = allocator,
             .io = io,
             .watcher = try FileWatcher.init(allocator, io),
-            .hashes = std.StringHashMap(u64).init(allocator),
-            .dir_paths = std.StringHashMap(void).init(allocator),
+            .hashes = .empty,
+            .dir_paths = .empty,
             .max_bytes = max_bytes,
         };
     }
@@ -47,10 +47,10 @@ pub const TrackedFileSet = struct {
         self.watcher.deinit();
         var it = self.hashes.keyIterator();
         while (it.next()) |k| self.allocator.free(k.*);
-        self.hashes.deinit();
+        self.hashes.deinit(self.allocator);
         var dit = self.dir_paths.keyIterator();
         while (dit.next()) |k| self.allocator.free(k.*);
-        self.dir_paths.deinit();
+        self.dir_paths.deinit(self.allocator);
     }
 
     /// 감시 대상 등록 + 해시 캐시 갱신.
@@ -58,7 +58,7 @@ pub const TrackedFileSet = struct {
     /// 반환값: watcher 등록 성공 여부.
     pub fn addPath(self: *Self, path: []const u8, overwrite: bool) bool {
         self.watcher.addPath(path) catch return false;
-        const gop = self.hashes.getOrPut(path) catch return true;
+        const gop = self.hashes.getOrPut(self.allocator, path) catch return true;
         if (gop.found_existing) {
             if (!overwrite) return true;
         } else {
@@ -81,7 +81,7 @@ pub const TrackedFileSet = struct {
         self.watcher.addPath(path) catch return false;
         if (self.dir_paths.contains(path)) return true;
         const key = self.allocator.dupe(u8, path) catch return true;
-        self.dir_paths.put(key, {}) catch {
+        self.dir_paths.put(self.allocator, key, {}) catch {
             self.allocator.free(key);
             return true;
         };
@@ -103,7 +103,7 @@ pub const TrackedFileSet = struct {
     /// 반환값: watcher 등록 성공 여부.
     pub fn addWatcherOnly(self: *Self, path: []const u8) bool {
         self.watcher.addPath(path) catch return false;
-        const gop = self.hashes.getOrPut(path) catch return true;
+        const gop = self.hashes.getOrPut(self.allocator, path) catch return true;
         if (!gop.found_existing) {
             const key = self.allocator.dupe(u8, path) catch {
                 _ = self.hashes.remove(path);
@@ -126,7 +126,7 @@ pub const TrackedFileSet = struct {
         return self.hashes.contains(path);
     }
 
-    pub fn keyIterator(self: *Self) std.StringHashMap(u64).KeyIterator {
+    pub fn keyIterator(self: *Self) std.StringHashMapUnmanaged(u64).KeyIterator {
         return self.hashes.keyIterator();
     }
 
@@ -134,7 +134,7 @@ pub const TrackedFileSet = struct {
     /// 읽기 실패/크기 초과 시 false.
     pub fn markIfChanged(self: *Self, path: []const u8) bool {
         const new_hash = wyhash.hashFileStreaming(self.io, path, self.max_bytes) orelse return false;
-        const gop = self.hashes.getOrPut(path) catch return false;
+        const gop = self.hashes.getOrPut(self.allocator, path) catch return false;
         if (gop.found_existing) {
             if (gop.value_ptr.* == new_hash) return false;
         } else {

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -1075,14 +1075,14 @@ pub const PrivateMethodNames = struct {
 /// function used inside the constructor.
 pub const PrivateNameAllocator = struct {
     allocator: std.mem.Allocator,
-    reserved: std.StringHashMap(void),
-    method_weaksets: std.StringHashMap([]const u8),
+    reserved: std.StringHashMapUnmanaged(void) = .empty,
+    method_weaksets: std.StringHashMapUnmanaged([]const u8) = .empty,
 
     pub fn init(allocator: std.mem.Allocator, ast: *const ast_mod.Ast) !PrivateNameAllocator {
         var self = PrivateNameAllocator{
             .allocator = allocator,
-            .reserved = std.StringHashMap(void).init(allocator),
-            .method_weaksets = std.StringHashMap([]const u8).init(allocator),
+            .reserved = .empty,
+            .method_weaksets = .empty,
         };
         errdefer self.deinit();
 
@@ -1100,8 +1100,8 @@ pub const PrivateNameAllocator = struct {
         while (keys.next()) |key| {
             self.allocator.free(key.*);
         }
-        self.reserved.deinit();
-        self.method_weaksets.deinit();
+        self.reserved.deinit(self.allocator);
+        self.method_weaksets.deinit(self.allocator);
     }
 
     fn collectExistingIdentifierNames(self: *PrivateNameAllocator, ast: *const ast_mod.Ast) !void {
@@ -1120,7 +1120,7 @@ pub const PrivateNameAllocator = struct {
         if (self.reserved.contains(name)) return;
         const owned = try self.allocator.dupe(u8, name);
         errdefer self.allocator.free(owned);
-        try self.reserved.put(owned, {});
+        try self.reserved.put(self.allocator, owned, {});
     }
 
     fn reserveGenerated(self: *PrivateNameAllocator, name: []const u8) !void {
@@ -1182,7 +1182,7 @@ pub const PrivateNameAllocator = struct {
         else blk: {
             const generated = try self.makePrivateVarName(orig_name);
             errdefer self.allocator.free(generated);
-            try self.method_weaksets.put(orig_name, generated);
+            try self.method_weaksets.put(self.allocator, orig_name, generated);
             break :blk generated;
         };
         errdefer self.allocator.free(weakset_name);

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -1505,7 +1505,7 @@ fn forwardTemplateInterpolations(
 fn collectModuleLevelBindingsFallback(
     self: *Transformer,
     program_idx: NodeIndex,
-    sink: *std.StringHashMap(void),
+    sink: *std.StringHashMapUnmanaged(void),
 ) Error!void {
     const program = self.ast.getNode(program_idx);
     if (program.tag != .program) return;
@@ -1518,7 +1518,7 @@ fn collectModuleLevelBindingsFallback(
 fn collectBindingsFromStatement(
     self: *Transformer,
     stmt_idx: NodeIndex,
-    sink: *std.StringHashMap(void),
+    sink: *std.StringHashMapUnmanaged(void),
 ) Error!void {
     if (stmt_idx.isNone()) return;
     const node = self.ast.getNode(stmt_idx);
@@ -1533,12 +1533,12 @@ fn collectBindingsFromStatement(
                 const spec = self.ast.getNode(spec_idx);
                 switch (spec.tag) {
                     .import_default_specifier, .import_namespace_specifier => {
-                        try sink.put(self.ast.getText(spec.data.string_ref), {});
+                        try sink.put(self.allocator, self.ast.getText(spec.data.string_ref), {});
                     },
                     .import_specifier => {
                         const local_idx = spec.data.binary.right;
                         if (!local_idx.isNone()) {
-                            try sink.put(self.ast.getText(self.ast.getNode(local_idx).span), {});
+                            try sink.put(self.allocator, self.ast.getText(self.ast.getNode(local_idx).span), {});
                         }
                     },
                     else => {},
@@ -1558,14 +1558,14 @@ fn collectBindingsFromStatement(
                 if (name_idx.isNone()) continue;
                 const name_node = self.ast.getNode(name_idx);
                 if (name_node.tag == .binding_identifier) {
-                    try sink.put(self.ast.getText(name_node.span), {});
+                    try sink.put(self.allocator, self.ast.getText(name_node.span), {});
                 }
             }
         },
         .function_declaration, .class_declaration => {
             const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[node.data.extra]);
             if (!name_idx.isNone()) {
-                try sink.put(self.ast.getText(self.ast.getNode(name_idx).span), {});
+                try sink.put(self.allocator, self.ast.getText(self.ast.getNode(name_idx).span), {});
             }
         },
         .export_named_declaration => {
@@ -1597,13 +1597,13 @@ fn resolveStyledInjectName(self: *Transformer) Error![]const u8 {
     const state = &self.plugins.styled_components;
     if (state.css_prop_needs_import) return state.css_prop_inject_name;
 
-    var bindings: std.StringHashMap(void) = .init(self.allocator);
-    defer bindings.deinit();
+    var bindings: std.StringHashMapUnmanaged(void) = .empty;
+    defer bindings.deinit(self.allocator);
     if (self.symbols.len > 0) {
         for (self.symbols) |sym| {
             if (sym.scope_id.isNone()) continue;
             if (sym.scope_id.toIndex() != 0) continue;
-            try bindings.put(sym.nameText(self.ast.source), {});
+            try bindings.put(self.allocator, sym.nameText(self.ast.source), {});
         }
     } else {
         const root_idx: NodeIndex = @enumFromInt(self.parser_node_count - 1);

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1379,10 +1379,10 @@ fn transpileWithCallbackInternal(
         const node_count = transformer.ast.nodes.items.len;
         mangle_metadata = .{
             .skip_nodes = std.DynamicBitSet.initEmpty(arena_alloc, node_count) catch return error.OutOfMemory,
-            // mr.renames 는 managed map. LinkingMetadata.renames 는 unmanaged 라
-            // backing handle (.unmanaged) 만 빌린다. 소유권은 mr 에 남아 mr.deinit()
+            // mr.renames 는 이제 unmanaged map. LinkingMetadata.renames 도 unmanaged 라
+            // backing handle 을 그대로 빌린다. 소유권은 mr 에 남아 mr.deinit()
             // 이 해제 — mangle_metadata 는 deinit 되지 않으므로 double-free 없음.
-            .renames = mr.renames.unmanaged,
+            .renames = mr.renames,
             .final_exports = null,
             .symbol_ids = if (transformer.symbol_ids.items.len > 0)
                 transformer.symbol_ids.items


### PR DESCRIPTION
## 배경

[#4021](https://github.com/ohah/zntc/pull/4021)(함수-로컬) · [#4023](https://github.com/ohah/zntc/pull/4023)(linker) 후속, **마지막**. 남은 모든 production managed HashMap(bundler 캐시·codegen mangler·semantic analyzer·transformer·server)을 0.16 unmanaged 로 전환합니다.

→ 이로써 **production 코드의 managed HashMap = 0**. ArrayList 에 이어 HashMap 도 100% unmanaged 로 통일됐습니다. 순수 컨벤션 일관성 — 측정 perf/메모리 이득은 없습니다.

> **안전 근거:** `managed → unmanaged` 는 **의미상 중립**(맵이 저장하던 allocator 를 호출부가 넘길 뿐, 수명·소유권 불변). 원본 allocator 보존 + 컴파일러가 누락 mutator 를 전부 잡음(`zig build` green) + 테스트 빌드의 **DebugAllocator 가 leak/double-free/UAF 감지**.

## 규모

86 occurrence-line, **45 파일**(production 38 + 테스트 7). FIELD 타입 변경이 reader 로 넓게 캐스케이드됐지만 **reader(`.get`/`.iterator`)는 무변경**, 타입 경계만 갱신.

주요 FIELD 구조체: `SemanticAnalyzer`(scope_maps 등 4), `ManglerResult.renames`, `MangleInput.{scope_maps,external_reserved*}`, `UnifiedMangleResult`, 캐시류(`PersistentModuleStore`/`IncrementalBundler`/`CompiledOutputCache`/`ChunkEmitCache`/`PackageJsonCache`/`DirEntryCache`/`RealpathCache`/`ResolveCache`/`ModuleGraph.path_to_module`/`TreeShaker`/`TraceResolver`), `file_watcher`(3 백엔드), `TrackedFileSet`, `EnvMap`.

## 소유권 / borrow 검증 (double-free·UAF 방지)

- **`transpile.zig`**: `ManglerResult.renames` 가 unmanaged 가 되어 `.renames = mr.renames`(직접 borrow). `mr` 단독 소유·해제, `mangle_metadata` 미deinit → 이중해제 없음. (#4023 의 `.unmanaged` 우회가 직접 참조로 정리됨.)
- **`unified_mangler` external_reserved\***, **`worker_map_per_module`**(nested: inner→outer 순서 해제), **`changed_files`** 체인, **`GlobalRefSet`** `?*const` 체인 — 전부 소유자 단독 해제, borrow 측은 deinit 안 함.

## 검증 (Zig 0.16.0)

- `zig build install` · `zig build test` **exit 0** (독립 재검증)
- **DebugAllocator(테스트 빌드) leak/double-free/UAF 보고 0건** — 테스트된 경로 메모리 정합성
- 남은 production managed `.init(` **0건** (마이그레이션 완료)
- 제거 라인 전수 스캔 → free/errdefer/제어흐름 **로직 드롭 0건** (전부 타입스왑 + allocator 인자)
- 소유권 민감 4곳 + borrow 직접 리뷰 → 원본과 의미 동일
- `/code-review max` → 버그 **0건**

🤖 Generated with [Claude Code](https://claude.com/claude-code)