### PR TITLE
feat(cli): JS dev 서버 lazy on-demand 청크 라우트 (env ZNTC_LAZY, #4062 PR-B-2)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -1938,6 +1938,27 @@ async function runServe(opts, config, { appDev = null } = {}) {
   let serverHandle = null;
   // #3779 follow-up — restart 시 stop 호출용. opts.bundle+watch+appDev+hmr 분기 안에서만 할당.
   let nativeWatchHandle = null;
+  // #4062 PR-B-2 — JS dev 서버 lazy on-demand 라우트(env ZNTC_LAZY=1 게이트, 실험적).
+  // D105 접근1: native lazy 프리미티브(#4069/#4070, watch lazySeeds + build lazyForceParse)
+  // 위에 JS 서버가 얇게 on-demand 라우팅을 얹는다. lazy 동적 청크는 emit-skip 되므로
+  // (디스크에 없음) 브라우저가 `/<stem>-<8hex>.js` 를 요청하면 그 seed 만 force-parse 한
+  // 단발 build() 로 즉석 생성·캐시해서 서빙한다. 게이트 OFF 면 아래 상태/분기 전부 무시 → 0 영향.
+  const lazyMode = process.env.ZNTC_LAZY === '1';
+  // pathHash(8 hex) → seed 절대경로. watch onReady/onRebuild 의 event.lazySeeds 로 갱신.
+  const lazySeedMap = new Map();
+  // pathHash → { body, type }. on-demand 빌드 결과 캐시. rebuild 마다 무효화(seed 본문 변경 가능).
+  const lazyChunkCache = new Map();
+  // pathHash → in-flight build Promise. 같은 청크 동시 요청을 coalesce(중복 build 회피).
+  const lazyInflight = new Map();
+  // on-demand build() 직렬화 tail. 페이지 로드 시 여러 lazy 청크가 동시 요청돼도 native build()
+  // 를 한 번에 하나씩만 돌려 watch worker 와의 동시 재진입 위험을 없앤다(/code-review Q2).
+  let lazyBuildTail = Promise.resolve();
+  // lazy entry 청크의 디스크 경로(`<entrystem>.js`). served index.html 은 prepareDev 가 non-split
+  // 으로 `/bundle.js` 를 참조하게 rewrite 했지만, watch lazy 빌드의 entry 청크는 stem 이름이라
+  // mismatch → `/bundle.js` 를 이 파일로 alias.
+  let lazyEntryFile = null;
+  // on-demand 단발 build() 옵션 템플릿(watchBuildOpts 와 동일 lazy 설정, callback/outdir 제거).
+  let lazyOnDemandOpts = null;
   const mimeTypes = {
     '.html': 'text/html',
     '.js': 'application/javascript',
@@ -2039,6 +2060,111 @@ async function runServe(opts, config, { appDev = null } = {}) {
     return { status: 200, body, type };
   }
 
+  // #4062 PR-B-2 — lazy 상태 갱신. watch onReady/onRebuild event 의 lazySeeds 로 pathHash→seed
+  // 맵을 다시 채우고, entry 청크 파일을 식별하고, 캐시를 무효화한다(seed 본문 변경 가능).
+  // event.outputs 는 디스크 경로 목록. entry 청크 = entry stem(`<name>.js`)과 basename 이 일치하는
+  // 출력(splitting 의 entry 청크 네이밍). dev 모드는 content-hash off 라 stem 그대로.
+  function captureLazyState(event) {
+    if (!lazyMode || !event) return;
+    lazySeedMap.clear();
+    lazyChunkCache.clear();
+    if (Array.isArray(event.lazySeeds)) {
+      for (const s of event.lazySeeds) {
+        if (s && typeof s.pathHash === 'string' && typeof s.path === 'string') {
+          lazySeedMap.set(s.pathHash, s.path);
+        }
+      }
+    }
+    const entryStem = basename(opts.entryPoints[0] ?? '', extname(opts.entryPoints[0] ?? ''));
+    // event.outputs 는 outdir 기준 bare 파일명("main.js") — serveDir 로 절대화한다(이미 절대면 그대로).
+    const outputs = (Array.isArray(event.outputs) ? event.outputs : [])
+      .filter((p) => typeof p === 'string')
+      .map((p) => resolve(serveDir, p));
+    let entry = outputs.find((p) => basename(p, '.js') === entryStem) ?? null;
+    // fallback: entry stem 매칭 실패 시 `__zntc_load_chunk` 를 포함한 .js 출력(동적 import 보유 청크).
+    if (!entry) {
+      for (const p of outputs) {
+        if (!p.endsWith('.js')) continue;
+        try {
+          if (readFileSync(p, 'utf8').includes('__zntc_load_chunk(')) {
+            entry = p;
+            break;
+          }
+        } catch {
+          // 읽기 실패 — skip
+        }
+      }
+    }
+    lazyEntryFile = entry;
+  }
+
+  // #4062 PR-B-2 — lazy on-demand 라우트. 반환 null = lazy 라우트가 처리 안 함(기존 handleRequest 로).
+  //   ① `/bundle.js` (served index.html 이 참조) → lazy entry 청크 alias.
+  //   ② `/<stem>-<8hex>.js` → seed 역참조 후 그 seed 만 force-parse 한 단발 build() 로 동적 청크 생성.
+  async function tryServeLazy(reqUrl) {
+    if (!lazyMode) return null;
+    let pathname = new URL(reqUrl, 'http://localhost').pathname;
+    if (base && base !== '/' && pathname.startsWith(base)) {
+      pathname = '/' + pathname.slice(base.length);
+    }
+    // ① entry alias — served index.html 의 `/bundle.js` 를 lazy entry 청크로.
+    if ((pathname === '/bundle.js' || pathname === '/index.js') && lazyEntryFile) {
+      try {
+        return {
+          status: 200,
+          body: readFileSync(lazyEntryFile),
+          type: 'application/javascript',
+        };
+      } catch {
+        return null; // 파일 사라짐 — 정적 fallback
+      }
+    }
+    // ② on-demand 동적 청크.
+    const m = pathname.match(/-([0-9a-f]{8})\.js$/);
+    if (!m) return null;
+    const pathHash = m[1];
+    const seedPath = lazySeedMap.get(pathHash);
+    if (!seedPath) return null; // 알 수 없는 hash — 정적 자산일 수 있어 fallback
+    const cached = lazyChunkCache.get(pathHash);
+    if (cached) return cached;
+    if (!lazyOnDemandOpts) return null;
+    // 같은 청크 동시 요청은 진행 중 build 를 공유(coalesce).
+    const existing = lazyInflight.get(pathHash);
+    if (existing) return existing;
+    // tail 에 체인 → on-demand build 들을 직렬화(동시 native build()+watch worker 재진입 회피).
+    const job = lazyBuildTail.then(async () => {
+      // 큐 대기 중 cache 가 채워졌으면(다른 동일 요청이 먼저 완료) 그대로 재사용.
+      const c = lazyChunkCache.get(pathHash);
+      if (c) return c;
+      try {
+        const r = await build({ ...lazyOnDemandOpts, lazyForceParse: [seedPath] });
+        if (r.errors && r.errors.length > 0) return null;
+        // seed 모듈을 포함한 청크를 moduleIds 로 찾는다(force-parse 라 그 seed 가 어느 청크에 인라인됨).
+        const chunk = (r.outputFiles ?? []).find(
+          (f) => Array.isArray(f.moduleIds) && f.moduleIds.includes(seedPath),
+        );
+        if (!chunk) return null;
+        const result = {
+          status: 200,
+          body: chunk.contents,
+          type: 'application/javascript',
+        };
+        lazyChunkCache.set(pathHash, result);
+        return result;
+      } catch (err) {
+        console.error('[serve] lazy chunk build failed:', err);
+        return null;
+      }
+    });
+    lazyBuildTail = job.catch(() => {}); // tail 은 reject 흡수(다음 build 가 멈추지 않게).
+    lazyInflight.set(pathHash, job);
+    try {
+      return await job;
+    } finally {
+      lazyInflight.delete(pathHash);
+    }
+  }
+
   const useTls = opts.certfile && opts.keyfile;
 
   // #3796/#3798 root-cause — watch handle 을 HTTP listen 전에 띄움. cold-start runBundle 제거
@@ -2052,6 +2178,31 @@ async function runServe(opts, config, { appDev = null } = {}) {
       filterCallerPreWarmCss: true,
     });
     watchBuildOpts.devMode = true;
+    // #4062 PR-B-2 — lazy on-demand 활성화. lazy 동적 청크는 (a) code splitting 으로 분리되고
+    // (b) IIFE registry(`__zntc_require`/`__zntc_load_chunk`) 로 로드되어야 한다. dev 단일파일
+    // 기본(applySingleFileDynamicImportDefault 가 splitting 미설정 시 inlineDynamicImports=true)
+    // 을 명시적으로 끄고 splitting+iife 를 강제한다. on-demand 단발 build() 템플릿도 동일 설정으로
+    // 준비(watch callback/outdir 제거 — build() 는 outdir 없으면 in-memory outputFiles 반환).
+    if (lazyMode) {
+      watchBuildOpts.splitting = true;
+      watchBuildOpts.inlineDynamicImports = false;
+      watchBuildOpts.lazyCompilation = true;
+      watchBuildOpts.format = 'iife';
+      lazyOnDemandOpts = {
+        ...watchBuildOpts,
+        splitting: true,
+        inlineDynamicImports: false,
+        lazyCompilation: true,
+        format: 'iife',
+      };
+      delete lazyOnDemandOpts.onReady;
+      delete lazyOnDemandOpts.onRebuild;
+      // outdir/outfile 둘 다 제거 → build() 가 write skip(in-memory outputFiles)해 watch 의
+      // 디스크 출력을 매 요청마다 clobber 하지 않게 한다(/code-review: outfile 누락 footgun).
+      delete lazyOnDemandOpts.outdir;
+      delete lazyOnDemandOpts.outfile;
+      delete lazyOnDemandOpts.watch;
+    }
     // issue #3858 — appDev path 에서 watchFolders 자동 = app root. 사용자가 직접
     // .css 파일을 import 없이 만들었을 때 (graph 외) 신규 file 의 add 감지를
     // native watcher (TrackedFileSet 의 dir-watch) 가 처리하도록 root_dir 등록.
@@ -2082,6 +2233,7 @@ async function runServe(opts, config, { appDev = null } = {}) {
         } else {
           hmr.clearError();
         }
+        captureLazyState(event); // #4062 — lazySeed 맵 + entry 청크 식별 (lazyMode 아니면 no-op)
         // #3796 — event.outputs (path 목록) 를 BundleResult shape 으로 변환해 injectBundleCssLinks.
         const mockResult = {
           outputFiles: (event && event.outputs ? event.outputs : []).map((p) => ({ path: p })),
@@ -2100,6 +2252,10 @@ async function runServe(opts, config, { appDev = null } = {}) {
       // 시점 — cold-start 는 watch 1회만).
       void (async () => {
         try {
+          // #4062 PR-B-2 — rebuild 마다 lazy 청크 캐시 무효화(편집으로 seed 본문 변경 가능 →
+          // 다음 요청이 fresh build() 로 재생성). seed 맵은 유지(onRebuild 가 lazySeeds 미노출 —
+          // 신규 seed 갱신은 PR-C). entry alias 는 매 요청 readFileSync 라 자동 fresh.
+          if (lazyMode) lazyChunkCache.clear();
           // issue #3858 — native onRebuild 의 cssChanges 분기는 PR #3859 머지로
           // 도입됐으나, drain (fs.watch) 가 이미 같은 fs event 받아 rebuildAppDevCss
           // (syncDirty + afterBundle, PostCSS incremental) 로 처리. dual watch race
@@ -2154,9 +2310,10 @@ async function runServe(opts, config, { appDev = null } = {}) {
     const serveOpts = {
       port: opts.port,
       hostname: opts.host,
-      fetch(req, server) {
+      async fetch(req, server) {
         const url = new URL(req.url);
         // /__hmr WebSocket upgrade — Bun-native API 사용 (Node 분기는 server.on('upgrade')).
+        // upgrade 는 첫 await 전에 동기 실행돼 async fetch 여도 안전.
         if (hmr && url.pathname === APP_DEV_HMR_WS_PATH) {
           if (server.upgrade(req)) return undefined;
           return new Response('Upgrade required', { status: 426 });
@@ -2166,6 +2323,18 @@ async function runServe(opts, config, { appDev = null } = {}) {
           if (url.pathname.startsWith(prefix)) {
             return fetch(target + url.pathname.slice(prefix.length) + url.search);
           }
+        }
+
+        // #4062 PR-B-2 — lazy 라우트(entry alias + on-demand 동적 청크). null = 정적 처리로.
+        const lazy = await tryServeLazy(req.url);
+        if (lazy) {
+          return new Response(lazy.body, {
+            status: lazy.status,
+            headers: {
+              'Content-Type': lazy.type,
+              'Access-Control-Allow-Origin': '*',
+            },
+          });
         }
 
         const { status, body, type } = handleRequest(req.url, req.headers.get('accept') ?? '');
@@ -2220,6 +2389,17 @@ async function runServe(opts, config, { appDev = null } = {}) {
           }
           return;
         }
+      }
+
+      // #4062 PR-B-2 — lazy 라우트(entry alias + on-demand 동적 청크). null = 정적 처리로.
+      const lazy = await tryServeLazy(req.url);
+      if (lazy) {
+        res.writeHead(lazy.status, {
+          'Content-Type': lazy.type,
+          'Access-Control-Allow-Origin': '*',
+        });
+        res.end(Buffer.isBuffer(lazy.body) ? lazy.body : Buffer.from(lazy.body));
+        return;
       }
 
       const { status, body, type } = handleRequest(req.url, req.headers.accept ?? '');

--- a/tests/integration/tests/js-dev-server-lazy.test.ts
+++ b/tests/integration/tests/js-dev-server-lazy.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { createFixture, ZNTC_JS_CLI } from './helpers';
+
+// #4062 PR-B-2: JS dev 서버(`zntc dev`, app 모드)의 lazy on-demand 라우트.
+// 게이트 = env `ZNTC_LAZY=1`(실험적). native lazy 프리미티브(#4069/#4070 + #4071 watch parity)
+// 위에 JS 서버가 얇게 on-demand 라우팅을 얹는다:
+//   ① served index.html 의 `/bundle.js` → watch lazy entry 청크(`__zntc_load_chunk` 포함) alias
+//   ② `/<stem>-<8hex>.js` → 그 seed 만 force-parse 한 단발 build() 로 동적 청크 즉석 생성·서빙
+// 동적 import 타겟(heavy)은 emit-skip 되어 초기 디스크에 없고, 브라우저가 그 URL 을 요청할 때만 빌드된다.
+
+async function waitForServer(port: number, timeoutMs = 15000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(`http://localhost:${port}/`);
+      if (r.ok || r.status === 404) return;
+    } catch {
+      // 아직 listen 안 함
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`dev server did not start on port ${port}`);
+}
+
+describe('JS dev server lazy on-demand route (#4062 PR-B-2)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  let proc: ReturnType<typeof Bun.spawn> | undefined;
+
+  afterEach(async () => {
+    if (proc) {
+      proc.kill();
+      await proc.exited;
+      proc = undefined;
+    }
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test('ZNTC_LAZY=1 → entry 가 __zntc_load_chunk, heavy 는 on-demand 로만 서빙', async () => {
+    const fixture = await createFixture({
+      'index.html': `<!doctype html><html><head><meta charset="utf-8"/><title>L</title></head><body><div id="root"></div><script type="module" src="/src/main.ts"></script></body></html>`,
+      'src/main.ts': `async function go(){ const m = await import('./heavy'); document.getElementById('root')!.textContent = m.h; }\ngo();`,
+      'src/heavy.ts': `export const h = 'HEAVY_LAZY_PRB2';`,
+    });
+    cleanup = fixture.cleanup;
+
+    // 테스트 파일 간 충돌 회피용 고정-대역 포트(다른 dev-server 테스트와 분리).
+    const port = 5390 + Math.floor(Math.random() * 40);
+    proc = Bun.spawn({
+      cmd: ['bun', ZNTC_JS_CLI, 'dev', fixture.dir, '--port', String(port)],
+      env: { ...process.env, ZNTC_LAZY: '1' },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    await waitForServer(port);
+
+    // ① entry alias: served index.html 은 `/bundle.js` 를 참조 → watch lazy entry 청크여야.
+    const indexHtml = await (await fetch(`http://localhost:${port}/`)).text();
+    expect(indexHtml).toContain('src="/bundle.js"');
+
+    const entryRes = await fetch(`http://localhost:${port}/bundle.js`);
+    expect(entryRes.status).toBe(200);
+    const entry = await entryRes.text();
+    // 동적 청크 로더로 재작성됨(#4071 watch parity 핵심 가드).
+    const m = entry.match(/__zntc_load_chunk\("([^"]+)"\)/);
+    expect(m).not.toBeNull();
+    const chunkUrl = m![1]; // 예: heavy-36529dae.js
+    expect(chunkUrl).toMatch(/-[0-9a-f]{8}\.js$/);
+    // heavy 본문은 미파싱 seed → entry 에 인라인 안 됨.
+    expect(entry).not.toContain('HEAVY_LAZY_PRB2');
+    // entry 는 cross-chunk require 로 heavy 모듈을 참조.
+    const reqMatch = entry.match(/__zntc_require\("([^"]+)"\)/g) ?? [];
+    expect(reqMatch.some((r) => r.includes('heavy'))).toBe(true);
+
+    // ② on-demand 동적 청크: entry 가 참조한 그 URL 을 요청하면 즉석 빌드돼 heavy 본문을 서빙.
+    const chunkRes = await fetch(`http://localhost:${port}/${chunkUrl}`);
+    expect(chunkRes.status).toBe(200);
+    const chunk = await chunkRes.text();
+    expect(chunk).toContain('HEAVY_LAZY_PRB2'); // 본문 존재
+    expect(chunk).toContain('__zntc_register'); // IIFE registry 로 등록
+    // registry 키가 entry 의 require 키와 정합해야 런타임에 resolve 된다(cross-chunk 정합).
+    expect(chunk).toMatch(/"heavy\.js":/);
+
+    // 동시 요청 coalesce/직렬화 가드: 같은 청크 5건 동시 요청도 전부 동일 본문 200.
+    const burst = await Promise.all(
+      Array.from({ length: 5 }, () => fetch(`http://localhost:${port}/${chunkUrl}`)),
+    );
+    for (const res of burst) {
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain('HEAVY_LAZY_PRB2');
+    }
+  }, 30000);
+
+  test('ZNTC_LAZY 미설정 → 기존 단일 번들(heavy 인라인, on-demand 라우트 비활성)', async () => {
+    const fixture = await createFixture({
+      'index.html': `<!doctype html><html><head><meta charset="utf-8"/><title>E</title></head><body><div id="root"></div><script type="module" src="/src/main.ts"></script></body></html>`,
+      'src/main.ts': `async function go(){ const m = await import('./heavy'); document.getElementById('root')!.textContent = m.h; }\ngo();`,
+      'src/heavy.ts': `export const h = 'HEAVY_EAGER_BASELINE';`,
+    });
+    cleanup = fixture.cleanup;
+
+    const port = 5430 + Math.floor(Math.random() * 40);
+    proc = Bun.spawn({
+      cmd: ['bun', ZNTC_JS_CLI, 'dev', fixture.dir, '--port', String(port)],
+      // ZNTC_LAZY 미설정 — lazy 라우트/옵션 전부 no-op 이어야(단일 파일 dynamic import inline).
+      env: { ...process.env, ZNTC_LAZY: '' },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    await waitForServer(port);
+
+    const entryRes = await fetch(`http://localhost:${port}/bundle.js`);
+    expect(entryRes.status).toBe(200);
+    const entry = await entryRes.text();
+    // 기존 dev 기본: 단일 파일이라 동적 import 가 인라인됨 → heavy 본문이 entry 에 존재.
+    expect(entry).toContain('HEAVY_EAGER_BASELINE');
+    // lazy 로더 미사용.
+    expect(entry).not.toContain('__zntc_load_chunk(');
+  }, 30000);
+});


### PR DESCRIPTION
## 무엇을

웹 CLI `zntc dev`(app 모드)의 **JS dev 서버**에 lazy compilation on-demand 라우트를 추가합니다. 게이트 = env **`ZNTC_LAZY=1`**(실험적 — `--lazy` CLI 플래그는 PR-C). [D105](../blob/main/docs/DECISIONS.md) 접근1대로 native lazy 프리미티브 위에 JS 서버가 **얇게 라우팅만** 얹습니다.

선행 머지:
- #4069 (PR-A) build `lazyForceParse` / 결과 `lazySeeds`
- #4070 (PR-B-1) watch onReady `lazySeeds`
- #4072 (#4071) watch lazy emit 이 `__zntc_load_chunk` 로 재작성(build parity) — **이 PR 의 직접 전제**

## 동작

watch 빌드를 lazy 로 강제(`splitting=true`, `inlineDynamicImports=false`, `lazyCompilation=true`, `format='iife'`)하고, 두 라우트를 얹습니다:

1. **entry alias** — `prepareDev` 가 served index.html 을 non-split `/bundle.js` 참조로 rewrite 하지만, watch lazy entry 청크는 stem 이름(`<entry>.js`)이라 mismatch → `/bundle.js`(또는 `/index.js`)를 watch lazy entry 청크로 alias. 그 청크가 `__zntc_load_chunk("<stem>-<8hex>.js")` 를 담습니다.
2. **on-demand 청크** — 동적 import 타겟(seed)은 emit-skip 되어 디스크에 없습니다. 브라우저가 `/<stem>-<8hex>.js` 를 요청하면 8hex 로 `lazySeed` 역참조 → 그 seed 만 `lazyForceParse` 한 단발 `build()` 로 청크를 즉석 생성, `moduleIds` 로 seed 포함 청크를 골라 서빙·캐시.

```
browser → /bundle.js        → watch lazy entry 청크(__zntc_load_chunk + __zntc_require("heavy.js"))
browser → /heavy-36529dae.js → 캐시 miss → build({lazyForceParse:[heavy]}) → __zntc_register({"heavy.js":…})
                              → entry 의 __zntc_require("heavy.js") 가 resolve (cross-chunk 키 정합)
```

rebuild 마다 청크 캐시 무효화(편집으로 seed 본문 변경 가능). entry alias 는 매 요청 `readFileSync` 라 자동 fresh.

## 견고성 (`/code-review max` 반영)

- **on-demand build() 직렬화 + coalesce**: tail-chain 으로 직렬화 + 같은 hash 동시요청 공유 → 동시 native `build()`+watch worker 재진입 위험 제거 + 중복 build 회피.
- **`outdir`/`outfile` 제거**: `lazyOnDemandOpts` 에서 둘 다 delete → `build()` 가 write skip(in-memory outputFiles)해 watch 디스크 출력을 매 요청마다 clobber 하지 않음.

## 게이트 OFF = 0 영향

`ZNTC_LAZY` 미설정이면 lazy 상태/분기/옵션 전부 no-op → 기존 dev 서버(단일 번들, 동적 import 인라인) 불변. (유일한 비-게이트 변경 = Bun `fetch` 를 `async` 로 — WS upgrade 는 첫 await 전 동기 실행이라 안전.)

## 테스트

신규 `tests/integration/tests/js-dev-server-lazy.test.ts`:
- **게이트 ON**: `/bundle.js` 가 `__zntc_load_chunk` 포함 + heavy 미인라인 + `__zntc_require("heavy")`; on-demand 청크가 heavy 본문 + `__zntc_register` + registry 키 `"heavy.js"` 정합; 같은 청크 5건 동시요청 전부 200 동일 본문(coalesce 가드).
- **게이트 OFF**: heavy 인라인 + `__zntc_load_chunk` 없음(기존 단일 번들 불변).

회귀: `devserver`(7) · `napi-dev-server`(19) · `hmr`(4) pass. type-check OK.

## 알려진 한계 (후속 PR-C)

- onRebuild 가 lazySeeds 미노출 → rebuild 중 **새로 추가된** 동적 import 청크는 full-reload 전까지 404.
- 진행 중 build 가 onRebuild 캐시 무효화와 겹치면 stale 바이트 캐시 가능(작은 window, native epoch 가드 미이식).

## Zig 초보자 메모

이 변경은 전부 JS(`packages/core/bin/zntc.mjs`)입니다. 웹 CLI 의 dev 서버는 Zig DevServer 가 아니라 이 JS 서버를 씁니다(Zig DevServer 는 RN/embed 전용). lazy 의 무거운 로직(파싱 지연·청크 분리·재작성)은 전부 native 에 있고, JS 는 "어떤 URL 이 오면 어떤 seed 를 빌드해 돌려준다"는 라우팅만 담당합니다.

Refs #4062

🤖 Generated with [Claude Code](https://claude.com/claude-code)