### PR TITLE
fix(bundler): namespace re-export collision — ns getter/멤버재작성을 cross-chunk 전역명으로 해석 (#4101)

### DIFF
--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -1490,6 +1490,7 @@ pub fn computeCrossChunkGlobalNames(
     lnk: *Linker,
 ) !void {
     lnk.clearCrossChunkGlobalNames();
+    lnk.ns_collision_present = false;
 
     // 1. cross-chunk 심볼 enumerate + (mod, name) dedup.
     const Sym = struct { mod: u32, name: []const u8 };
@@ -1530,6 +1531,9 @@ pub fn computeCrossChunkGlobalNames(
     defer used.deinit(allocator);
     for (syms.items) |s| {
         const preferred = lnk.getExportLocalName(s.mod, s.name) orelse s.name;
+        // #4101: preferred 가 이미 다른 cross-chunk 심볼이 점유 = *실제 동명 충돌*(예약어 회피
+        // 와 구분). ns 객체 finalize 재빌드 게이트(ns_collision_present)를 켠다.
+        if (used.contains(preferred)) lnk.ns_collision_present = true;
         const candidate = try deconflictGlobalName(allocator, &used, preferred);
         // candidate 소유권을 맵으로 이전. used 는 맵의 저장본을 borrow(used.deinit 가 키 미해제).
         try lnk.putCrossChunkGlobalName(s.mod, s.name, candidate);

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -193,6 +193,11 @@ pub const Linker = struct {
     /// 값(전역 이름)은 이 맵이 소유(owned dupe) — borrowed-ptr UAF(#3933) 회피.
     /// **Inc-1: 채우기만(비활성 read)** — 동작 변경 0, 후속 increment 가 wire.
     cross_chunk_global_names: std.AutoHashMapUnmanaged(u32, std.StringHashMapUnmanaged([]const u8)) = .empty,
+    /// #4101 ns collision: cross-chunk 전역명 deconflict 에서 *실제 동명 충돌*(예약어 회피
+    /// 아님)이 1건이라도 발생했는지. true 일 때만 ns 객체 literal 을 finalize 에서 canonical
+    /// 재빌드(getter 가 deconflict 된 inner const 참조) — 비충돌(대부분)은 frozen 유지해
+    /// 재빌드 비용 0(#perf: RN/large 번들 finalize 회귀 방지).
+    ns_collision_present: bool = false,
 
     /// dev mode: HMR용 모듈 참조를 __zntc_modules["id"].fn()으로 생성.
     /// init_xxx() 대신 동적 lookup을 사용하여 new Function()에서도 접근 가능.

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -255,9 +255,13 @@ pub fn registerNamespaceRewrites(
             try inner_map.put(self.allocator, exp.exported, rewrite_value);
             continue;
         }
-        // exp.local 은 owned=true 면 ns_export_cache 가, 아니면 target module 이 소유한다.
-        // metadata map 은 값 포인터만 빌린다.
-        try inner_map.put(self.allocator, exp.exported, exp.local);
+        // #4101 ns collision: target 의 inner const 가 다른 ns 의 동명 const 와 deconflict
+        // 되면(`k`/`k$1`), 이 멤버 재작성(`ns.k`→local)이 잘못된 const 를 가리킨다. inner
+        // const 의 chunk-local rename 은 이 시점(buildMetadataForAst)에 rename_table 에 아직
+        // 없으나, cross-chunk 전역명(emit 前 글로벌 패스)은 이미 확정 — 게다가 그 전역명이 곧
+        // provider 청크의 local 명이자 consumer import 명이라 양쪽 일치. cross-chunk 미해당
+        // (intra-chunk/non-shared)이면 fallback=exp.local(기존).
+        try inner_map.put(self.allocator, exp.exported, self.getCrossChunkGlobalName(target_mod_idx, exp.exported) orelse exp.local);
     }
     try ns_rewrite_list.append(self.allocator, .{
         .symbol_id = symbol_id,
@@ -422,8 +426,22 @@ pub fn appendSharedNamespacePreambleFiltered(
             if (!f.contains(target_mod_idx)) continue;
         }
         const entry = self.ns_shared_inline_cache.get(target_mod_idx) orelse continue;
+        // #4101 ns collision: entry.object_literal 은 cross-chunk 전역명 확정 전(computeCrossChunk
+        // Links)에 frozen 됐다 — getter 가 미-deconflict inner const 참조(`{get k(){return k}}`).
+        // *실제 동명 충돌이 있을 때만*(ns_collision_present) 전역명 확정된 이 시점에 ns_inline_cache
+        // 무효화 후 재빌드 → getter(buildInlineObjectStr)가 getCrossChunkGlobalName 으로 올바른
+        // const(=provider 청크 local)를 가리킨다. 비충돌(대부분)은 frozen 유지(재빌드 비용 0 —
+        // RN/large 번들 finalize 회귀 방지). OOM 시 frozen fallback(.ptr 비교로 free 분기).
+        const obj_literal = if (self.ns_collision_present) blk: {
+            const ms = @constCast(self);
+            // 옛 캐시 값은 fetchRemove 로 소유권 회수 후 free — 단순 remove 는 orphan 누수
+            // (deinit 은 맵에 남은 값만 해제). 재빌드가 새 값을 다시 캐시한다.
+            if (ms.ns_inline_cache.fetchRemove(target_mod_idx)) |kv| self.allocator.free(kv.value);
+            break :blk buildInlineObjectStr(self, target_mod_idx, 0) catch entry.object_literal;
+        } else entry.object_literal;
+        defer if (obj_literal.ptr != entry.object_literal.ptr) self.allocator.free(obj_literal);
         if (self.minify_whitespace) {
-            if (try tryRewriteGetterObjToArrowExport(self.allocator, entry.object_literal)) |arrow_map| {
+            if (try tryRewriteGetterObjToArrowExport(self.allocator, obj_literal)) |arrow_map| {
                 defer self.allocator.free(arrow_map);
                 if (!helper_emitted) {
                     try out.appendSlice(self.allocator, "var " ++ rt.NAMES.DEF_PROP_MIN ++ "=Object.defineProperty;");
@@ -449,7 +467,7 @@ pub fn appendSharedNamespacePreambleFiltered(
         try out.appendSlice(self.allocator, "var ");
         try out.appendSlice(self.allocator, entry.var_name);
         try out.appendSlice(self.allocator, " = ");
-        try out.appendSlice(self.allocator, entry.object_literal);
+        try out.appendSlice(self.allocator, obj_literal);
         try out.appendSlice(self.allocator, ";\n");
         // 큰 namespace inline 의 size 영향 측정. `get NAME(){return VAL}` 패턴은
         // esbuild/rolldown 의 `NAME:()=>VAL` arrow `__export` 보다 per-export ~9 byte 큼
@@ -878,7 +896,10 @@ pub fn buildInlineObjectStr(
                 defer self.allocator.free(value);
                 try buf.appendSlice(self.allocator, value);
             } else {
-                try buf.appendSlice(self.allocator, exp.local);
+                // #4101 ns collision: materialize 된 ns 객체의 getter 가 참조하는 inner const 도
+                // 동명 deconflict 시 cross-chunk 전역명을 써야 한다(그게 곧 provider 청크 local
+                // 명). chunk-local rename 은 이 시점 미확정이라 getCrossChunkGlobalName 사용.
+                try buf.appendSlice(self.allocator, self.getCrossChunkGlobalName(decl_mod_idx, exp.exported) orelse exp.local);
             }
             try buf.appendSlice(self.allocator, get_close);
         }

--- a/tests/integration/tests/cross-chunk-reexport.test.ts
+++ b/tests/integration/tests/cross-chunk-reexport.test.ts
@@ -705,22 +705,22 @@ describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
     expect(stdout.trim()).toBe('e1 AV BV ONLY');
   });
 
-  // collision 블록 일반화(이 PR)는 namespace re-export collision 의 **export emit** 을 고친다:
-  // 예전 단순 해석은 미존재 `export { ns }` SyntaxError 였고, 일반화는 single-owner 와 같은
-  // full resolution(nsReExportTarget→ensureSharedNsVar)으로 `export { x_ns as ns, y_ns as ns$1 }`
-  // (실존 ns 변수)를 낸다. 다만 ns 자체 materialization(`y_ns = {get k(){return k}}` 가 자기
-  // const `k$1` 이 아니라 다른 ns 의 `k` 참조) + 번들 consumer 의 멤버접근 collapse 는 export
-  // emit 이 아니라 shared-namespace finalize 의 **별도 선재 버그**라 범위 밖 → todo 로 고정.
-  test.todo('esm: namespace re-export collision 전체 동작 (ns materialize finalize 선재 버그)', async () => {
+  // namespace re-export collision: x.k/y.k 가 한 shared 청크에서 deconflict(k/k$1) 되고 두 ns
+  // (a.ns=x, b.ns=y)를 여러 entry 가 import. inner const 가 deconflict 됐으니 ns 멤버는 cross-chunk
+  // 전역명(provider 청크 local 명 = consumer import 명)으로 올바른 const 를 가리켜야 한다.
+  //  - 정적 멤버접근(`na.k`): ns_member_rewrites 경로 → 전역명.
+  //  - 동적 접근(`na[key]`): materialize 된 ns 객체 getter 경로 → 전역명.
+  // 예전엔 둘 다 미-deconflict `k` 로 collapse(`e1 XK XK ...`) 였다(#4101 ns materialize).
+  test('esm: namespace re-export collision — 멤버·객체 접근 모두 cross-chunk 전역명 (#4101)', async () => {
+    const body =
+      "import { ns as na } from './a';\nimport { ns as nb } from './b';\nconst kk = 'k';\n";
     const fixture = await createFixture({
       'x.ts': "export const k = 'XK';",
       'y.ts': "export const k = 'YK';",
       'a.ts': "export * as ns from './x';",
       'b.ts': "export * as ns from './y';",
-      'e1.ts':
-        "import { ns as na } from './a';\nimport { ns as nb } from './b';\nconsole.log('e1', na.k, nb.k);",
-      'e2.ts':
-        "import { ns as na } from './a';\nimport { ns as nb } from './b';\nconsole.log('e2', na.k, nb.k);",
+      'e1.ts': body + "console.log('e1', na.k, nb.k, na[kk], nb[kk]);",
+      'e2.ts': body + "console.log('e2', na.k, nb.k, na[kk], nb[kk]);",
     });
     cleanup = fixture.cleanup;
     const result = await build({
@@ -734,7 +734,8 @@ describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
     writeOutputs(fixture.dir, outs);
     const e1 = outs.find((o) => o.path.includes('e1') && o.path.endsWith('.js'))!;
     const { stdout } = await runNode(join(fixture.dir, e1.path));
-    expect(stdout.trim()).toBe('e1 XK YK');
+    // na.k=XK nb.k=YK (멤버 재작성) · na[kk]=XK nb[kk]=YK (객체 getter)
+    expect(stdout.trim()).toBe('e1 XK YK XK YK');
   });
 
   // === 추가 커버리지: 포맷(cjs/iife) · shape(3-way, default+named) 확장 ===


### PR DESCRIPTION
## 배경

#4118 follow-up. 서로 다른 모듈이 **같은 이름**으로 namespace re-export 하고 여러 entry 가 둘 다 import 하면 collapse 되는 선재 버그(#4118 에서 `test.todo` 로 고정)를 수정합니다.

```ts
// x.ts                  // y.ts
export const k = 'XK';   export const k = 'YK';
// a.ts                  // b.ts
export * as ns from './x';   export * as ns from './y';
// e1.ts / e2.ts (둘 다 entry, splitting)
import { ns as na } from './a';
import { ns as nb } from './b';
console.log(na.k, nb.k);   // 기대: XK YK · 실제(버그): XK XK
```

## 근본 원인 — 타이밍 seam

x.k 와 y.k 가 한 shared 청크에서 **deconflict**(`k` / `k$1`) 되는데, namespace 메타데이터 — materialize 된 getter 객체(`{get k(){return k}}`)와 ns 멤버 재작성 맵(`ns.k`→local) — 이 **심볼 rename 확정 *전*** 인 metadata/link 단계에서 inner const 명을 frozen 합니다. 그 시점 `getCanonicalName` 은 `null`(rename 미계산) → getter·멤버맵 둘 다 미-deconflict `k` 를 참조 → 정적(`na.k`)·동적(`na[key]`) 접근이 모두 XK 로 collapse.

## 핵심 통찰

inner const 의 *chunk-local* rename 은 이 시점에 미확정이나, **cross-chunk 전역명**(`getCrossChunkGlobalName`, emit 前 글로벌 패스 #4117)은 **이미 확정**돼 있습니다. 게다가 그 전역명이 곧:
- provider 청크의 **local 명**(`const k$1`), 그리고
- consumer 의 **import 명**(`import { k$1 }`)

과 일치 → getter(provider)와 멤버 재작성(consumer) **양쪽을 한 resolver 로** 일치시킵니다. x.k → `k`, y.k → `k$1`.

## 수정 (`shared_namespace.zig`)

| | |
|---|---|
| ns 멤버 재작성 | 값 = `getCrossChunkGlobalName(target, exported) orelse exp.local` (consumer `nb.k` → `k$1`) |
| ns getter 값 | `buildInlineObjectStr` 의 getter 도 동일 해석 (`na[key]` → 객체 getter → `k$1`) |
| ns 객체 literal | 전역명 확정 *전* frozen 되므로, **실제 동명 충돌이 있을 때만**(`ns_collision_present`) finalize 에서 재빌드. 비충돌(대부분)은 frozen 유지 → **재빌드 비용 0**(RN/large 번들 finalize 회귀 방지) |

`ns_collision_present` 는 `chunk.zig` 의 `computeCrossChunkGlobalNames` 에서 실제 동명 충돌(`used.contains(preferred)`)이 1건이라도 있으면 set(`linker.zig` bool 필드).

## Zig 초보자 설명

- **`orelse`**: `getCrossChunkGlobalName(...)` 은 `?[]const u8`(전역명 없으면 null). `... orelse exp.local` 은 \"전역명 있으면 그걸, 없으면 원본 local\". 비충돌이면 전역명==local 이라 같은 값 → 동작 불변.
- **frozen 캐시 무효화 + 재빌드**: ns 객체 문자열이 일찍 캐시(frozen)됐다 → 충돌 시 `ns_inline_cache.fetchRemove`(옛 값 소유권 회수+free)로 무효화 후 `buildInlineObjectStr` 재호출(전역명 확정 후라 올바른 const). `fetchRemove`(단순 remove 아님)로 orphan 누수 방지.
- **defer + `.ptr` 비교**: `defer if (obj_literal.ptr != entry.object_literal.ptr) free(obj_literal)` — 재빌드 성공 시 새 dupe 만 free, OOM fallback(frozen 재사용) 시 free 안 함(이중해제 방지).
- **게이트 플래그**: 비싼 재빌드를 *충돌 번들에서만* 돌려, 충돌 없는 번들(대부분)은 비용 0.

## 검증

- ns collision 테스트: 정적 `na.k`(멤버 재작성) + 동적 `na[kk]`(객체 getter) 모두 distinct(`XK YK XK YK`) green
- 유닛 **5760/5760**(GeneralPurposeAllocator leak 0 — 초기 leak 검출→fetchRemove 로 수정)
- **적대적 리뷰 PASS (3/3)**: (A) 메모리 안전(ownership 추적·이중해제 없음·emit 순차=race 없음) (B) **비충돌 byte-identity 6/6 namespace 시나리오 main vs 브랜치 napi sha256 동일**(single/barrel/export-star/cjs/nested/two-distinct-ns) (C) 충돌 정확성 adversarial 11/11(3-way·default+named·multi-key·spread·비대칭)
- 광역 subset 247(bundle-smoke·splitting·ns·preserve·dev-hmr), 전 빌드타겟(napi/wasm/wasm-bundler/test262/schema/bench/install)

### 전체 suite 잔여 2 실패 = 선재/flaky (본 PR 무관, A/B 확정)
- **Hermes RN 번들 5s 타임아웃**: RN 앱 + Flow 번들이 ~8s — main 도 8.1s(stash A/B). 5s 타임아웃이 빡빡한 선재 이슈.
- **watch-stress RSS 궤적**: fixture 가 `export const v=0` 뿐(ns/충돌 전무) → 본 변경 codepath 미진입. RSS 기울기 테스트의 본질적 noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)