### PR TITLE
feat(napi): watch() onReady 에 lazySeeds 노출 + 공용 빌더 추출 (D105 PR-B-1)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1360,6 +1360,17 @@ export interface WatchReadyEvent {
    * 는 메모리 비용이 커 path 만 노출 — caller 가 fs read 또는 path 기반 분기.
    */
   outputs?: string[];
+  /**
+   * D105 PR-B-1 — lazy 빌드(`lazyCompilation: true`)일 때만. 미파싱 lazy seed 들의
+   * `{ pathHash, path }` (build 결과 {@link NativeBuildResult.lazySeeds} 와 동일 shape).
+   * dev 서버가 watch(lazy)로 HMR 을 유지하며 on-demand lazy 라우팅을 구현하기 위한 **토대 데이터**
+   * — 요청 청크 URL `<stem>-<pathHash>.js` 의 해시로 seed 경로를 역참조해 on-demand 컴파일
+   * (`build({ lazyForceParse: [path] })`)할 수 있다.
+   *
+   * **범위**: *initial* 빌드(onReady)에서만 노출. rebuild(HMR)에서 동적 import 추가/삭제로
+   * seed 집합이 바뀌는 경우의 갱신 전략(델타 vs full-reload)은 PR-B-2(dev 서버 연동)에서 정한다.
+   */
+  lazySeeds?: Array<{ pathHash: string; path: string }>;
 }
 
 export interface WatchRebuildEvent {

--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -270,6 +270,44 @@ fn copyBytesOrEmpty(alloc: std.mem.Allocator, data_ptr: ?*anyopaque, byte_len: u
     return out;
 }
 
+/// D105: lazy seed 경로 목록 → JS `[{ pathHash, path }]` 배열을 만들어 반환한다.
+/// `pathHash` = `truncate(u32, Wyhash(0, path))` 8-hex — chunk.zig `lazy_path_hash` /
+/// chunks.zig `chunkPlaceholderStem` 과 동일 공식이라, dev 서버가 요청 청크 URL
+/// (`<stem>-<pathHash>.js`)의 hash 로 seed 를 역참조(JS 에서 Wyhash 재구현 없이)한다.
+/// 같은 path 중복은 제거(graph.lazy_seeds 가 중복 보유 가능). **build()/watch() 결과 빌더
+/// 공용** — Wyhash 공식을 한 곳에만 둬 두 경로 간 drift 차단.
+pub fn buildLazySeedsJs(env: c.napi_env, paths: []const []const u8) c.napi_value {
+    var js_seeds: c.napi_value = undefined;
+    _ = c.napi_create_array(env, &js_seeds);
+    var out_idx: u32 = 0;
+    for (paths, 0..) |path, i| {
+        var dup = false;
+        for (paths[0..i]) |prev| if (std.mem.eql(u8, prev, path)) {
+            dup = true;
+            break;
+        };
+        if (dup) continue;
+
+        var js_seed: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &js_seed);
+
+        var hash_buf: [8]u8 = undefined;
+        const h: u32 = @truncate(std.hash.Wyhash.hash(0, path));
+        _ = std.fmt.bufPrint(&hash_buf, "{x:0>8}", .{h}) catch unreachable;
+        var js_hash: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, &hash_buf, hash_buf.len, &js_hash);
+        _ = c.napi_set_named_property(env, js_seed, "pathHash", js_hash);
+
+        var js_path: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, path.ptr, path.len, &js_path);
+        _ = c.napi_set_named_property(env, js_seed, "path", js_path);
+
+        _ = c.napi_set_element(env, js_seeds, out_idx, js_seed);
+        out_idx += 1;
+    }
+    return js_seeds;
+}
+
 /// `alloc(T, len)` 후 일부 element 만 채운 채 `result[0..count]` 를 반환하면
 /// caller 가 그대로 free 시 alloc-size(`len`) vs free-size(`count`) mismatch
 /// (`getStringArg` 와 동일 root cause). 정확히 `count` 길이로 줄여 반환한다.

