### PR TITLE
feat(bundler): lazy compilation PR-3b-ii 완성 — shared-off + entry export-all-by-local

### DIFF
--- a/docs/RFC_LAZY_COMPILATION.md
+++ b/docs/RFC_LAZY_COMPILATION.md
@@ -191,22 +191,21 @@ MVP(parse eager)는 "시작 시 전체 그래프를 알므로 cross-chunk 심볼
     (lazy seed 면 force-emit). on-demand 컴파일의 emit 전제. `chunkRestrictSkip` 로 emit
     루프+resolveContentHashes 동일 skip. restrict=null=byte-identical 회귀0. **제약**: lazy
     청크(경로기반 reg_id 참조) 전용 — content-hash cross-ref 청크면 dangling.
-  - **PR-3b-ii (진행 중 — 접근 (B) 결정론적 재빌드 검증)**: on-demand 를 (A)세션 Linker 생존
-    대신 **(B) 결정론적 재빌드**(요청 seed 만 force-parse + `restrict_to_chunk` 로 단일청크
-    emit, Linker 는 매번 fresh)로 가는지 검증. **force-parse primitive** 추가 완료
-    (`BundleOptions.lazy_force_parse: []const []const u8` — 지정 절대경로 동적타겟을 lazy
-    defer 대신 즉시 parse. resolve_imports gate 에 `!pathInForceParse` 추가). **검증 결과
-    (B)는 2겹 선행 필요**:
-    1. **shared-splitting-off (§6.3)**: force-parse 시 seed 가 entry 와 공유하는 모듈이 공통
-       청크로 추출돼 entry 청크가 달라짐(비결정론). lazy 시 static-entry 비트 보유 모듈의
-       dynamic 비트를 collapse 해 entry 에 고정 → 결정론. (chunk.zig generateChunks Phase3 전.)
-    2. **entry export-all-by-local**: shared-off 로 shared 가 entry 에 hoist 되면, 동적 청크는
-       `__zntc_require("entry.js").<local>` 로 단방향 조회한다. 그런데 cross-chunk export 가
-       **demand-driven**(소비자 있을 때만)이라 초기 lazy 빌드(seed 미파싱)는 그 export 를 안
-       내 → on-demand seed 가 못 찾음. 해법: **lazy 시 entry 청크가 hoisted 모듈 export 를
-       전부 *local(deconflict) name* 으로 노출**(`exports.v=v; exports.v$1=v$1;`). export-name
-       으로는 동명 충돌(shared.v + dup.v)이라 local name 필수. 이건 registry emit 신규 경로
-       (chunks.zig xchunk_exports 의 reg-entry break 를 lazy export-all 로 대체). **미구현.**
+  - **PR-3b-ii DONE — 접근 = (B) 결정론적 재빌드** (요청 seed 만 force-parse + `restrict_to_chunk`
+    단일청크 emit, Linker 매번 fresh). on-demand 를 (A)세션 Linker 생존의 위험한 lifecycle
+    리팩터 없이 구현. 3겹 전부 완료:
+    - **force-parse primitive (#4056)**: `BundleOptions.lazy_force_parse` — 지정 resolved 절대경로
+      동적타겟을 lazy defer 대신 즉시 parse. resolve_imports gate `!pathInForceParse`.
+    - **shared-splitting-off (§6.3)**: lazy 시 static-entry 비트 보유 모듈의 dynamic 비트 collapse
+      (chunk.zig generateChunks Phase3 전) → shared 가 entry 에 고정 → entry 결정론.
+    - **entry export-all-by-local**: lazy 시 reg entry 청크가 hoisted 모듈 export 를 *local
+      (deconflict) name* 으로 전부 노출(`exports.v=v; exports.v$1=v$1;` — entry 함수 안). demand-
+      driven 이 아니라 export-all 이라 seed force-parse 유무와 무관히 결정적. local name 으로
+      동명 export 충돌 회피. (chunks.zig `emitLazyEntryExportAll`, xchunk gate 에 `lazy_reg_entry`.)
+    검증: entry byte-identical(force-parse 유무 무관) + entry 가 exports.v 노출 + heavy 가
+    `__zntc_require("entry.js").v` 단방향 조회 + node e2e `heavy.h==="HEAVY_SHARED_V"`.
+    **한계(후속)**: export-name≠local name(별칭/re-export/소비모듈 deconflict)은 미정합(crash
+    아님, 미해결 참조) — 일반 `export const/function` 케이스만.
     → 즉 (B)는 viable 하나 `shared-off + export-all-by-local` 선행. PR-3b-ii 잔여 = 이 둘 구현.
   - **PR-3b-iii**: lazy 라우트 — `/<heavy-pathhash>.js` GET 시 seed force-parse→`restrict_to_chunk`
     단일청크 emit→`LazyChunkCache`. 이름→seed 역참조는 `graph.lazy_seeds`. virtual/external 동적

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -3020,6 +3020,99 @@ test "LazyCompilation PR-3b-ii: lazy_force_parse 가 지정 seed 를 즉시 pars
     try std.testing.expect(try heavyPresent(&.{heavy_abs}, entry)); // force-parse → eager
 }
 
