### PR TITLE
fix(codegen): 타입 래퍼 벗길 때 load-bearing 괄호를 보존 ((a?.b as T).c, (42 as T).x 등)

### DIFF
--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -160,6 +160,95 @@ pub fn unwrapTransparentWrappersAst(ast: *const @import("../parser/ast.zig").Ast
     }
 }
 
+/// member/call spine 을 따라가며 optional chain(`?.`)이 하나라도 있으면 true.
+/// transparent **타입** 래퍼(as/satisfies/non-null/type-assertion/flow/instantiation)는 통과하지만
+/// 괄호(parenthesized_expression)는 통과하지 않고 거기서 멈춘다 — 괄호는 이미 체인을 끊으므로
+/// 그 안쪽 optional 은 바깥 괄호의 보존 여부와 무관하기 때문.
+///
+/// 용도: `(a?.b as T).c` / flow `(a?.b: T).c` 처럼 codegen 이 타입 래퍼를 벗기며 (래퍼가 감싼)
+/// 괄호를 떼려 할 때, 그 괄호가 optional chain 을 *끊는* 의미를 갖는지 판정한다. true 면 괄호를
+/// 유지해야 한다(안 그러면 `(a?.b).c`(nullish 면 `.c` 에서 throw)가 `a?.b.c`(short-circuit)로
+/// 의미가 바뀌고, tagged template 은 `a?.b`x`` 라는 invalid 출력이 된다).
+///
+/// es2020.findOptionalChainBase 와 달리 mid-spine 타입 래퍼(`a?.b!.c` 의 `!`)를 통과한다 —
+/// 그쪽은 lowering 용이라 타입 래퍼에서 멈춰 여기엔 부적합.
+pub fn spineHasOptionalChainThroughTypeWrappers(ast: *const @import("../parser/ast.zig").Ast, idx: NodeIndex) bool {
+    const extras = ast.extra_data.items;
+    var cur = idx;
+    var guard: u32 = 0;
+    while (guard < 100_000) : (guard += 1) {
+        if (cur.isNone()) return false;
+        const n = ast.getNode(cur);
+        // 타입 래퍼는 spine 을 끊지 않으므로 통과 (SSoT: isTransparentTypeWrapper, 괄호는 제외).
+        if (ast_mod.Node.Tag.isTransparentTypeWrapper(n.tag)) {
+            cur = n.data.unary.operand;
+            continue;
+        }
+        switch (n.tag) {
+            .static_member_expression, .computed_member_expression, .private_field_expression => {
+                const e = n.data.extra;
+                if (e + 2 < extras.len and (extras[e + 2] & ast_mod.MemberFlags.optional_chain) != 0) return true;
+                cur = @enumFromInt(extras[e]); // object
+            },
+            .call_expression => {
+                const e = n.data.extra;
+                if (e + 3 < extras.len and (extras[e + 3] & ast_mod.CallFlags.optional_chain) != 0) return true;
+                cur = @enumFromInt(extras[e]); // callee
+            },
+            else => return false, // identifier / parenthesized_expression(체인 끊김) / 기타 head
+        }
+    }
+    return false;
+}
+
+/// transparent 타입 래퍼(TS as/satisfies/non-null/`<T>`, Flow as/colon-cast)를 벗기며 그 래퍼가
+/// (흡수했거나 감싼) 괄호를 떼려 할 때, operand 가 단독으로 나와도 안전한지 판정한다.
+/// codegen 은 paren-node 기반(명시적 괄호 노드만 출력, 연산자 우선순위로 재유도 안 함)이라
+/// load-bearing 괄호를 떼면 의미가 바뀐다. 안전한 primary/postfix 면 false(괄호 제거 = babel 동형
+/// 최소 출력), 아니면 true(보존). 괄호는 idempotent(우선순위만 높임)라 과보존은 항상 안전 →
+/// "안전한 것만 화이트리스트, 모르는 건 보존" 방향. 선행 타입 래퍼는 통과해 실 operand 로 판정한다.
+/// Flow colon-cast(괄호 흡수)·TS `<T>(expr)`(괄호 unwrap)·node_dispatch 의 `(X as T)` paren 핸들러 공용.
+pub fn castOperandNeedsParen(ast: *const @import("../parser/ast.zig").Ast, operand: NodeIndex) bool {
+    if (operand.isNone()) return false;
+    // 선행 타입 래퍼 통과(`(a as U as T)` 의 a, `(X as T)` 의 X 까지) — whitelist 는 실 operand 기준.
+    var op = operand;
+    var guard: u32 = 0;
+    while (guard < 100_000) : (guard += 1) {
+        if (op.isNone()) return false;
+        if (!ast_mod.Node.Tag.isTransparentTypeWrapper(ast.getNode(op).tag)) break;
+        op = ast.getNode(op).data.unary.operand;
+    }
+    // optional chain 은 괄호가 체인을 *끊는* 의미 → 보존 (member/call optional, mid-spine `!` 포함).
+    if (spineHasOptionalChainThroughTypeWrappers(ast, op)) return true;
+    return switch (ast.getNode(op).tag) {
+        // 단독으로 안전한 primary/postfix — 괄호 불필요(`(obj: T)`→`obj`, `(a.b: T).c`→`a.b.c`).
+        // member/call 은 위 optional 체크가 false 였으니 non-optional → postfix 로 안전.
+        // bigint 은 `n` 접미사가 리터럴을 끝내 `42n.x` 가 유효(numeric 과 달리 안전).
+        .identifier_reference,
+        .this_expression,
+        .super_expression,
+        .boolean_literal,
+        .null_literal,
+        .string_literal,
+        .regexp_literal,
+        .bigint_literal,
+        .template_literal,
+        .array_expression,
+        .tagged_template_expression,
+        .parenthesized_expression,
+        .static_member_expression,
+        .computed_member_expression,
+        .private_field_expression,
+        .call_expression,
+        => false,
+        // numeric_literal 제외: 정수 뒤 멤버(`(42: T).x` → `42.x`)가 float 로 오파싱돼 invalid
+        // (codegen 이 number-then-dot 공백을 안 넣으므로 여기서 괄호 보존). 그 외(binary/logical/
+        // conditional/assignment/sequence/arrow/function/class/object/unary/yield/await/new/update/
+        // spread …)는 precedence·statement-start(`({x:1} as T).c`) 상 괄호가 필요할 수 있어 보존.
+        else => true,
+    };
+}
+
 /// `computed_property_key(identifier_reference(var_span))` 노드 생성.
 /// 임시 변수에 캡쳐된 computed key 식을 다시 key 위치로 참조할 때 사용 (#1511, static field key memoization).
 pub fn makeComputedKeyRef(self: anytype, var_span: Span, span: Span) !NodeIndex {

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -219,7 +219,7 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
         .spread_element,
         => self.visitUnaryNode(idx),
         .parenthesized_expression => {
-            // (expr as T) → expr: TS expression이면 괄호 불필요
+            // (expr as T) → expr: 타입 래퍼는 noop 이라 보통 괄호가 불필요.
             const inner = node.data.unary.operand;
             if (!inner.isNone()) {
                 const inner_tag = self.ast.getNode(inner).tag;
@@ -230,6 +230,16 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
                     inner_tag == .flow_as_expression or
                     inner_tag == .flow_type_cast_expression)
                 {
+                    // 단, 타입 래퍼 안쪽 operand 가 load-bearing 이면 괄호를 떼면 의미가 바뀐다:
+                    //   - optional chain: `(a?.b as T).c` 는 `(a?.b).c`(nullish 면 throw) ≠ `a?.b.c`
+                    //   - numeric: `(42 as T).x` 는 `(42).x` — `42.x` 는 float 오파싱 invalid
+                    //   - statement-start: `({x:1} as T).c` 는 `({x:1}).c` — `{x:1}.c` 는 블록 오파싱
+                    //   - arrow 등 저우선순위 callee: `(()=>{} as T)()` 등
+                    // castOperandNeedsParen 이 true 면 괄호 유지(visitUnaryNode 가 `(`+visitNode(inner)+`)`,
+                    // visitNode 가 래퍼를 벗겨 `(a?.b)`/`(42)` 산출). 안전한 primary/postfix 면 제거(최소).
+                    if (es_helpers.castOperandNeedsParen(self.ast, inner)) {
+                        return self.visitUnaryNode(idx);
+                    }
                     return self.visitNode(inner);
                 }
             }

--- a/src/transformer/transformer/type_expression.zig
+++ b/src/transformer/transformer/type_expression.zig
@@ -5,6 +5,7 @@ const NodeIndex = ast_mod.NodeIndex;
 const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
+const es_helpers = @import("../es_helpers.zig");
 
 /// TS/Flow expression wrappers keep only their runtime operand when type stripping is enabled.
 pub fn visitTsExpression(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
@@ -16,11 +17,35 @@ pub fn visitTsExpression(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
     if (node.tag == .ts_type_assertion and !operand.isNone()) {
         const op_node = self.ast.getNode(operand);
         if (op_node.tag == .parenthesized_expression and !op_node.data.unary.operand.isNone()) {
-            const inner = self.ast.getNode(op_node.data.unary.operand);
-            if (inner.tag != .sequence_expression) {
+            // TS prefix-assertion `<T>(x)`: x 가 안전하면 괄호까지 제거(`<T>(obj)`→`obj`).
+            // load-bearing 이면(`<T>(a+b)*c` / `<T>(a?.b).c` / sequence) 괄호 유지 — 아래 일반
+            // 경로가 parenthesized_expression 노드를 그대로 보존해 의미를 지킨다.
+            if (!es_helpers.castOperandNeedsParen(self.ast, op_node.data.unary.operand)) {
                 return self.visitNode(op_node.data.unary.operand);
             }
         }
+    }
+    // Flow colon-cast `(expr: T)` 는 괄호를 노드에 absorb 한 단일 flow_type_cast_expression 이라
+    // (TS `as`/`!` 처럼 parenthesized_expression 으로 감싸지 않으므로) node_dispatch 의 paren
+    // 핸들러를 거치지 않는다. codegen 은 paren-node 기반이라 우선순위로 괄호를 재유도하지
+    // 않으므로, 흡수했던 source 괄호가 load-bearing 이면(precedence/optional-chain/statement-start)
+    // paren 노드를 복원해 보존한다. 안전한 primary/postfix 면 종전대로 제거(최소 출력).
+    //   - `(a + b: T) * c` → `(a + b) * c` (precedence)
+    //   - `(a?.b: T).c`    → `(a?.b).c`    (optional chain break)
+    //   - `({x:1}: T).c`   → `({x:1}).c`   (statement-start 모호성)
+    //   - `(obj: T)`       → `obj`         (안전 → 제거)
+    // operand 이 또 flow_type_cast 면(중첩 `((a?.b: U): T)`) inner 가 제 괄호를 합성하므로 여기선
+    // 생략 — 안 그러면 레벨마다 괄호가 쌓여 `((a?.b)).c` 가 된다.
+    if (node.tag == .flow_type_cast_expression and
+        self.ast.getNode(operand).tag != .flow_type_cast_expression and
+        es_helpers.castOperandNeedsParen(self.ast, operand))
+    {
+        const paren = try self.ast.addNode(.{
+            .tag = .parenthesized_expression,
+            .span = node.span,
+            .data = .{ .unary = .{ .operand = operand, .flags = 0 } },
+        });
+        return self.visitNode(paren);
     }
     return self.visitNode(operand);
 }

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1396,6 +1396,172 @@ test "block scoping: optional chain property names are not lexical references" {
     try std.testing.expect(std.mem.indexOf(u8, code, "prototype$") != null);
 }
 
+test "codegen: 타입 래퍼로 감싼 optional chain 의 괄호는 체인을 끊으므로 보존 ((a?.b as T).c)" {
+    // ECMAScript: `(a?.b).c` 는 a 가 nullish 면 `.c` 에서 throw 인데 `a?.b.c` 는 전체
+    // short-circuit → undefined. 타입 래퍼(as/satisfies/non-null/type-assertion/flow)를
+    // 벗길 때 괄호까지 떼면 optional chain 이 이어져 의미가 바뀐다(silent miscompile). 또
+    // `(a?.b as T)`x`` 는 괄호를 떼면 `a?.b`x`` 라는 우리 파서마저 거부하는 출력이 된다.
+    // 따라서 래퍼 안쪽이 optional chain 이면 괄호를 유지한 채 타입만 스트립한다.
+    const Case = struct { src: []const u8, want: []const u8 };
+    const cases = [_]Case{
+        .{ .src = "(a?.b as any).c;", .want = "(a?.b).c" },
+        .{ .src = "(a?.b satisfies any).c;", .want = "(a?.b).c" },
+        .{ .src = "(a?.b!).c;", .want = "(a?.b).c" },
+        .{ .src = "(a?.b as any)`x`;", .want = "(a?.b)`x`" },
+        .{ .src = "(a?.b as any)();", .want = "(a?.b)()" },
+        .{ .src = "(a?.b as any)[c];", .want = "(a?.b)[c]" },
+        .{ .src = "(a?.b.c as any).d;", .want = "(a?.b.c).d" },
+        .{ .src = "(a.b?.c as any).d;", .want = "(a.b?.c).d" },
+        .{ .src = "(a?.() as any).c;", .want = "(a?.()).c" },
+        // mid-spine `!`(TS non-null)도 체인을 끊지 않으므로 spine 을 통과해 optional 검출.
+        .{ .src = "(a?.b!.c as any).d;", .want = "(a?.b.c).d" },
+        .{ .src = "(a?.b!() as any).c;", .want = "(a?.b()).c" },
+        .{ .src = "(a?.b![k] as any).c;", .want = "(a?.b[k]).c" },
+        .{ .src = "(a?.b!.c! as any).d;", .want = "(a?.b.c).d" },
+    };
+    for (cases) |c| {
+        var r = try parseAndTransform(std.testing.allocator, c.src);
+        defer r.deinit();
+        const code = try generateCode(&r);
+        defer std.testing.allocator.free(code);
+        try std.testing.expect(std.mem.indexOf(u8, code, c.want) != null);
+    }
+}
+
+test "codegen: optional chain 이 아닌 타입 래퍼 괄호는 종전처럼 제거 ((a.b as T).c → a.b.c)" {
+    // 괄호 유지는 optional chain 일 때만. 일반 멤버/호출은 괄호가 의미 없으므로 제거 유지
+    // (esbuild parity). `(a?.b).c`(paren 으로 이미 끊긴 체인) 도 .c 가 비-optional 이라 제거 OK.
+    const Case = struct { src: []const u8, want: []const u8, deny: []const u8 };
+    const cases = [_]Case{
+        .{ .src = "(a.b as any).c;", .want = "a.b.c", .deny = "(a.b)" },
+        .{ .src = "(f() as any).c;", .want = "f().c", .deny = "(f())" },
+        .{ .src = "((a?.b).c as any).d;", .want = "(a?.b).c.d", .deny = "(a?.b).c).d" },
+        // optional 이 computed key / call 인자 안이면 spine 이 아니므로 괄호 제거 (false-positive 가드).
+        .{ .src = "(a[b?.c] as any).d;", .want = "a[b?.c].d", .deny = "(a[" },
+        .{ .src = "(f(a?.b) as any).c;", .want = "f(a?.b).c", .deny = "(f(" },
+        // 래퍼가 감싼 *소스* 괄호(`((a?.b) as T).c`)는 그 안쪽 괄호가 이미 체인을 끊으므로
+        // 바깥 타입-래퍼 괄호를 새로 만들지 않는다 — 이중 괄호 `((a?.b)).c` 금지.
+        .{ .src = "((a?.b) as any).c;", .want = "(a?.b).c", .deny = "((a?.b)).c" },
+        .{ .src = "((a?.b)! as any).c;", .want = "(a?.b).c", .deny = "((a?.b)).c" },
+    };
+    for (cases) |c| {
+        var r = try parseAndTransform(std.testing.allocator, c.src);
+        defer r.deinit();
+        const code = try generateCode(&r);
+        defer std.testing.allocator.free(code);
+        try std.testing.expect(std.mem.indexOf(u8, code, c.want) != null);
+        try std.testing.expect(std.mem.indexOf(u8, code, c.deny) == null);
+    }
+}
+
+test "codegen: TS `(X as T)` 괄호 — numeric/statement-start/arrow 등 load-bearing 보존" {
+    // node_dispatch paren 핸들러도 castOperandNeedsParen 공용. optional chain 외에:
+    //   - numeric: `(42 as T).x` → `(42).x` (`42.x` 는 float 오파싱 invalid)
+    //   - statement-start: `({x:1} as T).c` → `({x:1}).c` (`{x:1}.c` 는 블록 오파싱)
+    //   - arrow/function callee: `(function(){} as T)()` 등
+    const Keep = struct { src: []const u8, want: []const u8 };
+    const keep = [_]Keep{
+        .{ .src = "(42 as number).toFixed(2);", .want = "(42).toFixed(2)" },
+        .{ .src = "(255 as number).toString(16);", .want = "(255).toString(16)" },
+        .{ .src = "({x:1} as any).c;", .want = "({ x: 1 }).c" },
+        .{ .src = "(function(){} as any)();", .want = "(function() {" },
+        .{ .src = "(<any>42).x;", .want = "(42).x" },
+    };
+    for (keep) |c| {
+        var r = try parseAndTransform(std.testing.allocator, c.src);
+        defer r.deinit();
+        const code = try generateCode(&r);
+        defer std.testing.allocator.free(code);
+        try std.testing.expect(std.mem.indexOf(u8, code, c.want) != null);
+    }
+    // bigint 은 `n` 접미사가 리터럴을 끝내 `42n.x` 가 유효 → 괄호 제거(최소).
+    var r = try parseAndTransform(std.testing.allocator, "(42n as any).x;");
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "42n.x") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "(42n)") == null);
+}
+
+test "codegen: Flow colon-cast `(expr: T)` 는 load-bearing 괄호만 보존 (paren absorb 경로)" {
+    // Flow `(expr: T)` 는 괄호를 노드에 흡수한 단일 flow_type_cast_expression 이라 paren 핸들러를
+    // 우회한다. codegen 은 paren-node 기반이라 우선순위로 괄호를 재유도하지 않으므로,
+    // visitTsExpression 에서 operand 가 load-bearing 이면(precedence/optional-chain/statement-start/
+    // numeric-then-dot) paren 노드를 합성해 보존하고, 안전한 primary/postfix 면 제거(최소 출력).
+    const Case = struct { src: []const u8, want: []const u8 };
+    const keep = [_]Case{
+        // optional chain (괄호가 체인을 끊음)
+        .{ .src = "// @flow\n(a?.b: any).c;", .want = "(a?.b).c" },
+        .{ .src = "// @flow\n(a?.b: any)`x`;", .want = "(a?.b)`x`" },
+        .{ .src = "// @flow\n(a?.b!.c: any).d;", .want = "(a?.b.c).d" }, // mid-spine `!`
+        .{ .src = "// @flow\n(a?.b(): any).c;", .want = "(a?.b()).c" },
+        // operator precedence
+        .{ .src = "// @flow\n(a + b: any) * c;", .want = "(a + b) * c" },
+        .{ .src = "// @flow\n(a || b: any) && c;", .want = "(a || b) && c" },
+        .{ .src = "// @flow\n(c ? x : y: any).z;", .want = "(c ? x : y).z" },
+        // statement-start 모호성 (object literal / new)
+        .{ .src = "// @flow\n({x:1}: any).c;", .want = "({ x: 1 }).c" },
+        .{ .src = "// @flow\n(new C: any).x;", .want = "(new C()).x" },
+        // numeric-then-dot: `42.x` 는 float 오파싱 → invalid. 괄호 보존.
+        .{ .src = "// @flow\n(42: any).x;", .want = "(42).x" },
+    };
+    for (keep) |c| {
+        var r = try parseAndTransform(std.testing.allocator, c.src);
+        defer r.deinit();
+        const code = try generateCode(&r);
+        defer std.testing.allocator.free(code);
+        try std.testing.expect(std.mem.indexOf(u8, code, c.want) != null);
+    }
+    // 안전한 primary/postfix 는 괄호 제거(최소 출력, babel 동형).
+    const DropCase = struct { src: []const u8, want: []const u8, deny: []const u8 };
+    const drop = [_]DropCase{
+        .{ .src = "// @flow\n(a.b: any).c;", .want = "a.b.c", .deny = "(a.b)" },
+        .{ .src = "// @flow\n(f(): any).c;", .want = "f().c", .deny = "(f())" },
+        .{ .src = "// @flow\nlet x = (obj: any);", .want = "let x = obj", .deny = "(obj)" },
+        .{ .src = "// @flow\n(\"s\": any).length;", .want = "\"s\".length", .deny = "(\"s\")" },
+    };
+    for (drop) |c| {
+        var r = try parseAndTransform(std.testing.allocator, c.src);
+        defer r.deinit();
+        const code = try generateCode(&r);
+        defer std.testing.allocator.free(code);
+        try std.testing.expect(std.mem.indexOf(u8, code, c.want) != null);
+        try std.testing.expect(std.mem.indexOf(u8, code, c.deny) == null);
+    }
+    // 중첩 Flow colon-cast 는 레벨마다 괄호를 쌓지 않는다 — `((a?.b: U): T).c` → `(a?.b).c` 단일.
+    var nr = try parseAndTransform(std.testing.allocator, "// @flow\n((a?.b: U): T).c;");
+    defer nr.deinit();
+    const ncode = try generateCode(&nr);
+    defer std.testing.allocator.free(ncode);
+    try std.testing.expect(std.mem.indexOf(u8, ncode, "(a?.b).c") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ncode, "((a?.b)).c") == null);
+}
+
+test "codegen: TS `<T>(expr)` prefix-assertion 도 load-bearing 괄호만 제거" {
+    // `<T>(x)` 특수케이스는 x 가 안전하면 괄호까지 제거(`<T>(obj)`→`obj`). load-bearing 이면
+    // 괄호 유지 — 아니면 `<T>(a+b)*c`→`a+b*c`(precedence), `<T>(a?.b).c`→`a?.b.c`(chain) miscompile.
+    const Keep = struct { src: []const u8, want: []const u8 };
+    const keep = [_]Keep{
+        .{ .src = "<T>(a + b) * c;", .want = "(a + b) * c" },
+        .{ .src = "(<T>(a?.b)).c;", .want = "(a?.b).c" },
+        .{ .src = "<T>(a, b);", .want = "(a,b)" }, // sequence
+    };
+    for (keep) |c| {
+        var r = try parseAndTransform(std.testing.allocator, c.src);
+        defer r.deinit();
+        const code = try generateCode(&r);
+        defer std.testing.allocator.free(code);
+        try std.testing.expect(std.mem.indexOf(u8, code, c.want) != null);
+    }
+    // 안전한 operand 는 괄호 제거(최소).
+    var r = try parseAndTransform(std.testing.allocator, "let x = <T>(obj);");
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "let x = obj") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "(obj)") == null);
+}
+
 test "block scoping: super member property names are not lexical references" {
     // `super.foo` 도 `static_member_expression` 이고 left 가 super_expression.
     // outer `value` 와 method body 의 inner `value` 가 shadow 될 때 inner

--- a/tests/integration/tests/tsc/__snapshots__/es6-destructuring.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-destructuring.test.ts.snap
@@ -641,7 +641,7 @@ exports[`TSC: es6/destructuring destructuringObjectBindingPatternAndAssignment5 
 "function a() {
 	let x;
 	let y;
-	({ x, ...y } = {});
+	({ x, ...y } = ({}));
 }
 "
 `;

--- a/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
@@ -1684,13 +1684,13 @@ var x = \`123\${\`456 \${" | "} 654\`}321 123\${\`456 \${" | "} 654\`}321\`;
 
 exports[`TSC: es6/templates templateStringWithEmbeddedTypeAssertionOnAddition 1`] = `
 "// @target: es2015
-var x = \`abc\${10 + 10}def\`;
+var x = \`abc\${(10 + 10)}def\`;
 "
 `;
 
 exports[`TSC: es6/templates templateStringWithEmbeddedTypeAssertionOnAdditionES6 1`] = `
 "// @target: ES6
-var x = \`abc\${10 + 10}def\`;
+var x = \`abc\${(10 + 10)}def\`;
 "
 `;
 

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -9351,11 +9351,11 @@ var generic2 = (n) => {
 };
 var generic2;
 // <Identifier> ((ParamList) => { ... } ) is a type assertion to an arrow function
-var asserted1 = (n) => [n];
+var asserted1 = ((n) => [n]);
 var asserted1;
-var asserted2 = (n) => {
+var asserted2 = ((n) => {
 	return n;
-};
+});
 var asserted2;
 "
 `;
@@ -10360,10 +10360,10 @@ foo.m?.();
 /*b3*/
 /*b4*/
 // https://github.com/microsoft/TypeScript/issues/50148
-foo?.m.length;
-foo?.m.length;
-foo?.["m"].length;
-foo?.["m"].length;
+(foo?.m).length;
+(foo?.m).length;
+(foo?.["m"]).length;
+(foo?.["m"]).length;
 "
 `;
 


### PR DESCRIPTION
## 배경
`/code-review max`(merged #4035) 검증이 적발한 codegen 버그 부류. transparent 타입 래퍼(TS `as`/`satisfies`/non-null `!`/`<T>`, Flow `as`/colon-cast)를 벗기며 **load-bearing 괄호를 잃어** silent miscompile / invalid 출력. `(a?.b).c`(nullish→throw) ≠ `a?.b.c`(short-circuit→undefined).

## 루트커즈
zntc codegen 은 **paren-node 기반**(명시적 괄호 노드만 출력, 우선순위로 재유도 안 함 — esbuild/babel/oxc/rolldown/swc/tsc 는 precedence 기반). 타입 래퍼 strip-site 가 **3곳**이라 한쪽만 고치면 다른 spelling 누수.

## 수정 (구조적, 3 strip-site 통일)
공용 술어 `es_helpers.castOperandNeedsParen(ast, operand)`:
- 선행 타입 래퍼 통과 후 실 operand 판정. **optional chain**(체인 끊김) 또는 **비-whitelist** operand 면 괄호 보존; 안전한 primary/postfix(identifier/this/super/bool/null/string/regexp/**bigint**/template/array/tagged-template/paren/member/call) 면 제거(최소·babel 동형).
- **numeric_literal 만 제외**(정수-then-dot `42.x` float 오파싱 invalid). bigint 은 `n` 종결로 `42n.x` 유효 → whitelist.
- 보조 `spineHasOptionalChainThroughTypeWrappers`: 타입 래퍼 통과(mid-spine `!`)·괄호서 멈춤(이중괄호 방지).
- 3 strip-site: ① node_dispatch `(X as T)` paren 핸들러 ② Flow colon-cast `(expr: T)`(파서가 괄호 absorb → paren 노드 합성, 중첩 시 inner 가 처리) ③ TS `<T>(expr)` prefix-assertion(괄호 unwrap).

한 술어로 전부 정정: `(a?.b as T).c`→`(a?.b).c` / `(a?.b!.c as T).d` / `(a+b: T)*c`·`<T>(a+b)*c` / `({x:1} as T).c`→`({x:1}).c` / `(42 as T).x`→`(42).x` / arrow callee. 안전한 `(a as T).c`→`a.c` 는 최소 유지.

## 검증
- **3자 차등**(zntc vs node vs esbuild): continuation·mid-spine·precedence·statement-start·numeric·false-positive 가드 일치.
- 전체 유닛 **5718/5718**, integration **bundle-smoke 151/151**.
- 회귀테스트 4 블록(TS as / Flow colon-cast / `<T>(expr)` / numeric·statement-start; keep·drop·false-positive·이중괄호 금지).
- PR 전 `/code-review max` **4 라운드**(라운드마다 더 좁은 누락 적발 → 전부 수정·통일).

## Zig 초보자 설명
codegen 은 AST 의 `(...)` 괄호 노드를 그대로 찍습니다(연산자 우선순위로 "여기 괄호 필요"를 다시 계산하지 않음 — esbuild 와 다른 점). 타입(`as T` 등)을 벗길 때 괄호까지 같이 떼면, 그 괄호가 의미를 갖던 경우(`(a?.b).c` 처럼) 결과가 달라집니다. 그래서 "이 표현식이 괄호 없이 나와도 안전한가"를 판정하는 술어를 만들어, 안전하면 괄호를 떼고(최소 출력) 위험하면 유지합니다.

## 장기 과제
codegen 을 precedence 기반(또는 하이브리드 A)으로 전환하면 이 버그 부류가 근본 소멸 → RFC #4042. 잔여 cosmetic(es2019 lowering 이중괄호)도 #4042 추적.

Closes #4043