### PR TITLE
fix(parser): 인자 없는 new 뒤 trailing optional chain(new new a()?.b)을 SyntaxError 로 거부

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1837,6 +1837,13 @@ pub const FormalParameterExtra = struct {
 pub const CallFlags = struct {
     pub const is_pure: u32 = 0x01; // @__PURE__ / #__PURE__
     pub const optional_chain: u32 = 0x02; // a?.()
+    /// new_expression 전용: 인자 절(괄호)이 있었는가. `new a()` (= `new MemberExpression
+    /// Arguments`, MemberExpression) 면 set, `new a`/`new new a()` 의 바깥 new (= NewExpression)
+    /// 면 unset. trailing optional chain(`new ...?.x`)의 base 체인 head 가 인자 없는 new 면
+    /// SyntaxError — ECMAScript 상 OptionalChain base 는 MemberExpression/CallExpression 만 가능.
+    /// parse-time 전용(finishNewExpressionWithArgs set, optionalChainBaseIsArglessNew read);
+    /// codegen/transformer 는 미사용.
+    pub const had_arguments: u32 = 0x04;
 };
 
 /// static_member_expression / computed_member_expression / private_field_expression의 flags (D082).

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -809,6 +809,9 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
     }
 
     var after_optional_chain = false;
+    // argless-new 가 head 인 optional chain 진단은 체인당 1회만 (체인의 head 는 고정이라
+    // 매 `?.` 마다 walk 가 같은 argless new 를 재발견 → 중복 방지). V8 도 1개.
+    var reported_new_optional = false;
 
     while (true) {
         const expr_start = self.ast.getNode(expr).span.start;
@@ -893,6 +896,13 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                 // optional chaining: a?.b, a?.[b], a?.()
                 if (self.ast.getNode(expr).tag == .super_expression) {
                     try self.addErrorCode(self.ast.getNode(expr).span, "'super' cannot be used as the base of an optional chain", .super_in_optional_chain);
+                }
+                // ECMAScript: OptionalChain 의 base 는 MemberExpression/CallExpression 만 가능.
+                // base 체인 head 가 인자 없는 new(NewExpression)면 SyntaxError(`new new a()?.b`,
+                // `new new a().b?.c`, `new a\`tpl\`?.b`). 인자 있는 new·call·기타 head 는 유효.
+                if (!reported_new_optional and optionalChainBaseIsArglessNew(self, expr)) {
+                    try self.addErrorCode(self.ast.getNode(expr).span, "Invalid optional chain in 'new' expression", .optional_chain_new);
+                    reported_new_optional = true;
                 }
                 try self.advance(); // skip ?.
                 if (self.current() == .l_bracket) {
@@ -1100,9 +1110,40 @@ fn followedByParenOnly(self: *const Parser) bool {
     return self.current() == .l_paren;
 }
 
+/// `?.`(OptionalChain)의 base 체인 head 가 *인자 없는* new(NewExpression)인지 판정.
+/// ECMAScript: OptionalChain 의 base 는 MemberExpression/CallExpression 만 가능하므로,
+/// 비-optional 멤버 접근(`.x`/`[k]`/`#p`)·tagged template 만 거쳐 인자 없는 new 에 도달하면
+/// SyntaxError(`new new a().b?.c`, `new a\`tpl\`?.b` 등). 인자 있는 new(MemberExpression)·
+/// call_expression·그 외 head 에서 멈춘다(유효). 즉시 base 가 argless new 인 `new new a()?.b`
+/// 도 이 walk 의 첫 step 에서 잡힌다. depth 가드로 무한루프 방지(정상 AST 는 짧다).
+fn optionalChainBaseIsArglessNew(self: *const Parser, base: NodeIndex) bool {
+    var cur = base;
+    var guard: u32 = 0;
+    while (guard < 100_000) : (guard += 1) {
+        const node = self.ast.getNode(cur);
+        switch (node.tag) {
+            .static_member_expression,
+            .computed_member_expression,
+            .private_field_expression,
+            .tagged_template_expression,
+            => {
+                // member 의 object / tagged template 의 tag = extra[0].
+                cur = self.ast.readExtraNode(node.data.extra, 0);
+                if (cur.isNone()) return false;
+            },
+            .new_expression => return (self.ast.readExtra(node.data.extra, 3) & ast_mod.CallFlags.had_arguments) == 0,
+            else => return false,
+        }
+    }
+    return false;
+}
+
 fn finishNewExpressionWithArgs(self: *Parser, start: u32, callee: NodeIndex, arg_list: NodeList) !NodeIndex {
+    // had_arguments: 인자 절(괄호)이 있는 new = MemberExpression → trailing optional chain
+    // (`new a()?.b`)의 valid base. 무인자 new 경로는 flags=0 으로 두어 `new new a()?.b`/
+    // `new new a().b?.c` 등을 optionalChainBaseIsArglessNew 가 거부.
     const ne = try self.ast.addExtras(&.{
-        @intFromEnum(callee), arg_list.start, arg_list.len, 0,
+        @intFromEnum(callee), arg_list.start, arg_list.len, ast_mod.CallFlags.had_arguments,
     });
     const new_expr = try self.ast.addNode(.{
         .tag = .new_expression,

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2140,6 +2140,19 @@ test "new + optional chain: callee 의 optional chain 은 SyntaxError" {
     try expectParseError("new a?.`t`", .{ .message = "Invalid optional chain in 'new' expression" });
     // 중첩 new 의 inner callee optional 도 재귀로 잡힘.
     try expectParseError("new new a?.b()()", .{ .message = "Invalid optional chain in 'new' expression" });
+    // trailing optional chain: 인자 없는 new(NewExpression) 뒤 `?.` 도 거부(#4027).
+    // `new new a()` 의 바깥 new 는 인자 절이 없어 NewExpression → `?.b`/`?.()` 불가.
+    try expectParseError("new new a()?.b", .{ .message = "Invalid optional chain in 'new' expression" });
+    try expectParseError("new new a()?.()", .{ .message = "Invalid optional chain in 'new' expression" });
+    // argless new 와 `?.` 사이에 비-optional 멤버/subscript/tagged-template 이 끼어도
+    // 체인 head 가 argless new 이므로 거부(base 체인을 walk). (max-review 가 적발한 누락.)
+    try expectParseError("new new a().b?.c", .{ .message = "Invalid optional chain in 'new' expression" });
+    try expectParseError("new new a()[0]?.c", .{ .message = "Invalid optional chain in 'new' expression" });
+    try expectParseError("new new a().b.c?.d", .{ .message = "Invalid optional chain in 'new' expression" });
+    try expectParseError("new a`x`?.b", .{ .message = "Invalid optional chain in 'new' expression" });
+    try expectParseError("new new a()`x`?.b", .{ .message = "Invalid optional chain in 'new' expression" });
+    // private-field 가 중간에 끼어도 walk 의 private_field_expression 분기로 head 도달.
+    try expectParseError("new new a().#x?.b", .{ .message = "Invalid optional chain in 'new' expression" });
 }
 
 test "new + optional chain: 진단은 callee 당 정확히 1개 (중복/cascade 노이즈 없음)" {
@@ -2153,6 +2166,10 @@ test "new + optional chain: 진단은 callee 당 정확히 1개 (중복/cascade 
     try expectSingleParseError("new a?.", "Invalid optional chain in 'new' expression");
     try expectSingleParseError("new a?.;", "Invalid optional chain in 'new' expression");
     try expectSingleParseError("new a?.+b", "Invalid optional chain in 'new' expression");
+    // trailing optional 도 단일 진단(멤버 끼인 경우 포함).
+    try expectSingleParseError("new new a()?.b", "Invalid optional chain in 'new' expression");
+    try expectSingleParseError("new new a()?.b?.c", "Invalid optional chain in 'new' expression");
+    try expectSingleParseError("new new a().b?.c", "Invalid optional chain in 'new' expression");
 }
 
 test "new + optional chain: 유효 형태는 통과" {
@@ -2166,6 +2183,14 @@ test "new + optional chain: 유효 형태는 통과" {
     // new 표현식 *뒤*의 optional 접근은 유효(`(new a()).b?.c`).
     try expectNoParseError("new a().b?.c");
     try expectNoParseError("(new a())?.b");
+    // 인자 *있는* new(MemberExpression) 뒤 trailing `?.` 는 유효 — argless new(#4027)만 거부.
+    try expectNoParseError("new a()?.b");
+    try expectNoParseError("new new a()()?.b"); // 바깥 new 가 인자 `()` 보유
+    try expectNoParseError("new new a().b"); // 비-optional `.b` 는 NewExpression 뒤에도 유효
+    try expectNoParseError("(new new a())?.b"); // paren 으로 감싼 NewExpression = PrimaryExpression
+    try expectNoParseError("new new a().b()?.c"); // `.b()` 호출 → CallExpression base → 유효
+    try expectNoParseError("new a()`x`?.b"); // 인자 있는 new + tagged template → MemberExpression
+    try expectNoParseError("new a`x`.b"); // 비-optional 접근만 → 유효
     // computed-member subscript 는 [+In] — for-init(allow_in=false) 안에서도 `in` 허용.
     // `new a[k in a]()` 가 오거부되던 pre-existing 버그(F1) 가드.
     try expectNoParseError("for (var x = new a[(\"k\" in a)]();;) { break; }");


### PR DESCRIPTION
## 문제

`new new a()?.b` (인자 없는 `new` 뒤 `?.`)는 ECMAScript/V8 에서 **SyntaxError** ("Invalid optional chain from new expression") 인데 zntc 가 수용했다. #4022/#4025(callee 내부 optional)와 **다른 규칙**: `OptionalChain` 의 base 는 `MemberExpression`/`CallExpression` 만 가능 — 인자 없는 `new`(NewExpression)는 불가.

```
new new a()?.b     | node: SyntaxError   zntc(before): OK
new new a().b?.c   | node: SyntaxError   zntc(before): OK   (멤버 끼임)
new a`tpl`?.b      | node: SyntaxError   zntc(before): OK   (tagged template)
```

## 수정

- `CallFlags.had_arguments`(0x04): `finishNewExpressionWithArgs`(괄호 있는 new=MemberExpression)에서 set, 무인자 new 경로는 unset. parse-time 전용(codegen/transformer 미사용).
- `optionalChainBaseIsArglessNew`: `?.` 의 base 체인을 **head 까지 walk**(member/computed/private/tagged-template 의 `extra[0]` 하강) → head 가 argless new 면 SyntaxError. call·인자있는 new·기타 head 는 유효.
- 진단은 **체인당 1회**(`reported_new_optional`, loop-local) — head 고정이라 매 `?.` 마다 같은 argless new 재발견하는 중복 방지. V8 동형.

## 코드 리뷰 (정식 `/code-review max` + 포커스 2-에이전트)

- **정식 max(19 에이전트)가 초기 구현의 누락을 적발**: 즉시-base-only 체크라 `new new a().b?.c`(멤버/템플릿 끼임)를 놓침 → **구조적 walk 로 교체**(리뷰의 altitude finding 반영).
- 포커스 리뷰 2건: walk 정확성(extra[0] 하강 전 태그 검증)·dedup(체인당 1, 문장간 리셋)·flag 안전성(call/new slot-3 의 모든 reader가 `& is_pure`/`& optional_chain` 마스크라 0x04 무영향, `flags==0` 등치 비교 없음)·테스트가 mutation 으로 진짜 가드임 확인. **correctness 버그 0.**

## 검증 (node parity 43+ 케이스)

- 거부: `new new a()?.b`/`.b?.c`/`[0]?.c`/`.b.c?.d`/`` `tpl`?.b ``/`.#x?.b`/중첩, 전부 **errors=1**
- 통과: `new a()?.b`/`new new a()()?.b`/`new new a().b()?.c`(call중간)/`new new a().b`(비-optional)/`(new new a())?.b`(paren)/`/* @__PURE__ */ new a()?.b`
- 비-new optional(`a?.b`/`a.b.c?.d`) 무영향
- 전체 유닛 `zig build test` ✅ / lib-scenario 19 ✅ / browser-smoke 95 ✅

## 메타

`new...?.` optional-chain 영역 시리즈 마무리: #4019/#4022(callee optional) → #4024/#4025(진단 품질+[+In]) → #4027(trailing on argless new). 이제 node 와 완전 parity.

Closes #4027

🤖 Generated with [Claude Code](https://claude.com/claude-code)