### PR TITLE
feat(bundler): lazy compilation PR-3a-i — 동적 import 경계 정지 + 미파싱 seed 인프라

### DIFF
--- a/docs/RFC_LAZY_COMPILATION.md
+++ b/docs/RFC_LAZY_COMPILATION.md
@@ -1,126 +1,247 @@
-# RFC: Lazy Compilation — dev 서버 온디맨드 청크 컴파일
+# RFC: Lazy Compilation — dev 서버 온디맨드 청크 컴파일 (A안: parse 지연)
 
-상태: **DRAFT · 구현 착수(PR 연쇄)** · 분류: dev UX / bundler
-관련: `src/server/dev_server.zig`, `src/bundler/bundler.zig`, `src/bundler/chunk.zig`, `src/bundler/emitter/chunks.zig`, `src/bundler/emitter.zig`, `src/bundler/linker.zig`, `src/bundler/runtime_helpers.zig`
+상태: **DRAFT · A안 재설계 · PR-1/PR-2 완료, PR-3+ 재정렬** · 분류: dev UX / bundler
+관련: `src/server/dev_server.zig`, `src/bundler/bundler.zig`, `src/bundler/chunk.zig`, `src/bundler/emitter/chunks.zig`, `src/bundler/graph/build_flow.zig`, `src/bundler/incremental.zig`, `src/bundler/linker.zig`, `src/bundler/runtime_helpers.zig`
+
+> **개정 이력**: 본 RFC 의 1차안(MVP)은 "parse eager, transform/codegen/emit 만 지연"이었다.
+> 측정(§1.3) 결과 parse 가 dev 빌드의 **81~93%** 를 차지해 MVP 의 cold-start 이득이 ~20% 에 그침이
+> 확인됐다. → 본 개정은 **parse 까지 지연(A안)** 으로 모델을 전환한다. PR-1/PR-2(eager dev-splitting
+> 토대)는 A안에서도 유효하다(동적 청크를 별도 파일로 emit 하는 기반).
 
 ## 1. 배경
 
 ZNTC dev 서버는 시작 시 전체 모듈 그래프를 parse → transform → codegen → emit 하고
