### PR TITLE
fix(lexer): 템플릿 치환 lookahead 후 template_depth_stack 복구 시 0xaa poison 수정

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -1770,8 +1770,16 @@ pub const Scanner = struct {
     /// - template_tail: }text` (템플릿 끝)
     /// - syntax_error: 닫히지 않은 템플릿
     fn scanTemplateContinuation(self: *Scanner) !Kind {
-        // 스택에서 현재 템플릿 depth를 pop
-        _ = self.template_depth_stack.pop();
+        // 스택에서 현재 템플릿 depth를 pop.
+        // `pop()` 대신 길이만 감소 — `Parser.restoreState` 는 lookahead/speculation 후
+        // `items.len` 을 되돌려 popped 값을 capacity 내 backing 에서 복구하는 설계인데,
+        // 안전모드 `pop()` 은 제거 슬롯을 `undefined`(Debug 0xaa) 로 덮어써 그 전제를 깬다.
+        // 그러면 복구된 top 이 0xaaaaaaaa 가 되어, template 안 `(x)` 같은 paren 식 lookahead
+        // 직후의 닫는 `}` 가 template continuation 이 아닌 일반 `r_curly` 로 오인식돼
+        // "Expected template continuation"(ZNTC0909) 가 난다 (Debug/ReleaseSafe 전용 회귀).
+        if (self.template_depth_stack.items.len > 0) {
+            self.template_depth_stack.items.len -= 1;
+        }
         return try self.scanTemplateContent(.template_tail, .template_middle);
     }
 


### PR DESCRIPTION
## 요약
`` tag`${(input)}` `` 처럼 템플릿 치환 `${...}` 안에 괄호식 `(x)` 가 들어가면 닫는 백틱이 **"Expected template continuation"(ZNTC0909)** 로 거부되던 파서 버그를 수정합니다.

> **Debug/ReleaseSafe 빌드 전용** 버그입니다. ReleaseFast(production)는 정상 동작하지만 UB 인 건 동일합니다. tests/integration의 `es6-templates` 스냅샷(Debug 실행)에서 드러났습니다.

## 근본 원인
1. 괄호식 `(x)` 는 arrow-function 파라미터인지 판별하기 위해 lookahead(`isTypedArrowFunction` 등 speculative scan)를 발동합니다.
2. 그 lookahead 가 `)` 다음의 `}` 까지 스캔하면서 scanner 의 `template_depth_stack` 을 **pop** 합니다 (scanner 는 `}` 를 만나면 template depth 와 매칭해 template continuation 으로 재-렉싱).
3. lookahead 가 끝나면 `Parser.restoreState` 가 스캐너 위치를 되돌립니다. `template_depth_stack` 은 **`items.len` 만 saved 길이로 되돌려** popped 값을 backing capacity 에서 복구하는 설계입니다(코드 주석에 명시).
4. 그런데 Zig **안전모드 `ArrayList.pop()` 은 제거된 슬롯을 `undefined`(Debug 에서 `0xAA`) 로 덮어씁니다.** 그래서 restoreState 가 `items.len` 을 늘려 복구해도 top 값이 `0xAAAAAAAA` 가 됩니다.
5. 이후 실제 닫는 `}` 를 스캔할 때 `brace_depth == template_depth_stack.top` 매칭이 빗나가, template continuation 이 아닌 일반 `r_curly` 로 오인식 → 파서가 template 종료를 못 찾고 ZNTC0909.

`(1 + 2)` 는 arrow-param 후보가 아니라 그 lookahead 가 `}` 를 건너뛰지 않아 정상 동작했고, `(x)` 같은 "괄호 안 단일 식별자"만 깨졌습니다.

## 수정
`scanTemplateContinuation` 의 pop 을 **비파괴적 `items.len -= 1`** 로 변경 — backing 값을 보존해 `restoreState` 의 복구 전제를 만족시킵니다. 후속 `${` 의 `append` 가 그 슬롯을 정상적으로 덮어쓰므로 무해합니다.

```zig
// pop() 대신 길이만 감소 — restoreState 가 items.len 을 되돌려 backing 값을 복구하는데
// 안전모드 pop() 의 undefined(0xaa) 덮어쓰기가 그 전제를 깨기 때문.
if (self.template_depth_stack.items.len > 0) {
    self.template_depth_stack.items.len -= 1;
}
```

> Zig 초보자 메모: `ArrayList.pop()` 은 안전 빌드에서 "제거한 칸을 다시 쓰면 잡아내려고" 그 칸을 `undefined`(0xaa)로 채웁니다. 여기선 그 칸을 나중에 **복구해서 다시 읽어야** 하므로, 덮어쓰지 않고 길이만 줄이는 게 맞습니다.

## 검증
- `` tag`${(input)}` ``, `` `${(x) => (x)}` ``, `` obj.prop`${(input) => ({ ...input })}` ``, 중첩 템플릿 `` `a${`b${(c)}d`}e` `` 모두 정상 transpile (Debug).
- `zig build test` 전체 통과 (scanner 변경 blast-radius 확인).
- tests/integration `es6-templates` 178개 스냅샷 통과 (이전엔 ZNTC0909 로 1개 fail).

## 회귀 가드
tests/integration `es6-templates` 스냅샷이 이 버그를 안정적으로 잡습니다. parser/transformer **unit** 하니스는 in-process 할당 인터리빙이 달라 이 특정 poison 을 재현하지 못해(빌드 모드 차이) 신뢰할 수 있는 unit 가드가 못 됩니다 — 잘못된 안심을 주지 않도록 통합 테스트를 가드로 둡니다.

## 범위
transpile/parse 경로의 latent 버그만 다룹니다. `#4045`(splitting mangle), 데코레이터 UAF PR 과 독립이며, 검증 중 발견된 별개의 장기 잠복 버그입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)