### PR TITLE
feat(bundler): dev_mode + code_splitting 경로 + #4038 수정 (lazy compilation PR-2)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -842,6 +842,7 @@ pub const Bundler = struct {
             .worklet_transform = self.options.worklet_transform,
             // codegen_transform 은 graph 만 사용 (load 시점). emitter 에는 전파 안 함.
             .compiled_cache = self.options.compiled_cache,
+            .code_splitting = self.options.code_splitting,
         };
     }
 
@@ -1318,6 +1319,7 @@ pub const Bundler = struct {
             // 실제로 없어도 런타임 값은 ReferenceError가 아니라 undefined가 된다.
             l.shim_missing_exports = self.options.shim_missing_exports or self.options.platform == .react_native;
             l.dev_mode = self.options.dev_mode;
+            l.code_splitting = self.options.code_splitting;
             l.entry_error_guard = self.options.entry_error_guard;
             l.inline_requires = self.options.platform == .react_native;
             l.strict_execution_order = self.options.strict_execution_order;
@@ -1591,7 +1593,13 @@ pub const Bundler = struct {
         // BundleResult 로 이관. NAPI handle 이 캐시하고 `/bundle.js.map` 요청 시 직렬화.
         var dev_sourcemap_builder: ?*@import("../codegen/sourcemap.zig").SourceMapBuilder = null;
 
-        if (self.options.dev_mode) {
+        // Lazy compilation (RFC docs/RFC_LAZY_COMPILATION.md): dev_mode + code_splitting +
+        // lazy_compilation 이면 단일 번들 경로 대신 아래 청크 경로로 우회한다. dev 의 단일번들
+        // init lowering(__zntc_modules[dev_id])은 청크 경계를 못 넘으므로(issue #4038),
+        // linker/emit 의 code_splitting 게이트가 splitting 시 프로덕션 init 으로 fallback 한다.
+        // kill-switch — lazy_compilation=false(또는 code_splitting=false)면 기존 dev 단일 번들 100% 보존.
+        const dev_split = self.options.dev_mode and self.options.code_splitting and self.options.lazy_compilation;
+        if (self.options.dev_mode and !dev_split) {
             // Dev mode: 프로덕션 파이프라인 재사용 (__commonJS/__esm 래핑 + HMR 런타임).
             var dev_emit_opts = self.makeEmitOptions();
             dev_emit_opts.sourcemap.enable = true;
@@ -1653,6 +1661,14 @@ pub const Bundler = struct {
             emit_opts.preserve_modules = self.options.preserve_modules;
             emit_opts.preserve_modules_root = self.options.preserve_modules_root;
             emit_opts.worker_map_per_module = &worker_map_per_module;
+            // Lazy dev-splitting: emitModule 이 dev wrapping(minify skip 등)을 적용하도록
+            // dev_mode 전파. dev init lowering(__zntc_modules)은 emit_opts.code_splitting=true
+            // (makeEmitOptions 가 self.options 에서 set)로 비활성화됨(issue #4038). 모듈별 HMR
+            // (__zntc_make_hot)은 dev_id 미설정이라 아직 미주입(PR-4 에서 추가). sourcemap 은 dev on.
+            if (dev_split) {
+                emit_opts.dev_mode = true;
+                emit_opts.sourcemap.enable = true;
+            }
 
             // CSS 코드스플리팅 계획을 emitChunks *전* 에 세워, 동적 청크가
             // 자기 CSS 를 런타임 <link> 로 로드하는 prologue 를 content-hash

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -2586,3 +2586,95 @@ test "Profile: pipeline stage timing (dev only, not for CI)" {
         });
     }
 }
+
+// ============================================================
+// Lazy compilation — dev + code_splitting (RFC docs/RFC_LAZY_COMPILATION.md, PR-2)
+// issue #4038: dev init lowering(__zntc_modules[dev_id])이 청크 경계를 못 넘던 버그 수정 검증.
+// ============================================================
+
+test "LazyDevSplitting: dev+split → 프로덕션 init 사용, __zntc_modules 누출 없음 (#4038)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // 공유 + 동적 + re-export 바렐까지 섞어 wrapped 모듈 init 경로(esm_wrap:838 re-export 등)도 커버.
+    try writeFile(tmp.dir, "shared.ts", "export const s = 'S';\nconsole.log('shared boot');");
+    try writeFile(tmp.dir, "barrel.ts", "export * from './shared';\nexport const b = 'B';"); // re-export init (#4038)
+    try writeFile(tmp.dir, "heavy.ts", "import { s, b } from './barrel';\nexport function heavy() { return 'HEAVY-' + s + b; }");
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { s, b } from './barrel';
+        \\async function go() { const m = await import('./heavy'); console.log(m.heavy()); }
+        \\console.log('entry boot', s, b);
+        \\go();
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .code_splitting = true,
+        .lazy_compilation = true,
+        .format = .iife,
+    });
+    defer bnd.deinit();
+    const result = try bnd.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+    try std.testing.expect(outs.len >= 2); // entry 청크 + 동적 heavy 청크
+
+    var has_register = false;
+    var has_loader = false;
+    var has_require_bootstrap = false; // entry 실행 트리거 (#4038 BUG2 회귀 가드)
+    for (outs) |o| {
+        if (std.mem.indexOf(u8, o.contents, "__zntc_register") != null) has_register = true;
+        if (std.mem.indexOf(u8, o.contents, "__zntc_load_chunk(\"") != null) has_loader = true;
+        if (std.mem.indexOf(u8, o.contents, "__zntc_require(\"") != null) has_require_bootstrap = true;
+        // #4038 BUG1 회귀 가드: dev 단일번들 HMR 레지스트리(__zntc_modules)가 청크에 누출되면 안 됨.
+        // (청크 런타임은 __zntc_mods/__zntc_require 사용. __zntc_modules 는 단일번들 전용.)
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "__zntc_modules") == null);
+        // 빈 dev_id 참조(__zntc_modules[""]) 절대 금지.
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "[\"\"]") == null);
+        // IIFE 청크에 ESM import/export 누출 금지.
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "\nexport {") == null);
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "\nimport {") == null);
+    }
+    try std.testing.expect(has_register);
+    try std.testing.expect(has_loader);
+    try std.testing.expect(has_require_bootstrap); // entry 가 실행되도록 bootstrap require 존재
+
+    // dev_mode 효과: minify 스킵 → 모듈 경계 주석(//#region) 보존.
+    var has_region = false;
+    for (outs) |o| {
+        if (std.mem.indexOf(u8, o.contents, "//#region ") != null) has_region = true;
+    }
+    try std.testing.expect(has_region);
+}
+
+test "LazyDevSplitting: kill-switch — lazy_compilation=false 면 dev 단일 번들 보존" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "heavy.ts", "export function heavy() { return 'H'; }");
+    try writeFile(tmp.dir, "entry.ts",
+        \\async function go() { const m = await import('./heavy'); console.log(m.heavy()); }
+        \\go();
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    // dev_mode + code_splitting 이지만 lazy_compilation=false → 기존 dev 단일 번들 경로.
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .code_splitting = true,
+        .lazy_compilation = false,
+        .format = .iife,
+    });
+    defer bnd.deinit();
+    const result = try bnd.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    // 단일 번들 경로: output 존재, outputs 없음(청크 분할 안 함). dev 단일번들은 __zntc_modules 사용.
+    try std.testing.expect(result.output.len > 0);
+    try std.testing.expect(result.outputs == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_modules") != null);
+}

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -100,7 +100,7 @@ pub const InputHasher = struct {
 ///   emit_module_pass 의 per-module 결과 (dev_codes / compiled_cache entry) 는 동일하므로
 ///   module-level cache key 에 영향 없음. dev_mode incremental rebuild 가 first=false 만
 ///   set 해도 first build 의 entry 와 동일 input_hash → cache hit.
-const expected_emit_options_field_count: usize = 56;
+const expected_emit_options_field_count: usize = 57;
 const intentionally_unhashed_fields = [_][]const u8{"skip_bundle_output"};
 
 comptime {
@@ -129,6 +129,8 @@ pub fn hashEmitOptions(h: *InputHasher, options: *const EmitOptions) void {
     h.addOptStr(options.sourcemap.source_root);
     h.addBool(options.sourcemap.sources_content);
     h.addBool(options.dev_mode);
+    // code_splitting 은 dev init lowering(__zntc_modules vs init_X)을 가른다 → 출력 영향, hash 필수.
+    h.addBool(options.code_splitting);
     h.addOptStr(options.root_dir);
     h.addBool(options.react_refresh);
     h.addBool(options.worklet_transform);

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -94,6 +94,9 @@ pub const EmitOptions = struct {
     /// dev mode: 각 모듈을 __zntc_register() 팩토리로 래핑하고
     /// HMR 런타임을 주입한다. import.meta.hot API 지원.
     dev_mode: bool = false,
+    /// code splitting emit 경로 여부. dev_mode 의 단일번들 init lowering
+    /// (`__zntc_modules[dev_id]`)을 splitting 시 비활성화하기 위함(issue #4038).
+    code_splitting: bool = false,
     /// dev mode에서 모듈 ID 생성 시 기준 경로 (상대 경로 계산용).
     /// null이면 절대 경로를 그대로 사용.
     root_dir: ?[]const u8 = null,

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -835,7 +835,7 @@ pub fn emitEsmWrappedModule(
                         } else {
                             try reexport_buf.appendSlice(allocator, "(");
                         }
-                        if (options.dev_mode) {
+                        if (options.dev_mode and !options.code_splitting) {
                             try reexport_buf.appendSlice(allocator, "__zntc_modules[\"");
                             try reexport_buf.appendSlice(allocator, source_mod.dev_id);
                             try reexport_buf.appendSlice(allocator, "\"].fn(), __toCommonJS(__zntc_modules[\"");
@@ -1196,7 +1196,7 @@ fn appendWrappedInitCall(
         .esm => {
             if (is_tla) try buf.appendSlice(allocator, "await ");
             if (guard) try buf.appendSlice(allocator, if (options.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
-            if (options.dev_mode) {
+            if (options.dev_mode and !options.code_splitting) {
                 try buf.appendSlice(allocator, "__zntc_modules[\"");
                 try buf.appendSlice(allocator, src_mod.dev_id);
                 try buf.appendSlice(allocator, "\"].fn()");
@@ -1302,7 +1302,7 @@ fn makeLazyEsmGetterValue(
         return try allocator.dupe(u8, target);
     }
 
-    const init_call = if (options.dev_mode) blk: {
+    const init_call = if (options.dev_mode and !options.code_splitting) blk: {
         break :blk try std.fmt.allocPrint(allocator, "__zntc_modules[\"{s}\"].fn()", .{src_mod.dev_id});
     } else blk: {
         const iv = try src_mod.allocInitName(allocator, rename_tbl);

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -102,7 +102,10 @@ pub fn promoteExportsKinds(self: *ModuleGraph) void {
     // - RN: circular dep 체인에서 초기화 순서 보장 (Rolldown 호환 lazy loading)
     // - dev mode: HMR을 위해 모든 모듈이 개별 팩토리 함수로 래핑되어야 함
     //   (scope-hoisted flat 모듈은 개별 교체 불가)
-    if (self.resolve_cache.platform == .react_native or self.dev_mode) {
+    // - dev + code_splitting: 단일번들 HMR wrap-all 을 끄고 프로덕션 wrapping 을 쓴다.
+    //   dev 의 cross-module init(__zntc_modules[dev_id])이 청크 경계를 못 넘기 때문(issue #4038).
+    //   → entry 가 scope-hoist(.none)로 인라인 실행되어 BUG2(entry 미실행)도 함께 해소.
+    if (self.resolve_cache.platform == .react_native or (self.dev_mode and !self.code_splitting)) {
         var it = self.modules.iterator(0);
         while (it.next()) |m| {
             if (m.wrap_kind != .none) continue;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -186,6 +186,10 @@ pub const Linker = struct {
     /// dev mode: HMR용 모듈 참조를 __zntc_modules["id"].fn()으로 생성.
     /// init_xxx() 대신 동적 lookup을 사용하여 new Function()에서도 접근 가능.
     dev_mode: bool = false,
+    /// code splitting emit 경로 여부. dev_mode 의 단일번들 HMR lowering
+    /// (`__zntc_modules[dev_id]`)은 청크 경계를 넘지 못하므로(issue #4038),
+    /// splitting 시엔 dev lowering 을 끄고 프로덕션 init(`init_X()`)을 쓴다.
+    code_splitting: bool = false,
 
     /// Metro inlineRequires 호환 경로. RN에서는 함수 내부에서만 읽히는 import의
     /// module init을 top-level preamble에서 미루고, 참조 지점에서 lazy init한다.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -67,7 +67,8 @@ fn getOrCreateCjsRequireRef(
     cache: *std.AutoHashMapUnmanaged(u32, []const u8),
     mod_idx: u32,
 ) ![]const u8 {
-    if (!self.dev_mode) return getOrCreateRequireVar(self, cache, mod_idx);
+    // splitting 시엔 dev lowering(__zntc_modules[dev_id]) 비활성 — 청크 경계 미지원(#4038).
+    if (!self.dev_mode or self.code_splitting) return getOrCreateRequireVar(self, cache, mod_idx);
     if (cache.get(mod_idx)) |cached| return cached;
 
     const target_mod = self.getModule(mod_idx).?;
@@ -1224,7 +1225,7 @@ pub fn buildMetadataForAst(
                     const guard = target_mod.shouldGuard(self.entry_error_guard);
                     if (is_tla) try preamble.write("await ");
                     if (guard) try preamble.write(if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
-                    if (self.dev_mode) {
+                    if (self.dev_mode and !self.code_splitting) {
                         try preamble.write("__zntc_modules[\"");
                         try preamble.write(target_mod.dev_id);
                         try preamble.write("\"].fn()");
@@ -1376,7 +1377,7 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module, format: types
             if (require_rewrites.get(rec.specifier)) |old| {
                 self.allocator.free(old);
             }
-            const req_ref = if (self.dev_mode)
+            const req_ref = if (self.dev_mode and !self.code_splitting)
                 try types.fmtDevRequireCallExpr(self.allocator, target_mod.dev_id)
             else
                 try target_mod.allocRequireName(self.allocator, &self.rename_table);
@@ -1386,7 +1387,7 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module, format: types
             if (require_rewrites.get(rec.specifier)) |old| {
                 self.allocator.free(old);
             }
-            if (self.dev_mode) {
+            if (self.dev_mode and !self.code_splitting) {
                 const call_expr = try types.fmtDevRequireExpr(self.allocator, target_mod.dev_id);
                 try require_rewrites.put(self.allocator, rec.specifier, call_expr);
             } else {


### PR DESCRIPTION
## 개요

dev 서버 lazy compilation(RFC `docs/RFC_LAZY_COMPILATION.md`)의 **본체 PR** — `dev_mode` 와 `code_splitting` 이 emit 분기에서 상호배타였던 것을 병합하고, 그 과정에서 드러난 **issue #4038**(dev init lowering 이 청크 경계를 못 넘어 깨진 출력)을 함께 수정합니다.

`Fixes #4038`

## dev+splitting 라우팅
- `dev_mode and code_splitting and lazy_compilation` → 단일 번들 대신 청크 경로로 우회(`emit_opts.dev_mode` 전파). 레지스트리 런타임(`__zntc_register`/`__zntc_require`/`__zntc_load_chunk`)은 IIFE reg_split 이 제공.
- **kill-switch**: `lazy_compilation=false`(기본) → 기존 dev 단일 번들 100% 보존.

## #4038 수정 — dev init lowering 의 code_splitting 게이트
**근본 원인**: dev_mode 가 (1) `finalize.zig` 에서 모든 모듈 `__esm` wrap-all, (2) cross-module init 을 단일번들 HMR 레지스트리 `__zntc_modules[dev_id]` 로 emit. 청크 경로는 `setDevId` 미호출(`dev_id=""`)이고 `__zntc_modules` 런타임도 미주입 → **BUG1**(`__zntc_modules[""]` ReferenceError) + **BUG2**(래핑된 entry 의 init 미호출 → entry 미실행).

**해결**: dev lowering 을 `and !code_splitting` 으로 게이트해 splitting 시 **프로덕션 init**(`init_X()` + entry 인라인 실행)으로 fallback. `Linker`/`EmitOptions`/`ModuleGraph` 에 `code_splitting` 전파. 게이트 7곳: `finalize.zig`(wrap-all) · `metadata.zig`(4) · `esm_wrap.zig`(3, re-export 포함). `code_splitting` 은 출력 영향 → `compiled_cache` hash 에 추가.

게이트가 `!code_splitting` 이라 dev 단일번들은 자동으로 기존 동작 보존 — 자연스러운 kill-switch.

> 모듈별 HMR(`__zntc_make_hot`)은 미주입(`dev_id` 미설정) → 변경 시 full-reload. PR-4 에서 추가.

## 검증
- **유닛**(splitting_dev.zig): dev+split(공유+동적+**re-export 바렐**) → 다중 청크 + 레지스트리 런타임 + **`__zntc_modules` 누출 0건(BUG1 가드)** + entry bootstrap require(BUG2 가드) + dev minify-skip. kill-switch(단일번들은 `__zntc_modules` 사용 확인).
- **전체** `zig build test` **5715/5715 통과**(회귀 없음), napi/wasm/install 통과.
- **e2e**(node vm): 실제 dev+split 출력 실행 — `ORDER: shared→entry→heavy-run→after-import`(entry 실행=BUG2 fixed), `__zntc_modules` 0건(BUG1 fixed), 동적 온디맨드, cross-chunk 공유 1회, 결과 정상. re-export 바렐 변형도 `util→entry→heavy` 정상.
- **`/code-review max`**: recall 리뷰가 esm_wrap re-export 게이트 누락 1건 포착 → 수정·재검증. 최종 결론 "#4038 fix browser dev+split 에 대해 **COMPLETE**". 순환/CJS/namespace 형태도 정상 해소 확인.

## 참고
- 리뷰가 **별개의 기존 버그** 발견 → **#4039**(`require.context` + code_splitting 시 `__zntc_modules` undefined, dev/prod 무관, 본 PR 무관)로 등록. 본 PR 범위 밖.
- 후속: PR-3 사전계산+lazy 라우트/캐시 · PR-4 watch/HMR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)