### PR TITLE
fix(bundler): dev_split 동적 청크가 re-export forwarding(export {x} from)을 네임스페이스 getter로 노출

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -2076,14 +2076,21 @@ fn emitLazyEntryExportAll(
 /// EntryExportAll 은 entry 를 *제외*(소비자가 local-name 으로 참조하는 hoisted dep 용)하므로 여기서
 /// entry 만 별도로, 소비자 `import().x` 가 쓰는 exported_name 키로 깐다.
 ///
-/// ⚠️ **`.local` export 만** 처리한다(`export function`/`export const`/`export default <local>` —
-/// 동적 route 의 대다수). re-export 류는 제외:
-///   - `export * as ns`(re_export_namespace): 청크에 `ns` 바인딩이 없어(`exports_<dep>` 네임스페이스
-///     뿐) `exports.ns = ns` 면 ReferenceError(crash). 제외해 crash 회피.
-///   - `export { x } from './dep'`(re_export): getCanonicalName 이 entry-local 아님→null →
-///     `local_name` fallback 이 *소스* 로컬명이라 deconflict 후 다른 모듈에 묶일 수 있음(오바인딩).
-///   - `export * from`(re_export_star): 단일 이름 `*` 없음.
-/// re-export 정확 해석(export-chain → 청크-로컬명)은 후속(현재 미노출 = crash/오바인딩보다 안전).
+/// 값은 entry 모듈의 **네임스페이스 객체(`exports_<entry>`) getter** 로 가져온다 — `__export`
+/// getter 가 local·`export { x } from`(re_export)·`export * as ns`(re_export_namespace)를 모두
+/// chunk-로컬로 정확 해석하므로, exported_name 키로 `exports.<name> = <ns>.<name>` 만 깔면 된다.
+/// (예전엔 `.local` 만 + local-name 으로 깔아 re-export forwarding 동적 route 의 export 가
+/// 누락됐다.)
+///
+/// 전제: entry 가 **ESM 래핑**(`wrap_kind == .esm`, `var exports_<entry>` 선언)이라는 것.
+/// dev_split 은 `exports_kind.isEsm()` 모듈을 전부 .esm 으로 강제(graph/finalize.zig:124)하므로
+/// **정적 export 를 가진 web dev_split entry 는 항상 .esm** = `exports_<entry>` 보장. 정적
+/// export 가 없는 순수 CJS 는 아래 early-return(`export_bindings.len == 0`)로 빠진다. (RN 의
+/// mixed-module .cjs 동적 entry 만 이 전제 밖 — pre-existing 한계로 별도 추적, 본 함수 범위 외.)
+///
+/// `export * from`(re_export_star)는 단일 이름이 없어 제외 — 이 이름들은 hoisted dep 으로서
+/// emitLazyEntryExportAll 이 dep 의 **local 명**으로 노출한다(re-export 시 rename 된 star export
+/// `export { x as y }` + `export *` 는 `.x` 만 닿고 `.y` 는 못 닿는 §6.3 한계, pre-existing).
 fn emitWrappedDynamicEntryExports(
     allocator: std.mem.Allocator,
     out: *std.ArrayList(u8),
@@ -2094,19 +2101,29 @@ fn emitWrappedDynamicEntryExports(
 ) !void {
     const l = linker orelse return;
     const m = graph.getModule(ModuleIndex.fromUsize(entry_mod_idx)) orelse return;
+    if (m.export_bindings.len == 0) return;
+    // entry 모듈의 네임스페이스 객체(`exports_<entry>`) — `__export` 가 깐 getter 가 local/
+    // re-export/namespace-re-export 를 모두 chunk-로컬로 정확 해석. init 트리거가 위에서 entry
+    // 포함 모든 모듈 init 을 돌려 네임스페이스를 채운 뒤라 스냅샷 값 정확.
+    const ns = try m.allocExportsName(allocator, &l.rename_table);
+    defer allocator.free(ns);
     var seen: std.StringHashMapUnmanaged(void) = .empty;
     defer seen.deinit(allocator);
     for (m.export_bindings) |eb| {
-        // 직접 로컬 export 만(re-export 는 정확 해석 복잡 + fallback 오바인딩/crash 위험 → 제외).
-        if (eb.kind != .local or eb.exported_name.len == 0) continue;
-        const local = l.getCanonicalName(@intCast(entry_mod_idx), eb.exported_name) orelse m.exportBindingLocalName(eb);
-        if (local.len == 0) continue;
+        // `export * from`(re_export_star)는 단일 이름(`*`)뿐 → 스킵. 스프레드 이름은
+        // emitLazyEntryExportAll 이 dep 의 local 명으로 별도 노출(doc-comment §re_export_star 참조).
+        if (eb.kind == .re_export_star or eb.exported_name.len == 0) continue;
         const gop = try seen.getOrPut(allocator, eb.exported_name);
         if (gop.found_existing) continue;
+        // exports.<name> = <ns>.<name> — 네임스페이스 getter 가 local/re-export 정확 해석.
+        // (스냅샷: re-export 된 가변 바인딩이 init 후 재할당돼도 갱신 안 됨 — 라우트엔 사실상
+        //  함수/const 라 무관. 예전 `.local` 도 동일 스냅샷이었고 re-export 는 아예 누락했었다.)
         try out.appendSlice(allocator, "exports.");
         try out.appendSlice(allocator, eb.exported_name);
         try out.appendSlice(allocator, if (minify_whitespace) "=" else " = ");
-        try out.appendSlice(allocator, local);
+        try out.appendSlice(allocator, ns);
+        try out.appendSlice(allocator, ".");
+        try out.appendSlice(allocator, eb.exported_name);
         try out.appendSlice(allocator, if (minify_whitespace) ";" else ";\n");
     }
 }

--- a/tests/integration/tests/napi-lazy-dev-hmr.test.ts
+++ b/tests/integration/tests/napi-lazy-dev-hmr.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
 import { join, basename } from 'node:path';
 import { writeFileSync, realpathSync } from 'node:fs';
+import vm from 'node:vm';
 import { createFixture, writeOutputs, runNode } from './helpers';
 import { init, close, build } from '../../../packages/core/index';
 
@@ -226,10 +227,10 @@ process.stdout.write(JSON.stringify({
     expect(routeChunk!.text.includes('exports.render')).toBe(true);
   });
 
-  // /code-review max: entry 모듈이 `export * as ns`(re_export_namespace)를 섞어도 `exports.ns = ns`
-  // (청크에 없는 바인딩) 를 emit 해 ReferenceError(crash) 나면 안 된다. re-export 류는 제외하고
-  // .local export(render)만 노출하는지 가드(crash 회피 + 유효 JS).
-  test('동적 청크 entry 가 re_export_namespace 섞어도 crash 패턴 없이 .local export 만 노출', async () => {
+  // entry 모듈이 `export * as ns`(re_export_namespace)를 섞으면, 청크에 없는 바인딩으로
+  // `exports.ns = ns`(ReferenceError crash) 를 emit 하면 안 되고, entry 네임스페이스 getter 로
+  // `exports.ns = exports_route.ns`(유효·정확) 를 emit 해야 한다. .local(render) + ns 둘 다 노출.
+  test('동적 청크 entry 의 re_export_namespace 는 네임스페이스 getter 로 노출 (crash 패턴 없음)', async () => {
     const fixture = await createFixture({
       'dep.ts': 'export const a = 1;\nexport const b = 2;',
       'route.ts': "export * as ns from './dep';\nexport function render(){ return 'R'; }",
@@ -254,8 +255,61 @@ process.stdout.write(JSON.stringify({
     expect(r.errors ?? []).toHaveLength(0);
     const routeChunk = (r.outputFiles ?? []).find((o) => o.path.includes('route-'));
     expect(routeChunk).toBeDefined();
-    expect(routeChunk!.text.includes('exports.render')).toBe(true); // .local 은 노출
-    // crash 패턴(`exports.ns = ns;` — ns 바인딩 없음) 부재.
+    expect(routeChunk!.text.includes('exports.render')).toBe(true); // .local 노출
+    // re_export_namespace 도 네임스페이스 getter 로 노출(`exports.ns = exports_route.ns`).
+    expect(/exports\.ns\s*=\s*exports_\w+\.ns;/.test(routeChunk!.text)).toBe(true);
+    // crash 패턴(`exports.ns = ns;` — 청크에 ns 바인딩 없음) 부재.
     expect(/exports\.ns\s*=\s*ns;/.test(routeChunk!.text)).toBe(false);
+  });
+
+  // #4079 후속: `export { default, meta } from './Page'`(re-export forwarding) 동적 route.
+  // 예전 `.local` 만 노출하던 코드는 re-export 를 스킵해 `import('./route').default` 가 undefined →
+  // 라우트 렌더 실패. 이제 entry 네임스페이스 getter(`exports.default = exports_route.default`)로
+  // re-export 체인을 정확히 해석하는지 **런타임**으로 가드(emit 문자열이 아니라 실제 값 검증).
+  test('동적 청크가 re-export forwarding(export {default,meta} from) 을 런타임에 정확히 노출', async () => {
+    const fixture = await createFixture({
+      'Page.ts': "export default function Page(){ return 'PAGE'; }\nexport const meta = 'M';",
+      'route.ts': "export { default, meta } from './Page';",
+      // import() 를 *정의만* 하고 top-level 에서 실행하지 않는다 — route 는 그래도 동적 import
+      // 타겟(seed)이지만, vm 안에서 native import() 폴백으로 비동기 reject 하는 일은 없다.
+      'entry.ts': "globalThis.loadRoute = () => import('./route');",
+    });
+    cleanup = fixture.cleanup;
+    const dir = realpathSync(fixture.dir);
+    const opts = {
+      entryPoints: [join(dir, 'entry.ts')],
+      platform: 'browser' as const,
+      devMode: true,
+      splitting: true,
+      format: 'iife' as const,
+      lazyCompilation: true,
+      rootDir: dir,
+    };
+    const base = await build(opts);
+    const seed = (base.lazySeeds ?? []).find((s) => s.path.endsWith('route.ts'));
+    expect(seed).toBeDefined();
+    const r = await build({ ...opts, lazyForceParse: [seed!.path] });
+    expect(r.errors ?? []).toHaveLength(0);
+    const entryChunk = (r.outputFiles ?? []).find((o) => o.path.endsWith('entry.js'));
+    const routeChunk = (r.outputFiles ?? []).find((o) => o.path.includes('route-'));
+    expect(entryChunk && routeChunk).toBeTruthy();
+    // emit 가드: default·meta 가 entry 네임스페이스 getter 로 노출(re-export 해석).
+    expect(/exports\.default\s*=\s*exports_\w+\.default;/.test(routeChunk!.text)).toBe(true);
+    expect(/exports\.meta\s*=\s*exports_\w+\.meta;/.test(routeChunk!.text)).toBe(true);
+
+    // 런타임 가드: entry 청크(=__zntc_require 코어) + route 청크 로드 후 require → 실제 값.
+    // entry 의 go() 가 vm 안에서 import('./route') 를 시도하면 비동기 reject(무시) 하므로 sync
+    // 검사(require)는 그 전에 완료된다.
+    const g: Record<string, unknown> = { console };
+    g.globalThis = g;
+    const ctx = vm.createContext(g);
+    vm.runInContext(entryChunk!.text, ctx); // __zntc_require 코어 + entry register
+    vm.runInContext(routeChunk!.text, ctx); // route.js register
+    const mods = g.__zntc_mods as Record<string, unknown>;
+    const id = Object.keys(mods).find((k) => /route/.test(k))!;
+    const required = (g.__zntc_require as (k: string) => Record<string, unknown>)(id);
+    expect(typeof required.default).toBe('function');
+    expect((required.default as () => string)()).toBe('PAGE');
+    expect(required.meta).toBe('M');
   });
 });


### PR DESCRIPTION
## 무엇을 / 왜

#4079 후속. dev_split(`zntc dev --lazy`) 동적 청크의 entry 모듈이 **re-export forwarding**(`export { default, meta } from './Page'`)을 쓰면, `import('./route').default`/`.meta` 가 **undefined** → lazy 라우트가 렌더되지 않았습니다.

원인: `emitWrappedDynamicEntryExports`(#4090 도입)가 **`.local` export 만** 노출하고 re-export 류는 방어적으로 스킵했기 때문입니다.

## 어떻게 (root-cause, 방어 스킵이 아님)

entry 모듈의 **네임스페이스 객체(`exports_<entry>`) getter** 로 값을 가져옵니다. `__export` 가 깐 getter 는 `local`·`export { x } from`(re_export)·`export * as ns`(re_export_namespace)를 **모두 chunk-로컬로 정확 해석**하므로, exported_name 키로 다음만 깔면 re-export 체인이 **실제 값**으로 풀립니다:

```js
exports.default = exports_route.default;  // re-export → Page 의 default 로 해석
exports.meta    = exports_route.meta;     // re-export → Page 의 meta 로 해석
```

즉 이전처럼 스킵하거나 소스 local 명으로 fallback(오바인딩)하지 않고, 네임스페이스 getter 에 **위임해 실해석**합니다.

## 변경

- `src/bundler/emitter/chunks.zig` — `emitWrappedDynamicEntryExports`: `.local`-only + `getCanonicalName` fallback → `allocExportsName` 네임스페이스 getter 위임. `export * from`(re_export_star)만 제외(스프레드 이름은 `emitLazyEntryExportAll` 이 dep 의 local 명으로 노출).
- `tests/integration/tests/napi-lazy-dev-hmr.test.ts` — **런타임** 회귀 테스트 추가: `export {default,meta} from` 동적 청크를 entry+route 청크로 vm 로드 후 `__zntc_require` → `import('./route').default()` === `'PAGE'`, `.meta` === `'M'` 실값 검증(emit 문자열이 아니라 동작). 기존 `re_export_namespace` 테스트는 새 동작(`exports.ns = exports_route.ns` getter 노출)에 맞춰 갱신.

## 안전성

- **production byte-identical**: 게이트가 `dev_split_chunk = reg_split and dev_mode and lazy_compilation`(chunks.zig:266) 이라 `dev_mode=false`(production)는 이 함수 호출 자체가 없습니다.
- `export * from` 의 일반 케이스(`export const`)는 이미 `emitLazyEntryExportAll` 이 노출(런타임 `a/b` 검증). rename 된 star export(`export {x as y}`+`export *`)가 `.y` 로 안 닿는 §6.3 한계는 **pre-existing**(본 diff 무관).

## 알려진 한계 (본 PR 범위 밖, pre-existing)

- **RN mixed-module `.cjs` 동적 entry**: `wrap_kind == .cjs` + 정적 export_bindings 인 경우 `exports_<X>` 네임스페이스가 없어 부정확합니다. 단 (a) web dev_split 은 `isEsm()` 모듈을 전부 `.esm` 강제(finalize.zig:124)하고 (b) 순수 CJS 는 `export_bindings.len==0` early-return 이라 **web 경로엔 도달 불가**, (c) #4090 의 `.local` 코드도 동일하게 깨졌던 자리 = 회귀 아님. RN 경로는 별도 추적 대상으로 함수 doc-comment 에 명시했습니다.
- JSON 을 static+dynamic 동시 사용하는 dev_split 케이스는 별개의 pre-existing 이슈(빈 `__export`)가 있으며 re-export forwarding 과 무관합니다.

## 테스트

- `zig build napi` / `zig build test` green
- `bun test napi-lazy-dev-hmr.test.ts` 5 pass (런타임 re-export 검증 포함)
- `/code-review max` (9-각도 병렬) 통과 — 핵심 리스크(네임스페이스 var 미선언 ReferenceError)를 빌드/런타임 재현으로 web 경로 안전 확인, 주석 정확도 2건 보강

🤖 Generated with [Claude Code](https://claude.com/claude-code)