### PR TITLE
fix(bundler): cross-chunk default export 의 RHS 예약어 SyntaxError 해결 (follow-up C) + B 한계 문서화

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -977,6 +977,19 @@ pub fn emitChunks(
                                 found_local = renamed;
                                 break;
                             }
+                            // 예약어 export 명(`default`)의 합성 local(`_default`)은 canonical 미등록
+                            // 일 수 있다 — 위 getCanonicalName 실패로 break 안 하면 아래 fallback 이
+                            // `name`(=`default`)으로 떨어져 `exports.default = default`(RHS 가 예약어
+                            // 식별자 = SyntaxError, #C)를 만든다. 예약어 export 명에 한해 owner 의
+                            // local(`_default`)로 break(비예약어 same-name 해석은 OLD 그대로 보존).
+                            // ⚠️ `local` 자체가 예약어면(예: `export {default} from './x'` 의 re-export
+                            // source 명이 `default`) 그걸 RHS 로 쓰면 다시 SyntaxError — 비예약어 local
+                            // 일 때만 채택하고, 아니면 계속 순회해 실제 owner(`_default`)를 찾는다.
+                            // (둘 다 없는 re-export 체인은 별도 follow-up — fallback 유지.)
+                            if (Linker.isReservedName(name) and !Linker.isReservedName(local)) {
+                                found_local = local;
+                                break;
+                            }
                         }
                     }
                     break :blk found_local orelse name;

--- a/tests/integration/tests/cross-chunk-reexport.test.ts
+++ b/tests/integration/tests/cross-chunk-reexport.test.ts
@@ -415,4 +415,37 @@ describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
       expect(/\bdefault\s*[},]/.test(crossImport!)).toBe(false);
     });
   }
+
+  // #C lock: production splitting 에서 default *import* 의 정의 모듈이 별도(shared) 청크면,
+  // 그 청크가 `exports.default = <local>` 로 노출한다. local 을 export 명 `default`(예약어
+  // 식별자)로 떨어뜨리면 `exports.default = default;` (RHS 예약어 = SyntaxError, 청크 parse
+  // 실패)였다. canonical synthetic local(`_default`)로 해석돼 모든 청크가 parse 되는지 가드.
+  for (const format of ['iife', 'cjs'] as const) {
+    test(`${format}: default import 의 shared 청크가 SyntaxError 없이 노출 (#C)`, async () => {
+      const fixture = await createFixture({
+        'esmdep.ts': "export default function(){ return 'DEF'; }\nexport const tag = 'T';",
+        'Card.ts': "import def from './esmdep';\nexport function card(){ return def(); }",
+        'entry.ts':
+          "import def from './esmdep';\nglobalThis.E = def();\nglobalThis.load = () => import('./Card');",
+      });
+      cleanup = fixture.cleanup;
+      const result = await build({
+        entryPoints: [join(fixture.dir, 'entry.ts')],
+        rootDir: fixture.dir,
+        platform: 'browser',
+        splitting: true,
+        format,
+      });
+      expect(result.errors ?? []).toHaveLength(0);
+      const jsChunks = (result.outputFiles ?? []).filter((o) => o.path.endsWith('.js'));
+      expect(jsChunks.length).toBeGreaterThan(1); // entry + Card + shared(esmdep)
+      for (const chunk of jsChunks) {
+        // 예약어 RHS(`exports.default = default;` / `= default,`) 부재. `_default` 는 word
+        // boundary 로 제외(= 정상). 있으면 = canonical 미해석 = SyntaxError 원인.
+        expect(/=\s*\bdefault\b\s*[;,)]/.test(chunk.text)).toBe(false);
+        // 함수 본문으로 감싸 parse 검증(실행 아님) — 예약어 RHS 면 throw.
+        expect(() => new Function('exports', 'module', 'require', chunk.text)).not.toThrow();
+      }
+    });
+  }
 });

--- a/tests/integration/tests/napi-lazy-dev-hmr.test.ts
+++ b/tests/integration/tests/napi-lazy-dev-hmr.test.ts
@@ -639,4 +639,30 @@ process.stdout.write(JSON.stringify({
     );
     expect((exports.r as () => string)()).toBe('TVAL:MK');
   });
