### PR TITLE
feat(napi): lazy compilation 프리미티브를 build/watch API 에 노출 (D105 PR-A)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -902,5 +902,14 @@
   - `clonePathRefIfNeeded` (module_store.zig) — `.interned` 만 store-owned 로 clone (others pass-through)
   - resolve_imports.zig:182/350 `unreachable` → `std.debug.panic` (release UB → meaningful diagnostic)
 
+### D105: 웹 CLI lazy 컴파일 = 접근 1(JS dev 서버 + 네이티브 프리미티브) (2026-05-31)
+- **결정**: 웹 CLI(`zntc dev`)의 lazy on-demand 컴파일은 **JS dev 서버(zntc.mjs)가 정본**으로 남고, lazy 의 어려운 로직(parse 지연·shared-off+export-all 결정론·경로해시 네이밍·IIFE registry)은 **네이티브(번들러)에 단일 진실**로 두며, **NAPI `build`/`watch` API 로 프리미티브를 노출**해 JS 가 그 위에 **얇게**(seed맵+청크캐시+라우트) 오케스트레이션한다. Zig DevServer(`startDevServer`)는 RN/임베더/no-JS 경로로 유지(웹 정본 아님). 접근 2(웹 CLI 를 네이티브 Zig 서버로 전환)는 **불채택**.
+- **이유**:
+  1. **포지션이 강제**: zntc 는 Vite/Rspack 형 **수평(남들이 위에 올라타는) 번들러** — 메타프레임워크/앱이 dev 라이프사이클에 JS 미들웨어·SSR·가상모듈·변환을 주입한다. 제품 표면 = **임베드 가능한 JS dev 서버**라 네이티브 서버로는 그 임베더빌리티를 못 준다. (zntc.config.ts 가 메인 설정인 건 vite.config 와 동형이고, Vite/Rollup 어댑터는 호환용.)
+  2. **선례 = Rspack**: Rust 코어 + **JS dev 서버(@rspack/dev-server)** + JS 플러그인. `experiments.lazyCompilation` 도 JS 미들웨어가 Rust 에 컴파일 요청 → 우리 접근 1 과 동형. (네이티브 서버는 Bun/Turbopack 처럼 런타임/프레임워크를 **소유한 수직형**만 정당.)
+  3. **이중화 최소화**: 컴파일 프리미티브·결정론은 번들러에 한 곳. dev 서버는 그 위 얇은 층뿐. 역참조(이름→seed)도 **네이티브가 `pathHash` 제공** → JS 가 Wyhash 재구현 안 함(drift 차단).
+- **노출(PR-A)**: `build`/`watch` 옵션에 `lazyCompilation`(bool), `lazyForceParse`(string[]); 결과에 `lazySeeds: [{ pathHash, path }]`(`pathHash` = `truncate(u32, Wyhash(0,path))` 8-hex, entry 의 `__zntc_load_chunk("<stem>-<pathHash>.js")` 와 매칭). `restrictToChunk` 는 PR-B 로 유보(JS 가 build-all 후 `moduleIds` 로 청크 선택 가능).
+- **후속**: PR-B(JS dev 서버 lazy 라우트+캐시), PR-C(watch/HMR 연동 + `--lazy`).
+
 ### Phase 6 (Advanced) 미결정 사항
 - 개발 서버 고급 기능 (증분 재빌드, 프레임워크 통합)

--- a/packages/core/bin/zntc-cli-schema-sync.test.ts
+++ b/packages/core/bin/zntc-cli-schema-sync.test.ts
@@ -449,6 +449,12 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
     // React Refresh 관련 opt-in — `reactRefresh` 자체가 config-only (CLI flag 없음).
     // hook signature emit (babel/SWC 동등) 도 config 에서만 켠다.
     'reactRefreshHookSignatures',
