### PR TITLE
fix(server): keep-alive connection thread teardown UAF — shutdown 으로 깨우기 (#4066)

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -131,6 +131,14 @@ pub const DevServer = struct {
     /// **#4063**: 예전엔 detach 라 deinit 이 frees 후에도 watchLoop 가 살아 self.* 를 건드려
     /// UAF(segfault 0xF0). 이제 핸들을 보관해 shutdown 신호 후 join → 모든 자원 해제 전에 종료 보장.
     watch_thread: ?std.Thread = null,
+    /// **#4066**: 활성 connection 의 socket fd 레지스트리. `shutdown()` 이 이들을 SHUT_RDWR 해
+    /// keep-alive 로 blocking read 중인 `handleConnection` 을 깨운다 — 안 그러면 listen close/
+    /// self-connect 가 accept 만 깨우고 수립된 connection 은 2s deinit timeout 너머 잔존 → freed
+    /// 자원 접근 UAF. register/deregister 는 `handleConnection` 이 `mutex` 안에서 수행.
+    conn_registry: struct {
+        mutex: spin.SpinLock = .{},
+        streams: std.ArrayListUnmanaged(std.Io.net.Stream) = .empty,
+    } = .{},
     plugins: []const plugin_mod.Plugin = &.{},
     proxy: []const ProxyRule = &.{},
     base_path: []const u8 = "/",
@@ -422,9 +430,13 @@ pub const DevServer = struct {
         const DEINIT_TIMEOUT_MS: i128 = 2000;
         const start_ns: i128 = std.Io.Timestamp.now(self.io, .awake).toNanoseconds();
         const deadline_ns: i128 = start_ns + DEINIT_TIMEOUT_MS * std.time.ns_per_ms;
+        var clean = false; // #4066: 좀비 connection 없이 깔끔히 종료됐는지
         while (true) {
             const count = self.active_connections.load(.acquire);
-            if (count == 0) break;
+            if (count == 0) {
+                clean = true;
+                break;
+            }
             const now_ns: i128 = std.Io.Timestamp.now(self.io, .awake).toNanoseconds();
             if (now_ns >= deadline_ns) {
                 // 같은 load 결과 (count) 를 log — re-load 시 사이에 0 으로 떨어졌으면
@@ -449,6 +461,10 @@ pub const DevServer = struct {
         if (self.tls_ctx) |*c| c.deinit();
         self.root_dir.close(self.io);
         self.error_state.deinit(self.io, self.allocator);
+        // #4066: clean(count==0, 모든 connection deregister 완료) 일 때만 레지스트리 free.
+        // timeout 잔존 thread 가 deregister 로 freed 리스트 접근하는 것 차단 — leak 은 비정상
+        // 경로(2s 안에 connection 미종료) 한정 + 미미(fd 몇 개분 capacity).
+        if (clean) self.conn_registry.streams.deinit(self.allocator);
     }
 
     /// dev overlay client raw template 의 `__ZNTC_HMR_*__` sentinel 들을
@@ -706,6 +722,42 @@ pub const DevServer = struct {
             const stream = addr.connect(self.io, .{ .mode = .stream }) catch return;
             stream.close(self.io);
         }
+
+        // #4066: 기존 keep-alive connection 의 blocking read 를 깨운다. listen close/self-connect
+        // 는 accept 만 깨우고 이미 수립된 connection 은 못 깨운다. socket 을 SHUT_RDWR 하면 그 fd
+        // 의 blocked read(receiveHead/ws/SSE)가 즉시 EOF/err 반환 → handleConnection 종료 →
+        // deinit 의 active_connections wait 가 빠르게 통과(좀비 thread UAF 차단). close 가 아닌
+        // shutdown 이라 fd reuse race 없음. mutex 안에서 수행해 owner 의 deregister+close 와
+        // 직렬화(shutdown 이 mutex 보유 중엔 owner 가 그 fd 를 deregister·close 못 함).
+        // 락을 syscall 들에 걸쳐 보유하지만 dev 서버 connection 수는 소규모(탭 몇 개)라 수용 —
+        // 스냅샷 후 락 밖 shutdown 은 fd reuse race 를 되살리므로 일부러 안 함.
+        self.conn_registry.mutex.lock();
+        defer self.conn_registry.mutex.unlock();
+        for (self.conn_registry.streams.items) |s| {
+            s.shutdown(self.io, .both) catch {};
+        }
+    }
+
+    /// #4066: 활성 connection 등록(handleConnection 진입). best-effort — append 실패해도
+    /// 2s deinit timeout 이 폴백. caller 가 mutex 미보유.
+    fn registerConn(self: *DevServer, stream: std.Io.net.Stream) void {
+        self.conn_registry.mutex.lock();
+        defer self.conn_registry.mutex.unlock();
+        self.conn_registry.streams.append(self.allocator, stream) catch |err|
+            self.routineLog("zntc: connection 등록 실패({}) — shutdown 시 못 깨워 2s timeout 폴백\n", .{err});
+    }
+
+    /// #4066: connection 등록 해제(handleConnection 종료, stream.close 보다 먼저 실행). socket
+    /// handle 로 매칭 — 같은 fd 의 등록분 제거.
+    fn deregisterConn(self: *DevServer, stream: std.Io.net.Stream) void {
+        self.conn_registry.mutex.lock();
+        defer self.conn_registry.mutex.unlock();
+        for (self.conn_registry.streams.items, 0..) |s, i| {
+            if (s.socket.handle == stream.socket.handle) {
+                _ = self.conn_registry.streams.swapRemove(i);
+                break;
+            }
+        }
     }
 
     fn handleConnection(self: *DevServer, stream: std.Io.net.Stream) void {
@@ -713,6 +765,12 @@ pub const DevServer = struct {
         // window 회피). 여기선 defer 로 fetchSub 만 — handleConnection 종료 시 한 번.
         defer _ = self.active_connections.fetchSub(1, .acq_rel);
         defer stream.close(self.io);
+
+        // #4066: shutdown() 이 깨울 수 있도록 fd 등록. deregister 는 defer 역순(뒤에 선언 →
+        // 먼저 실행)으로 stream.close *보다 먼저* 실행되어, shutdown 이 SHUT_RDWR 하는 fd 가
+        // 아직 열려있음을 보장(닫힌/재사용 fd 오접근 방지).
+        self.registerConn(stream);
+        defer self.deregisterConn(stream);
 
         var send_buf: [8192]u8 = undefined;
         // recv_buf: 32KB stack alloc — typical HTTP request header + body 가 다 fit.
@@ -1253,9 +1311,17 @@ pub const DevServer = struct {
         defer self.sse_clients.remove(self.io, &sink);
 
         // keep-alive: 30초마다 주석 전송. broadcast와 race 방지를 위해 sink mutex 사용.
-        while (true) {
-            // 0.16: std.Thread.sleep 제거 → io.sleep(duration, clock).
-            self.io.sleep(std.Io.Duration.fromSeconds(30), .awake) catch {};
+        // #4066: SSE 는 socket read 가 아니라 io.sleep 으로 대기 → shutdown(.both) 가 안 깨운다.
+        // 30s 를 짧게(500ms) 쪼개 sleep 중에도 shutdown_requested 를 폴링 → shutdown 후 ≤500ms
+        // 에 종료(안 그러면 connection thread 가 최대 30s 잔존 → 2s deinit timeout 너머 UAF).
+        while (!self.shutdown_requested.load(.acquire)) {
+            var slept_ms: u64 = 0;
+            while (slept_ms < 30_000) {
+                if (self.shutdown_requested.load(.acquire)) return;
+                // 0.16: std.Thread.sleep 제거 → io.sleep(duration, clock).
+                self.io.sleep(std.Io.Duration.fromMilliseconds(500), .awake) catch {};
+                slept_ms += 500;
+            }
             self.sse_clients.mutex.lockUncancelable(self.io);
             const ok = blk: {
                 response.writer.writeAll(": keep-alive\n\n") catch break :blk false;

--- a/tests/integration/tests/napi-dev-server.test.ts
+++ b/tests/integration/tests/napi-dev-server.test.ts
@@ -12,6 +12,7 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
+import { connect } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { createRequire } from 'node:module';
@@ -204,6 +205,39 @@ describe('NAPI startDevServer / stopDevServer', () => {
       quiet: false,
     });
     native.stopDevServer(handle);
+  });
+
+  test('blocked connection 이 stop 을 2s deinit timeout 으로 막지 않음 (#4066)', async () => {
+    // 원시 소켓으로 연결만 하고 *불완전한* 요청을 보냄 → 서버 handleConnection 이 receiveHead 에서
+    // 블록(결정적 — bun fetch keep-alive 의미에 의존 안 함). 수정 전: shutdown 이 listen 만 깨우고
+    // 기존 connection 은 못 깨워 deinit 가 2s timeout 까지 대기(+ UAF 위험). 수정 후: shutdown(.both)
+    // 로 blocked read 즉시 EOF → 빠른 종료. 정적 모드(no entry)라 watch join(~500ms)도 없어 측정 깔끔.
+    const port = reservePort();
+    const handle = native.startDevServer({
+      rootDir: tmpRoot,
+      port,
+      host: '127.0.0.1',
+      quiet: true,
+    });
+    let sock: ReturnType<typeof connect> | undefined;
+    try {
+      await waitUntilReady(`http://127.0.0.1:${port}/index.html`);
+      sock = connect({ host: '127.0.0.1', port });
+      sock.on('error', () => {}); // shutdown 시 ECONNRESET 등 무시
+      await new Promise<void>((res, rej) => {
+        sock!.once('connect', () => res());
+        sock!.once('error', rej);
+      });
+      sock.write('GET /index.html HTTP/1.1\r\n'); // 헤더 미완성 → 서버는 blank line 까지 더 읽으려 블록
+      await new Promise((r) => setTimeout(r, 150)); // 서버 accept + handleConnection read 블록할 시간
+      const t0 = Date.now();
+      native.stopDevServer(handle);
+      const dt = Date.now() - t0;
+      expect(dt).toBeLessThan(1500); // 수정 전이면 ~2000ms(timeout), 수정 후 수백 ms
+    } finally {
+      if (sock) sock.destroy();
+      native.stopDevServer(handle); // idempotent — finally 안전망
+    }
   });
 
   // GC-only cleanup (no explicit stopDevServer) — finalize callback 가 자동 정리한다는


### PR DESCRIPTION
## 요약
`stopDevServer`→`deinit` 시 keep-alive **connection thread**(`handleConnection`)가 blocking read 에 묶여 **2s timeout 너머 잔존** → deinit 이 자원 해제 후에도 살아 `self.*` 접근 **UAF**. `shutdown()` 은 listen socket 만(self-connect) 깨우고 *이미 수립된* connection 은 못 깨웠습니다. (#4063 의 watch thread 와 별개. 정적 모드에도 존재.)

## 수정 — connection 레지스트리 + SSE 폴링
- **`conn_registry`**(mutex + `ArrayListUnmanaged(Stream)`): `handleConnection` 이 진입 시 register, 종료 시 deregister(defer 역순으로 `stream.close` *보다 먼저* → shutdown 이 깨우는 fd 가 열려있음 보장).
- **`shutdown()`**: self-connect 후 레지스트리의 각 stream 에 **`shutdown(.both)`** → blocking read(`receiveHead`/WebSocket `readSmallMessage`)가 즉시 EOF/err 반환 → `handleConnection` 종료 → `active_connections` 빠르게 0 → deinit wait 통과. **`close` 아닌 `shutdown`** 이라 fd reuse race 없음; mutex 안에서 수행해 owner 의 deregister+close 와 직렬화.
- **SSE 잔여 수정 (`/code-review max` 발견)**: SSE keep-alive 는 socket read 가 아니라 `io.sleep(30s)` 대기라 socket shutdown 이 안 깨움 → 최대 30s 잔존. **30s 를 500ms 청크로 쪼개 sleep 중 `shutdown_requested` 폴링** → shutdown 후 ≤500ms 종료. (WebSocket 은 socket read 라 shutdown 으로 깨워짐.)
- **`deinit`**: `clean`(count==0) 일 때만 레지스트리 free — timeout 잔존 thread 가 freed 리스트에 deregister 하는 것 차단(leak 은 비정상 경로 한정·미미).

> Zig 초보 메모: `shutdown(fd, .both)` 는 소켓의 read/write 방향을 닫아 **블록된 read 를 EOF 로 즉시 깨웁니다**(fd 자체는 안 닫음 → owner 가 나중에 `close`). 그래서 다른 스레드가 read 에 묶인 connection 을 안전하게 깨워 종료시킬 수 있습니다.

## 검증
- 원시 소켓(`node:net`)으로 **불완전 요청**을 보내 서버를 `receiveHead` 에 **결정적으로 블록**시킨 뒤 stop 시간 측정: 수정 전 ~2000ms(timeout) → 수정 후 수백 ms(`<1500` assert), **3× 결정적**. 통합 **19 pass / 0 fail**.
- `zig build test` 전체 + napi/wasm-bundler/test262 + 누수 0.

## `/code-review max` (동시성)
fd-reuse 직렬화 airtight, Stream 사본 shutdown 동치, TLS `SSL_read` 깨어남, clean-flag leak 안전, 멱등 — 전부 **SAFE**. 리뷰가 잡은 **SSE 30s 잔여**를 in-scope 수정, `registerConn` OOM 로그 + 원시소켓 결정적 테스트로 false-pass 차단.

Closes #4066

🤖 Generated with [Claude Code](https://claude.com/claude-code)