### PR TITLE
feat(dev): web 네이티브 React Fast Refresh — 컴포넌트 편집 시 리로드 없이 state 보존 (RFC_LAZY_DEV_MODULE_HMR §5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ node_modules/
 # Playwright
 test-results/
 tests/e2e/test-results/
+# react-fast-refresh-e2e fixture (afterAll 가 정리하나 SIGKILL 시 누수 방지)
+tests/e2e/rfr-fixture-*/
 
 # compat-table report (CI에서 생성)
 tests/integration/compat-table-report.json

--- a/bun.lock
+++ b/bun.lock
@@ -816,6 +816,8 @@
         "@rspack/core": "2.0.1",
         "@zntc/test-helpers": "workspace:*",
         "react": "19.2.4",
+        "react-dom": "19.2.4",
+        "react-refresh": "0.18.0",
       },
     },
     "tests/integration": {
@@ -7202,6 +7204,8 @@
     "@zntc/benchmark/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "@zntc/benchmark/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@zntc/e2e/react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
     "@zntc/example-module-federation/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 

--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -84,6 +84,7 @@ export const FLAG_REGISTRY = [
   { kind: 'bool', flag: '--no-tree-shaking', target: 'treeShaking', value: false },
   { kind: 'bool', flag: '--no-scope-hoist', target: 'scopeHoist', value: false },
   { kind: 'bool', flag: '--no-emit-disk-sourcemap', target: 'emitDiskSourcemap', value: false },
+  { kind: 'bool', flag: '--no-react-refresh', target: 'reactRefresh', value: false },
   { kind: 'bool', flag: '--analyze', target: 'analyze', extra: { metafile: 'meta.json' } },
   { kind: 'bool', flag: '--flow', target: 'flow' },
   { kind: 'bool', flag: '--experimental-decorators', target: 'experimentalDecorators' },
@@ -270,6 +271,9 @@ export const FLAG_REGISTRY = [
   { kind: 'string-bool', flag: '--emit-disk-sourcemap', target: 'emitDiskSourcemap' },
   { kind: 'string-bool', flag: '--use-define-for-class-fields', target: 'useDefineForClassFields' },
   { kind: 'string-bool', flag: '--tokenize', target: 'tokenize' },
+  // React Fast Refresh. `zntc dev` 는 기본 on(아래 dev 블록) — `--react-refresh=false`
+  // / `--no-react-refresh` 로 opt-out. NAPI BuildOptions.reactRefresh 와 동일 target.
+  { kind: 'string-bool', flag: '--react-refresh', target: 'reactRefresh' },
 
   // ─── `zntc verify` 전용. 다른 모드와 silent 충돌 방지를 위해 prefix 강제 ───
   { kind: 'int', flag: '--verify-timeout', target: 'verifyTimeout' },

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -410,6 +410,11 @@ function parseArgs(argv) {
     // 런타임 누락 → broadcast 된 Update 가 client 에서 fallback reload. user 가
     // 명시적으로 `--dev=false` 줘서 override 하기 전엔 dev 모드 default 보장.
     opts.devMode = true;
+    // RFC_LAZY_DEV_MODULE_HMR PR-5 / web React Fast Refresh: dev 는 reactRefresh 기본 on.
+    // 번들러는 React 컴포넌트가 있는 모듈에만 $RefreshReg$/accept 를 emit(비-React 무해).
+    // 브라우저 런타임 preamble 주입은 runServe 가 react 존재 시에만 한다(비-React 노이즈 0).
+    // 명시 flag(`--react-refresh=false`)는 아래 flag 파싱이 덮어쓴다.
+    if (opts.reactRefresh === undefined) opts.reactRefresh = true;
   } else if (appCommand === 'build') {
     opts.bundle = true;
   } else if (appCommand === 'preview') {
@@ -1613,6 +1618,9 @@ async function buildBundleOptions(opts, config, { filterCallerPreWarmCss = false
     jsxImportSource: opts.jsxImportSource,
     inject: opts.inject.map((p) => resolve(p)),
     devMode: opts.devMode,
+    // web React Fast Refresh: native 빌드(options.zig:reactRefresh)에 전파 → 컴포넌트에
+    // $RefreshReg$/accept emit. dev 블록이 기본 on(비-React 무해).
+    reactRefresh: opts.reactRefresh,
     globalIdentifiers: opts.globalIdentifiers,
     // --polyfill / --run-before-main / --watch-folder 는 경로 → abs 변환 (--inject 와 동일).
     // --watch-include / --watch-exclude 는 루트 기준 glob 이므로 변환 안 함.
@@ -1936,6 +1944,18 @@ async function runServe(opts, config, { appDev = null } = {}) {
   const APP_DEV_HMR_CLIENT = web?.APP_DEV_HMR_CLIENT;
   const APP_DEV_HMR_CLIENT_PATH = web?.APP_DEV_HMR_CLIENT_PATH;
   const APP_DEV_HMR_WS_PATH = web?.APP_DEV_HMR_WS_PATH;
+  const APP_DEV_REACT_REFRESH_PATH = web?.APP_DEV_REACT_REFRESH_PATH;
+  // React Fast Refresh preamble (react-refresh 런타임 글로벌 노출 + injectIntoGlobalHook).
+  // reactRefresh on + react 설치 시에만 non-null(=비-React 앱은 주입/서빙/경고 0). lazy 1회 캐시.
+  const reactRefreshAppRoot = opts.appRoot ? resolve(opts.appRoot) : process.cwd();
+  let reactRefreshPreamble; // undefined=미계산, null=스킵, string=서빙
+  const getReactRefreshPreamble = () => {
+    if (reactRefreshPreamble === undefined) {
+      reactRefreshPreamble =
+        web && opts.reactRefresh ? web.buildReactRefreshPreamble(reactRefreshAppRoot) : null;
+    }
+    return reactRefreshPreamble;
+  };
   let serverHandle = null;
   // #3779 follow-up — restart 시 stop 호출용. opts.bundle+watch+appDev+hmr 분기 안에서만 할당.
   let nativeWatchHandle = null;
@@ -2023,6 +2043,11 @@ async function runServe(opts, config, { appDev = null } = {}) {
         body: APP_DEV_HMR_CLIENT,
         type: 'application/javascript',
       };
+    }
+    // React Fast Refresh preamble — 앱 번들보다 먼저 실행되는 classic <script> 본문.
+    if (appDev && opts.reactRefresh && pathname === APP_DEV_REACT_REFRESH_PATH) {
+      const body = getReactRefreshPreamble();
+      if (body != null) return { status: 200, body, type: 'application/javascript' };
     }
     // #3799 — HMR module 별 sourcemap. nativeWatchHandle 이 lazy cache 한 V3 JSON 을
     // moduleId 로 조회. handle 가 stop 됐거나 module 미수집 시 null → 404. 사용자

--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -92,6 +92,10 @@ export type HmrMessage =
 
 export const APP_DEV_HMR_CLIENT_PATH = '/__zntc_app_dev_hmr__';
 export const APP_DEV_HMR_WS_PATH = '/__hmr';
+// React Fast Refresh preamble — react-refresh/runtime 을 글로벌(__ReactRefresh)로 노출 +
+// injectIntoGlobalHook(window) 를 *앱 번들보다 먼저* 실행시키는 가상 엔드포인트. dev 서버가
+// reactRefresh 활성 시 HTML <head> 의 첫 <script> 앞에 classic <script> 로 주입한다.
+export const APP_DEV_REACT_REFRESH_PATH = '/__zntc_react_refresh__';
 
 // RFC 6455 §1.3 — handshake 에 쓰이는 fixed GUID. 변경 불가.
 export const HMR_WS_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -21,7 +21,9 @@ import {
   injectAppDevBundleCssLinksFromOutdir,
   injectAppDevHmrClient,
   injectAppDevPipelineCssLinks,
+  injectAppDevReactRefreshPreamble,
 } from './inject.ts';
+import { buildReactRefreshPreamble } from './react-refresh-preamble.ts';
 import {
   cssModuleGeneratedCssPath,
   cssModuleProxyPath,
@@ -63,6 +65,9 @@ export interface AppDevControllerOptions {
   base?: string | undefined;
   publicPath?: string | undefined;
   appRoot?: string | undefined;
+  /** React Fast Refresh preamble(`/__zntc_react_refresh__`) 을 HTML 에 주입할지.
+   *  react 미설치(=비-React 앱)면 주입 자체를 스킵(404 노이즈 방지). */
+  reactRefresh?: boolean | undefined;
   entryHtml?: string | undefined;
   publicDir?: string | false | undefined;
   envDir?: string | undefined;
@@ -539,6 +544,12 @@ export function createAppDevController(
   const { fallbackRequire } = deps;
   const outdir = resolve(opts.outdir || join(root, '.zntc-dev'));
   const base = normalizeBase(opts.base ?? opts.publicPath ?? '/');
+  // React Fast Refresh preamble 주입 여부 — reactRefresh on + react 설치(=React 앱)일 때만.
+  // buildReactRefreshPreamble 가 react 미설치면 null → 주입 스킵(비-React 앱 404 노이즈 0).
+  // 1회 계산(파일 resolve/read)해 afterBundle 마다 재계산 않음. runServe 의 서빙 게이트와
+  // 동일 함수·동일 appRoot 라 결정 일관.
+  const reactRefreshInject =
+    opts.reactRefresh === true && buildReactRefreshPreamble(opts.appRoot ?? root) != null;
   let cssDeps = new Set<string>();
   let cssDirDeps = new Set<string>();
   // issue #3847 — prepare 가 PostCSS 처리 (auto-discover 또는 override) 한 경우
@@ -663,6 +674,9 @@ export function createAppDevController(
         }
       }
       injectAppDevHmrClient(outdir);
+      // React Fast Refresh preamble — 앱 번들보다 먼저 실행되도록 첫 <script> 앞에 주입.
+      // prepareAppDevSync 가 HTML 을 매 cycle 덮어쓰므로 HMR client 와 똑같이 매번 재주입.
+      if (reactRefreshInject) injectAppDevReactRefreshPreamble(outdir);
       // dev mode 한정 — bundler 가 dev splitting=false 라 CSS chunk 를 emit 하지
       // 않으므로 Sass / CSS Modules 결과를 outdir 로 mirror + `<link>` 주입.
       // mirror (cpSync) 는 sass/module 입력이 dirty 일 때만 — 그 외엔 outdir 의 직전 mirror

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -7,6 +7,7 @@
 export {
   APP_DEV_HMR_CLIENT_PATH,
   APP_DEV_HMR_WS_PATH,
+  APP_DEV_REACT_REFRESH_PATH,
   broadcastRebuildEvent,
   type BunHmrClient,
   createHmrChannel,
@@ -39,8 +40,10 @@ export {
   injectAppDevBundleCssLinksFromOutdir,
   injectAppDevHmrClient,
   injectAppDevPipelineCssLinks,
+  injectAppDevReactRefreshPreamble,
   injectIntoDevHtml,
 } from './inject.ts';
+export { buildReactRefreshPreamble } from './react-refresh-preamble.ts';
 export {
   DEFAULT_HTML_ENV_PREFIX,
   type TransformHtmlEnvResult,

--- a/packages/web/src/inject.ts
+++ b/packages/web/src/inject.ts
@@ -1,7 +1,7 @@
 import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { basename, join, sep } from 'node:path';
 
-import { APP_DEV_HMR_CLIENT_PATH } from '@zntc/server';
+import { APP_DEV_HMR_CLIENT_PATH, APP_DEV_REACT_REFRESH_PATH } from '@zntc/server';
 
 import { isCssFile } from './style/postcss.ts';
 import { joinUrl } from './url.ts';
@@ -42,6 +42,41 @@ export function injectAppDevHmrClient(outdir: string): void {
     if (html.includes(APP_DEV_HMR_CLIENT_PATH)) return null;
     return `<script type="module" src="${APP_DEV_HMR_CLIENT_PATH}"></script>`;
   });
+}
+
+/**
+ * React Fast Refresh preamble `<script src="/__zntc_react_refresh__"></script>` 를 1회 삽입.
+ * ⚠️ **첫 `<script` 앞**에 넣는다 — classic(non-module) 스크립트라 파싱 중 동기 실행되어
+ * `injectIntoGlobalHook(window)` 가 React 를 import 하는 (deferred) module 스크립트보다 *먼저*
+ * 끝나야 reconciler 패치가 유효하다. injectIntoDevHtml(=`</head>` 앞 삽입)을 안 쓰는 이유.
+ */
+export function injectAppDevReactRefreshPreamble(outdir: string): void {
+  const htmlPath = join(outdir, 'index.html');
+  let html: string;
+  try {
+    html = readFileSync(htmlPath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return;
+    throw err;
+  }
+  if (html.includes(APP_DEV_REACT_REFRESH_PATH)) return; // 멱등
+  const tag = `<script src="${APP_DEV_REACT_REFRESH_PATH}"></script>`;
+  // <head> 여는 태그 *바로 뒤*(head 의 첫 자식)에 넣어 head 안 어떤 script 보다도 먼저
+  // 동기 실행되게 한다. 주석/텍스트 안의 `<script` 문자열에 잘못 매칭하지 않도록
+  // 단순 replace('<script') 대신 <head> 위치를 명시적으로 찾는다.
+  const headOpen = html.match(/<head\b[^>]*>/i);
+  let next: string;
+  if (headOpen && headOpen.index !== undefined) {
+    const at = headOpen.index + headOpen[0].length;
+    next = `${html.slice(0, at)}\n${tag}${html.slice(at)}`;
+  } else if (html.includes('</head>')) {
+    next = html.replace('</head>', `${tag}\n</head>`);
+  } else if (html.includes('<script')) {
+    next = html.replace('<script', `${tag}\n<script`);
+  } else {
+    next = `${tag}\n${html}`;
+  }
+  writeFileSync(htmlPath, next);
 }
 
 export function injectAppDevBundleCssLinks(

--- a/packages/web/src/react-refresh-preamble.test.ts
+++ b/packages/web/src/react-refresh-preamble.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { createRequire } from 'node:module';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import vm from 'node:vm';
+
+import { APP_DEV_REACT_REFRESH_PATH } from '@zntc/server';
+
+import { buildReactRefreshPreamble } from './react-refresh-preamble.ts';
+import { injectAppDevReactRefreshPreamble } from './inject.ts';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'zntc-rfr-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function installReactStub(): void {
+  mkdirSync(join(dir, 'node_modules/react'), { recursive: true });
+  writeFileSync(
+    join(dir, 'node_modules/react/package.json'),
+    '{"name":"react","version":"19.0.0","main":"index.js"}',
+  );
+  writeFileSync(join(dir, 'node_modules/react/index.js'), 'module.exports={};');
+}
+
+// 레포에 설치된 react-refresh 루트를 찾는다(repo root resolve → .bun glob fallback).
+// transitive dep 라 hoist 안 됐을 수 있어 .bun 도 본다. 못 찾으면 null(테스트 graceful skip).
+function findRepoReactRefresh(): string | null {
+  const repoRoot = resolve(process.cwd(), '../..'); // packages/web → repo root
+  try {
+    return dirname(createRequire(join(repoRoot, 'x.js')).resolve('react-refresh/runtime'));
+  } catch {
+    /* fall through to .bun */
+  }
+  try {
+    const bun = join(repoRoot, 'node_modules/.bun');
+    const entry = readdirSync(bun)
+      .filter((d) => d.startsWith('react-refresh@'))
+      .sort()
+      .pop();
+    if (entry) return join(bun, entry, 'node_modules/react-refresh');
+  } catch {
+    /* none */
+  }
+  return null;
+}
+
+function installReactRefresh(rrRoot: string): void {
+  cpSync(rrRoot, join(dir, 'node_modules/react-refresh'), { recursive: true });
+}
+
+describe('buildReactRefreshPreamble', () => {
+  test('react 미설치(비-React 앱) → null (주입/서빙/경고 스킵)', () => {
+    expect(buildReactRefreshPreamble(dir)).toBeNull();
+  });
+
+  test('react 있으나 react-refresh 미설치 → noop + 설치 경고', () => {
+    installReactStub();
+    const p = buildReactRefreshPreamble(dir);
+    expect(p).not.toBeNull();
+    expect(p!.includes('react-refresh not found')).toBe(true);
+  });
+
+  test('react + react-refresh 설치 → 런타임 번들 + injectIntoGlobalHook + __ReactRefresh', () => {
+    const rrRoot = findRepoReactRefresh();
+    if (!rrRoot) {
+      // 레포 환경에 react-refresh 가 없으면 skip(이 케이스만 — 다른 케이스는 무관).
+      console.warn(
+        '[react-refresh-preamble.test] react-refresh not in repo — skipping real-preamble case',
+      );
+      return;
+    }
+    installReactStub();
+    installReactRefresh(rrRoot);
+    const p = buildReactRefreshPreamble(dir);
+    expect(p).not.toBeNull();
+    // 런타임이 글로벌에 노출되고 reconciler 패치를 호출.
+    expect(p!.includes('g.__ReactRefresh=rt')).toBe(true); // resolveRefresh 단락의 핵심
+    expect(p!.includes('injectIntoGlobalHook(g)')).toBe(true);
+    expect(p!.includes('__zntc_react_refresh_preamble__')).toBe(true);
+    // process 셰도우(dev cjs 의 NODE_ENV 가드 통과) + 런타임 본문 번들.
+    expect(p!.includes('var process={env:{NODE_ENV:"development"}}')).toBe(true);
+    expect(p!.includes('createSignatureFunctionForTransform')).toBe(true);
+    // 실제 평가: 브라우저처럼 window/globalThis 만 있는 컨텍스트에서 깨지지 않고
+    // __ReactRefresh.injectIntoGlobalHook 가 함수로 노출된다.
+    const sandbox: Record<string, unknown> = { window: {}, console: { warn() {}, error() {} } };
+    sandbox.globalThis = sandbox;
+    vm.runInNewContext(p!, sandbox);
+    expect(
+      typeof (sandbox.__ReactRefresh as { injectIntoGlobalHook?: unknown })?.injectIntoGlobalHook,
+    ).toBe('function');
+  });
+});
+
+describe('injectAppDevReactRefreshPreamble', () => {
+  function html(content: string): string {
+    const out = join(dir, 'index.html');
+    writeFileSync(out, content);
+    return out;
+  }
+
+  test('첫 <script> 앞에 classic preamble script 를 삽입(앱 번들보다 먼저 실행)', () => {
+    const p = html(
+      '<!doctype html><head></head><body><script type="module" src="/src/main.tsx"></script></body>',
+    );
+    injectAppDevReactRefreshPreamble(dir);
+    const out = readFileSync(p, 'utf8');
+    const preIdx = out.indexOf(APP_DEV_REACT_REFRESH_PATH);
+    const appIdx = out.indexOf('/src/main.tsx');
+    expect(preIdx).toBeGreaterThanOrEqual(0);
+    expect(preIdx).toBeLessThan(appIdx); // preamble 이 앱 script 보다 앞
+    // classic(non-module) script 여야 동기 실행.
+    expect(out.includes(`<script src="${APP_DEV_REACT_REFRESH_PATH}"></script>`)).toBe(true);
+  });
+
+  test('멱등 — 두 번 호출해도 1회만 삽입', () => {
+    const p = html('<head></head><body><script src="/app.js"></script></body>');
+    injectAppDevReactRefreshPreamble(dir);
+    injectAppDevReactRefreshPreamble(dir);
+    const out = readFileSync(p, 'utf8');
+    const count = out.split(APP_DEV_REACT_REFRESH_PATH).length - 1;
+    expect(count).toBe(1);
+  });
+
+  test('index.html 없으면 silent no-op (ENOENT)', () => {
+    expect(() => injectAppDevReactRefreshPreamble(dir)).not.toThrow();
+  });
+});

--- a/packages/web/src/react-refresh-preamble.ts
+++ b/packages/web/src/react-refresh-preamble.ts
@@ -1,0 +1,76 @@
+// React Fast Refresh preamble — `zntc dev` 가 reactRefresh 활성 시 앱 번들보다 *먼저*
+// 실행시키는 classic <script> 본문을 만든다. Vite 의 `/@react-refresh` preamble 과 동치:
+//   1) react-refresh/runtime 을 글로벌 `__ReactRefresh` 로 노출(번들러가 깐
+//      `__zntc_resolveRefresh` 가 이 글로벌을 먼저 읽고 단락 — 브라우저에 없는
+//      `require("react-refresh/runtime")` 경로를 안 탄다).
+//   2) `injectIntoGlobalHook(window)` 를 React 로드 *전* 에 호출(리액트 reconciler 패치).
+//   3) `$RefreshReg$/$RefreshSig$` 글로벌 no-op 기본값(모듈별 wrapper 가 임시 override).
+// react-refresh 미설치 시 noop 폴백 + 경고(Fast Refresh 비활성, 빌드는 정상).
+
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
+
+const NOOP_PREAMBLE =
+  'console.warn("[zntc] react-refresh not found — React Fast Refresh disabled. ' +
+  '`npm install react-refresh` for HMR with state preservation.");\n' +
+  '(function(){var g=typeof globalThis!=="undefined"?globalThis:window;' +
+  'g.$RefreshReg$=g.$RefreshReg$||function(){};' +
+  'g.$RefreshSig$=g.$RefreshSig$||function(){return function(t){return t}};})();';
+
+/**
+ * react-refresh 런타임 소스를 글로벌 바인딩 + injectIntoGlobalHook 으로 감싼 preamble 문자열.
+ *  - react-refresh 설치됨 → 실제 preamble.
+ *  - react 는 있으나 react-refresh 없음 → noop + 설치 경고(=React 앱인데 FR 못 켬).
+ *  - react 도 없음 → `null`(비-React 앱 — 호출자가 주입/서빙 스킵, 경고 없음).
+ * @param rootDir 앱 루트(여기 node_modules 기준으로 resolve).
+ */
+export function buildReactRefreshPreamble(rootDir: string): string | null {
+  // createRequire 는 절대 경로 필요 — caller 가 상대 경로(예: `zntc dev ./app`)를 줘도 안전하게.
+  const req = createRequire(resolve(rootDir, '__zntc_resolve__.js'));
+  let runtimeSource: string;
+  try {
+    // runtime.js 는 보통 `require('./cjs/...development.js')` 디스패처. 그 dev cjs 본문을
+    // 직접 읽어 서빙한다(디스패처 자체는 process.env + require 라 브라우저에서 안 돈다).
+    const runtimeJsPath = req.resolve('react-refresh/runtime');
+    const pkgDir = dirname(runtimeJsPath);
+    const dispatcher = readFileSync(runtimeJsPath, 'utf8');
+    const m = dispatcher.match(/require\((['"])(\.[^'"]*development[^'"]*)\1\)/);
+    if (m) {
+      // path-traversal 가드: 추출 경로는 react-refresh 패키지 디렉토리 안이어야 한다
+      // (악성/손상 dep 가 `require('../../../etc/passwd')` 로 임의 파일을 서빙하는 것 차단).
+      const cjsPath = resolve(pkgDir, m[2]);
+      if (cjsPath !== pkgDir && !cjsPath.startsWith(pkgDir + sep)) return NOOP_PREAMBLE;
+      runtimeSource = readFileSync(cjsPath, 'utf8');
+    } else if (!/\brequire\s*\(/.test(dispatcher)) {
+      // 디스패처가 아니라 self-contained 런타임 본문(require 없음) — 그대로 사용(옛 버전).
+      runtimeSource = dispatcher;
+    } else {
+      // require 가 있으나 dev cjs 경로를 못 풀음 → 브라우저에서 ReferenceError 나므로 서빙 안 함.
+      return NOOP_PREAMBLE;
+    }
+  } catch {
+    try {
+      req.resolve('react');
+    } catch {
+      return null; // react 도 없음 = 비-React 앱. 조용히 스킵.
+    }
+    return NOOP_PREAMBLE; // React 앱인데 react-refresh 미설치 → 설치 안내.
+  }
+
+  // CJS shim + process 셰도우(dev cjs 의 `if(process.env.NODE_ENV!=="production")` 가드 통과).
+  return (
+    '(function(){\n' +
+    'var process={env:{NODE_ENV:"development"}};\n' +
+    'var exports={};var module={exports:exports};\n' +
+    runtimeSource +
+    '\nvar rt=module.exports;\n' +
+    'var g=typeof globalThis!=="undefined"?globalThis:window;\n' +
+    'g.__ReactRefresh=rt;g.__REACT_REFRESH_RUNTIME__=rt;\n' +
+    'if(rt&&typeof rt.injectIntoGlobalHook==="function")rt.injectIntoGlobalHook(g);\n' +
+    'g.$RefreshReg$=function(){};\n' +
+    'g.$RefreshSig$=function(){return function(t){return t}};\n' +
+    'g.__zntc_react_refresh_preamble__=true;\n' +
+    '})();'
+  );
+}

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1687,12 +1687,18 @@ pub const Bundler = struct {
             // 게이트 emit_opts.code_splitting=true 로 production init 유지, issue #4038 회피).
             // RFC_LAZY_DEV_MODULE_HMR PR-2: setDevId 로 dev_id 를 채워 finalize wrap-all + 청크
             // 등록 prelude(chunks.zig)가 모듈을 글로벌 __zntc_modules 에 per-module 등록 →
-            // cross-chunk hot-replace 의 *레지스트리 substrate* 완성. react_refresh/`__zntc_make_hot`
-            // accept 주입(=hot-replace 의 accept 콜백)과 dev 서버 모듈 transport 는 후속 PR 범위라
-            // 여기선 react_refresh 미전파(현 동작=apply_update 가 accept 없으면 full-reload). sourcemap 은 dev on.
+            // cross-chunk hot-replace 의 *레지스트리 substrate* 완성. sourcemap 은 dev on.
             if (dev_split) {
                 emit_opts.dev_mode = true;
                 emit_opts.sourcemap.enable = true;
+                // RFC_LAZY_DEV_MODULE_HMR PR-5: react_refresh 전파(단일번들 경로 1628 과 동일).
+                // dev_split 도 wrap-all(.esm)이라 emitModule/esm_wrap 의 Fast Refresh 경로
+                // (esm_wrap:960 has_refresh save/restore = 실제 $RefreshReg$ 바인딩 + emitter:1996
+                // `__zntc_make_hot(id).accept()` 주입)가 게이트(`dev_mode and react_refresh`,
+                // !code_splitting 아님)를 그대로 만족 → split 청크 컴포넌트가 Fast Refresh accept 를
+                // 받아 hot-replace 시 리로드 대신 state 보존. $RefreshReg$/__zntc_make_hot/
+                // __zntc_resolveRefresh 는 entry HMR_RUNTIME 가 글로벌 노출 → cross-chunk 동작.
+                emit_opts.react_refresh = self.options.react_refresh;
                 // RFC_LAZY_DEV_MODULE_HMR PR-1: emitChunks 가 per-module HMR code 를
                 // 수집하도록 collect_module_codes 전파(단일번들 경로와 동일 게이트).
                 emit_opts.collect_module_codes = self.options.collect_module_codes;

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1188,6 +1188,11 @@ pub fn wrapDevModuleCode(
     }
     return std.mem.concat(allocator, u8, &.{
         "(function(){\n",
+        // HMR update 는 (0,eval) 로 *글로벌 스코프* 에서 평가된다. 번들이 ESM(`type="module"`)
+        // 이면 번들의 `var __zntc_g` 가 모듈-로컬이라 eval 스코프에서 안 보인다 → 아래 alias 와
+        // 컴포넌트 FR save/restore 의 `__zntc_g.X` 가 ReferenceError → reload fallback. self-contained
+        // 하게 __zntc_g 를 여기서 globalThis 로 재결정한다(IIFE 번들이면 동일 globalThis 라 무해).
+        "var __zntc_g=typeof globalThis!==\"undefined\"?globalThis:typeof global!==\"undefined\"?global:typeof window!==\"undefined\"?window:this;\n",
         "var __esm=__zntc_g.__esm,__export=__zntc_g.__export,__commonJS=__zntc_g.__commonJS,",
         "__defProp=__zntc_g.__defProp,__toESM=__zntc_g.__toESM,__toCommonJS=__zntc_g.__toCommonJS,",
         "__zntc_modules=__zntc_g.__zntc_modules,__zntc_make_hot=__zntc_g.__zntc_make_hot,",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -13,6 +13,8 @@
     "@rspack/cli": "2.0.1",
     "@rspack/core": "2.0.1",
     "@zntc/test-helpers": "workspace:*",
-    "react": "19.2.4"
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "react-refresh": "0.18.0"
   }
 }

--- a/tests/e2e/tests/ports.ts
+++ b/tests/e2e/tests/ports.ts
@@ -26,4 +26,5 @@ export const PORTS = {
   DEV_JSX: 3984,
   BUILD_JSX: 3983,
   EXAMPLE_WEB_SMOKE: 3981,
+  REACT_FAST_REFRESH: 3980,
 } as const;

--- a/tests/e2e/tests/react-fast-refresh-e2e.test.ts
+++ b/tests/e2e/tests/react-fast-refresh-e2e.test.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { waitForServer } from '@zntc/test-helpers';
+import { PORTS } from './ports';
+
+// React Fast Refresh (web native `zntc dev`) — RFC_LAZY_DEV_MODULE_HMR §5 수용 기준의
+// 메인-번들 버전. 컴포넌트 파일 편집 → (a) 변경 반영 (b) **페이지 리로드 없이**(window
+// marker 생존) (c) **컴포넌트 state 보존**(카운터 값 유지). dev 서버가 react-refresh 런타임
+// preamble 을 앱보다 먼저 주입(injectIntoGlobalHook)하고, 번들러가 컴포넌트에 $RefreshReg$ +
+// `__zntc_make_hot(id).accept(boundary)` 를 emit 한 뒤, watch rebuild → module update broadcast
+// → __zntc_apply_update → performReactRefresh 로 state 를 보존한 채 재렌더한다.
+//
+// fixture 는 tests/e2e 하위에 만들어 react/react-dom/react-refresh 가 tests/e2e/node_modules
+// 로 resolve 되게 한다(tmp /tmp 면 resolve 실패).
+
+const ZNTC_JS_CLI = resolve(__dirname, '../../../packages/core/bin/zntc.mjs');
+const PORT = PORTS.REACT_FAST_REFRESH;
+
+// classic JSX(React.createElement) + 명시 `import * as React` — automatic JSX runtime
+// import 의 dev-mode 바인딩 이슈와 무관하게 Fast Refresh 자체를 가드한다.
+const APP_V1 =
+  "import * as React from 'react';\n" +
+  'export function App() {\n' +
+  '  const [n, setN] = React.useState(0);\n' +
+  '  return (\n' +
+  '    <div>\n' +
+  '      <span data-testid="ver">COUNTER_V1</span>\n' +
+  '      <span data-testid="count">{n}</span>\n' +
+  '      <button data-testid="inc" onClick={() => setN((x) => x + 1)}>inc</button>\n' +
+  '    </div>\n' +
+  '  );\n' +
+  '}\n';
+
+const FILES: Record<string, string> = {
+  'index.html':
+    '<!doctype html><html><head><meta charset="utf-8"/><title>RFR</title></head>' +
+    '<body><div id="root">loading</div>' +
+    '<script type="module" src="/src/main.tsx"></script></body></html>',
+  'src/main.tsx':
+    "import * as React from 'react';\n" +
+    "import { createRoot } from 'react-dom/client';\n" +
+    "import { App } from './App';\n" +
+    "createRoot(document.getElementById('root')).render(<App />);\n",
+  'src/App.tsx': APP_V1,
+};
+
+test.describe.serial('React Fast Refresh (web native zntc dev)', () => {
+  let dir: string;
+  let server: ChildProcess | null = null;
+
+  test.beforeAll(async () => {
+    // tests/e2e 하위에 fixture 생성 → node_modules resolution 이 tests/e2e/node_modules 도달.
+    dir = await mkdtemp(join(__dirname, '..', 'rfr-fixture-'));
+    for (const [name, content] of Object.entries(FILES)) {
+      const fp = join(dir, name);
+      await mkdir(join(fp, '..'), { recursive: true });
+      await writeFile(fp, content);
+    }
+    server = spawn('bun', [ZNTC_JS_CLI, 'dev', dir, '--port', String(PORT)], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    await waitForServer(PORT);
+  });
+
+  test.afterAll(async () => {
+    server?.kill();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  test('preamble 이 앱보다 먼저 주입되고 react-refresh 런타임을 글로벌에 노출', async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${PORT}/`);
+    await expect(page.getByTestId('ver')).toHaveText('COUNTER_V1', { timeout: 15000 });
+    // preamble 이 injectIntoGlobalHook + __ReactRefresh 를 깔았다.
+    const installed = await page.evaluate(
+      () =>
+        (window as { __zntc_react_refresh_preamble__?: boolean })
+          .__zntc_react_refresh_preamble__ === true &&
+        typeof (window as { __ReactRefresh?: unknown }).__ReactRefresh === 'object',
+    );
+    expect(installed).toBe(true);
+  });
+
+  test('컴포넌트 편집 → 리로드 없이 반영 + 카운터 state 보존', async ({ page }) => {
+    await page.goto(`http://localhost:${PORT}/`);
+    await expect(page.getByTestId('ver')).toHaveText('COUNTER_V1', { timeout: 15000 });
+
+    // state 를 올린다(카운터 → 2).
+    await page.getByTestId('inc').click();
+    await page.getByTestId('inc').click();
+    await expect(page.getByTestId('count')).toHaveText('2');
+
+    // 리로드 시 사라지는 window marker.
+    await page.evaluate(() => ((window as { __rfMarker?: string }).__rfMarker = 'KEEP_ME'));
+
+    // 컴포넌트 본문만 편집(hook signature 동일 → Fast Refresh 가 state 보존).
+    writeFileSync(join(dir, 'src/App.tsx'), APP_V1.replace('COUNTER_V1', 'COUNTER_V2'));
+
+    // (a) 변경 반영.
+    await expect(page.getByTestId('ver')).toHaveText('COUNTER_V2', { timeout: 15000 });
+    // (b) 리로드 없음(marker 생존) + (c) state 보존(카운터 여전히 2).
+    expect(await page.evaluate(() => (window as { __rfMarker?: string }).__rfMarker)).toBe(
+      'KEEP_ME',
+    );
+    await expect(page.getByTestId('count')).toHaveText('2');
+  });
+});

--- a/tests/integration/tests/napi-lazy-dev-hmr.test.ts
+++ b/tests/integration/tests/napi-lazy-dev-hmr.test.ts
@@ -126,4 +126,64 @@ process.stdout.write(JSON.stringify({
     expect(res.hotNew).toBe('HOT_OK');
     expect(res.statePreserved).toBe(true);
   });
+
+  // RFC_LAZY_DEV_MODULE_HMR PR-5: dev_split 에 react_refresh 전파 → split 청크의 React
+  // 컴포넌트가 Fast Refresh 와이어링(실제 $RefreshReg$ 바인딩 + `__zntc_make_hot(id).accept()`)
+  // 을 받는다. 이게 "리로드 없이 state 보존"의 emit-side 조각. 컴포넌트를 *별도 청크*
+  // (2 entry 가 정적 공유)에 두어 cross-chunk(비-entry 청크) Fast Refresh 를 가드한다.
+  // (브라우저에서의 실제 state 보존 e2e = 에픽 capstone, 별도.)
+  test('split 청크 React 컴포넌트가 Fast Refresh accept + 실제 $RefreshReg$ 바인딩을 받는다', async () => {
+    const fixture = await createFixture({
+      // classic JSX → React.createElement (jsx-runtime 불요, react stub 의 createElement 사용).
+      'node_modules/react/package.json': '{"name":"react","main":"index.js"}',
+      'node_modules/react/index.js':
+        'exports.useState=function(i){return [i,function(){}]};exports.createElement=function(){return {}};module.exports.default=exports;',
+      'Counter.tsx':
+        "import * as React from 'react';\n" +
+        'export function Counter(){ const [n]=React.useState(0); return React.createElement("div",null,String(n)); }',
+      'a.tsx': "import { Counter } from './Counter';\nglobalThis.__A = typeof Counter;",
+      'b.tsx': "import { Counter } from './Counter';\nglobalThis.__B = typeof Counter;",
+    });
+    cleanup = fixture.cleanup;
+    const dir = realpathSync(fixture.dir);
+
+    const r = await build({
+      entryPoints: [join(dir, 'a.tsx'), join(dir, 'b.tsx')],
+      platform: 'browser',
+      devMode: true,
+      splitting: true,
+      format: 'iife',
+      lazyCompilation: true,
+      rootDir: dir,
+      reactRefresh: true,
+      jsx: 'classic',
+    });
+    expect(r.errors ?? []).toHaveLength(0);
+    const outs = (r.outputFiles ?? []).map((o) => ({ path: basename(o.path), text: o.text }));
+
+    // Counter 는 2 entry 가 정적 공유 → 별도 chunk-*.js (비-entry).
+    const shared = outs.find(
+      (o) => o.path.startsWith('chunk-') && o.text.includes('function Counter'),
+    );
+    expect(shared).toBeDefined();
+    const entries = outs.filter((o) => o.path === 'a.js' || o.path === 'b.js');
+    expect(entries.length).toBe(2);
+
+    const t = shared!.text;
+    // 컴포넌트 등록 (transform-level — react_refresh 없이도 나오나 함께 가드).
+    expect(t.includes('$RefreshReg$(')).toBe(true);
+    // PR-5 핵심 1 — Fast Refresh accept 주입 (이게 있어야 apply_update 가 리로드 대신 hot-replace).
+    expect(/__zntc_make_hot\([^)]*\)\.accept\(/.test(t)).toBe(true);
+    // PR-5 핵심 2 — 실제 $RefreshReg$ 바인딩 save/restore (no-op 글로벌이 아닌 react-refresh register).
+    expect(t.includes('__prevRefreshReg')).toBe(true);
+    // cross-chunk: 비-entry 청크라 $RefreshReg$/resolveRefresh 를 글로벌(__zntc_g/entry 노출)로 해석.
+    expect(t.includes('__zntc_g.$RefreshReg$')).toBe(true);
+    expect(t.includes('__zntc_resolveRefresh()')).toBe(true);
+
+    // entry 청크엔 컴포넌트가 없으므로 그 reg/accept 가 새지 않는다.
+    for (const e of entries) {
+      expect(e.text.includes('function Counter')).toBe(false);
+      expect(/__zntc_make_hot\(["'][^"']*Counter[^"']*["']\)\.accept\(/.test(e.text)).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
## 무엇을 / 왜

`zntc dev`(네이티브 JS 웹 dev 서버)가 **React Fast Refresh** 를 end-to-end 로 지원한다. 컴포넌트 파일을 편집하면 (a) 변경이 화면에 반영되고 (b) **페이지 리로드 없이** (c) **컴포넌트 state(예: 카운터)가 보존**된다. = [RFC_LAZY_DEV_MODULE_HMR](../blob/main/docs/RFC_LAZY_DEV_MODULE_HMR.md) §5 수용 기준의 메인-번들 버전.

### 배경
번들러는 **이미** 컴포넌트에 `$RefreshReg$` save/restore + `__zntc_make_hot(id).accept(boundary)` 를 emit 하고(`esm_wrap.zig`), HMR 런타임에 boundary 판정(`__zntc_isReactRefreshBoundary`) + `performReactRefresh`(`__zntc_enqueueUpdate`)가 있었다. 그러나 웹에서 실제로 동작하려면 **빠진 2조각 + 1버그**가 있었다:
1. react-refresh **런타임이 브라우저에 노출**되지 않음 + `injectIntoGlobalHook(window)` 미호출(reconciler 패치 안 됨).
2. 웹 dev 에서 **reactRefresh 가 꺼져** 있음.
3. (HMR 버그) HMR update payload 가 `(0,eval)` 글로벌 스코프에서 `__zntc_g.X` 를 참조하는데 ESM(`type="module"`) 번들에선 `__zntc_g` 가 모듈-로컬이라 `ReferenceError` → 풀리로드.

## 변경 (Zig 초보자 설명 포함)

**브라우저 런타임 노출 (packages/web, packages/server, zntc.mjs)**
- `buildReactRefreshPreamble(rootDir)`(신규, TS): react-refresh/runtime 의 dev cjs 본문을 읽어 글로벌 `__ReactRefresh` 로 노출 + `injectIntoGlobalHook(window)` 를 호출하는 classic `<script>` preamble 문자열을 만든다. Vite 의 `/@react-refresh` 와 동치. react 미설치=`null`(비-React 앱 스킵), react 만=noop+설치경고. **path-traversal 가드**(추출 경로가 패키지 디렉토리 밖이면 거부) + 디스패처 못 풀면 noop.
- `injectAppDevReactRefreshPreamble`: `<head>` 여는 태그 *바로 뒤*(첫 자식)에 주입 — classic 스크립트라 파싱 중 동기 실행되어 React 를 import 하는 deferred module 보다 먼저 `injectIntoGlobalHook` 이 끝난다.
- `protocol.ts`: `APP_DEV_REACT_REFRESH_PATH = '/__zntc_react_refresh__'` 가상 엔드포인트.
- `zntc.mjs`: dev 는 reactRefresh 기본 on(비-React 무해, `--no-react-refresh`/`--react-refresh=false` 로 opt-out — `cli-flags.mjs` 에 등록) + `/__zntc_react_refresh__` 서빙(react 설치 시) + dev-controller 가 react 설치 시 매 cycle preamble 재주입.

**번들러 (Zig)**
- `bundler.zig` (RFC PR-5): dev_split(lazy+split)에도 `react_refresh` 전파 → split 청크 컴포넌트도 Fast Refresh 와이어링. `if (A or B)` 게이트에 한 줄 추가하는 식. dev 전용이라 production/단일번들 byte-identical.
- `emitter.zig` (HMR 핵심 fix): HMR update IIFE(`wrapDevModuleCode`) 맨 앞에 `var __zntc_g=globalThis...` 를 self-define. ESM 번들의 모듈-로컬 `__zntc_g` 가 eval 스코프에서 안 보여 나던 `ReferenceError`→풀리로드 를 고친다(= 모듈-포맷 웹 dev HMR 의 사전 잠재 버그; 이게 없으면 state 보존 자체가 안 됨). IIFE 번들엔 무해.

## 테스트
- `react-refresh-preamble.test.ts`(신규): preamble 3케이스(null/noop/real) + 실제 `vm` eval(injectIntoGlobalHook 노출) + 주입 위치(`<head>` 뒤)/멱등.
- `react-fast-refresh-e2e.test.ts`(신규, Playwright): 실 브라우저로 카운터 컴포넌트를 2 증가 → 파일 편집 → **리로드 없이 반영 + 카운터=2 보존 + window marker 생존**. react-dom/react-refresh 를 `tests/e2e` 에 추가.
- `napi-lazy-dev-hmr.test.ts`: split 청크 React 컴포넌트가 Fast Refresh accept + 실제 `$RefreshReg$` 바인딩을 받는지(PR-5).

## 검증
- ✅ **production splitting byte-identical**(diff 없음 — Zig 변경 둘 다 dev-gated)
- ✅ 전체 `zig build test` · napi/wasm/wasm-bundler/test262/schema 빌드
- ✅ web(180)+server(95) 단위 · 통합(napi-lazy-dev-hmr) · **e2e green**(Fast Refresh + state 보존 실증)
- ✅ `--no-react-refresh` opt-out 동작 확인

`/code-review max` 반영: `--react-refresh`/`--no-react-refresh` 플래그 등록(거짓 주석/크래시 수정) · preamble path-traversal 가드 + 디스패처-폴백 noop · `<head>` 기준 robust 주입(주석 내 `<script>` 오매칭 방지) · e2e fixture `.gitignore`.

## 알려진 한계 (별도 follow-up)
- **dev 모드 + automatic JSX**(`react/jsx-runtime` auto-import)의 다중모듈 바인딩 이슈(`_jsx$1 not defined`)는 Fast Refresh 와 무관한 사전 버그. 본 PR 의 e2e/예시는 classic JSX(`import * as React`)로 검증.
- **Zig DevServer**(`src/server/dev_server.zig` `serveReactRefresh`, RN/embed 전용)는 `__REACT_REFRESH_RUNTIME__` 만 세팅하고 `__ReactRefresh` 는 빠뜨려 동일 fix 필요(본 PR 범위 밖, 별도).
- lazy split 청크의 비-boundary(비-React/혼합 export) 모듈 편집은 여전히 module update 가 full-reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)