### PR TITLE
feat(napi): watch() onRebuild 이벤트에 lazySeeds 노출 (#4062 PR-C-1)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -2065,10 +2065,19 @@ async function runServe(opts, config, { appDev = null } = {}) {
   // event.outputs 는 디스크 경로 목록. entry 청크 = entry stem(`<name>.js`)과 basename 이 일치하는
   // 출력(splitting 의 entry 청크 네이밍). dev 모드는 content-hash off 라 stem 그대로.
   function captureLazyState(event) {
-    if (!lazyMode || !event) return;
-    lazySeedMap.clear();
+    // 실패한 rebuild(event.success===false)는 무시 — 직전 성공 빌드의 seed/cache 를 유지한다
+    // (clear 하면 다음 요청이 또 실패할 빌드를 돌려 last-good 청크를 잃는다). onReady event 는
+    // success 필드가 없어(undefined) 통과한다.
+    if (!lazyMode || !event || event.success === false) return;
+    // 캐시는 매 성공 rebuild 마다 무효화(편집으로 seed 본문 변경 가능).
     lazyChunkCache.clear();
+    // seed 맵은 event.lazySeeds 가 *실제로 올 때만* 교체한다. 일반 편집(동적 import 를 가진
+    // 모듈이 cache-hit)은 native 가 graph.lazy_seeds 를 다시 안 쌓아 lazySeeds 가 undefined 로
+    // 온다 — 무조건 clear 하면 직전 유효 맵을 날려(PR-B-2 보다 나쁨) on-demand 라우트가 죽는다.
+    // 새 seed 집합(동적 import 추가/제거 = importer 재파싱)일 때만 clear+repopulate.
+    // (lazyEntryFile 의 `if (entry)` 보존과 같은 원리.)
     if (Array.isArray(event.lazySeeds)) {
+      lazySeedMap.clear();
       for (const s of event.lazySeeds) {
         if (s && typeof s.pathHash === 'string' && typeof s.path === 'string') {
           lazySeedMap.set(s.pathHash, s.path);
@@ -2095,7 +2104,10 @@ async function runServe(opts, config, { appDev = null } = {}) {
         }
       }
     }
-    lazyEntryFile = entry;
+    // dev rebuild 는 skip_bundle_output 라 event.outputs 가 비어있을 수 있다(#3796). entry 를
+    // 못 찾았으면 직전 값을 유지(entry 청크 파일명은 stem 고정이라 안정 — 매 요청 readFileSync 라
+    // 내용은 자동 fresh). 찾았을 때만 갱신.
+    if (entry) lazyEntryFile = entry;
   }
 
   // #4062 PR-B-2 — lazy on-demand 라우트. 반환 null = lazy 라우트가 처리 안 함(기존 handleRequest 로).
@@ -2252,10 +2264,11 @@ async function runServe(opts, config, { appDev = null } = {}) {
       // 시점 — cold-start 는 watch 1회만).
       void (async () => {
         try {
-          // #4062 PR-B-2 — rebuild 마다 lazy 청크 캐시 무효화(편집으로 seed 본문 변경 가능 →
-          // 다음 요청이 fresh build() 로 재생성). seed 맵은 유지(onRebuild 가 lazySeeds 미노출 —
-          // 신규 seed 갱신은 PR-C). entry alias 는 매 요청 readFileSync 라 자동 fresh.
-          if (lazyMode) lazyChunkCache.clear();
+          // #4062 PR-C-1 — rebuild 마다 lazy 상태 갱신: seed 맵을 event.lazySeeds 로 다시 채우고
+          // (신규 동적 import 추가/제거 반영) 청크 캐시를 무효화한다. captureLazyState 가 실패한
+          // rebuild 는 skip, outputs 가 비면(skip_bundle_output) entry 는 유지한다. (PR-B-2 는
+          // onRebuild 가 lazySeeds 미노출이라 cache.clear 만 했음 — PR-C-1 에서 native 가 노출.)
+          captureLazyState(event);
           // issue #3858 — native onRebuild 의 cssChanges 분기는 PR #3859 머지로
           // 도입됐으나, drain (fs.watch) 가 이미 같은 fs event 받아 rebuildAppDevCss
           // (syncDirty + afterBundle, PostCSS incremental) 로 처리. dual watch race

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1504,6 +1504,14 @@ export interface WatchRebuildEvent {
   /** Number of modules reparsed in the incremental graph. Counts cache-missed
    * modules only. Not exposed for full builds. */
   reparsedModules?: number;
+  /**
+   * D105 PR-C-1: lazy 빌드의 미파싱 seed 목록 `{ pathHash, path }`
+   * ({@link WatchReadyEvent.lazySeeds} 와 동일 shape/공식). `lazyCompilation` 이 켜진
+   * watch 세션에서 매 rebuild 마다 노출 → dev 서버가 rebuild 중 새로 추가/제거된 동적
+   * import seed 집합을 갱신할 수 있다 (onReady 한정이던 PR-B-1 의 rebuild 확장).
+   * lazy 빌드가 아니거나 동적 import 가 없으면 생략(`undefined`).
+   */
+  lazySeeds?: Array<{ pathHash: string; path: string }>;
 }
 
 export interface WatchHandle {

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -348,6 +348,11 @@ const WatchRebuildEvent = struct {
     /// (`error_msg`) 와 달리 file path + message 둘 다 보존. caller (broadcastRebuildEvent)
     /// 가 우선 사용, 없으면 error_msg fallback.
     errors: ?[]const ErrorEntry = null,
+    /// D105 PR-C-1: rebuild 의 lazy seed 절대경로 목록(`rebuild_result.lazy_seed_paths` 사본).
+    /// onRebuild 이벤트가 `lazySeeds: [{pathHash, path}]` 로 노출 → dev 서버가 rebuild 중 새로
+    /// 추가/제거된 동적 import seed 집합을 갱신(onReady 한정이던 PR-B-1 의 확장). onReady 와
+    /// 동일 빌더(common.buildLazySeedsJs)라 pathHash 공식 단일 소스.
+    lazy_seeds: ?[]const []const u8 = null,
 
     const ModuleUpdate = struct {
         id: []const u8,
@@ -382,6 +387,10 @@ const WatchRebuildEvent = struct {
                 native_alloc.free(e.message);
             }
             native_alloc.free(errs);
+        }
+        if (self.lazy_seeds) |paths| {
+            for (paths) |p| native_alloc.free(p);
+            native_alloc.free(paths);
         }
         native_alloc.destroy(self);
     }
@@ -579,6 +588,14 @@ fn watchRebuildTsfn(env: c.napi_env, js_func: c.napi_value, _: ?*anyopaque, data
             var js_n: c.napi_value = undefined;
             _ = c.napi_create_int64(env, @intCast(n), &js_n);
             _ = c.napi_set_named_property(env, js_event, "reparsedModules", js_n);
+        }
+
+        // D105 PR-C-1: lazySeeds: Array<{pathHash, path}> — lazy 빌드일 때만. onReady(PR-B-1)
+        // 와 동일 빌더(common.buildLazySeedsJs)라 pathHash 공식 단일 소스. dev 서버가 rebuild 마다
+        // seed 집합을 갱신(신규 동적 import 추가/제거 반영).
+        if (event.lazy_seeds) |paths| {
+            const js_seeds = common.buildLazySeedsJs(env, paths);
+            _ = c.napi_set_named_property(env, js_event, "lazySeeds", js_seeds);
         }
     } else {
         // error: string (catch 분기 — bundle() 자체가 throw 한 케이스)
@@ -1305,6 +1322,27 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
                     event.changed = ch_arr[0..valid];
                 } else {
                     allocator.free(ch_arr);
+                }
+            }
+        }
+
+        // D105 PR-C-1: lazy seed 경로 사본 (onReady 의 lazy_seeds_copy 와 동일 패턴 —
+        // partial alloc 실패 시 정리). onRebuild 가 lazySeeds 를 노출해 dev 서버가 rebuild 마다
+        // 신규/제거된 동적 import seed 집합을 갱신할 수 있게 한다.
+        if (rebuild_result.lazy_seed_paths) |lsp| {
+            const arr = allocator.alloc([]const u8, lsp.len) catch null;
+            if (arr) |paths| {
+                var fill: usize = 0;
+                for (lsp) |p| {
+                    const dup = allocator.dupe(u8, p) catch break;
+                    paths[fill] = dup;
+                    fill += 1;
+                }
+                if (fill == lsp.len) {
+                    event.lazy_seeds = paths;
+                } else {
+                    for (paths[0..fill]) |p| allocator.free(p);
+                    allocator.free(paths);
                 }
             }
         }

--- a/tests/integration/tests/js-dev-server-lazy.test.ts
+++ b/tests/integration/tests/js-dev-server-lazy.test.ts
@@ -1,4 +1,6 @@
 import { describe, test, expect, afterEach } from 'bun:test';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { createFixture, ZNTC_JS_CLI } from './helpers';
 
 // #4062 PR-B-2: JS dev 서버(`zntc dev`, app 모드)의 lazy on-demand 라우트.
@@ -118,5 +120,55 @@ describe('JS dev server lazy on-demand route (#4062 PR-B-2)', () => {
     expect(entry).toContain('HEAVY_EAGER_BASELINE');
     // lazy 로더 미사용.
     expect(entry).not.toContain('__zntc_load_chunk(');
+  }, 30000);
+
+  // PR-C-1: rebuild 후에도 lazy on-demand 라우트가 살아있고(seed 맵 갱신) 청크 캐시가 무효화돼
+  // 편집된 seed 본문이 반영돼야 한다. onRebuild 가 captureLazyState(event) 로 seed 맵을
+  // event.lazySeeds 로 다시 채우고 캐시를 비운다.
+  test('ZNTC_LAZY=1 → 파일 편집 rebuild 후 on-demand 청크가 새 본문 반영(캐시 무효화)', async () => {
+    const fixture = await createFixture({
+      'index.html': `<!doctype html><html><head><meta charset="utf-8"/><title>R</title></head><body><div id="root"></div><script type="module" src="/src/main.ts"></script></body></html>`,
+      'src/main.ts': `async function go(){ const m = await import('./heavy'); document.getElementById('root')!.textContent = m.h; }\ngo();`,
+      'src/heavy.ts': `export const h = 'HEAVY_V1';`,
+    });
+    cleanup = fixture.cleanup;
+
+    const port = 5470 + Math.floor(Math.random() * 40);
+    proc = Bun.spawn({
+      cmd: ['bun', ZNTC_JS_CLI, 'dev', fixture.dir, '--port', String(port)],
+      env: { ...process.env, ZNTC_LAZY: '1' },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    await waitForServer(port);
+
+    // heavy 본문이 보이는지(entry 인라인 또는 동적 청크) — entry 를 재조회해 *현재* 청크 URL 로
+    // 확인한다. 편집된 seed 는 hash 가 바뀔 수 있으므로(content-hash 승격) URL 을 고정하지 않는다.
+    async function heavyBodyVisible(marker: string): Promise<boolean> {
+      const e = await (await fetch(`http://localhost:${port}/bundle.js`)).text();
+      if (e.includes(marker)) return true; // entry 에 인라인/승격
+      const mm = e.match(/__zntc_load_chunk\("([^"]+)"\)/);
+      if (!mm) return false;
+      const c = await (await fetch(`http://localhost:${port}/${mm[1]}`)).text();
+      return c.includes(marker);
+    }
+
+    expect(await heavyBodyVisible('HEAVY_V1')).toBe(true); // 초기 = V1
+
+    // heavy 본문 편집 → rebuild. onRebuild 가 lazySeeds 로 seed 맵 갱신 + 청크 캐시 무효화.
+    writeFileSync(join(fixture.dir, 'src/heavy.ts'), `export const h = 'HEAVY_V2';`);
+
+    // rebuild 후 새 본문이 (현재 entry 가 가리키는 경로로) 보일 때까지 폴링(최대 ~8s).
+    let ok = false;
+    const deadline = Date.now() + 8000;
+    while (Date.now() < deadline) {
+      if (await heavyBodyVisible('HEAVY_V2')) {
+        ok = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    expect(ok).toBe(true); // 캐시 무효화 + seed 맵 갱신 → 편집된 본문이 on-demand 로 반영
+    expect(await heavyBodyVisible('HEAVY_V1')).toBe(false); // 옛 본문은 사라짐
   }, 30000);
 });

--- a/tests/integration/tests/napi-lazy-primitives.test.ts
+++ b/tests/integration/tests/napi-lazy-primitives.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
 import { join } from 'node:path';
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { createFixture, byContent } from './helpers';
 import { init, close, build, watch } from '../../../packages/core/index';
 
@@ -185,6 +185,76 @@ describe('NAPI lazy compilation primitives (D105 PR-A)', () => {
       }
       // heavy 본문은 미파싱 seed → 어느 청크에도 인라인 안 됨.
       expect(contents.some((c) => c.includes('HEAVY_4071'))).toBe(false);
+    } finally {
+      handle?.stop();
+    }
+  });
+
+  // PR-C-1: watch() 의 onRebuild 이벤트도 lazySeeds 를 노출(onReady 한정이던 PR-B-1 확장).
+  // dev 서버가 rebuild 중 *새로 추가된* 동적 import 의 seed 집합을 갱신할 수 있는 토대 —
+  // 없으면 mid-session 에 추가된 lazy 청크가 full-reload 전까지 404.
+  test('watch() onRebuild 가 lazySeeds 노출 + 신규 동적 import 가 seed 로 추가됨', async () => {
+    const fixture = await createFixture({
+      'heavy.ts': `export const h = 'HEAVY_PRC1';`,
+      'extra.ts': `export const x = 'EXTRA_PRC1';`,
+      'entry.ts': `async function go(){ const m = await import('./heavy'); console.log(m.h); }\ngo();`,
+    });
+    cleanup = fixture.cleanup;
+    const entryPath = join(fixture.dir, 'entry.ts');
+
+    let rebuildResolve: ((e: any) => void) | undefined;
+    let rebuildEvent: Promise<any> = new Promise((r) => {
+      rebuildResolve = r;
+    });
+    let handle: ReturnType<typeof watch> | undefined;
+
+    const ready = new Promise<any>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('onReady timeout')), 8000);
+      handle = watch({
+        entryPoints: [entryPath],
+        platform: 'browser',
+        devMode: true,
+        splitting: true,
+        lazyCompilation: true,
+        format: 'iife',
+        outdir: join(fixture.dir, 'out'),
+        onReady: (e: any) => {
+          clearTimeout(t);
+          resolve(e);
+        },
+        onRebuild: (e: any) => {
+          rebuildResolve?.(e);
+        },
+      });
+    });
+    try {
+      const readyEvent = await ready;
+      // 초기엔 seed 1개(heavy).
+      expect(readyEvent.lazySeeds?.length).toBe(1);
+
+      // entry 에 두 번째 동적 import 추가 → rebuild 트리거.
+      writeFileSync(
+        entryPath,
+        `async function go(){ const m = await import('./heavy'); console.log(m.h); }\n` +
+          `async function go2(){ const e = await import('./extra'); console.log(e.x); }\n` +
+          `go(); go2();`,
+      );
+
+      const rebuild = await Promise.race([
+        rebuildEvent,
+        new Promise((_r, rej) => setTimeout(() => rej(new Error('onRebuild timeout')), 8000)),
+      ]);
+      expect(rebuild.success).toBe(true);
+      // onRebuild 가 lazySeeds 를 노출해야 함(PR-C-1 핵심).
+      expect(Array.isArray(rebuild.lazySeeds)).toBe(true);
+      // 이제 동적 import 가 2개 → seed 2개(heavy, extra). 신규 seed 가 갱신돼야.
+      expect(rebuild.lazySeeds.length).toBe(2);
+      const paths = rebuild.lazySeeds.map((s: any) => s.path);
+      expect(paths.some((p: string) => p.endsWith('heavy.ts'))).toBe(true);
+      expect(paths.some((p: string) => p.endsWith('extra.ts'))).toBe(true);
+      for (const s of rebuild.lazySeeds) {
+        expect(s.pathHash).toMatch(/^[0-9a-f]{8}$/);
+      }
     } finally {
       handle?.stop();
     }


### PR DESCRIPTION
## 무엇을

PR-B-1(#4070)이 **onReady 한정**으로 노출하던 `lazySeeds`를 **onRebuild에도** 노출합니다. dev 서버가 rebuild 중 새로 추가/제거된 동적 import seed 집합을 갱신할 수 있는 토대 — 없으면 mid-session에 추가된 lazy 라우트가 full-reload 전까지 동작하지 않습니다.

## 변경

**native (`watch.zig`)** — `WatchReadyEvent.lazy_seeds`와 완전 대칭:
- `WatchRebuildEvent.lazy_seeds` 필드 + deinit
- watchWorkerThread rebuild 루프가 `rebuild_result.lazy_seed_paths` 사본화 (onReady의 `lazy_seeds_copy`와 동일 partial-alloc 정리 패턴)
- `watchRebuildTsfn`이 success 분기에서 `lazySeeds: [{pathHash, path}]` 노출 (`common.buildLazySeedsJs` 공용 — pathHash 공식 단일 소스)

**JS (`index.ts` / `zntc.mjs`)**:
- `WatchRebuildEvent`에 `lazySeeds?` 타입 추가
- runServe onRebuild가 `lazyChunkCache.clear()` 대신 `captureLazyState(event)` 호출 — seed 맵 갱신 + 캐시 무효화

## 견고성 (`/code-review max` 반영)

리뷰가 잡은 **실제 회귀를 수정**했습니다:
- **seed 맵은 `event.lazySeeds`가 실제로 올 때만 교체**. 일반 편집(동적 import 보유 모듈이 cache-hit)은 native가 `lazySeeds`를 `undefined`로 보내는데, 무조건 `clear`하면 직전 유효 맵을 날려 on-demand 라우트가 죽습니다(PR-B-2보다 나쁨). `lazyEntryFile`의 `if (entry)` 보존과 같은 원리로 맵도 보존.
- 실패한 rebuild(`success===false`)는 skip(last-good 유지). outputs가 비면(skip_bundle_output) entry도 직전 값 유지.
- Zig 메모리 안전성: 이벤트당 `deinit` 정확히 1회(모든 경로 트레이스 확인), `allocator`==`native_alloc` 일관, 빈 슬라이스 안전.

## 테스트

- `napi-lazy-primitives`: onRebuild가 `lazySeeds` 노출 + 신규 동적 import 추가 시 seed 2개로 갱신 (TDD red→green — native 없이는 `lazySeeds` undefined로 fail).
- `js-dev-server-lazy`: seed 본문 편집 rebuild 후 새 본문 반영(캐시 무효화), entry 재조회로 hash 변동에 robust.
- 회귀: hmr(4)·watch-json(6)·napi-dev-server(19) pass. type-check OK.

## 알려진 한계 (후속)

- **#4074**: watch rebuild가 *미요청* lazy seed 청크를 디스크에 emit → rebuild 후 laziness 손실(buildIncremental emit 축, PR-C-1과 직교). 이 리뷰에서 발견해 별도 이슈로 분리.
- 진행 중 on-demand build가 onRebuild 캐시무효화와 겹치면 stale 바이트 캐시 가능(작은 window, native epoch 가드 미이식 → PR-C-2 예정).

## Zig 초보자 메모

TSFN(thread-safe function)은 watch worker 스레드가 메인(JS) 스레드로 이벤트를 넘기는 통로입니다. native에서 만든 `lazy_seeds` 슬라이스는 worker가 alloc하고, 메인 스레드의 `watchRebuildTsfn`이 JS 객체로 변환한 뒤 `deinit`이 한 번만 free합니다.

Refs #4062

🤖 Generated with [Claude Code](https://claude.com/claude-code)