### PR TITLE
feat(bundler): dev_split cross-chunk 같은 이름 충돌 해결 — 전역 일관 네이밍 활성화 (Inc-2/3, #4101)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1681,10 +1681,14 @@ pub const Bundler = struct {
 
             try chunk_mod.computeCrossChunkLinks(&chunk_graph, graph, self.allocator, if (linker) |*l| l else null);
 
-            // RFC #3940 / #4101 — cross-chunk 전역 일관 네이밍 채우기(Inc-1: read 비활성, 동작 변경 0).
-            // imports_from 확정 직후. linker 있고 splitting 일 때만(전역 이름은 cross-chunk 에서만 의미).
+            // RFC #3940 / #4101 — cross-chunk 전역 일관 네이밍 채우기. imports_from 확정 직후.
+            // **lazy(dev_split)로 scope** — production splitting 은 `export { local as public }`
+            // 브리지가 cross-chunk 이름을 따로 보존하므로 전역 네이밍을 적용하면 충돌. 맵이 비면
+            // 모든 wiring(crossChunkBindingName/metadata/override)이 fallback = production 불변.
+            // production cross-chunk 전역 네이밍(+ mangle 정합)은 별도 increment.
             if (linker) |*l| {
-                if (self.options.code_splitting) try chunk_mod.computeCrossChunkGlobalNames(self.allocator, &chunk_graph, l);
+                if (self.options.code_splitting and self.options.lazy_compilation)
+                    try chunk_mod.computeCrossChunkGlobalNames(self.allocator, &chunk_graph, l);
             }
 
             var emit_opts = self.makeEmitOptions();

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -1297,8 +1297,11 @@ fn addCrossChunkSymbol(
 
     const ifgop = try chunk.imports_from.getOrPut(allocator, src_ci);
     if (!ifgop.found_existing) ifgop.value_ptr.* = .empty;
+    // dedup 은 (export 이름, canonical 모듈) 둘 다로 — 서로 다른 모듈이 *같은* export
+    // 이름(두 `v`)을 내고 한 소비자가 둘 다 가져오면 이름만으론 하나로 붕괴(#B). canonical
+    // 모듈이 다르면 별개 심볼이라 둘 다 유지(전역 네이밍이 `v`/`v$1` 로 구분, #4101).
     for (ifgop.value_ptr.items) |existing| {
-        if (std.mem.eql(u8, existing.name, export_name)) break;
+        if (std.mem.eql(u8, existing.name, export_name) and existing.canonical_module == canonical_module) break;
     } else {
         try ifgop.value_ptr.append(allocator, .{ .name = export_name, .canonical_module = canonical_module });
     }

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -67,6 +67,9 @@ fn appendCssLinkPrologue(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), 
 /// cross-chunk 가 발생하지 않으므로 export 명 그대로.
 fn crossChunkBindingName(linker: ?*Linker, sym: chunk_mod.CrossChunkSym) []const u8 {
     if (linker) |l| {
+        // #4101 전역 일관 네이밍: cross-chunk 심볼은 provider/consumer 가 같은 전역 이름을
+        // 써야 한다. 전역 맵에 있으면 그걸 우선(같은 이름 다른 모듈 `v`/`v$1` 구분).
+        if (l.getCrossChunkGlobalName(sym.canonical_module, sym.name)) |g| return g;
         if (Linker.isReservedName(sym.name)) {
             return l.resolveToLocalName(.{
                 .module_index = @enumFromInt(sym.canonical_module),
@@ -555,13 +558,15 @@ pub fn emitChunks(
                     } else {
                         // key == binding → 축약. 단 같은 export 명이 여러 dep 에서 오면
                         // 중복 로컬 선언 충돌 → 2번째부터 `key: key$N` deconfliction.
+                        // lazy(전역 네이밍)는 binding 이 이미 전역 deconflict(`v`/`v$1`)라
+                        // `$N` 불필요(이중 deconflict 로 소비자 참조와 어긋남). non-lazy 만.
                         const total = name_total_count.get(name) orelse 1;
                         const seen_gop = try name_seen_count.getOrPut(allocator, name);
                         if (!seen_gop.found_existing) seen_gop.value_ptr.* = 0;
                         seen_gop.value_ptr.* += 1;
                         const seen = seen_gop.value_ptr.*;
 
-                        if (total > 1 and seen > 1) {
+                        if (total > 1 and seen > 1 and !lazy_local_keys) {
                             const alias = try std.fmt.allocPrint(allocator, "{s}${d}", .{ key, seen });
                             try alias_strs.append(allocator, alias);
                             try chunk_output.appendSlice(allocator, key);
@@ -2123,7 +2128,14 @@ fn emitLazyEntryExportAll(
             // 여기선 스킵한다. (`export * as ns`=re_export_namespace 는 실제 로컬 ns
             // 심볼이 있으므로 스킵 대상 아님.)
             if (eb.kind == .re_export_star) continue;
-            const local = l.getCanonicalName(@intCast(mi), eb.exported_name) orelse m.exportBindingLocalName(eb);
+            // 노출 키 = deconflict 된 local 명. export 명이 canonical 이면 그걸(`export const v`),
+            // 아니면(예: `default` 의 합성 local `_default`) export 의 *local* 명의 canonical 로
+            // fallback — 안 하면 default 가 un-deconflict 된 `_default` 로 떨어져 동명 default 둘이
+            // dedup(소비자 본문 `_default$1` 미노출). #4101 전역 override 가 local canonical 을
+            // `_default$1` 로 고정하므로 그 경로로 정확히 노출된다.
+            const export_local = m.exportBindingLocalName(eb);
+            const local = l.getCanonicalName(@intCast(mi), eb.exported_name) orelse
+                (l.getCanonicalName(@intCast(mi), export_local) orelse export_local);
             if (local.len == 0) continue;
             const gop = try seen.getOrPut(allocator, local);
             if (gop.found_existing) continue;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2699,6 +2699,24 @@ pub const Linker = struct {
         // 2. 충돌하는 이름에 대해 리네임 계산 (cross-chunk 점유 마커는 skip)
         try self.calculateRenames(&name_to_owners, true);
 
+        // 2.5 #4101 cross-chunk 전역 네이밍 override — 이 청크가 export 하는 cross-chunk 심볼을
+        // 전역 이름으로 고정. calculateRenames 의 per-chunk deconflict 순서(exec_index)가 전역
+        // 순서(mod,name)와 어긋나면 어느 심볼이 `v`/`v$1` 을 갖는지 달라진다 → override 로 전역
+        // 맵과 일치시켜 provider/consumer 가 같은 이름을 본다. dupe → putCanonicalName 이
+        // canonical_strings 로 소유권 이전. (전역명==per-chunk 결과면 no-op. reserve 마커는 안 둔다
+        // — non-cross-chunk 동명 심볼(dup.v)까지 밀어내 `v$2` 가 되는 부작용 때문. calculateRenames
+        // 자연 순서가 cross-chunk owner 에게 preferred 를 주므로 override 는 divergence 만 교정.)
+        // minify 는 아래 mangle 이 다시 덮으므로 production 전역 네이밍은 별도 increment.
+        for (module_indices) |mod_idx| {
+            const inner = self.cross_chunk_global_names.get(mod_idx.toU32()) orelse continue;
+            var git = inner.iterator();
+            while (git.next()) |e| {
+                const local = self.getExportLocalName(mod_idx.toU32(), e.key_ptr.*) orelse e.key_ptr.*;
+                const dup = try self.allocator.dupe(u8, e.value_ptr.*);
+                try self.putCanonicalName(mod_idx.toU32(), local, dup);
+            }
+        }
+
         // 3. #4045: production code splitting + minify 시 deconflict 이후 청크 *내부*
         // 로컬 식별자를 축약(mangle)한다. deconflict(calculateRenames)를 먼저 돌려
         // 단일 번들의 computeRenames→computeMangling 순서를 그대로 재현 — 1-char

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -319,6 +319,18 @@ fn putOwnedRename(
     try renames.put(self.allocator, sid, v);
 }
 
+/// import 바인딩의 최종 이름 — cross-chunk **전역 일관 네이밍**(#4101) 우선.
+/// 바인딩이 cross-chunk 심볼로 해석되고 전역 이름이 있으면 그걸(provider/consumer 가
+/// 합의한 deconflict 이름, 같은 이름 다른 모듈 `v`/`v$1` 구분), 아니면 per-chunk
+/// `getCanonicalByRef`(같은 청크/비충돌), 그것도 없으면 `fallback`.
+/// 같은 청크 import 는 전역 맵에 없어 fallback 경로 = 기존 동작 불변.
+fn importBindingName(self: *const Linker, module_index: u32, ib: anytype, fallback: []const u8) []const u8 {
+    if (self.getResolvedBinding(module_index, ib.local_span)) |rb| {
+        if (self.getCrossChunkGlobalName(@intFromEnum(rb.canonical.module_index), rb.canonical.export_name)) |g| return g;
+    }
+    return self.getCanonicalByRef(ib.local_symbol) orelse fallback;
+}
+
 /// identifier 의 첫 byte 가 정상 ASCII (0x21-0x7F) 인지. UAF 시 채워지는 0xAA / 0 등
 /// invalid byte 를 reject — `target_name` 이 freed memory 면 rename 등록 skip.
 fn isValidIdentStartByte(b: u8) bool {
@@ -577,7 +589,7 @@ pub fn buildMetadataForAst(
                 if (rec.is_lazy_resolved) continue;
                 if (rec.kind.isEagerEvalDependency()) {
                     if (!ib.is_helper and !ib.local_symbol.isValid()) continue;
-                    const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
+                    const preamble_name = importBindingName(self, module_index, ib, m.importBindingLocalName(ib));
                     // helper binding (JSX runtime 등) + ESM-wrapped 모듈 조합에서는 top-level
                     // 에 이미 `var _jsxDEV, _Fragment;` 선언이 호이스팅됨 (esm_wrap). init 함수
                     // 본문에서 `var` 로 재선언하면 outer scope 를 shadow → #1209.
@@ -738,7 +750,7 @@ pub fn buildMetadataForAst(
                         }
                     } else {
                         const interop_mode = cjsInteropMode(self, &m);
-                        const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
+                        const preamble_name = importBindingName(self, module_index, ib, m.importBindingLocalName(ib));
                         const hoisted_name = try self.allocator.dupe(u8, preamble_name);
                         errdefer self.allocator.free(hoisted_name);
                         try ns_var_list.append(self.allocator, hoisted_name);
@@ -765,7 +777,7 @@ pub fn buildMetadataForAst(
                 // 도 같이 drop 한다. `tree_shaker_active` 가 false (linker 단독 unit test)
                 // 면 `is_included` 비트가 신뢰할 수 없으므로 가드를 적용하지 않는다.
                 if (self.tree_shaker_active and !canonical_m_opt.?.is_included) continue;
-                const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
+                const preamble_name = importBindingName(self, module_index, ib, m.importBindingLocalName(ib));
                 const req_var = try getOrCreateCjsRequireRef(self, &cjs_var_cache, @intCast(canonical_mod));
                 const interop_mode = cjsInteropMode(self, &m);
                 // ESM-wrapped + helper binding: top-level 에 이미 var 선언됨 (esm_wrap) → 할당만
@@ -886,7 +898,7 @@ pub fn buildMetadataForAst(
                 if (!self.dev_mode and namespaceHasCjsStar(self, canonical_mod) and
                     !(self.tree_shaker_active and !target_included))
                 {
-                    const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse local_name;
+                    const preamble_name = importBindingName(self, module_index, ib, local_name);
                     // ESM-local getter 객체 (CJS plain-star 멤버는 부재, inner-CJS 는 __toESM).
                     const obj = try self.buildNamespaceInlineObject(@intCast(canonical_mod), 0);
                     defer self.allocator.free(obj);
@@ -942,7 +954,7 @@ pub fn buildMetadataForAst(
             // 롤다운 shimMissingExports 호환: 소스 모듈에 해당 export가 없으면
             // strict mode ReferenceError 대신 undefined를 반환하도록 shim 생성.
             if (resolved == null and self.shim_missing_exports) {
-                const shim_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
+                const shim_name = importBindingName(self, module_index, ib, m.importBindingLocalName(ib));
                 try preamble.write("var ");
                 try preamble.write(shim_name);
                 try preamble.write(" = void 0;\n");
@@ -958,7 +970,7 @@ pub fn buildMetadataForAst(
                 const cjs_mod: u32 = @intCast(@intFromEnum(rb.canonical.module_index));
                 const cjs_mod_opt = self.graph.getModule(rb.canonical.module_index);
                 if (cjs_mod_opt != null and cjs_mod_opt.?.wrap_kind == .cjs) {
-                    const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
+                    const preamble_name = importBindingName(self, module_index, ib, m.importBindingLocalName(ib));
                     const req_var = try getOrCreateCjsRequireRef(self, &cjs_var_cache, cjs_mod);
                     const interop_mode2 = cjsInteropMode(self, &m);
                     const effective_name = rb.canonical.export_name;
@@ -1048,7 +1060,14 @@ pub fn buildMetadataForAst(
             // 중첩 스코프 충돌은 resolveNestedShadowConflicts에서 이미 처리됨.
             // 방어 — target_name 이 use-after-free 로 0xAA / 0 등 invalid byte 로
             // 채워졌으면 rename 스킵 (#2429).
-            if (!isReservedName(target_name) and target_name.len > 0 and isValidIdentStartByte(target_name[0])) {
+            // #4101 cross-chunk 전역 일관 네이밍 — 이 바인딩이 cross-chunk 심볼로 해석되고
+            // 전역 이름이 있으면(같은 이름 다른 모듈 `v`/`v$1` 구분) per-chunk target_name 대신
+            // 전역명을 본문 참조로 쓴다. synth_member/lazy_esm(특수 표현)은 target_name 유지.
+            const effective_target = if (resolved) |rb|
+                (self.getCrossChunkGlobalName(@intFromEnum(rb.canonical.module_index), rb.canonical.export_name) orelse target_name)
+            else
+                target_name;
+            if (!isReservedName(effective_target) and effective_target.len > 0 and isValidIdentStartByte(effective_target[0])) {
                 if (ib.local_symbol.semanticIndex()) |sym_idx| {
                     // #3664 P2: synthetic_named_exports → canonical(default/target) export 의 member
                     // access 로 rename(`{target_name}.{member}`). 정적으로 export 안 된 named import 를
@@ -1060,7 +1079,7 @@ pub fn buildMetadataForAst(
                     else if (lazy_esm_import)
                         try allocLazyEsmImportExpr(self, canonical_m_opt.?, lazy_esm_import_mod orelse canonical_m_opt.?, target_name)
                     else
-                        target_name;
+                        effective_target;
                     if (synth_member != null or lazy_esm_import) {
                         var rename_owned_by_list = false;
                         errdefer if (!rename_owned_by_list) self.allocator.free(rename_value);

--- a/tests/integration/tests/cross-chunk-symbol-naming.test.ts
+++ b/tests/integration/tests/cross-chunk-symbol-naming.test.ts
@@ -172,7 +172,7 @@ describe('cross-chunk 심볼 네이밍 (이슈 #4101 방어 스위트)', () => {
   // lifecycle 재설계로 cross-chunk 심볼명이 전역 일관되면 `test.todo`→`test` flip.
 
   // 서로 다른 모듈의 같은 named export 둘을 한 소비자가 import → 본문 참조 collapse.
-  test.todo('전역일관성: 다른 모듈의 같은 named export 둘 (va·vb → AB)', async () => {
+  test('전역일관성: 다른 모듈의 같은 named export 둘 (va·vb → AB)', async () => {
     const { require } = await loadDevSplit(
       {
         'a.ts': "export const v = 'A';",
@@ -188,7 +188,7 @@ describe('cross-chunk 심볼 네이밍 (이슈 #4101 방어 스위트)', () => {
   });
 
   // 서로 다른 모듈의 default 둘.
-  test.todo('전역일관성: 다른 모듈의 default 둘 (da()·db() → DADB)', async () => {
+  test('전역일관성: 다른 모듈의 default 둘 (da()·db() → DADB)', async () => {
     const { require } = await loadDevSplit(
       {
         'a.ts': "export default function(){ return 'DA'; }",
@@ -204,7 +204,7 @@ describe('cross-chunk 심볼 네이밍 (이슈 #4101 방어 스위트)', () => {
   });
 
   // 세 모듈의 같은 이름.
-  test.todo('전역일관성: 세 모듈의 같은 named export (a+b+c → ABC)', async () => {
+  test('전역일관성: 세 모듈의 같은 named export (a+b+c → ABC)', async () => {
     const { require } = await loadDevSplit(
       {
         'a.ts': "export const v = 'A';",

--- a/tests/integration/tests/napi-lazy-dev-hmr.test.ts
+++ b/tests/integration/tests/napi-lazy-dev-hmr.test.ts
@@ -57,7 +57,7 @@ describe('NAPI lazy dev split HMR runtime (RFC_LAZY_DEV_MODULE_HMR PR-2)', () =>
     const lazyChunk = (r.outputFiles ?? []).find((o) => o.path.includes(lazyPrefix));
     expect(entryChunk && lazyChunk).toBeTruthy();
     // 예약어 축약 destructuring(`const { default }`) 이 없어야 한다(SyntaxError 원인).
-    expect(/const\s*\{[^}]*\bdefault\b[^}:]*\}\s*=/.test(lazyChunk!.text)).toBe(false);
+    expect(/const\s*\{[^}]*\bdefault\b(?!\$)[^}:]*\}\s*=/.test(lazyChunk!.text)).toBe(false);
     const g: Record<string, unknown> = { console };
     g.globalThis = g;
     const ctx = vm.createContext(g);
@@ -495,7 +495,7 @@ process.stdout.write(JSON.stringify({
     const routeChunk = (r.outputFiles ?? []).find((o) => o.path.includes('Route-'));
     expect(entryChunk && routeChunk).toBeTruthy();
     // emit 가드: 예약어 축약 destructuring(`const { default ...`) 이 없어야 한다(SyntaxError 원인).
-    expect(/const\s*\{[^}]*\bdefault\b[^}:]*\}\s*=/.test(routeChunk!.text)).toBe(false);
+    expect(/const\s*\{[^}]*\bdefault\b(?!\$)[^}:]*\}\s*=/.test(routeChunk!.text)).toBe(false);
 
     // 런타임 가드: Route 청크가 parse 되고(runInContext 가 안 던짐) default/named 실값이 맞아야 한다.
     const g: Record<string, unknown> = { console };
@@ -544,7 +544,7 @@ process.stdout.write(JSON.stringify({
     const cardChunk = (r.outputFiles ?? []).find((o) => o.path.includes('Card-'));
     expect(entryChunk && cardChunk).toBeTruthy();
     // 예약어 축약 destructuring(`const { default ...`) 이 없어야 한다(SyntaxError 원인).
-    expect(/const\s*\{[^}]*\bdefault\b[^}:]*\}\s*=/.test(cardChunk!.text)).toBe(false);
+    expect(/const\s*\{[^}]*\bdefault\b(?!\$)[^}:]*\}\s*=/.test(cardChunk!.text)).toBe(false);
 
     const g: Record<string, unknown> = { console };
     g.globalThis = g;
@@ -651,7 +651,7 @@ process.stdout.write(JSON.stringify({
   // 하고(provider 의 deconflict 된 이름 persistence), 그건 RFC_GRAPH_PERSISTENCE(CLOSED) /
   // lifecycle scope redesign 급 변경이다. 부분 수정은 본문이 여전히 붕괴해 순효과가 없어
   // 보류 — 전역 네이밍 일관성 확보 후 `test.todo`→`test` 로 전환.
-  test.todo('다른 모듈의 같은 이름 export 둘을 한 lazy 청크가 import (dedup 붕괴 #B)', async () => {
+  test('다른 모듈의 같은 이름 export 둘을 한 lazy 청크가 import (dedup 붕괴 #B)', async () => {
     const { exports } = await loadDevSplitLazy(
       {
         'a.ts': "export const v = 'A';",


### PR DESCRIPTION
## 🎯 해결

[#4101](https://github.com/ohah/zntc/issues/4101)의 **#B** — 서로 다른 모듈의 *같은* export 이름이 한 lazy 청크에서 소비자 **본문 참조 collapse**(`va·vb→va`, `r()='AA'`) — 를 근본 해결합니다. Inc-1(전역 네이밍 인프라, 비활성)을 wire한 **Inc-2/3**. **dev_split로 scope**(production은 `export { local as public }` 브리지가 따로 처리).

## 🔑 순환을 끊은 방법

`occupied(rename 입력) ↔ 이름 맵(rename 출력)` 순환을 끊은 핵심:
- cross-chunk 심볼만 **occupied 무관하게 전역 deconflict**(Inc-1, self-contained)
- per-chunk rename이 그걸 **reserve 아닌 override**로 받음 — 자연 deconflict 순서가 전역과 어긋날 때만 교정, **non-cross-chunk 동명 심볼은 안 건드림**(reserve 마커는 `dup.v`를 `v$2`로 미는 부작용 → 제거)

## 🛠️ 활성화

- **chunk.zig**: `imports_from` dedup을 `(이름, canonical 모듈)`로 — 동명 다른 모듈 둘 다 유지
- **chunks.zig**: `crossChunkBindingName`이 전역 이름 우선(`const { v, v$1 }`); lazy는 `$N` skip; `emitLazyEntryExportAll`이 `default`의 합성 local(`_default`)을 canonical로 fallback → 동명 default 둘을 `exports._default`/`exports._default$1`로 노출(예전 dedup 버그)
- **linker.zig**: `computeRenamesForModules`가 `calculateRenames` 후 cross-chunk 심볼을 전역 이름으로 **override**(provider 노출=전역명)
- **metadata.zig**: `importBindingName` 헬퍼(전역명 우선) 6 사이트 + ESM rename의 `effective_target`
- **bundler.zig**: 전역 네이밍 pass 게이트를 `code_splitting and lazy_compilation`로
- **테스트**: #B `test.todo`→`test` flip(cross-chunk-symbol-naming **9**, napi-lazy-dev-hmr **16**); 예약어 default 정규식 가드를 `default$N` 제외로 정정(전역명 `default$1` false-positive)

## ✅ 검증

- **두 v / 두 default / 세 v / renamed re-export** 전부 ✅
- unit **5749** + test262 + 전 빌드타깃(wasm/wasm-bundler/schema/install)
- 광범위 회귀 **0**: cross-chunk-reexport 23 · manual-chunks 44 · splitting 전 포맷(iife/cjs/umd/css) · **js-dev-server-lazy 5**(materialize/render)
- **#6 ⭐ 독립 청크 이름 재사용(번들 크기) lock 유지**
- production **byte-identical**(맵 비어 fallback)
- focused 코드리뷰 **0 실제 결함**(re-export-with-rename 실증 refute)

## 후속

production cross-chunk 전역 네이밍(+ mangle 정합)은 별도 increment.

관련: #4101 · Inc-1 #4104

🤖 Generated with [Claude Code](https://claude.com/claude-code)