### PR TITLE
fix(transformer): TC39 데코레이터 access getter 멤버 이름 UAF 수정 (string_table realloc)

### DIFF
--- a/src/transformer/transformer/stage3_decorator_helpers.zig
+++ b/src/transformer/transformer/stage3_decorator_helpers.zig
@@ -337,10 +337,17 @@ pub fn buildAccessObject(self: anytype, info: Stage3MemberInfo) Error!NodeIndex 
     const name_node = self.ast.getNode(info.name);
     const raw_name = self.ast.getText(name_node.data.string_ref);
     // 따옴표 제거: "\"foo\"" → "foo"
-    const member_name = if (raw_name.len >= 2 and raw_name[0] == '"')
+    const stripped = if (raw_name.len >= 2 and raw_name[0] == '"')
         raw_name[1 .. raw_name.len - 1]
     else
         raw_name;
+    // raw_name 이 string_table 슬라이스(synthetic name)면, 아래 has/get/set 가 호출하는
+    // addString("obj")/addString(member_name) 등 후속 addString 이 string_table 을 realloc 해
+    // 이 슬라이스를 dangling 으로 만든다 → addString 의 alias 가드는 *현재* 버퍼만 보호하므로
+    // stale ptr 은 not-in-table 로 분류돼 freed 메모리를 appendSlice → 출력에 0xaa garbage
+    // (`obj.method` → `obj.<0xaa…>`, #3100 동류). 안정 owned 복사로 캡처해 함수 끝까지 유지.
+    const member_name = try self.allocator.dupe(u8, stripped);
+    defer self.allocator.free(member_name);
 
     // identifier-safe 판정: 숫자로 시작하거나 유효하지 않은 식별자면 computed access 사용
     // obj.name (static) vs obj["name"] or obj[0] (computed)

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -724,6 +724,29 @@ test "experimentalDecorators + es5: inheritance + all decorators" {
     try std.testing.expectEqual(@as(u32, 4), r.statementCount());
 }
 
+// stage3(TC39) 데코레이터의 access 객체 getter 멤버 이름이 손상되지 않는다.
+// 회귀: buildAccessObject 가 멤버 이름을 string_table 슬라이스로 잡은 뒤 `obj`
+// 파라미터 등 후속 addString 이 string_table 을 realloc 시켜 슬라이스가 dangling
+// → `get: (obj) => obj.<0xaa…>` 로 출력 (Debug/ReleaseSafe 전용). 안정 owned
+// 복사로 캡처해 수정. `"method" in obj`(Span 직접 재사용)는 원래 안전했고
+// `obj.method`(이름 재-addString)만 깨졌었다.
+test "stage3 decorator: access getter 멤버 이름이 손상되지 않는다 (string_table UAF)" {
+    var r = try parseAndTransform(
+        std.testing.allocator,
+        "export default class { @dec method() {} }",
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer r.allocator.free(code);
+
+    // 데코레이터가 __esDecorate 로 lower 되어 access 객체가 생성됐는지 확인.
+    try std.testing.expect(std.mem.indexOf(u8, code, "__esDecorate") != null);
+    // get 접근자가 정확한 멤버 이름을 참조한다.
+    try std.testing.expect(std.mem.indexOf(u8, code, "obj.method") != null);
+    // undefined(0xaa) poison 바이트가 출력에 새지 않는다.
+    try std.testing.expect(std.mem.indexOf(u8, code, "\xaa") == null);
+}
+
 // ============================================================
 // 두 옵션 동시 활성화 테스트
 // ============================================================


### PR DESCRIPTION
## 요약
`@dec method() {}` 같은 stage3(TC39) 데코레이터를 lower 할 때 생성되는 access 객체의 `get: (obj) => obj.method` 에서 멤버 이름이 `obj.<0xaa…>` (garbage) 로 출력되던 **use-after-free**를 수정합니다.

> 이 버그는 **Debug/ReleaseSafe 빌드 전용**입니다. ReleaseFast(production)는 freed 메모리가 우연히 값을 유지해 정상 출력되지만, UB 인 건 동일합니다. tests/integration의 `es6-decorators` 스냅샷 테스트(Debug 빌드 실행)에서 드러났습니다.

## 근본 원인
`buildAccessObject` 는 멤버 이름을 `self.ast.getText(name_node.data.string_ref)` 로 얻는데, 이는 AST `string_table` 의 슬라이스를 **빌려온** 것입니다. 그 뒤 `addString("obj")` 등 후속 `addString` 호출이 `string_table` 을 realloc 하면 빌려온 슬라이스가 dangling 됩니다.

`addString` 에는 "입력이 string_table 자기 자신의 슬라이스"인 경우를 위한 alias 가드가 있지만, 이는 **현재** 버퍼 범위만 검사합니다. realloc 으로 이미 버퍼가 옮겨진 뒤의 **stale 포인터**(옛 버퍼를 가리킴)는 not-in-table 로 분류돼 `appendSlice` 가 freed 메모리에서 복사 → 안전모드 poison 바이트 `0xAA` 가 그대로 출력됩니다.

`has: (obj) => "method" in obj` 는 `Span`(offset 쌍, realloc 무관)을 직접 재사용해 안전했고, 이름을 다시 `addString` 하는 `get:`/`set:` 분기만 깨졌습니다.

## 수정
멤버 이름을 안정 owned 복사(`self.allocator.dupe`)로 캡처하고 `defer free` — 함수 끝까지 유효해 어떤 realloc 에도 무관합니다.

```zig
const member_name = try self.allocator.dupe(u8, stripped);
defer self.allocator.free(member_name);
```

> Zig 초보자 메모: `getText` 가 돌려주는 `[]const u8` 은 다른 버퍼(`string_table`)를 가리키는 **참조**라 그 버퍼가 커지면(realloc) 무효가 됩니다. `dupe` 는 바이트를 **복사한 새 메모리**를 만들어 그 의존을 끊습니다. `defer free` 는 함수가 끝날 때 자동 해제(arena allocator 면 no-op 라 안전).

## 회귀 가드
- `src/transformer/transformer_test.zig`: 데코레이터가 `__esDecorate` 로 lower 되고 access getter 가 `obj.method` 를 정확히 참조하며 출력에 `0xaa` poison 이 없는지 검사하는 unit 테스트 추가. **fix 없이 돌리면 fail** 확인.
- tests/integration `es6-decorators` 스냅샷 12개 동시 통과.

## 범위
이 PR 은 transpile 경로의 latent UAF 만 다룹니다. `#4045`(splitting mangle)와 독립이며, 검증 중 발견된 별개의 장기 잠복 버그입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)