### PR TITLE
fix(parser): destructuring default 직후 invalid 바인딩 타겟에서 파서 세그폴트 수정

### DIFF
--- a/src/parser/binding.zig
+++ b/src/parser/binding.zig
@@ -222,6 +222,11 @@ pub fn tryWrapDefaultValue(self: *Parser, node: NodeIndex) ParseError2!NodeIndex
         const def_saved = self.enterAllowInContext(true);
         const default_val = try self.parseAssignmentExpression();
         self.restoreContext(def_saved);
+        // 바인딩 타겟이 없으면(parseBindingName/parseBindingPattern 이 에러 복구로
+        // .none 을 반환) assignment_pattern 으로 감싸지 않는다. getNode(.none) OOB
+        // 역참조(nodes.items[4294967295])를 방지하고, 호출자의 "none = no-op" 계약과
+        // 일치시킨다. default 표현식은 위에서 이미 소비되어 파서 전진은 보장된다.
+        if (node.isNone()) return node;
         return try self.ast.addNode(.{
             .tag = .assignment_pattern,
             .span = .{ .start = self.ast.getNode(node).span.start, .end = self.currentSpan().start },

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4765,3 +4765,23 @@ test "TS: for header allows `using` and `await using` declarations" {
     defer r.deinit();
     try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
 }
+
+// 회귀(#4107): 바인딩 타겟 없이 default(`= expr`)만 오는 destructuring 패턴은
+// 파서를 크래시(tryWrapDefaultValue 의 getNode(.none) OOB 역참조)시키면 안 되고
+// 진단을 내고 정상 복구해야 한다. parser 테스트는 #4111 로 zig build test 에 포함됨.
+fn parseExpectErrorNoCrash(src: []const u8) !void {
+    var scanner = try Scanner.init(std.testing.allocator, src);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+    // 크래시 없이 여기 도달 + 진단이 1건 이상 기록되어야 한다.
+    try std.testing.expect(parser.errors.items.len > 0);
+}
+
+test "Parser regression #4107: destructuring default with missing binding target does not crash" {
+    try parseExpectErrorNoCrash("const [= 1] = x;");
+    try parseExpectErrorNoCrash("const [, = 1] = x;");
+    try parseExpectErrorNoCrash("const [a, = 1] = x;");
+    try parseExpectErrorNoCrash("const { a: = 1 } = x;");
+}


### PR DESCRIPTION
## 문제
바인딩 타겟 없이 `= default` 만 오는 destructuring 패턴에서 파서가 **세그폴트(SIGSEGV, exit 139)** 했다.

```sh
printf 'const [= 1] = x;\n' > t.js
./zig-out/bin/zntc t.js   # 수정 전: exit 139 (SIGSEGV)
```
같은 크래시: `const [, = 1] = x;`, `const { a: = 1 } = x;`, `const [a, = 1] = x;`, `function f([= 1]) {}`.

## 근본 원인
`src/parser/binding.zig` `tryWrapDefaultValue` 가 `node.isNone()` 가드 없이 `self.ast.getNode(node).span.start` 를 역참조. `parseBindingName`/`parseBindingPattern` 의 에러 복구 경로는 현재 토큰이 바인딩을 시작할 수 없을 때(`=` 등) **스캐너를 advance 하지 않고 `.none` 을 반환**한다. 호출자가 그 none 에 `tryWrapDefaultValue` 를 호출하면 current()=`=` → `eat(.eq)` 성공 → `getNode(.none)` = `nodes.items[4294967295]` OOB.

## 수정 (루트커즈, single choke point)
`tryWrapDefaultValue` 6개 호출처가 공유하는 단일 지점에서 `node.isNone()` 가드 추가 — default 표현식은 소비(파서 전진 보장)하되 `assignment_pattern` 으로 감싸지 않고 none 반환. 호출자의 "none = no-op" 계약과 일치(배열/객체/함수 파라미터 패턴 전부 커버).

## 검증
- 크래시 입력 전부 `exit 139` → `exit 1` + `ZNTC0501 Binding pattern expected`
- 엣지(invalid default `[= ]`, 중첩 `[[= 1]]`, 함수 파라미터 `f([= 1])`, 다중 `[= 1, = 2]`) 전부 크래시 없이 진단
- 정상 destructuring default(`[a = 1]`, `{ a: b = 1 }`, `[a, b = 2, ...c]`) 회귀 없음
- `zig build test` → 7/7 steps, 5751/5751 tests passed
- bundle 경로: 501 은 fatal 이라 parse_module 이 모듈 skip → codegen 미도달 (다운스트림 크래시 없음)
- `/code-review max`: 결함 없음(`[]`) — 호출처·다운스트림 `.none` 가드 전수 확인

회귀 테스트(`parseExpectErrorNoCrash`)는 #4111 로 parser 테스트가 CI 에 포함되어 실제 가드된다.

Closes #4107