### PR TITLE
feat(cli): dev 서버가 방문된 lazy 청크를 watch 에 materialize 요청 (#4079 PR-3)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -2165,6 +2165,12 @@ async function runServe(opts, config, { appDev = null } = {}) {
     const pathHash = m[1];
     const seedPath = lazySeedMap.get(pathHash);
     if (!seedPath) return null; // 알 수 없는 hash — 정적 자산일 수 있어 fallback
+    // #4079 PR-3 (dev materialize) — 이 seed 가 방문됐으니 watch worker 가 그것을 force-parse 해
+    // 정식 청크로 emit(이후 정적 서빙) + transitive deps 를 감시(깊은 편집 HMR + warm 재빌드)하게
+    // 한다. native 가 dedup 하므로 매 요청 호출 무해. PR-1 의 path-hash 안정 이름 덕에 on-demand
+    // 청크 URL ↔ watch emit 청크 URL 이 동일해 전환이 매끄럽다. 아래 on-demand build 는 첫 요청
+    // 즉시성용(watch rebuild 는 ≤200ms 비동기). 구 native 바이너리면 메서드 부재 → 옵셔널 no-op.
+    nativeWatchHandle?.requestLazySeed?.(seedPath);
     const cached = lazyChunkCache.get(pathHash);
     if (cached) return cached;
     if (!lazyOnDemandOpts) return null;

--- a/tests/integration/tests/js-dev-server-lazy.test.ts
+++ b/tests/integration/tests/js-dev-server-lazy.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from 'bun:test';
-import { writeFileSync } from 'node:fs';
+import { writeFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { createFixture, ZNTC_JS_CLI } from './helpers';
 
@@ -212,5 +212,62 @@ describe('JS dev server lazy on-demand route (#4062 PR-B-2)', () => {
     const after = await (await fetch(`http://localhost:${port}/${chunkUrl}`)).text();
     expect(after).toContain('HEAVY_KEEP');
     expect(after).not.toContain('SIDE_'); // heavy 청크엔 sidecar 가 섞이지 않음
+  }, 30000);
+
+  // #4079 PR-3 (dev materialize): lazy 청크를 한 번 요청하면 dev 서버가 watch 에 requestLazySeed
+  // 를 호출 → worker 가 그 seed 를 force-parse 해 정식 청크로 outdir 에 emit 한다(이후 정적 서빙
+  // + subtree 감시). 요청 전엔 emit-skip(디스크에 없음), 요청 후엔 디스크에 나타나야 한다.
+  // ⚠️ 이 테스트는 *빌드된* @zntc/core(dist)의 `requestLazySeed` 래퍼 + 최신 NAPI 바이너리를
+  // 요구한다(dist 는 gitignore — `bun run --cwd packages/core build:js` + `zig build napi`).
+  // stale 시 `nativeWatchHandle.requestLazySeed` 가 undefined → `?.` no-op → materialize 안 됨.
+  test('--lazy → lazy 청크 요청 시 watch 가 그 seed 를 materialize(디스크 emit)', async () => {
+    const fixture = await createFixture({
+      'index.html': `<!doctype html><html><head><meta charset="utf-8"/><title>M</title></head><body><div id="root"></div><script type="module" src="/src/main.ts"></script></body></html>`,
+      'src/main.ts': `async function go(){ const m = await import('./heavy'); document.getElementById('root')!.textContent = m.h; }\ngo();`,
+      'src/heavy.ts': `export const h = 'HEAVY_MAT';`,
+    });
+    cleanup = fixture.cleanup;
+    const outdir = join(fixture.dir, '.zntc-dev');
+    const heavyOnDisk = () => {
+      try {
+        return readdirSync(outdir).some((f) => /heavy-[0-9a-f]{8}\.js$/.test(f));
+      } catch {
+        return false;
+      }
+    };
+
+    const port = 5550 + Math.floor(Math.random() * 40);
+    proc = Bun.spawn({
+      cmd: ['bun', ZNTC_JS_CLI, 'dev', fixture.dir, '--port', String(port), '--lazy'],
+      env: { ...process.env, ZNTC_LAZY: '' },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    await waitForServer(port);
+
+    const entry = await (await fetch(`http://localhost:${port}/bundle.js`)).text();
+    const chunkUrl = entry.match(/__zntc_load_chunk\("([^"]+)"\)/)![1];
+    expect(heavyOnDisk()).toBe(false); // 요청 전 = emit-skip
+
+    // lazy 청크 요청 → on-demand 즉시 서빙 + watch 에 requestLazySeed.
+    expect(await (await fetch(`http://localhost:${port}/${chunkUrl}`)).text()).toContain(
+      'HEAVY_MAT',
+    );
+
+    // watch 가 force-parse 해 디스크에 materialize 할 때까지 폴링(최대 ~8s).
+    let materialized = false;
+    const deadline = Date.now() + 8000;
+    while (Date.now() < deadline) {
+      if (heavyOnDisk()) {
+        materialized = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    expect(materialized).toBe(true); // requestLazySeed → watch force-parse → 정식 청크 emit
+    // materialize 후에도 그 URL 이 동일 본문을 서빙(PR-1 path-hash 안정 → 정적 서빙 전환 매끄러움).
+    expect(await (await fetch(`http://localhost:${port}/${chunkUrl}`)).text()).toContain(
+      'HEAVY_MAT',
+    );
   }, 30000);
 });


### PR DESCRIPTION
## 무엇을

`RFC_LAZY_DEV_MATERIALIZE` **PR-3 (완결)**. PR-1(path-hash 안정 이름) + PR-2(NAPI `requestLazySeed`)를 JS dev 서버에서 연결해 **#4079(깊은 편집 HMR) + seed 편집 warm 재빌드**를 완성합니다.

## 변경

`tryServeLazy`가 lazy 청크 요청을 받으면 seed 해석 직후 `nativeWatchHandle?.requestLazySeed?.(seedPath)` 호출:

1. **첫 요청** = 기존 on-demand `build()`가 즉시 서빙 (watch rebuild는 ≤200ms 비동기)
2. **watch worker**가 그 seed를 force-parse 누적 → 다음 rebuild가 정식 청크로 outdir emit (PR-1 path-hash 안정 이름이라 **on-demand URL ↔ watch emit URL 동일**) + transitive 정적 deps가 `module_paths`→tracked에 들어가 **자동 감시**
3. **force-parse 후** 그 seed는 `onRebuild.lazySeeds`에서 빠져 `captureLazyState`가 `lazySeedMap`에서 제거 → 이후 요청은 정적 `handleRequest`가 디스크 청크 서빙. native가 worker에서 디스크 write를 **onRebuild 이벤트 전에** 완료하므로 transition gap 없음.

## 결과

이제 `--lazy` 라우트를 방문하면:
- 그 라우트의 **안쪽 파일을 편집해도 HMR 동작** (seed subtree 감시) ← #4079 해결
- seed 본인 편집도 **warm watch 그래프 재빌드** (별개 cold build 아님)
- **방문 안 한 라우트는 여전히 미컴파일** (lazy 핵심 가치 유지) — webpack `lazyCompilation` 모델

## 검증

`/code-review max`(5항목): transition gap(404/stale) · on-demand↔watch-emit byte divergence · optional-chain · epoch 가드 상호작용 · test **전부 REFUTED/safe**. #1 핵심: worker가 chunk 디스크 write(watch.zig:1307)를 event fire 전 완료. #4 핵심: 두 청크 변형이 동일 path-hash URL + 동일 `__zntc_register` 키라 `__zntc_require` 호환.

- **TDD**: lazy 청크 요청 후 watch가 그 seed를 디스크에 materialize(emit-skip→디스크 출현) red→green
- 회귀: js-dev-server-lazy(5)·napi-lazy-primitives(10)·hmr(4)·napi-dev-server(19)·devserver(7)

## ⚠️ 테스트 환경

이 흐름은 *빌드된* `@zntc/core`(dist)의 `requestLazySeed` 래퍼 + 최신 NAPI 바이너리 필요(dist gitignore — `build:js` + `zig build napi`). stale 시 래퍼 부재로 `?.` no-op → materialize 안 됨(테스트 주석에 명시).

## 🎉 #4079 에픽 완결

RFC → PR-1(emitter) → PR-2(NAPI) → PR-3(JS wiring) 으로 dev materialize 완성.

Closes #4079
Refs #4062

🤖 Generated with [Claude Code](https://claude.com/claude-code)