### PR TITLE
feat(bundler): lazy 빌드 동적 청크가 force-parse 후에도 path-hash 안정 이름 유지 (#4079 PR-1)

### DIFF
--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -205,6 +205,12 @@ pub const Chunk = struct {
     /// content-hash 가 아닌 `lazy_path_hash`(경로 기반) 로 안정화 — entry 가 아직
     /// 안 만든 청크를 안정 이름으로 선참조할 수 있게 한다.
     is_lazy_seed: bool = false,
+    /// #4079: 파일명을 content-hash 가 아니라 `lazy_path_hash`(경로 기반)로 쓸지 여부.
+    /// `is_lazy_seed`(미파싱·emit-skip)와 분리된 개념 — lazy 빌드의 *동적 import 타겟*
+    /// 청크는 force-parse 되어 본문이 있어도(=emit 됨, is_lazy_seed=false) path-hash
+    /// 이름을 유지해야 브라우저가 박은 `__zntc_load_chunk` URL 이 lazy↔force-parse 전환에
+    /// 불변이다(dev materialize 토대). is_lazy_seed ⊂ use_lazy_path_name.
+    use_lazy_path_name: bool = false,
     /// lazy seed 청크의 경로 기반 안정 hash (entry 모듈 path 의 Wyhash). content-hash
     /// 와 달리 청크 본문이 없어도 결정되며, PR-3b 가 on-demand 빌드 시 같은 이름 재현.
     lazy_path_hash: u64 = 0,
@@ -808,12 +814,16 @@ pub fn generateChunks(
         } }, bits);
         chunk.name = name;
         chunk.explicit_file_name = explicit_file_name;
