### PR TITLE
feat(bundler): cross-chunk 전역 일관 네이밍 인프라 — Inc-1 (비활성, #4101)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1681,6 +1681,12 @@ pub const Bundler = struct {
 
             try chunk_mod.computeCrossChunkLinks(&chunk_graph, graph, self.allocator, if (linker) |*l| l else null);
 
+            // RFC #3940 / #4101 — cross-chunk 전역 일관 네이밍 채우기(Inc-1: read 비활성, 동작 변경 0).
+            // imports_from 확정 직후. linker 있고 splitting 일 때만(전역 이름은 cross-chunk 에서만 의미).
+            if (linker) |*l| {
+                if (self.options.code_splitting) try chunk_mod.computeCrossChunkGlobalNames(self.allocator, &chunk_graph, l);
+            }
+
             var emit_opts = self.makeEmitOptions();
             emit_opts.preserve_modules = self.options.preserve_modules;
             emit_opts.preserve_modules_root = self.options.preserve_modules_root;

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -1471,6 +1471,87 @@ fn linkNamespaceCrossChunk(
     try fanOutModuleExports(allocator, chunk_graph, chunk, seen_static, lnk, target, module_count);
 }
 
+/// RFC #3940 / 이슈 #4101 — cross-chunk 심볼에 **전역 일관 이름**을 배정한다.
+/// 모든 청크의 imports_from(`CrossChunkSym`=canonical_module+export_name)을 enumerate 해
+/// `(canonical_module, export_name)` 집합을 만들고, **occupied(per-chunk rename 입력)와 무관
+/// 하게** 전역 deconflict 한다 — 이 self-contained 성질이 occupied↔이름 순환을 끊는 핵심.
+/// 결과는 `linker.cross_chunk_global_names` 에 owned 로 저장(provider/consumer 단일 출처).
+///
+/// **Inc-1(본 변경): 채우기만 — read 비활성**. metadata/emit/per-chunk-rename 은 아직 이 맵을
+/// 안 본다 → 동작 변경 0. 후속 increment 가 ① per-chunk rename 이 전역 이름 reserve+사용,
+/// ② metadata import 바인딩 read 로 wire 한다(그때 #B test.todo flip).
+/// `computeCrossChunkLinks` 직후(imports_from 확정 후)에 호출.
+pub fn computeCrossChunkGlobalNames(
+    allocator: std.mem.Allocator,
+    chunk_graph: *const ChunkGraph,
+    lnk: *Linker,
+) !void {
+    lnk.clearCrossChunkGlobalNames();
+
+    // 1. cross-chunk 심볼 enumerate + (mod, name) dedup.
+    const Sym = struct { mod: u32, name: []const u8 };
+    var syms: std.ArrayListUnmanaged(Sym) = .empty;
+    defer syms.deinit(allocator);
+    var seen: std.StringHashMapUnmanaged(void) = .empty;
+    defer {
+        var kit = seen.keyIterator();
+        while (kit.next()) |k| allocator.free(k.*);
+        seen.deinit(allocator);
+    }
+    for (chunk_graph.chunks.items) |*chunk| {
+        var it = chunk.imports_from.iterator();
+        while (it.next()) |entry| {
+            for (entry.value_ptr.items) |sym| {
+                const key = try std.fmt.allocPrint(allocator, "{d}\x00{s}", .{ sym.canonical_module, sym.name });
+                const gop = try seen.getOrPut(allocator, key);
+                if (gop.found_existing) {
+                    allocator.free(key);
+                    continue;
+                }
+                try syms.append(allocator, .{ .mod = sym.canonical_module, .name = sym.name });
+            }
+        }
+    }
+
+    // 2. 결정론적 정렬 (mod, name) — 같은 입력 → 같은 전역 이름.
+    const SymSort = struct {
+        fn lt(_: void, a: Sym, b: Sym) bool {
+            if (a.mod != b.mod) return a.mod < b.mod;
+            return std.mem.lessThan(u8, a.name, b.name);
+        }
+    };
+    std.mem.sort(Sym, syms.items, {}, SymSort.lt);
+
+    // 3. 전역 deconflict — preferred(원본 local 명)로 시도, 충돌/예약이면 `$N`.
+    var used: std.StringHashMapUnmanaged(void) = .empty;
+    defer used.deinit(allocator);
+    for (syms.items) |s| {
+        const preferred = lnk.getExportLocalName(s.mod, s.name) orelse s.name;
+        const candidate = try deconflictGlobalName(allocator, &used, preferred);
+        // candidate 소유권을 맵으로 이전. used 는 맵의 저장본을 borrow(used.deinit 가 키 미해제).
+        try lnk.putCrossChunkGlobalName(s.mod, s.name, candidate);
+        try used.put(allocator, lnk.getCrossChunkGlobalName(s.mod, s.name).?, {});
+    }
+}
+
+/// `preferred` 이름을 `used`(이미 배정된 전역 이름) + JS 예약어를 회피해 유니크화.
+/// 충돌 없으면 preferred dupe, 있으면 `preferred$1`, `preferred$2`... 반환값은 **owned**
+/// (caller 소유). `computeCrossChunkGlobalNames` 의 deconflict 코어 — 단위 테스트 대상.
+pub fn deconflictGlobalName(
+    allocator: std.mem.Allocator,
+    used: *const std.StringHashMapUnmanaged(void),
+    preferred: []const u8,
+) ![]const u8 {
+    var candidate = try allocator.dupe(u8, preferred);
+    var suffix: u32 = 0;
+    while (used.contains(candidate) or Linker.isReservedName(candidate)) {
+        allocator.free(candidate);
+        suffix += 1;
+        candidate = try std.fmt.allocPrint(allocator, "{s}${d}", .{ preferred, suffix });
+    }
+    return candidate;
+}
+
 pub fn computeCrossChunkLinks(
     chunk_graph: *ChunkGraph,
     graph: *const ModuleGraph,

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -790,6 +790,40 @@ test "computeCrossChunkLinks: no cross-chunk deps — 모든 모듈이 같은 �
     try std.testing.expectEqual(@as(usize, 0), cg.getChunk(ci).cross_chunk_dynamic_imports.items.len);
 }
 
+test "deconflictGlobalName: 동명 → \\$N 유니크화 + 예약어 회피 (#4101 전역 네이밍 코어)" {
+    const alloc = std.testing.allocator;
+    var used: std.StringHashMapUnmanaged(void) = .empty;
+    defer used.deinit(alloc);
+
+    // 첫 'v' → 'v'.
+    const n1 = try chunk_mod.deconflictGlobalName(alloc, &used, "v");
+    defer alloc.free(n1);
+    try std.testing.expectEqualStrings("v", n1);
+    try used.put(alloc, n1, {});
+
+    // 둘째 'v' → 'v$1' (충돌 회피).
+    const n2 = try chunk_mod.deconflictGlobalName(alloc, &used, "v");
+    defer alloc.free(n2);
+    try std.testing.expectEqualStrings("v$1", n2);
+    try used.put(alloc, n2, {});
+
+    // 셋째 'v' → 'v$2'.
+    const n3 = try chunk_mod.deconflictGlobalName(alloc, &used, "v");
+    defer alloc.free(n3);
+    try std.testing.expectEqualStrings("v$2", n3);
+
+    // 예약어는 그대로 못 씀 → suffix.
+    const nd = try chunk_mod.deconflictGlobalName(alloc, &used, "default");
+    defer alloc.free(nd);
+    try std.testing.expect(!std.mem.eql(u8, nd, "default"));
+    try std.testing.expectEqualStrings("default$1", nd);
+
+    // 충돌 없는 이름은 그대로.
+    const nf = try chunk_mod.deconflictGlobalName(alloc, &used, "foo");
+    defer alloc.free(nf);
+    try std.testing.expectEqualStrings("foo", nf);
+}
+
 test "computeCrossChunkLinks: static cross-chunk import" {
     // 구조: 청크 A(모듈 0), 청크 B(모듈 1). 모듈 0 → 모듈 1 정적 의존.
     // 기대: A.cross_chunk_imports에 B가 포함.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -184,6 +184,16 @@ pub const Linker = struct {
     /// 모듈 변수로 사용하지 않도록 리네이밍.
     global_identifiers: []const []const u8 = &.{},
 
+    /// RFC #3940 / 이슈 #4101 — cross-chunk 심볼 **전역 일관 네이밍**.
+    /// `module_index → (export_name → 전역 이름)`. cross-chunk 로 노출/소비되는 심볼은
+    /// provider/consumer 가 *같은* 이름을 써야 하는데, per-chunk `rename_table` 은 청크별로
+    /// clear 되어 소비자가 provider 의 deconflict 이름을 못 본다(소비자 본문 collapse, #B).
+    /// 이 맵은 cross-chunk 심볼만 **occupied 와 무관하게** 전역 deconflict 해(순환 끊기),
+    /// per-chunk pass 가 reserved 로 받고 metadata/emit 이 참조할 단일 출처다.
+    /// 값(전역 이름)은 이 맵이 소유(owned dupe) — borrowed-ptr UAF(#3933) 회피.
+    /// **Inc-1: 채우기만(비활성 read)** — 동작 변경 0, 후속 increment 가 wire.
+    cross_chunk_global_names: std.AutoHashMapUnmanaged(u32, std.StringHashMapUnmanaged([]const u8)) = .empty,
+
     /// dev mode: HMR용 모듈 참조를 __zntc_modules["id"].fn()으로 생성.
     /// init_xxx() 대신 동적 lookup을 사용하여 new Function()에서도 접근 가능.
     dev_mode: bool = false,
@@ -413,6 +423,9 @@ pub const Linker = struct {
         self.canonical_names_used.deinit(self.allocator);
         self.rename_table.deinit(self.allocator);
         self.reserved_globals.deinit(self.allocator);
+        // cross-chunk 전역 이름(#4101): owned value 해제 + inner/outer 맵 deinit.
+        self.clearCrossChunkGlobalNames();
+        self.cross_chunk_global_names.deinit(self.allocator);
         // chain_cache: 키는 allocator로 dupe됨
         var cc_it = self.chain_cache.keyIterator();
         while (cc_it.next()) |key| self.allocator.free(key.*);
@@ -1324,6 +1337,37 @@ pub const Linker = struct {
     /// 다른 모듈의 리네임 대상으로 이미 할당된 이름인지 O(1) 확인.
     fn isCanonicalNameTaken(self: *const Linker, name: []const u8) bool {
         return self.canonical_names_used.contains(name);
+    }
+
+    // ── cross-chunk 전역 일관 네이밍(RFC #3940 / #4101) ─────────────────────────
+
+    /// `(canonical_module, export_name)` 의 cross-chunk 전역 이름을 등록. `global_name` 은
+    /// owned(caller 가 dupe 해 넘김) — 맵이 소유하고 `clearCrossChunkGlobalNames`/`deinit` 에서
+    /// 해제. `export_name` 키는 borrow(export binding 소유, bundle 수명 안정).
+    pub fn putCrossChunkGlobalName(self: *Linker, module_index: u32, export_name: []const u8, global_name: []const u8) !void {
+        const gop = try self.cross_chunk_global_names.getOrPut(self.allocator, module_index);
+        if (!gop.found_existing) gop.value_ptr.* = .empty;
+        // 같은 (mod, name) 재등록 시 이전 owned value 해제(leak 방지).
+        if (try gop.value_ptr.fetchPut(self.allocator, export_name, global_name)) |old| {
+            self.allocator.free(old.value);
+        }
+    }
+
+    /// cross-chunk 전역 이름 조회. 없으면 null(호출처는 기존 per-chunk fallback).
+    pub fn getCrossChunkGlobalName(self: *const Linker, module_index: u32, export_name: []const u8) ?[]const u8 {
+        const inner = self.cross_chunk_global_names.get(module_index) orelse return null;
+        return inner.get(export_name);
+    }
+
+    /// 전역 이름 맵 비우기 — owned value 해제 + inner 맵 deinit.
+    pub fn clearCrossChunkGlobalNames(self: *Linker) void {
+        var it = self.cross_chunk_global_names.valueIterator();
+        while (it.next()) |inner| {
+            var vit = inner.valueIterator();
+            while (vit.next()) |v| self.allocator.free(v.*);
+            inner.deinit(self.allocator);
+        }
+        self.cross_chunk_global_names.clearRetainingCapacity();
     }
 
     /// (module_index, local_name)의 최종 이름(`rename_table`)을 설정. value 소유권은


### PR DESCRIPTION
## 목적

이슈 #4101(cross-chunk 같은 이름 충돌 → 소비자 본문 collapse)의 근본 수정을 **incremental**하게 진행하는 첫 단계입니다. **인프라만 추가하고 read는 비활성 = 동작 변경 0.**

## 배경 (왜 이렇게 쪼개나)

per-chunk `rename_table`이 청크별로 `clear()`되어 소비자가 provider의 deconflict 이름(`v$1`)을 못 봅니다. bolt-on 맵은 **occupied(rename 입력) ↔ 이름 맵(rename 출력) 순환**에 막힙니다(#4101에 코드레벨 증명). 순환을 끊는 핵심 = cross-chunk 심볼만 **occupied와 무관하게** 전역 deconflict하는 self-contained pass.

## 이번 변경 (Inc-1)

- **linker.zig**: `cross_chunk_global_names` 맵(`module→export명→전역명`) + put/get/clear + deinit. 값은 맵이 **owned(dupe)** — borrowed-ptr UAF(#3933 실패 모드) 회피.
- **chunk.zig**: `computeCrossChunkGlobalNames` pass — 모든 청크 `imports_from` enumerate → `(mod,name)` dedup → 결정론 정렬 → 전역 deconflict. deconflict 코어 `deconflictGlobalName` 순수 함수로 추출(단위 테스트).
- **bundler.zig**: `computeCrossChunkLinks` 직후 호출(splitting+linker 시). **map 채우기만.**
- **chunk_test.zig**: `deconflictGlobalName` 단위 테스트(동명→`$N`, 예약어 회피).

## 검증

- unit **5750**(신규 deconflict 테스트 포함) 통과
- 통합 **0 회귀** — `cross-chunk-symbol-naming` 6 pass / 3 todo **불변**(= 비활성 확인) · napi-lazy-dev-hmr 15+1todo · cross-chunk-reexport 23 · manual-chunks 44 · iife/cjs splitting
- 전 빌드타깃(wasm/wasm-bundler/test262/schema)
- `splitting_dev.zig`의 `testing.allocator` 빌드가 pass를 **leak-check**(통과)

## 후속

- **Inc-2**: per-chunk rename이 전역명 reserve+사용
- **Inc-3**: metadata import 바인딩 read로 wire → #4101의 #B `test.todo`(va·vb→AB) flip

관련: #4101

🤖 Generated with [Claude Code](https://claude.com/claude-code)