### PR TITLE
test(bundler): production cross-chunk same-name 타깃 TDD (todo, #4101)

### DIFF
--- a/tests/integration/tests/cross-chunk-reexport.test.ts
+++ b/tests/integration/tests/cross-chunk-reexport.test.ts
@@ -448,4 +448,45 @@ describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
       }
     });
   }
+
+  // #4101 production 범위 (todo): 서로 다른 모듈의 *같은* export 이름(두 `v`)이 한 shared
+  // 청크에 묶이고 여러 entry 가 둘 다 import 하면, production 브리지가 public=export 명이라
+  // 충돌 → `export { v$1 as v }` 하나만 노출 + 소비자 `import { v, v as v$2 }` 둘 다 같은
+  // public "v" 에 바인딩 → collapse(둘 다 한 값). dev_split 은 #4105 에서 전역 네이밍으로
+  // 해결됐으나 production 은 ① exports_to 가 export 명으로만 dedup(자료구조) ② 브리지
+  // public=전역명 ③ 소비자 import key=전역명 ④ override 를 lazy 로 게이트 ⑤ mangle 정합 이
+  // 필요한 별도 increment. 전역 네이밍 pass 를 production 으로 확장하면 green.
+  for (const format of ['esm', 'iife'] as const) {
+    test.todo(`${format}: 다른 모듈의 같은 export 둘을 여러 entry 가 import (전역 네이밍 production #4101)`, async () => {
+      const fixture = await createFixture({
+        'a.ts': "export const v = 'AV';",
+        'b.ts': "export const v = 'BV';",
+        'e1.ts':
+          "import { v as a } from './a';\nimport { v as b } from './b';\nconsole.log('e1', a, b);",
+        'e2.ts':
+          "import { v as a } from './a';\nimport { v as b } from './b';\nconsole.log('e2', a, b);",
+      });
+      cleanup = fixture.cleanup;
+      const result = await build({
+        entryPoints: [join(fixture.dir, 'e1.ts'), join(fixture.dir, 'e2.ts')],
+        rootDir: fixture.dir,
+        platform: 'node',
+        splitting: true,
+        format,
+      });
+      const outs = result.outputFiles!;
+      writeOutputs(fixture.dir, outs);
+      const e1 = outs.find((o) => o.path.includes('e1') && o.path.endsWith('.js'))!;
+      const driver =
+        format === 'esm'
+          ? join(fixture.dir, e1.path)
+          : browserDriver(
+              fixture.dir,
+              e1.path,
+              outs.map((o) => o.path),
+            );
+      const { stdout } = await runNode(driver);
+      expect(stdout.trim()).toBe('e1 AV BV'); // 현재 'e1 BV BV' (collapse)
+    });
+  }
 });


### PR DESCRIPTION
## 목적

dev_split의 #B(같은 이름 cross-chunk collapse)는 전역 네이밍으로 해결(#4105)됐으나, **production splitting**은 같은 클래스 한계가 남아 있습니다. 그 타깃을 코드로 고정합니다(현재 red, `test.todo`).

## production이 dev_split보다 큰 이유

| | dev_split (#4105 완료) | production (남은 범위) |
|--|--|--|
| 노출 | `emitLazyEntryExportAll`(local-key, override 가능) | **`export { local as public }` 브리지**(public=export명→동명 충돌) |
| dedup | `imports_from`(canonical 모듈 보유) | **`exports_to`가 export명으로만 dedup**(자료구조 한계) |
| mangle | dev=없음 | **mangle이 local 건드림**(정합 필요) |
| 테스트 | 신규 | **100+ production cross-chunk 테스트가 현 브리지 shape 인코딩** |

## 해결에 필요 (별도 dedicated increment)

① `exports_to`에 canonical 모듈 추가 ② 브리지 public=전역명 ③ 소비자 import key=전역명 ④ override를 lazy로 게이트(이미) ⑤ mangle 정합 ⑥ **reserved-default(#4099)와 same-name의 브리지 public 상호작용** 정합.

전역 네이밍 pass를 production으로 확장하면 `todo`→`test` flip.

관련: #4101 · dev_split 해결 #4105

🤖 Generated with [Claude Code](https://claude.com/claude-code)