### PR TITLE
fix(server): entry 모드 dev 서버 teardown segfault — watch thread join (#4063)

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -127,6 +127,10 @@ pub const DevServer = struct {
     /// handleConnection 의 fetchAdd/Sub 가 path 분기 전이라 모든 connection (plain
     /// HTTP / SSE / HMR WS) 통일 카운팅.
     active_connections: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+    /// entry 모드의 watch 스레드(`watchLoop`) 핸들. `start()` 가 채우고 `deinit()` 이 join.
+    /// **#4063**: 예전엔 detach 라 deinit 이 frees 후에도 watchLoop 가 살아 self.* 를 건드려
+    /// UAF(segfault 0xF0). 이제 핸들을 보관해 shutdown 신호 후 join → 모든 자원 해제 전에 종료 보장.
+    watch_thread: ?std.Thread = null,
     plugins: []const plugin_mod.Plugin = &.{},
     proxy: []const ProxyRule = &.{},
     base_path: []const u8 = "/",
@@ -400,6 +404,16 @@ pub const DevServer = struct {
         // accept() 를 깨움 (macOS/Linux 에서 listen socket close 만으론 accept 안 깨움).
         // 그 뒤 listen socket 정리.
         self.shutdown();
+        // #4063: watch 스레드를 *자원 해제 전* 에 join. shutdown_requested 를 본 watchLoop 가
+        // 늦어도 한 폴링 주기(500ms) 안에 종료한다. join 후 watchLoop 의 inc_bundler/watcher
+        // (self.allocator·self.io 사용) defer 정리도 끝나 있어, 아래 frees 와 충돌(UAF) 없음.
+        // join 시점엔 abs_entry/lazy_state/root_dir 모두 아직 유효(아래에서 해제). watchLoop 가
+        // 종료 직전 ws_clients.broadcast/lazy_state.mutex 를 잡아도 짧은 임계영역이라 join 지연은
+        // 유한하고, deinit 스레드는 어떤 락도 안 쥐고 join 하므로 deadlock 불가.
+        if (self.watch_thread) |t| {
+            t.join();
+            self.watch_thread = null; // 중복 deinit 시 재join(UB) 방지
+        }
         if (self.tcp_server) |*s| s.deinit(self.io);
         // 살아있는 connection (handleConnection thread) 가 종료할 때까지 wait. 최대
         // 2초 (best-effort) — production 은 process exit 직전 deinit 라 그 시점엔
@@ -539,15 +553,15 @@ pub const DevServer = struct {
             } else |_| {}
         }
 
-        // entry가 있으면 watch 스레드 시작
+        // entry가 있으면 watch 스레드 시작. #4063: detach 대신 핸들을 self 에 보관 →
+        // deinit 이 shutdown 신호 후 join 해 자원 해제 전에 종료 보장(UAF 차단).
         if (self.abs_entry != null) {
-            const watch_thread = std.Thread.spawn(.{}, watchLoop, .{self}) catch |err| {
+            self.watch_thread = std.Thread.spawn(.{}, watchLoop, .{self}) catch |err| {
                 // **critical**: watch thread spawn fail — HMR / file watch 자체 안 됨.
                 // 사용자가 진단 봐야 함. quiet 와 무관 stderr.
                 getLog().print("zntc: failed to start watch thread: {}\n", .{err}) catch {};
                 return err;
             };
-            watch_thread.detach();
         }
 
         self.acceptLoop();
@@ -889,8 +903,11 @@ pub const DevServer = struct {
 
         self.routineLog("  [watch] watching {d} files for changes...\n", .{watcher.watchCount()});
 
-        while (true) {
+        // #4063: shutdown 시 종료. waitForChanges 는 watch_interval_ms(500ms) 타임아웃이라
+        // shutdown 후 늦어도 한 폴링 주기 안에 루프 top 으로 와 빠져나간다(deinit join 이 그만큼만 대기).
+        while (!self.shutdown_requested.load(.acquire)) {
             const events = watcher.waitForChanges(watch_interval_ms) catch continue;
+            if (self.shutdown_requested.load(.acquire)) break; // 폴링 반환 직후 재확인 — rebuild 진입 회피
 
             // Control API 경유 캐시 리셋 요청 처리 — 파일 변경 없어도 다음 rebuild를 전체 빌드로.
             if (self.cache_reset_requested.swap(false, .acquire)) {

--- a/tests/integration/tests/napi-dev-server.test.ts
+++ b/tests/integration/tests/napi-dev-server.test.ts
@@ -214,3 +214,75 @@ describe('NAPI startDevServer / stopDevServer', () => {
   //   - stopped atomic flag 가 명시 stop 과 finalizer 의 race 차단.
   // production 사용자에게는 명시 stopDevServer 권장 — finalize 는 GC safety net.
 });
+
+// #4063 회귀 + PR-5 통합: entry 모드(번들링 + watch thread) start→fetch→stop 이 좀비 watch
+// thread 로 인한 teardown segfault 없이 완료되는지 + lazyCompilation 옵션이 lazy 모드를
+// 켜는지 동시 검증. 예전엔 watch thread 가 detach 라 deinit frees 후에도 살아 self.* UAF
+// (segfault 0xF0) → 본 describe 가 멀티-사이클로 그 경로를 밟는다(크래시 시 rc=139).
+describe('NAPI startDevServer — entry 모드 teardown(#4063) + lazyCompilation(PR-5)', () => {
+  let lazyRoot: string;
+  let entryAbs: string;
+
+  beforeAll(() => {
+    lazyRoot = mkdtempSync(join(tmpdir(), 'zntc-lazy-opt-'));
+    writeFileSync(join(lazyRoot, 'heavy.ts'), "export const h = 'HEAVY_LAZY_MARKER';\n");
+    writeFileSync(
+      join(lazyRoot, 'entry.ts'),
+      "async function go(){ const m = await import('./heavy'); console.log(m.h); }\ngo();\n",
+    );
+    writeFileSync(join(lazyRoot, 'index.html'), '<script type="module" src="/bundle.js"></script>');
+    entryAbs = join(lazyRoot, 'entry.ts');
+  });
+
+  afterAll(() => {
+    if (lazyRoot) rmSync(lazyRoot, { recursive: true, force: true });
+  });
+
+  async function fetchBundle(opts: Record<string, unknown>): Promise<string> {
+    const handle = native.startDevServer({
+      rootDir: lazyRoot,
+      port: 0,
+      host: '127.0.0.1',
+      entry: entryAbs,
+      quiet: true,
+      ...opts,
+    });
+    try {
+      const port = native.getDevServerPort(handle);
+      await waitUntilReady(`http://127.0.0.1:${port}/bundle.js`);
+      const res = await fetch(`http://127.0.0.1:${port}/bundle.js`, {
+        headers: { Connection: 'close' },
+      });
+      expect(res.status).toBe(200);
+      return await res.text();
+    } finally {
+      native.stopDevServer(handle);
+      // watch thread join 이 끝났는지(좀비 부재) 확인할 시간 — 예전이면 이 창에서 crash.
+      await new Promise((r) => setTimeout(r, 600));
+    }
+  }
+
+  test('lazyCompilation:true → 동적 청크 지연(__zntc_load_chunk), heavy 본문 미포함', async () => {
+    const lazy = await fetchBundle({ lazyCompilation: true });
+    expect(lazy).toContain('__zntc_load_chunk(');
+    expect(lazy).toContain('__zntc_register');
+    expect(lazy).not.toContain('HEAVY_LAZY_MARKER'); // 미파싱 seed → 본문 없음
+  });
+
+  test('lazyCompilation 미지정(기본 false) → 단일 번들에 heavy 인라인', async () => {
+    const eager = await fetchBundle({});
+    expect(eager).toContain('HEAVY_LAZY_MARKER'); // 인라인(지연 안 함)
+  });
+
+  test('entry 모드 반복 start/stop — 좀비 watch thread teardown segfault 없음(#4063)', async () => {
+    // 여러 사이클 — 예전엔 detach 된 watch thread 가 다음 사이클/대기 중 freed 메모리 접근으로 crash
+    // (rc=139). 크래시 없이 3 사이클을 돌고 **이후에도 네이티브 모듈이 정상 동작**하면(아래 마지막
+    // 빌드가 유효 번들 반환) 좀비 thread 가 모듈 상태를 오염시키지 않았다는 신호.
+    let last = '';
+    for (let i = 0; i < 3; i++) {
+      last = await fetchBundle({ lazyCompilation: i % 2 === 0 });
+    }
+    // 마지막 사이클은 lazyCompilation:true(i=2) → lazy 마커가 있어야 함 = 모듈 여전히 기능적.
+    expect(last).toContain('__zntc_load_chunk(');
+  });
+});


### PR DESCRIPTION
## 요약
`startDevServer({ entry })` (entry 모드 = 번들링 + file watch) 를 `stopDevServer` 한 뒤 프로세스가 계속 실행되면 `panic: Segmentation fault at 0xF0` 로 크래시하던 버그를 고칩니다.

## 원인
`watchLoop` 스레드가 `start()` 에서 spawn 후 **detach** 돼 핸들이 보관/join 되지 않았습니다. `deinit()` 이 자원(abs_entry/lazy_state/root_dir/error_state)을 해제하고 NAPI finalizer 가 DevServer 구조체를 destroy 하는 동안, 살아있는 watchLoop 가 `self.*` 를 건드려 **UAF → segfault**(0xF0 = freed 구조체 필드 근처 오프셋). lazy 무관 — eager entry 모드도 동일(원래 serveBundle/watchLoop 경로). entry 모드를 쓰는 통합 테스트가 없어 그동안 미발견.

## 수정
- `DevServer.watch_thread: ?std.Thread` 필드 추가.
- `start()`: detach 대신 핸들을 `self.watch_thread` 에 보관.
- `watchLoop`: `while (true)` → `while (!shutdown_requested)` + `waitForChanges` 반환 직후 재확인(shutdown 시 rebuild 진입 회피). 늦어도 한 폴링 주기(500ms) 안에 종료.
- `deinit()`: `shutdown()` 직후 **자원 해제 전** 에 `watch_thread.join()`(후 null 로 재join 방지). join 시점엔 `self.*` 전부 유효 → watchLoop 의 inc_bundler/watcher defer 정리도 안전 완료.

> Zig 초보 메모: 스레드를 `spawn` 하면 핸들이 나오는데, `detach()` 하면 "알아서 끝나라" 며 핸들을 버립니다. 그러면 부모가 그 스레드가 끝났는지 알 수 없어, 부모가 자원을 해제해도 detached 스레드는 계속 돌며 그 자원을 건드릴 수 있습니다(UAF). `join()` 은 "그 스레드가 끝날 때까지 기다림" 이라, 자원 해제 전에 join 하면 안전합니다.

## 검증
- 3 사이클 start→fetch `/bundle.js`→stop + 좀비 윈도우 repro **무크래시** + **마지막 빌드 정상 동작**(네이티브 모듈 무오염).
- entry-모드 통합 테스트 신설(`napi-dev-server.test.ts`) — 수정 전엔 파일 전체 **rc=139**, 수정 후 **18 pass / 0 fail**. 이 테스트는 보너스로 **PR-5 의 `lazyCompilation` 옵션 통합 검증**(#4063 으로 막혀있던)도 겸합니다.
- `zig build test` 전체 + napi/wasm-bundler/test262 + 누수 0.

## 범위
**watch thread 한정**. keep-alive **connection thread** 가 2s deinit timeout 너머로 잔존하는 `[deinit] ... UAF 위험` 로그는 **별개·기존 이슈**(정적 모드에도 존재, 연결 force-close 미구현)로 본 PR 미포함.

## `/code-review max`
동시성 분석: deadlock / NAPI accept→watch 순서 / join-before-free / double-join / spawn-fail / 메모리 오더(release-acquire) / lazy_state·ws_clients 락 보유 중 join — **전부 SAFE**, BLOCKER 0. 테스트 회귀 신호 강화(`expect(true)` → 마지막 빌드 기능 검증), deinit deadlock-free 근거 주석 추가.

Closes #4063

🤖 Generated with [Claude Code](https://claude.com/claude-code)