### PR TITLE
fix(semantic,bundler): import 바인딩/namespace 멤버 변형을 번들 단계에서 거부 (esbuild/rolldown parity)

### DIFF
--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -34,6 +34,7 @@ comptime {
     _ = @import("bundler_test/virtual_ns_treeshake.zig");
     _ = @import("bundler_test/ns_member_shadow.zig");
     _ = @import("bundler_test/exports_name_dedup.zig");
+    _ = @import("bundler_test/import_mutation.zig");
     _ = @import("bundler_test/lowering_rename_leak.zig");
     _ = @import("bundler_test/manual_chunks.zig");
     _ = @import("bundler_test/runtime_helper_shadow.zig");

--- a/src/bundler/bundler_test/import_mutation.zig
+++ b/src/bundler/bundler_test/import_mutation.zig
@@ -1,0 +1,243 @@
+//! #4020: ESM import 바인딩/namespace 멤버 변형(assign/delete/update) 을 번들 단계에서
+//! 거부. esbuild/rolldown parity — import 바인딩은 read-only, namespace 객체는 sealed.
+//!   - `marker = v` / `delete marker` / `marker++` (import 바인딩 직접)        → 에러
+//!   - `ns.x = v` / `delete ns.x` / `ns.x++` (namespace 멤버, `import * as ns`)  → 에러
+//!   - `obj.x = v` (named import 객체 멤버) / `ns.a.b = v` (중첩) / shadowing      → 합법
+//! 검출은 semantic analyzer(번들 단계 gate), 진단(ZNTC0805)은 parse_module 가 fatal 로 승격.
+//! single-file transform/transpile 은 통과(esbuild transform parity, gate off).
+
+const std = @import("std");
+const testing = std.testing;
+const helpers = @import("../test_helpers.zig");
+const writeFile = helpers.writeFile;
+
+fn bundleEntry(backing: std.mem.Allocator, tmp: *std.testing.TmpDir, entry_name: []const u8) !helpers.Bundled {
+    return helpers.bundleEntry(backing, tmp, entry_name, .{ .scope_hoist = true, .tree_shaking = true });
+}
+
+fn hasImportMutationDiag(r: *const helpers.Bundled) bool {
+    const diags = r.result.diagnostics orelse return false;
+    for (diags) |d| {
+        if (d.code == .assign_to_import) return true;
+    }
+    return false;
+}
+
+fn writeMod(tmp: *std.testing.TmpDir) !void {
+    try writeFile(tmp.dir, "mod.js",
+        \\export const marker = 1;
+        \\export let mutable = 2;
+        \\export const obj = { x: 1 };
+    );
+}
+
+// ============================================================
+// 에러: import 바인딩/namespace 멤버 변형
+// ============================================================
+
+test "import mutation: delete ns.member 는 build error (존재 멤버)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ns from './mod.js';
+        \\globalThis.r = delete ns.marker;
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(r.result.hasErrors());
+    try testing.expect(hasImportMutationDiag(&r));
+}
+
+test "import mutation: delete ns.member 는 build error (미존재 멤버)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ns from './mod.js';
+        \\globalThis.r = delete ns.nope;
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(hasImportMutationDiag(&r));
+}
+
+test "import mutation: ns.member = v 는 build error" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ns from './mod.js';
+        \\ns.marker = 5;
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(hasImportMutationDiag(&r));
+}
+
+test "import mutation: ns.member++ 는 build error" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ns from './mod.js';
+        \\ns.marker++;
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(hasImportMutationDiag(&r));
+}
+
+test "import mutation: named import 직접 재대입(marker = v)은 build error" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js",
+        \\import { marker } from './mod.js';
+        \\globalThis.x = 1;
+        \\marker = 5;
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(hasImportMutationDiag(&r));
+}
+
+test "import mutation: let export 직접 재대입(mutable = v)은 build error" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js",
+        \\import { mutable } from './mod.js';
+        \\mutable = 5;
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(hasImportMutationDiag(&r));
+}
+
+// ============================================================
+// 합법: false-positive 가드
+// ============================================================
+
+test "import mutation: named import 객체 멤버 변형(obj.x = v)은 합법" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js",
+        \\import { obj } from './mod.js';
+        \\obj.x = 5;
+        \\globalThis.r = obj.x;
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(!hasImportMutationDiag(&r));
+    try testing.expect(!r.result.hasErrors());
+}
+
+test "import mutation: namespace 의 *중첩* 멤버(ns.obj.x = v)는 합법" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ns from './mod.js';
+        \\globalThis.r = ns.obj;
+        \\ns.obj.x = 5;
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(!hasImportMutationDiag(&r));
+}
+
+test "import mutation: 같은 이름 local 이 shadow 하면 합법" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ns from './mod.js';
+        \\globalThis.r = ns.marker;
+        \\function f(ns) { ns.marker = 5; return ns; }
+        \\globalThis.f = f;
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(!hasImportMutationDiag(&r));
+}
+
+test "import mutation: import 읽기(ns.marker)는 합법" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ns from './mod.js';
+        \\globalThis.r = ns.marker;
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(!hasImportMutationDiag(&r));
+    try testing.expect(!r.result.hasErrors());
+}
+
+test "import mutation: 자기 export let 재대입(x = v)은 합법" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\export let x = 1;
+        \\x = 5;
+        \\globalThis.r = x;
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(!hasImportMutationDiag(&r));
+}
+
+// ============================================================
+// max-review 가 적발한 우회 경로 (for-in/of · destructuring · wrapper) — 전부 거부.
+// ============================================================
+
+fn expectMutationErr(comptime src: []const u8) !void {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js", src);
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(hasImportMutationDiag(&r));
+}
+
+test "import mutation: for-in/of LHS 가 import 바인딩/namespace 멤버면 build error" {
+    try expectMutationErr("import * as ns from './mod.js'; for (ns.marker in {a:1}) {}");
+    try expectMutationErr("import { marker } from './mod.js'; for (marker of [1,2]) {}");
+    try expectMutationErr("import * as ns from './mod.js'; for (ns.marker of [1]) {}");
+}
+
+test "import mutation: destructuring assignment target 도 leaf 까지 검출" {
+    try expectMutationErr("import { marker } from './mod.js'; [marker] = [5];");
+    try expectMutationErr("import { marker } from './mod.js'; ({ a: marker } = { a: 5 });");
+    try expectMutationErr("import * as ns from './mod.js'; [ns.marker] = [5];");
+    try expectMutationErr("import { marker } from './mod.js'; [...marker] = [5];");
+    try expectMutationErr("import { mutable } from './mod.js'; ({ mutable } = { mutable: 5 });");
+}
+
+test "import mutation: parenthesized / TS wrapper 타겟도 언래핑해 검출" {
+    try expectMutationErr("import { marker } from './mod.js'; (marker) = 5;");
+    try expectMutationErr("import * as ns from './mod.js'; (ns.marker) = 5;");
+    try expectMutationErr("import * as ns from './mod.js'; globalThis.r = delete (ns.marker);");
+    try expectMutationErr("import { mutable } from './mod.js'; mutable! = 5;");
+    try expectMutationErr("import * as ns from './mod.js'; ns.marker! = 5;");
+}
+
+test "import mutation: for-in/of 의 선언 head / 로컬 destructure 는 합법" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeMod(&tmp);
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ns from './mod.js';
+        \\globalThis.r = ns.marker;
+        \\for (let k in { a: 1 }) { globalThis.k = k; }
+        \\for (const [v] of [[1]]) { globalThis.v = v; }
+    );
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    try testing.expect(!hasImportMutationDiag(&r));
+    try testing.expect(!r.result.hasErrors());
+}

