### PR TITLE
perf(cli): lazy on-demand 캐시 정밀(per-seed) 무효화 — 무관한 편집 시 cold 재빌드 회피 (#4062 후속)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -2075,9 +2075,29 @@ async function runServe(opts, config, { appDev = null } = {}) {
     // (clear 하면 다음 요청이 또 실패할 빌드를 돌려 last-good 청크를 잃는다). onReady event 는
     // success 필드가 없어(undefined) 통과한다.
     if (!lazyMode || !event || event.success === false) return;
-    // 캐시는 매 성공 rebuild 마다 무효화(편집으로 seed 본문 변경 가능) + epoch 증가
-    // (진행 중 on-demand build 가 이 무효화를 넘겨 stale 바이트를 재캐시하지 못하게).
-    lazyChunkCache.clear();
+    // 정밀 캐시 무효화(#4062 후속) — 매 rebuild 전체 clear 하면 무관한 편집에도 멀쩡한 lazy
+    // 청크가 버려져 다음 요청이 cold build()(store 없는 단발이라 ~수초)를 돈다. 대신 변경 파일
+    // (event.changed, 절대경로)이 *닿은* 청크만 버린다 — 캐시 항목의 moduleIds(청크 내 모듈
+    // 절대경로)와 교집합이 있을 때만. graph 모양이 바뀐 rebuild(graphChanged=모듈 추가/제거)는
+    // moduleIds 가 stale 일 수 있어(신규 파일이 옛 moduleIds 에 없음) 전체 clear 로 fallback.
+    // changed 가 없으면(onReady 등) 보수적으로 전체 clear.
+    const changedAbs =
+      Array.isArray(event.changed) && event.changed.length > 0
+        ? new Set(event.changed.map((p) => resolve(p)))
+        : null;
+    if (event.graphChanged || !changedAbs) {
+      lazyChunkCache.clear();
+    } else {
+      for (const [hash, entry] of lazyChunkCache) {
+        const ids = entry.moduleIds;
+        // moduleIds 미보유(방어) 또는 변경 파일과 교집합 → 버림.
+        if (!Array.isArray(ids) || ids.some((id) => changedAbs.has(resolve(id)))) {
+          lazyChunkCache.delete(hash);
+        }
+      }
+    }
+    // epoch 증가는 항상 — 진행 중 on-demand build 가 이 무효화를 넘겨 stale 바이트를 재캐시하지
+    // 못하게(in-flight race backstop). 정밀 delete 와 직교(어떤 항목을 버리든 race 가드는 유지).
     lazyEpoch++;
     // seed 맵은 event.lazySeeds 가 *실제로 올 때만* 교체한다. 일반 편집(동적 import 를 가진
     // 모듈이 cache-hit)은 native 가 graph.lazy_seeds 를 다시 안 쌓아 lazySeeds 가 undefined 로
@@ -2170,6 +2190,9 @@ async function runServe(opts, config, { appDev = null } = {}) {
           status: 200,
           body: chunk.contents,
           type: 'application/javascript',
+          // 정밀 무효화용 — 이 청크에 들어간 모듈 절대경로 집합. rebuild 시 event.changed 와
+          // 교집합이 있을 때만 이 항목을 버린다(무관한 편집엔 보존 → cold 재빌드 회피).
+          moduleIds: Array.isArray(chunk.moduleIds) ? chunk.moduleIds : [],
         };
         // 빌드 도중 rebuild 가 끼지 않았을 때만 캐시(epoch 불변). 끼었으면 이 결과는 옛 소스
         // 기반이라 캐시하지 않고(다음 요청이 fresh 재빌드) 이번 응답으로만 반환.

--- a/tests/integration/tests/js-dev-server-lazy.test.ts
+++ b/tests/integration/tests/js-dev-server-lazy.test.ts
@@ -172,4 +172,45 @@ describe('JS dev server lazy on-demand route (#4062 PR-B-2)', () => {
     expect(ok).toBe(true); // 캐시 무효화 + seed 맵 갱신 → 편집된 본문이 on-demand 로 반영
     expect(await heavyBodyVisible('HEAVY_V1')).toBe(false); // 옛 본문은 사라짐
   }, 30000);
+
+  // 정밀(per-seed) 캐시 무효화: 동적 import 와 무관한 파일을 편집해 rebuild 가 나도, 그 lazy
+  // 청크는 캐시에서 보존돼(변경 파일 ∩ 청크 moduleIds = ∅) 정상 서빙된다. 매 rebuild 전체 clear
+  // 하던 동작은 무관한 편집에도 멀쩡한 청크를 버려 다음 요청이 cold build()(~수초)를 돌게 했다.
+  test('--lazy → 무관한 파일 편집 rebuild 후에도 lazy 청크가 보존·정상 서빙', async () => {
+    const fixture = await createFixture({
+      'index.html': `<!doctype html><html><head><meta charset="utf-8"/><title>P</title></head><body><div id="root"></div><script type="module" src="/src/main.ts"></script></body></html>`,
+      'src/main.ts':
+        `import { s } from './sidecar';\n` +
+        `async function go(){ const m = await import('./heavy'); document.getElementById('root')!.textContent = m.h + s; }\ngo();`,
+      'src/sidecar.ts': `export const s = 'SIDE_A';`,
+      'src/heavy.ts': `export const h = 'HEAVY_KEEP';`,
+    });
+    cleanup = fixture.cleanup;
+
+    const port = 5510 + Math.floor(Math.random() * 40);
+    proc = Bun.spawn({
+      cmd: ['bun', ZNTC_JS_CLI, 'dev', fixture.dir, '--port', String(port), '--lazy'],
+      env: { ...process.env, ZNTC_LAZY: '' },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    await waitForServer(port);
+
+    const entry = await (await fetch(`http://localhost:${port}/bundle.js`)).text();
+    const chunkUrl = entry.match(/__zntc_load_chunk\("([^"]+)"\)/)![1];
+    // heavy 청크를 한 번 요청 → 캐시에 적재(moduleIds 기억).
+    expect(await (await fetch(`http://localhost:${port}/${chunkUrl}`)).text()).toContain(
+      'HEAVY_KEEP',
+    );
+
+    // heavy 와 무관한 sidecar.ts 편집 → rebuild. heavy 청크의 moduleIds 에 sidecar 가 없어
+    // 캐시 보존돼야 한다.
+    writeFileSync(join(fixture.dir, 'src/sidecar.ts'), `export const s = 'SIDE_B';`);
+    await new Promise((r) => setTimeout(r, 2500)); // rebuild flush
+
+    // 보존된 heavy 청크가 여전히 올바른 본문을 서빙(무관한 편집이 망가뜨리지 않음).
+    const after = await (await fetch(`http://localhost:${port}/${chunkUrl}`)).text();
+    expect(after).toContain('HEAVY_KEEP');
+    expect(after).not.toContain('SIDE_'); // heavy 청크엔 sidecar 가 섞이지 않음
+  }, 30000);
 });


### PR DESCRIPTION
## 무엇을

dev 서버 lazy on-demand 청크 캐시를 **매 rebuild 전체 clear** 하던 것을, **변경 파일이 실제로 닿은 청크만 버리는** 정밀 무효화로 바꿉니다.

## 문제 (조사로 확정)

`--lazy` watch 세션에서 *무관한* 파일을 편집해도 `onRebuild` → `captureLazyState`가 `lazyChunkCache`를 통째로 비웠습니다. 그러면 멀쩡한 lazy 청크 캐시까지 날아가, 다음 브라우저 요청이 **cold `build()`**(on-demand 단발이라 `module_store`/`compiled_cache`가 NAPI 경계를 못 넘어 entry 그래프 전체를 재파싱 ~수초)를 돌았습니다.

→ **"seed 편집 시 ~5s" 한계의 진짜 원인은 watcher가 아니라 이 blanket clear**였습니다.

## 수정

캐시 항목에 그 청크의 `moduleIds`(청크 내 모듈 절대경로)를 함께 저장하고, rebuild 시 `event.changed`(변경 파일 절대경로)와 **교집합이 있는 항목만 delete**.

- `graphChanged`(모듈 추가/제거)면 `moduleIds`가 stale일 수 있어(신규 파일이 옛 moduleIds에 없음) **전체 clear로 fallback**
- `changed`가 없으면(onReady 등) 보수적 전체 clear
- **epoch 가드는 그대로** — in-flight 빌드 race backstop

## 효과

무관한 편집은 그 lazy 청크를 안 건드림 → **cold 재빌드 사라짐**(churn 캐시적중↓ 한계도 해소). 편집한 seed 본인만 무효화(정당). 경로는 양쪽 다 resolver realpath 산출이라 일치(macOS `/private/tmp` 정합).

## 검증

`/code-review max`(6항목): **diff 자체는 정확, 새 stale-serve 없음** — `moduleIds ∩ changed`가 청크에 든 watched 모듈 편집을 정확히 포착, `graphChanged` fallback이 신규파일 gap 차단, 경로형 일치, 기존 동작(seed 편집→무효화 / onReady→clear / epoch) 보존.

**리뷰가 별개 아키텍처 한계 발견 → #4079 (pre-existing, 이 PR 회귀 아님)**: lazy seed는 미파싱 stub이라 transitive 정적 deps가 watch 그래프에 없어 깊은 편집은 rebuild 자체가 안 남(HMR gap). 정밀 무효화는 *발생한 rebuild*에 대해선 정확.

- `js-dev-server-lazy`에 "무관한 파일 편집 후에도 lazy 청크 보존·정상 서빙" 추가(precise-delete surviving-entry 경로)
- 기존 "seed 편집→새 본문"(정밀 무효화의 핵심 correctness 가드)·hmr(4)·napi-dev-server(19) 회귀 없음

## Zig 초보자 메모

캐시를 "전부 비우기" 대신 "바뀐 파일이 들어간 청크만 비우기"로 바꾼 것입니다. 각 청크가 어떤 파일들로 만들어졌는지(`moduleIds`)를 기억해 뒀다가, 편집된 파일이 그 목록에 있을 때만 그 청크를 버립니다.

Refs #4062, #4079

🤖 Generated with [Claude Code](https://claude.com/claude-code)