--- a/packages/core/src/napi/result.zig
+++ b/packages/core/src/napi/result.zig
@@ -1,6 +1,5 @@
 //! NAPI result object builders.
 
-const std = @import("std");
 const zntc_lib = @import("zntc_lib");
 const common = @import("common.zig");
 const options_mod = @import("options.zig");
@@ -213,40 +212,9 @@ pub fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult,
     }
 
     // D105 PR-A: lazySeeds — lazy 빌드의 미파싱 seed 를 `{ pathHash, path }` 로 노출.
-    // pathHash = truncate(u32, Wyhash(0, path)) 의 8-hex — entry 가 부르는
-    // `__zntc_load_chunk("<stem>-<pathHash>.js")` 의 해시 세그먼트와 동일(chunk.zig
-    // lazy_path_hash 와 같은 공식). JS dev 서버가 요청 청크 이름의 해시로 seed 경로를
-    // 역참조(Wyhash 재구현 없이)할 수 있게 한다.
+    // 빌더는 common.buildLazySeedsJs 공용(watch() 이벤트와 Wyhash 공식 단일 소스).
     if (result.lazy_seed_paths) |seeds| {
-        var js_seeds: c.napi_value = undefined;
-        _ = c.napi_create_array(env, &js_seeds); // dedup 후 길이 불확정 → 동적 array
-        var out_idx: u32 = 0;
-        for (seeds, 0..) |path, i| {
-            // dedup: graph.lazy_seeds 가 같은 seed 를 중복 포함할 수 있어 앞선 path 와 같으면 skip.
-            var dup = false;
-            for (seeds[0..i]) |prev| if (std.mem.eql(u8, prev, path)) {
-                dup = true;
-                break;
-            };
-            if (dup) continue;
-
-            var js_seed: c.napi_value = undefined;
-            _ = c.napi_create_object(env, &js_seed);
-
-            var hash_buf: [8]u8 = undefined;
-            const h: u32 = @truncate(std.hash.Wyhash.hash(0, path));
-            _ = std.fmt.bufPrint(&hash_buf, "{x:0>8}", .{h}) catch unreachable;
-            var js_hash: c.napi_value = undefined;
-            _ = c.napi_create_string_utf8(env, &hash_buf, hash_buf.len, &js_hash);
-            _ = c.napi_set_named_property(env, js_seed, "pathHash", js_hash);
-
-            var js_path: c.napi_value = undefined;
-            _ = c.napi_create_string_utf8(env, path.ptr, path.len, &js_path);
-            _ = c.napi_set_named_property(env, js_seed, "path", js_path);
-
-            _ = c.napi_set_element(env, js_seeds, out_idx, js_seed);
-            out_idx += 1;
-        }
+        const js_seeds = common.buildLazySeedsJs(env, seeds);
         _ = c.napi_set_named_property(env, js_result, "lazySeeds", js_seeds);
     }
 

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -240,9 +240,17 @@ const WatchReadyEvent = struct {
     /// `success` 는 watch lifecycle 자체에 보존, errors 는 별도 노출. consumer (runServe) 가
     /// reportError 호출.
     errors: ?[]const WatchRebuildEvent.ErrorEntry = null,
+    /// D105 PR-B-1: lazy 빌드의 미파싱 seed 절대경로 목록(`result.lazy_seed_paths` 사본).
+    /// onReady 이벤트가 `lazySeeds: [{pathHash, path}]` 로 노출 → JS dev 서버 lazy 라우팅의 토대.
+    /// null/빈 = lazy 아님. (rebuild 시 seed 변경 갱신은 PR-B-2 범위 — onReady 만 노출.)
+    lazy_seeds: ?[]const []const u8 = null,
 
     fn deinit(self: *WatchReadyEvent, allocator: std.mem.Allocator) void {
         if (self.outputs) |paths| {
+            for (paths) |p| allocator.free(p);
+            allocator.free(paths);
+        }
+        if (self.lazy_seeds) |paths| {
             for (paths) |p| allocator.free(p);
             allocator.free(paths);
         }
@@ -415,6 +423,13 @@ fn watchReadyTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data: 
             _ = c.napi_set_element(env, js_outputs, @intCast(idx), js_str);
         }
         _ = c.napi_set_named_property(env, js_event, "outputs", js_outputs);
+    }
+
+    // D105 PR-B-1: lazySeeds: Array<{pathHash, path}> — lazy 빌드일 때만. build() 결과와
+    // 동일 빌더(common.buildLazySeedsJs)라 pathHash 공식 단일 소스.
+    if (event.lazy_seeds) |paths| {
+        const js_seeds = common.buildLazySeedsJs(env, paths);
+        _ = c.napi_set_named_property(env, js_event, "lazySeeds", js_seeds);
     }
 
     // #3799 root-cause — errors: Array<{file, message}> (initial diagnostics 의 error 목록).