-        // PR-3a-ii: entry 모듈이 미파싱 lazy seed 면 청크도 lazy — emit-skip + 경로기반
-        // 안정 이름. lazy_path_hash 는 entry path 의 Wyhash(content 무관, PR-3b 재현 가능).
-        if (entry_mod.is_lazy_seed) {
-            chunk.is_lazy_seed = true;
+        // PR-3a-ii / #4079: lazy 빌드의 동적 import 타겟 청크는 parse 여부와 무관히 path-hash
+        // 안정 이름을 쓴다 — 브라우저가 박은 `__zntc_load_chunk("<stem>-<pathhash>.js")` URL 이
+        // lazy(미파싱)↔force-parse(파싱·emit) 전환에도 불변이어야 dev materialize(#4079)가 성립.
+        // emit-skip 은 별개로 is_lazy_seed(미파싱)일 때만 — force-parse 면 본문이 있어 emit 한다.
+        // lazy_path_hash 는 entry path 의 Wyhash(content 무관, on-demand 빌드가 같은 이름 재현).
+        if (entry_mod.is_lazy_seed or (entry.is_dynamic and graph.lazy_compilation)) {
+            chunk.use_lazy_path_name = true;
             chunk.lazy_path_hash = std.hash.Wyhash.hash(0, entry_mod.path);
         }
+        if (entry_mod.is_lazy_seed) chunk.is_lazy_seed = true;
 
         // PR B-1: [dir] 토큰 치환용 raw dir. PR B-4b sub-1b: dirname(entry path)
         // 를 *graph.entry_dir 기준 relative* 로 변환해 사용자 머신 절대경로

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -2013,11 +2013,12 @@ fn chunkPlaceholderStem(
     // dir 의미 약함 + Rollup `chunkFileNames` 도 dir 토큰 미사용.
     const dir = if (is_static_entry) (chunk.name_dir orelse "") else "";
 
-    // PR-3a-ii: lazy seed 청크는 미생성(미파싱)이라 content-hash 불가 — `[hash]` 를
-    // 경로 기반 안정 hash 로 치환한다. content-hash placeholder(\x00ZH) prefix 가 없으므로
-    // resolveContentHashes 가 건드리지 않아 그대로 안정 이름이 된다. entry 의
-    // __zntc_load_chunk("<stem>-<pathhash>.js") 가 미생성 청크를 안정 이름으로 선참조.
-    if (chunk.is_lazy_seed) {
+    // PR-3a-ii / #4079: lazy 빌드의 동적 import 타겟 청크는 `[hash]` 를 경로 기반 안정 hash 로
+    // 치환한다(content-hash placeholder \x00ZH prefix 가 없어 resolveContentHashes 가 건드리지
+    // 않음 → 안정 이름). lazy seed(미파싱)는 content-hash 불가라 필수고, force-parse 된 동적 타겟
+    // (본문 있음·emit 됨)도 같은 path-hash 를 써 entry 의 __zntc_load_chunk URL 이 lazy↔force-parse
+    // 전환에 불변(#4079). `use_lazy_path_name` = is_lazy_seed ∪ (lazy 빌드 동적 타겟).
+    if (chunk.use_lazy_path_name) {
         var path_hash: [HASH_PLACEHOLDER_LEN]u8 = undefined;
         _ = std.fmt.bufPrint(&path_hash, "{x:0>8}", .{@as(u32, @truncate(chunk.lazy_path_hash))}) catch unreachable;
         try applyNamingPatternWithDir(out, allocator, pattern, base_name, &path_hash, dir);

--- a/tests/integration/tests/napi-lazy-primitives.test.ts
+++ b/tests/integration/tests/napi-lazy-primitives.test.ts
@@ -76,6 +76,40 @@ describe('NAPI lazy compilation primitives (D105 PR-A)', () => {
     expect(byContent(forced.outputFiles!, 'HEAVY_PRA_MARKER')).toBeDefined(); // 즉시 parse → 본문 존재
   });
 
+  // #4079 PR-1: force-parse 된 동적 청크는 lazy 빌드와 *같은 path-hash 이름*을 유지해야 한다.
+  // 안 그러면 lazy→force-parse 전환 시 entry 의 __zntc_load_chunk URL 이 content-hash 로 바뀌어
+  // 브라우저가 이미 박아둔 path-hash URL 과 어긋난다(dev materialize 의 토대). 동적 청크 네이밍을
+  // is_lazy_seed(미파싱)가 아니라 "lazy 빌드의 동적 타겟"으로 게이트해 parse 여부와 무관히 안정화.
+  test('#4079: force-parse 된 동적 청크가 lazy 빌드와 같은 path-hash 이름 유지', async () => {
+    const fixture = await createFixture({
+      'heavy.ts': `export const h = 'HEAVY_4079';`,
+      'entry.ts': `async function go(){ const m = await import('./heavy'); console.log(m.h); }\ngo();`,
+    });
+    cleanup = fixture.cleanup;
+    const entry = join(fixture.dir, 'entry.ts');
+
+    // 1) lazy 빌드 — entry 가 참조하는 path-hash URL 캡처.
+    const lazy = await build(lazyOpts(entry));
+    expect(lazy.errors ?? []).toHaveLength(0);
+    const lazyEntry = byContent(lazy.outputFiles!, '__zntc_load_chunk(');
+    const lazyUrl = lazyEntry!.text.match(/__zntc_load_chunk\("([^"]+)"\)/)![1];
+    expect(lazyUrl).toMatch(/-[0-9a-f]{8}\.js$/);
+    const seedPath = lazy.lazySeeds![0].path;
+
+    // 2) force-parse 빌드 — entry 의 load_chunk URL 과 emit 된 청크 파일명이 *동일 path-hash* 여야.
+    const forced = await build({ ...lazyOpts(entry), lazyForceParse: [seedPath] });
+    expect(forced.errors ?? []).toHaveLength(0);
+    const forcedEntry = byContent(forced.outputFiles!, '__zntc_load_chunk(');
+    expect(forcedEntry).toBeDefined();
+    const forcedUrl = forcedEntry!.text.match(/__zntc_load_chunk\("([^"]+)"\)/)![1];
+    // 핵심 가드: lazy ↔ force-parse 의 동적 청크 URL 이 동일(path-hash 안정).
+    expect(forcedUrl).toBe(lazyUrl);
+    // 그 URL 이름의 청크가 실제로 emit 되고 heavy 본문을 담아야(force-parse 라 emit-skip 아님).
+    const chunkFile = forced.outputFiles!.find((f) => f.path.endsWith(forcedUrl));
+    expect(chunkFile).toBeDefined();
+    expect(chunkFile!.text).toContain('HEAVY_4079');
+  });
+
   test('lazyCompilation 미지정 → lazySeeds 없음(기존 단일/스플릿 빌드 불변)', async () => {
     const fixture = await createFixture({
       'heavy.ts': `export const h = 'HEAVY_PRA_MARKER';`,


### PR DESCRIPTION
## 무엇을

`RFC_LAZY_DEV_MATERIALIZE` **PR-1**. dev materialize(#4079 — 요청 seed 를 watch 그래프에서 force-parse)의 **토대**: 동적 import 타겟 청크 이름을 lazy(미파싱)↔force-parse(파싱·emit) 전환에 **불변**으로 안정화합니다.

## 문제

lazy seed 청크 이름 = `<stem>-<lazy_path_hash>.js`(경로 기반). force-parse되면 `is_lazy_seed=false` → **content-hash 이름으로 바뀌어**, 브라우저가 이미 박아둔 `__zntc_load_chunk("<stem>-<pathhash>.js")` URL과 어긋납니다. (한 빌드 내부는 정합하나 빌드 *전환* 시 외부 URL이 깨짐)

```
LAZY:        entry → "heavy-f6ed827a.js" (path-hash)
FORCE-PARSE: entry → "heavy-463da356.js" (content-hash)   ← 다름 → materialize 시 URL 깨짐
```

## 수정

`is_lazy_seed`(미파싱·emit-skip)에서 **네이밍 개념을 분리**한 새 플래그 `Chunk.use_lazy_path_name` 도입. lazy 빌드의 동적 import 타겟 청크(`entry.is_dynamic and graph.lazy_compilation`)는 parse 여부와 무관히 **path-hash 이름**을 씁니다.

- `chunkPlaceholderStem` 네이밍 게이트: `is_lazy_seed` → `use_lazy_path_name`
- emit-skip 게이트(`chunkRestrictSkip`)는 그대로 `is_lazy_seed` — force-parse는 본문이 있어 **emit됨**
- 즉 `use_lazy_path_name ⊇ is_lazy_seed`, `emit-skip ⊂ is_lazy_seed`
- **non-lazy/production은 `graph.lazy_compilation` 게이트로 byte-identical**(content-hash 불변)

force-parse 청크는 path-hash 리터럴 이름(`\x00ZH` placeholder 없음)이라 `resolveContentHashes`가 그 placeholder를 영원히 못 찾아 **no-op** — emit-skip과 달리 *emit은 됨*(out_idx alignment는 emit 루프와 동일 predicate·sorted_indices라 유지).

## 검증

`/code-review max`(7항목): **resolveContentHashes corruption/alignment · is_dynamic-on-static-entry · import-call 정합 · byte-identical 전부 REFUTED/safe, 새 버그 0**. main/static/preserve entry는 `is_dynamic=false`(chunk.zig:657)라 path-hash 오염 불가.

- **TDD**: "force-parse 동적 청크가 lazy 빌드와 같은 path-hash 이름 유지" 추가 (red: content-hash≠path-hash → green)
- 회귀: `iife`/`cjs`/`css-code-splitting`·`bundle-dynamic-import`·`zig build test`·`install`/`test262`/`wasm`·`js-dev-server-lazy` 전부 통과 (non-lazy byte-identical 확인)

## Zig 초보자 메모

청크 파일 이름은 보통 *내용*을 해시해 정합니다(content-hash, 캐시 무효화용). 하지만 lazy 동적 청크는 "아직 안 만들어졌어도 브라우저가 URL로 먼저 부를 수 있어야" 해서 *경로*를 해시합니다(path-hash, 내용 무관·안정). 이 PR은 "한 번 만들어진(force-parse) 뒤에도 그 경로-해시 이름을 그대로 쓰게" 해서 URL이 안 바뀌게 합니다.

Refs #4079, #4062

🤖 Generated with [Claude Code](https://claude.com/claude-code)