-(`dev_server.zig` `watchLoop` → `inc_bundler.rebuild()`, `:713`), `/bundle.js` 요청마다
-fresh `Bundler.bundle()` 로 전체를 다시 번들한다 (`dev_server.zig:1287` `serveBundle`).
-라우트 기반 code splitting 앱에서도 **진입조차 안 한 route 의 코드를 시작 시 전부 컴파일**하므로
-cold-start 가 느리다 (실측 CLI dev lodash 307~398ms — RFC #3931 측정).
+(`dev_server.zig` `watchLoop` → `inc_bundler.rebuild()`), `/bundle.js` 요청마다
+전체를 다시 번들한다. 라우트 기반 code splitting 앱에서도 **진입조차 안 한 route 의 코드를 시작 시
+전부 컴파일**하므로 cold-start 가 느리다 (실측 CLI dev lodash 307~398ms — RFC #3931 측정).
 
 webpack `experiments.lazyCompilation` / rspack lazy compilation 처럼 **브라우저가 실제로 요청하는
-청크만 온디맨드로 컴파일**해 dev cold-start 를 줄이는 것이 목표다. (로드맵 "Lazy compilation = 미구현"
-항목의 실제 구현.)
+청크만 온디맨드로 컴파일**해 dev cold-start 를 줄이는 것이 목표다.
 
-### 1.1 현재 emit 분기 — dev 와 splitting 이 상호배타
+### 1.1 emit 분기 — dev+splitting 은 PR-2 로 성립
 
-`bundler.zig` `bundle()` 의 emit 분기:
+과거 `bundler.zig` `bundle()` 의 emit 분기는 dev(단일번들)와 splitting(per-chunk)이 **상호배타**였다.
+**PR-2(#4040)** 가 `dev_mode AND code_splitting AND lazy_compilation` 경로(`bundler.zig:1601`
+`dev_split`)를 추가해 dev 에서도 per-chunk emit(`emitChunks`)이 동작한다. dev init lowering
+(`__zntc_modules[dev_id]`)은 청크 경계를 못 넘으므로(issue #4038) splitting 시 프로덕션 init 으로
+fallback 한다. kill-switch: `lazy_compilation=false` 면 기존 dev 단일번들 100% 보존.
 
-- `:1594` `if (dev_mode)` → **단일 번들** (`emitWithTreeShaking`, `__commonJS`/`__esm` 래핑 + HMR 런타임).
-- `:1625` `else if (code_splitting or preserve_modules)` → **per-chunk** (`emitChunks`).
-
-두 경로는 **상호배타**다. dev 는 항상 단일 `/bundle.js` (HTML `<script type="module" src="/bundle.js">`
-`dev_server.zig:1444`). 그리고 **`emitChunks` 는 dev/HMR 을 전혀 모른다** (`emitter/chunks.zig` 에
-`dev_mode`/`collect_module_codes`/`react_refresh`/make-hot 0건). 즉 lazy 의 본체는 **chunk emit 경로에
-dev HMR 런타임을 이식**해 `dev_mode + code_splitting` 조합을 성립시키는 작업이다.
+**PR-2 까지는 여전히 eager** 다 — 전체 그래프를 parse/transform 한 뒤 청크로 나눠 emit 할 뿐, 시작
+비용은 안 줄었다. A안은 이 토대 위에 **parse 자체를 지연**한다.
 
 ### 1.2 선행 게이트 — RFC #3940 은 GREEN
 
-청크를 나중에 재컴파일하려면 심볼 rename 이 graph 에 박혀 있으면 안 된다(stale). `linker.zig:175`
-`rename_table` 가 이미 **build-scope 단일 store** 로 이행 완료(RFC #3940 L.5c — `Symbol.canonical_name`
-field 제거됨). `getCanonicalName` 이 `rename_table` 만 조회(`:1392-1400`). → **lazy 의 토대가 이미 깔려
-있음.** 단 `rename_table` 는 Linker 소유(build-scope deinit) 이므로, **lazy dev 는 Linker(+graph)를
-세션 동안 살려둬야** 온디맨드 emit 이 rename 을 읽는다 — `IncrementalBundler` 가 graph 를 빌드 간
-유지하는 패턴(`incremental.zig`)을 그대로 따른다.
+청크를 나중에 컴파일하려면 심볼 rename 이 graph 에 박혀 있으면 안 된다(stale). RFC #3940
+Sub-PR-L.5c 에서 `Symbol.canonical_name` field 가 **제거**되고 rename 이 **build-scope 단일 store**
+(`linker.zig:175` `rename_table: RenameTable`)로 이행 완료됐다. `getCanonicalName` 이 `rename_table`
+만 조회(`linker.zig:1400` `lookupSymbolCanonical`). → **lazy 의 심볼-안정성 토대가 이미 깔려 있음.**
 
-RFC #3933 (graph persistence) 은 NO-GO 였으나, 본 MVP 은 **parse 를 eager** 로 두어(아래 §3) 의존하지 않는다.
+> **Zig 초보 메모**: `rename_table` 은 `AutoHashMapUnmanaged(SymbolID, []const u8)` 로, "어떤 모듈의
+> 어떤 심볼 → 최종 출력 이름" 매핑이다. 과거엔 이 이름을 각 `Symbol` 구조체 필드에 직접 박았는데
+> (`canonical_name`), 그러면 그 `Symbol` 을 만든 빌드가 끝나면 이름 메모리가 해제돼 다음 빌드에서
+> stale(이미 해제된 메모리 참조)이 됐다. 이제는 별도 테이블이 소유하므로, 그 테이블만 살려두면
+> 나중 빌드에서도 안전하게 읽을 수 있다 — A안이 동적 청크를 나중에 컴파일할 수 있는 핵심 근거.
 
-## 2. 제안 — "청크 = 첫 GET 시 컴파일" 통일 모델
+`rename_table` 은 Linker 소유(build-scope deinit)이므로, **lazy dev 는 Linker(+graph)를 세션 동안
+살려둬야** 온디맨드 emit 이 상위 청크 rename 을 읽는다 — `IncrementalBundler`(`incremental.zig`)가
+graph 를 빌드 간 유지하는 패턴을 그대로 따른다.
 
-ZNTC dev 서버는 **모든 청크 URL 라우트를 직접 제어**한다. 따라서 webpack 식 proxy 모듈 없이
+RFC #3933(graph persistence)은 NO-GO 였다. A안은 그 PoC 의 stale-pointer 경로를 쓰지 않고,
+**미파싱 모듈은 애초에 그래프에 없다가(placeholder seed) 첫 GET 시 새로 parse** 하는 방식이라
+stale 문제 자체가 발생하지 않는다(§4).
+
+### 1.3 측정 — 왜 parse 지연(A안)인가
+
+`--profile=all` (Release/ReleaseFast 빌드, `src/profile.zig`) 로 dev 빌드 파이프라인을 분해한 결과
+(7-run median, minify-off = dev-like):
+
+| 케이스 | 모듈 | parse total | 나머지(transform+link+codegen+emit) | **parse 비중** | wall |
+|---|---|---|---|---|---|
+| lodash-es 부분 import | 641 | 37.7ms | 3.7ms | **91.1%** | 13.6ms |
+| date-fns 부분 import | 305 | 27.1ms | 1.9ms | **93.4%** | 10.3ms |
+| route-split (lodash+date-fns+d3 동적) | 1511 | 144.9ms | 32.6ms | **81.6%** | 97.8ms |
+
+**parse 가 dev 빌드의 81~93%** 다. 메모리 추정치(~70%)를 Release 측정이 확증(상회)했다.
+
+route-split 앱에서 동적 import 를 제거한 baseline(entry 청크만):
+
+| 케이스 | 모듈 | 청크 | wall |
+|---|---|---|---|
+| route-split 전체 (eager) | 1511 | 4 (entry + 동적 3) | **97.81ms** |
+| entry 청크만 (동적 import 제거) | 1 | 1 | **0.46ms** |
+
+→ **A안의 win = 진입 안 한 route 의 parse+transform+codegen+emit 전체를 cold-start 에서 제거.**
+위 극단(entry 가 거의 빈) 케이스에서 97.81ms → 0.46ms. 현실 앱은 entry 셸이 있어 win 은 더 작지만,
+**"진입 안 한 route 비중"에 비례**한다.
+
+**MVP(parse eager)가 약한 이유**: parse 가 81~93% 인데 그걸 eager 로 두면, emit 만 지연해 봐야
+나머지 7~19% 의 일부만 절약한다. A안은 parse 를 포함한 lazy 청크의 **100% 파이프라인**을 지연한다.
+
+**dev server cold-start 실측 (서버 spawn ~ `/bundle.js` 첫 응답, 6-run median):** 위 빌드 비중은
+서버 오버헤드를 뺀 값이라, 실제 dev cold-start 로 검증했다.
+
+| 앱 | eager | entry-only(=lazy 근사) | lazy 절약 |
+|---|---|---|---|
+| 극단(entry 빈, 1511모듈) | 128ms | 12ms | 91% |
+| **현실 SPA**(react 셸 + lazy route 3) | 118ms | 54ms | **54%** |
+
+ZNTC 는 **native dev server 라 서버 오버헤드가 12ms 뿐** → 빌드(parse)가 cold-start 를 지배 →
+lazy(빌드 스킵)가 직접 절약한다. **대조 — Rspack 2.0 dev cold-start 는 169ms 인데 그 중 서버
+오버헤드(Node 부팅 + serve)가 ~150ms 지배라 lazy on/off 차이가 없다(169 vs 171ms).** 즉 동일한
+lazy 전략이라도 **ZNTC(가벼운 native 서버) 에선 빌드가 노출돼 효과가 크고, Rspack(무거운 서버)
+에선 묻힌다** — A안이 ZNTC dev 에 특히 유효한 이유다.
+
+> 한계: entry-only 는 "route 0" 근사다. 실제 첫 진입 route 1개는 빌드되므로 절약은 진입 안 한
+> route 수에 비례(많을수록 ↑). dev mode(react dev 셸 포함) 실측. 빌드 엔진 자체는 Rspack 2.0 과
+> 대등(단일 동등, splitting 은 ZNTC 가 빠르나 splitting 번들 mangle 누락 #4045 로 크기 열위).
+
+## 2. 제안 — "청크 = 첫 GET 시 parse+compile" 모델 (A안)
+
+ZNTC dev 서버는 **모든 청크 URL 라우트를 직접 제어**한다. webpack 식 proxy 모듈·별도 활성화 채널 없이
 **dev 서버 라우트 핸들러 자체가 lazy 백엔드**가 된다.
 
-1. **시작 시 (전역 1회, cheap)**: 전체 그래프 parse/discover + 청크 배치(`chunk.zig`) +
-   cross-chunk 심볼 인터페이스 계산(`computeCrossChunkLinks`, per-chunk `computeRenamesForModules`).
-   → 청크 그래프(청크→모듈, 안정적 청크 이름, 청크 간 export 이름 계약)만 확정. **transform/codegen/emit 안 함.**
-2. **청크 첫 GET 시 (per-chunk, 온디맨드)**: 해당 청크 모듈집합만 transform(미수행 시) → codegen → emit
-   → 캐시 → 응답.
-   - entry 청크: HTML `<script src="/bundle.js">` 첫 로드가 트리거 (= lazy entry).
-   - 동적 청크: 런타임 `__zntc_load_chunk("<chunk>.js")`(`runtime_helpers.zig:232`)의 `<script>` GET 이
-     트리거 → 기존 동적 import 런타임 그대로 재사용, **클라이언트 변경 거의 없음**.
+1. **시작 시 (cheap)**: **entry point 모듈만** parse 한다. 그래프 BFS 가 동적 `import()` 경계에 닿으면
+   **멈추고**, 타겟 모듈을 "미파싱 청크 seed"로 기록(parse 안 함). entry 청크만 transform→codegen→emit.
+   - entry 청크 코드 안의 동적 import 는 `__zntc_load_chunk("<경로기반 안정이름>.js")` 로 lowering.
+     타겟 경로만 알면 이름이 결정되므로 청크를 아직 안 만들었어도 참조 가능.
+2. **동적 청크 첫 GET 시 (온디맨드)**: 그 seed 경로부터 BFS parse → 청크 모듈집합 transform → codegen
+   → emit → 캐시 → 응답. 이 과정에서 또 다른 `import()` 를 만나면 **새 seed 등록**(재귀적 lazy).
+   - 트리거: 런타임 `__zntc_load_chunk("...")`(`runtime_helpers.zig:232`)의 `<script>` GET. 기존
+     동적 import 런타임 그대로 재사용 → **클라이언트 변경 없음**.
 3. **watch/HMR**: 변경 파일이 **이미 활성화된** 청크 소속이면 그 청크만 재컴파일 후 HMR push;
-   **미활성** 청크 소속이면 캐시 invalidate 만(컴파일 안 함).
+   **미활성** 청크 소속이면 캐시 invalidate 만(parse·컴파일 안 함).
 
-핵심: 시작 시 **비싼 per-module 작업(transform/codegen/emit)을 건너뛰고**, 청크 그래프와 심볼 계약
-(상대적으로 cheap)만 확정 → cross-chunk 이름 불안정 문제를 구조적으로 회피.
+### 2.1 cross-chunk 심볼 모델 — "전역 1회 확정" → "단방향 조회"
 
-webpack 은 proxy 모듈 + XHR 활성화 미들웨어(`/_rspack/lazy/trigger`)가 필요하지만, ZNTC dev 서버는
-임의 청크 URL 을 GET 시점에 컴파일할 수 있어 **proxy 도, 별도 활성화 채널도 불필요**하다.
+MVP(parse eager)는 "시작 시 전체 그래프를 알므로 cross-chunk 심볼 계약을 **전역 1회 확정**"으로
+안정성을 보장했다. **A안은 동적 청크를 parse 조차 안 하므로 이 전제가 깨진다** — 시작 시점엔 동적 청크가
+무슨 심볼을 import 하는지 모른다. 따라서 모델을 전환한다:
 
-## 3. 결정된 범위 (확정)
+> **entry/shared 청크만 시작 시 rename 확정, 동적 청크는 자기 빌드 시점에 상위 rename 을 조회.**
+
+이게 성립하는 근거:
+
+- **cross-chunk 참조는 단방향(동적 → entry/shared)만 존재.** entry 가 동적 청크 심볼을 정적으로
+  참조하는 일은 없다 — `import()` 는 `Promise` 를 반환하는 런타임 경계라 정적 심볼 바인딩이 없다.
+- **entry/shared 는 시작 시 parse → `rename_table` 확정.** 동적 청크 빌드 시 그 상위 심볼 이름을
+  살아있는 `rename_table`(세션 Linker)에서 조회한다.
+- **dev 는 tree-shaking off**(`bundler.zig` dev 경로). entry/shared export 가 전부 보존되므로,
+  동적 청크가 나중에 어떤 export 를 참조할지 시작 시 몰라도 안전하다(없어서 깨질 export 가 없음).
+- **청크 이름은 모듈경로 기반(안정)** — content-hash 아님. 현재 prod splitting 은 content-hash 이름
+  (`split-full.js` 가 `__zntc_load_chunk("lodash-c897bb73.js")` 를 박음). A안 dev 는 동적 청크를 아직
+  안 만든 시점에 이름을 박아야 하므로, **타겟 모듈 경로로부터 결정되는 안정 이름**을 쓴다(컴파일 순서
+  무관). 이로써 entry 가 동적 청크 이름을 미리 알 수 있다.
+
+핵심: 시작 시 **비싼 per-module 작업(parse 포함)을 entry 청크로 한정**하고, 동적 청크는 단방향으로만
+상위를 참조하므로 "나중에 컴파일"이 구조적으로 안전하다.
+
+## 3. 결정된 범위 (A안)
 
 - **경계**: entry point + 동적 `import()` **둘 다** lazy (webpack `entries:true, imports:true` 동치).
-- **지연 깊이**: **transform/codegen/emit 만 지연**. parse(graph discover)는 시작 시 전체 수행
-  (MVP — RFC #3933 NO-GO 의존 회피, 안전).
+- **지연 깊이**: **parse 까지 지연.** 동적 import 경계 너머 모듈은 첫 GET 전까지 parse·transform·
+  codegen·emit 어느 것도 안 함. (MVP 의 "transform/emit 만 지연"에서 전환 — §1.3 측정 근거.)
 - **적용 면**: **dev 서버 전용** (`zntc <entry> --serve` / JS `startDevServer`). 프로덕션 빌드 불변.
+- **shared 청크**: dev lazy 에서는 **shared splitting off**(§6.3). 각 동적 청크가 "entry 에 없는 자기
+  의존성"을 인라인(중복 허용). entry 의존성은 단방향 조회. → 점진 parse 와 양립.
 
-## 4. 재사용 인프라 (신규 작성 최소화)
+## 4. 재사용 인프라 + 신규로 필요한 것
 
-- 동적 import = 청크 경계: `chunk.zig:651-664` `addDynamicEntry`. 이미 동작.
-- 임의 모듈집합 per-chunk rename: `linker.zig:2525` `computeRenamesForModules(module_indices, occupied_names)`
-  + `emitter/chunks.zig:570` (청크별 독립 네임스페이스). code-splitting 경로가 이미 사용.
-- cross-chunk 심볼 배선: `bundler.zig:1650` `computeCrossChunkLinks`.
-- 런타임 청크 로더: `runtime_helpers.zig:232` `__zntc_load_chunk` (DOM `<script>`/Worker/Node-ESM) +
-  `__zntc_register`/`__zntc_require`(`:194,219`). dev/HMR 도 `__zntc_register` 를 공유.
-- 모듈 동적 추가·parse 캐시: `incremental.zig`, `graph/build_flow.zig:676` `buildIncremental`,
-  `PersistentModuleStore`. 시작 parse + watch 재컴파일에 재사용.
-- federation lazy wrapper 선례: `chunk.zig:666-669` (MF expose = 동적 wrapper 재사용) — lazy 청크 변환의 일반화.
-- dev 라우팅/HMR: `dev_server.zig:1246` 라우터, `:713` `watchLoop`, WS `/__hmr`.
+**재사용:**
+- 동적 import = 청크 경계: `chunk.zig:585` `addDynamicEntry`. 이미 동작(PR-2).
+- 임의 모듈집합 per-chunk rename: `linker.zig` `computeRenamesForModules` + `emitter/chunks.zig`.
+- cross-chunk 심볼 배선: `bundler.zig` `computeCrossChunkLinks`.
+- 런타임 청크 로더: `runtime_helpers.zig:232` `__zntc_load_chunk` + `__zntc_register`/`__zntc_require`.
+- 세션 graph/parse 캐시: `incremental.zig`, `graph/build_flow.zig` `buildIncremental`, `PersistentModuleStore`.
+- dev 라우팅/HMR: `dev_server.zig` 라우터, `watchLoop`, WS `/__hmr`.
 
-## 5. 단계별 PR 분할
+**신규(A안 핵심):**
+- **미파싱 seed placeholder** — `build_flow` 의 BFS discovery 가 동적 `import()` 경계에서 멈추고,
+  타겟을 "아직 parse 안 한 청크 seed"로 graph 에 등록하는 인프라. 현재 `addModule` 은 즉시 parse 하므로
+  "경로만 등록, 본문 미parse" 상태를 표현할 수 있어야 한다.
+  - kill-switch: `lazy_compilation=false` 면 seed 를 즉시 parse(기존 eager 동작) → 회귀 0.
+- **온디맨드 parse 백엔드** — dev 서버 라우트가 청크 GET 시 seed 부터 BFS parse → emit. 세션 Linker
+  생존(§1.2). `LazyChunkCache`(경로기반 키).
 
-- **PR-1 (이 RFC)**: RFC 문서 + `lazy_compilation` 내부 옵션 스캐폴딩(`BundleOptions`, `DevServer.Options`).
-  동작 변경 없음(옵션 미소비). 후속 PR 의 토대.
-- **PR-2 — dev+splitting emit 병합 (크럭스)**: `emitChunks` 가 `dev_mode`(HMR 래핑 + `collect_module_codes`)를
-  지원하도록 확장. `bundler.zig` 에 `dev_mode AND code_splitting` 경로 추가. **eager** 로 먼저 동작시켜
-  dev code-splitting 자체를 회귀 없이 성립(가장 위험한 단계 — corpus/HMR 가드 필수).
-- **PR-3 — 사전계산/온디맨드 emit 분리 + dev 서버 lazy 라우트·캐시**: 시작 시 chunk plan 까지만,
-  청크 첫 GET 시 emit. `LazyChunkCache`. 안정적(content-hash 대신 모듈경로 기반) dev 청크 이름.
-- **PR-4 — watch/HMR 통합**: 활성/미활성 청크 분기, 그래프 구조 변경 시 사전계산 재실행.
-- **PR-5 — 검증/벤치 + 로드맵 갱신 + `--lazy` 사용자 노출**: cold-start 벤치, 로드맵 "미구현" 제거,
-  CLI `--lazy`/JS 옵션 공개(메모리 `feedback_default_change_napi_drift` 5곳 동기).
+> **Zig 초보 메모**: BFS discovery(`build_flow.zig`)는 entry 부터 import 를 따라가며 "다음에 parse 할
+> 모듈" 큐를 넓혀가는 너비우선 탐색이다. 현재는 정적 import 든 동적 import 든 전부 큐에 넣어 끝까지
+> parse 한다. A안의 신규 작업은 동적 import 타겟을 **큐에 넣는 대신 seed 목록에 따로 빼두는 것** 뿐이라,
+> 탐색 알고리즘 자체는 그대로다.
+
+## 5. 단계별 PR 분할 (A안 재정렬)
+
+- **PR-0 — 측정** ✅(본 RFC §1.3): parse 81~93% 확증, A안 GO.
+- **PR-1 #4037** ✅: RFC + `lazy_compilation` 옵션 스캐폴딩.
+- **PR-2 #4040** ✅: dev+splitting emit 병합(eager). `dev_split` 경로. #4038 CLOSED. **A안 토대.**
+- **PR-3a — 미파싱 seed + 경계 정지**: 구현 surface 가 커서(emit-skip·경로기반 naming 까지
+  transitively 필요) **3a-i / 3a-ii 로 분할**(CLAUDE.md "작은 PR").
+  - **PR-3a-i (구현 중)**: discovery 경계 정지 + seed materialize 인프라. `resolve_imports` 가
+    `lazy_compilation and kind==.dynamic_import` 면 타겟을 `graph.lazy_seeds` 로 deferred(addModule=
+    parse 회피), `build_flow.materializeLazySeeds` 가 BFS 종료 후 일괄 등록 — static 도달이면 그
+    파싱 모듈에 link, 아니면 미파싱 seed(`Module.is_lazy_seed`, state=.ready, ast=null). 동적 청크는
+    seed 본문 없이 emit(stub). **`lazy_compilation=false` = byte-identical 회귀 0**(전 코드경로 게이트).
+  - **PR-3a-ii**: 미파싱 seed 청크 emit-skip + **경로기반 안정 청크 이름**(content-hash 는 청크를
+    만들어야 계산되므로 미생성 동적 청크 참조와 모순). entry 가 미생성 청크를 안정 이름으로 선참조.
+- **PR-3b — dev 서버 lazy 라우트**: 청크 첫 GET 시 seed 부터 parse→emit. `LazyChunkCache`. 세션
+  Linker 생존 배선. 단방향 cross-chunk 조회(§2.1).
+- **PR-4 — watch/HMR + 재귀 lazy**: 활성/미활성 청크 분기. 동적 청크 parse 중 발견한 새 `import()` 를
+  seed 로 추가. 그래프 구조 변경 시 entry 청크 재계산.
+- **PR-5 — 검증/벤치 + `--lazy` 노출**: cold-start 벤치(§1.3 harness 확장), 로드맵 "미구현" 제거,
+  CLI `--lazy`/JS 옵션 공개.
+
+> **메모리 `feedback_default_change_napi_drift`**: PR-5 에서 `--lazy` 를 사용자에게 노출할 때
+> `options.zig`/`index.ts`/typo-suggest/`cli-flags.mjs`/`zntc.mjs`/`dto_test` 6곳을 일관 변경.
+> 한 곳 누락 시 사용자 옵션이 silent 무시된다.
 
 ## 6. 핵심 리스크와 완화
 
-- **cross-chunk 심볼 계약 안정성** (L 난이도 핵심): 동적 청크를 나중에 컴파일할 때 entry/shared 청크 export
-  심볼 이름을 정확히 참조해야 함. → 심볼 rename·cross-chunk 링크를 **시작 시 전역 1회 확정**(PR-3 사전계산),
-  지연은 codegen 문자열/emit 뿐. 이름이 고정돼 청크 컴파일 순서와 무관하게 일관.
-- **dev 모드 회귀** (PR-2): 현재 dev = 단일 `/bundle.js`. splitting 을 켜며 런타임 청크 로더/HMR 상호작용에서
-  회귀 가능 → 전체 corpus + HMR 통합 테스트 가드, kill-switch(`lazy_compilation=false` 시 기존 경로 100% 보존).
-- **Linker 생명주기**: rename_table 가 Linker 소유 → 세션 동안 graph+linker 유지 필요. `IncrementalBundler`
-  패턴 재사용으로 해결(이미 graph 를 빌드 간 유지).
+### 6.1 cross-chunk 심볼 안정성 (A안 핵심 난이도)
+동적 청크를 나중에 parse·컴파일할 때 상위(entry/shared) export 이름을 정확히 참조해야 한다.
+→ §2.1 단방향 모델: entry/shared 는 시작 시 rename 확정 + 세션 Linker 로 `rename_table` 생존 +
+dev tree-shake off 로 export 보존. 역방향 정적 참조는 구조적으로 없음(`import()` = Promise).
+**가드**: route-split corpus 에서 "동적 청크가 entry 심볼 참조" 케이스의 출력이 eager 빌드와
+의미 동치인지(런타임 실행 결과) 검증.
+
+### 6.2 dev 모드 회귀
+kill-switch(`lazy_compilation=false`)가 기존 dev 단일번들/eager-splitting 경로를 100% 보존하는지
+매 PR 확인. PR-3a 의 seed 도 eager fallback 으로 회귀 0.
+
+### 6.3 shared 청크 / 청크 이름 (신규 결정)
+- **shared splitting off (dev lazy)**: 점진 parse 와 shared 청크 분리는 충돌한다 — 동적 청크 A·B 를
+  parse 하기 전엔 그들이 공유하는 모듈을 알 수 없다. dev 에서는 shared 를 분리하지 않고 각 동적 청크가
+  자기 의존성을 인라인(중복 허용)한다. 코드 중복은 dev cold-start 목표와 무관하고, 메모리
+  `project_css_chunk_multi_owner`(CSS 의 도달-모든-청크 복제)의 JS 판이다. **단 entry 청크에 이미 있는
+  모듈은 동적 청크가 인라인하지 않고 단방향 조회**(entry 는 시작 시 parse 됨 → 모듈집합 확정).
+- **경로기반 안정 청크 이름**: content-hash 는 청크를 만들어야 계산되므로 A안과 모순(entry 가 미생성
+  동적 청크 이름을 박아야 함). dev lazy 는 타겟 모듈 경로로부터 결정되는 이름을 쓴다.
+
+### 6.4 Linker 생명주기 / 메모리 소유
+`rename_table` 이 Linker 소유 → 세션 동안 graph+Linker 유지. `IncrementalBundler` 패턴 재사용.
+> **메모리 `CLAUDE.md` arena 규칙**: 세션 동안 살아있는 graph/Linker 의 arena 리소스에 개별
+> `defer X.deinit()` 를 걸지 말 것 — 세션 종료 시 arena 일괄 해제(#1287 segfault 회피).
 
 ## 7. 측정 / 검증
 
-- **cold-start 벤치**: route-split 샘플(entry + `import('./routes/heavy')`)에서 `--serve --lazy` vs `--serve`
-  서버 기동~첫 응답 시간. 기대: lazy 시작 시 heavy route 미컴파일(로그), 진입 시 `/<chunk>.js` 첫 GET 에 최초 컴파일.
-- **통합 테스트**(`tests/integration` cwd 준수): dev 기동 → `GET /bundle.js`(entry 컴파일·200) → 동적 청크
-  URL 캐시 miss 확인 → 그 URL GET(유효 JS·200) → 2차 GET 캐시 hit.
+- **cold-start 벤치**(§1.3 harness 확장): route-split 샘플에서 `--serve --lazy` vs `--serve` 서버
+  기동~첫 응답. 기대: lazy 시작 시 heavy route 미parse(로그), 진입 시 `/<chunk>.js` 첫 GET 에 최초 parse+compile.
+  GO 기준: route-split 앱 cold-start 가 entry 청크 parse 시간 수준으로 수렴(진입 안 한 route parse 0).
+- **통합 테스트**(`tests/integration` cwd 준수 — 메모리 `feedback_integration_test_cwd`): dev 기동 →
+  `GET /bundle.js`(entry 컴파일·200) → 동적 청크 URL 캐시 miss → 그 URL GET(유효 JS·200, 단방향 심볼
+  참조 정확) → 2차 GET 캐시 hit.
 - **HMR 회귀**: 활성 청크 모듈 edit → HMR `update`; 미활성 청크 모듈 edit → recompile/reload 없음.
-- **빌드 게이트**(메모리 `feedback_zig_build_all_targets_before_merge`): `zig build` 전 타깃 + `zig build install`
-  후 통합/e2e(스테일 바이너리 방지).
+- **빌드 게이트**(메모리 `feedback_zig_build_all_targets_before_merge`): `zig build` 전 타깃 +
+  `zig build install` 후 통합/e2e(스테일 바이너리 방지 — 본 RFC 측정도 ReleaseFast 재빌드 후 수행).
 
 ## 8. 범위 밖 (후속)
 
-- parse 까지 지연(최대 cold-start) — RFC #3940 충분 진행 후 별도 단계.
-- 프로덕션 빌드 lazy, 활성화용 client→server WS 프로토콜 — MVP 는 청크 GET 자체가 트리거라 불필요.
+- 프로덕션 빌드 lazy(프로덕션은 content-hash·shared splitting·tree-shake 가 핵심이라 단방향 모델 부적합).
+- 활성화용 client→server WS 프로토콜 — 청크 GET 자체가 트리거라 불필요.
 - NAPI dev 경로(RN, 이미 빠름) lazy 노출 — CLI/web dev MVP 이후.
+- shared 청크를 점진적으로 재분리(dev) — 중복 인라인으로 충분, 복잡도 대비 이득 낮음.
 
 ## 9. 선행 게이트 / GO 조건
 
-- ✅ RFC #3940 rename_table build-scope 이행 완료(§1.2) — GO.
-- PR-2(emit 병합) 후 전체 corpus + HMR 통과가 PR-3 진행 게이트.
-- kill-switch: `lazy_compilation=false` 가 기존 dev 경로를 100% 보존하는지 매 PR 확인.
+- ✅ RFC #3940 rename_table build-scope 이행 완료(§1.2) — 심볼-안정성 GREEN.
+- ✅ PR-0 측정(§1.3): parse 81~93% + **dev cold-start 실측(현실 SPA 118→54ms = 54% 절약, 극단 91%)** → **A안 GO**. ZNTC native 서버(오버헤드 12ms)라 빌드가 cold-start 지배 → lazy 직접 효과. 단 Rspack(무거운 서버)은 lazy 묻힘이라 **A안은 ZNTC native dev 에 특히 유효**(범용 일반화 주의).
+- ✅ PR-2(emit 병합) 머지 — dev per-chunk emit 토대.
+- PR-3a 의 eager fallback(`lazy_compilation=false`)이 전체 corpus 회귀 0 인지가 PR-3b 진행 게이트.
+- kill-switch: `lazy_compilation=false` 가 기존 경로를 100% 보존하는지 매 PR 확인.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1172,6 +1172,8 @@ pub const Bundler = struct {
         graph.code_splitting = self.options.code_splitting;
         graph.preserve_modules = self.options.preserve_modules;
         graph.minify_identifiers = self.options.minify_identifiers;
+        // PR-3a: dev lazy compilation — discovery 가 동적 import 경계 정지(seed 등록).
+        graph.lazy_compilation = self.options.lazy_compilation;
         graph.transform_options_base = self.buildTransformOptionsBase();
         // RFC #3933 Sub-PR-B.2: external_graph 면 deinit skip (caller 보존).
         defer if (!has_external_graph) graph.deinit();

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -2650,6 +2650,269 @@ test "LazyDevSplitting: dev+split → 프로덕션 init 사용, __zntc_modules �
     try std.testing.expect(has_region);
 }
 
+test "LazyCompilation PR-3a: lazy=true 면 동적 import 타겟이 미파싱 seed (본문 미컴파일)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "heavy.ts", "export function heavyMarkerFn() { return 'HEAVY_BODY_MARKER'; }");
+    try writeFile(tmp.dir, "entry.ts",
+        \\async function go() { const m = await import('./heavy'); console.log(m.heavyMarkerFn()); }
+        \\console.log('entry boot');
+        \\go();
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .code_splitting = true,
+        .lazy_compilation = true,
+        .format = .iife,
+    });
+    defer bnd.deinit();
+    const result = try bnd.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+    // heavy 본문(HEAVY_BODY_MARKER)이 어느 출력에도 없어야 한다 — 미파싱 seed (경계 정지).
+    for (outs) |o| {
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "HEAVY_BODY_MARKER") == null);
+    }
+    // entry 는 정상 컴파일 (boot 로그 + 동적 로더 존재).
+    var has_entry = false;
+    var has_loader = false;
+    for (outs) |o| {
+        if (std.mem.indexOf(u8, o.contents, "entry boot") != null) has_entry = true;
+        if (std.mem.indexOf(u8, o.contents, "__zntc_load_chunk(\"") != null) has_loader = true;
+    }
+    try std.testing.expect(has_entry);
+    try std.testing.expect(has_loader);
+}
+
+// 대조군: lazy=false(eager)면 동적 import 타겟이 정상 컴파일된다 (kill-switch 회귀 0).
+test "LazyCompilation PR-3a: lazy=false 면 동적 import 타겟 본문이 컴파일된다 (eager)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "heavy.ts", "export function heavyMarkerFn() { return 'HEAVY_BODY_MARKER'; }");
+    try writeFile(tmp.dir, "entry.ts",
+        \\async function go() { const m = await import('./heavy'); console.log(m.heavyMarkerFn()); }
+        \\go();
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .code_splitting = true,
+        .lazy_compilation = false,
+        .format = .iife,
+    });
+    defer bnd.deinit();
+    const result = try bnd.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    // lazy=false → 기존 eager 경로. heavy 본문이 출력 어딘가에 존재.
+    const present = if (result.outputs) |outs| blk: {
+        for (outs) |o| if (std.mem.indexOf(u8, o.contents, "HEAVY_BODY_MARKER") != null) break :blk true;
+        break :blk false;
+    } else std.mem.indexOf(u8, result.output, "HEAVY_BODY_MARKER") != null;
+    try std.testing.expect(present);
+}
+
+// 전이적 경계 정지: 동적 타겟이 미파싱이라 그 *정적* deps 도 발견조차 안 된다.
+test "LazyCompilation PR-3a: 동적 타겟의 정적 의존성도 미파싱(전이 경계정지)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "heavydep.ts", "export const DEP_BODY_MARKER = 'DEP_BODY';");
+    try writeFile(tmp.dir, "heavy.ts",
+        \\import { DEP_BODY_MARKER } from './heavydep';
+        \\export function heavyMarkerFn() { return 'HEAVY_BODY_MARKER' + DEP_BODY_MARKER; }
+    );
+    try writeFile(tmp.dir, "entry.ts",
+        \\async function go() { const m = await import('./heavy'); console.log(m.heavyMarkerFn()); }
+        \\console.log('entry boot');
+        \\go();
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .code_splitting = true,
+        .lazy_compilation = true,
+        .format = .iife,
+    });
+    defer bnd.deinit();
+    const result = try bnd.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+    for (outs) |o| {
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "HEAVY_BODY_MARKER") == null);
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "DEP_BODY") == null); // 전이 deps 도 미발견
+    }
+}
+
+// 핵심 정확성: 정적 + 동적 둘 다로 도달하는 모듈은 *파싱*된다 (deferred materialization 이
+// dedup 으로 static 도달을 우선 — 미파싱 seed 로 잘못 마크하면 안 됨).
+test "LazyCompilation PR-3a: 정적+동적 둘 다 도달하는 모듈은 파싱된다 (dedup)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "shared.ts", "export const SHARED_BODY_MARKER = 'SHARED_BODY';");
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { SHARED_BODY_MARKER } from './shared';
+        \\async function go() { const m = await import('./shared'); console.log(m); }
+        \\console.log('entry boot', SHARED_BODY_MARKER);
+        \\go();
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .code_splitting = true,
+        .lazy_compilation = true,
+        .format = .iife,
+    });
+    defer bnd.deinit();
+    const result = try bnd.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+    // shared 는 entry 의 정적 import 로 도달 → 파싱됨 (동적 타겟이기도 하지만 static 우선).
+    var has_shared = false;
+    for (outs) |o| if (std.mem.indexOf(u8, o.contents, "SHARED_BODY") != null) {
+        has_shared = true;
+    };
+    try std.testing.expect(has_shared);
+}
+
+// 다중 동적 import: 각 타겟이 독립 seed.
+test "LazyCompilation PR-3a: 다중 동적 import 각각 미파싱 seed" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "export const A_BODY_MARKER = 'A_BODY';");
+    try writeFile(tmp.dir, "b.ts", "export const B_BODY_MARKER = 'B_BODY';");
+    try writeFile(tmp.dir, "entry.ts",
+        \\async function go() {
+        \\  const a = await import('./a'); const b = await import('./b');
+        \\  console.log(a, b);
+        \\}
+        \\go();
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .code_splitting = true,
+        .lazy_compilation = true,
+        .format = .iife,
+    });
+    defer bnd.deinit();
+    const result = try bnd.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+    for (outs) |o| {
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "A_BODY") == null);
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "B_BODY") == null);
+    }
+}
+
+// 동적 import 없는 entry: lazy=true 여도 seed 0 → eager 와 동일(안전).
+test "LazyCompilation PR-3a: 동적 import 없으면 lazy=true 여도 정상 (seed 0)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.ts", "export const LIB_BODY_MARKER = 'LIB_BODY';");
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { LIB_BODY_MARKER } from './lib';
+        \\console.log(LIB_BODY_MARKER);
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .code_splitting = true,
+        .lazy_compilation = true,
+        .format = .iife,
+    });
+    defer bnd.deinit();
+    const result = try bnd.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    // 동적 import 없음 → 정적 lib 정상 컴파일.
+    const present = if (result.outputs) |outs| blk: {
+        for (outs) |o| if (std.mem.indexOf(u8, o.contents, "LIB_BODY") != null) break :blk true;
+        break :blk false;
+    } else std.mem.indexOf(u8, result.output, "LIB_BODY") != null;
+    try std.testing.expect(present);
+}
+
+// 게이트: lazy=true 라도 code_splitting=false 면 seed 안 만든다 (단일번들 emit 보호).
+// 미파싱 seed 가 동적 로더 없는 단일번들에 들어가면 런타임이 깨지므로 eager 로 fallback.
+test "LazyCompilation PR-3a: lazy=true + code_splitting=false 면 eager (seed 안 만듦)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "heavy.ts", "export function heavyMarkerFn() { return 'HEAVY_BODY_MARKER'; }");
+    try writeFile(tmp.dir, "entry.ts",
+        \\async function go() { const m = await import('./heavy'); console.log(m.heavyMarkerFn()); }
+        \\go();
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .code_splitting = false, // splitting off → lazy 게이트 비활성 → eager
+        .lazy_compilation = true,
+        .format = .iife,
+    });
+    defer bnd.deinit();
+    const result = try bnd.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    // 단일번들(code_splitting=false) → heavy 가 eager 로 포함.
+    const present = if (result.outputs) |outs| blk: {
+        for (outs) |o| if (std.mem.indexOf(u8, o.contents, "HEAVY_BODY_MARKER") != null) break :blk true;
+        break :blk false;
+    } else std.mem.indexOf(u8, result.output, "HEAVY_BODY_MARKER") != null;
+    try std.testing.expect(present);
+}
+
+// 게이트: lazy=true + splitting=true 라도 dev_mode=false(프로덕션)면 eager (프로덕션 불변).
+test "LazyCompilation PR-3a: lazy=true + dev_mode=false 면 eager (프로덕션 불변)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "heavy.ts", "export function heavyMarkerFn() { return 'HEAVY_BODY_MARKER'; }");
+    try writeFile(tmp.dir, "entry.ts",
+        \\async function go() { const m = await import('./heavy'); console.log(m.heavyMarkerFn()); }
+        \\go();
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = false, // production → lazy 게이트 비활성
+        .code_splitting = true,
+        .lazy_compilation = true,
+        .format = .iife,
+    });
+    defer bnd.deinit();
+    const result = try bnd.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+    // 프로덕션 splitting → heavy 가 동적 청크에 eager 로 컴파일.
+    var present = false;
+    for (outs) |o| if (std.mem.indexOf(u8, o.contents, "HEAVY_BODY_MARKER") != null) {
+        present = true;
+    };
+    try std.testing.expect(present);
+}
+
 test "LazyDevSplitting: kill-switch — lazy_compilation=false 면 dev 단일 번들 보존" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -51,6 +51,16 @@ const graph_accessors = @import("graph/accessors.zig");
 
 pub const determineExportsKind = graph_parse_helpers.determineExportsKind;
 
