### PR TITLE
fix(bundler): dev wrap-all 에서 겹치는 helper import(jsx-runtime)의 hoisted 선언을 canonical 명으로 (automatic JSX dev)

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -371,7 +371,11 @@ pub fn emitEsmWrappedModule(
     // 선언하고 init 안에서 `_jsxDEV = ...` (할당만) 으로 처리.
     for (module.import_bindings) |ib| {
         if (ib.is_helper) {
-            try hoisted_var_names.append(allocator, try arena_alloc.dupe(u8, module.importBindingLocalName(ib)));
+            const hoist_name = if (linker) |l|
+                l.getCanonicalByRef(ib.local_symbol) orelse module.importBindingLocalName(ib)
+            else
+                module.importBindingLocalName(ib);
+            try hoisted_var_names.append(allocator, try arena_alloc.dupe(u8, hoist_name));
         }
     }
 

--- a/tests/e2e/tests/react-fast-refresh-e2e.test.ts
+++ b/tests/e2e/tests/react-fast-refresh-e2e.test.ts
@@ -19,12 +19,13 @@ import { PORTS } from './ports';
 const ZNTC_JS_CLI = resolve(__dirname, '../../../packages/core/bin/zntc.mjs');
 const PORT = PORTS.REACT_FAST_REFRESH;
 
-// classic JSX(React.createElement) + 명시 `import * as React` — automatic JSX runtime
-// import 의 dev-mode 바인딩 이슈와 무관하게 Fast Refresh 자체를 가드한다.
+// automatic JSX(`--jsx=automatic-dev`, React import 불요) — `zntc dev` 의 실 사용 형태.
+// 다중모듈 jsx-runtime helper(_jsxDEV) 바인딩까지 end-to-end 로 가드(dev wrap-all 의 helper
+// hoist canonical-name 회귀 = napi-dev-jsx-binding.test.ts 의 브라우저 버전).
 const APP_V1 =
-  "import * as React from 'react';\n" +
+  "import { useState } from 'react';\n" +
   'export function App() {\n' +
-  '  const [n, setN] = React.useState(0);\n' +
+  '  const [n, setN] = useState(0);\n' +
   '  return (\n' +
   '    <div>\n' +
   '      <span data-testid="ver">COUNTER_V1</span>\n' +
@@ -40,7 +41,6 @@ const FILES: Record<string, string> = {
     '<body><div id="root">loading</div>' +
     '<script type="module" src="/src/main.tsx"></script></body></html>',
   'src/main.tsx':
-    "import * as React from 'react';\n" +
     "import { createRoot } from 'react-dom/client';\n" +
     "import { App } from './App';\n" +
     "createRoot(document.getElementById('root')).render(<App />);\n",
@@ -59,9 +59,13 @@ test.describe.serial('React Fast Refresh (web native zntc dev)', () => {
       await mkdir(join(fp, '..'), { recursive: true });
       await writeFile(fp, content);
     }
-    server = spawn('bun', [ZNTC_JS_CLI, 'dev', dir, '--port', String(PORT)], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    server = spawn(
+      'bun',
+      [ZNTC_JS_CLI, 'dev', dir, '--port', String(PORT), '--jsx=automatic-dev'],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
     await waitForServer(PORT);
   });
 

--- a/tests/integration/tests/napi-dev-jsx-binding.test.ts
+++ b/tests/integration/tests/napi-dev-jsx-binding.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { realpathSync } from 'node:fs';
+import { createFixture } from './helpers';
+import { init, close, build } from '../../../packages/core/index';
+
+// dev + automatic JSX 다중모듈 바인딩 회귀: dev wrap-all(__esm) 에서 helper import(jsx-runtime
+// 의 `_jsx`/`_jsxs`/`_jsxDEV`)가 여러 모듈에 겹치면 deconflict 가 두 번째 모듈의 심볼을
+// `_jsx$1` 로 rename 한다. 참조/할당(`_jsx$1 = require(...)`, `_jsx$1(...)`)은 canonical 명을
+// 썼으나, hoisted **선언**(`var _jsx;`)이 *원본* 명을 써서 `_jsx$1` 이 선언 없이 쓰여
+// `ReferenceError: _jsx$1 is not defined` → 브라우저에서 앱이 렌더 안 됨. (esm_wrap.zig 의
+// helper hoist 가 getCanonicalByRef 로 canonical 명을 쓰도록 수정.)
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// `var X;` / `var X, Y;` / `var A, X;` / `var X, Y, Z;` 등 콤마-리스트 선언에서도 X 가
+// *선언*됐는지 본다(emitter 가 같은 모듈의 helper 들을 한 `var` 로 묶을 수 있음).
+function isDeclared(out: string, name: string): boolean {
+  return new RegExp(`(?:\\bvar\\s+|,\\s*)${escapeRe(name)}\\s*[;,=]`).test(out);
+}
+
+describe('NAPI dev automatic-JSX helper binding (multi-module)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  // jsx:'automatic'(_jsx/_jsxs) 와 'automatic-dev'(_jsxDEV) 둘 다 가드 — `zntc dev` 기본은
+  // automatic-dev 라 후자가 실사용 경로.
+  test.each([
+    { jsx: 'automatic' as const, runtimeFile: 'jsx-runtime.js', helper: '_jsx' },
+    { jsx: 'automatic-dev' as const, runtimeFile: 'jsx-dev-runtime.js', helper: '_jsxDEV' },
+  ])(
+    'jsx=$jsx: 겹치는 jsx helper 의 hoisted 선언이 canonical(rename) 명과 일치 — 미선언 없음',
+    async ({ jsx, runtimeFile, helper }) => {
+      // 두 모듈이 모두 같은 helper 를 써서 collision → 한쪽은 `$1` 로 rename.
+      const fixture = await createFixture({
+        'node_modules/react/package.json': '{"name":"react","version":"19.0.0","main":"index.js"}',
+        'node_modules/react/index.js': 'module.exports={};',
+        'node_modules/react/jsx-runtime.js':
+          'exports.jsx=function(){return {}};exports.jsxs=function(){return {}};exports.Fragment={};',
+        'node_modules/react/jsx-dev-runtime.js':
+          'exports.jsxDEV=function(){return {}};exports.Fragment={};',
+        'App.tsx': 'export function App(){ return <div>X</div>; }',
+        'main.tsx':
+          "import { App } from './App';\nexport function render(){ return <App />; }\nrender();",
+      });
+      cleanup = fixture.cleanup;
+      void runtimeFile;
+      const dir = realpathSync(fixture.dir);
+
+      const r = await build({
+        entryPoints: [join(dir, 'main.tsx')],
+        platform: 'browser',
+        devMode: true, // wrap-all(__esm) — collision + hoisted 선언 경로
+        format: 'iife',
+        jsx,
+      });
+      expect(r.errors ?? []).toHaveLength(0);
+      const out = r.outputFiles!.map((o) => o.text).join('\n');
+
+      // collision 으로 rename 된 helper(`<helper>$N`)가 실제로 emit 됐다(가드 — 미발생이면
+      // 테스트가 의미 없음). 그리고 *모든* rename 식별자는 대응 선언이 있어야 한다(없으면
+      // 그 식별자가 선언 없이 할당/사용돼 ReferenceError = 정확한 버그 형상).
+      const reHelper = new RegExp(`\\b(${escapeRe(helper)}\\$\\d+)\\b`, 'g');
+      const renamed = [...new Set([...out.matchAll(reHelper)].map((m) => m[1]))];
+      expect(renamed.length).toBeGreaterThan(0);
+      for (const name of renamed) {
+        expect(isDeclared(out, name)).toBe(true);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## 증상
`zntc dev` + **automatic JSX** 다중모듈 React 앱이 브라우저에서 `ReferenceError: _jsx$1 is not defined` 로 렌더되지 않음(div 가 `loading` 에서 멈춤).

## 원인
dev wrap-all(`__esm`)에서 JSX automatic 의 helper import(`import { jsx as _jsx } from "react/jsx-runtime"`)가 여러 모듈에 겹치면, deconflict 가 두 번째 모듈의 `_jsx` 심볼을 `_jsx$1` 로 rename 한다. 그런데:
- 참조(`_jsx$1(App)`) + 할당(`_jsx$1 = require("react/jsx-runtime").jsx`)은 canonical 명 사용 ✓
- 하지만 esm_wrap 의 helper hoist 루프(`emitEsmWrappedModule`)가 hoisted **선언**을 `importBindingLocalName`(=*원본* `_jsx`)으로 emit → `var _jsx;` 만 있고 `var _jsx$1;` 가 없음 → `_jsx$1` 이 선언 없이 할당/사용 → ReferenceError.

단일모듈(충돌 없음) · classic JSX(`React.createElement`)는 무사라 지금까지 안 드러났다.

## 수정 (5줄)
```zig
// helper hoist 시 canonical(rename) 명 사용 — 참조/할당과 일치
const hoist_name = if (linker) |l|
    l.getCanonicalByRef(ib.local_symbol) orelse module.importBindingLocalName(ib)
else
    module.importBindingLocalName(ib);
```
helper import 만이 hoist 에서 pre-deconflict 명을 쓰던 유일 경로(비-helper named import 는 이미 `collectImportBindingNames`→`resolveNodeName` 으로 rename 해석). `getCanonicalByRef` 가 invalid/미rename 시 null → 원본명 fallback(기존 동작 보존) → **non-colliding/production byte-identical**.

## 테스트/검증
- **napi-dev-jsx-binding.test.ts**(신규): `automatic`(_jsx/_jsxs) + `automatic-dev`(_jsxDEV, `zntc dev` 기본) 둘 다 — 2모듈 빌드에서 rename 된 helper 가 *모두* 대응 선언(`var X;` / 콤마-리스트 `var X, Y;`)을 갖는지 가드. **fix 전 RED → 후 GREEN**.
- **react-fast-refresh-e2e.test.ts**: fixture 를 **automatic-dev JSX** 로 전환(React import 불요 = `zntc dev` 실 사용 형태) → 풀 React 앱 렌더 + Fast Refresh state 보존을 automatic JSX end-to-end 로 가드(이전엔 classic JSX 로 이 버그를 우회).
- production splitting **byte-identical** · 전체 zig build test · napi/wasm/test262/schema · lazy-dev-hmr(공유 esm_wrap 경로) 무회귀.

`/code-review max`: correctness 무결(production byte-identical, dedup 안전, is_helper 스코핑 정확) 확인. 발견된 테스트 약점(콤마-리스트 assertion, _jsxDEV 미커버, e2e classic JSX) 모두 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)