### PR TITLE
feat(site): 벤치마크 2026-05-30 고반복 재측정 갱신 + 플레이그라운드 반응형 사이드바

### DIFF
--- a/documents/src/components/Playground.tsx
+++ b/documents/src/components/Playground.tsx
@@ -226,10 +226,14 @@ export default function Playground() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
   const [options, setOptions] = useState<Options>({ ...DEFAULT_OPTIONS, ...hashData.options });
-  const [showConfig, setShowConfig] = useState(true);
+  // 데스크탑은 펼침, 모바일(<768px)은 닫힘으로 시작 — 좁은 화면에서 에디터가 가려지지 않게.
+  const [showConfig, setShowConfig] = useState(() =>
+    typeof window === "undefined" ? true : window.innerWidth >= 768,
+  );
   const [outputTab, setOutputTab] = useState<"code" | "sourcemap">("code");
   const transpileFnRef = useRef<TranspileFn | undefined>(undefined);
   const inputEditorRef = useRef<any>(null);
+  const outputEditorRef = useRef<any>(null);
   const monacoRef = useRef<any>(null);
   const [sourcemapOutput, setSourcemapOutput] = useState("");
 
@@ -308,6 +312,16 @@ export default function Playground() {
     })();
   }, []);
 
+  // 사이드바 펼침/닫힘으로 에디터 영역 폭이 바뀌면 Monaco 를 즉시 재레이아웃.
+  // (automaticLayout 이 켜져 있어도 transition 직후 한 번 강제로 맞춰 줘야 깔끔하다.)
+  useEffect(() => {
+    const id = setTimeout(() => {
+      inputEditorRef.current?.layout?.();
+      outputEditorRef.current?.layout?.();
+    }, 60);
+    return () => clearTimeout(id);
+  }, [showConfig]);
+
   function handleInputChange(value: string | undefined) {
     const code = value ?? "";
     setInput(code);
@@ -372,6 +386,7 @@ export default function Playground() {
   }
 
   function handleOutputMount(editor: any) {
+    outputEditorRef.current = editor;
     setTimeout(() => {
       editor.layout();
       const m = (window as any).monaco;
@@ -387,10 +402,16 @@ export default function Playground() {
       className="not-content playground-root flex flex-col overflow-hidden bg-surface-950"
       style={{ height: "calc(100vh - 64px)" }}
     >
-      <div className="flex shrink-0 items-center justify-between border-b border-surface-800 bg-surface-900 px-4 py-2">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-surface-800 bg-surface-900 px-4 py-2">
         <div className="flex items-center gap-2">
-          <button type="button" onClick={() => setShowConfig(!showConfig)} className={BTN_CLASS}>
-            {showConfig ? "◀" : "▶"}
+          <button
+            type="button"
+            onClick={() => setShowConfig(!showConfig)}
+            className={BTN_CLASS}
+            aria-label={showConfig ? "옵션 패널 닫기" : "옵션 패널 열기"}
+            aria-expanded={showConfig}
+          >
+            {showConfig ? "✕" : "☰"}
           </button>
           <a href="/zntc/" className="text-sm font-bold text-neutral-200 no-underline">
             ZNTC Playground
@@ -427,9 +448,17 @@ export default function Playground() {
         </div>
       </div>
 
-      <div className="flex flex-1 overflow-hidden">
+      <div className="relative flex flex-1 overflow-hidden">
         {showConfig && (
-          <div className="pg-config w-60 min-w-[15rem] shrink-0 overflow-y-auto border-r border-surface-800 bg-surface-900 p-3 text-[13px]">
+          <>
+            {/* 모바일: 옵션 패널을 오버레이 드로어로 띄우고 뒤 배경 탭하면 닫힘 */}
+            <button
+              type="button"
+              aria-label="옵션 패널 닫기"
+              onClick={() => setShowConfig(false)}
+              className="absolute inset-0 z-30 cursor-default border-0 bg-black/50 p-0 md:hidden"
+            />
+            <div className="pg-config absolute inset-y-0 left-0 z-40 w-60 min-w-0 max-w-[85vw] shrink-0 overflow-y-auto border-r border-surface-800 bg-surface-900 p-3 text-[13px] md:static md:z-auto md:min-w-[15rem] md:max-w-none">
             <Section title="Parser">
               <Sel label="Language" value={options.filename} onChange={(v) => updateOption("filename", v)} options={[["input.tsx","TypeScript+JSX"],["input.ts","TypeScript"],["input.jsx","JavaScript+JSX"],["input.js","JavaScript"]]} />
               <Chk label="Flow" checked={options.flow} onChange={(v) => updateOption("flow", v)} />
@@ -467,10 +496,11 @@ export default function Playground() {
               <Chk label="console.*" checked={options.dropConsole} onChange={(v) => updateOption("dropConsole", v)} />
               <Chk label="debugger" checked={options.dropDebugger} onChange={(v) => updateOption("dropDebugger", v)} />
             </Section>
-          </div>
+            </div>
+          </>
         )}
 
-        <div className="pg-editors flex flex-1 overflow-hidden">
+        <div className="pg-editors flex min-w-0 flex-1 flex-col overflow-hidden md:flex-row">
           <EditorPanel
             header={
               <span>
@@ -480,7 +510,7 @@ export default function Playground() {
           >
             <Editor height="100%" language={inputLang} theme="vs-dark" value={input} onChange={handleInputChange} onMount={handleInputMount} options={editorOpts} />
           </EditorPanel>
-          <div className="pg-divider w-[2px] shrink-0 bg-surface-800" />
+          <div className="pg-divider h-[2px] w-full shrink-0 bg-surface-800 md:h-auto md:w-[2px]" />
           <EditorPanel
             header={
               <div className="flex w-full items-center justify-between">

--- a/documents/src/components/PlaygroundBundler.tsx
+++ b/documents/src/components/PlaygroundBundler.tsx
@@ -374,7 +374,10 @@ export default function PlaygroundBundler() {
   const [activeChunkPath, setActiveChunkPath] = useState<string>("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
-  const [showSidebar, setShowSidebar] = useState(true);
+  // 데스크탑은 펼침, 모바일(<768px)은 닫힘으로 시작 — 좁은 화면에서 에디터가 가려지지 않게.
+  const [showSidebar, setShowSidebar] = useState(() =>
+    typeof window === "undefined" ? true : window.innerWidth >= 768,
+  );
   const wasmRef = useRef<WasmModule | null>(null);
   const vfsRef = useRef<InstanceType<WasmModule["VirtualFileSystem"]> | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -547,15 +550,16 @@ export default function PlaygroundBundler() {
       className="not-content playground-root flex flex-col overflow-hidden bg-surface-950"
       style={{ height: "calc(100vh - 64px)" }}
     >
-      <div className="flex shrink-0 items-center justify-between border-b border-surface-800 bg-surface-900 px-4 py-2">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-surface-800 bg-surface-900 px-4 py-2">
         <div className="flex items-center gap-2">
           <button
             type="button"
             onClick={() => setShowSidebar(!showSidebar)}
             className={BTN_CLASS}
-            aria-label="Toggle file panel"
+            aria-label={showSidebar ? "파일 패널 닫기" : "파일 패널 열기"}
+            aria-expanded={showSidebar}
           >
-            {showSidebar ? "◀" : "▶"}
+            {showSidebar ? "✕" : "☰"}
           </button>
           <a href={`${BASE_URL}playground/`} className="text-sm font-bold text-neutral-200 no-underline">
             ZNTC Bundler Playground
@@ -600,9 +604,17 @@ export default function PlaygroundBundler() {
         </div>
       </div>
 
-      <div className="flex flex-1 overflow-hidden">
+      <div className="relative flex flex-1 overflow-hidden">
         {showSidebar && (
-          <div className="w-56 min-w-[14rem] shrink-0 overflow-y-auto border-r border-surface-800 bg-surface-900 p-2 text-[13px]">
+          <>
+            {/* 모바일: 파일/옵션 패널을 오버레이 드로어로 띄우고 뒤 배경 탭하면 닫힘 */}
+            <button
+              type="button"
+              aria-label="파일 패널 닫기"
+              onClick={() => setShowSidebar(false)}
+              className="absolute inset-0 z-30 cursor-default border-0 bg-black/50 p-0 md:hidden"
+            />
+            <div className="absolute inset-y-0 left-0 z-40 w-56 min-w-0 max-w-[85vw] shrink-0 overflow-y-auto border-r border-surface-800 bg-surface-900 p-2 text-[13px] md:static md:z-auto md:min-w-[14rem] md:max-w-none">
             <div className="mb-2 flex items-center justify-between border-b border-surface-800 pb-1">
               <span className="text-[11px] font-bold uppercase tracking-[0.08em] text-neutral-400">
                 Files
@@ -842,10 +854,11 @@ export default function PlaygroundBundler() {
                 />
               </Section>
             </div>
-          </div>
+            </div>
+          </>
         )}
 
-        <div className="flex flex-1 overflow-hidden">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden md:flex-row">
           <EditorPanel
             header={
               <span>
@@ -863,7 +876,7 @@ export default function PlaygroundBundler() {
               options={editorOpts}
             />
           </EditorPanel>
-          <div className="w-[2px] shrink-0 bg-surface-800" />
+          <div className="h-[2px] w-full shrink-0 bg-surface-800 md:h-auto md:w-[2px]" />
           <EditorPanel
             header={
               <div className="flex w-full items-center justify-between gap-2">

--- a/documents/src/content/docs/en/index.mdx
+++ b/documents/src/content/docs/en/index.mdx
@@ -43,12 +43,12 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <StatsStrip
   stats={[
-    { value: "13", unit: "ms", label: "Transpile", caption: "1K LOC · TypeScript" },
-    { value: "11", unit: "ms", label: "Bundle", caption: "10 modules" },
-    { value: "19", unit: "×", label: "faster", caption: "vs rolldown (small)" },
+    { value: "4.1", unit: "ms", label: "Transpile", caption: "1K LOC · TypeScript" },
+    { value: "4.3", unit: "ms", label: "Bundle", caption: "10 modules" },
+    { value: "11", unit: "×", label: "faster", caption: "vs rolldown (small)" },
     { value: "340", unit: "+", label: "Doc pages", caption: "ko · en" },
   ]}
-  note="As of 2026-05-25 · darwin arm64 · 20-run median"
+  note="As of 2026-05-30 · darwin arm64 · 50-run median"
 />
 
 <Section padding="py-16">
@@ -60,29 +60,29 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     <div class="mt-6 grid gap-4 text-sm sm:grid-cols-3">
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">small (10 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">11.4 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">4.3 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs esbuild 29.4 · Bun 68.8 · rolldown 219 · rspack 304 ms
+          vs Bun 5.0 · esbuild 6.5 · rolldown 48 · rspack 56 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">medium (1000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">46.5 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">16.5 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(tied 1st)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 65.9 · esbuild 88.2 · rolldown 333 · rspack 679 ms
+          vs Bun 16.1 · esbuild 19.7 · rolldown 65 · rspack 82 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">large (5000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">177 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2nd)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">67.6 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2nd)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 174 · esbuild 334 · rolldown 599 · rspack 1279 ms
+          vs Bun 55.2 · esbuild 73 · rolldown 119 · rspack 173 ms
         </div>
       </div>
     </div>
 
     <p class="mt-6 text-center text-xs text-[color:var(--sl-color-gray-3)]">
-      2026-05-25 · darwin arm64 · 20-run median · fan-out tree fixture (see <a href="/zntc/en/reference/benchmarks/" class="text-zig-400 hover:underline">full benchmarks →</a>)
+      2026-05-30 · darwin arm64 · 50-run median · fan-out tree fixture (see <a href="/zntc/en/reference/benchmarks/" class="text-zig-400 hover:underline">full benchmarks →</a>)
     </p>
   </div>
 </Section>
@@ -106,9 +106,9 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">effect</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">122 KB</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">114 KB</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          <strong>1.16–1.56× smaller</strong> than esbuild 191 KB · rspack 142 KB
+          <strong>1.25–1.69× smaller</strong> than esbuild 191 KB · rspack 142 KB
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
@@ -121,7 +121,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     </div>
 
     <p class="mt-6 text-center text-xs text-[color:var(--sl-color-gray-3)]">
-      2026-05-17 · darwin arm64 · 9 real npm libraries · <code>--minify-all</code> (see <a href="/zntc/en/reference/benchmarks/" class="text-zig-400 hover:underline">full benchmarks →</a>)
+      2026-05-30 · darwin arm64 · 9 real npm libraries · <code>--minify-all</code> (see <a href="/zntc/en/reference/benchmarks/" class="text-zig-400 hover:underline">full benchmarks →</a>)
     </p>
   </div>
 </Section>

--- a/documents/src/content/docs/en/reference/benchmarks.mdx
+++ b/documents/src/content/docs/en/reference/benchmarks.mdx
@@ -10,12 +10,12 @@ ZNTC compares transpile and bundle performance — and final bundle size (tree-s
 ## Environment
 
 - **Platform**: `darwin arm64`
-- **Baseline date**: 2026-05-21
-- **CLI**: `bench.ts`, 20-run median, direct CLI binary execution without npx overhead
-- **NAPI / WASM / CLI**: `napi-bench.ts`, 5 warmups + 20-run median
-- **Bundle perf**: `bundle-perf.ts`, 5 warmups + 20-run median, CI-style same-run ZNTC/Rolldown/Rspack comparison
-- **Pipeline**: `pipeline.ts`, 5-run median, profile total
-- **Bundle size**: `smoke.ts --minify-all`, 2026-05-17, 9 real npm libraries bundled + minified, raw output bytes
+- **Baseline date**: 2026-05-30
+- **CLI**: `bench.ts`, 50-run median, direct CLI binary execution without npx overhead
+- **NAPI / WASM / CLI**: `napi-bench.ts`, 10 warmups + 100-run median
+- **Bundle perf**: `bundle-perf.ts`, 5 warmups + 50-run median, CI-style same-run ZNTC/Rolldown/Rspack comparison
+- **Pipeline**: `pipeline.ts`, 15-run median, profile total
+- **Bundle size**: `smoke.ts --minify-all`, 2026-05-30, 9 real npm libraries bundled + minified, raw output bytes
 
 For time charts, lower is faster (bar label = median wall time). For the bundle-size chart, lower is smaller (bar label = raw bytes).
 

--- a/documents/src/content/docs/index.mdx
+++ b/documents/src/content/docs/index.mdx
@@ -43,12 +43,12 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <StatsStrip
   stats={[
-    { value: "13", unit: "ms", label: "트랜스파일", caption: "1K LOC · TypeScript" },
-    { value: "11", unit: "ms", label: "번들링", caption: "10 modules" },
-    { value: "19", unit: "×", label: "faster", caption: "vs rolldown (small)" },
+    { value: "4.1", unit: "ms", label: "트랜스파일", caption: "1K LOC · TypeScript" },
+    { value: "4.3", unit: "ms", label: "번들링", caption: "10 modules" },
+    { value: "11", unit: "×", label: "faster", caption: "vs rolldown (small)" },
     { value: "340", unit: "+", label: "문서 페이지", caption: "ko · en 지원" },
   ]}
-  note="2026-05-25 기준 · darwin arm64 · 20회 median"
+  note="2026-05-30 기준 · darwin arm64 · 50회 median"
 />
 
 <Section padding="py-16">
@@ -60,29 +60,29 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     <div class="mt-6 grid gap-4 text-sm sm:grid-cols-3">
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">small (10 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">11.4 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">4.3 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs esbuild 29.4 · Bun 68.8 · rolldown 219 · rspack 304 ms
+          vs Bun 5.0 · esbuild 6.5 · rolldown 48 · rspack 56 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">medium (1000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">46.5 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">16.5 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(공동 1위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 65.9 · esbuild 88.2 · rolldown 333 · rspack 679 ms
+          vs Bun 16.1 · esbuild 19.7 · rolldown 65 · rspack 82 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">large (5000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">177 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2위)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">67.6 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 174 · esbuild 334 · rolldown 599 · rspack 1279 ms
+          vs Bun 55.2 · esbuild 73 · rolldown 119 · rspack 173 ms
         </div>
       </div>
     </div>
 
     <p class="mt-6 text-center text-xs text-[color:var(--sl-color-gray-3)]">
-      2026-05-25 · darwin arm64 · 20회 median · fan-out tree fixture (자세히는 <a href="/zntc/reference/benchmarks/" class="text-zig-400 hover:underline">전체 벤치마크 →</a>)
+      2026-05-30 · darwin arm64 · 50회 median · fan-out tree fixture (자세히는 <a href="/zntc/reference/benchmarks/" class="text-zig-400 hover:underline">전체 벤치마크 →</a>)
     </p>
   </div>
 </Section>
@@ -106,9 +106,9 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">effect</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">122 KB</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">114 KB</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          esbuild 191 KB · rspack 142 KB 대비 <strong>1.16–1.56× 작음</strong>
+          esbuild 191 KB · rspack 142 KB 대비 <strong>1.25–1.69× 작음</strong>
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
@@ -121,7 +121,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
     </div>
 
     <p class="mt-6 text-center text-xs text-[color:var(--sl-color-gray-3)]">
-      2026-05-17 · darwin arm64 · 9개 실제 npm 라이브러리 · <code>--minify-all</code> (자세히는 <a href="/zntc/reference/benchmarks/" class="text-zig-400 hover:underline">전체 벤치마크 →</a>)
+      2026-05-30 · darwin arm64 · 9개 실제 npm 라이브러리 · <code>--minify-all</code> (자세히는 <a href="/zntc/reference/benchmarks/" class="text-zig-400 hover:underline">전체 벤치마크 →</a>)
     </p>
   </div>
 </Section>

--- a/documents/src/content/docs/reference/benchmarks.mdx
+++ b/documents/src/content/docs/reference/benchmarks.mdx
@@ -10,12 +10,12 @@ ZNTC의 트랜스파일/번들 성능과 최종 번들 크기(tree-shaking + min
 ## 측정 환경
 
 - **Platform**: `darwin arm64`
-- **기준 일시**: 2026-05-21
-- **CLI**: `bench.ts` median 20회, 직접 CLI 바이너리 실행 (npx 오버헤드 제거)
-- **NAPI / WASM / CLI**: `napi-bench.ts` warmup 5회 + median 20회
-- **Bundle perf**: `bundle-perf.ts` warmup 5회 + median 20회, CI와 같은 ZNTC/Rolldown/Rspack same-run 비교
-- **Pipeline**: `pipeline.ts` median 5회, profile total 기준
-- **번들 크기**: `smoke.ts --minify-all`, 2026-05-17, 실제 npm 라이브러리 9종을 번들 + minify 한 raw 출력 바이트
+- **기준 일시**: 2026-05-30
+- **CLI**: `bench.ts` median 50회, 직접 CLI 바이너리 실행 (npx 오버헤드 제거)
+- **NAPI / WASM / CLI**: `napi-bench.ts` warmup 10회 + median 100회
+- **Bundle perf**: `bundle-perf.ts` warmup 5회 + median 50회, CI와 같은 ZNTC/Rolldown/Rspack same-run 비교
+- **Pipeline**: `pipeline.ts` median 15회, profile total 기준
+- **번들 크기**: `smoke.ts --minify-all`, 2026-05-30, 실제 npm 라이브러리 9종을 번들 + minify 한 raw 출력 바이트
 
 시간 차트는 낮을수록 빠르며(막대 끝 숫자 = median wall time), 번들 크기 차트는 낮을수록 작습니다(막대 끝 숫자 = raw bytes).
 

--- a/documents/src/data/benchmark-data.json
+++ b/documents/src/data/benchmark-data.json
@@ -1,109 +1,125 @@
 {
-  "date": "2026-05-25",
+  "date": "2026-05-30",
   "platform": "darwin arm64",
   "runs": {
-    "cli": { "iterations": 20 },
-    "napi": { "warmup": 5, "iterations": 20 },
-    "bundlePerf": { "warmup": 5, "iterations": 20 },
-    "pipeline": { "iterations": 5 }
+    "cli": { "iterations": 50 },
+    "napi": { "warmup": 10, "iterations": 100 },
+    "bundlePerf": { "warmup": 5, "iterations": 50 },
+    "pipeline": { "iterations": 15 }
   },
   "results": {
     "transpileCli": [
-      { "tool": "ZNTC", "scale": "small (100 lines)", "medianMs": 5.07, "minMs": 2.57, "maxMs": 53.0, "p95Ms": 40.7 },
-      { "tool": "esbuild", "scale": "small (100 lines)", "medianMs": 14.1, "minMs": 8.69, "maxMs": 117, "p95Ms": 79.0 },
-      { "tool": "Bun", "scale": "small (100 lines)", "medianMs": 23.3, "minMs": 10.5, "maxMs": 103, "p95Ms": 70.3 },
-      { "tool": "oxc (node)", "scale": "small (100 lines)", "medianMs": 50.3, "minMs": 33.9, "maxMs": 177, "p95Ms": 84.2 },
-      { "tool": "SWC", "scale": "small (100 lines)", "medianMs": 247, "minMs": 130, "maxMs": 574, "p95Ms": 551 },
+      { "tool": "ZNTC", "scale": "small (100 lines)", "medianMs": 3.34, "minMs": 3.04, "maxMs": 4.04, "p95Ms": 3.75 },
+      { "tool": "Bun", "scale": "small (100 lines)", "medianMs": 3.59, "minMs": 3.4, "maxMs": 3.91, "p95Ms": 3.85 },
+      { "tool": "esbuild", "scale": "small (100 lines)", "medianMs": 3.67, "minMs": 3.41, "maxMs": 5.26, "p95Ms": 4.4 },
+      { "tool": "oxc (node)", "scale": "small (100 lines)", "medianMs": 17.7, "minMs": 17, "maxMs": 18.6, "p95Ms": 18.4 },
+      { "tool": "SWC", "scale": "small (100 lines)", "medianMs": 47.1, "minMs": 46.1, "maxMs": 48.7, "p95Ms": 48 },
 
-      { "tool": "ZNTC", "scale": "medium (1K lines)", "medianMs": 12.8, "minMs": 6.75, "maxMs": 82.4, "p95Ms": 52.9 },
-      { "tool": "Bun", "scale": "medium (1K lines)", "medianMs": 17.9, "minMs": 9.63, "maxMs": 47.6, "p95Ms": 32.1 },
-      { "tool": "esbuild", "scale": "medium (1K lines)", "medianMs": 33.3, "minMs": 10.1, "maxMs": 107, "p95Ms": 92.2 },
-      { "tool": "oxc (node)", "scale": "medium (1K lines)", "medianMs": 69.8, "minMs": 37.1, "maxMs": 120, "p95Ms": 104 },
-      { "tool": "SWC", "scale": "medium (1K lines)", "medianMs": 248, "minMs": 140, "maxMs": 633, "p95Ms": 480 },
+      { "tool": "esbuild", "scale": "medium (1K lines)", "medianMs": 3.63, "minMs": 3.37, "maxMs": 3.97, "p95Ms": 3.94 },
+      { "tool": "Bun", "scale": "medium (1K lines)", "medianMs": 3.97, "minMs": 3.82, "maxMs": 4.35, "p95Ms": 4.29 },
+      { "tool": "ZNTC", "scale": "medium (1K lines)", "medianMs": 4.1, "minMs": 3.76, "maxMs": 5.4, "p95Ms": 4.66 },
+      { "tool": "oxc (node)", "scale": "medium (1K lines)", "medianMs": 18.5, "minMs": 17, "maxMs": 20.4, "p95Ms": 20.2 },
+      { "tool": "SWC", "scale": "medium (1K lines)", "medianMs": 49.4, "minMs": 48.5, "maxMs": 52.6, "p95Ms": 50.8 },
 
-      { "tool": "ZNTC", "scale": "large (5K lines)", "medianMs": 16.0, "minMs": 8.85, "maxMs": 43.5, "p95Ms": 31.0 },
-      { "tool": "Bun", "scale": "large (5K lines)", "medianMs": 19.9, "minMs": 11.1, "maxMs": 193, "p95Ms": 77.3 },
-      { "tool": "esbuild", "scale": "large (5K lines)", "medianMs": 35.2, "minMs": 9.41, "maxMs": 134, "p95Ms": 106 },
-      { "tool": "oxc (node)", "scale": "large (5K lines)", "medianMs": 51.2, "minMs": 37.5, "maxMs": 84.3, "p95Ms": 82.5 },
-      { "tool": "SWC", "scale": "large (5K lines)", "medianMs": 279, "minMs": 167, "maxMs": 469, "p95Ms": 436 }
+      { "tool": "esbuild", "scale": "large (5K lines)", "medianMs": 3.67, "minMs": 3.42, "maxMs": 5.04, "p95Ms": 4.01 },
+      { "tool": "Bun", "scale": "large (5K lines)", "medianMs": 5.79, "minMs": 5.59, "maxMs": 6.15, "p95Ms": 6.06 },
+      { "tool": "ZNTC", "scale": "large (5K lines)", "medianMs": 7.12, "minMs": 6.83, "maxMs": 7.5, "p95Ms": 7.39 },
+      { "tool": "oxc (node)", "scale": "large (5K lines)", "medianMs": 17.8, "minMs": 17.1, "maxMs": 19.3, "p95Ms": 18.4 },
+      { "tool": "SWC", "scale": "large (5K lines)", "medianMs": 55.6, "minMs": 54.6, "maxMs": 60.1, "p95Ms": 58.3 }
     ],
     "bundleCli": [
-      { "tool": "ZNTC", "scale": "small (10 modules)", "medianMs": 11.4, "minMs": 5.16, "maxMs": 50.1, "p95Ms": 47.9 },
-      { "tool": "esbuild", "scale": "small (10 modules)", "medianMs": 29.4, "minMs": 23.2, "maxMs": 52.0, "p95Ms": 51.6 },
-      { "tool": "Bun", "scale": "small (10 modules)", "medianMs": 68.8, "minMs": 20.7, "maxMs": 140, "p95Ms": 138 },
-      { "tool": "rolldown", "scale": "small (10 modules)", "medianMs": 219, "minMs": 134, "maxMs": 357, "p95Ms": 354 },
-      { "tool": "rspack", "scale": "small (10 modules)", "medianMs": 304, "minMs": 181, "maxMs": 560, "p95Ms": 550 },
+      { "tool": "ZNTC", "scale": "small (10 modules)", "medianMs": 4.28, "minMs": 3.94, "maxMs": 4.64, "p95Ms": 4.54 },
+      { "tool": "Bun", "scale": "small (10 modules)", "medianMs": 5.05, "minMs": 4.77, "maxMs": 6.33, "p95Ms": 5.74 },
+      { "tool": "esbuild", "scale": "small (10 modules)", "medianMs": 6.53, "minMs": 6.25, "maxMs": 6.99, "p95Ms": 6.78 },
+      { "tool": "rolldown", "scale": "small (10 modules)", "medianMs": 47.9, "minMs": 47, "maxMs": 50.8, "p95Ms": 49.2 },
+      { "tool": "rspack", "scale": "small (10 modules)", "medianMs": 56, "minMs": 55, "maxMs": 60.5, "p95Ms": 57.6 },
 
-      { "tool": "ZNTC", "scale": "medium (1000 modules)", "medianMs": 46.5, "minMs": 28.0, "maxMs": 103, "p95Ms": 92.7 },
-      { "tool": "Bun", "scale": "medium (1000 modules)", "medianMs": 65.9, "minMs": 38.0, "maxMs": 193, "p95Ms": 132 },
-      { "tool": "esbuild", "scale": "medium (1000 modules)", "medianMs": 88.2, "minMs": 58.9, "maxMs": 158, "p95Ms": 142 },
-      { "tool": "rolldown", "scale": "medium (1000 modules)", "medianMs": 333, "minMs": 162, "maxMs": 683, "p95Ms": 575 },
-      { "tool": "rspack", "scale": "medium (1000 modules)", "medianMs": 679, "minMs": 306, "maxMs": 1041, "p95Ms": 929 },
+      { "tool": "Bun", "scale": "medium (1000 modules)", "medianMs": 16.1, "minMs": 13.2, "maxMs": 17.7, "p95Ms": 17.5 },
+      { "tool": "ZNTC", "scale": "medium (1000 modules)", "medianMs": 16.5, "minMs": 16.2, "maxMs": 17.1, "p95Ms": 17 },
+      { "tool": "esbuild", "scale": "medium (1000 modules)", "medianMs": 19.7, "minMs": 19.2, "maxMs": 20.2, "p95Ms": 20.2 },
+      { "tool": "rolldown", "scale": "medium (1000 modules)", "medianMs": 64.9, "minMs": 62.2, "maxMs": 68.5, "p95Ms": 68.1 },
+      { "tool": "rspack", "scale": "medium (1000 modules)", "medianMs": 81.6, "minMs": 79, "maxMs": 91.9, "p95Ms": 82.7 },
 
-      { "tool": "Bun", "scale": "large (5000 modules)", "medianMs": 174, "minMs": 121, "maxMs": 256, "p95Ms": 240 },
-      { "tool": "ZNTC", "scale": "large (5000 modules)", "medianMs": 177, "minMs": 139, "maxMs": 270, "p95Ms": 254 },
-      { "tool": "esbuild", "scale": "large (5000 modules)", "medianMs": 334, "minMs": 257, "maxMs": 569, "p95Ms": 479 },
-      { "tool": "rolldown", "scale": "large (5000 modules)", "medianMs": 599, "minMs": 337, "maxMs": 1055, "p95Ms": 941 },
-      { "tool": "rspack", "scale": "large (5000 modules)", "medianMs": 1279, "minMs": 825, "maxMs": 1691, "p95Ms": 1682 }
+      { "tool": "Bun", "scale": "large (5000 modules)", "medianMs": 55.2, "minMs": 50.6, "maxMs": 66.9, "p95Ms": 62.8 },
+      { "tool": "ZNTC", "scale": "large (5000 modules)", "medianMs": 67.6, "minMs": 66.3, "maxMs": 68.8, "p95Ms": 68.5 },
+      { "tool": "esbuild", "scale": "large (5000 modules)", "medianMs": 72.8, "minMs": 71.8, "maxMs": 73.8, "p95Ms": 73.4 },
+      { "tool": "rolldown", "scale": "large (5000 modules)", "medianMs": 119, "minMs": 115, "maxMs": 126, "p95Ms": 121 },
+      { "tool": "rspack", "scale": "large (5000 modules)", "medianMs": 173, "minMs": 167, "maxMs": 187, "p95Ms": 180 }
     ],
     "napiWasmCli": [
-      { "tool": "NAPI (.node)", "scale": "small (100 lines)", "medianMs": 0.139, "minMs": 0.058, "maxMs": 0.221, "p95Ms": 0.211 },
-      { "tool": "WASM (.wasm)", "scale": "small (100 lines)", "medianMs": 0.995, "minMs": 0.593, "maxMs": 2.578, "p95Ms": 2.085 },
-      { "tool": "CLI (subprocess)", "scale": "small (100 lines)", "medianMs": 9.901, "minMs": 7.096, "maxMs": 69.787, "p95Ms": 49.551 },
+      { "tool": "NAPI (.node)", "scale": "small (100 lines)", "medianMs": 0.049, "minMs": 0.048, "maxMs": 0.061, "p95Ms": 0.054 },
+      { "tool": "WASM (.wasm)", "scale": "small (100 lines)", "medianMs": 0.13, "minMs": 0.108, "maxMs": 0.942, "p95Ms": 0.343 },
+      { "tool": "CLI (subprocess)", "scale": "small (100 lines)", "medianMs": 2.967, "minMs": 2.77, "maxMs": 3.442, "p95Ms": 3.326 },
 
-      { "tool": "NAPI (.node)", "scale": "medium (1K lines)", "medianMs": 0.534, "minMs": 0.531, "maxMs": 7.337, "p95Ms": 4.306 },
-      { "tool": "WASM (.wasm)", "scale": "medium (1K lines)", "medianMs": 3.571, "minMs": 1.518, "maxMs": 80.927, "p95Ms": 72.222 },
-      { "tool": "CLI (subprocess)", "scale": "medium (1K lines)", "medianMs": 72.509, "minMs": 39.157, "maxMs": 165.254, "p95Ms": 132.219 },
+      { "tool": "NAPI (.node)", "scale": "medium (1K lines)", "medianMs": 0.492, "minMs": 0.475, "maxMs": 0.543, "p95Ms": 0.506 },
+      { "tool": "WASM (.wasm)", "scale": "medium (1K lines)", "medianMs": 1.127, "minMs": 0.945, "maxMs": 1.279, "p95Ms": 1.225 },
+      { "tool": "CLI (subprocess)", "scale": "medium (1K lines)", "medianMs": 3.376, "minMs": 3.174, "maxMs": 5.124, "p95Ms": 3.636 },
 
-      { "tool": "NAPI (.node)", "scale": "large (5K lines)", "medianMs": 4.302, "minMs": 2.682, "maxMs": 7.684, "p95Ms": 7.131 },
-      { "tool": "WASM (.wasm)", "scale": "large (5K lines)", "medianMs": 16.348, "minMs": 5.883, "maxMs": 47.426, "p95Ms": 44.129 },
-      { "tool": "CLI (subprocess)", "scale": "large (5K lines)", "medianMs": 154.972, "minMs": 124.798, "maxMs": 232.138, "p95Ms": 222.254 },
+      { "tool": "NAPI (.node)", "scale": "large (5K lines)", "medianMs": 2.457, "minMs": 2.329, "maxMs": 2.511, "p95Ms": 2.494 },
+      { "tool": "CLI (subprocess)", "scale": "large (5K lines)", "medianMs": 4.839, "minMs": 4.609, "maxMs": 5.557, "p95Ms": 5.105 },
+      { "tool": "WASM (.wasm)", "scale": "large (5K lines)", "medianMs": 4.892, "minMs": 4.577, "maxMs": 5.603, "p95Ms": 5.355 },
 
-      { "tool": "NAPI (.node)", "scale": "xlarge (10K lines)", "medianMs": 13.148, "minMs": 5.237, "maxMs": 21.776, "p95Ms": 21.034 },
-      { "tool": "WASM (.wasm)", "scale": "xlarge (10K lines)", "medianMs": 22.103, "minMs": 14.296, "maxMs": 45.581, "p95Ms": 39.408 },
-      { "tool": "CLI (subprocess)", "scale": "xlarge (10K lines)", "medianMs": 184.181, "minMs": 139.687, "maxMs": 355.104, "p95Ms": 335.728 }
+      { "tool": "NAPI (.node)", "scale": "xlarge (10K lines)", "medianMs": 4.937, "minMs": 4.692, "maxMs": 5.101, "p95Ms": 4.999 },
+      { "tool": "CLI (subprocess)", "scale": "xlarge (10K lines)", "medianMs": 6.189, "minMs": 5.907, "maxMs": 6.743, "p95Ms": 6.494 },
+      { "tool": "WASM (.wasm)", "scale": "xlarge (10K lines)", "medianMs": 9.804, "minMs": 9.273, "maxMs": 10.577, "p95Ms": 10.023 }
     ],
     "bundlePerf": [
-      { "tool": "ZNTC", "scale": "small (10 modules, 0 ext)", "medianMs": 8.20 },
-      { "tool": "Rolldown", "scale": "small (10 modules, 0 ext)", "medianMs": 189 },
-      { "tool": "Rspack", "scale": "small (10 modules, 0 ext)", "medianMs": 344 },
+      { "tool": "ZNTC", "scale": "small (10 modules, 0 ext)", "medianMs": 4.48 },
+      { "tool": "Rolldown", "scale": "small (10 modules, 0 ext)", "medianMs": 47.8 },
+      { "tool": "Rspack", "scale": "small (10 modules, 0 ext)", "medianMs": 55.7 },
 
-      { "tool": "ZNTC", "scale": "medium (100 modules, 3 ext)", "medianMs": 14.6 },
-      { "tool": "Rolldown", "scale": "medium (100 modules, 3 ext)", "medianMs": 242 },
-      { "tool": "Rspack", "scale": "medium (100 modules, 3 ext)", "medianMs": 377 },
+      { "tool": "ZNTC", "scale": "medium (100 modules, 3 ext)", "medianMs": 9.02 },
+      { "tool": "Rolldown", "scale": "medium (100 modules, 3 ext)", "medianMs": 52.3 },
+      { "tool": "Rspack", "scale": "medium (100 modules, 3 ext)", "medianMs": 60.6 },
 
-      { "tool": "ZNTC", "scale": "large (200 modules, 5 ext)", "medianMs": 18.4 },
-      { "tool": "Rolldown", "scale": "large (200 modules, 5 ext)", "medianMs": 230 },
-      { "tool": "Rspack", "scale": "large (200 modules, 5 ext)", "medianMs": 365 },
+      { "tool": "ZNTC", "scale": "large (200 modules, 5 ext)", "medianMs": 12.9 },
+      { "tool": "Rolldown", "scale": "large (200 modules, 5 ext)", "medianMs": 54.9 },
+      { "tool": "Rspack", "scale": "large (200 modules, 5 ext)", "medianMs": 63.9 },
 
-      { "tool": "ZNTC", "scale": "xlarge (1000 modules, 8 ext)", "medianMs": 53.5 },
-      { "tool": "Rolldown", "scale": "xlarge (1000 modules, 8 ext)", "medianMs": 297 },
-      { "tool": "Rspack", "scale": "xlarge (1000 modules, 8 ext)", "medianMs": 659 }
+      { "tool": "ZNTC", "scale": "xlarge (1000 modules, 8 ext)", "medianMs": 45.7 },
+      { "tool": "Rolldown", "scale": "xlarge (1000 modules, 8 ext)", "medianMs": 71.2 },
+      { "tool": "Rspack", "scale": "xlarge (1000 modules, 8 ext)", "medianMs": 88.6 }
     ],
     "pipelineTotal": [
-      { "tool": "simple", "scale": "1K lines", "medianMs": 1.14 },
-      { "tool": "expr", "scale": "1K lines", "medianMs": 2.14 },
-      { "tool": "string", "scale": "1K lines", "medianMs": 0.507 },
-      { "tool": "object", "scale": "1K lines", "medianMs": 0.879 },
-      { "tool": "react", "scale": "1K lines", "medianMs": 1.55 },
+      { "tool": "simple", "scale": "1K lines", "medianMs": 0.988 },
 
-      { "tool": "simple", "scale": "5K lines", "medianMs": 4.72 },
-      { "tool": "expr", "scale": "5K lines", "medianMs": 11.0 },
-      { "tool": "string", "scale": "5K lines", "medianMs": 2.46 },
-      { "tool": "object", "scale": "5K lines", "medianMs": 4.26 },
-      { "tool": "react", "scale": "5K lines", "medianMs": 7.41 },
+      { "tool": "simple", "scale": "5K lines", "medianMs": 4.83 },
 
-      { "tool": "simple", "scale": "10K lines", "medianMs": 9.26 },
-      { "tool": "expr", "scale": "10K lines", "medianMs": 21.7 },
-      { "tool": "string", "scale": "10K lines", "medianMs": 4.85 },
-      { "tool": "object", "scale": "10K lines", "medianMs": 8.55 },
-      { "tool": "react", "scale": "10K lines", "medianMs": 14.9 },
+      { "tool": "simple", "scale": "10K lines", "medianMs": 9.78 },
 
-      { "tool": "simple", "scale": "50K lines", "medianMs": 47.5 },
-      { "tool": "expr", "scale": "50K lines", "medianMs": 111 },
-      { "tool": "string", "scale": "50K lines", "medianMs": 24.6 },
-      { "tool": "object", "scale": "50K lines", "medianMs": 44.0 },
-      { "tool": "react", "scale": "50K lines", "medianMs": 75.2 }
+      { "tool": "simple", "scale": "50K lines", "medianMs": 50.1 },
+
+      { "tool": "expr", "scale": "1K lines", "medianMs": 2.29 },
+
+      { "tool": "expr", "scale": "5K lines", "medianMs": 11.5 },
+
+      { "tool": "expr", "scale": "10K lines", "medianMs": 23.3 },
+
+      { "tool": "expr", "scale": "50K lines", "medianMs": 119 },
+
+      { "tool": "string", "scale": "1K lines", "medianMs": 0.515 },
+
+      { "tool": "string", "scale": "5K lines", "medianMs": 2.5 },
+
+      { "tool": "string", "scale": "10K lines", "medianMs": 5 },
+
+      { "tool": "string", "scale": "50K lines", "medianMs": 25.5 },
+
+      { "tool": "object", "scale": "1K lines", "medianMs": 0.899 },
+
+      { "tool": "object", "scale": "5K lines", "medianMs": 4.46 },
+
+      { "tool": "object", "scale": "10K lines", "medianMs": 9.04 },
+
+      { "tool": "object", "scale": "50K lines", "medianMs": 46 },
+
+      { "tool": "react", "scale": "1K lines", "medianMs": 1.45 },
+
+      { "tool": "react", "scale": "5K lines", "medianMs": 7.12 },
+
+      { "tool": "react", "scale": "10K lines", "medianMs": 14.4 },
+
+      { "tool": "react", "scale": "50K lines", "medianMs": 73.2 }
     ],
     "bundleSize": [
       { "tool": "ZNTC", "scale": "immer", "bytes": 8963 },
@@ -116,7 +132,7 @@
       { "tool": "rolldown", "scale": "preact", "bytes": 10290 },
       { "tool": "rspack", "scale": "preact", "bytes": 10405 },
 
-      { "tool": "ZNTC", "scale": "lodash-es", "bytes": 19587 },
+      { "tool": "ZNTC", "scale": "lodash-es", "bytes": 19559 },
       { "tool": "esbuild", "scale": "lodash-es", "bytes": 20661 },
       { "tool": "rolldown", "scale": "lodash-es", "bytes": 18419 },
       { "tool": "rspack", "scale": "lodash-es", "bytes": 17654 },
@@ -126,12 +142,12 @@
       { "tool": "rolldown", "scale": "date-fns", "bytes": 19411 },
       { "tool": "rspack", "scale": "date-fns", "bytes": 18540 },
 
-      { "tool": "ZNTC", "scale": "three", "bytes": 36047 },
+      { "tool": "ZNTC", "scale": "three", "bytes": 36041 },
       { "tool": "esbuild", "scale": "three", "bytes": 222275 },
       { "tool": "rolldown", "scale": "three", "bytes": 220177 },
       { "tool": "rspack", "scale": "three", "bytes": 139674 },
 
-      { "tool": "ZNTC", "scale": "mobx", "bytes": 55975 },
+      { "tool": "ZNTC", "scale": "mobx", "bytes": 55674 },
       { "tool": "esbuild", "scale": "mobx", "bytes": 55532 },
       { "tool": "rolldown", "scale": "mobx", "bytes": 53877 },
       { "tool": "rspack", "scale": "mobx", "bytes": 53967 },
@@ -141,19 +157,19 @@
       { "tool": "rolldown", "scale": "zod", "bytes": 56428 },
       { "tool": "rspack", "scale": "zod", "bytes": 56403 },
 
-      { "tool": "ZNTC", "scale": "effect", "bytes": 125330 },
+      { "tool": "ZNTC", "scale": "effect", "bytes": 116357 },
       { "tool": "esbuild", "scale": "effect", "bytes": 196059 },
       { "tool": "rolldown", "scale": "effect", "bytes": 125426 },
       { "tool": "rspack", "scale": "effect", "bytes": 145559 },
 
-      { "tool": "ZNTC", "scale": "rxjs", "bytes": 157131 },
+      { "tool": "ZNTC", "scale": "rxjs", "bytes": 149638 },
       { "tool": "esbuild", "scale": "rxjs", "bytes": 146677 },
       { "tool": "rolldown", "scale": "rxjs", "bytes": 136800 },
       { "tool": "rspack", "scale": "rxjs", "bytes": 141278 }
     ]
   },
   "sizeBenchmark": {
-    "date": "2026-05-17",
+    "date": "2026-05-30",
     "platform": "darwin arm64",
     "mode": "--minify-all (production minify + tree-shake)",
     "libraries": 9,

--- a/documents/src/pages/llms.txt.ts
+++ b/documents/src/pages/llms.txt.ts
@@ -36,19 +36,19 @@ export async function GET() {
 
 ## Core features
 
-- TypeScript / JSX / Flow stripping (~3 ms / 1K lines)
+- TypeScript / JSX / Flow stripping (~4 ms / 1K lines)
 - ES2015+ downleveling (target=es5/es2015/es2020/es2022)
 - Tree-shake + minify (on par with or smaller than rolldown/esbuild/rspack)
 - Bundle (rollup-style + esbuild-style API)
 - React Native (Metro / Hermes compatible)
-- C NAPI in-process calls (Node/Bun, ~50× faster than CLI spawn)
+- C NAPI in-process calls (Node/Bun, ~60× faster than CLI spawn when warmed — no subprocess)
 - Vite / Rollup plugin adapter
 
-## Performance (2026-05-21, darwin arm64, 20-run median)
+## Performance (2026-05-30, darwin arm64, 50-run median)
 
-- Transpile small (100 lines): **1.79 ms** (1st, vs esbuild 3.90 / Bun 5.16)
-- Bundle small (10 modules): **2.62 ms** (1st, vs Bun 8.05 / esbuild 10.8)
-- Bundle medium (1000 modules): **17.0 ms** (1st, vs Bun 23.3 / esbuild 26.8)
+- Transpile small (100 lines): **3.34 ms** (1st, vs Bun 3.59 / esbuild 3.67)
+- Bundle small (10 modules): **4.28 ms** (1st, vs Bun 5.05 / esbuild 6.53)
+- Bundle medium (1000 modules): **16.5 ms** (≈ Bun 16.1 — tied lead, vs esbuild 19.7)
 - Warm incremental rebuild (lodash-es, 641 modules): **21.7 ms** (47.3 → 21.7 ms after graph_discover optimization epic, -54%)
 
 ## Documentation


### PR DESCRIPTION
## 개요

GitHub Pages(문서 사이트)의 벤치마크 노출 전수 갱신과 플레이그라운드 사이드바 반응형 개편을 함께 담았습니다.

## 1. 벤치마크 고반복 재측정 (`docs(site)`)

신뢰성을 위해 반복 횟수를 늘려 **한가한 머신에서 전 스위트를 직렬 실행**(darwin arm64):

| 스위트 | 이전 | 이번 |
|---|---|---|
| CLI `bench.ts` | 20회 | **50회** |
| NAPI `napi-bench.ts` | warmup 3 + 10회 | **warmup 10 + 100회** |
| `bundle-perf.ts` | warmup 5 + 20회 | **warmup 5 + 50회** |
| `pipeline.ts` | 5회 | **15회** |

`benchmark-data.json` 6개 카테고리(transpile/bundle/napiWasm/bundlePerf/pipeline/bundleSize)를 전부 실측값으로 재생성하고, 사이트 내 모든 벤치마크 노출 위치를 **단일 출처(JSON)** 와 일치시켰습니다.

- `index.mdx` / `en/index.mdx` — StatsStrip · 번들 성능/크기 카드 · 측정일·median 횟수
- `benchmarks.mdx` / `en` — 기준일 2026-05-30, 방법론 반복 횟수
- `llms.txt` — 성능 섹션 · NAPI 비율 · median 횟수

### 고반복으로 드러난 사실 (정직 반영)
- **transpile small(100줄)**: ZNTC 3.34ms로 **1위** — 저반복 땐 프로세스 spawn-floor 노이즈로 순위가 뒤집혔음
- **bundle medium(1000모듈)**: Bun 16.1 vs ZNTC 16.5 — **사실상 동률**(공동 선두)로 표기
- **NAPI vs CLI**: warmup 충분 시 small에서 **61×** — 장기 실행 프로세스(Node/Bun 서버)에 representative

> README의 "Synthetic bench"는 GitHub **Pages**가 아닌 저장소 랜딩이고 출처가 다른 별도 합성 벤치라 이번 스위트로 1:1 매핑이 안 돼 제외했습니다.

## 2. 플레이그라운드 반응형 사이드바 (`feat(site)`)

Transpile/Bundler 두 플레이그라운드의 왼쪽 옵션·파일 패널을 반응형으로 개편:

- **모바일(<768px)**: 오버레이 드로어(배경 탭하면 닫힘), 기본 닫힘으로 시작 → 좁은 화면에서 에디터가 가려지지 않음. 드로어 폭 `max-w-[85vw]`로 초소형 뷰포트 오버플로 방지
- **PC(`md:`)**: 기존처럼 인라인 push 패널 — 펼침/닫힘 시 에디터 영역이 늘어남
- 토글 버튼 `☰`/`✕` + `aria-expanded`/`aria-label`
- 두 에디터 모바일 세로 스택 / PC 가로 분할(구분선도 반응형)
- 오른쪽 **Monaco 동적 리사이즈**: `automaticLayout`(컨테이너 리사이즈 자동감지) + 사이드바 토글 시 명시적 `editor.layout()`
- 상단 툴바 `flex-wrap`로 모바일 버튼 오버플로 방지

## 검증

- `bun run build` (Astro 549페이지) exit 0, 렌더 산출물에서 새 수치 확인
- `/code-review max`: 수치 정합성 전 항목 일치, 컴포넌트 저심각도 1건(초소형 뷰포트 드로어 오버플로) 발견 → 본 PR에서 수정 반영
- 벤치 스크립트 임시 상수 수정은 원복(추적 파일 깨끗)

## 확인 요청
모바일 사이드바 동작은 실제 좁은 뷰포트/디바이스에서 시각 확인을 권장합니다(`cd documents && bun run dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)