### PR TITLE
feat(bundler): lazy compilation PR-3b-ii — force-parse primitive + (B) 결정론 재빌드 검증

### DIFF
--- a/docs/RFC_LAZY_COMPILATION.md
+++ b/docs/RFC_LAZY_COMPILATION.md
@@ -191,10 +191,25 @@ MVP(parse eager)는 "시작 시 전체 그래프를 알므로 cross-chunk 심볼
     (lazy seed 면 force-emit). on-demand 컴파일의 emit 전제. `chunkRestrictSkip` 로 emit
     루프+resolveContentHashes 동일 skip. restrict=null=byte-identical 회귀0. **제약**: lazy
     청크(경로기반 reg_id 참조) 전용 — content-hash cross-ref 청크면 dangling.
-  - **PR-3b-ii**: 세션 graph/Linker 생존(rename_table 조회용) — dev 서버가 빌드 결과를 세션
-    동안 유지. (현재 `serveBundle` 은 요청마다 fresh Bundler.)
-  - **PR-3b-iii**: lazy 라우트 — `/<heavy-pathhash>.js` GET 시 seed parse→closure→`restrict_to_chunk`
-    로 단일청크 emit→`LazyChunkCache`. 단방향 cross-chunk 조회(§2.1). virtual/external 동적
+  - **PR-3b-ii (진행 중 — 접근 (B) 결정론적 재빌드 검증)**: on-demand 를 (A)세션 Linker 생존
+    대신 **(B) 결정론적 재빌드**(요청 seed 만 force-parse + `restrict_to_chunk` 로 단일청크
+    emit, Linker 는 매번 fresh)로 가는지 검증. **force-parse primitive** 추가 완료
+    (`BundleOptions.lazy_force_parse: []const []const u8` — 지정 절대경로 동적타겟을 lazy
+    defer 대신 즉시 parse. resolve_imports gate 에 `!pathInForceParse` 추가). **검증 결과
+    (B)는 2겹 선행 필요**:
+    1. **shared-splitting-off (§6.3)**: force-parse 시 seed 가 entry 와 공유하는 모듈이 공통
+       청크로 추출돼 entry 청크가 달라짐(비결정론). lazy 시 static-entry 비트 보유 모듈의
+       dynamic 비트를 collapse 해 entry 에 고정 → 결정론. (chunk.zig generateChunks Phase3 전.)
+    2. **entry export-all-by-local**: shared-off 로 shared 가 entry 에 hoist 되면, 동적 청크는
+       `__zntc_require("entry.js").<local>` 로 단방향 조회한다. 그런데 cross-chunk export 가
+       **demand-driven**(소비자 있을 때만)이라 초기 lazy 빌드(seed 미파싱)는 그 export 를 안
+       내 → on-demand seed 가 못 찾음. 해법: **lazy 시 entry 청크가 hoisted 모듈 export 를
+       전부 *local(deconflict) name* 으로 노출**(`exports.v=v; exports.v$1=v$1;`). export-name
+       으로는 동명 충돌(shared.v + dup.v)이라 local name 필수. 이건 registry emit 신규 경로
+       (chunks.zig xchunk_exports 의 reg-entry break 를 lazy export-all 로 대체). **미구현.**
+    → 즉 (B)는 viable 하나 `shared-off + export-all-by-local` 선행. PR-3b-ii 잔여 = 이 둘 구현.
+  - **PR-3b-iii**: lazy 라우트 — `/<heavy-pathhash>.js` GET 시 seed force-parse→`restrict_to_chunk`
+    단일청크 emit→`LazyChunkCache`. 이름→seed 역참조는 `graph.lazy_seeds`. virtual/external 동적
     타겟 lazy 도 여기.
 - **PR-4 — watch/HMR + 재귀 lazy**: 활성/미활성 청크 분기. 동적 청크 parse 중 발견한 새 `import()` 를
   seed 로 추가. 그래프 구조 변경 시 entry 청크 재계산.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -148,6 +148,14 @@ pub const BundleOptions = struct {
     /// 청크만 transform/codegen/emit 한다. `dev_mode + code_splitting` 조합 위에서 동작.
     /// 현재는 스캐폴딩(미소비) — 동작은 RFC `docs/RFC_LAZY_COMPILATION.md` 의 PR-2~ 에서 추가.
     lazy_compilation: bool = false,
+    /// PR-3b-ii primitive: lazy_compilation 이어도 *이 경로들* 의 동적 import 타겟은 미파싱
+    /// seed 로 deferred 하지 않고 즉시 parse(eager) 한다. 빈 slice(기본)면 기존 lazy 동작.
+    /// 경로는 **resolver 가 내는 resolved 절대경로**와 정확히 일치(exact eql)해야 매칭된다
+    /// (불일치 시 silent no-op=lazy 유지). on-demand caller 는 `graph.lazy_seeds[].path`
+    /// (= 같은 resolved 경로)로 넘기면 일치. 슬라이스 borrow(caller 소유).
+    /// 주의: 이 primitive 만으론 on-demand 가 완성되지 않는다 — 전체 (B) 는 shared-splitting-off
+    /// + entry export-all-by-local 까지 필요(RFC §2.1/§6.3, PR-3b-ii 잔여).
+    lazy_force_parse: []const []const u8 = &.{},
     /// dev mode에서 모듈 ID 생성 시 기준 경로 (상대 경로 계산용).
     root_dir: ?[]const u8 = null,
     /// React Fast Refresh 활성화. $RefreshReg$/$RefreshSig$ 주입.
@@ -1174,6 +1182,7 @@ pub const Bundler = struct {
         graph.minify_identifiers = self.options.minify_identifiers;
         // PR-3a: dev lazy compilation — discovery 가 동적 import 경계 정지(seed 등록).
         graph.lazy_compilation = self.options.lazy_compilation;
+        graph.lazy_force_parse = self.options.lazy_force_parse;
         graph.transform_options_base = self.buildTransformOptionsBase();
         // RFC #3933 Sub-PR-B.2: external_graph 면 deinit skip (caller 보존).
         defer if (!has_external_graph) graph.deinit();

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -2978,6 +2978,48 @@ test "LazyCompilation PR-3a-ii: 동적 청크 emit-skip + 경로기반 이름은
     }
 }
 
