### PR TITLE
fix(bundler): dev_split user-entry 청크가 cross-chunk const export 를 init 전 snapshot 하던 버그 (follow-up A)

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -818,17 +818,26 @@ pub fn emitChunks(
             );
         }
 
-        // dev_split (RFC_LAZY_DEV_MODULE_HMR PR-2): 비-entry 청크(shared/common)의 wrapped
-        // 모듈 init 트리거. production 은 모듈이 wrap 안 돼 청크 factory 실행 = 즉시 init
-        // 이지만, dev wrap-all 은 모듈을 `init_X = __esm({...})` 로 lazy wrap. 청크 factory
-        // 가 init 을 안 부르면 아래 cross-chunk `exports.x = local` 이 init 전 값(undefined)을
-        // 스냅샷 → cross-chunk 소비자가 `const {x} = __zntc_require(...)` 로 undefined 캡처
-        // (s=undefined 버그). entry 청크는 935 블록이 처리하므로 여기선 비-entry 만. 반드시
-        // cross-chunk exports emit *앞* 에서 호출해 local 값을 채운다. __esm memoize=중복 무해.
-        if (dev_split_chunk and !chunk_is_user_entry) {
+        // dev_split (RFC_LAZY_DEV_MODULE_HMR PR-2): 청크의 hoisted wrapped 모듈 init 트리거.
+        // production 은 모듈이 wrap 안 돼 청크 factory 실행 = 즉시 init 이지만, dev wrap-all 은
+        // 모듈을 `init_X = __esm({...})` 로 lazy wrap. 청크 factory 가 init 을 안 부르면 아래
+        // cross-chunk `exports.x = local` 이 init 전 값(undefined)을 스냅샷 → cross-chunk 소비자가
+        // `const {x} = __zntc_require(...)` 로 undefined 캡처(const export = s/tag undefined 버그;
+        // 함수는 hoisting 으로 정상이라 const 만 노출됐다, follow-up #A).
+        // ⚠️ user-entry 청크의 *entry 모듈 자체* 는 제외 — 1015 블록 + bootstrap 이 init 하며
+        // 그게 앱 실행 시점이라 여기서 당겨 실행하면 안 된다. hoisted **dep** 모듈만 선-init 해
+        // const export 스냅샷을 채운다(entry 도 dep 를 import 해 hoist 시킨 경우 포함).
+        // __esm memoize=중복 무해.
+        if (dev_split_chunk) {
             for (sorted_mods) |mod_idx| {
                 const mi = @intFromEnum(mod_idx);
                 if (mi >= module_count) continue;
+                // user-entry 청크: entry 모듈 자체는 skip(1015 블록/bootstrap 이 init).
+                if (chunk_is_user_entry) {
+                    if (entry_mod_idx) |ei| {
+                        if (mi == ei) continue;
+                    }
+                }
                 const m = graph.getModule(mod_idx) orelse continue;
                 const tla = m.wrap_kind == .esm and m.uses_top_level_await;
                 if (m.wrap_kind.isWrapped() and !tla) {

--- a/tests/integration/tests/napi-lazy-dev-hmr.test.ts
+++ b/tests/integration/tests/napi-lazy-dev-hmr.test.ts
@@ -620,4 +620,23 @@ process.stdout.write(JSON.stringify({
     expect(exports.own).toBe('OWN');
     expect((exports.r as () => string)()).toBe('R');
   });
+
+  // follow-up A: cross-chunk ESM *const* named export 가 lazy 청크에서 실값이어야 한다.
+  // entry 청크가 dep 를 hoist 하지만, dep 의 const 초기화(`tag="TVAL"`)가 cross-chunk export
+  // 스냅샷(`exports.tag = tag`)보다 늦게 돌면 undefined 를 캡처했다(함수는 hoisting 으로 정상,
+  // const 만 실패). dev_split user-entry 청크가 hoisted dep wrapped 모듈을 cross-chunk export
+  // *앞* 에서 선-init 하도록 수정.
+  test('lock: cross-chunk ESM const named export 가 lazy 청크에서 실값 (snapshot 순서 #A)', async () => {
+    const { exports } = await loadDevSplitLazy(
+      {
+        'dep.ts': "export const tag = 'TVAL';\nexport function mk(){ return 'MK'; }",
+        'Route.ts':
+          "import { tag, mk } from './dep';\nexport function r(){ return tag + ':' + mk(); }",
+        'entry.ts':
+          "import { mk } from './dep';\nglobalThis.E = mk();\nglobalThis.r = () => import('./Route');",
+      },
+      'Route.ts',
+    );
+    expect((exports.r as () => string)()).toBe('TVAL:MK');
+  });
 });


### PR DESCRIPTION
## 🐛 문제 (follow-up A)

dev_split(dev+splitting+lazy) lazy 청크가 다른 청크의 **ESM const named export**(`export const tag='T'`)를 import 하면 값이 `undefined` 였다. **함수 export 는 hoisting 으로 정상**, const 만 실패.

```js
//#region dep.ts (entry 청크에 hoist)
var tag; __export(exports_dep, { tag: () => tag });
var init_dep = __esm({ "dep.ts"() { tag = "T"; } });
//#region entry.ts
var init_entry = __esm({ "entry.ts"() { ... } });
exports.tag = tag;   // ❌ init_entry() 전 → tag 아직 undefined (snapshot)
init_entry();        // tag = "T" 는 여기서
```

## 🔍 근본 원인

비-entry 청크는 cross-chunk `exports.x = local` snapshot **앞**에서 wrapped 모듈 init 을 트리거하는 루프(`dev_split_chunk and !chunk_is_user_entry`)가 있었으나, **user-entry 청크는 제외**돼 있었다. user-entry 의 entry 모듈 init 은 1015 블록(snapshot **뒤**)이라, hoisted dep 의 const 가 미초기화 상태로 snapshot 됐다.

## 🛠️ 수정

그 선-init 루프를 user-entry 청크에도 적용하되 **entry 모듈 자체는 skip**(1015 블록 + bootstrap 이 init = 앱 실행 시점 보존). hoisted **dep** 모듈만 export 앞에서 init → const export snapshot 이 실값을 담는다. `__esm` memoize 라 중복 무해.

- 비-user-entry 청크 동작 **byte-identical**(루프가 entry 모듈만 skip, 나머지 불변)

## ✅ 검증

- **red→green**: `napi-lazy-dev-hmr` 의 `snapshot 순서 #A` 테스트
- 회귀 **0**: hmr 14 · cross-chunk-reexport 21 · manual-chunks 44 · cjs/iife splitting · lazy-primitives 10 · **js-dev-server-lazy 5**(materialize/render)
- full unit test · wasm · wasm-bundler · test262 · schema · install **전부 통과**
- focused 코드리뷰: **0 defects**(double-init 없음, entry_mod_idx 유효, dep 선-init 안전)

#4096 후속 3건(A/B/C) 중 **A** 완료. B(같은 이름 dedup), C(production 공유청크 default) 진행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)