### PR TITLE
fix(cli): --lazy dev 깊은 파일 편집이 화면에 반영 안 되던 버그 — full-reload 폴백 + 브라우저 e2e (#4079)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -2342,7 +2342,22 @@ async function runServe(opts, config, { appDev = null } = {}) {
                   })),
                 }
               : event;
-          web.broadcastRebuildEvent(hmr, annotated);
+          const outcome = web.broadcastRebuildEvent(hmr, annotated);
+          // #4079: lazy(splitting) dev 는 분할 청크가 dev HMR 모듈 레지스트리에 없어 module-level
+          // HMR 이 불가하다(dev init lowering 이 production init 로 fallback). 그래서 lazy 청크
+          // 안의 모듈을 편집하면 rebuild 는 변경을 감지(event.changed)하지만 module update 를
+          // 못 만들어 broadcastRebuildEvent 가 'noop' 으로 끝나 화면이 안 갱신된다 → full reload 로 갈음.
+          // 단 (a) 'update'(메인 번들 모듈 변경 — 진짜 HMR 적용 가능)와 'full-reload'(graphChanged)
+          //  /'error' 는 제외, (b) CSS 변경은 drain 의 CSS-only HMR(live <link> swap)이 처리하므로
+          //  *비-CSS* 변경이 하나라도 있을 때만 full reload(전부 CSS 면 CSS HMR 보존).
+          // errors 가 있으면(partial build) overlay 가 latch 된 상태 — full reload 는 overlay 를
+          // 숨기고 깨진 상태로 리로드하므로 skip(에러는 그대로 보여줌, 다음 성공 빌드가 갱신).
+          if (lazyMode && event.success && outcome === 'noop' && !event.errors?.length) {
+            const hasNonCss = (event.changed ?? []).some(
+              (p) => !/\.(css|scss|sass|less|styl|pcss|postcss)$/i.test(p),
+            );
+            if (hasNonCss) hmr.broadcast({ type: web.HMR_MSG.FullReload, timestamp: Date.now() });
+          }
         } catch (err) {
           console.error('[serve] hmr broadcast error:', err);
         }