+// PR-3b-ii: lazy_force_parse 가 지정 seed 를 lazy defer 대신 즉시 parse(eager). dev lazy
+// on-demand 가 요청된 청크 seed 만 끌어올리는 primitive. (전체 (B) on-demand 완성은
+// shared-splitting-off + entry export-all-by-local 까지 필요 — RFC §2.1/§6.3 verify 결과.)
+test "LazyCompilation PR-3b-ii: lazy_force_parse 가 지정 seed 를 즉시 parse(eager)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "heavy.ts", "export function heavyMarkerFn() { return 'HEAVY_BODY_MARKER'; }");
+    try writeFile(tmp.dir, "entry.ts",
+        \\async function go() { const m = await import('./heavy'); console.log(m.heavyMarkerFn()); }
+        \\go();
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const heavy_abs = try absPath(&tmp, "heavy.ts");
+    defer std.testing.allocator.free(heavy_abs);
+
+    const heavyPresent = struct {
+        fn check(force: []const []const u8, e: []const u8) !bool {
+            var bnd = Bundler.init(std.testing.allocator, .{
+                .entry_points = &.{e},
+                .dev_mode = true,
+                .code_splitting = true,
+                .lazy_compilation = true,
+                .lazy_force_parse = force,
+                .format = .iife,
+            });
+            defer bnd.deinit();
+            const result = try bnd.bundle(std.testing.io);
+            defer result.deinit(std.testing.allocator);
+            try std.testing.expect(!result.hasErrors());
+            const outs = result.outputs orelse return error.TestUnexpectedResult;
+            for (outs) |o| if (std.mem.indexOf(u8, o.contents, "HEAVY_BODY_MARKER") != null) return true;
+            return false;
+        }
+    }.check;
+
+    // force-parse 가 *유일한* 차이 — 같은 lazy 빌드에서 목록만 다르게 두 번 빌드.
+    // 목록 비었을 때: heavy 는 미파싱 seed → 본문 없음. heavy 지정 시: 즉시 parse → 본문 있음.
+    try std.testing.expect(!try heavyPresent(&.{}, entry)); // force-parse 없음 → seed
+    try std.testing.expect(try heavyPresent(&.{heavy_abs}, entry)); // force-parse → eager
+}
+
 test "LazyDevSplitting: kill-switch — lazy_compilation=false 면 dev 단일 번들 보존" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -246,6 +246,10 @@ pub const ModuleGraph = struct {
     /// seed 로 등록한다(아래 `lazy_seeds`). `false`(기본)면 기존 eager 동작 그대로 →
     /// kill-switch 회귀 0. `dev_mode and code_splitting` 와 함께여야 의미 있음.
     lazy_compilation: bool = false,
+    /// PR-3b-ii primitive: lazy_compilation 이어도 이 경로들(resolver resolved 절대경로와
+    /// exact match)의 동적 import 타겟은 deferred 하지 않고 즉시 parse(eager). 슬라이스
+    /// borrow(BundleOptions 소유). 전체 on-demand 는 shared-off + export-all 까지 필요(RFC).
+    lazy_force_parse: []const []const u8 = &.{},
     /// PR-3a: discovery 중 동적 import 경계에서 정지한 타겟. BFS 종료 후 일괄
     /// materialize(`materializeLazySeeds`) — static 으로도 도달했으면 그 파싱 모듈에
     /// link, 아니면 미파싱 seed(`Module.is_lazy_seed`, state=.ready, ast=null)로 등록.

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -16,6 +16,15 @@ const graph_import_usage = @import("import_usage.zig");
 const graph_requested_exports = @import("requested_exports.zig");
 const profile = @import("../../profile.zig");
 
+/// PR-3b-ii: 동적 import 타겟 `path` 가 lazy_force_parse 목록에 있으면 lazy defer 대신
+/// 즉시 parse. on-demand 컴파일이 요청된 lazy 청크 seed 만 eager 로 끌어올린다.
+fn pathInForceParse(self: *const ModuleGraph, path: []const u8) bool {
+    for (self.lazy_force_parse) |fp| {
+        if (std.mem.eql(u8, fp, path)) return true;
+    }
+    return false;
+}
+
 fn appendResolvedDep(
     self: *ModuleGraph,
     mod_idx: usize,
@@ -342,7 +351,9 @@ pub fn applyResolveResult(
                 //   셋 중 하나라도 빠지면 미파싱 seed 가 단일번들/프로덕션 emit 을 깨므로(동적
                 //   로더 미생성) eager 유지 → kill-switch 회귀 0. (virtual/external 동적 타겟은
                 //   이 .file arm 밖이라 PR-3a-i 에선 eager — PR-3b 범위.)
-                if (self.lazy_compilation and self.code_splitting and self.dev_mode and record.kind == .dynamic_import) {
+                // PR-3b-ii: lazy_force_parse 에 든 타겟은 deferred 하지 않고 즉시 parse(eager)
+                // — on-demand 가 그 seed 만 force-parse 한 fresh 빌드로 단일청크를 만든다.
+                if (self.lazy_compilation and self.code_splitting and self.dev_mode and record.kind == .dynamic_import and !pathInForceParse(self, f.path)) {
                     const pa = self.path_arena.allocator();
                     try self.lazy_seeds.append(self.allocator, .{
                         .from = mod_index,


### PR DESCRIPTION
## 요약
RFC [docs/RFC_LAZY_COMPILATION.md](../blob/main/docs/RFC_LAZY_COMPILATION.md) PR-3b 의 on-demand 컴파일을 **(A)세션 Linker 생존** 대신 **(B)결정론적 재빌드**(요청 seed 만 force-parse + `restrict_to_chunk` 단일청크 emit, Linker 매번 fresh)로 갈 수 있는지 **검증**한 PR입니다. (A)의 `bundle()` lifecycle 리팩터 위험을 피하는 게 동기였습니다.

## 구현 (primitive)
- **`BundleOptions.lazy_force_parse: []const []const u8`** (+ `graph` 전파). `lazy_compilation` 이어도 이 경로들(resolver resolved 절대경로 exact match)의 동적 import 타겟은 미파싱 seed 로 deferred 하지 않고 **즉시 parse(eager)**. `resolve_imports` lazy gate 에 `!pathInForceParse(self, f.path)` 추가. 빈 slice(기본) = 기존 lazy 동작 → **회귀 0**.

## (B) 검증 결과 — viable 하나 2겹 선행 필요 (RFC §5 에 기록)
"verify first" 가 (B)의 숨은 비용을 끝까지 규명했습니다:
1. **shared-splitting-off (§6.3)**: force-parse 시 seed 가 entry 와 공유하는 모듈이 **공통 청크로 추출**돼 entry 청크가 비결정적으로 달라집니다. → lazy 시 static-entry 비트 보유 모듈의 dynamic 비트를 collapse 해 entry 에 고정 필요.
2. **entry export-all-by-local**: shared 가 entry 에 hoist 되면 동적 청크가 `__zntc_require("entry.js").<local>` 로 단방향 조회하는데, cross-chunk export 가 **demand-driven**(소비자 있을 때만)이라 초기 lazy 빌드(seed 미파싱)는 그 export 를 안 냅니다 → on-demand seed 가 못 찾음. → lazy 시 entry 가 hoisted export 를 **local(deconflict) name** 으로 전부 노출 필요(`exports.v=v; exports.v$1=v$1;`). export-name 으론 동명 충돌(shared.v + dup.v)이라 local name 필수. **registry emit 신규 경로** = PR-3b-ii 잔여.

> 즉 (B)는 가능하나 위 둘 선행. 이 PR 은 **안전한 force-parse primitive + 검증 문서화**만 담습니다. (shared-off PoC 는 cross-chunk export 미배선으로 runtime 이 깨져 미포함 — 두 작업이 함께 가야 함을 확인.)

## 검증
- `zig build test` 전체 + napi/wasm/test262 빌드 + d3 splitting **byte-identical**(`7089bac4` — force-parse 옵션은 `lazy + 매칭경로`만 작동, non-lazy 불변).
- 테스트: 같은 lazy 빌드에서 `lazy_force_parse` 목록만 **비움 vs heavy 지정**으로 두 번 빌드 → heavy 본문 **부재 vs 존재**로 primitive 를 격리 검증.

## /code-review max
9각도 → 검증 → sweep 1회: (1) 테스트가 force-parse 를 격리 못 하던 것 → negative case 추가, (2) 주석이 on-demand 완성 과대주장 → primitive 임을 명시, (3) 경로 exact-match 요구 문서화. 효율 O(N×M)은 on-demand=1경로라 무시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)