+// PR-3b-ii 잔여: shared-off + entry export-all-by-local → (B) on-demand 성립.
+// shared 를 entry(static) + heavy(dynamic) 둘이 사용. shared-off 로 shared 는 entry 에 남고,
+// entry 가 export-all 로 shared 의 v 를 노출 → heavy 는 __zntc_require("entry.js").v 단방향
+// 조회. 결정론: heavy force-parse 유무와 무관히 entry 본문 동일(on-demand 정합).
+test "LazyCompilation PR-3b-ii: shared-off + export-all → 결정론 + entry cross-chunk export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "shared.ts", "export const v = 'SHARED_V';");
+    try writeFile(tmp.dir, "dup.ts", "export const v = 'DUP_V';");
+    try writeFile(tmp.dir, "heavy.ts",
+        \\import { v } from './shared';
+        \\export const h = 'HEAVY_' + v;
+    );
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { v as sv } from './shared';
+        \\import { v as dv } from './dup';
+        \\async function go() { const m = await import('./heavy'); console.log(m.h); }
+        \\console.log('boot', sv, dv);
+        \\go();
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const heavy_abs = try absPath(&tmp, "heavy.ts");
+    defer std.testing.allocator.free(heavy_abs);
+
+    const H = struct {
+        fn entryNorm(alloc: std.mem.Allocator, outs: []const emitter.OutputFile) !?[]u8 {
+            for (outs) |o| {
+                const lc = std.mem.indexOf(u8, o.contents, "__zntc_load_chunk(\"") orelse continue;
+                const arg = lc + "__zntc_load_chunk(\"".len;
+                const end = std.mem.indexOfScalarPos(u8, o.contents, arg, '"') orelse continue;
+                var b: std.ArrayListUnmanaged(u8) = .empty;
+                errdefer b.deinit(alloc);
+                try b.appendSlice(alloc, o.contents[0..arg]);
+                try b.appendSlice(alloc, "<CHUNK>");
+                try b.appendSlice(alloc, o.contents[end..]);
+                return try b.toOwnedSlice(alloc);
+            }
+            return null;
+        }
+        fn chunkWith(outs: []const emitter.OutputFile, needle: []const u8) ?[]const u8 {
+            for (outs) |o| if (std.mem.indexOf(u8, o.contents, needle) != null) return o.contents;
+            return null;
+        }
+    };
+
+    var b1 = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .code_splitting = true,
+        .lazy_compilation = true,
+        .format = .iife,
+    });
+    defer b1.deinit();
+    const r1 = try b1.bundle(std.testing.io);
+    defer r1.deinit(std.testing.allocator);
+    try std.testing.expect(!r1.hasErrors());
+    const e1 = (try H.entryNorm(std.testing.allocator, r1.outputs.?)) orelse return error.TestUnexpectedResult;
+    defer std.testing.allocator.free(e1);
+    // 초기 lazy 빌드도 shared 의 v 를 cross-chunk export 해야 on-demand heavy 가 찾는다.
+    // export-all-by-local: shared.v→exports.v, dup.v(deconflict)→exports.v$1 둘 다 노출(충돌 회피).
+    try std.testing.expect(std.mem.indexOf(u8, e1, "exports.v = v") != null);
+    try std.testing.expect(std.mem.indexOf(u8, e1, "exports.v$1 = v$1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, e1, "SHARED_V") != null); // shared 는 entry 에 인라인
+
+    var b2 = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .code_splitting = true,
+        .lazy_compilation = true,
+        .lazy_force_parse = &.{heavy_abs},
+        .format = .iife,
+    });
+    defer b2.deinit();
+    const r2 = try b2.bundle(std.testing.io);
+    defer r2.deinit(std.testing.allocator);
+    try std.testing.expect(!r2.hasErrors());
+    const e2 = (try H.entryNorm(std.testing.allocator, r2.outputs.?)) orelse return error.TestUnexpectedResult;
+    defer std.testing.allocator.free(e2);
+
+    // 결정론: 동적 청크 이름만 빼면 entry 본문 동일 → on-demand entry 정합.
+    try std.testing.expectEqualStrings(e1, e2);
+    // heavy 청크는 entry 의 v 를 __zntc_require("entry.js") 로 단방향 조회(공통 청크 없음).
+    const heavy_chunk = H.chunkWith(r2.outputs.?, "HEAVY_") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, heavy_chunk, "__zntc_require(\"entry.js\")") != null);
+    // heavy 는 *shared* 의 v(=SHARED_V)를 바인딩(이름 v) — dup 의 v$1 가 아니다(값 정합).
+    try std.testing.expect(std.mem.indexOf(u8, heavy_chunk, "{ v }") != null or
+        std.mem.indexOf(u8, heavy_chunk, "{v}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, heavy_chunk, "v$1") == null);
+    // common 청크가 생기지 않았다(shared-off) — 출력은 entry + heavy 만.
+    try std.testing.expectEqual(@as(usize, 2), r2.outputs.?.len);
+}
+
 test "LazyDevSplitting: kill-switch — lazy_compilation=false 면 dev 단일 번들 보존" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -1017,6 +1017,29 @@ pub fn generateChunks(
         }
     }
 
