### PR TITLE
fix(jsx): 값없는 key 속성(<div key>)이 dev/automatic 런타임 positional 인자 시프트 수정

### DIFF
--- a/src/codegen/codegen_test/engine_jsx.zig
+++ b/src/codegen/codegen_test/engine_jsx.zig
@@ -536,3 +536,27 @@ test "JSX automatic: single non-spread child stays as scalar jsx (#4109)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "children: a") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "children: [") == null);
 }
+
+// 회귀(#4110): 값 없는 key 속성(`<div key>`)은 다른 속성처럼 boolean true 로
+// 정규화되어 positional key 슬롯을 유지해야 한다. 정규화 없이 .none 이면 codegen 이
+// .none 인자를 통째로 skip 해 _jsxDEV 의 positional 인자(key/isStaticChildren/
+// source/this)가 한 칸씩 시프트됐다.
+test "JSX dev: valueless key normalizes to true without arg shift (#4110)" {
+    var r = try e2eJSXDev(std.testing.allocator, "const x = <div key>{y}</div>;");
+    defer r.deinit();
+    // key=true 가 3번째 positional 인자, isStaticChildren(false)가 4번째 (시프트 없음)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "{ children: y }, true, false,") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ", this)") != null);
+}
+
+test "JSX automatic: valueless key normalizes to true (#4110)" {
+    var r = try e2eJSXAutomatic(std.testing.allocator, "const x = <div key>{y}</div>;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "{ children: y }, true)") != null);
+}
+
+test "JSX dev: keyed value still works (#4110 regression guard)" {
+    var r = try e2eJSXDev(std.testing.allocator, "const x = <div key=\"k\">{y}</div>;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "{ children: y }, \"k\", false,") != null);
+}

--- a/src/transformer/jsx_lowering.zig
+++ b/src/transformer/jsx_lowering.zig
@@ -889,7 +889,21 @@ pub fn JsxLowering(comptime Transformer: type) type {
         fn getKeyValue(self: *Transformer, attrs_start: u32, key_idx: u32) Transformer.Error!NodeIndex {
             const attr_node_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[attrs_start + key_idx]);
             const attr = self.ast.getNode(attr_node_idx);
-            return self.visitNode(attr.data.binary.right);
+            const value_idx = attr.data.binary.right;
+            // 값 없는 key 속성(`<div key>`)은 다른 모든 속성과 동일하게 boolean true 로
+            // 정규화한다(lowerJSXAttribute 의 값없음→true 경로와 일치). 그렇지 않으면
+            // visitNode(.none) 이 .none 을 반환하고, codegen 의 emitNodeListImpl 이 .none
+            // 인자를 separator 없이 통째로 skip 해 _jsx/_jsxDEV 의 positional 인자
+            // (key/isStaticChildren/source/this)가 한 칸씩 시프트된다.
+            if (value_idx.isNone()) {
+                const true_span = try self.ast.addString("true");
+                return self.ast.addNode(.{
+                    .tag = .boolean_literal,
+                    .span = true_span,
+                    .data = .{ .none = 0 },
+                });
+            }
+            return self.visitNode(value_idx);
         }
 
         // ================================================================


### PR DESCRIPTION
## 문제
값 없는 `key` 속성(`<div key>`)이 automatic-dev 런타임에서 `_jsxDEV` 의 positional 인자를 한 칸씩 시프트시킨다.

```sh
printf 'const x = <div key>{y}</div>;\n' > t.jsx
./zig-out/bin/zntc t.jsx --jsx=automatic-dev
# 수정 전: _jsxDEV("div", { children: y }, false, {…source}, this)   ← key 인자 누락, false(isStaticChildren)가 key 자리로 시프트
```

## 근본 원인
key 추출 경로(`getKeyValue`)가 다른 모든 속성이 받는 **"값없으면 true" 정규화**(`lowerJSXAttribute`)를 누락. `<div key>` 의 `getKeyValue` 가 `visitNode(.none)` = none 을 반환하고, codegen 의 `emitNodeListImpl` 이 `.none` 인자를 separator 없이 통째로 skip → positional 시프트.

## 수정 (루트커즈)
`getKeyValue` 에서 우변이 `.none` 이면 boolean `true` 리터럴을 반환 — 다른 속성과 **동일한 값없음→true 정규화**를 key 경로에도 적용. 즉 `<div key>` ≡ `<div key={true}>`.

## 출력 (node --check 통과)
| 입력 | 출력 |
|------|------|
| `<div key>{y}</div>` (dev) | `_jsxDEV("div", { children: y }, true, false, {…}, this)` |
| `<div key>{y}</div>` (prod) | `_jsx("div", { children: y }, true)` |
| `<div key="k">{y}</div>` (회귀확인) | `_jsxDEV("div", { children: y }, "k", false, {…}, this)` (불변) |

## 검증
- node --check OK (시프트 해소), 값있는 key/다른 속성(`<div key id="a">`)/classic 런타임 회귀 없음
- 회귀 테스트 3건 추가(engine_jsx.zig). **수정 revert 시 2건 FAIL** 확인
- `zig build test` → 7/7 steps, 5760/5760 tests passed
- `/code-review max`: 결함 없음(`[]`) — 호출처/key-after-spread/classic/codegen 렌더 전수 확인

## 참고
oxc/esbuild/babel 은 valueless key 를 추가로 **진단**(warn/error, "Using key as a shorthand for key={true} is not allowed")한다. zntc transformer 에 per-node 진단 인프라가 없어 이번엔 출력 정규화만 적용했고, 진단 추가는 별도 후속으로 가능.

Closes #4110