### PR TITLE
fix(bundler): cross-chunk 예약어 export(default) destructuring SyntaxError — canonical 모듈 기반 바인딩 해석

### DIFF
--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -181,6 +181,17 @@ pub const ChunkKind = union(enum) {
 // Chunk — 단일 청크
 // ============================================================
 
+/// 심볼 수준 cross-chunk import 한 건. `imports_from` 값 목록의 원소.
+/// `name` 은 dep 청크가 노출하는 **export 키**(destructuring 좌변; `default`
+/// 같은 예약어일 수 있다). `canonical_module` 은 그 export 의 canonical 정의
+/// 모듈 — emitter 가 예약어 키일 때 `resolveToLocalName(SymbolRef)` 로 소비자
+/// 가 실제 참조하는 local 바인딩명(예: `_default`)을 해석하는 데 쓴다. 비예약어
+/// 키는 export 명 == 바인딩명이라 canonical_module 을 보지 않는다(기존 동작).
+pub const CrossChunkSym = struct {
+    name: []const u8,
+    canonical_module: u32,
+};
+
 /// 번들 출력의 단위. 하나의 JS 파일로 출력된다.
 /// 동일한 BitSet(진입점 집합)을 가진 모듈들이 하나의 Chunk에 묶인다.
 pub const Chunk = struct {
@@ -237,9 +248,10 @@ pub const Chunk = struct {
     /// 이 청크가 동적 import하는 다른 청크 목록
     cross_chunk_dynamic_imports: std.ArrayListUnmanaged(ChunkIndex),
 
-    /// 심볼 수준 크로스 청크 import: source_chunk_index → 가져올 심볼 이름 목록.
-    /// computeCrossChunkLinks에서 linker가 있을 때만 채워진다.
-    imports_from: std.AutoHashMapUnmanaged(u32, std.ArrayListUnmanaged([]const u8)),
+    /// 심볼 수준 크로스 청크 import: source_chunk_index → 가져올 심볼 목록.
+    /// computeCrossChunkLinks에서 linker가 있을 때만 채워진다. 각 원소는 export
+    /// 키 + canonical 모듈(예약어 키의 바인딩명 해석용) — `CrossChunkSym` 참조.
+    imports_from: std.AutoHashMapUnmanaged(u32, std.ArrayListUnmanaged(CrossChunkSym)),
     /// 이 청크에서 다른 청크로 내보내는 심볼 이름 집합.
     /// 공통 청크에서 export 문을 생성할 때 사용.
     exports_to: std.StringHashMapUnmanaged(void),
@@ -1269,6 +1281,9 @@ fn addCrossChunkSymbol(
     seen_static: *std.AutoHashMapUnmanaged(u32, void),
     src_chunk_idx: ChunkIndex,
     export_name: []const u8,
+    /// `export_name` 의 canonical 정의 모듈 인덱스. 예약어 export 키(`default`)일
+    /// 때 emitter 가 소비자 바인딩명을 `resolveToLocalName` 으로 해석하는 데 쓴다.
+    canonical_module: u32,
 ) !void {
     const src_ci = @intFromEnum(src_chunk_idx);
 
@@ -1283,9 +1298,9 @@ fn addCrossChunkSymbol(
     const ifgop = try chunk.imports_from.getOrPut(allocator, src_ci);
     if (!ifgop.found_existing) ifgop.value_ptr.* = .empty;
     for (ifgop.value_ptr.items) |existing| {
-        if (std.mem.eql(u8, existing, export_name)) break;
+        if (std.mem.eql(u8, existing.name, export_name)) break;
     } else {
-        try ifgop.value_ptr.append(allocator, export_name);
+        try ifgop.value_ptr.append(allocator, .{ .name = export_name, .canonical_module = canonical_module });
     }
 
     try chunk_graph.chunks.items[src_ci].exports_to.put(allocator, export_name, {});
@@ -1310,7 +1325,7 @@ fn linkReExportName(
     const src_chunk_idx = chunk_graph.getModuleChunk(canon.module_index);
     if (src_chunk_idx.isNone()) return;
     if (src_chunk_idx == chunk.index) return; // 같은 청크 → 스킵
-    try addCrossChunkSymbol(allocator, chunk_graph, chunk, seen_static, src_chunk_idx, canon.export_name);
+    try addCrossChunkSymbol(allocator, chunk_graph, chunk, seen_static, src_chunk_idx, canon.export_name, @intFromEnum(canon.module_index));
 }
 
 /// `mod_idx` 의 `export_name` 이 namespace re-export 인지 판정하고, 맞으면
@@ -1451,7 +1466,8 @@ fn linkNamespaceCrossChunk(
     // computeCrossChunkLinks 가 namespace 메타데이터보다 먼저 도는 timing
     // seam — ensureSharedNsVar 가 선제 materialize. 상세는 그 doc 참조.
     const ns_var = try lnk.ensureSharedNsVar(target);
-    try addCrossChunkSymbol(allocator, chunk_graph, chunk, seen_static, tgt_chunk, ns_var);
+    // ns_var 는 합성 namespace 변수명(예약어 아님) → canonical_module 미사용.
+    try addCrossChunkSymbol(allocator, chunk_graph, chunk, seen_static, tgt_chunk, ns_var, @intFromEnum(target));
     try fanOutModuleExports(allocator, chunk_graph, chunk, seen_static, lnk, target, module_count);
 }
 
@@ -1521,7 +1537,7 @@ pub fn computeCrossChunkLinks(
                     if (src_chunk_idx.isNone()) continue;
                     if (src_chunk_idx == chunk.index) continue; // 같은 청크 → 스킵
 
-                    try addCrossChunkSymbol(allocator, chunk_graph, chunk, &seen_static, src_chunk_idx, rb.canonical.export_name);
+                    try addCrossChunkSymbol(allocator, chunk_graph, chunk, &seen_static, src_chunk_idx, rb.canonical.export_name, @intFromEnum(rb.canonical.module_index));
 
                     // canonical 이 namespace re-export 면 그 이름만 가져와선
                     // 안 된다 — 정적 멤버는 정의자 export 로 elision, 값/동적은

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -58,6 +58,25 @@ fn appendCssLinkPrologue(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), 
     try buf.appendSlice(allocator, "\",import.meta.url).href;document.head.appendChild(__zntc_css);}\n");
 }
 
+/// 심볼 수준 cross-chunk import 의 **바인딩명**(destructuring 우변/로컬 식별자).
+/// dep 청크는 export 를 그 *키*(`default` 같은 예약어 가능)로 노출하지만, 소비자
+/// 코드는 그 키를 식별자로 못 쓴다 — 대신 canonical local 명(`_default`, 또는
+/// `export default function foo` → `foo`)을 참조한다. `resolveToLocalName` 이
+/// default→_default→named-default 체인을 해석해 그 이름을 돌려준다. 비예약어 키는
+/// export 명 == 바인딩명(기존 동작 유지). linker 없으면(단위 테스트) 예약어
+/// cross-chunk 가 발생하지 않으므로 export 명 그대로.
+fn crossChunkBindingName(linker: ?*Linker, sym: chunk_mod.CrossChunkSym) []const u8 {
+    if (linker) |l| {
+        if (Linker.isReservedName(sym.name)) {
+            return l.resolveToLocalName(.{
+                .module_index = @enumFromInt(sym.canonical_module),
+                .export_name = sym.name,
+            });
+        }
+    }
+    return sym.name;
+}
+
 pub fn emitChunks(
     allocator: std.mem.Allocator,
     graph: *const ModuleGraph,
@@ -420,8 +439,8 @@ pub fn emitChunks(
         for (chunk.cross_chunk_imports.items) |dep_chunk_idx| {
             const dep_ci = @intFromEnum(dep_chunk_idx);
             if (chunk.imports_from.get(dep_ci)) |syms| {
-                for (syms.items) |name| {
-                    const gop = try name_total_count.getOrPut(allocator, name);
+                for (syms.items) |sym| {
+                    const gop = try name_total_count.getOrPut(allocator, sym.name);
                     if (!gop.found_existing) gop.value_ptr.* = 0;
                     gop.value_ptr.* += 1;
                 }
@@ -506,23 +525,51 @@ pub fn emitChunks(
                 } else {
                     try chunk_output.appendSlice(allocator, if (reg_like) "const{" else "import{");
                 }
-                // 결정론적 출력을 위해 심볼명 정렬
-                std.mem.sort([]const u8, symbols.?.items, {}, types.stringLessThan);
-                for (symbols.?.items, 0..) |name, si| {
-                    const total = name_total_count.get(name) orelse 1;
-                    const seen_gop = try name_seen_count.getOrPut(allocator, name);
-                    if (!seen_gop.found_existing) seen_gop.value_ptr.* = 0;
-                    seen_gop.value_ptr.* += 1;
-                    const seen = seen_gop.value_ptr.*;
+                // 결정론적 출력을 위해 심볼명(export 키) 정렬
+                const SymSort = struct {
+                    fn lessThan(_: void, a: chunk_mod.CrossChunkSym, b: chunk_mod.CrossChunkSym) bool {
+                        return std.mem.lessThan(u8, a.name, b.name);
+                    }
+                };
+                std.mem.sort(chunk_mod.CrossChunkSym, symbols.?.items, {}, SymSort.lessThan);
+                // dep 청크가 심볼을 노출하는 **프로퍼티 키**: lazy(emitLazyEntryExportAll)
+                // 는 hoisted 로컬을 *local 명*으로 export-all 하므로 키=바인딩명(예: `_default`)
+                // → 축약 `{ _default }`. 비-lazy(production)은 *export 명*(`default`)으로 노출
+                // → `{ default: _default }` alias. 키가 dep 노출과 어긋나면 값이 undefined.
+                // 조건은 emitLazyEntryExportAll 발동 조건(`reg_fmt and !preserve_modules and
+                // lazy`)과 정확히 일치해야 한다 — reg_split(iife/umd/amd) 뿐 아니라 cjs_split
+                // 도 emitLazyEntryExportAll 로 local 명 키를 노출하므로 둘 다 포함.
+                const lazy_local_keys = graph.lazy_compilation and (reg_split or cjs_split);
+                for (symbols.?.items, 0..) |sym, si| {
+                    const name = sym.name;
+                    const binding = crossChunkBindingName(linker, sym);
+                    const key = if (lazy_local_keys) binding else name;
 
-                    if (total > 1 and seen > 1) {
-                        const alias = try std.fmt.allocPrint(allocator, "{s}${d}", .{ name, seen });
-                        try alias_strs.append(allocator, alias);
-                        try chunk_output.appendSlice(allocator, name);
+                    if (!std.mem.eql(u8, key, binding)) {
+                        // key != binding(예약어 export 키 `default` → 소비자 local `_default`).
+                        // 좌변=dep 노출 키(문자열이라 예약어 OK), 우변=소비자 참조 식별자.
+                        // 축약 `{ default }` 면 예약어를 바인딩으로 써 SyntaxError → alias 가 방지.
+                        try chunk_output.appendSlice(allocator, key);
                         try chunk_output.appendSlice(allocator, if (reg_like) ": " else " as ");
-                        try chunk_output.appendSlice(allocator, alias);
+                        try chunk_output.appendSlice(allocator, binding);
                     } else {
-                        try chunk_output.appendSlice(allocator, name);
+                        // key == binding → 축약. 단 같은 export 명이 여러 dep 에서 오면
+                        // 중복 로컬 선언 충돌 → 2번째부터 `key: key$N` deconfliction.
+                        const total = name_total_count.get(name) orelse 1;
+                        const seen_gop = try name_seen_count.getOrPut(allocator, name);
+                        if (!seen_gop.found_existing) seen_gop.value_ptr.* = 0;
+                        seen_gop.value_ptr.* += 1;
+                        const seen = seen_gop.value_ptr.*;
+
+                        if (total > 1 and seen > 1) {
+                            const alias = try std.fmt.allocPrint(allocator, "{s}${d}", .{ key, seen });
+                            try alias_strs.append(allocator, alias);
+                            try chunk_output.appendSlice(allocator, key);
+                            try chunk_output.appendSlice(allocator, if (reg_like) ": " else " as ");
+                            try chunk_output.appendSlice(allocator, alias);
+                        } else {
+                            try chunk_output.appendSlice(allocator, key);
+                        }
                     }
                     if (si + 1 < symbols.?.items.len) {
                         if (!options.minify_whitespace) {
@@ -585,8 +632,11 @@ pub fn emitChunks(
         {
             var ifit = chunk.imports_from.iterator();
             while (ifit.next()) |if_entry| {
-                for (if_entry.value_ptr.items) |name| {
-                    try occupied.append(allocator, name);
+                for (if_entry.value_ptr.items) |sym| {
+                    // 점유 이름 = 실제 **바인딩명**(예약어 키면 `_default`). export 키
+                    // (`default`)가 아니라 로컬과 충돌할 수 있는 바인딩명을 예약해야
+                    // 다른 로컬이 cross-chunk 바인딩과 겹치지 않는다.
+                    try occupied.append(allocator, crossChunkBindingName(linker, sym));
                 }
             }
             // deconfliction alias 이름도 점유 목록에 추가

--- a/tests/integration/tests/napi-lazy-dev-hmr.test.ts
+++ b/tests/integration/tests/napi-lazy-dev-hmr.test.ts
@@ -415,4 +415,102 @@ process.stdout.write(JSON.stringify({
     expect((required.r as () => string)()).toBe('R');
     expect(g.__SIDE).toBe(1); // side-effect import 실행(레지스트리 init), 1회
   });
+
+  // dev_split lazy 청크에서 `export { default } from './cjs'`(예약어 export 이름).
+  // 예전엔 chunk 수준 cross-chunk import 가 `const { default, named } = __zntc_require(...)`
+  // 로 emit 돼 **예약어 축약 destructuring → SyntaxError**(청크 전체 parse 실패)였다.
+  // dev_split 은 per-module 레지스트리가 심볼을 참조 지점에서 직접 해석(getter)하므로
+  // 이 chunk 수준 destructuring 은 죽은 코드 → side-effect `__zntc_require(...)` 만 남겨
+  // SyntaxError 제거. default 값 자체는 `_default = __toESM(__zntc_modules[...].fn()).default`
+  // 로 레지스트리에서 채워진다. parse + 실값을 런타임으로 가드.
+  test('dev_split lazy 청크가 re-export default(export {default} from CJS) 를 SyntaxError 없이 노출', async () => {
+    const fixture = await createFixture({
+      'cjslib.js':
+        "module.exports = function(){ return 'CJSDEFAULT'; };\nmodule.exports.named = 9;",
+      'Route.ts':
+        "export { default, named } from './cjslib.js';\nexport function r(){ return 'R'; }",
+      'entry.ts':
+        "import lib from './cjslib.js';\nglobalThis.E = lib;\nglobalThis.load = () => import('./Route');",
+    });
+    cleanup = fixture.cleanup;
+    const dir = realpathSync(fixture.dir);
+    const opts = {
+      entryPoints: [join(dir, 'entry.ts')],
+      platform: 'browser' as const,
+      devMode: true,
+      splitting: true,
+      format: 'iife' as const,
+      lazyCompilation: true,
+      rootDir: dir,
+    };
+    const base = await build(opts);
+    const seed = (base.lazySeeds ?? []).find((s) => s.path.endsWith('Route.ts'));
+    expect(seed).toBeDefined();
+    const r = await build({ ...opts, lazyForceParse: [seed!.path] });
+    expect(r.errors ?? []).toHaveLength(0);
+    const entryChunk = (r.outputFiles ?? []).find((o) => o.path.endsWith('entry.js'));
+    const routeChunk = (r.outputFiles ?? []).find((o) => o.path.includes('Route-'));
+    expect(entryChunk && routeChunk).toBeTruthy();
+    // emit 가드: 예약어 축약 destructuring(`const { default ...`) 이 없어야 한다(SyntaxError 원인).
+    expect(/const\s*\{[^}]*\bdefault\b[^}:]*\}\s*=/.test(routeChunk!.text)).toBe(false);
+
+    // 런타임 가드: Route 청크가 parse 되고(runInContext 가 안 던짐) default/named 실값이 맞아야 한다.
+    const g: Record<string, unknown> = { console };
+    g.globalThis = g;
+    const ctx = vm.createContext(g);
+    vm.runInContext(entryChunk!.text, ctx);
+    vm.runInContext(routeChunk!.text, ctx); // 예약어 SyntaxError 면 여기서 throw
+    const mods = g.__zntc_mods as Record<string, unknown>;
+    const id = Object.keys(mods).find((k) => /Route/.test(k))!;
+    const required = (g.__zntc_require as (k: string) => Record<string, unknown>)(id);
+    expect((required.default as () => string)()).toBe('CJSDEFAULT'); // 예약어 default re-export, cross-chunk
+    expect(required.named).toBe(9);
+    expect((required.r as () => string)()).toBe('R');
+  });
+
+  // dev_split lazy 청크에서 `import def from './shared'`(예약어 default *import*).
+  // dep 청크(emitLazyEntryExportAll)는 hoisted 로컬을 *local 명*(`_default`)으로 노출하므로
+  // 소비자는 export 키 `default` 가 아니라 local 키로 destructure 해야 한다(`const { _default }`).
+  // 예전엔 `const { default }` 축약 → SyntaxError. 이제 chunk.zig 가 canonical 모듈을 들고
+  // emitter 가 resolveToLocalName 으로 `_default` 키를 emit → parse + 실값.
+  test('dev_split lazy 청크가 default import(import def from)를 SyntaxError 없이 해석', async () => {
+    const fixture = await createFixture({
+      // 익명 default 함수(→ 합성 `_default`) 를 lazy 청크가 import 해 호출.
+      'esmdep.ts': "export default function(){ return 'DEF'; }",
+      'Card.ts': "import def from './esmdep';\nexport function card(){ return def(); }",
+      'entry.ts':
+        "import def from './esmdep';\nglobalThis.E = def();\nglobalThis.load = () => import('./Card');",
+    });
+    cleanup = fixture.cleanup;
+    const dir = realpathSync(fixture.dir);
+    const opts = {
+      entryPoints: [join(dir, 'entry.ts')],
+      platform: 'browser' as const,
+      devMode: true,
+      splitting: true,
+      format: 'iife' as const,
+      lazyCompilation: true,
+      rootDir: dir,
+    };
+    const base = await build(opts);
+    const seed = (base.lazySeeds ?? []).find((s) => s.path.endsWith('Card.ts'));
+    expect(seed).toBeDefined();
+    const r = await build({ ...opts, lazyForceParse: [seed!.path] });
+    expect(r.errors ?? []).toHaveLength(0);
+    const entryChunk = (r.outputFiles ?? []).find((o) => o.path.endsWith('entry.js'));
+    const cardChunk = (r.outputFiles ?? []).find((o) => o.path.includes('Card-'));
+    expect(entryChunk && cardChunk).toBeTruthy();
+    // 예약어 축약 destructuring(`const { default ...`) 이 없어야 한다(SyntaxError 원인).
+    expect(/const\s*\{[^}]*\bdefault\b[^}:]*\}\s*=/.test(cardChunk!.text)).toBe(false);
+
+    const g: Record<string, unknown> = { console };
+    g.globalThis = g;
+    const ctx = vm.createContext(g);
+    vm.runInContext(entryChunk!.text, ctx);
+    vm.runInContext(cardChunk!.text, ctx); // 예약어 SyntaxError 면 throw
+    const mods = g.__zntc_mods as Record<string, unknown>;
+    const id = Object.keys(mods).find((k) => /Card/.test(k))!;
+    const required = (g.__zntc_require as (k: string) => Record<string, unknown>)(id);
+    expect((required.card as () => string)()).toBe('DEF'); // cross-chunk default import 실값
+  });
 });


### PR DESCRIPTION
## 🐛 문제

dev_split(`zntc dev --lazy`) 및 production splitting 에서 cross-chunk 로 **예약어 export 이름**(`default`)을 가져오면 청크 전체가 parse 실패했습니다.

```js
const { default, named } = __zntc_require("entry.js");
// ❌ Cannot use abbreviated destructuring syntax for keyword 'default'
```

`default` 은 식별자 바인딩으로 못 쓰는 예약어인데 **축약 destructuring** 으로 emit → SyntaxError → lazy 라우트 렌더 실패. production iife/cjs splitting 도 동일.

## 🔍 근본 원인 (2겹)

1. **예약어 키를 바인딩으로 직접 사용** — `imports_from` 가 export 이름 문자열만 저장 → 소비자 바인딩이 그 이름(`default`)을 식별자로 사용. 소비자가 실제 참조하는 canonical local 명(`_default`, 또는 `export default function foo` → `foo`)과 불일치.
2. **dep 노출 키가 format 별 비대칭** — lazy(`emitLazyEntryExportAll`)는 *local 명 키*(`exports._default`), production(`xchunk`)은 *export 명 키*(`exports.default`). 소비자 키가 어긋나면 값이 `undefined`.

## 🛠️ 수정 (근본, 밴드에이드 아님)

- **`chunk.zig`**: `imports_from` 값을 `[]const u8` → `CrossChunkSym{ name, canonical_module }` 로 확장. `addCrossChunkSymbol` 의 3 caller(re-export·namespace·import_binding)가 canonical 모듈 인덱스 전달. dedup·deinit·clearAndFree 동반 갱신.
- **`chunks.zig`**:
  - `crossChunkBindingName` 헬퍼 — 예약어면 `resolveToLocalName(SymbolRef{canonical_module, name})` 로 소비자 바인딩명 해석(default→_default→named-default 체인), 아니면 export 명(기존 동작 유지).
  - key/binding 분리: `key = lazy_local_keys ? binding : name`. `lazy_local_keys = graph.lazy_compilation and (reg_split or cjs_split)` — `emitLazyEntryExportAll` 발동조건(`reg_fmt and !preserve_modules`)과 정확히 일치. `key ≠ binding` 이면 `key: binding` alias, 같으면 축약.
  - `occupied` 점유 이름을 export 명이 아닌 **바인딩명**으로 수집.

```js
// dev_split lazy
const { _default } = __zntc_require("entry.js");          // local 키 축약 ✅
// production
const { default: _default, named } = __zntc_require(...); // export 키 alias ✅ parse OK
```

## 🗺️ 소스맵 — 안 깨집니다 (최우선 검증)

변경은 `const { … } = __zntc_require(…)` **한 줄 안의 식별자**만 바꿉니다(줄 추가/삭제 0). 뒤따르는 모듈 본문의 줄·열이 이동하지 않아 VLQ 매핑 영향 0. cross-chunk import 영역은 소스 매핑 없는 합성 preamble.

- ✅ sourcemap 통합 테스트 **117 pass** (batch-e-cli 20 · round5 17 · sourcemap 18 · footer 5 · rsc 53 · min-chunk 4)
- ✅ 구조적 줄-수 중립

## ✅ 검증

| 항목 | 결과 |
|------|------|
| dev_split `export { default, named } from './cjs'` 런타임 | ✅ default()='CJSDEFAULT', named=9 |
| dev_split `import def from './shared'` (함수 default) | ✅ def()='DEF' |
| production iife `export { default } from './cjs'` | ✅ parse OK |
| CJS-lazy default re-export 키 | ✅ `const { _default, named }` |
| 회귀 — hmr 9 · cross-chunk-reexport 18 · cjs/iife/umd splitting · manual-chunks 77 · lazy-primitives 10 | ✅ 0 fail |
| full unit test · wasm · wasm-bundler · test262 · schema · bench · install | ✅ 전부 통과 |
| 신규 통합 테스트 2종 | ✅ 9/9 hmr |

## 🔬 코드 리뷰 (`/code-review max`)

- **수정 반영**: CJS-lazy 게이트 갭 — 초기 `reg_split` 만 → `reg_split or cjs_split`(emitLazyEntryExportAll 조건 일치). CJS-lazy default 키도 정합.
- 나머지 후보는 finder 자체 refute(canonical_module 경계검사 선행, `resolveToLocalName` fallback 안전, namespace ns_var 비예약어, occupied 는 통과 테스트가 증명).

## ⚠️ 발견한 별개 pre-existing 이슈 (이 PR 범위 밖, 직교)

1. **cross-chunk ESM const named export 의 init-순서 snapshot** — entry 가 `exports.tag = tag` 를 `init_entry()` *전에* 실행 → const 값 undefined(함수는 hoisting 으로 정상). default 없는 named-only 도 baseline 에서 실패 → pre-existing.
2. **같은 이름 cross-chunk 심볼 dedup 붕괴** — 다른 모듈의 동명 export(두 `default`, 두 `v`)를 export 명으로만 dedup 해 합침. 비예약어 named 도 동일 한계 → pre-existing. 이 PR 은 default 를 기존 named 동작과 *일관*되게 만들 뿐.
3. **production iife 공유 청크 default 노출** — production default *import* 는 공유 청크 쪽에 또 다른 `default` 노출 이슈가 남음(이 PR 은 소비자측 parse 복구). cross-chunk-reexport 18 통과 = 테스트 경로 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)