### PR TITLE
fix(bundler): watch/dev lazy 경로가 동적 청크를 안 만들던 버그 — buildIncremental 에서 materializeLazySeeds 호출 (#4071)

### DIFF
--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -896,6 +896,17 @@ pub fn buildIncremental(
         parse_start = parse_end;
     }
 
+    // #4071: build() 와 동일하게 동적 import seed 를 materialize 한다. buildIncremental
+    // 은 자체 sequential discovery 라 build() 의 `materializeLazySeeds`(위 build_flow:139)
+    // 호출을 공유하지 않는다. 그래서 `module_store` 가 주입되는 watch/dev lazy 경로에선
+    // 동적 import 의 lazy 게이트(resolve_imports:356)가 seed 만 쌓고 materialize 가 안 돼
+    // → 동적 청크가 생성되지 않고 entry 의 `import()` 가 dangling raw 로 남았다(build()
+    // 는 `__zntc_load_chunk` 로 정상 재작성). seed 가 신규 모듈(미파싱 lazy seed)을 추가하면
+    // graph_changed=true 로 표시해 rebuild 가 no-change 로 오판되지 않게 한다.
+    const before_lazy_count = self.modules.count();
+    try materializeLazySeeds(self, io);
+    if (self.modules.count() > before_lazy_count) graph_changed = true;
+
     var runtime_indices: std.ArrayList(types.ModuleIndex) = .empty;
     defer runtime_indices.deinit(self.allocator);
     const before_runtime_count = self.modules.count();

--- a/tests/integration/tests/napi-lazy-primitives.test.ts
+++ b/tests/integration/tests/napi-lazy-primitives.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
 import { join } from 'node:path';
+import { readFileSync, readdirSync } from 'node:fs';
 import { createFixture, byContent } from './helpers';
 import { init, close, build, watch } from '../../../packages/core/index';
 
@@ -136,6 +137,54 @@ describe('NAPI lazy compilation primitives (D105 PR-A)', () => {
       expect(e.lazySeeds.length).toBe(1);
       expect(e.lazySeeds[0].pathHash).toMatch(/^[0-9a-f]{8}$/);
       expect(e.lazySeeds[0].path.endsWith('heavy.ts')).toBe(true);
+    } finally {
+      handle?.stop();
+    }
+  });
+
+  // #4071 회귀: watch() 가 *디스크에 쓰는* entry 출력이 build() 와 동일하게 동적 import 를
+  // `__zntc_load_chunk` 로 재작성해야 한다(raw `import("./heavy")` 가 남으면 안 됨). 버그
+  // 원인은 `module_store` 가 주입되는 watch 경로가 `graph.buildIncremental` 을 타는데 거기서
+  // `materializeLazySeeds` 가 호출되지 않아 동적 청크가 안 생기던 것. lazySeeds 노출(위 테스트)
+  // 만으론 못 잡는다 — 실제 emit 산출물을 검증해야 함.
+  test('watch() 가 쓰는 entry 출력이 __zntc_load_chunk 로 재작성됨 (raw import 잔존 금지)', async () => {
+    const fixture = await createFixture({
+      'heavy.ts': `export const h = 'HEAVY_4071';`,
+      'entry.ts': `async function go(){ const m = await import('./heavy'); console.log(m.h); }\ngo();`,
+    });
+    cleanup = fixture.cleanup;
+    const outdir = join(fixture.dir, 'out');
+
+    let handle: ReturnType<typeof watch> | undefined;
+    const ready = new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('onReady timeout')), 8000);
+      handle = watch({
+        entryPoints: [join(fixture.dir, 'entry.ts')],
+        platform: 'browser',
+        devMode: true,
+        splitting: true,
+        lazyCompilation: true,
+        format: 'iife',
+        outdir,
+        onReady: () => {
+          clearTimeout(t);
+          resolve();
+        },
+      });
+    });
+    try {
+      await ready;
+      // onReady 이후 디스크에 emit 된 .js 들을 읽어 entry 청크를 찾는다.
+      const files = readdirSync(outdir).filter((f) => f.endsWith('.js'));
+      const contents = files.map((f) => readFileSync(join(outdir, f), 'utf8'));
+      const entry = contents.find((c) => c.includes('__zntc_load_chunk('));
+      expect(entry).toBeDefined(); // 동적 청크 로더로 재작성됨 (#4071 핵심 가드)
+      // 어떤 청크에도 raw 동적 import 가 남으면 안 된다(런타임에 존재하지 않는 ./heavy fetch).
+      for (const c of contents) {
+        expect(c).not.toMatch(/import\(["']\.\/heavy["']\)/);
+      }
+      // heavy 본문은 미파싱 seed → 어느 청크에도 인라인 안 됨.
+      expect(contents.some((c) => c.includes('HEAVY_4071'))).toBe(false);
     } finally {
       handle?.stop();
     }


### PR DESCRIPTION
## 무엇을 고쳤나

`lazyCompilation: true` + `splitting: true` 로 `watch()` / dev 서버를 돌리면, entry 의 동적 `import()` 가 `__zntc_load_chunk(...)` 로 재작성되지 않고 **raw `import("./heavy")`** 로 남았습니다. 그 결과 런타임에 존재하지 않는 청크를 fetch 하려다 깨집니다. 동일 옵션의 `build()` / `buildSync()` 는 정상이었습니다(#4071).

## 원인

`module_store` 가 주입되는 watch/dev 경로는 그래프를 만들 때 `graph.build()` 가 아니라 **`graph.buildIncremental()`** 을 탑니다(증분 캐시 재활용 목적). 그런데 `buildIncremental` 은 자체 sequential discovery 루프만 돌고, `build()` 가 호출하던 **`materializeLazySeeds`** 를 호출하지 않았습니다.

- 동적 import lazy 게이트(`resolve_imports.zig:356`)는 타겟을 즉시 파싱하지 않고 `lazy_seeds` 에 쌓고 BFS 를 멈춥니다.
- `materializeLazySeeds` 가 그 seed 를 **별도 미파싱 청크**로 그래프에 등록해야 동적 청크가 생기고, emit 단계가 `import()` → `__zntc_load_chunk()` 로 재작성합니다.
- 이 호출이 빠지니 seed 는 쌓이기만 하고 청크가 안 생겨 → 재작성 타겟이 없어 raw 가 그대로 남았습니다.

```
build():  graph.build()           → materializeLazySeeds 호출 ✅  → __zntc_load_chunk
watch():  graph.buildIncremental()→ (호출 누락) ❌               → raw import 잔존
```

## 수정

`buildIncremental` 의 discovery 루프 직후(`applyRuntimePolyfills` 전)에 `build()` 와 동일하게 `materializeLazySeeds` 를 호출합니다.

- `lazy_seeds` 가 비어있으면 즉시 return 하므로 **비-lazy watch/dev 경로는 0 영향(no-op)**.
- 새 lazy seed 모듈이 추가되면 `graph_changed = true` 로 표시해 rebuild 가 no-change 로 오판되지 않게 합니다.

## 테스트

`tests/integration/tests/napi-lazy-primitives.test.ts` 에 회귀 테스트 추가: `watch()` 가 **디스크에 쓰는** entry 출력이 `__zntc_load_chunk` 로 재작성되는지(+ raw 동적 import 잔존 금지 + `heavy` 본문 미인라인) 검증합니다. 기존 `lazySeeds` 노출 테스트만으론 실제 emit 산출물 회귀를 못 잡아 별도 디스크 검증을 둡니다.

- TDD red→green 확인: 수정 전 새 테스트는 `__zntc_load_chunk` 단언에서 fail, 수정 후 green.
- `zig build test` / `napi` / `install` / `test262` / `wasm` 빌드 OK.
- 통합 테스트 `napi-lazy-primitives`(6 pass), `hmr` · `watch-json` · `bundle-dynamic-import` · `iife-code-splitting` · `inline-dynamic-imports` · `napi-dev-server`(61 pass) 회귀 없음.
- `watch-stress` 의 RSS-궤적 fail 은 이 변경과 무관한 **사전 존재 환경 flake**(clean tree 에서도 동일 fail, 해당 테스트는 lazy 미사용).

## 알려진 한계 (범위 밖, 후속)

캐시 **HIT** 으로 도는 warm 증분 rebuild 는 importer 가 replay 경로를 타 동적 타겟을 eager 로 materialize 합니다(laziness 미보존). 이는 기존 replay 설계의 속성으로 이번 dangling-import fix 와 직교합니다 — cold 초기 빌드의 dangling-import 회귀를 막는 것이 이 PR 의 범위입니다.

## Zig 초보자 메모

- `buildIncremental` = watch 모드의 "재번들" 함수. 한 번 빌드한 모듈을 `PersistentModuleStore` 에 캐시해 다음 빌드에서 재활용합니다. 그래서 `build()`(1회성)와는 별개 코드 경로입니다.
- `materializeLazySeeds` = "아직 파싱 안 한 동적 import 타겟을 그래프에 빈 모듈로 등록"하는 단계. 이게 있어야 그 타겟이 독립 청크가 되고 동적 로더가 생성됩니다.
- 한쪽 빌드 경로에만 있고 다른 쪽에 빠져 있던 단계가 이 버그의 핵심이었습니다.

Fixes #4071

🤖 Generated with [Claude Code](https://claude.com/claude-code)