--- a/tests/e2e/tests/lazy-dev-materialize-e2e.test.ts
+++ b/tests/e2e/tests/lazy-dev-materialize-e2e.test.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { writeFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { waitForServer } from '@zntc/test-helpers';
+
+// #4079 dev materialize — 실제 브라우저로 lazy compilation 의 end-to-end 를 닫는다:
+//   (1) lazy 라우트 방문 → on-demand 컴파일 + cross-chunk 런타임(__zntc_load_chunk/__zntc_require)
+//       이 브라우저에서 동작해 라우트가 렌더된다.
+//   (2) 라우트 *안쪽 깊은 파일*(route → Chart → util, 2단계) 편집 → watch 가 그 seed 를
+//       materialize 해 깊은 파일을 감시 중이므로 rebuild → HMR(full reload) → 화면 갱신.
+// (2) 가 #4079 가 고친 핵심 — materialize 전엔 깊은 파일이 unwatched 라 편집해도 무반응이었다.
+
+const ZNTC_JS_CLI = resolve(__dirname, '../../../packages/core/bin/zntc.mjs');
+const PORT = 3971;
+
+const FILES: Record<string, string> = {
+  'index.html':
+    '<!doctype html><html><head><meta charset="utf-8"/><title>Lazy</title></head>' +
+    '<body><div id="root" data-testid="out">loading</div>' +
+    '<script type="module" src="/src/main.ts"></script></body></html>',
+  // 진입 시 lazy 라우트를 동적 import 해 그 출력을 #root 에 렌더.
+  'src/main.ts':
+    "async function go(){ const m = await import('./route'); " +
+    "document.getElementById('root')!.textContent = m.render(); }\ngo();",
+  'src/route.ts': "import { chart } from './Chart';\nexport function render(){ return chart(); }",
+  'src/Chart.ts': "import { fmt } from './util';\nexport function chart(){ return fmt('chart'); }",
+  'src/util.ts': "export function fmt(s: string){ return 'UTIL_V1[' + s + ']'; }",
+};
+
+test.describe.serial('lazy dev materialize (브라우저 e2e #4079)', () => {
+  let dir: string;
+  let server: ChildProcess | null = null;
+
+  test.beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'zntc-lazy-e2e-'));
+    for (const [name, content] of Object.entries(FILES)) {
+      const fp = join(dir, name);
+      await mkdir(join(fp, '..'), { recursive: true });
+      await writeFile(fp, content);
+    }
+    server = spawn('bun', [ZNTC_JS_CLI, 'dev', dir, '--port', String(PORT), '--lazy'], {
+      env: { ...process.env, ZNTC_LAZY: '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    await waitForServer(PORT);
+  });
+
+  test.afterAll(async () => {
+    server?.kill();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  test('lazy 라우트 방문 → 브라우저에서 렌더(cross-chunk 런타임)', async ({ page }) => {
+    await page.goto(`http://localhost:${PORT}/`);
+    // entry 로드 → __zntc_load_chunk(route 청크) on-demand fetch → __zntc_require resolve → 렌더.
+    await expect(page.getByTestId('out')).toHaveText('UTIL_V1[chart]', { timeout: 15000 });
+  });
+
+  test('라우트 안쪽 깊은 파일(util.ts, 2단계) 편집 → HMR 로 화면 갱신(#4079 핵심)', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${PORT}/`);
+    await expect(page.getByTestId('out')).toHaveText('UTIL_V1[chart]', { timeout: 15000 });
+
+    // 방문 직후엔 materialize(force-parse rebuild)가 진행 중일 수 있다 — util 이 watch 그래프에
+    // 들어가 감시되기까지 기다린다. 고정 sleep 대신 라우트 청크가 outdir 에 emit(=materialize 완료,
+    // subtree 감시 시작)될 때까지 폴링(결정론적, 느린 CI 에도 안정).
+    const outdir = join(dir, '.zntc-dev');
+    const materialized = () => {
+      try {
+        return readdirSync(outdir).some((f) => /route-[0-9a-f]{8}\.js$/.test(f));
+      } catch {
+        return false;
+      }
+    };
+    for (let i = 0; i < 100 && !materialized(); i++) await page.waitForTimeout(100);
+    expect(materialized()).toBe(true);
+
+    // 깊은 파일 편집 → watch rebuild → lazy 모드 full-reload HMR 로 화면이 *자동* 갱신돼야 한다
+    // (수동 새로고침 없이). lazy split 청크는 module-level HMR 불가라 full-reload 로 갈음.
+    writeFileSync(
+      join(dir, 'src/util.ts'),
+      "export function fmt(s: string){ return 'UTIL_V2[' + s + ']'; }",
+    );
+    await expect(page.getByTestId('out')).toHaveText('UTIL_V2[chart]', { timeout: 15000 });
+  });
+});


### PR DESCRIPTION
## 무엇을 (브라우저 e2e 가 발견)

`--lazy` 라우트를 방문(materialize)한 뒤 그 라우트 **안쪽 깊은 파일**(route→Chart→util)을 편집하면, watch 는 rebuild 하는데 **브라우저 화면이 안 바뀌던** 버그(수동 새로고침 필요). 기존 server-side 통합 테스트는 다 통과해 못 잡았고, 실제 브라우저 e2e 로 드러났습니다.

## 근본 원인 (instrument 로 확정)

```
util.ts 편집 → outcome=noop  changed=["util.ts"]  updates=0
```

lazy(splitting) dev 는 분할 청크가 **dev HMR 모듈 레지스트리에 없습니다**(dev init lowering 이 청크 경계를 못 넘어 production init 로 fallback, #4038) → lazy 청크 안 모듈은 module-level HMR 로 적용 불가 → 편집 시 rebuild 가 변경을 감지하지만 module update 를 못 만들어 `broadcastRebuildEvent` 가 `'noop'` → **HMR 신호 없음** → 화면 stale.

## 수정 (표준 폴백)

"module-HMR 불가 시 full reload" 는 HMR 클라이언트의 기존 폴백(`!updated → location.reload()`)인데, `'noop'` 경로에서 그게 안 불리던 게 버그. lazy 모드에서 코드 변경이 `'noop'` 으로 끝나면 full reload 를 보냅니다:
- `outcome === 'noop'` 만 (`'update'`=main 번들 HMR 보존, `'full-reload'`=graphChanged 중복 회피, `'error'` 제외)
- **비-CSS 변경**이 있을 때만 (CSS-only 는 drain 의 CSS-only HMR 가 처리 — `/code-review max` 가 잡은 회귀)
- errors latch 시 skip (overlay 유지)

## 검증

**실제 브라우저(Playwright) e2e 2개 신설**:
1. lazy 라우트 방문 → 렌더 (entry→`__zntc_load_chunk`→on-demand→`__zntc_require`→DOM, cross-chunk 런타임 전체)
2. 깊은 파일(util.ts 2단계) 편집 → **수동 새로고침 없이 자동 갱신** (#4079 핵심). materialize 완료(라우트 청크 outdir emit) 폴링 후 편집(결정론적).

`/code-review max` 2회: 첫 버전 회귀(CSS full-reload·main-bundle 중복 reload) 발견·수정 → refined 게이트 재리뷰 "ship 권장". 회귀: hmr(4)·js-dev-server-lazy(5)·napi-lazy-primitives(10).

## ⚠️ 한계 / 트레이드오프 (정직하게)

- **full-reload 는 표준 폴백이지 이상적 HMR 이 아닙니다**: 앱 상태(스크롤·폼·메모리)가 날아가고, *안 보는* 라우트의 파일을 편집해도 전체 페이지를 리로드합니다.
- 이상적 fix(리로드 없이 lazy 청크 모듈만 교체 = 상태 보존)는 **#4038(청크 경계 넘는 dev init)** 의존이라 별도 이슈로 분리합니다(후속).
- lazy 첫 방문 직후 materialize(~수백ms) 완료 전 그 라우트 내부 편집은 누락(그 뒤론 정상).

## Zig 초보자 메모

HMR(Hot Module Replacement)은 페이지 새로고침 없이 바뀐 모듈만 교체하는 기술인데, 코드가 여러 청크로 쪼개진 lazy 모드에선 그 교체 레지스트리가 없어 불가합니다. 그래서 "그냥 페이지 새로고침"으로 갈음합니다(보이는 결과는 같음). CSS 는 더 가벼운 자체 갱신 경로가 있어 제외했습니다.

Refs #4079, #4038

🤖 Generated with [Claude Code](https://claude.com/claude-code)