### PR TITLE
fix(parser): import attribute 중복키 검사의 use-after-scope 로 정상 키 오거부(ZNTC0304) 수정

### DIFF
--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -1072,6 +1072,11 @@ fn parseImportAttributes(self: *Parser) ParseError2!NodeList {
 
     // 중복 키 검사용 (최대 16개, 초과 시 검사 생략)
     var keys: [16][]const u8 = undefined;
+    // 각 키의 디코드 결과 백킹 스토리지. keys 와 동일 수명(루프 전체)을 갖도록 루프
+    // 밖에 둔다. 루프-지역 버퍼에 디코드하면 그 슬라이스가 keys 에 저장된 뒤 다음
+    // 반복에서 같은 스택 슬롯이 덮어써져, 디코드 길이가 같은 escape 키 2개가 서로
+    // 다른데도 false-positive 중복으로 오거부되는 use-after-scope 가 된다 (#4108).
+    var decoded_bufs: [16][256]u8 = undefined;
     var key_count: usize = 0;
 
     while (self.current() != .r_curly and self.current() != .eof) {
@@ -1087,9 +1092,8 @@ fn parseImportAttributes(self: *Parser) ParseError2!NodeList {
 
         // 중복 키 검사
         if (key_count < 16) {
-            var decoded_buf: [256]u8 = undefined;
             const effective_key = if (key_text.len >= 2 and (key_text[0] == '\'' or key_text[0] == '"'))
-                decodeStringKey(key_text[1 .. key_text.len - 1], &decoded_buf)
+                decodeStringKey(key_text[1 .. key_text.len - 1], &decoded_bufs[key_count])
             else
                 key_text;
 

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4785,3 +4785,44 @@ test "Parser regression #4107: destructuring default with missing binding target
     try parseExpectErrorNoCrash("const [a, = 1] = x;");
     try parseExpectErrorNoCrash("const { a: = 1 } = x;");
 }
+
+// 회귀(#4108): import attribute 중복키 검사의 디코드 버퍼가 루프-지역이면, 디코드
+// 길이가 같은 서로 다른 escape 키 2개가 같은 스택 슬롯을 공유(use-after-scope)해
+// false-positive 중복(ZNTC0304)으로 오거부됐다. decoded_bufs 를 루프 밖으로 hoist.
+// 결함은 escape 키(decodeStringKey 경로)에서만 발생하므로(plain 키는 소스 슬라이스
+// fast-path) 회귀 테스트의 소스 키는 반드시 unicode escape 형태로 둔다.
+fn parseModuleErrCount(src: []const u8) !usize {
+    var scanner = try Scanner.init(std.testing.allocator, src);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    parser.is_module = true;
+    defer parser.deinit();
+    _ = try parser.parse();
+    return parser.errors.items.len;
+}
+
+test "Parser regression #4108: distinct escaped import-attribute keys are not false duplicates" {
+    // 디코드 ab / cd: 서로 다른 키(디코드 길이 2 동일) → 중복 아님
+    try std.testing.expectEqual(@as(usize, 0), try parseModuleErrCount(
+        \\import data from "m" with { "\u0061b": "1", "\u0063d": "2" };
+    ));
+    // 디코드 길이가 다른 escape 키도 정상 (type=4 vs other=5)
+    try std.testing.expectEqual(@as(usize, 0), try parseModuleErrCount(
+        \\import data from "m" with { "\u0074ype": "json", "\u006fther": "x" };
+    ));
+    // escape 없는 plain 키 대조군
+    try std.testing.expectEqual(@as(usize, 0), try parseModuleErrCount(
+        \\import data from "m" with { "type": "json", "other": "x" };
+    ));
+}
+
+test "Parser regression #4108: genuine duplicate import-attribute keys still detected" {
+    // 둘 다 escape, 같은 디코드 값(ab) → 진짜 중복 → 검출
+    try std.testing.expect((try parseModuleErrCount(
+        \\import data from "m" with { "\u0061b": "1", "a\u0062": "2" };
+    )) > 0);
+    // plain 중복도 검출
+    try std.testing.expect((try parseModuleErrCount(
+        \\import data from "m" with { "type": "1", "type": "2" };
+    )) > 0);
+}


### PR DESCRIPTION
## 문제
서로 다른 import attribute 키인데 `ZNTC0304 Duplicate import attribute key` 로 **오거부**된다.

```sh
printf 'import data from "m" with { "ab": "1", "cd": "2" };\n' > t.js
./zig-out/bin/zntc t.js   # 수정 전: × Duplicate import attribute key [ZNTC0304]
```
`"ab"` → `ab`, `"cd"` → `cd` 로 서로 다른 키지만 거부됨. 트리거 조건: **escape 키 2개 + 디코드 길이 동일**. (plain 키 / 길이 상이 escape 키 / escape+plain 혼합은 정상)

## 근본 원인
`parseImportAttributes` 의 중복키 검사가 루프-지역 `decoded_buf: [256]u8` 의 슬라이스를 루프 수명 `keys: [16][]const u8` 에 저장. 같은 스택 슬롯이 다음 반복에서 재사용되어 use-after-scope — 디코드 길이가 같은 두 escape 키가 같은 슬롯을 가리켜 항상 동등 비교 → false-positive 중복. (escape 없는 키는 소스 슬라이스 fast-path 라 무관.)

## 수정 (루트커즈)
디코드 키의 백킹 스토리지 수명을 컨테이너(`keys[]`)와 일치시킨다: `decoded_bufs: [16][256]u8` 를 루프 밖으로 hoist 하여 키별 독립·안정 슬롯(`decoded_bufs[key_count]`) 사용. 16-키 cap 과 일치, 추가 할당 없음.

## 검증
- escaped distinct(`ab`/`cd`, `type`/`other`) → exit 0 (오거부 해소)
- genuine duplicate(`ab`/`ab` 둘 다 ab) → ZNTC0304 검출 **유지**
- 회귀 테스트 추가(#4111 로 CI 포함). **수정 revert 시 distinct 테스트가 실제 FAIL** 함을 확인 → 회귀 가드 유효성 검증.
- `zig build test` → 7/7 steps, 5753/5753 tests passed. plain/길이상이 키 회귀 없음.
- `/code-review max`: 결함 없음(`[]`) — 인덱싱·버퍼 수명·스택·dedup off-by-one 전수 확인.

Closes #4108