+
+  // follow-up B (todo: cross-chunk 네이밍 일관성 = 더 깊은 아키텍처 과제):
+  // 서로 다른 모듈이 *같은* export 이름(`v`)을 내고 한 lazy 청크가 둘 다 import 하면,
+  // va·vb 가 같은 값으로 collapse 된다(r()='AA', 'AB' 아님). dep 청크는 renamer deconflict 로
+  // 양쪽(`exports.v`/`exports.v$1`)을 노출하고, imports_from dedup 을 (이름,canonical모듈)로
+  // 고치면 destructuring(`const {v, v$1}`)·바인딩까지는 맞출 수 있다. 그러나 소비자 **본문**
+  // 참조(`return va + vb`)는 codegen 이 cross-chunk 심볼을 *export 명*(`v`)으로 렌더한다 —
+  // provider 청크의 deconflict 된 `v$1` 을 모른다(rename_table 이 청크별로 clear 됨). 본문
+  // 참조와 destructuring 바인딩을 일치시키려면 cross-chunk 심볼명을 전역 일관되게 유지해야
+  // 하고(provider 의 deconflict 된 이름 persistence), 그건 RFC_GRAPH_PERSISTENCE(CLOSED) /
+  // lifecycle scope redesign 급 변경이다. 부분 수정은 본문이 여전히 붕괴해 순효과가 없어
+  // 보류 — 전역 네이밍 일관성 확보 후 `test.todo`→`test` 로 전환.
+  test.todo('다른 모듈의 같은 이름 export 둘을 한 lazy 청크가 import (dedup 붕괴 #B)', async () => {
+    const { exports } = await loadDevSplitLazy(
+      {
+        'a.ts': "export const v = 'A';",
+        'b.ts': "export const v = 'B';",
+        'Route.ts':
+          "import { v as va } from './a';\nimport { v as vb } from './b';\nexport function r(){ return va + vb; }",
+        'entry.ts':
+          "import { v as va } from './a';\nimport { v as vb } from './b';\nglobalThis.E = va + vb;\nglobalThis.r = () => import('./Route');",
+      },
+      'Route.ts',
+    );
+    expect((exports.r as () => string)()).toBe('AB');
+  });
 });


### PR DESCRIPTION
## 🐛 C — 문제

production splitting 에서 default *import* 의 정의 모듈이 별도(shared) 청크면, 그 청크가 `exports.default = <local>` 로 노출하는데, local 이 예약어 `default` 로 떨어져 청크 전체가 parse 실패했다.

```js
// shared 청크
exports.default = default;   // ❌ RHS default = 예약어 식별자 → SyntaxError
```

## 🔍 근본 원인

xchunk export 의 `local_name` 해석이 `default` export 의 합성 local `_default` 를 못 찾으면(`getCanonicalName` 미등록) fallback `name`(=`default`)으로 떨어진다. 좌변 `exports.default`(멤버 키)는 OK 지만 우변 `default`(식별자)는 예약어라 SyntaxError.

## 🛠️ 수정

`getExportLocalName` 이 owner 모듈을 식별하면 — **예약어 export 명에 한해** — 그 local(`_default`)로 break. ⚠️ `local` 자체가 예약어면(re-export source 명이 `default`) RHS 도 예약어가 되므로 **비예약어 local 일 때만** 채택(아니면 순회 계속해 실제 `_default` owner 탐색). 비예약어 same-name(`val`/`val$1`) 해석은 **OLD 그대로 보존**.

> 코드리뷰가 `local` 자체가 예약어인 re-export 케이스를 발견 → 비예약어 가드 추가.

## ✅ 검증

- 모든 청크 parse ✅ · runtime `card()`='DEF' ✅
- 회귀 **0**: unit 5748 · test262 · cross-chunk-reexport 23 · manual-chunks 44 · iife/cjs splitting · hmr 14
- `cross-chunk-reexport` 에 iife/cjs `#C` lock 테스트 추가
- focused 코드리뷰: 발견 1건(local 예약어) → 가드로 해소

## 📌 B — 문서화 (test.todo, 아키텍처 한계)

서로 다른 모듈의 *같은* export 이름(두 `default`/두 `v`)을 한 청크가 import 하면 소비자 **본문** 참조가 codegen 에서 export 명으로 렌더돼 collapse 된다(va·vb→va). imports_from dedup·destructuring 바인딩까지는 고칠 수 있으나, 본문 참조 일치는 **cross-chunk 심볼명 전역 일관성**(provider 의 deconflict 된 이름 persistence = RFC_GRAPH_PERSISTENCE[CLOSED] / lifecycle scope redesign 급 변경)이 필요해 보류. 부분 수정은 본문이 여전히 붕괴해 순효과가 없어, `napi-lazy-dev-hmr` 에 `test.todo` 로 한계를 고정(전역 네이밍 일관성 확보 후 `test` 전환).

---

#4096 후속 **A**(#4098 머지)·**C**(본 PR) 완료. **B** 는 아키텍처 과제로 문서화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)