### PR TITLE
fix(bundler): require.context + code_splitting 풀 지원 + production 단일번들 수정 (#4039)

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -1333,9 +1333,105 @@ test "Bundler: require.context emits webpackContext IIFE (sync)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "//#region a.tsx") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "//#region b.tsx") != null);
     // `ctx(req)` 가 module exports 를 반환해야 — Metro/webpack require.context semantic.
-    // `fn()` 만 호출하면 init 만 실행되고 exports 가 undefined 로 떨어져서 expo-router 등이
-    // 빈 route module 을 보고 "Unmatched Route" 로 fallback.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toCommonJS(__zntc_modules[") != null);
+    // #4039 fix: production/split 은 wrapped 매치 모듈을 init-call `(init_X(),__toCommonJS(
+    // exports_X))` 로 직접 참조(dev HMR 전용 `__zntc_modules` 는 청크 경계 미지원이라 안 씀 —
+    // 과거엔 production 에서도 런타임에 깨지는 `__zntc_modules` 를 emit 했음).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_modules") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "(),__toCommonJS(") != null);
+}
+
+test "Bundler: require.context + code_splitting → init-call 참조, __zntc_modules 누출 없음 (#4039)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var ts = threadSafeArena(&arena);
+    const alloc = ts.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(std.testing.io, "pages", .default_dir);
+    try writeFile(tmp.dir, "pages/a.tsx", "export default function A(){ return 'A'; }");
+    try writeFile(tmp.dir, "pages/b.tsx", "export default function B(){ return 'B'; }");
+    try writeFile(tmp.dir, "entry.ts",
+        \\const ctx = require.context('./pages', true, /\.tsx?$/, 'sync');
+        \\for (const k of ctx.keys()) console.log(k, ctx(k).default());
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcScanDir }};
+    var b = Bundler.init(alloc, .{
+        .entry_points = &.{entry},
+        .plugins = &plugins,
+        .code_splitting = true,
+        .format = .iife,
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(alloc);
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    var has_init_ref = false;
+    var has_entry_call = false; // wrapped entry trigger (BUG2 회귀 가드)
+    for (outs) |o| {
+        // #4039 회귀 가드: 청크에 dev HMR 전용 `__zntc_modules` 누출 금지.
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "__zntc_modules") == null);
+        // 매치 모듈은 같은 청크 wrapped 모듈 init-call `(init_X(),__toCommonJS(exports_X))` 로 참조.
+        if (std.mem.indexOf(u8, o.contents, "(),__toCommonJS(") != null and
+            std.mem.indexOf(u8, o.contents, "var map={") != null) has_init_ref = true;
+        // require.context 사용으로 CJS-wrap 된 entry 가 factory 안에서 호출돼야 본문 실행(BUG2).
+        if (std.mem.indexOf(u8, o.contents, "require_entry();") != null or
+            std.mem.indexOf(u8, o.contents, "init_entry();") != null) has_entry_call = true;
+        // 원본 require.context 호출 잔존 금지.
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "require.context(") == null);
+    }
+    try std.testing.expect(has_init_ref);
+    try std.testing.expect(has_entry_call);
+}
+
+test "Bundler: require.context + code_splitting — CJS 매치 + minify 형태 (#4039 리뷰 회귀)" {
+    // 리뷰가 잡은 두 케이스: (a) CJS 매치 모듈은 init_X 가 없으니 `require_X()` 로,
+    // (b) minify 시 __toCommonJS 는 `$tC` 로 emit 되어야 한다. 둘 다 wrong 이면 런타임 크래시.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var ts = threadSafeArena(&arena);
+    const alloc = ts.allocator();
+
+    inline for (.{ false, true }) |minify| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        try tmp.dir.createDir(std.testing.io, "pages", .default_dir);
+        try writeFile(tmp.dir, "pages/esm.tsx", "export default function E(){ return 'E'; }");
+        try writeFile(tmp.dir, "pages/cjs.js", "module.exports = { default: function(){ return 'C'; } };");
+        try writeFile(tmp.dir, "entry.ts",
+            \\const ctx = require.context('./pages', true, /\.(tsx?|js)$/, 'sync');
+            \\for (const k of ctx.keys()) console.log(ctx(k).default());
+        );
+        const entry = try absPath(&tmp, "entry.ts");
+        defer std.testing.allocator.free(entry);
+        const plugins = [_]Plugin{.{ .name = "rc", .resolveContext = rcScanDir }};
+        var b = Bundler.init(alloc, .{
+            .entry_points = &.{entry},
+            .plugins = &plugins,
+            .code_splitting = true,
+            .format = .iife,
+            .minify_whitespace = minify,
+            .minify_identifiers = minify,
+        });
+        defer b.deinit();
+        const result = try b.bundle(std.testing.io);
+        defer result.deinit(alloc);
+        try std.testing.expect(!result.hasErrors());
+        const outs = result.outputs orelse return error.TestUnexpectedResult;
+        for (outs) |o| {
+            // dev HMR 전용 레지스트리 누출 금지(모든 모드).
+            try std.testing.expect(std.mem.indexOf(u8, o.contents, "__zntc_modules") == null);
+            if (minify) {
+                // minify 시 helper 는 `$tC` — 풀네임 `__toCommonJS` 가 raw 로 남으면 undefined 참조.
+                try std.testing.expect(std.mem.indexOf(u8, o.contents, "__toCommonJS") == null);
+            }
+        }
+    }
 }
 
 test "Bundler: require.context emits empty map when no matches" {
@@ -1422,9 +1518,10 @@ test "Bundler: require.context normalizes trailing slash and missing ./" {
     defer result.deinit(alloc);
     try std.testing.expect(!result.hasErrors());
 
-    // plugin 이 dot-slash 없이 반환 → key 도 그대로. value 는 __zntc_modules wrapper (#1579 follow-up).
+    // plugin 이 dot-slash 없이 반환 → key 도 그대로. value 는 wrapped 모듈 init-call (#4039).
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"nested/a.tsx\":function()") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_modules[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_modules") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "(),__toCommonJS(") != null);
     // raw `require(./...)` 는 IIFE 안에 없어야 — RN/Hermes runtime 호환.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./pages/") == null);
     // emitJoinedPath 가 중복 slash 안 만들어야.
@@ -1486,10 +1583,11 @@ test "Bundler: multiple require.context calls resolve to distinct maps (span mat
     try std.testing.expect(!result.hasErrors());
 
     // 첫 호출 (./pages) 는 first.tsx 만, 둘째 호출 (./other) 는 second.tsx 만.
-    // matches key (relative) + __zntc_modules wrapper (raw require 회피, #1579 follow-up).
+    // matches key (relative) + wrapped 모듈 init-call (raw require 회피, #4039).
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"./first.tsx\":function()") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"./second.tsx\":function()") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_modules[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_modules") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "(),__toCommonJS(") != null);
     // cross-contamination 또는 raw require 없음.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./pages/") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./other/") == null);
@@ -1732,8 +1830,9 @@ test "Bundler: require.context IIFE has no raw require call (RN runtime invarian
         // 같은 정상 호출은 require 와 무관).
         try std.testing.expect(std.mem.indexOf(u8, iife, "return require(") == null);
         try std.testing.expect(std.mem.indexOf(u8, iife, " require(\"./") == null);
-        // 정상 emit 검증: __zntc_modules wrapper 호출.
-        try std.testing.expect(std.mem.indexOf(u8, iife, "__zntc_modules[") != null);
+        // 정상 emit 검증: wrapped 모듈 init-call (#4039 — `__zntc_modules` 미사용).
+        try std.testing.expect(std.mem.indexOf(u8, iife, "__zntc_modules") == null);
+        try std.testing.expect(std.mem.indexOf(u8, iife, "(),__toCommonJS(") != null);
         pos = end + 4;
     }
     try std.testing.expect(found_iife);

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1851,6 +1851,62 @@ pub fn emitModule(
     const cjs_ex_name = if (cjs_mangle) CJS_MANGLE_EXPORTS else cg_options.default_cjs_exports_name;
     const cjs_mod_name = if (cjs_mangle) CJS_MANGLE_MODULE else cg_options.default_cjs_module_name;
 
+    // require.context: emit 직전에 매치 모듈의 init-call 참조를 linker 로 계산.
+    // dev 단일번들은 기존 `__zntc_modules` HMR 경로 유지(refs 비움 → codegen fallback).
+    // code_splitting / production 단일번들은 `__zntc_modules`(dev 전용)를 못 쓰므로
+    // 같은 청크/번들 내 wrapped 매치 모듈을 `(init_X(),__toCommonJS(exports_X))` 로 직접
+    // 참조한다(issue #4039 + production require.context). 매치 모듈은 finalize Pass 3b 가
+    // 항상 wrap → init_X/exports_X 존재. arena 할당이라 별도 free 불요.
+    const rc_init_refs: []const []const ?[]const u8 = blk: {
+        if (options.dev_mode and !options.code_splitting) break :blk &.{};
+        const l = linker orelse break :blk &.{};
+        var any = false;
+        for (module.import_records) |rec| {
+            if (rec.kind == .require_context) {
+                any = true;
+                break;
+            }
+        }
+        if (!any) break :blk &.{};
+        const refs = arena_alloc.alloc([]const ?[]const u8, module.import_records.len) catch break :blk &.{};
+        for (module.import_records, 0..) |rec, ri| {
+            if (rec.kind != .require_context or rec.context_resolved_paths.len == 0) {
+                refs[ri] = &.{};
+                continue;
+            }
+            const per = arena_alloc.alloc(?[]const u8, rec.context_resolved_paths.len) catch {
+                refs[ri] = &.{};
+                continue;
+            };
+            for (rec.context_resolved_paths, 0..) |abs_opt, mi| {
+                per[mi] = null;
+                const abs = abs_opt orelse continue;
+                const tgt_idx = l.graph.path_to_module.get(abs) orelse continue;
+                const tgt = l.graph.getModule(tgt_idx) orelse continue;
+                // metadata.zig 의 require lowering 과 동일 dispatch — wrap_kind 별 참조 형태.
+                // .cjs 모듈은 init_X/exports_X 가 없고 require_X 만 있으므로 `require_X()`.
+                // .esm 모듈은 `(init_X(), <toCommonJS>(exports_X))` (minify 시 `$tC`).
+                switch (tgt.wrap_kind) {
+                    .cjs => {
+                        const req_name = tgt.allocRequireName(arena_alloc, &l.rename_table) catch continue;
+                        per[mi] = std.fmt.allocPrint(arena_alloc, "{s}()", .{req_name}) catch null;
+                    },
+                    .esm => {
+                        const init_name = tgt.allocInitName(arena_alloc, &l.rename_table) catch continue;
+                        const exp_name = tgt.allocExportsName(arena_alloc, &l.rename_table) catch continue;
+                        const to_cjs: []const u8 = if (options.minify_whitespace) rt.NAMES.TOCOMMONJS_MIN else "__toCommonJS";
+                        per[mi] = std.fmt.allocPrint(arena_alloc, "({s}(),{s}({s}))", .{ init_name, to_cjs, exp_name }) catch null;
+                    },
+                    // .none = wrap 누락(force-wrap 실패 등) → null 로 두면 codegen 이
+                    // __zntc_modules fallback(dev) 또는 throw stub. 정상 경로는 Pass 3b 가 wrap.
+                    .none => per[mi] = null,
+                }
+            }
+            refs[ri] = per;
+        }
+        break :blk refs;
+    };
+
     var cg = Codegen.initWithOptions(arena_alloc, transformer.ast, .{
         .minify_whitespace = options.minify_whitespace,
         .cjs_exports_name = cjs_ex_name,
@@ -1894,6 +1950,7 @@ pub fn emitModule(
         // dev mode: import.meta.hot → __zntc_make_hot("dev_id")
         .dev_module_id = if (options.dev_mode and module.dev_id.len > 0) module.dev_id else null,
         .require_context_module_id_root = options.root_dir,
+        .require_context_init_refs = rc_init_refs,
         .import_records = module.import_records,
         .worker_map = if (options.worker_map_per_module) |outer| outer.getPtr(module.path) else null,
         .assert_no_raw_private_syntax = options.unsupported.requiresPrivateDownlevel(),

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -873,6 +873,27 @@ pub fn emitChunks(
             }
         }
 
+        // Wrapped entry 모듈은 factory body 안에서 명시적으로 호출해야 본문이 실행된다.
+        // scope-hoist(.none) entry 는 인라인 실행되지만, require.context/CJS-interop 등으로
+        // wrap 된 entry 는 `var require_X=__commonJS(...)`/`var init_X=__esm(...)` 정의만 되고
+        // 호출 안 돼 본문 미실행이었다(issue #4039 / verifier BUG2). bootstrap 의
+        // `__zntc_require("entry-chunk")` 는 factory 를 1회 실행하므로 여기서 wrapped entry
+        // init 을 호출하면 정확히 1회 실행(__commonJS/__esm 가 memoize).
+        if (reg_split and chunk_is_user_entry) {
+            if (entry_mod_idx) |ei| {
+                if (graph.getModule(@enumFromInt(ei))) |em| {
+                    // TLA(.esm + top-level await) entry 는 appendModuleCall 이 `await init_X()`
+                    // 를 내는데, reg_split 청크 factory 는 비-async `function(...)` 이라 top-level
+                    // await = SyntaxError. TLA+reg_split entry 는 이 PR 이전에도 미실행이었으므로
+                    // 여기서 제외(회귀 없음 — 무효 JS 생성 방지). 비-TLA wrapped entry 만 호출.
+                    const tla_entry = em.wrap_kind == .esm and em.uses_top_level_await;
+                    if (em.wrap_kind.isWrapped() and !tla_entry) {
+                        try parent.appendModuleCall(&chunk_output, allocator, em, if (linker) |l| &l.rename_table else null);
+                    }
+                }
+            }
+        }
+
         // IIFE splitting: self-register factory 닫기 + (entry) bootstrap.
         // prefix `(function(g){<INSTALL>({"id":function(exports,module,require){`
         // 의 짝: factory fn `}` + 객체 `}` + register 호출 `)` + `;` + wrapper

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -126,6 +126,19 @@ pub fn promoteExportsKinds(self: *ModuleGraph) void {
         }
     }
 
+    // Pass 3b: require.context 매치 모듈(is_context_dep)은 런타임 `ctx(req)` 가 모듈을
+    // init-call(`(init_X(),__toCommonJS(exports_X))`)로 참조하므로 **항상 wrap** 되어
+    // init_X/exports_X 를 가져야 한다. Pass 3 은 dev/RN 게이트라 production·code_splitting
+    // 에선 안 돌아 매치 모듈이 scope-hoist 되어 init_X 가 없었다(issue #4039 + production
+    // require.context). 게이트 무관 별도 pass 로 강제 wrap.
+    {
+        var it = self.modules.iterator(0);
+        while (it.next()) |m| {
+            if (!m.is_context_dep or m.wrap_kind != .none) continue;
+            m.wrap_kind = if (m.exports_kind.isEsm()) .esm else .cjs;
+        }
+    }
+
     // Pass 4: inlineDynamicImports — dynamic-import target 만 __esm 래핑.
     // 일반 모듈은 scope-hoisting 그대로, dynamic target 만 lazy factory 로
     // 묶어서 emitter 가 `import("./x")` 호출을 init/exports 호출로 재작성.

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -722,6 +722,12 @@ pub const ImportRecord = struct {
     /// 못 받기 때문에 wrapper module 호출로 emit (#1579 Phase 4 follow-up).
     /// element 가 null = 해당 매치 resolve 실패 (codegen 이 throw stub 으로 emit).
     context_resolved_paths: []const ?[]const u8 = &.{},
+    /// require.context: context_resolved_paths 와 1:1. emitter 가 emit 직전에 linker 로
+    /// 계산한 매치 모듈의 init-call 참조 문자열 — `(init_X(),__toCommonJS(exports_X))`.
+    /// code_splitting / production 단일번들에서 `__zntc_modules[id]`(단일번들 dev HMR 전용,
+    /// 청크 경계 미지원)를 대체한다(issue #4039 + production require.context). null = 미계산
+    /// (dev 단일번들 → codegen 이 `__zntc_modules` fallback). emit 후 emitter 가 free.
+    context_init_refs: []const ?[]const u8 = &.{},
     /// require/dynamic import call 이 function/arrow/method/getter body 안에 있어
     /// 호출 시점에만 평가되는 lazy callback 인지. RN core `index.js` 의
     /// `get DevSettings() { return require(...).default }` 같은 lazy getter 패턴

--- a/src/codegen/calls.zig
+++ b/src/codegen/calls.zig
@@ -145,13 +145,22 @@ fn tryEmitGlobObject(self: anytype, callee: ast_mod.NodeIndex, args_start: u32, 
 fn tryEmitRequireContextObject(self: anytype, node: Node) !bool {
     if (!self.has_require_context_records) return false;
 
+    var rec_index: usize = 0;
     const rec: *const ImportRecord = blk: {
-        for (self.options.import_records) |*r| {
-            if (r.kind == .require_context and std.meta.eql(r.span, node.span))
+        for (self.options.import_records, 0..) |*r, ri| {
+            if (r.kind == .require_context and std.meta.eql(r.span, node.span)) {
+                rec_index = ri;
                 break :blk r;
+            }
         }
         return false;
     };
+    // emitter 가 미리 계산한 init-call 참조 (code_splitting / production 단일번들 —
+    // `__zntc_modules` 미사용 경로). null/빈 슬라이스면 dev 단일번들 → __zntc_modules fallback.
+    const init_refs: []const ?[]const u8 = if (rec_index < self.options.require_context_init_refs.len)
+        self.options.require_context_init_refs[rec_index]
+    else
+        &.{};
 
     try self.write("(function(){var map={");
     if (rec.context_matches) |matches| {
@@ -167,14 +176,16 @@ fn tryEmitRequireContextObject(self: anytype, node: Node) !bool {
                 rec.context_resolved_paths[i]
             else
                 null;
-            if (resolved_abs) |abs| {
-                // `ctx(req)` 는 Metro/webpack 의 require.context semantic 대로 module
-                // exports 를 반환해야 한다. `fn()` 만 호출하면 init 은 실행되지만 exports
-                // 는 undefined — expo-router 가 `ctx(req)` 반환값을 route module 로 사용해
-                // tree 구성이 실패하고 "Unmatched Route" 로 fallback.
-                // 다른 require 호출과 동일한 `(fn(), __toCommonJS(.exports))` 패턴으로 emit.
-                // `__zntc_modules` 의 key 는 모듈 등록 ID — emitter 가 `dev.makeModuleId`
-                // 로 normalize 해서 등록하므로 lookup 도 동일 normalize 적용 (#2466 follow-up).
+            // emitter 가 init-call 참조를 계산했으면(code_splitting/production 단일번들)
+            // `(init_X(),__toCommonJS(exports_X))` 직접 참조 — `__zntc_modules`(dev 전용,
+            // 청크 경계 미지원)를 우회(issue #4039 + production require.context).
+            const pre_ref: ?[]const u8 = if (i < init_refs.len) init_refs[i] else null;
+            if (pre_ref) |ref| {
+                try self.write(ref);
+            } else if (resolved_abs) |abs| {
+                // dev 단일번들: `ctx(req)` 는 Metro/webpack semantic 대로 module exports 를
+                // 반환해야 한다. `__zntc_modules` 의 key 는 `dev.makeModuleId` normalize 한
+                // 등록 ID (#2466). HMR 런타임(dev_mode)이 `__zntc_modules` 를 주입한다.
                 const id = dev.makeModuleId(abs, self.options.require_context_module_id_root);
                 try self.write("(__zntc_modules[\"");
                 try writeJsStringContent(self, id);

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -144,6 +144,12 @@ pub const CodegenOptions = struct {
     /// `__zntc_modules[<id>]` lookup 이 모듈 등록 ID 와 일치해야 하므로 emitter 가 동일
     /// `root_dir` 을 전달. null 이면 변환 없음 (legacy 절대 경로).
     require_context_module_id_root: ?[]const u8 = null,
+    /// require.context match 의 init-call 참조 문자열 — import_records 와 같은 인덱스로
+    /// [record_index][match_index]. emitter 가 linker 로 미리 계산해 전달
+    /// (`(init_X(),__toCommonJS(exports_X))`). code_splitting / production 단일번들에서
+    /// `__zntc_modules[id]`(dev HMR 전용) 대신 사용(issue #4039 + production require.context).
+    /// 비어있으면(dev 단일번들) codegen 이 `__zntc_modules` fallback. element null = resolve 실패.
+    require_context_init_refs: []const []const ?[]const u8 = &.{},
     /// import.meta.glob 레코드. codegen이 glob 호출을 객체 리터럴로 직접 출력.
     import_records: []const types.ImportRecord = &.{},
     /// Metro x_facebook_sources function map emit 활성화.


### PR DESCRIPTION
## 개요

`require.context` 가 매치 모듈을 **단일번들 dev HMR 레지스트리 `__zntc_modules[id]`** 로 참조했는데, 이 레지스트리는 (1) `dev_mode` 일 때만 주입되고 (2) 청크 단위라 모듈 단위 lookup 불가입니다. 결과:
- **code_splitting** 에서 `__zntc_modules` undefined → 크래시 (**#4039**)
- **production 단일번들** 에서도 런타임 크래시 (별개의 기존 버그 — 테스트가 문자열만 검사해 미포착)

`Fixes #4039`

## 통합 해법 — wrapped 모듈 init-call 직접 참조

매치 모듈을 같은 청크/번들 안의 wrapped 모듈로 두고 다른 require 와 동일하게 참조 (`__zntc_modules` 의존 제거):
- **`finalize.zig` Pass 3b**: `is_context_dep` 모듈을 **항상 force-wrap** (모든 경로에서 `init_X`/`exports_X`/`require_X` 보장). 기존엔 Pass 3(dev/RN 게이트) 안에만 있어 production/split 에서 누락.
- **`emitter.zig`**: emit 직전 linker(rename_table)로 매치별 참조를 계산 — `metadata.zig` 의 require lowering 과 동일 dispatch: **`.cjs` → `require_X()`**, **`.esm` → `(init_X(), __toCommonJS(exports_X))`**(minify 시 `$tC`). dev 단일번들은 기존 `__zntc_modules` HMR 경로 유지(hot-reload 보존).
- **`codegen`**: 계산된 참조가 있으면 그것을, 없으면(dev 단일번들) `__zntc_modules` fallback.
- **`emitChunks`**: require.context/CJS-interop 로 wrap 된 **entry 를 factory 안에서 호출**(BUG2 — 기존엔 정의만 되고 미호출이라 entry 본문 미실행). TLA(.esm+top-level await) entry 는 비-async factory 에 `await` 무효 JS 방지 위해 제외.

## 검증

- **e2e(node vm)**: require.context 'sync' 가 **split + production 단일번들 둘 다** 실제 실행 — `ctx(k).default()` 가 매치 모듈 exports 반환, named export·**CJS 매치**·**minify** 모두 정상, `__zntc_modules` 0건.
- **유닛**: split init-ref/entry-trigger 가드 + CJS/minify 회귀 가드 신규, 기존 4개 테스트를 새 동작으로 갱신.
- 전체 `zig build test` **5717/5717**, napi/wasm/install 통과.
- **`/code-review max` 2회**: recall 리뷰가 (1) CJS 매치 `init_X` 미정의, (2) minify `__toCommonJS` 미정의, (3) TLA entry SyntaxError 를 포착 → canonical 형태로 수정 + 회귀 테스트 추가. (low-sev: split entry 의 `entry_error_guard` 미적용 — 후속.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)