+/// Lazy compilation(PR-3a) 의 미파싱 동적 청크 seed. discovery 가 동적 `import()`
+/// 경계에서 정지하며 기록 → BFS 종료 후 materialize. `path`/`resolve_dir` 는
+/// path_arena 소유(개별 free 불요).
+pub const LazySeed = struct {
+    from: ModuleIndex,
+    rec_i: u32,
+    path: []const u8,
+    resolve_dir: ?[]const u8,
+};
+
 pub const ModuleGraph = struct {
     pub const matchSideEffectsPatterns = graph_package_side_effects.matchPatterns;
     const configureParserForModule = graph_parse_helpers.configureParserForModule;
@@ -230,6 +240,17 @@ pub const ModuleGraph = struct {
     /// identifier mangling 활성화. transformer pre-pass 이후 생성된 임시 binding도
     /// mangler 입력에 포함하려고 transformed AST semantic을 재구축할 때 사용.
     minify_identifiers: bool = false,
+
+    /// Lazy compilation (RFC docs/RFC_LAZY_COMPILATION.md, A안). dev 서버 온디맨드
+    /// 청크 컴파일 — BFS discovery 가 동적 `import()` 경계에서 멈추고 타겟을 미파싱
+    /// seed 로 등록한다(아래 `lazy_seeds`). `false`(기본)면 기존 eager 동작 그대로 →
+    /// kill-switch 회귀 0. `dev_mode and code_splitting` 와 함께여야 의미 있음.
+    lazy_compilation: bool = false,
+    /// PR-3a: discovery 중 동적 import 경계에서 정지한 타겟. BFS 종료 후 일괄
+    /// materialize(`materializeLazySeeds`) — static 으로도 도달했으면 그 파싱 모듈에
+    /// link, 아니면 미파싱 seed(`Module.is_lazy_seed`, state=.ready, ast=null)로 등록.
+    /// `path` 는 path_arena 소유(개별 free 불요), 리스트 자체만 deinit.
+    lazy_seeds: std.ArrayListUnmanaged(LazySeed) = .empty,
 
     /// transformer pre-pass 의 옵션 base (#1961). bundler 가 init 시 BundleOptions →
     /// TransformOptions 매핑을 1회 채움. parseModule 이 base 를 복사 후 per-module

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -134,6 +134,10 @@ pub fn build(self: *ModuleGraph, io: std.Io, entry_points: []const []const u8) !
         // (정상 종료 시 group reap 은 상단 `defer group.await` 가 처리)
     }
 
+    // PR-3a: BFS 가 동적 import 경계에서 정지하며 모은 seed 를 일괄 materialize.
+    // static 도달 여부가 확정된 시점(워커 reap 후, 단일스레드)이라 안전.
+    try materializeLazySeeds(self, io);
+
     var runtime_indices: std.ArrayList(types.ModuleIndex) = .empty;
     defer runtime_indices.deinit(self.allocator);
     try applyRuntimePolyfills(self, io, &runtime_indices);
@@ -180,6 +184,38 @@ fn dispatchPendingChunked(
             s = e;
         }
         spawned_up_to.* = hi;
+    }
+}
+
+/// PR-3a (lazy compilation): discovery 가 동적 import 경계에서 모은 미파싱 seed 를
+/// BFS 종료 후 일괄 처리한다. `addModuleWithResolveDir` 로 dedup:
+///   - static 으로도 도달해 이미 parse(.ready + ast) 된 모듈이면 미파싱 마크 없이 link
+///     만 (entry/shared 단방향 참조, RFC §2.1).
+///   - 우리가 방금 추가한 신규 경로(.reserved, ast==null)면 미파싱 seed 로 등록
+///     (is_lazy_seed, state=.ready 로 dispatch/parse 회피). 첫 GET 시 parse 는 PR-3b.
+/// 워커 reap 후 단일스레드 실행이라 race 없음. lazy_compilation=false 면 seed 가 비어
+/// no-op → eager 경로 회귀 0.
+fn materializeLazySeeds(self: *ModuleGraph, io: std.Io) !void {
+    if (self.lazy_seeds.items.len == 0) return;
+    for (self.lazy_seeds.items) |seed| {
+        const dep_idx = try self.addModuleWithResolveDir(io, seed.path, seed.resolve_dir);
+        if (self.moduleAtMut(dep_idx)) |to_mod| {
+            // BFS 종료 후이므로 static 도달 모듈은 .ready(파싱 완료), external/disabled 도
+            // .ready. 아직 .reserved + ast 없음 + 비-external 이면 이 seed 가 처음 추가한
+            // 미파싱 모듈이다(!is_external 은 방어적 — .reserved external 은 없지만 명시).
+            if (to_mod.state == .reserved and to_mod.ast == null and !to_mod.is_external) {
+                to_mod.is_lazy_seed = true;
+                to_mod.state = .ready;
+            }
+        }
+        try self.linkDynamicImport(seed.from, dep_idx);
+        // entry 의 `import()` lowering 이 resolved 타겟(→ 동적 청크)을 참조하도록 갱신.
+        if (self.moduleAtMut(seed.from)) |from_mod| {
+            if (seed.rec_i < from_mod.import_records.len) {
+                from_mod.import_records[seed.rec_i].resolved = dep_idx;
+                from_mod.import_records[seed.rec_i].is_lazy_resolved = false;
+            }
+        }
     }
 }
 

