### PR TITLE
fix(jsx): automatic 런타임에서 spread-only child 가 invalid JS(children: ...arr) 생성 수정

### DIFF
--- a/src/codegen/codegen_test/engine_jsx.zig
+++ b/src/codegen/codegen_test/engine_jsx.zig
@@ -498,3 +498,41 @@ test "Flow: component param with complex type annotation" {
 }
 
 // ============================================================
+
+// 회귀(#4109): 자식이 spread child 하나뿐이면 object property value 위치에 bare
+// spread 가 와서 SyntaxError(`children: ...arr`)였다. esbuild 처럼 [...arr] 로 감싸고
+// spread children 은 static 이므로 _jsxs 로 승격한다.
+test "JSX automatic: spread-only child wraps in array and uses jsxs (#4109)" {
+    var r = try e2eJSXAutomatic(std.testing.allocator, "const x = <Foo>{...arr}</Foo>;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "children: [...arr]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_jsxs(Foo") != null);
+    // invalid 한 bare spread(`children: ...arr`)가 없어야 함
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "children: ...arr") == null);
+}
+
+test "JSX automatic: fragment spread-only child wraps in array (#4109)" {
+    var r = try e2eJSXAutomatic(std.testing.allocator, "const x = <>{...arr}</>;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "children: [...arr]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_jsxs(_Fragment") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "children: ...arr") == null);
+}
+
+test "JSX dev: spread-only child wraps in array, isStaticChildren true (#4109)" {
+    var r = try e2eJSXDev(std.testing.allocator, "const x = <Foo>{...arr}</Foo>;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "children: [...arr]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "children: ...arr") == null);
+    // key 자리 undefined 다음 isStaticChildren=true
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "undefined, true,") != null);
+}
+
+// 회귀(#4109): 단일 일반 child 는 그대로 단일 값 _jsx 유지 (배열 미사용)
+test "JSX automatic: single non-spread child stays as scalar jsx (#4109)" {
+    var r = try e2eJSXAutomatic(std.testing.allocator, "const x = <Foo>{a}</Foo>;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_jsx(Foo") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "children: a") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "children: [") == null);
+}

--- a/src/transformer/jsx_lowering.zig
+++ b/src/transformer/jsx_lowering.zig
@@ -269,7 +269,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
             }
 
             const effective_children = countEffective(self, children_start, children_len);