+    // PR-3b-ii (RFC §6.3): lazy(dev on-demand) 면 shared splitting off. static(비-dynamic)
+    // entry 비트가 있는 모듈에서 dynamic entry 비트를 제거 → {E,D}→{E} collapse. 그 모듈은
+    // 공통 청크가 아니라 entry 청크에 남고, 동적 청크는 그것을 __zntc_require 로 단방향 조회
+    // (entry 청크가 lazy 시 hoisted export 를 local name 으로 전부 노출 — emitter
+    // emitLazyEntryExportAll). 효과: 동적 seed 를 나중에 force-parse 해도 entry 청크가
+    // 불변(결정론) → on-demand 단일청크가 초기 entry 와 정합. entry 에 없는 동적 전용 deps 는
+    // 그대로 동적 청크에 남는다(on-demand 는 seed 1개만 parse 라 dynamic-dynamic 공유 미발생).
+    if (graph.lazy_compilation) {
+        for (splitting_info) |*bs| {
+            var has_static = false;
+            for (entries.items, 0..) |e, b| {
+                if (!e.is_dynamic and bs.hasBit(@intCast(b))) {
+                    has_static = true;
+                    break;
+                }
+            }
+            if (!has_static) continue;
+            for (entries.items, 0..) |e, b| {
+                if (e.is_dynamic) bs.clearBit(@intCast(b));
+            }
+        }
+    }
+
     // ── Phase 3: 모듈을 청크에 할당 ──
     // exec_index 순으로 처리하여 청크 내 모듈 순서(=ESM 실행 순서)를 보장.
     // 동일한 BitSet을 가진 모듈들은 같은 청크에 묶인다.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -726,7 +726,10 @@ pub fn emitChunks(
         // 다른 청크가 이 청크에서 심볼을 가져가는 경우에만 출력.
         // preserve-modules에서는 모듈 자체의 export가 유지되므로 cross-chunk export 불필요.
         // linker가 심볼을 rename한 경우 export { local_name as export_name } 형태로 출력.
