### PR TITLE
test(parser): zig build test 에 parser 유닛 테스트 포함 (root.zig _ = parser;)

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -35,6 +35,7 @@ pub const bench = @import("bench.zig");
 
 test {
     _ = lexer;
+    _ = parser;
     _ = regexp;
     _ = semantic;
     _ = transformer;


### PR DESCRIPTION
## 배경
`src/root.zig` 의 test 블록은 테스트를 포함할 모듈을 명시적으로 열거(`_ = lexer; _ = semantic; _ = transformer; ...`)하는데, **`_ = parser;` 만 누락**되어 있었다. build.zig 의 test 스텝이 `src/root.zig` 를 root_module 로 쓰므로, `parser/mod.zig` 의 테스트 집계 블록(parser_test/ast_test/ast_walk_test)이 `zig build test` 에서 통째로 제외되어 있었다.

→ 파서 회귀(크래시 포함)가 CI 에서 silent 하게 통과되던 사각. 실제로 파서 segfault 버그(#4107)가 이 사각으로 메인에 살아 있었다.

## 변경
- `root.zig` test 블록에 `_ = parser;` 한 줄 추가 (lexer↔regexp 사이, 파이프라인 순서).

## 검증
- 와이어링 전: parser_test 에 `expect(false)` probe 추가 후 `zig build test -Dtest-filter=...` → **exit 0** (probe 미실행, 통과로 표시).
- 와이어링 후: 동일 probe → **exit 1**, `'parser.parser_test.test.WIRING_PROBE...' failed` (probe 실제 실행·실패 = 와이어링 작동).
- 전체: `zig build test --summary all` → **7/7 steps succeeded; 5725/5725 tests passed** (기존 parser 테스트 전부 green, 회귀 0).

## 리뷰
`/code-review max` — diff 1줄(idiomatic 테스트 와이어링), correctness 결함 없음(`[]`).

이 PR 이 머지되어야 후속 파서 버그(#4107 등)의 회귀 테스트가 CI 에서 실제로 가드된다.

Closes #4111