### PR TITLE
fix(bundler): cache-hit rebuild replay 경로가 lazy seed 를 eager parse·emit 하던 버그 (#4074)

### DIFF
--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -61,6 +61,12 @@ pub fn reset(self: *ModuleGraph) void {
     while (req_it.next()) |req| req.deinit(self.allocator);
     self.requested_exports.clearRetainingCapacity();
 
+    // #4074 방어: lazy_seeds 도 per-build 상태다. 현재는 매 rebuild 가 fresh graph 라
+    // 무관하지만, graph persistence(RFC #3933)로 reset() 재사용이 도입되면 비우지 않을 시
+    // 이전 빌드 seed 가 누적돼 materializeLazySeeds 가 fresh module set 에 stale seed 를
+    // 처리한다. path/resolve_dir 은 path_arena 소유라 clearRetainingCapacity 로 충분(개별 free 불요).
+    self.lazy_seeds.clearRetainingCapacity();
+
     self.source_read_cache.deinit(self.allocator);
     self.source_read_cache = .{};
 

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -45,6 +45,30 @@ pub fn replayCachedResolvedDeps(self: *ModuleGraph, io: std.Io, mod_idx: usize) 
     for (mod_ptr.resolved_deps.items) |dep| {
         switch (dep.target) {
             .file, .virtual => {
+                // #4074: cache-hit rebuild 의 replay 경로에도 miss 경로(resolveModuleImports:356)
+                // 와 동일한 lazy 게이트를 적용한다. 없으면 동적 import 타겟을 여기서 addModule
+                // (=.reserved 모듈 추가) → discovery 루프가 파싱 → emit 해 *rebuild 마다* 미요청
+                // lazy seed 가 디스크에 떨어진다(첫 빌드는 emit-skip, 첫 rebuild 부터 laziness 손실).
+                // 게이트가 통과하면 addModule/link 대신 lazy_seeds 에 쌓고 continue → 루프 종료 후
+                // materializeLazySeeds 가 미파싱 seed(state=.ready, ast=null, is_lazy_seed)로 처리.
+                // miss 경로와 달리 dep 는 이미 resolved_deps 에 있어 appendResolvedDep 재등록 안 함.
+                // .file 만(virtual/external 동적 타겟은 miss 경로도 eager — PR-3b 범위).
+                if (dep.target == .file and dep.kind == .dynamic_import and
+                    self.lazy_compilation and self.code_splitting and self.dev_mode)
+                {
+                    if (dep.record_index) |rec_idx| {
+                        if (!pathInForceParse(self, dep.path.bytes())) {
+                            const pa = self.path_arena.allocator();
+                            try self.lazy_seeds.append(self.allocator, .{
+                                .from = mod_index,
+                                .rec_i = @intCast(rec_idx),
+                                .path = try pa.dupe(u8, dep.path.bytes()),
+                                .resolve_dir = if (dep.resolve_dir) |rd| try pa.dupe(u8, rd.bytes()) else null,
+                            });
+                            continue;
+                        }
+                    }
+                }
                 var s_am = profile.begin(.graph_discover_incr_replay_add_module);
                 const dep_idx = try self.addModuleWithResolveDir(io, dep.path.bytes(), if (dep.resolve_dir) |rd| rd.bytes() else null);
                 s_am.end();

--- a/tests/integration/tests/napi-lazy-primitives.test.ts
+++ b/tests/integration/tests/napi-lazy-primitives.test.ts
@@ -259,4 +259,70 @@ describe('NAPI lazy compilation primitives (D105 PR-A)', () => {
       handle?.stop();
     }
   });
+
+  // #4074: rebuild 후에도 lazy seed 는 미파싱·emit-skip 으로 유지돼야 한다. cache-hit rebuild 의
+  // replay 경로(resolve_imports.replayCachedResolvedDeps)가 동적 import 타겟을 일반 모듈로
+  // addModule→파싱→emit 하던 버그 — replay 에도 miss 경로의 lazy 게이트를 적용해 수정. 없으면
+  // 무관한 파일 한 번만 편집해도 미요청 lazy 청크가 디스크에 떨어져 laziness 가 사라진다.
+  test('#4074: 무관한 파일 편집 rebuild 후에도 lazy seed 청크가 emit-skip 유지', async () => {
+    const fixture = await createFixture({
+      'heavy.ts': `export const h = 'HEAVY_4074';`,
+      'sidecar.ts': `export const s = 'SIDE_A';`,
+      'entry.ts':
+        `import { s } from './sidecar';\n` +
+        `async function go(){ const m = await import('./heavy'); console.log(m.h, s); }\ngo();`,
+    });
+    cleanup = fixture.cleanup;
+    const outdir = join(fixture.dir, 'out');
+    const heavyChunkOnDisk = () =>
+      readdirSync(outdir).some((f) => /heavy-[0-9a-f]{8}\.js$/.test(f));
+
+    let rebuildResolve: ((e: any) => void) | undefined;
+    const rebuilt: Promise<any> = new Promise((r) => {
+      rebuildResolve = r;
+    });
+    let handle: ReturnType<typeof watch> | undefined;
+    const ready = new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('onReady timeout')), 8000);
+      handle = watch({
+        entryPoints: [join(fixture.dir, 'entry.ts')],
+        platform: 'browser',
+        devMode: true,
+        splitting: true,
+        lazyCompilation: true,
+        format: 'iife',
+        outdir,
+        onReady: () => {
+          clearTimeout(t);
+          resolve();
+        },
+        onRebuild: (e: any) => rebuildResolve?.(e),
+      });
+    });
+    try {
+      await ready;
+      // 초기: heavy seed 는 emit-skip(디스크에 없음).
+      expect(heavyChunkOnDisk()).toBe(false);
+
+      // 동적 import 와 무관한 sidecar.ts 편집 → cache-hit rebuild(entry 는 replay 경로).
+      writeFileSync(join(fixture.dir, 'sidecar.ts'), `export const s = 'SIDE_B';`);
+      await Promise.race([
+        rebuilt,
+        new Promise((_r, rej) => setTimeout(() => rej(new Error('onRebuild timeout')), 8000)),
+      ]);
+      // rebuild flush 여유.
+      await new Promise((r) => setTimeout(r, 300));
+
+      // rebuild 가 실제로 돌고 *emit 했음* 을 명시 증명 — entry 청크에 sidecar 새 본문(SIDE_B)이
+      // 반영돼야 한다. (이게 없으면 "rebuild 가 아예 안 돌아 heavy 가 없을 뿐" 의 거짓통과 가능.)
+      const entryChunk = readdirSync(outdir).find((f) => /^entry.*\.js$/.test(f));
+      expect(entryChunk).toBeDefined();
+      expect(readFileSync(join(outdir, entryChunk!), 'utf8')).toContain('SIDE_B');
+
+      // 핵심 가드: rebuild 후에도 heavy seed 는 여전히 emit-skip(디스크에 없어야 함).
+      expect(heavyChunkOnDisk()).toBe(false);
+    } finally {
+      handle?.stop();
+    }
+  });
 });


