### PR TITLE
fix(bundler): production cross-chunk 전역 네이밍으로 동명 export collapse·divergence 해결 (#4101)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1682,12 +1682,14 @@ pub const Bundler = struct {
             try chunk_mod.computeCrossChunkLinks(&chunk_graph, graph, self.allocator, if (linker) |*l| l else null);
 
             // RFC #3940 / #4101 — cross-chunk 전역 일관 네이밍 채우기. imports_from 확정 직후.
-            // **lazy(dev_split)로 scope** — production splitting 은 `export { local as public }`
-            // 브리지가 cross-chunk 이름을 따로 보존하므로 전역 네이밍을 적용하면 충돌. 맵이 비면
-            // 모든 wiring(crossChunkBindingName/metadata/override)이 fallback = production 불변.
-            // production cross-chunk 전역 네이밍(+ mangle 정합)은 별도 increment.
+            // dev_split + production splitting 모두. dev 는 emitLazyEntryExportAll local-key +
+            // override(lazy 전용)로, production 은 provider 가 전역명을 public 으로 노출(`export
+            // { local as global }`) + 소비자 import key=global 로 일치(emit 측 분기). 단순 export
+            // (local==export명)는 global==export명이라 byte-identical, 동명 충돌(global=`v$1`)·공유
+            // default·renamed export 만 달라진다. ⚠️ preserve_modules 는 제외 — emit 측 xchunk
+            // 블록이 `!preserve_modules` 게이트라, 켜면 consumer 만 전역명으로 바뀌어 mismatch.
             if (linker) |*l| {
-                if (self.options.code_splitting and self.options.lazy_compilation)
+                if (self.options.code_splitting and !self.options.preserve_modules)
                     try chunk_mod.computeCrossChunkGlobalNames(self.allocator, &chunk_graph, l);
             }
 

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -719,9 +719,14 @@ test "CodeSplitting: cross-chunk export alias with renamed symbol" {
             std.mem.indexOf(u8, o.contents, "export{") != null)
         {
             has_export = true;
-            // 공통 청크에 val$1 rename이 있으면 "as val" 형태도 있어야 함
+            // #4101 production 전역 네이밍: 동명 cross-chunk(shared1.val + shared2.val)이 deconflict
+            // 되면 둘 다 *전역명*으로 distinct 노출(`export { val, val$1 }`) — 예전엔 `val$1 as val`
+            // 한쪽만(collapse) 노출돼 소비자가 둘 다 같은 값을 받았다(#B). val$1 이 있으면 export
+            // 에 distinct 노출 + collapse(`val$1 as val`) 부재여야 한다.
             if (std.mem.indexOf(u8, o.contents, "val$1") != null) {
-                try std.testing.expect(std.mem.indexOf(u8, o.contents, "as val") != null);
+                try std.testing.expect(std.mem.indexOf(u8, o.contents, "val$1 as val") == null);
+                try std.testing.expect(std.mem.indexOf(u8, o.contents, "val$1 }") != null or
+                    std.mem.indexOf(u8, o.contents, "val$1}") != null);
             }
         }
     }

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -546,7 +546,13 @@ pub fn emitChunks(
                 for (symbols.?.items, 0..) |sym, si| {
                     const name = sym.name;
                     const binding = crossChunkBindingName(linker, sym);
-                    const key = if (lazy_local_keys) binding else name;
+                    // #4101 cross-chunk 전역 네이밍: 심볼이 전역 이름을 가지면 그 이름이 곧
+                    // provider 노출 키(dev=emitLazyEntryExportAll local-key, production=브리지
+                    // `export { local as global }` public)라, 소비자 import key 도 전역명이어야
+                    // 동명 다른 모듈(`v`/`v$1`)을 구별한다. lazy 는 항상 binding-key. 전역명
+                    // 없으면(map 미populate/비-cross-chunk) export 명 키(기존).
+                    const has_global = if (linker) |l| l.getCrossChunkGlobalName(sym.canonical_module, sym.name) != null else false;
+                    const key = if (lazy_local_keys or has_global) binding else name;
 
                     if (!std.mem.eql(u8, key, binding)) {
                         // key != binding(예약어 export 키 `default` → 소비자 local `_default`).
@@ -558,15 +564,15 @@ pub fn emitChunks(
                     } else {
                         // key == binding → 축약. 단 같은 export 명이 여러 dep 에서 오면
                         // 중복 로컬 선언 충돌 → 2번째부터 `key: key$N` deconfliction.
-                        // lazy(전역 네이밍)는 binding 이 이미 전역 deconflict(`v`/`v$1`)라
-                        // `$N` 불필요(이중 deconflict 로 소비자 참조와 어긋남). non-lazy 만.
+                        // 전역 네이밍(has_global)/lazy 는 binding 이 이미 전역 deconflict
+                        // (`v`/`v$1`)라 `$N` 불필요(이중 deconflict 로 소비자 참조와 어긋남).
                         const total = name_total_count.get(name) orelse 1;
                         const seen_gop = try name_seen_count.getOrPut(allocator, name);
                         if (!seen_gop.found_existing) seen_gop.value_ptr.* = 0;
                         seen_gop.value_ptr.* += 1;
                         const seen = seen_gop.value_ptr.*;
 
-                        if (total > 1 and seen > 1 and !lazy_local_keys) {
+                        if (total > 1 and seen > 1 and !lazy_local_keys and !has_global) {
                             const alias = try std.fmt.allocPrint(allocator, "{s}${d}", .{ key, seen });
                             try alias_strs.append(allocator, alias);
                             try chunk_output.appendSlice(allocator, key);
@@ -948,6 +954,48 @@ pub fn emitChunks(
                 }
             }
             for (export_names.items, 0..) |name, ni| {
+                // #4101 production cross-chunk same-name collision: 서로 다른 모듈이 *같은*
+                // export 명(`v`)을 이 청크에서 cross-chunk export 하면(global map 에 owner 2+),
+                // export 명 1개로 dedup 된 export_names 로는 한쪽만 노출돼 소비자가 둘 다 같은
+                // public 에 바인딩 → collapse. 각 owner 를 **전역 public**(`v`/`v$1`)으로 노출해
+                // 구별한다(소비자 import key 도 전역명, change B). common(owner 1개)은 아래
+                // 기존 경로(public=export 명=global) = byte-identical.
+                if (linker) |l| {
+                    var owner_count: usize = 0;
+                    for (sorted_mods) |mod_idx| {
+                        const mi = @intFromEnum(mod_idx);
+                        if (mi >= module_count) continue;
+                        if (l.getCrossChunkGlobalName(@intCast(mi), name) != null) owner_count += 1;
+                    }
+                    if (owner_count > 1) {
+                        var first = true;
+                        for (sorted_mods) |mod_idx| {
+                            const mi = @intFromEnum(mod_idx);
+                            if (mi >= module_count) continue;
+                            const global = l.getCrossChunkGlobalName(@intCast(mi), name) orelse continue;
+                            const local = l.getCanonicalName(@intCast(mi), l.getExportLocalName(@intCast(mi), name) orelse name) orelse global;
+                            if (cjs_x) {
+                                try chunk_output.appendSlice(allocator, "exports.");
+                                try chunk_output.appendSlice(allocator, global);
+                                try chunk_output.appendSlice(allocator, if (options.minify_whitespace) "=" else " = ");
+                                try chunk_output.appendSlice(allocator, local);
+                                try chunk_output.appendSlice(allocator, if (options.minify_whitespace) ";" else ";\n");
+                            } else {
+                                if (!first) try chunk_output.appendSlice(allocator, if (options.minify_whitespace) "," else ", ");
+                                try chunk_output.appendSlice(allocator, local);
+                                if (!std.mem.eql(u8, local, global)) {
+                                    try chunk_output.appendSlice(allocator, " as ");
+                                    try chunk_output.appendSlice(allocator, global);
+                                }
+                            }
+                            first = false;
+                        }
+                        if (!cjs_x and ni + 1 < export_names.items.len) {
+                            try chunk_output.appendSlice(allocator, if (options.minify_whitespace) "," else ", ");
+                        }
+                        continue;
+                    }
+                }
                 // export_name의 원본 심볼이 이 청크에서 rename되었는지 확인.
                 // rename된 경우: export { local_name as export_name }
                 // rename 안 된 경우: export { export_name }
@@ -982,16 +1030,17 @@ pub fn emitChunks(
                                 found_local = renamed;
                                 break;
                             }
-                            // 예약어 export 명(`default`)의 합성 local(`_default`)은 canonical 미등록
-                            // 일 수 있다 — 위 getCanonicalName 실패로 break 안 하면 아래 fallback 이
-                            // `name`(=`default`)으로 떨어져 `exports.default = default`(RHS 가 예약어
-                            // 식별자 = SyntaxError, #C)를 만든다. 예약어 export 명에 한해 owner 의
-                            // local(`_default`)로 break(비예약어 same-name 해석은 OLD 그대로 보존).
-                            // ⚠️ `local` 자체가 예약어면(예: `export {default} from './x'` 의 re-export
-                            // source 명이 `default`) 그걸 RHS 로 쓰면 다시 SyntaxError — 비예약어 local
-                            // 일 때만 채택하고, 아니면 계속 순회해 실제 owner(`_default`)를 찾는다.
-                            // (둘 다 없는 re-export 체인은 별도 follow-up — fallback 유지.)
-                            if (Linker.isReservedName(name) and !Linker.isReservedName(local)) {
+                            // canonical 미등록(미-rename)이라도 비예약어 local 은 그대로 채택 —
+                            // getExportLocalName 이 곧 이 export 의 실제 chunk 로컬(권위 소스).
+                            // `export { _x as renamed }`(local `_x`≠export명)·same-name(local==
+                            // export명, 채택=fallback 과 동치) 모두 올바른 로컬 참조. 이로써 아래
+                            // `orelse name` fallback 은 *진짜 미해결*(ns/RBM 등 local 부재) 안전망
+                            // 으로만 남는다 — 예전엔 비예약어 renamed export 가 fallback=export명
+                            // 으로 떨어져 미존재 로컬 참조(`export { renamed }`/`exports.default =
+                            // default`) SyntaxError(main 선재 버그, #C 예약어 처리의 일반화).
+                            // ⚠️ `local` 이 예약어면(예: `export {default} from './x'` 의 source 명
+                            // `default`) bare 참조 불가 → 채택 말고 계속 순회해 실제 owner 를 찾는다.
+                            if (!Linker.isReservedName(local)) {
                                 found_local = local;
                                 break;
                             }
@@ -1000,10 +1049,25 @@ pub fn emitChunks(
                     break :blk found_local orelse name;
                 } else name;
 
+                // #4101 cross-chunk 전역 네이밍: provider 가 노출하는 public 은 consumer 가
+                // import 하는 전역명(getCrossChunkGlobalName)과 같아야 한다. 이 export 명의
+                // 전역명을 가진 모듈(single-owner 경로라 최대 1개; owner_count>1 은 위 collision
+                // 블록이 처리)을 찾아 그 전역명을 public 으로 사용 — 공유 `export default`(전역명=
+                // local `thing`), 분산 청크 동명 export(전역명=`v$1`)도 rename 여부와 무관하게
+                // consumer 와 일치. 전역명 없으면 export 명(common: global==export명=byte-identical).
+                const public_name = if (linker) |l| blk2: {
+                    for (sorted_mods) |mod_idx| {
+                        const mi2 = @intFromEnum(mod_idx);
+                        if (mi2 >= module_count) continue;
+                        if (l.getCrossChunkGlobalName(@intCast(mi2), name)) |g| break :blk2 g;
+                    }
+                    break :blk2 name;
+                } else name;
+
                 if (cjs_x) {
-                    // exports.<name> = <local>;  (min: 공백 제거, 형태 동일)
+                    // exports.<public> = <local>;  (min: 공백 제거, 형태 동일)
                     try chunk_output.appendSlice(allocator, "exports.");
-                    try chunk_output.appendSlice(allocator, name);
+                    try chunk_output.appendSlice(allocator, public_name);
                     try chunk_output.appendSlice(allocator, if (options.minify_whitespace) "=" else " = ");
                     try chunk_output.appendSlice(allocator, local_name);
                     try chunk_output.appendSlice(allocator, if (options.minify_whitespace) ";" else ";\n");
@@ -1011,10 +1075,10 @@ pub fn emitChunks(
                 }
 
                 try chunk_output.appendSlice(allocator, local_name);
-                // local_name과 export_name이 다르면 as 절 추가
-                if (!std.mem.eql(u8, local_name, name)) {
+                // local_name과 public(전역명)이 다르면 as 절 추가
+                if (!std.mem.eql(u8, local_name, public_name)) {
                     try chunk_output.appendSlice(allocator, " as ");
-                    try chunk_output.appendSlice(allocator, name);
+                    try chunk_output.appendSlice(allocator, public_name);
                 }
                 if (ni + 1 < export_names.items.len) {
                     if (!options.minify_whitespace) {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2706,14 +2706,19 @@ pub const Linker = struct {
         // canonical_strings 로 소유권 이전. (전역명==per-chunk 결과면 no-op. reserve 마커는 안 둔다
         // — non-cross-chunk 동명 심볼(dup.v)까지 밀어내 `v$2` 가 되는 부작용 때문. calculateRenames
         // 자연 순서가 cross-chunk owner 에게 preferred 를 주므로 override 는 divergence 만 교정.)
-        // minify 는 아래 mangle 이 다시 덮으므로 production 전역 네이밍은 별도 increment.
-        for (module_indices) |mod_idx| {
-            const inner = self.cross_chunk_global_names.get(mod_idx.toU32()) orelse continue;
-            var git = inner.iterator();
-            while (git.next()) |e| {
-                const local = self.getExportLocalName(mod_idx.toU32(), e.key_ptr.*) orelse e.key_ptr.*;
-                const dup = try self.allocator.dupe(u8, e.value_ptr.*);
-                try self.putCanonicalName(mod_idx.toU32(), local, dup);
+        // ⚠️ **lazy(dev_split) 전용** — production 은 `export { local as public }` 브리지가
+        // public=전역명을 따로 노출(emit 측 처리)하므로 local 을 전역명으로 강제하면 안 된다
+        // (브리지가 mangle 된 local 을 전역 public 으로 보존; override 하면 그 분리가 깨짐).
+        // dev_split 은 emitLazyEntryExportAll 이 local 명을 그대로 노출하므로 local==전역명 필요.
+        if (self.graph.lazy_compilation) {
+            for (module_indices) |mod_idx| {
+                const inner = self.cross_chunk_global_names.get(mod_idx.toU32()) orelse continue;
+                var git = inner.iterator();
+                while (git.next()) |e| {
+                    const local = self.getExportLocalName(mod_idx.toU32(), e.key_ptr.*) orelse e.key_ptr.*;
+                    const dup = try self.allocator.dupe(u8, e.value_ptr.*);
+                    try self.putCanonicalName(mod_idx.toU32(), local, dup);
+                }
             }
         }
 

--- a/tests/integration/tests/cross-chunk-reexport.test.ts
+++ b/tests/integration/tests/cross-chunk-reexport.test.ts
@@ -383,7 +383,7 @@ describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
   // 로 나와야 한다. dev_split 런타임 가드는 napi-lazy-dev-hmr 에 있고, 여기선 production
   // splitting 의 emit 형태(예약어 미축약)를 3포맷에서 잠근다.
   for (const format of ['iife', 'cjs', 'esm'] as const) {
-    test(`${format}: export { default } from cjs — 예약어가 축약 아닌 alias 로 emit (#4096)`, async () => {
+    test(`${format}: export { default } from cjs — 예약어가 bare 아닌 유효 식별자로 emit (#4096)`, async () => {
       const fixture = await createFixture({
         'cjslib.js': "module.exports = function(){ return 'D'; };\nmodule.exports.named = 9;",
         'Route.ts': "export { default, named } from './cjslib.js';",
@@ -404,15 +404,18 @@ describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
       );
       expect(route).toBeDefined();
       // cross-chunk import 라인(`… = __zntc_require(…)` / `… = require(…)` / `… from "…"`)을
-      // 찾아 예약어 default 가 alias 됐는지 확인.
+      // 찾아 예약어 default 가 유효 식별자로 바인딩됐는지 확인. 전역 네이밍(#4101)으로 deconflict
+      // 된 식별자(`default$1`) 또는 #4096 alias(`default: _default`) 둘 다 유효 — 핵심은 bare 아님.
       const crossImport = route!.text
         .split('\n')
         .find((l) => /\bdefault\b/.test(l) && /(__zntc_require|require|from)\s*[("]/.test(l));
       expect(crossImport).toBeDefined();
-      // alias 형태: `default: <local>` 또는 `default as <local>`.
-      expect(/\bdefault\s*(:|\bas\b)/.test(crossImport!)).toBe(true);
       // 축약 바인딩(`{ default }` / `{ default, … }` / `{ …, default }`) 부재 = SyntaxError 없음.
       expect(/\bdefault\s*[},]/.test(crossImport!)).toBe(false);
+      // iife/cjs 청크는 함수 본문으로 parse 검증(예약어 bare RHS/바인딩이면 throw). esm 은 불가.
+      if (format !== 'esm') {
+        expect(() => new Function('exports', 'module', 'require', route!.text)).not.toThrow();
+      }
     });
   }
 
@@ -449,15 +452,15 @@ describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
     });
   }
 
-  // #4101 production 범위 (todo): 서로 다른 모듈의 *같은* export 이름(두 `v`)이 한 shared
-  // 청크에 묶이고 여러 entry 가 둘 다 import 하면, production 브리지가 public=export 명이라
-  // 충돌 → `export { v$1 as v }` 하나만 노출 + 소비자 `import { v, v as v$2 }` 둘 다 같은
-  // public "v" 에 바인딩 → collapse(둘 다 한 값). dev_split 은 #4105 에서 전역 네이밍으로
-  // 해결됐으나 production 은 ① exports_to 가 export 명으로만 dedup(자료구조) ② 브리지
-  // public=전역명 ③ 소비자 import key=전역명 ④ override 를 lazy 로 게이트 ⑤ mangle 정합 이
-  // 필요한 별도 increment. 전역 네이밍 pass 를 production 으로 확장하면 green.
+  // #4101 production 전역 네이밍(DONE): 서로 다른 모듈의 *같은* export 이름(두 `v`)이 한 shared
+  // 청크에 묶이고 여러 entry 가 둘 다 import 해도, 전역 네이밍 pass(computeCrossChunkGlobalNames)
+  // 가 (module, export_name) 별 owned 전역명을 deconflict → provider `export { v, v$1 }` +
+  // consumer `import { v, v$1 }` 로 distinct. 예전엔 브리지 public=export 명이라 충돌 →
+  // `export { v$1 as v }` 하나만 노출 + 소비자가 둘 다 public "v" 에 바인딩 → collapse(둘 다 한
+  // 값)였다. dev_split 은 #4105, production 은 이 PR 에서 전역 네이밍 pass 를 production 으로
+  // 확장(bundler.zig: code_splitting 게이트)해 해결.
   for (const format of ['esm', 'iife'] as const) {
-    test.todo(`${format}: 다른 모듈의 같은 export 둘을 여러 entry 가 import (전역 네이밍 production #4101)`, async () => {
+    test(`${format}: 다른 모듈의 같은 export 둘을 여러 entry 가 import (전역 네이밍 production #4101)`, async () => {
       const fixture = await createFixture({
         'a.ts': "export const v = 'AV';",
         'b.ts': "export const v = 'BV';",
@@ -477,16 +480,228 @@ describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
       const outs = result.outputFiles!;
       writeOutputs(fixture.dir, outs);
       const e1 = outs.find((o) => o.path.includes('e1') && o.path.endsWith('.js'))!;
+      const e2 = outs.find((o) => o.path.includes('e2') && o.path.endsWith('.js'))!;
       const driver =
         format === 'esm'
           ? join(fixture.dir, e1.path)
           : browserDriver(
               fixture.dir,
               e1.path,
-              outs.map((o) => o.path),
+              // 다른 entry(e2)는 제외. entry 는 self-execute 하며 static cross-chunk import 를
+              // 즉시 __zntc_require 하므로, 같은 글로벌에 섞이면 (a) e2 도 실행돼 stdout 오염
+              // (b) chunk 미등록 시점에 require → throw. e1 + 공유 chunk 만 로드(실브라우저의
+              // 페이지당 1 entry 와 동치) → e1 이 distinct 값을 받는지만 검증.
+              outs.filter((o) => o.path.endsWith('.js') && o.path !== e2.path).map((o) => o.path),
             );
       const { stdout } = await runNode(driver);
-      expect(stdout.trim()).toBe('e1 AV BV'); // 현재 'e1 BV BV' (collapse)
+      expect(stdout.trim()).toBe('e1 AV BV'); // 예전 'e1 BV BV' (collapse) → 전역 네이밍으로 distinct
     });
   }
+
+  // #4101 회귀 방어: production 전역 네이밍을 모든 splitting 으로 확장하면서, consumer 는
+  // 전역명으로 import 키를 바꾸는데 single-owner provider 경로는 export 名을 그대로 노출 →
+  // 전역명≠export名(공유 `export default`, 분산 청크 동명)일 때 provider/consumer divergence
+  // = `SyntaxError: does not provide an export named …`. provider single-owner 도 전역명을
+  // public 으로 노출해야 일치. (collision owner_count>1 은 이미 전역명, common 은 global==name).
+
+  // 회귀 1: `export default` 가 여러 entry 에 공유 → shared 청크가 default 를 cross-chunk
+  // 노출. consumer 는 default 의 전역명(=local `thing`)으로 import → provider 도 그 전역명을
+  // 노출해야 한다. 예전(이 회귀)엔 `export { thing as default }` 만 내 consumer `import { thing }`
+  // 가 깨짐.
+  test('esm: 공유 export default 가 consumer/provider 전역명 일치 (#4101 회귀)', async () => {
+    const fixture = await createFixture({
+      'shared.ts': "export default function thing(){ return 'D'; }",
+      'e1.ts': "import f from './shared';\nconsole.log('e1', f());",
+      'e2.ts': "import f from './shared';\nconsole.log('e2', f());",
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'e1.ts'), join(fixture.dir, 'e2.ts')],
+      rootDir: fixture.dir,
+      platform: 'node',
+      splitting: true,
+      format: 'esm',
+    });
+    const outs = result.outputFiles!;
+    writeOutputs(fixture.dir, outs);
+    const e1 = outs.find((o) => o.path.includes('e1') && o.path.endsWith('.js'))!;
+    const { stdout } = await runNode(join(fixture.dir, e1.path));
+    expect(stdout.trim()).toBe('e1 D');
+  });
+
+  test('iife: 공유 export default 가 consumer/provider 전역명 일치 (#4101 회귀)', async () => {
+    const fixture = await createFixture({
+      'shared.ts': "export default function thing(){ return 'D'; }",
+      'e1.ts': "import f from './shared';\nconsole.log('e1', f());",
+      'e2.ts': "import f from './shared';\nconsole.log('e2', f());",
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'e1.ts'), join(fixture.dir, 'e2.ts')],
+      rootDir: fixture.dir,
+      platform: 'browser',
+      splitting: true,
+      format: 'iife',
+    });
+    const outs = result.outputFiles!;
+    writeOutputs(fixture.dir, outs);
+    const e1 = outs.find((o) => o.path.includes('e1') && o.path.endsWith('.js'))!;
+    const e2 = outs.find((o) => o.path.includes('e2') && o.path.endsWith('.js'))!;
+    // e1 + 공유 chunk 만 (다른 entry e2 제외 — self-execute/조기 require 회피).
+    const driver = browserDriver(
+      fixture.dir,
+      e1.path,
+      outs.filter((o) => o.path.endsWith('.js') && o.path !== e2.path).map((o) => o.path),
+    );
+    const { stdout } = await runNode(driver);
+    expect(stdout.trim()).toBe('e1 D');
+  });
+
+  // 회귀 2: 서로 다른 모듈의 동명 export 가 *서로 다른* 청크에 분산(각 owner_count==1).
+  // 전역 deconflict 가 a.v→`v`, b.v→`v$1` 를 배정 → main 은 `import { v$1 } from chunk-b`
+  // 하지만 chunk-b 는 single-owner 라 `export { v }` 만 냈다(divergence). provider 가 전역명
+  // 을 노출하면 `export { v as v$1 }` → 일치.
+  test('esm: 분산 청크 동명 export 가 consumer/provider 일치 (#4101 회귀)', async () => {
+    const fixture = await createFixture({
+      'a.ts': "export const v = 'AV';",
+      'b.ts': "export const v = 'BV';",
+      'route1.ts': "import { v } from './a';\nexport const r1 = v;",
+      'route2.ts': "import { v } from './b';\nexport const r2 = v;",
+      'main.ts':
+        "import { v as av } from './a';\nimport { v as bv } from './b';\n" +
+        "async function run(){ const m1=await import('./route1'); const m2=await import('./route2'); console.log('main', av, bv, m1.r1, m2.r2); }\nrun();",
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'main.ts')],
+      rootDir: fixture.dir,
+      platform: 'node',
+      splitting: true,
+      format: 'esm',
+    });
+    const outs = result.outputFiles!;
+    writeOutputs(fixture.dir, outs);
+    const main = outs.find((o) => o.path.includes('main') && o.path.endsWith('.js'))!;
+    const { stdout } = await runNode(join(fixture.dir, main.path));
+    expect(stdout.trim()).toBe('main AV BV AV BV');
+  });
+
+  // 회귀 3 (Angle A): 사용자 실제 export `v$1` 이 동명 collision 의 생성 전역명 `v$1` 과
+  // 한 청크에서 겹치면 안 된다. 전역 deconflict 가 used set 으로 회피(사용자 v$1→`v$1$1`)
+  // 하고, provider 가 전역명을 노출하면 중복 export(`export { v$1, v$1 }`) 없이 distinct.
+  test('esm: 사용자 v$1 export 가 collision 생성 v$1 과 충돌 안 함 (#4101 회귀)', async () => {
+    const fixture = await createFixture({
+      'a.ts': "export const v = 'AV';",
+      'b.ts': "export const v = 'BV';",
+      'c.ts': "export const v$1 = 'C1';",
+      'e1.ts':
+        "import { v as a } from './a';\nimport { v as b } from './b';\nimport { v$1 as c } from './c';\nconsole.log('e1', a, b, c);",
+      'e2.ts':
+        "import { v as a } from './a';\nimport { v as b } from './b';\nimport { v$1 as c } from './c';\nconsole.log('e2', a, b, c);",
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'e1.ts'), join(fixture.dir, 'e2.ts')],
+      rootDir: fixture.dir,
+      platform: 'node',
+      splitting: true,
+      format: 'esm',
+    });
+    const outs = result.outputFiles!;
+    writeOutputs(fixture.dir, outs);
+    // 어떤 청크도 같은 export 명을 2번 내면 안 된다(중복 export = SyntaxError).
+    for (const o of outs) {
+      if (!o.path.endsWith('.js')) continue;
+      const m = o.text.match(/export\s*\{([^}]*)\}/g) ?? [];
+      for (const stmt of m) {
+        const names = stmt
+          .replace(/export\s*\{|\}/g, '')
+          .split(',')
+          .map((s) => (s.includes(' as ') ? s.split(' as ')[1] : s).trim())
+          .filter(Boolean);
+        expect(new Set(names).size).toBe(names.length); // 중복 public 없음
+      }
+    }
+    const e1 = outs.find((o) => o.path.includes('e1') && o.path.endsWith('.js'))!;
+    const { stdout } = await runNode(join(fixture.dir, e1.path));
+    expect(stdout.trim()).toBe('e1 AV BV C1');
+  });
+
+  // 회귀 4(main 선재 버그 일반화): `export { local as exportName }`(local≠export명)이 여러
+  // entry 에 공유되면 provider 는 실제 local 을 참조해야 한다. 예전엔 local_name 스캔이
+  // 미-rename local 을 놓치고 export명으로 fallback → `export { renamed }`(main) /
+  // `export { renamed as _x }`(전역명 도입 시) — 둘 다 미존재 local 참조 = SyntaxError.
+  // getExportLocalName(권위 소스) 채택으로 해결.
+  test('esm: renamed export(local≠export명) 공유가 실제 local 참조 (#4101 회귀)', async () => {
+    const fixture = await createFixture({
+      'util.ts': "const _x = 'X';\nexport { _x as renamed };",
+      'e1.ts': "import { renamed } from './util';\nconsole.log('e1', renamed);",
+      'e2.ts': "import { renamed } from './util';\nconsole.log('e2', renamed);",
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'e1.ts'), join(fixture.dir, 'e2.ts')],
+      rootDir: fixture.dir,
+      platform: 'node',
+      splitting: true,
+      format: 'esm',
+    });
+    const outs = result.outputFiles!;
+    writeOutputs(fixture.dir, outs);
+    const e1 = outs.find((o) => o.path.includes('e1') && o.path.endsWith('.js'))!;
+    const { stdout } = await runNode(join(fixture.dir, e1.path));
+    expect(stdout.trim()).toBe('e1 X');
+  });
+
+  // 회귀 5: 단순 export + renamed export + re-export 가 한 shared 청크에 혼재해도 전부 정확.
+  test('esm: 단순+renamed+re-export 혼재 shared 청크 (#4101 회귀)', async () => {
+    const fixture = await createFixture({
+      'inner.ts': "export const reexported = 'RX';",
+      'util.ts':
+        "const _x = 'X';\nexport { _x as renamed };\nexport const helper = 'H';\nexport { reexported } from './inner';",
+      'e1.ts':
+        "import { helper, renamed, reexported } from './util';\nconsole.log('e1', helper, renamed, reexported);",
+      'e2.ts':
+        "import { helper, renamed, reexported } from './util';\nconsole.log('e2', helper, renamed, reexported);",
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'e1.ts'), join(fixture.dir, 'e2.ts')],
+      rootDir: fixture.dir,
+      platform: 'node',
+      splitting: true,
+      format: 'esm',
+    });
+    const outs = result.outputFiles!;
+    writeOutputs(fixture.dir, outs);
+    const e1 = outs.find((o) => o.path.includes('e1') && o.path.endsWith('.js'))!;
+    const { stdout } = await runNode(join(fixture.dir, e1.path));
+    expect(stdout.trim()).toBe('e1 H X RX');
+  });
+
+  // 회귀 6: 한 shared 청크에 collision(owner_count>1, `v`) 과 normal(owner_count==1, `only`)
+  // 이 공존 → collision 블록과 single-owner 경로를 동시에 타도 둘 다 정확.
+  test('esm: collision + normal export 가 한 청크에 공존 (#4101 회귀)', async () => {
+    const fixture = await createFixture({
+      'a.ts': "export const v = 'AV';\nexport const only = 'ONLY';",
+      'b.ts': "export const v = 'BV';",
+      'e1.ts':
+        "import { v as a, only } from './a';\nimport { v as b } from './b';\nconsole.log('e1', a, b, only);",
+      'e2.ts':
+        "import { v as a, only } from './a';\nimport { v as b } from './b';\nconsole.log('e2', a, b, only);",
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'e1.ts'), join(fixture.dir, 'e2.ts')],
+      rootDir: fixture.dir,
+      platform: 'node',
+      splitting: true,
+      format: 'esm',
+    });
+    const outs = result.outputFiles!;
+    writeOutputs(fixture.dir, outs);
+    const e1 = outs.find((o) => o.path.includes('e1') && o.path.endsWith('.js'))!;
+    const { stdout } = await runNode(join(fixture.dir, e1.path));
+    expect(stdout.trim()).toBe('e1 AV BV ONLY');
+  });
 });


### PR DESCRIPTION
## 배경 (#4101)

production code-splitting 에서 **서로 다른 모듈의 같은 export 명**이 한 shared 청크에 묶이는 경우가 깨져 있었습니다.

```ts
// a.ts
export const v = 'AV';
// b.ts
export const v = 'BV';
// e1.ts / e2.ts (둘 다 entry)
import { v as a } from './a';
import { v as b } from './b';
console.log(a, b); // 기대: AV BV
```

`exports_to`(청크가 다른 청크에 내보내는 심볼 목록)가 **export 명으로 dedup** 되어 `v` 가 한 번만 노출 → 두 entry 가 둘 다 import 하면 소비자가 같은 public `v` 에 바인딩 → `BV BV` 로 **collapse**.

dev_split(`zntc dev --lazy`)은 이미 `computeCrossChunkGlobalNames`(전역명 deconfliction)로 해결했지만, 그 pass 가 lazy 전용으로 게이트돼 있어 production 에는 적용되지 않았습니다.

## 수정 — root-cause

**전역명 deconfliction pass 를 production 으로 확장**하고, provider(내보내는 청크)와 consumer(가져오는 청크)가 **모두 같은 전역명을 사용**하도록 통일했습니다. 전역명 맵 `getCrossChunkGlobalName(module, export명)` 이 cross-chunk 이름의 **단일 진실원천**입니다.

| 위치 | 변경 |
|---|---|
| `bundler.zig` | 게이트 `code_splitting and lazy_compilation` → `code_splitting and !preserve_modules` — 전역명 맵을 production 에도 채움 |
| `chunks.zig` (consumer) | import key 를 전역명으로(`has_global`) → 동명 다른 모듈(`v`/`v$1`) 구별 |
| `chunks.zig` (provider, 충돌) | `owner_count>1` 이면 각 owner 를 전역 public 으로 노출 (`export { local as global }`) |
| `chunks.zig` (provider, 단일) | public 을 export 명이 아니라 **전역명**으로 — 공유 `export default`·분산 청크 동명도 consumer 와 일치 |
| `linker.zig` | rename override 를 lazy 전용 게이트 (production 은 bridge 가 mangle 된 local 과 전역 public 을 분리 보존) |

### 발견한 회귀 (code-review max 가 잡음)

전역명을 consumer 에만 적용하고 single-owner provider 가 export 명을 그대로 쓰면 **이름이 어긋나 `SyntaxError`** 가 납니다. code-review 가 이를 잡았고, provider single-owner 도 전역명을 쓰도록 수정했습니다.

- 공유 `export default`: consumer `import { thing }` ↔ provider `export { thing as default }` → ❌ → `export { thing }` 로 일치 ✅
- 분산 청크 동명: consumer `import { v$1 }` ↔ provider `export { v }` → ❌ → `export { v as v$1 }` 로 일치 ✅

### 부수 수정 (main 선재 버그)

`export { _x as renamed }`(local 명 ≠ export 명)을 여러 entry 가 공유하면 `export { renamed }`(존재하지 않는 local 참조) `SyntaxError` 였습니다. `local_name` 스캔이 미-rename local 을 놓치고 export 명으로 fallback 하던 결함을, `getExportLocalName`(권위 소스)을 비예약어면 그대로 채택해 일반화 수정했습니다.

## Zig 초보자 설명

- **optional unwrap**: `if (linker) |l| { ... }` 은 nullable(`?T`)을 풀어 `l` 로 쓰는 패턴입니다. `getCrossChunkGlobalName(...)` 은 `?[]const u8`(전역명 없으면 null)을 반환해, `if (l.getCrossChunkGlobalName(...)) |g| ...` 로 있을 때만 `g` 를 씁니다.
- **labeled block** `blk2: { ... break :blk2 value; }`: 블록을 값처럼 평가합니다. provider 의 public 을 정할 때 \"이 청크 모듈들 중 이 export 명의 전역명을 가진 모듈을 찾아 그 전역명, 없으면 export 명\" 을 한 식으로 계산합니다.
- **owner 판정은 rename 여부가 아니라 전역명 보유로**: 미-rename(`getCanonicalName`=null) 인 분산 청크 동명도 놓치지 않도록 `getCrossChunkGlobalName` 보유로 owner 를 찾습니다.
- **메모리**: 전역명 문자열은 `computeCrossChunkGlobalNames` 가 owned 로 만들어 linker 맵이 보관(arena 일괄 해제) — emit 은 빌림만 합니다.

## 검증 (TDD)

방어 테스트를 **먼저** 작성해 FAIL 을 확인한 뒤 수정했습니다(테스트=회귀 방어, 수정=근본).

- 회귀 6종: 공유 `export default`(esm/iife), 분산 청크 동명, 사용자 `v$1` 충돌, renamed export, 단순+renamed+re-export 혼재, collision+normal 공존
- 유닛 **5750/5750**, 통합(cross-chunk 32 · splitting · dev-hmr · bundle-smoke · preserve-modules)
- 전 빌드타겟: napi / wasm / wasm-bundler / test262 / schema / bench / install
- **sourcemap 무영향**: bridge 는 청크 끝 trailing·unmapped(`chunk_sm` 은 모듈 루프에서만 매핑 커밋) → 모듈 매핑 불변. esm 줄수 중립, iife +1 trailing
- 런타임 확인: minify · cjs · iife · umd · amd · namespace re-export · re-export 체인

## Follow-up (이 PR 범위 밖)

collision 블록(`owner_count>1`)과 single-owner 경로가 cross-chunk export emit 로직을 일부 중복합니다. 둘 다 정확하나(전역명 노출), owner-iterating 단일 루프로 일반화하면 중복 제거 + collision 블록의 ns/예약어 해석 보강 가능 — 별도 refactor PR 로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)