### PR TITLE
fix(transformer,codegen,semantic): 깊은 좌결합 이항 체인 스택 오버플로우 반복 변환 (#4123 PR-1)

### DIFF
--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -64,22 +64,9 @@ pub fn emitUpdate(self: anytype, node: Node) !void {
     if (is_postfix) try self.write(op.symbol());
 }
 
-pub fn emitBinary(self: anytype, node: Node) !void {
-    try self.addSourceMapping(node.span);
+/// 이항 연산자 심볼 + 양옆 spacing 을 좌/우 피연산자 사이에 emit. 재귀·반복 경로 공용.
+fn emitBinaryOperator(self: anytype, node: Node) !void {
     const op: Kind = @enumFromInt(node.data.binary.flags);
-    if (self.options.linking_metadata != null and node.tag == .logical_expression) {
-        if (self.evalBooleanCondition(node.data.binary.left)) |left_val| {
-            if ((op == .amp2 and !left_val) or
-                (op == .pipe2 and left_val))
-            {
-                try self.write(if (left_val) "true" else "false");
-                return;
-            }
-            try self.emitNode(node.data.binary.right);
-            return;
-        }
-    }
-    try self.emitNode(node.data.binary.left);
     if (op == .kw_in or op == .kw_instanceof) {
         // 영문 키워드 연산자는 양옆 공백 필수 (`a in b` ≠ `ainb`) — minify 와 무관.
         try self.writeByte(' ');
@@ -101,6 +88,68 @@ pub fn emitBinary(self: anytype, node: Node) !void {
             try self.writeSpace();
         }
     }
+}
+
+/// idx 가 좌결합 평탄화 대상 스파인 노드인지. binary 는 항상, logical 은 상수 단락(fold)이
+/// 없을 때(linking_metadata == null)만 — fold 는 좌/우 일부만 emit 해 평탄화를 깨므로 그땐
+/// 재귀 경로로 둔다(깊은 `&&`/`||` 체인 + 번들 상수폴드 조합은 드묾). (#4123)
+fn emitSpineContinues(self: anytype, idx: NodeIndex) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return false;
+    const t = self.ast.getNode(idx).tag;
+    if (t == .binary_expression) return true;
+    if (t == .logical_expression and self.options.linking_metadata == null) return true;
+    return false;
+}
+
+/// 이항 노드 emit. 좌결합 체인(a+b+c+…)은 좌 스파인이 N-deep 라 순수 재귀면 스택 오버플로우
+/// (#4123) → 좌 스파인을 명시 스택으로 평탄화해 반복 emit 한다. 출력 텍스트와 addSourceMapping
+/// 순서(root → 스파인 top-down → 최좌단 leaf → operator+right bottom-up)는 재귀판과 동일.
+pub fn emitBinary(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
+    const op: Kind = @enumFromInt(node.data.binary.flags);
+    if (self.options.linking_metadata != null and node.tag == .logical_expression) {
+        if (self.evalBooleanCondition(node.data.binary.left)) |left_val| {
+            if ((op == .amp2 and !left_val) or
+                (op == .pipe2 and left_val))
+            {
+                try self.write(if (left_val) "true" else "false");
+                return;
+            }
+            try self.emitNode(node.data.binary.right);
+            return;
+        }
+    }
+
+    const left = node.data.binary.left;
+    // 빠른 경로(depth 1, 대부분의 `a OP b`): 좌 자식이 스파인 노드가 아니면 기존 형태(할당 0).
+    if (!emitSpineContinues(self, left)) {
+        try self.emitNode(left);
+        try emitBinaryOperator(self, node);
+        try self.emitNode(node.data.binary.right);
+        return;
+    }
+
+    // 느린 경로: 좌 스파인 평탄화 (체인당 1회 할당). root 는 위에서 이미 addSourceMapping/fold 처리.
+    var spine: std.ArrayListUnmanaged(NodeIndex) = .empty;
+    defer spine.deinit(self.allocator);
+    var cur = left;
+    while (true) {
+        try spine.append(self.allocator, cur);
+        const nl = self.ast.getNode(cur).data.binary.left;
+        if (emitSpineContinues(self, nl)) cur = nl else break;
+    }
+    // 스파인 노드(left..bottom) addSourceMapping 을 top-down 으로 (재귀판 순서 보존).
+    for (spine.items) |s| try self.addSourceMapping(self.ast.getNode(s).span);
+    // 최좌단 leaf(최하단 스파인 노드의 left).
+    try self.emitNode(self.ast.getNode(spine.items[spine.items.len - 1]).data.binary.left);
+    // bottom-up: 각 스파인 노드 operator+right (소스순), 마지막에 root.
+    var i = spine.items.len;
+    while (i > 0) : (i -= 1) {
+        const sn = self.ast.getNode(spine.items[i - 1]);
+        try emitBinaryOperator(self, sn);
+        try self.emitNode(sn.data.binary.right);
+    }
+    try emitBinaryOperator(self, node);
     try self.emitNode(node.data.binary.right);
 }
 

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1333,6 +1333,13 @@ pub const SemanticAnalyzer = struct {
     // AST Visitor — switch 기반 (D042)
     // ================================================================
 
+    /// idx 가 유효하고 binary_expression/logical_expression 인지 (좌결합 스파인 평탄화용, #4123).
+    fn isBinaryOrLogical(self: *SemanticAnalyzer, idx: NodeIndex) bool {
+        if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return false;
+        const tag = self.ast.getNode(idx).tag;
+        return tag == .binary_expression or tag == .logical_expression;
+    }
+
     fn visitNode(self: *SemanticAnalyzer, idx: NodeIndex) AllocError!void {
         if (idx.isNone()) return;
         // 바운드 체크: 잘못된 인덱스 방어
@@ -1555,8 +1562,34 @@ pub const SemanticAnalyzer = struct {
             .binary_expression,
             .logical_expression,
             => {
-                try self.visitNode(node.data.binary.left);
-                try self.visitNode(node.data.binary.right);
+                const left0 = node.data.binary.left;
+                if (!self.isBinaryOrLogical(left0)) {
+                    // 빠른 경로(depth 1, 대부분의 `a OP b`): 좌→우 그대로, 할당 없음.
+                    try self.visitNode(left0);
+                    try self.visitNode(node.data.binary.right);
+                } else {
+                    // 깊은 좌결합 체인(a+b+c+…)은 좌 스파인을 재귀로 내려가면 스택 오버플로우
+                    // (#4123). 스파인을 명시적 스택으로 평탄화해 반복 순회한다. 방문 순서는
+                    // 재귀판과 동일(최좌단 leaf → 각 노드의 right 를 bottom-up = 소스순 a,b,c,d)
+                    // 이라 ref 수집 결과 불변.
+                    var spine: std.ArrayListUnmanaged(NodeIndex) = .empty;
+                    defer spine.deinit(self.allocator);
+                    var cur_idx = idx;
+                    while (true) {
+                        try spine.append(self.allocator, cur_idx);
+                        const left = self.ast.getNode(cur_idx).data.binary.left;
+                        if (self.isBinaryOrLogical(left)) {
+                            cur_idx = left;
+                        } else break;
+                    }
+                    // 최좌단 leaf(최하단 스파인 노드의 left) 먼저.
+                    try self.visitNode(self.ast.getNode(spine.items[spine.items.len - 1]).data.binary.left);
+                    // 그다음 각 스파인 노드의 right 를 bottom→top(소스순) 으로.
+                    var i = spine.items.len;
+                    while (i > 0) : (i -= 1) {
+                        try self.visitNode(self.ast.getNode(spine.items[i - 1]).data.binary.right);
+                    }
+                }
             },
             .conditional_expression => {
                 // ternary: { a = condition, b = consequent, c = alternate }

--- a/src/transformer/transformer/node_helpers.zig
+++ b/src/transformer/transformer/node_helpers.zig
@@ -172,23 +172,75 @@ pub fn visitUnaryNode(self: anytype, idx: NodeIndex) Error!NodeIndex {
     });
 }
 
-/// 이항 노드: left, right를 재귀 방문 후 복사.
+/// left 노드가 lowering 없이 visitBinaryNode 로 직행하는 "일반" 좌결합 스파인 노드인지.
+/// node_dispatch.zig:276-305 의 per-node 다운레벨링 트리거(`**`→Math.pow, `??`→삼항,
+/// `#x in`)를 제외 — 그 노드들은 평탄화로 건너뛰면 안 되고 visitNode 로 재-dispatch 되어
+/// lowering 돼야 하므로 스파인 경계가 된다. (#4123 좌 스파인 평탄화용.)
+fn binarySpineContinues(self: anytype, idx: NodeIndex) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return false;
+    const n = self.ast.getNode(idx);
+    if (n.tag != .binary_expression and n.tag != .logical_expression) return false;
+    const op: token_mod.Kind = @enumFromInt(n.data.binary.flags);
+    if (n.tag == .binary_expression and op == .star2 and self.options.unsupported.exponentiation) return false;
+    if (n.tag == .logical_expression and op == .question2 and self.options.unsupported.nullish_coalescing) return false;
+    if (n.tag == .binary_expression and op == .kw_in and
+        (self.current_private_fields.len > 0 or self.current_private_methods.len > 0)) return false;
+    return true;
+}
+
+/// 이항 노드: left, right를 방문 후 복사. 좌결합 체인(a+b+c+…)은 좌 스파인이 N-deep 라
+/// 순수 재귀면 스택 오버플로우(#4123) → 좌 스파인을 명시 스택으로 평탄화해 반복 처리한다.
+/// 방문 순서(최좌단 leaf → 각 right bottom-up = 소스순)와 "자식 불변 시 idx 재사용" 동작은
+/// 재귀판과 동일 → 출력 byte-identical.
 pub fn visitBinaryNode(self: anytype, idx: NodeIndex) Error!NodeIndex {
     const node = self.ast.getNode(idx);
-    const old_left = node.data.binary.left;
-    const old_right = node.data.binary.right;
-    const new_left = try self.visitNode(old_left);
-    const new_right = try self.visitNode(old_right);
-    if (new_left == old_left and new_right == old_right) return idx;
-    return self.ast.addNode(.{
-        .tag = node.tag,
-        .span = node.span,
-        .data = .{ .binary = .{
+    const root_left = node.data.binary.left;
+
+    // 빠른 경로(depth 1, 대부분의 `a OP b`): 좌 자식이 스파인 노드가 아니면 기존 재귀형(할당 0).
+    if (!binarySpineContinues(self, root_left)) {
+        const old_right = node.data.binary.right;
+        const new_left = try self.visitNode(root_left);
+        const new_right = try self.visitNode(old_right);
+        if (new_left == root_left and new_right == old_right) return idx;
+        return self.ast.addNode(.{ .tag = node.tag, .span = node.span, .data = .{ .binary = .{
             .left = new_left,
             .right = new_right,
             .flags = node.data.binary.flags,
-        } },
-    });
+        } } });
+    }
+
+    // 느린 경로: 좌 스파인 평탄화. 체인당 1회만 할당(노드당 아님).
+    var spine: std.ArrayListUnmanaged(NodeIndex) = .empty;
+    defer spine.deinit(self.allocator);
+    var cur = idx;
+    while (true) {
+        try spine.append(self.allocator, cur);
+        const left = self.ast.getNode(cur).data.binary.left;
+        if (binarySpineContinues(self, left)) cur = left else break;
+    }
+    // 최좌단 leaf(최하단 스파인 노드의 left)는 정식 dispatch 로 방문(여기서 lowering 가능).
+    var acc = try self.visitNode(self.ast.getNode(spine.items[spine.items.len - 1]).data.binary.left);
+    // bottom→top: 각 스파인 노드의 right 방문 후 재조립(자식 불변이면 원본 idx 재사용).
+    // (재조립된 중간 스파인 노드는 visitNode 를 거치지 않아 propagateSymbolId 가 호출되지
+    //  않지만, binary/logical 연산자 노드는 symbol_id 를 갖지 않으므로 무해. leaf/right 는
+    //  여전히 visitNode 로 방문돼 정상 전파된다.)
+    var i = spine.items.len;
+    while (i > 0) : (i -= 1) {
+        const sidx = spine.items[i - 1];
+        const n = self.ast.getNode(sidx);
+        const old_right = n.data.binary.right;
+        const new_right = try self.visitNode(old_right);
+        if (acc == n.data.binary.left and new_right == old_right) {
+            acc = sidx;
+        } else {
+            acc = try self.ast.addNode(.{ .tag = n.tag, .span = n.span, .data = .{ .binary = .{
+                .left = acc,
+                .right = new_right,
+                .flags = n.data.binary.flags,
+            } } });
+        }
+    }
+    return acc;
 }
 
 /// unary/update expression: extra = [operand, operator_and_flags]

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1640,6 +1640,37 @@ fn expectFastFullParity(
     try std.testing.expectEqual(@as(usize, 0), full.diagnostics.len);
 }
 
+test "deep left-assoc binary chain does not overflow the stack (#4123)" {
+    // `0 + 1 + 2 + … (N항)` 은 N-deep 좌편향 BinaryExpression 트리. 재귀 visitor
+    // (semantic visitNode / transformer visitBinaryNode / codegen emitBinary)가 이 깊이에서
+    // 스택 오버플로우했다(#4123, depth ~5000 에서 SIGSEGV). 좌 스파인 반복 평탄화 후 정상 처리.
+    const n: usize = 20000; // pre-fix 크래시 임계(~4000-5000) 를 넉넉히 초과.
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(std.testing.allocator);
+    try src.appendSlice(std.testing.allocator, "const x = 0");
+    var buf: [24]u8 = undefined;
+    var i: usize = 1;
+    while (i < n) : (i += 1) {
+        try src.appendSlice(std.testing.allocator, try std.fmt.bufPrint(&buf, " + {d}", .{i}));
+    }
+    try src.appendSlice(std.testing.allocator, ";\n");
+
+    // full=true 로 semantic 경로(#3)까지 포함해 세 site 모두 거친다.
+    var result = try transpileWithCallbackInternal(
+        std.testing.allocator,
+        src.items,
+        "input.js",
+        .{},
+        null,
+        true,
+    );
+    defer result.deinit(std.testing.allocator);
+
+    // 크래시 없이 도달 + 진단 0 + 출력이 모든 `+`(N-1 개)를 보존(codegen 정확성).
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+    try std.testing.expectEqual(n - 1, std.mem.count(u8, result.code, "+"));
+}
+
 test "TransformPlan: simple TypeScript strip skips semantic" {
     const plan = try testTransformPlan(
         "export const x: number = 1;\nexport function f(v: string): string { return v; }\ninterface Foo { x: number }\ntype Bar = string;\n",


### PR DESCRIPTION
## 무엇을 / 왜

`a + b + c + … (N항)` 은 N-deep 좌편향 BinaryExpression 트리입니다. AST visitor 가 `visit(node.left)` 로 좌 스파인을 N단계 **재귀**로 내려가, depth ~5000 에서 **스택 오버플로우** (SIGSEGV; ReleaseFast 에선 스택 가드페이지 침범으로 garbage 출력). 모듈/번들과 무관하며 단일 파일 transpile 로도 재현됩니다. Debug 빌드 스택트레이스로 root cause 확정 (#4123).

> 이전엔 "flat 5000 모듈 메모리 손상"으로 보였으나, 진짜 원인은 fixture 의 `console.log(fn0(val0) + … + fn4999(val4999))` 가 만든 **5000-항 `+` 표현식**이었습니다(모듈 수는 우연).

## 수정

기본(무옵션) transpile·bundle 이 **항상** 거치는 3개 재귀 site 를 **좌 스파인 평탄화**(명시적 스택 → bottom-up 재구성, esbuild/oxc 방식)로 반복화:

| site | 역할 |
|---|---|
| semantic `analyzer.zig` visitNode (binary/logical arm) | 모든 파싱에서 실행 — **이슈 최초 목록엔 없었으나 audit 으로 발견**. 이것만 빠지면 transpile 경로가 여전히 크래시 |
| transformer `node_helpers.zig` visitBinaryNode | AST 재조립 |
| codegen `expressions.zig` emitBinary | 텍스트 emit |

각 site: 좌 자식이 평탄화 대상이 아니면 **기존 재귀형 유지(depth 1, 할당 0)** 빠른 경로 + 깊은 체인만 명시 스택으로 평탄화(**체인당 1회 할당**). 보존한 불변식:
- 방문/emit **순서**(최좌단 leaf → 각 right bottom-up = 소스순 a,b,c,d)
- transformer 의 **"자식 불변 시 idx 재사용"**(identity reuse)
- codegen 의 **addSourceMapping 순서**(root → 스파인 top-down → leaf → operator+right bottom-up)
- per-node lowering(`**`→Math.pow, `??`→삼항, `#x in`) · logical 상수 fold 경계 → 이런 노드는 스파인 경계로 두고 정식 dispatch 로 재귀(재귀 범위를 그 서브트리로 한정)

→ 정상 코드 출력 **byte-identical**.

## 검증 (fix vs pre-fix 바이너리 직접 대조)

- **크래시 해소**: `+` 체인 depth 5000/50000/**200000** + `&&` 20000, transpile·bundle 전부 exit 0.
- **출력 정확**: `0+1+…+4999 = 12497500` (실행 일치).
- **byte-identical**: lodash-es · date-fns · nanoid · bytes (plain + minify, 8케이스) 전부 pre-fix == fix.
- **원래 #4123 repro**(flat-5000 단일 entry): default · `--jobs=2` exit 0 + 결정적.
- `zig build test` 통과 + 깊은 체인 회귀 유닛 테스트(`transpile.zig`, depth 20000, full semantic 경로) 추가.
- `/code-review max` (4 finder): correctness·메모리안전·byte-identical 확인, critical 0. 지적 2건(transformer predicate 상위 bound 체크 누락 / 재조립 노드 symbol_id) 반영.

## 범위 (staged)

이 PR = **기본 경로(좌결합, 신고된 케이스)**. 남은 항목은 별도 추적:
- **PR-2 예정**: flag-gated 재귀 site(--minify refs/immutable, named-import shadow scan, `#private` mangler, 저ES TLA/async-gen 등 ~7곳). audit 결과 다수가 공통 `children` 이터레이터 패턴이라 `walkChildrenIterative` 헬퍼 하나로 일괄 반복화 가능.
- **잔존 엣지(드묾)**: 번들 모드의 깊은 `&&`/`||` 체인(상수폴드 단락이 평탄화를 깨므로 재귀 유지), 우결합 체인(`a=b=c`, `a**b**c` 레거시 타깃).

Refs #4123

🤖 Generated with [Claude Code](https://claude.com/claude-code)