### PR TITLE
fix(parser): optional chain 이 assignment target 체인 어디든 있으면 거부 (a?.b.c = 1)

### DIFF
--- a/src/parser/cover.zig
+++ b/src/parser/cover.zig
@@ -43,6 +43,39 @@ const spread_trailing_comma = Parser.spread_trailing_comma;
 /// 태그를 변환하고 (setTag) 검증도 수행한다.
 /// 반환값: true면 valid assignment target, false면 에러를 이미 추가했거나 invalid.
 /// is_top이 true면 최상위 호출 (invalid일 때 "Invalid assignment target" 에러 추가).
+/// member/call 체인 spine 에 optional `?.` 가 하나라도 있는지. ECMAScript: optional chain 은
+/// assignment/update target 이 될 수 없다 — `a?.b` 뿐 아니라 `a?.b.c`, `a?.b().c`, `a.b?.c.d`
+/// 처럼 spine *앞쪽* optional 도 거부해야 한다(LeftHandSideExpression 에 OptionalChain 포함 금지).
+/// `(a?.b).c` 는 paren 으로 체인이 끊겨 valid — object 가 parenthesized_expression 등 비-체인
+/// 노드면 walk 가 거기서 멈춰 false 반환.
+fn memberChainHasOptional(self: *const Parser, start: NodeIndex) bool {
+    var cur = start;
+    var guard: u32 = 0;
+    while (guard < 100_000) : (guard += 1) {
+        if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return false;
+        const n = self.ast.getNode(cur);
+        switch (n.tag) {
+            .static_member_expression, .computed_member_expression, .private_field_expression => {
+                if (!self.ast.hasExtra(n.data.extra, 2)) return false;
+                if (self.ast.readExtra(n.data.extra, 2) != 0) return true; // optional member (a?.b / a?.[b])
+                cur = self.ast.readExtraNode(n.data.extra, 0); // object
+            },
+            .call_expression => {
+                if (!self.ast.hasExtra(n.data.extra, 3)) return false;
+                if (self.ast.readExtra(n.data.extra, 3) & ast_mod.CallFlags.optional_chain != 0) return true; // a?.()
+                cur = self.ast.readExtraNode(n.data.extra, 0); // callee
+            },
+            // TS non-null/as/satisfies 는 spine 을 끊지 않는다(`a?.b!.c`, `(a?.b as T).c` 의
+            // `!`/`as` 는 cover 의 top-level 분기가 이미 언래핑) — 내부로 내려가 그 아래
+            // optional 을 본다. paren 은 (위 else 로) 체인을 끊으므로 `(a?.b)!.c` 는 valid.
+            .ts_non_null_expression => cur = n.data.unary.operand,
+            .ts_as_expression, .ts_satisfies_expression => cur = n.data.binary.left,
+            else => return false, // identifier / paren(체인 끊김) / 기타 head
+        }
+    }
+    return false;
+}
+
 pub fn coverExpressionToAssignmentTarget(self: *Parser, idx: NodeIndex, is_top: bool) ParseError2!bool {
     if (idx.isNone()) return false;
     const node = self.ast.getNode(idx);
@@ -56,12 +89,13 @@ pub fn coverExpressionToAssignmentTarget(self: *Parser, idx: NodeIndex, is_top: 
             self.ast.setTag(idx, .assignment_target_identifier);
             return true;
         },
-        .private_identifier, .private_field_expression => true,
+        .private_identifier => true,
 
-        // 2) member expression — optional chaining이 아니면 valid (태그 유지)
-        .static_member_expression, .computed_member_expression => {
-            if (self.ast.readExtra(node.data.extra, 2) == 0) return true; // normal (not optional chain)
-            // optional chaining (a?.b, a?.[b])은 assignment target이 아님
+        // 2) member expression — 체인 spine 에 optional `?.` 가 없어야 valid (태그 유지).
+        //    `a?.b`(이 노드 optional) 뿐 아니라 `a?.b.c`/`a?.b().c`(spine 앞쪽 optional)도 거부.
+        //    `(a?.b).c` 는 paren 으로 끊겨 valid. private field(`obj.#x`)도 같은 규칙.
+        .static_member_expression, .computed_member_expression, .private_field_expression => {
+            if (!memberChainHasOptional(self, idx)) return true;
             if (is_top) try self.addErrorCode(node.span, "Invalid assignment target", .invalid_assignment_target);
             return false;
         },

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2197,6 +2197,33 @@ test "new + optional chain: 유효 형태는 통과" {
     try expectNoParseError("for (var x = a[(\"k\" in a)];;) { break; }");
 }
 
+test "optional chain in assignment target: spine 의 ?. 는 LHS 불가 (SyntaxError)" {
+    // ECMAScript: OptionalChain 은 assignment/update target 이 될 수 없다. 끝 멤버(`a?.b`)뿐
+    // 아니라 체인 *앞쪽* optional(`a?.b.c`)도 거부 — LHS 체인 spine 에 `?.` 가 있으면 invalid.
+    try expectParseError("a?.b = 1", .{ .message = "Invalid assignment target" });
+    try expectParseError("a?.b.c = 1", .{ .message = "Invalid assignment target" });
+    try expectParseError("a?.b.c.d = 1", .{ .message = "Invalid assignment target" });
+    try expectParseError("a.b?.c.d = 1", .{ .message = "Invalid assignment target" });
+    try expectParseError("a?.[x].c = 1", .{ .message = "Invalid assignment target" });
+    try expectParseError("a?.b().c = 1", .{ .message = "Invalid assignment target" });
+    try expectParseError("a?.b.c += 1", .{ .message = "Invalid assignment target" });
+    try expectParseError("a?.b.c++", .{ .message = "Invalid assignment target" });
+    try expectParseError("a?.b.c &&= 2", .{ .message = "Invalid assignment target" });
+    try expectParseError("[a?.b.c] = x", .{ .message = "Invalid assignment target" });
+    try expectParseError("for (a?.b.c in y) {}", .{ .message = "Invalid assignment target" });
+}
+
+test "optional chain in assignment target: paren 으로 끊기거나 optional 없으면 유효" {
+    // `(a?.b).c = 1` 은 paren 으로 체인이 끊겨 valid. optional 이 *computed key* 안이거나
+    // (`a[b?.c] = 1`) RHS read(`x = a?.b.c`)면 LHS spine 과 무관 → 유효.
+    try expectNoParseError("(a?.b).c = 1");
+    try expectNoParseError("a.b.c = 1");
+    try expectNoParseError("a.b().c = 1"); // call 이지만 optional 없음
+    try expectNoParseError("a[b?.c] = 1"); // optional 이 key 안 (spine 아님)
+    try expectNoParseError("x = a?.b.c"); // RHS read
+    try expectNoParseError("delete a?.b.c"); // delete 는 optional chain 허용
+}
+
 test "ErrorMsg: expect() shows 'found' token" {
     // `if (true]` → Expected ')' but found ']'
     try expectParseError("if (true]", .{ .message = ")", .has_found = true });


### PR DESCRIPTION
## 문제 ("잔여 케이스 더 없는지" 차등 감사에서 발견)

ECMAScript: OptionalChain 은 assignment/update target 이 될 수 없습니다. zntc 는 **끝 멤버가 optional 인 `a?.b = 1` 만** 거부하고, optional 이 LHS 체인 **앞쪽/중간**이고 끝이 non-optional 이면 통과시켰습니다 — node·esbuild 는 전부 거부. #4027(`new new a()?.b`)과 **동형 패턴**(체인 앞쪽 optional 미검출).

| 케이스 | node | esbuild | zntc(before) |
|---|---|---|---|
| `a?.b.c = 1` / `a?.b().c = 1` / `a.b?.c.d = 1` | ERR | ERR | 통과 |
| `a?.b.c++` / `a?.b.c &&= 1` | ERR | ERR | 통과 |
| `[a?.b.c] = x` / `for(a?.b.c in y){}` | ERR | ERR | 통과 |
| `a?.b!.c = 1` (TS non-null mid-spine) | ERR(tsc/esbuild) | ERR | 통과 |

## 루트커즈

`cover.zig` `coverExpressionToAssignmentTarget` member 케이스가 **이 노드의 optional 플래그(extra[2])만** 보고 object 체인을 walk 하지 않아, 끝이 non-optional 이면 즉시 `return true`.

## 수정

`memberChainHasOptional` 헬퍼 — member/call spine(`extra[0]` 하강)에 optional `?.` 가 하나라도 있으면 거부. TS non-null/as/satisfies 도 spine 으로 하강(`a?.b!.c=1` 거부 = esbuild/tsc parity; `a?.b! = 1` 만 잡던 내부 불일치 제거). **valid 유지**: paren(`(a?.b).c=1` — 체인 끊김)·computed key 안 optional(`a[b?.c]=1` — spine 아님)·RHS read·`delete a?.b.c`.

## 코드 리뷰 (focused 2-에이전트)

- **false-positive 헌트**: 53-케이스 매트릭스(node/esbuild/tsc) → **오탐 0**. paren/computed-key/no-opt/call/destructuring/for-of 전부 valid 유지.
- **walk 완전성/엣지**: call callee 하강·private field·crash/loop 안전·perf(O(depth), non-optional fast-false) 확인. TS non-null mid-spine 잔여 발견 → 같은 PR 에서 수정.

## 검증

- zntc vs node 차등 배터리 ~40 케이스 **divergence 0**, 거부 ~15 / valid ~12 parity
- 전체 유닛 `zig build test` ✅ / lib-scenario 19 ✅ / browser-smoke 95 ✅ (회귀 0)

## 회귀 테스트

`parser_test.zig` 2 블록 — spine 앞쪽 optional 거부(11종) + valid 가드(paren/no-opt/call/computed-key/RHS/delete).

Closes #4032

🤖 Generated with [Claude Code](https://claude.com/claude-code)