### PR TITLE
fix(bundler): dev_split 동적 청크가 entry 모듈 export 를 노출 — lazy 라우트 렌더 복구 (#4079 회귀)

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -831,6 +831,13 @@ pub fn emitChunks(
                 // 그 외(eager)는 기존대로 break(emitCjsEntryExports 에 일임).
                 if (graph.lazy_compilation) {
                     try emitLazyEntryExportAll(allocator, &chunk_output, graph, linker, sorted_mods, entry_mod_idx.?, module_count, options.minify_whitespace);
+                    // dev_split(wrap-all) 동적 청크: entry 모듈이 __esm 래핑이라 emitCjsEntryExports
+                    // 를 안 타 entry export 가 청크 exports 에 없다 → `import('./route')` 가 받는
+                    // `__zntc_require` 결과에 entry export(render) 누락(#4079 e2e 회귀). entry 만
+                    // exported_name 키로 추가. user-entry 는 bootstrap(__zntc_require 결과 미소비)라 제외.
+                    if (dev_split_chunk and !chunk_is_user_entry) {
+                        try emitWrappedDynamicEntryExports(allocator, &chunk_output, graph, linker, entry_mod_idx.?, options.minify_whitespace);
+                    }
                 }
                 break :xchunk_exports;
             }
@@ -2055,6 +2062,49 @@ fn emitLazyEntryExportAll(
     for (locals.items) |local| {
         try out.appendSlice(allocator, "exports.");
         try out.appendSlice(allocator, local);
+        try out.appendSlice(allocator, if (minify_whitespace) "=" else " = ");
+        try out.appendSlice(allocator, local);
+        try out.appendSlice(allocator, if (minify_whitespace) ";" else ";\n");
+    }
+}
+
+/// dev_split(wrap-all) 동적 청크의 entry 모듈(=`import()` 타겟) export 를 청크 `exports` 에
+/// **exported_name 키**로 노출한다. RFC_LAZY_DEV_MODULE_HMR PR-2 wrap-all 이후, 동적 청크의
+/// entry 모듈이 `__esm` 래핑되어 emitModule 의 emitCjsEntryExports 경로(emitter.zig:2136, CJS/
+/// iife_split factory 한정)를 안 탄다 → `__zntc_require("<chunk>")`(= `import('./route')` 결과)
+/// 에 entry export(예: `render`)가 없어 `m.render is not a function` (#4079 e2e 회귀). emitLazy-
+/// EntryExportAll 은 entry 를 *제외*(소비자가 local-name 으로 참조하는 hoisted dep 용)하므로 여기서
+/// entry 만 별도로, 소비자 `import().x` 가 쓰는 exported_name 키로 깐다.
+///
+/// ⚠️ **`.local` export 만** 처리한다(`export function`/`export const`/`export default <local>` —
+/// 동적 route 의 대다수). re-export 류는 제외:
+///   - `export * as ns`(re_export_namespace): 청크에 `ns` 바인딩이 없어(`exports_<dep>` 네임스페이스
+///     뿐) `exports.ns = ns` 면 ReferenceError(crash). 제외해 crash 회피.
+///   - `export { x } from './dep'`(re_export): getCanonicalName 이 entry-local 아님→null →
+///     `local_name` fallback 이 *소스* 로컬명이라 deconflict 후 다른 모듈에 묶일 수 있음(오바인딩).
+///   - `export * from`(re_export_star): 단일 이름 `*` 없음.
+/// re-export 정확 해석(export-chain → 청크-로컬명)은 후속(현재 미노출 = crash/오바인딩보다 안전).
+fn emitWrappedDynamicEntryExports(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayList(u8),
+    graph: *const ModuleGraph,
+    linker: ?*Linker,
+    entry_mod_idx: usize,
+    minify_whitespace: bool,
+) !void {
+    const l = linker orelse return;
+    const m = graph.getModule(ModuleIndex.fromUsize(entry_mod_idx)) orelse return;
+    var seen: std.StringHashMapUnmanaged(void) = .empty;
+    defer seen.deinit(allocator);
+    for (m.export_bindings) |eb| {
+        // 직접 로컬 export 만(re-export 는 정확 해석 복잡 + fallback 오바인딩/crash 위험 → 제외).
+        if (eb.kind != .local or eb.exported_name.len == 0) continue;
+        const local = l.getCanonicalName(@intCast(entry_mod_idx), eb.exported_name) orelse m.exportBindingLocalName(eb);
+        if (local.len == 0) continue;
+        const gop = try seen.getOrPut(allocator, eb.exported_name);
+        if (gop.found_existing) continue;
+        try out.appendSlice(allocator, "exports.");
+        try out.appendSlice(allocator, eb.exported_name);
         try out.appendSlice(allocator, if (minify_whitespace) "=" else " = ");
         try out.appendSlice(allocator, local);
         try out.appendSlice(allocator, if (minify_whitespace) ";" else ";\n");

--- a/tests/integration/tests/napi-lazy-dev-hmr.test.ts
+++ b/tests/integration/tests/napi-lazy-dev-hmr.test.ts
@@ -186,4 +186,76 @@ process.stdout.write(JSON.stringify({
       expect(/__zntc_make_hot\(["'][^"']*Counter[^"']*["']\)\.accept\(/.test(e.text)).toBe(false);
     }
   });
+
+  // #4079 회귀: dev_split wrap-all 이후 동적 청크의 entry 모듈이 __esm 래핑되어
+  // emitCjsEntryExports 경로를 안 타 → `__zntc_require("<chunk>")`(= `import('./route')`
+  // 결과)에 entry export(render)가 없어 `m.render is not a function` → lazy 라우트가 렌더 안 됨.
+  // 동적 청크가 entry 모듈 export 를 exported_name 키로 노출하는지 가드.
+  test('dev_split 동적 청크가 entry 모듈 export 를 노출 (import() 가 render 받음, #4079 회귀)', async () => {
+    const fixture = await createFixture({
+      'util.ts': "export function fmt(s: string){ return 'UTIL[' + s + ']'; }",
+      'Chart.ts': "import { fmt } from './util';\nexport function chart(){ return fmt('chart'); }",
+      'route.ts': "import { chart } from './Chart';\nexport function render(){ return chart(); }",
+      'entry.ts':
+        "async function go(){ const m = await import('./route'); globalThis.__OUT = m.render(); }\ngo();",
+    });
+    cleanup = fixture.cleanup;
+    const dir = realpathSync(fixture.dir);
+    const opts = {
+      entryPoints: [join(dir, 'entry.ts')],
+      platform: 'browser' as const,
+      devMode: true,
+      splitting: true,
+      format: 'iife' as const,
+      lazyCompilation: true,
+      rootDir: dir,
+    };
+    // 1) base 빌드 → route 가 동적 import 타겟이라 lazy seed.
+    const base = await build(opts);
+    expect(base.errors ?? []).toHaveLength(0);
+    const seed = (base.lazySeeds ?? []).find((s) => s.path.endsWith('route.ts'));
+    expect(seed).toBeDefined();
+    // 2) force-parse(= dev 서버 materialize 동치) → route 가 정식 청크로 emit.
+    const r = await build({ ...opts, lazyForceParse: [seed!.path] });
+    expect(r.errors ?? []).toHaveLength(0);
+    const routeChunk = (r.outputFiles ?? []).find(
+      (o) => o.path.includes('route-') && o.text.includes('function render'),
+    );
+    expect(routeChunk).toBeDefined();
+    // 핵심 가드: 동적 청크가 entry 모듈 export 를 exported_name 키로 노출 → import().render 동작.
+    expect(routeChunk!.text.includes('exports.render')).toBe(true);
+  });
+
+  // /code-review max: entry 모듈이 `export * as ns`(re_export_namespace)를 섞어도 `exports.ns = ns`
+  // (청크에 없는 바인딩) 를 emit 해 ReferenceError(crash) 나면 안 된다. re-export 류는 제외하고
+  // .local export(render)만 노출하는지 가드(crash 회피 + 유효 JS).
+  test('동적 청크 entry 가 re_export_namespace 섞어도 crash 패턴 없이 .local export 만 노출', async () => {
+    const fixture = await createFixture({
+      'dep.ts': 'export const a = 1;\nexport const b = 2;',
+      'route.ts': "export * as ns from './dep';\nexport function render(){ return 'R'; }",
+      'entry.ts':
+        "async function go(){ const m = await import('./route'); globalThis.__OUT = m.render(); }\ngo();",
+    });
+    cleanup = fixture.cleanup;
+    const dir = realpathSync(fixture.dir);
+    const opts = {
+      entryPoints: [join(dir, 'entry.ts')],
+      platform: 'browser' as const,
+      devMode: true,
+      splitting: true,
+      format: 'iife' as const,
+      lazyCompilation: true,
+      rootDir: dir,
+    };
+    const base = await build(opts);
+    const seed = (base.lazySeeds ?? []).find((s) => s.path.endsWith('route.ts'));
+    expect(seed).toBeDefined();
+    const r = await build({ ...opts, lazyForceParse: [seed!.path] });
+    expect(r.errors ?? []).toHaveLength(0);
+    const routeChunk = (r.outputFiles ?? []).find((o) => o.path.includes('route-'));
+    expect(routeChunk).toBeDefined();
+    expect(routeChunk!.text.includes('exports.render')).toBe(true); // .local 은 노출
+    // crash 패턴(`exports.ns = ns;` — ns 바인딩 없음) 부재.
+    expect(/exports\.ns\s*=\s*ns;/.test(routeChunk!.text)).toBe(false);
+  });
 });


### PR DESCRIPTION
## 증상
`zntc dev --lazy` 로 lazy 라우트(`import('./route')`)를 방문하면 브라우저가 `m.render is not a function` 으로 렌더되지 않음 → **lazy-dev-materialize-e2e (#4079) CI 실패**.

## 근본 원인 (RFC_LAZY_DEV_MODULE_HMR PR-2 #4088 회귀)
PR-2 의 dev_split wrap-all 이후, **동적 import 타겟 청크의 entry 모듈(route.ts)이 `__esm` 로 래핑**되면서 `emitModule` 의 `emitCjsEntryExports` 경로(emitter.zig:2136 — CJS/iife_split factory 한정)를 더 이상 타지 않게 됐다. 그 결과 동적 청크의 `exports` 객체에 entry 모듈의 export(`render`)가 깔리지 않음:
- `import('./route')` 는 `__zntc_load_chunk(...).then(()=>__zntc_require("route.js"))` 로 lowering 됨.
- `__zntc_require("route.js")` 는 청크 factory 의 `exports` 를 반환하는데, 거기엔 `exports.chart`/`exports.fmt$1`(hoisted dep, `emitLazyEntryExportAll`)만 있고 **`exports.render` 가 없음**.
- `emitLazyEntryExportAll` 은 entry 모듈을 *제외*한다("emitCjsEntryExports 담당" 전제) — user-entry 청크는 bootstrap 이라 무해했지만, **동적 청크는 그 entry 가 곧 `import()` 결과**라 entry export 가 필수.

## 수정
`emitWrappedDynamicEntryExports` 추가 — dev_split(wrap-all) 동적 청크(`dev_split_chunk and !chunk_is_user_entry`)에 entry 모듈의 export 를 **exported_name 키**(소비자 `import().x` 접근)로 노출. user-entry 는 미소비라 제외. production/non-lazy 무영향(게이트가 dev_split 한정 → byte-identical).

`/code-review max` 반영(엣지 crash/오바인딩 회피): **`.local` export 만 처리**(`export function`/`export const`/`export default <local>` — 동적 route 대다수). re-export 류 제외 — `export * as ns`(re_export_namespace)는 청크에 `ns` 바인딩이 없어 `exports.ns = ns` 가 ReferenceError(crash)를, `export { x } from`(re_export)는 잘못된 local fallback 으로 오바인딩을 유발하므로. re-export 정확 해석(export-chain)은 후속(현재 미노출 = crash/오바인딩보다 안전).

## 테스트
- napi-lazy-dev-hmr.test.ts: (a) force-parse 한 동적 청크에 `exports.render` 존재 (b) `export * as ns` 섞여도 crash 패턴(`exports.ns = ns`) 부재 + .local 노출.
- **lazy-dev-materialize-e2e #4079 green 복구**(2 passed).

## 검증
production splitting **byte-identical** · 전체 zig build test · napi/wasm/wasm-bundler/test262/schema 빌드 · React Fast Refresh e2e 무회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)