-        if ((chunk.exports_to.count() > 0 or rbm_export_names.items.len > 0) and !options.preserve_modules) xchunk_exports: {
+        // PR-3b-ii: lazy reg(IIFE/CJS) entry 청크는 소비자(동적 청크)가 시작 시 미파싱이라
+        // exports_to 가 비어도 export-all 해야 하므로 별도로 진입한다.
+        const lazy_reg_entry = graph.lazy_compilation and entry_mod_idx != null and (options.format == .cjs or reg_split);
+        if ((chunk.exports_to.count() > 0 or rbm_export_names.items.len > 0 or lazy_reg_entry) and !options.preserve_modules) xchunk_exports: {
             // 결정론적 출력을 위해 이름을 정렬
             var export_names: std.ArrayList([]const u8) = .empty;
             defer export_names.deinit(allocator);
@@ -756,7 +759,16 @@ pub fn emitChunks(
             //    은 이 경로가 cross-chunk `exports.x=local;`. → cjs 와 동일하게
             //    entry 청크는 break(이중정의·module.exports= 손상 방지).
             const reg_fmt = options.format == .cjs or reg_split;
-            if (reg_fmt and entry_mod_idx != null) break :xchunk_exports;
+            if (reg_fmt and entry_mod_idx != null) {
+                // PR-3b-ii: lazy 면 entry 청크가 hoisted 모듈 export 를 local name 으로 전부
+                // 노출(export-all) — on-demand 동적 청크가 시작 시 미파싱 seed 라 어떤 export 를
+                // 참조할지 몰라도 찾게 + demand-driven 이 아니라 결정론(seed force-parse 무관).
+                // 그 외(eager)는 기존대로 break(emitCjsEntryExports 에 일임).
+                if (graph.lazy_compilation) {
+                    try emitLazyEntryExportAll(allocator, &chunk_output, graph, linker, sorted_mods, entry_mod_idx.?, module_count, options.minify_whitespace);
+                }
+                break :xchunk_exports;
+            }
             const cjs_x = reg_fmt;
 
             // 버그 B (#3321 후속): ESM entry/dynamic 청크는 codegen 이 entry
@@ -1925,6 +1937,53 @@ fn chunkRegistryId(
 ///     때만 skip.
 ///   - 없으면 비워진 청크(mergeSmallChunks/manualChunks 흡수) + PR-3a-ii lazy seed
 ///     (미파싱, on-demand)를 제외.
+/// PR-3b-ii: lazy 시 reg(IIFE/CJS) entry 청크가 hoisted 모듈들의 export 를 *local(deconflict)
+/// name* 으로 전부 노출한다 (`exports.<local> = <local>;`). on-demand 동적 청크가 시작 시
+/// 어떤 export 를 참조할지 몰라도(seed 미파싱) 찾을 수 있게 — demand-driven(chunk.exports_to)
+/// 이 아니라 export-all 이라 seed force-parse 유무와 무관히 결정적(초기 lazy 빌드와 동일).
+/// local name 키잉으로 동명 export(shared.v + dup.v, deconflict 로 local 구별) 충돌 회피.
+/// entry 모듈 자신의 export 는 emitCjsEntryExports 담당 → 제외.
+/// **한계(RFC §6.3, 후속)**: export-name 과 local name 이 다른 케이스(① 소비 모듈이 entry
+/// 안에서 deconflict, ② `export { a as b }` 별칭, ③ re-export)는 소비자 imports_from 이
+/// export-name 키라 mismatch — `export const`/`export function` 처럼 export-name==local-name
+/// 인 일반 케이스만 정합(dev on-demand 의 대다수). mismatch 는 crash 가 아니라 미해결 참조.
+fn emitLazyEntryExportAll(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayList(u8),
+    graph: *const ModuleGraph,
+    linker: ?*Linker,
+    sorted_mods: []const ModuleIndex,
+    entry_mod_idx: usize,
+    module_count: usize,
+    minify_whitespace: bool,
+) !void {
+    const l = linker orelse return;
+    var seen: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen.deinit(allocator);
+    var locals: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer locals.deinit(allocator);
+    for (sorted_mods) |mod_idx| {
+        const mi = @intFromEnum(mod_idx);
+        if (mi >= module_count or mi == entry_mod_idx) continue;
+        const m = graph.getModule(mod_idx) orelse continue;
+        for (m.export_bindings) |eb| {
+            const local = l.getCanonicalName(@intCast(mi), eb.exported_name) orelse m.exportBindingLocalName(eb);
+            if (local.len == 0) continue;
+            const gop = try seen.getOrPut(allocator, local);
+            if (gop.found_existing) continue;
+            try locals.append(allocator, local);
+        }
+    }
+    std.mem.sort([]const u8, locals.items, {}, types.stringLessThan); // 결정론
+    for (locals.items) |local| {
+        try out.appendSlice(allocator, "exports.");
+        try out.appendSlice(allocator, local);
+        try out.appendSlice(allocator, if (minify_whitespace) "=" else " = ");
+        try out.appendSlice(allocator, local);
+        try out.appendSlice(allocator, if (minify_whitespace) ";" else ";\n");
+    }
+}
+
 fn chunkRestrictSkip(chunk: *const Chunk, ci: usize, restrict_to_chunk: ?usize) bool {
     if (restrict_to_chunk) |r| {
         if (ci != r) return true;


### PR DESCRIPTION
## 요약
**(B) 결정론적 재빌드 on-demand 모델을 완성**합니다. PR #4056(force-parse primitive + 검증)에서 "(B)는 shared-off + export-all-by-local 선행 필요"로 규명한 두 전제를 구현합니다 (둘이 의존 → 함께 가야 동작).

## 구현
### 1. shared-splitting-off (RFC §6.3, `chunk.zig` generateChunks Phase3 전)
lazy 시 각 모듈 `splitting_info` 에 **static(비-dynamic) entry 비트**가 있으면 **dynamic entry 비트를 collapse** → entry+동적 둘이 쓰는 모듈(shared)이 공통 청크로 추출되지 않고 **entry 청크에 고정**. 효과: 동적 seed 를 나중에 force-parse 해도 entry 청크 불변(**결정론**).

### 2. entry export-all-by-local (`chunks.zig` `emitLazyEntryExportAll`)
lazy reg(IIFE/CJS) entry 청크가 hoisted 모듈들의 export 를 **local(deconflict) name** 으로 전부 노출(`exports.<local> = <local>;`, **entry 함수 안** — local 이 scope 에 있음). demand-driven(`chunk.exports_to`)이 아니라 **export-all** 이라 소비자(동적 seed)가 시작 시 미파싱이어도 찾고, force-parse 유무와 무관히 **결정적**. local name 키잉으로 동명 export(shared.v + dup.v→v$1) 충돌 회피. xchunk gate 에 `lazy_reg_entry` 추가(소비자 없어 `exports_to` 비어도 진입).

> **왜 둘이 함께?** shared-off 로 shared 가 entry 에 hoist 되면 동적 청크는 `__zntc_require("entry.js").<local>` 로 단방향 조회합니다. 그런데 cross-chunk export 가 demand-driven 이라 초기 lazy 빌드(seed 미파싱)는 그 export 를 안 냄 → on-demand seed 가 못 찾음. 그래서 export-all 이 필수입니다.

> Zig 초보 메모: dev splitting 은 한 청크의 모듈들을 **하나의 `__zntc_register({"entry.js": function(){...}})`** 함수로 합칩니다(scope-hoist). 다른 청크가 이 안의 심볼을 쓰려면 그 함수가 `exports.x = x` 로 노출해야 합니다. export-all 은 lazy 일 때 "나중에 올 동적 청크가 뭘 쓸지 모르니 전부 노출"하는 것이고, 동명 충돌을 피하려 **deconflict 된 local 이름**을 키로 씁니다.

## 검증
- **결정론**: entry 청크가 force-parse 유무와 무관히 byte-identical.
- **구조**: entry 가 `exports.v`/`exports.v$1` 노출, heavy 가 `__zntc_require("entry.js").v`(shared 의 v, dup 의 v$1 아님) 단방향 조회, common 청크 없음(outs=entry+heavy 2개).
- **node e2e**: entry(export-all) + heavy(단방향 require) 결합 실행 → **`heavy.h === "HEAVY_SHARED_V"`** ✓.
- `zig build test` 전체 + napi/wasm/test262 빌드 + d3 splitting **byte-identical**(`7089bac4` — 둘 다 `graph.lazy_compilation` 게이트라 non-lazy 불변). 기존 dev+lazy 테스트(#4038 등) 통과.

## /code-review max
9각도 → 검증 → sweep: 테스트 **값-정합** 보강(heavy 가 shared.v 바인딩, dup 아님 확인), export-all **한계 문서화**(export-name≠local: 별칭 `export { a as b }`/re-export/소비모듈 deconflict 는 미정합 — crash 아닌 미해결 참조, 일반 `export const/function` 케이스만 정합). 효율(export-all O(exports)·nested-loop collapse)은 dev 라 수용.

## 다음
PR-3b-iii — dev 서버 lazy 라우트: `/<heavy-pathhash>.js` GET → seed force-parse + `restrict_to_chunk` 단일청크 emit → `LazyChunkCache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)