### PR TITLE
docs(claude): 메인 설정은 자체 zntc.config — Vite/Rollup 어댑터는 호환 목적 명확화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,9 @@
 # ZNTC - Zig Native Transpiler & Compiler
 
 Zig로 작성하는 JS/TS/Flow 트랜스파일러 + 번들러 (SWC/oxc 수준 목표).
-C NAPI 바인딩으로 Node.js/Bun에서 in-process 사용, Vite/Rollup 플러그인 어댑터 지원.
+C NAPI 바인딩으로 Node.js/Bun에서 in-process 사용.
+**설정/플러그인의 메인은 자체 `zntc.config.{ts,js,json}`** ([docs/CONFIG.md](./docs/CONFIG.md)).
+Vite/Rollup 플러그인 어댑터는 **호환/마이그레이션 목적**(기존 생태계 재사용)일 뿐, 메인 표면이 아니다.
 
 ## Tech Stack
 Zig 0.16.0 · C NAPI v8 (vendor/node-api-headers/) · Node.js 24+ / Bun 1.3+ · mise · `zig build`


### PR DESCRIPTION
## 요약
CLAUDE.md 인트로가 "Vite/Rollup 플러그인 어댑터 지원"을 메인 포지셔닝처럼 적어 오해 소지가 있었습니다. 실제 메인 설정/플러그인 표면은 **자체 `zntc.config.{ts,js,json}`**(docs/CONFIG.md)이고, Vite/Rollup 어댑터는 기존 생태계 재사용을 위한 **호환/마이그레이션 목적**임을 명시합니다.

문서 한 단락 수정(코드 변경 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)