--- a/src/bundler/graph/parse_module.zig
+++ b/src/bundler/graph/parse_module.zig
@@ -182,7 +182,19 @@ pub fn parseModule(self: *ModuleGraph, io: std.Io, idx: ModuleIndex) void {
         analyzer.is_ts = parser.source_mode == .ts;
         analyzer.is_flow = parser.is_flow;
         analyzer.enable_stmt_info = true; // tree_shaker가 AST 재순회 없이 StmtInfo 사용
+        // import 바인딩/namespace 멤버 변형(`ns.x = v`/`delete ns.x`) 검출 — 번들 단계만
+        // (esbuild/rolldown 처럼 bundle 시 에러, single-file transform/transpile 은 통과).
+        analyzer.check_import_mutation = true;
         const analyze_ok = if (analyzer.analyze()) |_| true else |_| false;
+
+        // import-mutation 진단(ZNTC0805)만 사용자 노출 fatal 로 승격. 다른 semantic 에러
+        // (재선언 등)는 기존대로 번들에서 비-fatal 유지 — 코퍼스 회귀 회피, 범위 한정.
+        for (analyzer.errors.items) |sem_err| {
+            if (sem_err.code == .assign_to_import) {
+                const m = if (sem_err.message.len > 0) sem_err.message else "Cannot assign to or delete an imported binding";
+                self.addDiag(.assign_to_import, .@"error", module.path, sem_err.span, .link, m, null);
+            }
+        }
 
         // OOM 시 semantic = null로 유지 (부분 데이터로 linker가 오동작하는 것 방지)
         if (analyze_ok) {

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -766,6 +766,9 @@ pub const BundlerDiagnostic = struct {
         /// 한 이름이 2개 이상의 서로 다른 `export *` 소스에서 도달 — ESM spec(ResolveExport
         /// ambiguity)상 접근 불가. named import = error, namespace 멤버 = undefined. #3982
         ambiguous_export,
+        /// import 바인딩/namespace 멤버 변형(`marker = v`/`ns.x = v`/`delete ns.x`). ESM:
+        /// import 바인딩 read-only, namespace 객체 sealed. esbuild/rolldown parity (#4020).
+        assign_to_import,
         /// 순환 참조 감지
         circular_dependency,
         /// re-export source가 자기 자신으로 resolve (alias/plugin 잘못)

--- a/src/error_codes.zig
+++ b/src/error_codes.zig
@@ -168,6 +168,10 @@ pub const Code = enum(u16) {
     octal_escape_strict = 802,
     delete_identifier_strict = 803,
     use_strict_non_simple = 804,
+    /// import 바인딩/namespace 멤버 변형(`marker = v`/`ns.x = v`/`delete ns.x`/`ns.x++`).
+    /// ESM: import 바인딩은 read-only, namespace 객체는 sealed. 번들 단계 검출(esbuild/
+    /// rolldown parity — 둘 다 bundle 시 에러, transform/transpile 은 통과).
+    assign_to_import = 805,
 
     // ═══════════════════════════════════════════════════════
     // 0900-0999: 파서 — await/yield/템플릿/JSX/TS/Flow
@@ -413,6 +417,7 @@ pub const Code = enum(u16) {
             .octal_literal_strict => "Octal literals are not allowed in strict mode",
             .octal_escape_strict => "Octal escape sequences are not allowed in strict mode",
             .delete_identifier_strict => "Deleting an identifier is not allowed in strict mode",
+            .assign_to_import => "Cannot assign to or delete an imported binding",
             .use_strict_non_simple => "\"use strict\" not allowed in function with non-simple parameters",
             // 파서: await/yield/템플릿/JSX/TS/Flow
             .await_identifier => "'await' cannot be used as identifier in this context",

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -181,6 +181,10 @@ pub const SemanticAnalyzer = struct {
 
     /// StmtInfo 사전 수집 활성화 여부. 번들러 모드에서만 true.
     enable_stmt_info: bool = false,
+    /// import 바인딩/namespace 멤버 변형(`marker = v`/`ns.x = v`/`delete ns.x`) 검출 활성화.
+    /// 번들 단계(parse_module)에서만 true — esbuild/rolldown 처럼 *bundle* 시에만 에러
+    /// (single-file transpile/transform 은 통과). false 면 checkImportMutation no-op.
+    check_import_mutation: bool = false,
     /// 현재 순회 중인 top-level statement 인덱스. visitProgram 2nd pass 에서만 설정되고
     /// 함수/블록 진입 후에도 유지 — 내부 참조를 enclosing top-level stmt 로 귀속시키는 용도.
     /// tree-shaker `stmt_info` 의 referenced_symbols 분배에 사용된다.
@@ -1187,6 +1191,88 @@ pub const SemanticAnalyzer = struct {
         return false;
     }
 
+    /// 현재 스코프 체인을 따라 name 의 바인딩 DeclFlags 를 순수 조회(reference 미기록).
+    /// shadowing 존중 — 가장 가까운(안쪽) 선언 반환. import 변형 검출용.
+    fn lookupBindingFlags(self: *const SemanticAnalyzer, name: []const u8) ?symbol_mod.DeclFlags {
+        var scope_id = self.current_scope;
+        while (!scope_id.isNone()) {
+            if (self.findSymbolInScope(scope_id, name)) |sym| return sym.decl_flags;
+            const i = scope_id.toIndex();
+            if (i >= self.scopes.items.len) break;
+            scope_id = self.scopes.items[i].parent;
+        }
+        return null;
+    }
+
+    /// import 바인딩/namespace 멤버 변형(assign/update/delete)을 ESM 불법으로 진단(번들 단계만).
+    /// esbuild/rolldown parity: import 바인딩 read-only, namespace 객체 sealed.
+    ///   - target 이 식별자고 import 바인딩(named/namespace) → 에러 (`marker = v`, `delete ns`).
+    ///   - target 이 member 이고 *직접* object 가 namespace import 식별자 → 에러
+    ///     (`ns.x = v`, `delete ns.x`, `ns.x++`). `ns.a.b = v`(중첩)·named import 멤버
+    ///     (`obj.x = v`)는 합법이라 제외. shadowing 된 local 도 lookupBindingFlags 가 제외.
+    /// parenthesized/TS-type wrapper(`(x)`, `x!`, `x as T`)를 벗겨 내부 노드 인덱스 반환.
+    /// 전부 unary.operand 로 내부 표현(transparent type wrapper 는 extern union 으로 동일).
+    fn unwrapTarget(self: *const SemanticAnalyzer, start: NodeIndex) NodeIndex {
+        var idx = start;
+        var guard: u8 = 0;
+        while (guard < 64) : (guard += 1) {
+            if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return idx;
+            const n = self.ast.getNode(idx);
+            if (!Tag.isTransparentWrapper(n.tag)) return idx;
+            idx = n.data.unary.operand;
+        }
+        return idx;
+    }
+
+    fn checkImportMutation(self: *SemanticAnalyzer, target_idx: NodeIndex, is_delete: bool) AllocError!void {
+        if (!self.check_import_mutation) return;
+        const ti = self.unwrapTarget(target_idx);
+        if (ti.isNone() or @intFromEnum(ti) >= self.ast.nodes.items.len) return;
+        const t = self.ast.getNode(ti);
+        switch (t.tag) {
+            .identifier_reference, .assignment_target_identifier => {
+                const flags = self.lookupBindingFlags(self.ast.getSourceText(t.span)) orelse return;
+                if (flags.is_import) try self.addImportMutationError(t.span, is_delete);
+            },
+            .static_member_expression, .computed_member_expression, .private_field_expression => {
+                // object 도 wrapper 언래핑 후 *직접* namespace import 식별자인지. `ns.a.b`(중첩)·
+                // named import 멤버(`obj.x`)는 object 가 namespace import 가 아니라 제외.
+                const obj = self.ast.getNode(self.unwrapTarget(self.ast.readExtraNode(t.data.extra, 0)));
+                if (obj.tag != .identifier_reference) return;
+                const flags = self.lookupBindingFlags(self.ast.getSourceText(obj.span)) orelse return;
+                if (flags.is_namespace_import) try self.addImportMutationError(t.span, is_delete);
+            },
+            // destructuring target — leaf 까지 재귀(visitAsWriteTarget 구조 대응). default 값
+            // (read)은 제외하고 target 부분만 따라간다.
+            .array_assignment_target, .object_assignment_target => {
+                const split = self.ast.nodeListSplitRest(t.data.list);
+                for (split.elements) |raw| try self.checkImportMutation(@enumFromInt(raw), is_delete);
+                if (split.rest_operand) |op| try self.checkImportMutation(op, is_delete);
+            },
+            .assignment_target_property_identifier => try self.checkImportMutation(t.data.binary.left, is_delete),
+            .assignment_target_property_property => try self.checkImportMutation(t.data.binary.right, is_delete),
+            .assignment_target_with_default => try self.checkImportMutation(t.data.binary.left, is_delete),
+            .assignment_target_rest => try self.checkImportMutation(t.data.unary.operand, is_delete),
+            else => {},
+        }
+    }
+
+    fn addImportMutationError(self: *SemanticAnalyzer, span: Span, is_delete: bool) AllocError!void {
+        const msg = try self.allocator.dupe(u8, if (is_delete)
+            "Cannot delete an imported binding or namespace member"
+        else
+            "Cannot assign to an imported binding or namespace member");
+        self.errors.append(self.allocator, .{
+            .span = span,
+            .message = msg,
+            .kind = .semantic,
+            .code = .assign_to_import,
+        }) catch {
+            self.allocator.free(msg);
+            return error.OutOfMemory;
+        };
+    }
+
     // ================================================================
     // 에러 추가
     // ================================================================
@@ -1447,6 +1533,8 @@ pub const SemanticAnalyzer = struct {
             // ---- 일반 표현식 순회 (private name 참조 등을 위해) ----
             .assignment_expression => {
                 const lhs_idx = node.data.binary.left;
+                // ESM(번들): import 바인딩/namespace 멤버 대입 불가 (esbuild/rolldown parity).
+                try self.checkImportMutation(lhs_idx, false);
                 // operator 토큰은 binary.flags 에 저장. compound 면 LHS 는 read+write, 아니면 pure write.
                 const op_kind: token.Kind = @enumFromInt(node.data.binary.flags);
                 const lhs_flags: symbol_mod.ReferenceFlags = if (op_kind.isCompoundAssignment())
@@ -1482,6 +1570,8 @@ pub const SemanticAnalyzer = struct {
                 const extras = self.ast.extra_data.items;
                 if (e < extras.len) {
                     const operand_idx: NodeIndex = @enumFromInt(extras[e]);
+                    // ESM(번들): import 바인딩/namespace 멤버 update(`ns.x++`) 불가.
+                    try self.checkImportMutation(operand_idx, false);
                     if (!self.tryResolveNodeAsRef(operand_idx, .{ .read = true, .write = true })) {
                         if (!operand_idx.isNone() and @intFromEnum(operand_idx) < self.ast.nodes.items.len and
                             self.ast.getNode(operand_idx).tag == .private_field_expression)
@@ -1496,7 +1586,13 @@ pub const SemanticAnalyzer = struct {
             .unary_expression => {
                 // extra: [operand, operator_and_flags]
                 const e = node.data.extra;
-                if (e < self.ast.extra_data.items.len) {
+                if (e + 1 < self.ast.extra_data.items.len) {
+                    const operand_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+                    // ESM(번들): `delete ns.x`(namespace 멤버)·`delete importedBinding` 불가.
+                    const op: token.Kind = @enumFromInt(@as(u8, @truncate(self.ast.extra_data.items[e + 1])));
+                    if (op == .kw_delete) try self.checkImportMutation(operand_idx, true);
+                    try self.visitNode(operand_idx);
+                } else if (e < self.ast.extra_data.items.len) {
                     try self.visitNode(@enumFromInt(self.ast.extra_data.items[e]));
                 }
             },
@@ -2199,6 +2295,17 @@ pub const SemanticAnalyzer = struct {
             // checkStrictBindingName 은 2nd-pass visitImportDeclaration 가 수행
             // (predeclare* 들은 declare 만 하고 strict 검증은 visit 단계 — 일관).
             try self.declareSymbolWithNode(name_span, .import_binding, spec_node.span, @intFromEnum(local_idx));
+            // `import * as ns` 는 namespace 바인딩 표시 — checkImportMutation 의 `ns.x = v`
+            // 판정용. named import(`import {obj}`)는 표시 안 함(객체 멤버 변형은 합법).
+            if (spec_node.tag == .import_namespace_specifier) self.markNamespaceImport(name_span);
+        }
+    }
+
+    /// 방금 선언한 namespace import 심볼에 is_namespace_import 플래그를 set.
+    fn markNamespaceImport(self: *SemanticAnalyzer, name_span: Span) void {
+        const name = self.ast.getSourceText(name_span);
+        if (self.findSymbolIndexInScope(self.current_scope, name)) |si| {
+            self.symbols.items[si].decl_flags.is_namespace_import = true;
         }
     }
 
@@ -2795,6 +2902,10 @@ pub const SemanticAnalyzer = struct {
     fn visitForInOf(self: *SemanticAnalyzer, node: Node) AllocError!void {
         // ternary: { a = left, b = right, c = body }
         const saved = try self.enterScope(.block, self.is_strict_mode);
+        // for-in/of LHS 는 매 iteration 마다 write target — `for(ns.x in y)`/`for(marker of y)`
+        // 처럼 import 바인딩/namespace 멤버를 변형하면 ESM 불법(번들). 선언 head
+        // (`for(let x in y)`)는 variable_declaration 이라 checkImportMutation no-op.
+        try self.checkImportMutation(node.data.ternary.a, false);
         try self.visitNode(node.data.ternary.a);
         try self.visitNode(node.data.ternary.b);
         try self.visitNode(node.data.ternary.c);
@@ -3113,6 +3224,7 @@ pub const SemanticAnalyzer = struct {
                     try self.checkStrictBindingName(spec_node.span);
                     if (self.isInPredeclaredScope()) continue;
                     try self.declareSymbolWithNode(spec_node.span, .import_binding, spec_node.span, @intFromEnum(spec_idx));
+                    self.markNamespaceImport(spec_node.span);
                 },
                 .import_specifier => {
                     const local_idx = spec_node.data.binary.right;

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -134,8 +134,10 @@ pub const DeclFlags = packed struct(u16) {
     /// inner name binding. ECMA spec: 외부 scope 에서 안 보이고 `.name` 프로퍼티로만
     /// 관찰됨. mangler 가 이 이름을 mangle 하면 `.name` 도 변하므로 (#2197) skip.
     is_class_expr_name: bool = false,
-    /// 나머지 패딩
-    _padding: u1 = 0,
+    /// `import * as ns` 네임스페이스 import 바인딩. is_import 와 함께 set.
+    /// `ns.x = v`/`delete ns.x` 등 namespace 멤버 변형이 ESM-불법(namespace 객체 sealed)
+    /// 인지 판정. named import(`import {obj}`) 멤버 변형(`obj.x=v`)은 합법이라 구분 필요.
+    is_namespace_import: bool = false,
 
     /// 모든 "값(value)" 비트. 재선언 체크에 사용할 전체 마스크.
     pub const all_values: DeclFlags = .{


### PR DESCRIPTION
## 문제 (#4020)

ESM 에서 import 바인딩은 read-only, namespace 객체는 sealed. **esbuild·rolldown 은 import 변형을 bundle 시 빌드 에러**로 막는데(둘 다 전 케이스), zntc 는 전부 통과시켜 왔습니다. 특히 `delete ns.x` 는 strict 번들에서 `delete <bare-identifier>` 로 emit 돼 **SyntaxError 로 번들 전체가 깨지고**, 일부 destructuring/for-of 변형은 const 재대입으로 런타임 크래시했습니다.

### 3-번들러 비교 (규칙 확정)
| 케이스 | esbuild | rolldown | node 런타임 | zntc(before) |
|---|---|---|---|---|
| `delete ns.x` / `ns.x = v` / `marker = v` / `ns.x++` | ERR | ERR | TypeError | 통과(일부 SyntaxError 번들깨짐) |
| `import {obj}; obj.x = v` (named 객체 멤버) | ok | ok | ok | 통과 ✓(합법) |

esbuild·rolldown 모두 **bundle 시 에러, single-file transform 은 통과**.

## 수정

검출은 **semantic analyzer**, 번들 단계 gate(`check_import_mutation`)로만 활성화 → single-file transpile/transform 은 통과(esbuild transform parity). 진단(ZNTC0805)만 `parse_module` 가 fatal 로 승격 — 다른 semantic 에러(재선언 등)는 기존대로 비-fatal(코퍼스 회귀 회피).

`checkImportMutation` 은 **재귀**:
- import 바인딩 직접 변형 (`marker = v`/`marker++`/`delete marker`/`ns = v`)
- `import * as ns` 의 *직접* 멤버 변형 (`ns.x = v`/`ns.x++`/`delete ns.x`) — `is_namespace_import` 플래그로 named import(`obj.x=v` 합법)·중첩(`ns.a.b=v` 합법)과 구분
- parenthesized/TS wrapper(`(x)`/`x!`/`x as T`) 언래핑
- destructuring target(`[marker]=x`/`({a:marker}=x)`/`[...marker]`) leaf 재귀
- for-in/of LHS(`for(ns.x in y)`/`for(marker of y)`)
- shadowing 된 local 은 scope-walk 가 제외(false-positive 0)

## 코드 리뷰 (`/code-review max`)

- **정식 max(45 에이전트)** 가 초기 구현의 false-negative(for-in/of·destructuring·paren/TS wrapper — 일부는 런타임 크래시 번들 emit) 적발 → **checkImportMutation 재귀화**로 전부 수정.
- **focused false-positive 리뷰**(9 카테고리 + ~30 adversarial 엣지): **오탐 0**. 재귀가 leaf-scoped(default/computed-key 는 read, shadowing 존중, TS 래퍼 대칭, crash/무한루프 없음).

## 검증 (node/esbuild parity)

- 거부 ~16 케이스(직접/ns멤버/delete/update/destructuring/for-in-of/paren/TS) 전부 ERR
- 합법 케이스(named 멤버/중첩/shadow/read/for-let/local destructure/own-export-let) 전부 통과
- transpile 통과(esbuild transform parity)
- 전체 유닛 `zig build test` ✅ / lib-scenario 19 ✅ / browser-smoke 95(실제 라이브러리, 코퍼스 회귀 0) ✅

## 회귀 테스트

`src/bundler/bundler_test/import_mutation.zig` — 거부/합법 양방향, max-review 가 적발한 우회 경로(for-in-of/destructuring/wrapper) 포함.

Closes #4020

🤖 Generated with [Claude Code](https://claude.com/claude-code)