@@ -1049,10 +1064,30 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
                 }
             }
         }
+        // D105 PR-B-1: lazy seed 경로 사본 (outputs_copy 와 동일 패턴 — partial alloc 실패 시 정리).
+        var lazy_seeds_copy: ?[]const []const u8 = null;
+        if (result.lazy_seed_paths) |lsp| {
+            const arr = allocator.alloc([]const u8, lsp.len) catch null;
+            if (arr) |paths| {
+                var fill: usize = 0;
+                for (lsp) |p| {
+                    const dup = allocator.dupe(u8, p) catch break;
+                    paths[fill] = dup;
+                    fill += 1;
+                }
+                if (fill == lsp.len) {
+                    lazy_seeds_copy = paths;
+                } else {
+                    for (paths[0..fill]) |p| allocator.free(p);
+                    allocator.free(paths);
+                }
+            }
+        }
         ready_event.* = .{
             .files = initial_watch_count,
             .bytes = initial_bytes,
             .outputs = outputs_copy,
+            .lazy_seeds = lazy_seeds_copy,
             // #3799 root-cause — initial build 의 diagnostics 에 error 가 있으면 별도 노출.
             // success/lifecycle 영향 없음, consumer (runServe onReady) 가 reportError 처리.
             .errors = if (result.hasErrors()) collectErrorsFromResult(allocator, &result) else null,

--- a/tests/integration/tests/napi-lazy-primitives.test.ts
+++ b/tests/integration/tests/napi-lazy-primitives.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
 import { join } from 'node:path';
 import { createFixture, byContent } from './helpers';
-import { init, close, build } from '../../../packages/core/index';
+import { init, close, build, watch } from '../../../packages/core/index';
 
 // D105 PR-A: NAPI build API 에 lazy on-demand 프리미티브 노출.
 // `lazyCompilation` → 동적 import 타겟을 미파싱 seed 로 두고 `lazySeeds: [{pathHash, path}]`
@@ -102,5 +102,42 @@ describe('NAPI lazy compilation primitives (D105 PR-A)', () => {
     expect(r.errors ?? []).toHaveLength(0);
     expect(r.lazySeeds ?? []).toHaveLength(1); // 두 import 가 같은 seed → 1개로 dedup
     expect(r.lazySeeds![0].path.endsWith('heavy.ts')).toBe(true);
+  });
+
+  // PR-B-1: watch() 의 onReady 이벤트도 lazySeeds 를 노출(build 결과와 동일 shape/공식,
+  // common.buildLazySeedsJs 공용). dev 서버가 watch(lazy)로 HMR 유지하며 on-demand 라우팅하는 토대.
+  test('watch() onReady 가 lazySeeds 노출 (HMR 경로용)', async () => {
+    const fixture = await createFixture({
+      'heavy.ts': `export const h = 'HEAVY_PRB';`,
+      'entry.ts': `async function go(){ const m = await import('./heavy'); console.log(m.h); }\ngo();`,
+    });
+    cleanup = fixture.cleanup;
+
+    let handle: ReturnType<typeof watch> | undefined;
+    const ready = new Promise<any>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('onReady timeout')), 8000);
+      handle = watch({
+        entryPoints: [join(fixture.dir, 'entry.ts')],
+        platform: 'browser',
+        devMode: true,
+        splitting: true,
+        lazyCompilation: true,
+        format: 'iife',
+        outdir: join(fixture.dir, 'out'),
+        onReady: (e: any) => {
+          clearTimeout(t);
+          resolve(e);
+        },
+      });
+    });
+    try {
+      const e = await ready;
+      expect(e.lazySeeds).toBeDefined();
+      expect(e.lazySeeds.length).toBe(1);
+      expect(e.lazySeeds[0].pathHash).toMatch(/^[0-9a-f]{8}$/);
+      expect(e.lazySeeds[0].path.endsWith('heavy.ts')).toBe(true);
+    } finally {
+      handle?.stop();
+    }
   });
 });


