### PR TITLE
test(bundler): B test.todo 를 추적 이슈 #4101 에 연결

### DIFF
--- a/tests/integration/tests/napi-lazy-dev-hmr.test.ts
+++ b/tests/integration/tests/napi-lazy-dev-hmr.test.ts
@@ -640,7 +640,7 @@ process.stdout.write(JSON.stringify({
     expect((exports.r as () => string)()).toBe('TVAL:MK');
   });
 
-  // follow-up B (todo: cross-chunk 네이밍 일관성 = 더 깊은 아키텍처 과제):
+  // follow-up B (todo: cross-chunk 네이밍 일관성 = 더 깊은 아키텍처 과제 — 이슈 #4101):
   // 서로 다른 모듈이 *같은* export 이름(`v`)을 내고 한 lazy 청크가 둘 다 import 하면,
   // va·vb 가 같은 값으로 collapse 된다(r()='AA', 'AB' 아님). dep 청크는 renamer deconflict 로
   // 양쪽(`exports.v`/`exports.v$1`)을 노출하고, imports_from dedup 을 (이름,canonical모듈)로


### PR DESCRIPTION
## 변경

cross-chunk 같은 이름 export 충돌(B — 소비자 본문 참조 collapse)을 GitHub 이슈 #4101 로 등록했고, `napi-lazy-dev-hmr.test.ts` 의 `test.todo` 주석에 이슈 번호를 명시해 **양방향 추적성**을 확보합니다(코드 변경 없음, 주석 1줄).

- 이슈: #4101 — cross-chunk 같은 이름 export 충돌: 소비자 본문 참조가 export명으로 collapse (전역 심볼 네이밍 일관성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)