### PR TITLE
feat(napi): lazy compilation PR-5 — startDevServer 에 lazyCompilation 옵션 노출

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -218,6 +218,7 @@ interface NativeModule {
     certPath?: string;
     keyPath?: string;
     quiet?: boolean;
+    lazyCompilation?: boolean;
   }): unknown;
   /** startDevServer 가 반환한 handle 로 graceful shutdown. idempotent. */
   stopDevServer(handle: unknown): void;
@@ -591,6 +592,18 @@ export interface StartDevServerOptions {
    * cause 를 추적할 수 있도록 보장.
    */
   quiet?: boolean;
+  /**
+   * Lazy on-demand compilation. Default false. When true, the dev server builds
+   * with code-splitting + lazy mode (IIFE registry): only the entry chunk is
+   * served at `/bundle.js`, and each dynamic `import()` target is compiled on
+   * demand when the browser requests its chunk URL. Reduces cold-start time for
+   * large apps (parse work is deferred to first use).
+   *
+   * **Note**: this is honored by the native (`startDevServer`) dev server only.
+   * The `zntc dev` web CLI runs a separate JS dev server that does not yet
+   * support lazy compilation — tracked as a backlog item.
+   */
+  lazyCompilation?: boolean;
 }
 
 /** Opaque handle from {@link startDevServer}. */
@@ -775,7 +788,13 @@ export interface EmotionOptions {
   importMap?: Record<string, Record<string, { canonicalImport: [string, string] }>>;
 }
 
-/** Vite-style dev server options used by `zntc dev` / `zntc --serve`. */
+/**
+ * Vite-style dev server options used by `zntc dev` / `zntc --serve`.
+ *
+ * Note: `startDevServer()` (native NAPI) accepts extra options such as
+ * `lazyCompilation` — see {@link StartDevServerOptions}. The `zntc dev` web CLI
+ * runs a separate JS dev server and does not honor those yet (backlog).
+ */
 export interface DevServerOptions {
   /** Port to listen on. CLI `--port` overrides this value. */
   port?: number;

--- a/packages/core/src/napi/serve_entry.zig
+++ b/packages/core/src/napi/serve_entry.zig
@@ -1,6 +1,6 @@
 //! HTTPS-capable dev server NAPI entry.
 //!
-//! `startDevServer({rootDir, port?, host?, entry?, open?, certPath?, keyPath?})`
+//! `startDevServer({rootDir, port?, host?, entry?, open?, certPath?, keyPath?, quiet?, lazyCompilation?})`
 //!   → opaque handle (napi_external).
 //! `stopDevServer(handle)` → undefined. shutdown + thread join + deinit.
 //!
@@ -176,6 +176,8 @@ pub fn napiStartDevServer(env: c.napi_env, info: c.napi_callback_info) callconv(
     // 하게 항상 stderr** — 사용자가 throw 메시지 너머 진단 못 보면 NAPI throwError
     // generic 메시지로 root cause 추적 불가.
     const quiet = getObjectBool(env, argv[0], "quiet", true);
+    // PR-5: lazy on-demand 컴파일(Zig DevServer 전용). default false.
+    const lazy_compilation = getObjectBool(env, argv[0], "lazyCompilation", false);
 
     // cert 와 key 둘 다 있거나 둘 다 없거나.
     if ((cert_path == null) != (key_path == null)) {
@@ -198,6 +200,7 @@ pub fn napiStartDevServer(env: c.napi_env, info: c.napi_callback_info) callconv(
         .cert_path = cert_path,
         .key_path = key_path,
         .quiet = quiet,
+        .lazy_compilation = lazy_compilation,
     }) catch |err| {
         native_alloc.destroy(server);
         cleanupStrings(root_dir, host, entry, cert_path, key_path);


### PR DESCRIPTION
## 요약
lazy on-demand 컴파일(PR-3a~PR-4)을 **프로그램틱 `startDevServer()` JS API** 에 노출합니다. `startDevServer({ rootDir, entry, lazyCompilation: true })` 면 Zig DevServer 가 dev_split(IIFE registry) 빌드로 entry 청크만 서빙하고, 동적 `import()` 타겟을 브라우저 요청 시 on-demand 컴파일합니다.

## 변경
- `packages/core/index.ts`: `lazyCompilation?: boolean` 추가 — `NativeModule.startDevServer` 인라인 타입 + `StartDevServerOptions`(TSDoc 로 동작 + native-전용 명시). `DevServerOptions`(CLI config)에는 **의도적으로 미추가** + 사유 주석.
- `packages/core/src/napi/serve_entry.zig`: `getObjectBool("lazyCompilation", false)` → `DevServer.init(.lazy_compilation = ...)` 매핑(`open`/`quiet` 와 동일 패턴).

## 범위 결정 (사용자 확인)
lazy 는 **Zig DevServer** 에만 구현돼 있고, 웹 CLI `zntc dev` 는 **자체 JS dev 서버**라 그 서버를 안 씁니다(`zntc.mjs` 가 `startDevServer` 미호출). 그래서 `--lazy` CLI 플래그를 추가하면 **no-op**(silent ignore)이 되므로 **추가하지 않았습니다**. CLI 지원은 백로그 → **#4062**.

## 검증
- **단독 repro**: `startDevServer({ entry, lazyCompilation: true })` → `GET /bundle.js` 가 `__zntc_load_chunk(` + `__zntc_register` 포함 + **heavy 본문 미포함**(지연), 기본(false)은 heavy 인라인 → 옵션이 배선 통과해 lazy 를 토글함을 end-to-end 확인.
- entry-모드 통합 테스트는 lazy 와 **무관한 pre-existing teardown segfault**(eager entry 모드도 동일) 때문에 보류 — 별도 버그 **#4063** 로 트래킹. (그 테스트의 assertion 자체는 "1 pass" 로 통과, 크래시는 teardown.)
- `tsc -b --force` 0 errors + `zig build test` 전체 + napi 빌드 OK + 누수 0.

## `/code-review max`
배선 정합(JS 키 `lazyCompilation` ↔ Zig `getObjectBool` 문자열 ↔ struct `lazy_compilation`), default(false) 일관, 완전성(누락 sync 지점 없음 — `.d.ts` 는 tsc 생성), TSDoc 정확성 전부 PASS. MINOR(DevServerOptions 미포함 사유 주석) 반영.

## 후속
- #4062 — 웹 CLI `zntc dev --lazy` 지원.
- #4063 — startDevServer entry 모드 teardown segfault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)