### PR TITLE
fix(napi): watch changed_files 를 unmanaged borrow 로 (#4026 napi 빌드 회귀 복구)

### DIFF
--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -1166,8 +1166,10 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         incremental_opts.compiled_cache = &async_data.compiled_cache;
         // Watcher-driven mtime cache (Issue #1727 §3): changed 집합을 graph 에 넘겨
         // 나머지 모듈 stat 을 skip 한다. detect 단계에서 이미 content hash 필터링까지
-        // 통과한 `touched` 를 그대로 재사용 — StringHashMap 포인터라 복사 없음.
-        incremental_opts.changed_files = &touched;
+        // 통과한 `touched` 를 그대로 재사용 — 복사 없음. changed_files 는 0.16 unmanaged
+        // 전환(#4026) 후 `?*const StringHashMapUnmanaged` 라, managed `touched` 의 backing
+        // handle(`.unmanaged`)만 빌린다(read-only borrow; touched 가 소유·1077 에서 deinit).
+        incremental_opts.changed_files = &touched.unmanaged;
         // Lazy sourcemap (Issue #1727 Phase B): initial build 와 동일 경로 유지. cache 키
         // 일치 필수 — initial 에서 lazy=true 로 put 된 엔트리가 rebuild 에서 hit 해야 함.
         if (bundle_opts.dev_mode and bundle_opts.sourcemap.enable) incremental_opts.sourcemap.lazy = true;


### PR DESCRIPTION
## 문제

[#4026](https://github.com/ohah/zntc/pull/4026)(HashMap unmanaged 마이그레이션 완료) 머지 후 **main 의 napi 빌드가 깨짐**:

```
packages/core/src/napi/watch.zig:1170: error: expected type
'?*const HashMapUnmanaged([]const u8,void,StringContext)',
found '*HashMap([]const u8,void,StringContext)'
        incremental_opts.changed_files = &touched;
```

#4026 이 `BundleOptions.changed_files` 를 `?*const StringHashMapUnmanaged(void)` 로 바꿨는데, 그 소비자인 napi watch 코드는 managed `touched` 를 그대로 넘기고 있었습니다.

## 원인 (검증 구멍)

#4021/#4023/#4026 의 grep 범위가 `src/` 였고 검증이 `zig build install`/`test`(= CLI + 유닛테스트)만이라, **`packages/` 의 소비자 + `napi`/`wasm` 별도 타깃을 빌드하지 않았습니다.** auto-merge 가 필수 CI 체크로 게이트되지 않아 머지 후 main CI(napi 잡)에서 드러났습니다.

## 수정 (1줄, borrow)

`touched` 는 `packages/` 의 다른 managed 맵들과 일관되게 managed 로 유지하고, backing handle(`.unmanaged`)만 빌려 넘깁니다:

```zig
incremental_opts.changed_files = &touched.unmanaged;
```

- read-only 경계(`?*const`), `touched` 가 저장소 소유 + 1077 에서 deinit → 이중해제/UAF 없음
- #4023 `transpile.zig` 의 `mr.renames.unmanaged` borrow 와 동일 패턴

## 검증 (Zig 0.16.0 — 이번엔 전 타깃)

`install` · `napi` · `wasm` · `wasm-bundler` · `test262` · `bench-callback` · `schema` **모두 green**. (PR4/5/6 통틀어 다른 숨은 break 없음도 확인.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)