-            const is_static = effective_children > 1;
+            const is_static = childrenAreStaticArray(self, children_start, children_len);
 
             // callee 선택
             const callee = if (is_dev) blk: {
@@ -346,7 +346,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
         ) Transformer.Error!NodeIndex {
             self.jsx_import_info.used_fragment = true;
             const effective_children = countEffective(self, children_start, children_len);
-            const is_static = effective_children > 1;
+            const is_static = childrenAreStaticArray(self, children_start, children_len);
 
             const callee = if (is_dev) blk: {
                 self.jsx_import_info.used_jsxDEV = true;
@@ -595,7 +595,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
 
             // children
             if (effective_children > 0) {
-                const children_prop = try buildChildrenProp(self, children_start, children_len, effective_children, span);
+                const children_prop = try buildChildrenProp(self, children_start, children_len, span);
                 if (!children_prop.isNone()) {
                     try self.scratch.append(self.allocator, children_prop);
                 }
@@ -610,7 +610,6 @@ pub fn JsxLowering(comptime Transformer: type) type {
             self: *Transformer,
             children_start: u32,
             children_len: u32,
-            effective_children: u32,
             span: Span,
         ) Transformer.Error!NodeIndex {
             const key_span = try self.ast.addString("children");
@@ -620,8 +619,9 @@ pub fn JsxLowering(comptime Transformer: type) type {
                 .data = .{ .string_ref = key_span },
             });
 
-            if (effective_children > 1) {
-                // 배열로 감싸기
+            if (childrenAreStaticArray(self, children_start, children_len)) {
+                // 배열로 감싸기 (다중 child 또는 단일 spread). 단일 spread 는
+                // collectChildren 이 [spread_element] 로 모아 `[...arr]` 가 된다.
                 const children = try collectChildren(self, children_start, children_len);
                 const list = try self.ast.addNodeList(children);
                 const arr_node = try self.ast.addNode(.{
@@ -830,6 +830,30 @@ pub fn JsxLowering(comptime Transformer: type) type {
                 count += 1;
             }
             return count;
+        }
+
+        /// children 을 정적 배열 리터럴(`[...]`)로 렌더해야 하는지 (esbuild 동형).
+        /// effective child 가 2개 이상이거나, 유일 effective child 가 spread 인 경우 true.
+        /// 단일 spread(`<Foo>{...arr}</Foo>`)는 object property value 위치에 직접 올 수
+        /// 없어 `[...arr]` 로 감싸야 하고, esbuild 처럼 isStaticChildren=true(_jsxs)로
+        /// 승격한다. is_static 판정과 buildChildrenProp 의 배열 분기가 이 술어를 공유한다.
+        fn childrenAreStaticArray(self: *Transformer, start: u32, len: u32) bool {
+            if (len == 0) return false;
+            var count: u32 = 0;
+            var single_spread = false;
+            const indices = self.ast.extra_data.items[start .. start + len];
+            for (indices) |raw_idx| {
+                const child = self.ast.getNode(@enumFromInt(raw_idx));
+                if (child.tag == .jsx_text) {
+                    const trimmed = std.mem.trim(u8, self.ast.getText(child.span), " \t\n\r");
+                    if (trimmed.len == 0) continue;
+                } else if (child.tag == .jsx_expression_container and child.data.unary.operand.isNone()) {
+                    continue;
+                }
+                count += 1;
+                single_spread = (child.tag == .jsx_spread_child);
+            }
+            return count > 1 or (count == 1 and single_spread);
         }
 
         // ================================================================


### PR DESCRIPTION
## 문제
자식이 spread child 하나뿐인 JSX 를 automatic 런타임으로 변환하면 **구문 오류(SyntaxError)** 를 출력한다.

```sh
printf 'const x = <Foo>{...arr}</Foo>;\n' > t.jsx
./zig-out/bin/zntc t.jsx --jsx=automatic
# 수정 전: const x = _jsx(Foo, { children: ...arr });   ← object value 위치 bare spread = SyntaxError
```
`<>{...arr}</>` (fragment) 도 동일.

## 근본 원인
`buildChildrenProp` 의 단일-child 분기가 `collectSingleChild` 가 반환한 `spread_element` 를 배열로 감싸지 않고 그대로 children 프로퍼티 값으로 사용. spread 는 object property value 가 될 수 없다.

## 수정 (esbuild 동형)
esbuild(`js_parser.go`)는 spread children 을 static 으로 취급해 `[...arr]` 로 감싸고 `isStaticChildren=true` 로 승격한다. 동일하게:
- 공통 술어 `childrenAreStaticArray`(effective>1 **또는** 단일 spread)를 도입해 `is_static`(_jsx/_jsxs) 판정과 `buildChildrenProp` 의 배열 분기를 **하나의 술어로 통일**.
- 단일 spread child → `[...arr]` 로 감싸고 `_jsxs`(isStaticChildren=true)로 승격.

## 출력 (node --check 통과)
| 입력 | 출력 |
|------|------|
| `<Foo>{...arr}</Foo>` (prod) | `_jsxs(Foo, { children: [...arr] })` |
| `<Foo>{...arr}</Foo>` (dev) | `_jsxDEV(Foo, { children: [...arr] }, undefined, true, {…}, this)` |
| `<>{...arr}</>` | `_jsxs(_Fragment, { children: [...arr] })` |
| `<Foo>{a}</Foo>` (회귀확인) | `_jsx(Foo, { children: a })` (불변) |

## 검증
- node --check OK (SyntaxError 해소), 단일 일반 child/다중 child/classic 런타임 회귀 없음
- 회귀 테스트 4건 추가(engine_jsx.zig). **수정 revert 시 3건 FAIL** 확인
- `zig build test` → 7/7 steps, 5757/5757 tests passed
- `/code-review max`: 결함 없음(`[]`) — esbuild 레퍼런스 대조 + 엣지케이스(다중 spread/공백/텍스트/key 결합) 전수 검증

Closes #4109