+    // alias 의 exact-match 변형 — 프로그램틱 build() 전용 (`--alias` 만 CLI 노출).
+    'aliasExact',
+    // D105 PR-A: lazy on-demand 프리미티브 — build()/watch() 전용, dev 서버가 오케스트레이션.
+    // CLI `--lazy` 노출은 PR-C 예정.
+    'lazyCompilation',
+    'lazyForceParse',
   ]);
 
   test('CLI flag 가 BuildOptions / TranspileOptions 키와 매칭되거나 cliOnlyFlags 에 등록', () => {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -126,6 +126,15 @@ interface NativeBuildResult {
   moduleCodes?: Array<{ id: string; code: string }>;
   modulePaths?: string[];
   rnAssetMetadata?: RnAssetMetadata[];
+  /**
+   * Lazy compilation seeds (only when `lazyCompilation: true`): each unparsed
+   * dynamic-import target deferred to on-demand build. `pathHash` is the 8-hex
+   * `truncate(u32, Wyhash(path))` matching the entry's
+   * `__zntc_load_chunk("<stem>-<pathHash>.js")` reference; `path` is the absolute
+   * seed module path. A dev server maps a requested chunk URL's hash → seed path
+   * (no need to reimplement Wyhash in JS), then rebuilds with `lazyForceParse: [path]`.
+   */
+  lazySeeds?: Array<{ pathHash: string; path: string }>;
 }
 
 interface NativeWatchHandle {
@@ -850,6 +859,29 @@ interface BuildOptionsCommon {
   minifyIdentifiers?: boolean;
   minifySyntax?: boolean;
   splitting?: boolean;
+  /**
+   * Lazy on-demand compilation primitive (dev-only). Requires `splitting: true` +
+   * `devMode: true`. When true, dynamic `import()` targets are left as UNPARSED
+   * "lazy seeds" (emit-skipped); the entry references them by stable path-hash name
+   * (`__zntc_load_chunk("<stem>-<pathHash>.js")`), and the result exposes
+   * {@link NativeBuildResult.lazySeeds}. A dev server compiles each seed on demand
+   * by rebuilding with `lazyForceParse: [seedPath]`. Low-level primitive — the web
+   * CLI dev server orchestrates this; most users use it indirectly.
+   */
+  lazyCompilation?: boolean;
+  /**
+   * Force-parse specific lazy seeds even under `lazyCompilation: true` — array of
+   * dynamic-import target paths to compile eagerly instead of deferring. A dev
+   * server passes the requested seed's path here to materialize exactly that
+   * on-demand chunk. No effect without `lazyCompilation: true`.
+   *
+   * **Contract**: each entry must be the EXACT path from a {@link NativeBuildResult.lazySeeds}
+   * entry's `.path` (the bundler-resolved absolute path — e.g. symlink-resolved
+   * `/private/tmp/...`, not your own `./x` specifier). A path that doesn't match a
+   * seed is **silently ignored** (that seed stays lazy). Source these from a prior
+   * `lazySeeds` result, never reconstruct them.
+   */
+  lazyForceParse?: string[];
   /** Rollup `output.inlineDynamicImports` — absorbs the dynamic import target
    * into the importer's chunk and rewrites the `import("./x")` call into an
    * `__esm` wrapper init/exports call. Combine with `splitting: true`. The

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -326,6 +326,14 @@ pub fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, exts)) return null;
     }
 
+    // D105 PR-A: lazyForceParse — lazy 시에도 즉시 parse 할 동적타겟 절대경로 목록.
+    // JS dev 서버의 on-demand 빌드가 요청된 seed 만 끌어올릴 때 쓴다.
+    const lazy_force_parse = getObjectStringArray(env, opts_obj, "lazyForceParse", native_alloc);
+    if (lazy_force_parse) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+
     // debug: 활성화할 디버그 로그 카테고리 목록 (ZNTC_DEBUG env 와 합집합).
     const debug_categories = getObjectStringArray(env, opts_obj, "debug", native_alloc);
     if (debug_categories) |cats| {
@@ -789,6 +797,9 @@ pub fn parseBuildOptions(
         // options.zig 의 `if (mfb.exposes.len>0) opts.splitting=true` 미러).
         .code_splitting = getObjectBool(env, opts_obj, "splitting", false) or
             (if (mf_cfg) |m| m.exposes.len > 0 else false),
+        // D105 PR-A: lazy on-demand 프리미티브 (dev_mode + splitting 조합 시 동작).
+        .lazy_compilation = getObjectBool(env, opts_obj, "lazyCompilation", false),
+        .lazy_force_parse = lazy_force_parse orelse &.{},
         .inline_dynamic_imports = getObjectBool(env, opts_obj, "inlineDynamicImports", false),
         .min_chunk_size = @as(usize, getObjectUint32(env, opts_obj, "minChunkSize", 0)),
         .sourcemap = .{

--- a/packages/core/src/napi/result.zig
+++ b/packages/core/src/napi/result.zig
@@ -1,5 +1,6 @@
 //! NAPI result object builders.
 
+const std = @import("std");
 const zntc_lib = @import("zntc_lib");
 const common = @import("common.zig");
 const options_mod = @import("options.zig");
@@ -209,6 +210,44 @@ pub fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult,
             _ = c.napi_set_element(env, js_paths, @intCast(i), js_p);
         }
         _ = c.napi_set_named_property(env, js_result, "modulePaths", js_paths);
+    }
+
+    // D105 PR-A: lazySeeds — lazy 빌드의 미파싱 seed 를 `{ pathHash, path }` 로 노출.
+    // pathHash = truncate(u32, Wyhash(0, path)) 의 8-hex — entry 가 부르는
+    // `__zntc_load_chunk("<stem>-<pathHash>.js")` 의 해시 세그먼트와 동일(chunk.zig
+    // lazy_path_hash 와 같은 공식). JS dev 서버가 요청 청크 이름의 해시로 seed 경로를
+    // 역참조(Wyhash 재구현 없이)할 수 있게 한다.
+    if (result.lazy_seed_paths) |seeds| {
+        var js_seeds: c.napi_value = undefined;
+        _ = c.napi_create_array(env, &js_seeds); // dedup 후 길이 불확정 → 동적 array
+        var out_idx: u32 = 0;
+        for (seeds, 0..) |path, i| {
+            // dedup: graph.lazy_seeds 가 같은 seed 를 중복 포함할 수 있어 앞선 path 와 같으면 skip.
+            var dup = false;
+            for (seeds[0..i]) |prev| if (std.mem.eql(u8, prev, path)) {
+                dup = true;
+                break;
+            };
+            if (dup) continue;
+
+            var js_seed: c.napi_value = undefined;
+            _ = c.napi_create_object(env, &js_seed);
+
+            var hash_buf: [8]u8 = undefined;
+            const h: u32 = @truncate(std.hash.Wyhash.hash(0, path));
+            _ = std.fmt.bufPrint(&hash_buf, "{x:0>8}", .{h}) catch unreachable;
+            var js_hash: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, &hash_buf, hash_buf.len, &js_hash);
+            _ = c.napi_set_named_property(env, js_seed, "pathHash", js_hash);
+
+            var js_path: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, path.ptr, path.len, &js_path);
+            _ = c.napi_set_named_property(env, js_seed, "path", js_path);
+
+            _ = c.napi_set_element(env, js_seeds, out_idx, js_seed);
+            out_idx += 1;
+        }
+        _ = c.napi_set_named_property(env, js_result, "lazySeeds", js_seeds);
     }
 
     // mjs `rn-asset-copy` 가 release asset 복사를 위해 이 배열을 직접 소비.

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -58,6 +58,9 @@ const bundler_only_fields = [_][]const u8{
     "inlineDynamicImports",
     "minChunkSize",
     "manualChunks",
+    // D105 PR-A: lazy on-demand 프리미티브 (build()/watch() 전용, dev 서버 오케스트레이션).
+    "lazyCompilation",
+    "lazyForceParse",
     "sourcemapMode",
     "outputExports",
     "mf", // Module Federation config 블록 (#3318 P1-0)

--- a/tests/integration/tests/napi-lazy-primitives.test.ts
+++ b/tests/integration/tests/napi-lazy-primitives.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { createFixture, byContent } from './helpers';
+import { init, close, build } from '../../../packages/core/index';
+
+// D105 PR-A: NAPI build API 에 lazy on-demand 프리미티브 노출.
+// `lazyCompilation` → 동적 import 타겟을 미파싱 seed 로 두고 `lazySeeds: [{pathHash, path}]`
+// 반환(entry 의 `__zntc_load_chunk("<stem>-<pathHash>.js")` 와 매칭). `lazyForceParse:[path]`
+// → 그 seed 만 즉시 parse(인라인). JS dev 서버가 이 위에서 on-demand 라우팅.
+
+describe('NAPI lazy compilation primitives (D105 PR-A)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  const lazyOpts = (entry: string) => ({
+    entryPoints: [entry],
+    platform: 'browser' as const,
+    devMode: true,
+    splitting: true,
+    format: 'iife' as const,
+    lazyCompilation: true,
+  });
+
+  test('lazyCompilation → lazySeeds{pathHash,path} (중복 제거) + entry 가 그 해시로 load_chunk', async () => {
+    const fixture = await createFixture({
+      'heavy.ts': `export const h = 'HEAVY_PRA_MARKER';`,
+      'entry.ts': `async function go(){ const m = await import('./heavy'); console.log(m.h); }\ngo();`,
+    });
+    cleanup = fixture.cleanup;
+    const r = await build(lazyOpts(join(fixture.dir, 'entry.ts')));
+
+    expect(r.errors ?? []).toHaveLength(0); // 빌드 성공 가드 — 무음 에러로 false-pass 방지
+    expect(r.outputFiles?.length ?? 0).toBeGreaterThan(0);
+    expect(r.lazySeeds).toBeDefined();
+    expect(r.lazySeeds!.length).toBe(1); // 중복 제거됨
+    const seed = r.lazySeeds![0];
+    expect(seed.path.endsWith('heavy.ts')).toBe(true);
+    expect(seed.pathHash).toMatch(/^[0-9a-f]{8}$/);
+
+    // entry 청크가 그 pathHash 로 동적 청크를 선참조.
+    const entry = byContent(r.outputFiles!, '__zntc_load_chunk(');
+    expect(entry).toBeDefined();
+    const m = entry!.text.match(/__zntc_load_chunk\("([^"]+)"\)/);
+    expect(m).not.toBeNull();
+    expect(m![1]).toContain(seed.pathHash); // 요청 URL ↔ seed 역참조 정합
+
+    // heavy 본문은 미파싱 seed → 어느 청크에도 인라인 안 됨.
+    expect(byContent(r.outputFiles!, 'HEAVY_PRA_MARKER')).toBeUndefined();
+  });
+
+  test('lazyForceParse:[seed.path] → 그 seed 즉시 parse(lazySeeds 에서 빠지고 인라인)', async () => {
+    const fixture = await createFixture({
+      'heavy.ts': `export const h = 'HEAVY_PRA_MARKER';`,
+      'entry.ts': `async function go(){ const m = await import('./heavy'); console.log(m.h); }\ngo();`,
+    });
+    cleanup = fixture.cleanup;
+    const entry = join(fixture.dir, 'entry.ts');
+
+    const base = await build(lazyOpts(entry));
+    expect(base.errors ?? []).toHaveLength(0);
+    // force-parse 는 lazySeeds 의 *정확한* path(번들러 해석 절대경로, 예: macOS /private/tmp)
+    // 를 받는다. 사용자가 `./heavy` 같은 자기 specifier 를 넘기면 mismatch → 무음 no-op.
+    const seedPath = base.lazySeeds![0].path;
+
+    const forced = await build({ ...lazyOpts(entry), lazyForceParse: [seedPath] });
+    expect(forced.errors ?? []).toHaveLength(0);
+    expect(forced.lazySeeds ?? []).toHaveLength(0); // seed 가 parse 됨 → 목록에서 빠짐
+    expect(byContent(forced.outputFiles!, 'HEAVY_PRA_MARKER')).toBeDefined(); // 즉시 parse → 본문 존재
+  });
+
+  test('lazyCompilation 미지정 → lazySeeds 없음(기존 단일/스플릿 빌드 불변)', async () => {
+    const fixture = await createFixture({
+      'heavy.ts': `export const h = 'HEAVY_PRA_MARKER';`,
+      'entry.ts': `async function go(){ const m = await import('./heavy'); console.log(m.h); }\ngo();`,
+    });
+    cleanup = fixture.cleanup;
+    const r = await build({
+      entryPoints: [join(fixture.dir, 'entry.ts')],
+      platform: 'browser',
+      format: 'iife',
+      splitting: true,
+    });
+    expect(r.lazySeeds ?? []).toHaveLength(0); // 게이트 OFF → seed 노출 안 함
+  });
+
+  test('같은 seed 를 두 번 import → lazySeeds 1개 (dedup)', async () => {
+    // graph.lazy_seeds 는 같은 타겟을 여러 import record 로 중복 보유할 수 있다.
+    // NAPI 경계에서 dedup 하므로 동일 seed 를 여러 번 import 해도 lazySeeds 는 1개여야.
+    const fixture = await createFixture({
+      'heavy.ts': `export const h = 'HEAVY_PRA_MARKER';`,
+      'entry.ts': `async function a(){ return (await import('./heavy')).h; }\nasync function b(){ return (await import('./heavy')).h; }\na(); b();`,
+    });
+    cleanup = fixture.cleanup;
+    const r = await build(lazyOpts(join(fixture.dir, 'entry.ts')));
+    expect(r.errors ?? []).toHaveLength(0);
+    expect(r.lazySeeds ?? []).toHaveLength(1); // 두 import 가 같은 seed → 1개로 dedup
+    expect(r.lazySeeds![0].path.endsWith('heavy.ts')).toBe(true);
+  });
+});


### PR DESCRIPTION
## 요약
웹 CLI lazy 컴파일(**접근 1**: JS dev 서버 정본 + 네이티브 프리미티브, [D105](../blob/main/docs/DECISIONS.md))의 **토대**입니다. lazy 의 어려운 로직(parse 지연·shared-off+export-all 결정론·경로해시 네이밍)은 **네이티브 단일 진실**로 두고, NAPI `build`/`watch` API 로 **프리미티브만 노출**해 JS dev 서버(PR-B)가 그 위에 **얇게** 오케스트레이션하게 합니다.

## 노출
- **옵션** (`options.zig`, `build`/`watch`/`buildSync` 공용 `parseBuildOptions`):
  - `lazyCompilation` (bool) → `BundleOptions.lazy_compilation`.
  - `lazyForceParse` (string[], 해석 절대경로) → `lazy_force_parse`. `external` 과 동일 트래킹.
- **결과** (`result.zig`): `lazySeeds: [{ pathHash, path }]` — 미파싱 seed 별로 `pathHash = {x:0>8}(truncate(u32, Wyhash(0, path)))`. entry 의 `__zntc_load_chunk("<stem>-<pathHash>.js")` 해시 세그먼트와 **byte 일치**(chunk.zig `lazy_path_hash` + chunks.zig `chunkPlaceholderStem` 과 동일 공식). **dedup** 적용. → JS 가 요청 URL 해시로 seed 경로를 **역참조(Wyhash 재구현 없이)**.
- **TS** (`index.ts`): `BuildOptionsCommon` += 옵션 2개; `NativeBuildResult` += `lazySeeds`. `lazyForceParse` TSDoc 에 **정확-path 계약**(`lazySeeds[].path` 그대로 써야 하고 mismatch 는 무음 no-op) 명시.

> Zig 초보 메모: `lazySeeds[].pathHash` 는 entry 가 부르는 동적 청크 URL(`heavy-<hash>.js`)의 `<hash>` 와 같은 값입니다. 브라우저가 그 URL 을 요청하면, JS 서버가 URL 의 hash 로 `lazySeeds` 에서 seed 경로를 찾아 `lazyForceParse:[그 경로]` 로 그 청크만 빌드합니다. hash 계산은 네이티브 한 곳에만 있어 JS↔Zig 가 어긋날 일이 없습니다.

## drift 가드 동기 (build()-API 전용, CLI flag 없음)
- `zntc-cli-schema-sync.test.ts` `buildOptionsOnlyKeys` += 옵션 2개 (+ 기존 누락 `aliasExact` — 이 테스트는 main 에서 이미 red 였음, 같이 정리).
- `config_options_dto_test.zig` `bundler_only_fields` += 옵션 2개.

## 검증
- 통합 테스트 신설(`napi-lazy-primitives.test.ts`, **4 케이스**): `lazyCompilation`→`lazySeeds` 1개 + entry 의 `load_chunk` 이름이 그 `pathHash` 포함(**역참조 round-trip**) + heavy 미인라인; `lazyForceParse[seed.path]`→`lazySeeds` 비고 heavy 인라인; 게이트 OFF→`lazySeeds` 없음; 같은 seed 2회 import→**dedup 1개**. 모두 build 성공 가드.
- `zig build test` 전체 + napi/wasm-bundler/test262/install + schema-sync 13 pass + `tsc -b --force` 0.

## `/code-review max`
2 에이전트 — **hash 공식 byte 일치 검증**(역참조 drift 없음), string-array 소유권/cleanup(`external` 미러) 정합, sync 완전성(build/watch 공용 parseBuildOptions). 반영: 테스트 build-성공 가드, `lazyForceParse` 정확-path TSDoc, dedup 테스트 추가. `restrictToChunk` 는 PR-B 유보(타당).

## 다음
PR-B(JS dev 서버 lazy 라우트 + 청크 캐시) → PR-C(watch/HMR 연동 + `--lazy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)