### PR DESCRIPTION
## 요약
PR-A 가 `build()` 결과에 `lazySeeds` 를 노출했지만, **웹 dev 서버는 `watch()`**(증분 + HMR)를 씁니다. `watch()` 의 onReady 이벤트도 `lazySeeds` 를 노출해, JS dev 서버가 `watch(lazy)` 로 **HMR 을 유지하며** on-demand lazy 라우팅을 하는 **토대**를 만듭니다(접근 1, D105). HMR 희생 없이 가는 게 핵심 — Rspack `lazyCompilation` 과 동형.

## 변경
- **common.zig**: `buildLazySeedsJs(env, paths)` **공용 빌더 추출** — `[{pathHash, path}]`, `pathHash={x:0>8}(truncate(u32,Wyhash(0,path)))`, dedup. `build()`/`watch()` 결과가 **공유** → Wyhash 공식을 한 곳에만 둬 두 경로 간 drift 차단.
- **result.zig**: PR-A 의 인라인 lazySeeds 블록 → 공용 빌더 호출(동작 **byte-동일**). 미사용 `std` import 제거.
- **watch.zig**: `WatchReadyEvent` += `lazy_seeds`(`result.lazy_seed_paths` 사본 — `outputs_copy` 와 동일 partial-alloc 정리 + deinit). `watchReadyTsfn` 이 공용 빌더로 `lazySeeds` emit.
- **index.ts**: `WatchReadyEvent` += `lazySeeds?: [{pathHash, path}]` (토대 데이터·onReady 한정 명시).

## 검증
- 단독 repro: `watch({lazyCompilation,splitting,devMode,iife})` onReady → `lazySeeds=[{pathHash,path}]`.
- 통합 테스트(`napi-lazy-primitives.test.ts`) += watch onReady lazySeeds 케이스 → **5 pass**. watch teardown **clean**(isolated rc=0, Zig DevServer 의 #4063/#4066 와 달리 stop() 깨끗). 기존 splitting/build 테스트 회귀 없음.
- `zig build test` + napi/wasm-bundler/install + schema-sync 13 + `tsc -b --force` 0.

## `/code-review max`
2 에이전트 — 공용 빌더 **byte-동일**·lifecycle leak/double-free 0·**非lazy 빌드 불변** 확인. "Promise/handle race" 지적은 **오판**(NAPI TSFN 콜백은 동기 executor 반환 후 main-loop 에서 실행 → `handle` 항상 선할당; teardown rc=0 실증). 반영: TSDoc 을 "토대"로 명확화 + **onRebuild seed 갱신은 PR-B-2 범위** 명시.

## 범위
PR-B-1 = watch 이벤트가 lazySeeds 노출(토대, **다음 PR-B-2 의 전제**). **PR-B-2** = JS dev 서버가 `watch(lazy)` + lazy 청크 라우트 소비. onRebuild lazySeeds(rebuild 시 seed 변경 갱신)도 PR-B-2 에서 판단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)