### PR DESCRIPTION
## 무엇을 고쳤나

`lazyCompilation` watch/dev 세션에서 **첫 rebuild부터** lazy compilation의 핵심 이득(미사용 동적 import 미파싱·미emit)이 사라지던 버그입니다. 초기 빌드는 lazy seed를 emit-skip하지만, **무관한 파일 한 번만 편집해도** *요청한 적 없는* lazy 청크가 디스크(outdir)에 떨어졌습니다.

```
.zntc-dev rebuild 전:  [main.js]                    ← heavy emit-skip (lazy 정상)
무관한 sidecar.ts 편집 →
.zntc-dev rebuild 후:  [main.js, heavy-XXXX.js]     ← 요청 없는 heavy가 디스크에 emit
```

## 근본 원인

`graph.buildIncremental`의 cache-hit rebuild는 동적 import를 가진 모듈을 `replayCachedResolvedDeps`(**replay 경로**)로 처리하는데, 그 `.file` 분기가 동적 import 타겟을 `addModuleWithResolveDir`로 일반 `.reserved` 모듈로 추가 → discovery 루프가 파싱 → 일반 청크로 emit했습니다.

cache-**miss** 경로(`resolveModuleImports`)에는 동적 import를 `lazy_seeds`로 defer하는 게이트가 있지만, **replay 경로에는 그 게이트가 없었습니다**. (#4071로 `materializeLazySeeds`를 buildIncremental에 추가했어도, replay가 seed를 먼저 parse 모듈로 만들어버려 무의미했습니다.)

```
miss  (resolveModuleImports): 동적 import → lazy_seeds defer ✅
replay(replayCachedResolvedDeps): 동적 import → addModule → parse → emit ❌  ← 버그
```

## 수정

replay 경로의 `.file` 분기에도 miss 경로와 **동일한 lazy 게이트**를 추가했습니다. `dep.kind==.dynamic_import and lazy_compilation and code_splitting and dev_mode` (+ `record_index` 존재 + `!force_parse`)면 addModule/link 대신 `lazy_seeds`에 쌓고 `continue` → 루프 종료 후 `materializeLazySeeds`가 미파싱 seed(`state=.ready, ast=null, is_lazy_seed`)로 처리합니다. miss 경로와 달리 dep는 이미 `resolved_deps`에 있어 `appendResolvedDep` 재등록은 안 합니다.

**4-way AND**라 non-lazy/production 증분 빌드는 게이트 미진입 → **0 영향**.

**부수효과(정상)**: 편집된 seed도 더 이상 content-hash 청크로 승격 안 됨 → 동적 청크 URL(path-hash)이 rebuild 간 안정. PR-B-2/C-1의 on-demand 라우트가 첫 페이지 로드뿐 아니라 **세션 내내 실효**(이전엔 첫 rebuild 후 디스크 정적서빙으로 대체돼 lazy가 무의미했음).

**방어(`lifecycle.zig`)**: `ModuleGraph.reset()`에 `lazy_seeds.clearRetainingCapacity()` 추가 — 현재는 매 rebuild fresh graph라 무관하나 graph persistence(RFC #3933)로 reset() 재사용 시 stale seed 누적 방지(다른 per-build 리스트와 동일 패턴).

## 테스트

`napi-lazy-primitives`에 #4074 회귀 추가 — watch(lazy)에서 무관한 파일(sidecar.ts) 편집 rebuild 후에도 `heavy-<hash>.js`가 outdir에 없어야 함. **rebuild가 실제로 돌고 emit했음은 entry 청크의 sidecar 새 본문(SIDE_B)으로 명시 증명**(거짓통과 차단). TDD red→green(replay 게이트 없이는 heavy가 디스크에 떨어져 fail — `/code-review max` 검증자가 revert로 재확인).

`/code-review max`(2 finder + 6 verify): **모든 시나리오에서 정확** 판정. 최고위험 항목(rebuild 간 stale ModuleIndex)은 정의적 트레이스로 REFUTED(동적 import record는 그 window에서 안 읽힘 + graph fresh-per-build). dual-reach(정적+동적 동시)·seed 편집·force-parse 상호작용 모두 정상 확인.

빌드/회귀: `zig build test`(unit)·install·test262·wasm·napi 전부 OK. hmr(4)·watch-json(6)·bundle-dynamic-import(10)·iife-code-splitting(17)·inline-dynamic-imports(5)·js-dev-server-lazy(3)·napi-lazy-primitives(8) pass.

## Zig 초보자 메모

번들러는 watch 모드에서 안 바뀐 모듈을 캐시로 재사용합니다(cache-hit). 그때 그 모듈의 의존성을 "다시 해석"하지 않고 캐시된 결과를 "재생(replay)"하는데, 이 replay가 동적 import를 일반 import처럼 취급해 미사용 코드까지 파싱·출력하던 게 문제였습니다. miss(처음 보는 모듈) 경로엔 있던 "동적 import는 지연" 규칙을 replay 경로에도 똑같이 넣어준 수정입니다.

Closes #4074

🤖 Generated with [Claude Code](https://claude.com/claude-code)