--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -125,4 +125,6 @@ pub fn deinit(self: *ModuleGraph) void {
     self.rn_asset_metadata.deinit(self.allocator);
     if (self.plugins_with_helpers) |p| self.allocator.free(p);
     self.runtime_polyfill_roots.deinit(self.allocator);
+    // PR-3a lazy seeds — path 는 path_arena 소유라 리스트 자체만 해제.
+    self.lazy_seeds.deinit(self.allocator);
 }

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -334,6 +334,33 @@ pub fn applyResolveResult(
                     return;
                 }
 
+                // PR-3a lazy: 동적 import 타겟은 BFS 경계에서 정지 — addModule(=parse 유발)
+                // 대신 seed 로 deferred 한다. BFS 종료 후 materializeLazySeeds 가 일괄 처리
+                // (static 으로도 도달했으면 그 파싱 모듈에 link, 아니면 미파싱 seed). incremental
+                // 캐시 정합 위해 appendResolvedDep 는 유지.
+                //   게이트는 dev_split(=dev_mode and code_splitting and lazy_compilation)과 동일.
+                //   셋 중 하나라도 빠지면 미파싱 seed 가 단일번들/프로덕션 emit 을 깨므로(동적
+                //   로더 미생성) eager 유지 → kill-switch 회귀 0. (virtual/external 동적 타겟은
+                //   이 .file arm 밖이라 PR-3a-i 에선 eager — PR-3b 범위.)
+                if (self.lazy_compilation and self.code_splitting and self.dev_mode and record.kind == .dynamic_import) {
+                    const pa = self.path_arena.allocator();
+                    try self.lazy_seeds.append(self.allocator, .{
+                        .from = mod_index,
+                        .rec_i = @intCast(rec_i),
+                        .path = try pa.dupe(u8, f.path),
+                        .resolve_dir = if (f.resolve_dir) |d| try pa.dupe(u8, d) else null,
+                    });
+                    try appendResolvedDep(self, mod_idx, .{
+                        .record_index = @intCast(rec_i),
+                        .kind = record.kind,
+                        .target = .file,
+                        .path = .{ .interned = f.path },
+                        .resolve_dir = if (f.resolve_dir) |d| .{ .interned = d } else null,
+                        .target_is_module_field = f.is_module_field,
+                    });
+                    return;
+                }
+
                 const dep_idx = try self.addModuleWithResolveDir(io, f.path, f.resolve_dir);
                 if (f.is_module_field or self.modules.at(mod_idx).is_module_field) {
                     self.modules.at(@intFromEnum(dep_idx)).is_module_field = true;

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -359,6 +359,11 @@ pub const Module = struct {
     /// `meta.getModuleInfo` / `info.importedIds` 등 graph traversal API 의 1급 노드로 보이지만
     /// chunk 배정 / emit / tree-shake 에선 제외. AST 없음, source 없음, path = original specifier.
     is_external: bool = false,
+    /// Lazy compilation(PR-3a) 의 미파싱 동적 청크 seed. 동적 `import()` 타겟이
+    /// static 으로 도달되지 않아 미파싱으로 남은 모듈 — state=.ready, ast=null 이지만
+    /// is_external 과 달리 "나중에 첫 GET 시 parse" 대상이다(PR-3b). chunk emit 은
+    /// 이 모듈 코드를 stub 으로 둔다(미파싱이라 본문 없음).
+    is_lazy_seed: bool = false,
     /// tree-shake 결과 — 번들에 포함된 모듈인지 (Rollup `info.isIncluded` 호환).
     /// `TreeShaker.analyze` 가 finalize 후 set. 기본 false 라 tree-shaking 비활성 시
     /// 의미 없음 — chunk gen 단계에서도 `m.side_effects or entry_set.isSet` 으로 항상 alive 처리.


### PR DESCRIPTION
## 요약
RFC [docs/RFC_LAZY_COMPILATION.md](../blob/main/docs/RFC_LAZY_COMPILATION.md) (A안 — parse 지연) 의 **PR-3a** 를 구현 surface 가 커서 **3a-i / 3a-ii 로 분할**한 첫 단계입니다. dev 서버 온디맨드 청크 컴파일의 **discovery-side 기반**: BFS 가 동적 `import()` 경계에서 멈추고 타겟을 **미파싱 seed** 로 둡니다.

PR-3a-ii(emit-skip + 경로기반 naming)·PR-3b(첫 GET 시 on-demand parse)는 후속.

## 구현
- `ModuleGraph.lazy_compilation` 플래그(bundler.zig 옵션 전파) + `lazy_seeds` deferred 리스트 + `LazySeed` 타입. `Module.is_lazy_seed` 플래그(PR-3a-ii/3b 가 소비).
- **discovery 경계 정지** (`resolve_imports.applyResolveResult`): `dev_mode and code_splitting and lazy_compilation and kind==.dynamic_import`(= dev_split 게이트와 동일) 이면 `.file` 동적 타겟을 `addModule`(=parse 유발) 대신 `lazy_seeds` 로 deferred. 셋 중 하나라도 빠지면 미파싱 seed 가 단일번들/프로덕션 emit 을 깨므로 eager 유지(kill-switch).
- **post-BFS 일괄 materialize** (`build_flow.materializeLazySeeds`, 워커 reap 후 단일스레드): `addModule` dedup →
  - static 으로도 도달해 이미 파싱(.ready + ast)된 모듈이면 **link 만**(entry/shared 단방향 참조, RFC §2.1).
  - 아직 `.reserved` + ast 없음 + 비-external 이면 **미파싱 seed**(`is_lazy_seed`, `state=.ready`, `ast=null`)로 등록.
- 동적 청크는 seed 본문 없이 **stub** 으로 emit(미파싱이라 `__zntc_register({"heavy.js": function(){}})` 빈 본문). 무crash.

> **왜 deferred materialization?** 동적 타겟은 정적으로도 import 될 수 있습니다(dedup-by-path + 병렬 BFS 순서). "동적 엣지에서 즉시 seed" 는 정적으로 필요한 모듈을 미파싱으로 남길 위험이 있어, BFS 가 정적 도달을 모두 확정한 *후* 단일스레드로 seed 를 materialize 합니다 — promotion/race 로직 없이 정확.

> Zig 초보 메모: BFS discovery 는 entry 부터 import 를 따라가며 모듈을 parse 큐에 넣습니다. 이 PR 은 동적 import 타겟만 큐 대신 `lazy_seeds` 목록으로 빼두고(=경계 정지), 탐색이 끝난 뒤 처리합니다. `state` 는 모듈 생애주기(`.reserved`→`.parsing`→`.parsed`→`.ready`)이고, 미파싱 seed 는 `is_external`(외부 모듈)처럼 `.ready`+`ast=null` 이지만 "나중에 parse 할 대상" 이라는 점이 다릅니다.

## 검증 (kill-switch 회귀 0)
- **byte-identical**: d3 splitting(lazy=false) 출력이 main 과 동일(동일 entry 명 기준 SHA 일치) — lazy 게이트 비활성 시 전 코드경로 불변.
- `zig build test` 전체 통과 + napi/wasm/test262 빌드 OK + 통합 baseline 대비 회귀 0(남은 2 fail = 기존 Hermes 5s 타임아웃·watch RSS flaky, lazy 무관).
- **시나리오 unit 테스트 8종**: 기본 seed(heavy 미파싱) / lazy=false eager / **전이 경계정지**(동적 타겟의 정적 deps 도 미발견) / **정적+동적 둘 다 도달→파싱**(dedup 정확성) / 다중 동적 / 동적 import 없음 / **splitting=false→eager** / **dev_mode=false(프로덕션)→eager**.

## /code-review max
9각도 → 검증 → sweep 풀 프로토콜 1회. **버그 1건 발견·수정**: 게이트가 `lazy_compilation` 만 검사해 `code_splitting=false`/`dev_mode=false` + lazy=true 시 미파싱 seed 가 단일번들/프로덕션 emit 을 깨뜨릴 수 있었음 → 게이트를 `dev_split`(dev+splitting+lazy) 조건으로 일치 + 방어적 `!is_external` 가드 추가. 알려진 범위 한계: virtual/external 동적 타겟 lazy(PR-3b), incremental+lazy(PR-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)