### PR TITLE
chore(bench): incremental/watch rebuild 벤치 추가 (ZNTC vs esbuild vs rolldown)

### DIFF
--- a/tests/benchmark/incremental-rebuild.ts
+++ b/tests/benchmark/incremental-rebuild.ts
@@ -1,0 +1,298 @@
+#!/usr/bin/env bun
+/**
+ * Incremental rebuild benchmark — ZNTC vs esbuild vs rolldown.
+ *
+ * Watch mode 시작 → entry 파일에 1 byte 추가 → output 파일 mtime 변화까지 시간 측정.
+ * 도구별 stdout 마커 차이를 우회하기 위해 fs mtime 기준.
+ *
+ * 측정 의도: ZNTC의 2-phase + 모듈 캐싱이 incremental rebuild 에서 실제로
+ * 경쟁사 대비 우위가 있는지. cold build 우위(4-26x, RN bench)는 별도 측정이며
+ * 본 bench 는 *warm rebuild* 만 측정한다.
+ *
+ * 실행: bun run incremental-rebuild.ts
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { appendFileSync, existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+const ZNTC_BIN = join(ROOT, 'zig-out/bin/zntc');
+const ESBUILD_BIN = join(__dirname, 'node_modules/.bin/esbuild');
+const ROLLDOWN_BIN = join(__dirname, 'node_modules/.bin/rolldown');
+
+const ITERATIONS = 10;
+const INITIAL_BUILD_TIMEOUT_MS = 15_000;
+const REBUILD_TIMEOUT_MS = 10_000;
+const POLL_INTERVAL_MS = 2;
+const POST_BUILD_SETTLE_MS = 200;
+
+interface Fixture {
+  name: string;
+  description: string;
+  build(dir: string): { entry: string };
+}
+
+const fixtures: Fixture[] = [
+  {
+    name: 'tiny',
+    description: 'single 2-line file, no deps',
+    build(dir) {
+      const entry = join(dir, 'entry.ts');
+      writeFileSync(entry, `export const x = 1;\nconsole.log(x);\n`);
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', type: 'module' }));
+      return { entry };
+    },
+  },
+  {
+    name: 'medium',
+    description: '10 local modules, mutual imports',
+    build(dir) {
+      for (let i = 0; i < 10; i++) {
+        writeFileSync(
+          join(dir, `m${i}.ts`),
+          `export function fn${i}(x: number) { return x + ${i}; }\n`,
+        );
+      }
+      const imports = Array.from(
+        { length: 10 },
+        (_, i) => `import { fn${i} } from './m${i}';`,
+      ).join('\n');
+      const calls = Array.from({ length: 10 }, (_, i) => `fn${i}(1)`).join(' + ');
+      const entry = join(dir, 'entry.ts');
+      writeFileSync(entry, `${imports}\nconsole.log(${calls});\n`);
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', type: 'module' }));
+      return { entry };
+    },
+  },
+  {
+    name: 'lodash',
+    description: 'lodash-es subset import (real npm dep, large dep graph)',
+    build(dir) {
+      // benchmark dir의 node_modules에 lodash-es가 있음 — symlink로 접근
+      const benchNm = join(__dirname, 'node_modules');
+      const localNm = join(dir, 'node_modules');
+      try {
+        require('node:fs').symlinkSync(benchNm, localNm, 'dir');
+      } catch {}
+      const entry = join(dir, 'entry.ts');
+      writeFileSync(
+        entry,
+        `import { groupBy, sortBy, uniq, map, filter, reduce } from 'lodash-es';\nconsole.log(groupBy, sortBy, uniq, map, filter, reduce);\n`,
+      );
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', type: 'module' }));
+      return { entry };
+    },
+  },
+];
+
+interface ToolRunner {
+  name: string;
+  enabled: boolean;
+  spawnWatch(dir: string, entry: string, outFile: string): ChildProcess;
+}
+
+import { basename } from 'node:path';
+
+const tools: ToolRunner[] = [
+  {
+    name: 'zntc',
+    enabled: existsSync(ZNTC_BIN),
+    spawnWatch(dir, entry, outFile) {
+      // --watch-delay=0: debounce window 제거 (기본 50ms — 측정 차감 위해).
+      return spawn(
+        ZNTC_BIN,
+        ['--bundle', basename(entry), '-o', basename(outFile), '--watch', '--watch-delay=0'],
+        { cwd: dir, stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+    },
+  },
+  {
+    name: 'esbuild',
+    enabled: existsSync(ESBUILD_BIN),
+    spawnWatch(dir, entry, outFile) {
+      // `--watch=forever`: esbuild 는 stdin close 시 자동 stop 하므로 명시적 keep-alive.
+      return spawn(
+        ESBUILD_BIN,
+        [
+          basename(entry),
+          '--bundle',
+          `--outfile=${basename(outFile)}`,
+          '--watch=forever',
+          '--loader:.ts=ts',
+          '--format=iife',
+        ],
+        { cwd: dir, stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+    },
+  },
+  {
+    name: 'rolldown',
+    enabled: existsSync(ROLLDOWN_BIN),
+    spawnWatch(dir, entry, outFile) {
+      return spawn(ROLLDOWN_BIN, [basename(entry), '-o', basename(outFile), '--watch'], {
+        cwd: dir,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    },
+  },
+];
+
+async function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForFile(path: string, timeoutMs: number): Promise<number> {
+  const t0 = performance.now();
+  while (performance.now() - t0 < timeoutMs) {
+    if (existsSync(path)) return statSync(path).mtimeMs;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(`timeout waiting for ${path}`);
+}
+
+async function waitForMtimeChange(
+  path: string,
+  prevMtime: number,
+  timeoutMs: number,
+): Promise<number> {
+  const t0 = performance.now();
+  while (performance.now() - t0 < timeoutMs) {
+    if (existsSync(path)) {
+      const m = statSync(path).mtimeMs;
+      if (m > prevMtime) return m;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(`timeout waiting for mtime change on ${path} (prev=${prevMtime})`);
+}
+
+interface Stats {
+  iters: number[];
+  initialMs: number;
+}
+
+function summarize(arr: number[]): {
+  min: number;
+  max: number;
+  median: number;
+  mean: number;
+} {
+  const sorted = [...arr].sort((a, b) => a - b);
+  const n = sorted.length;
+  const median = n % 2 === 1 ? sorted[(n - 1) >> 1] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
+  const mean = sorted.reduce((a, b) => a + b, 0) / n;
+  return { min: sorted[0], max: sorted[n - 1], median, mean };
+}
+
+async function measureTool(tool: ToolRunner, fx: Fixture): Promise<Stats | { error: string }> {
+  const dir = mkdtempSync(join(tmpdir(), `inc-${tool.name}-${fx.name}-`));
+  const { entry } = fx.build(dir);
+  const outFile = join(dir, `${tool.name}.out.js`);
+
+  const child = tool.spawnWatch(dir, entry, outFile);
+  const stderrChunks: string[] = [];
+  child.stderr?.on('data', (d) => stderrChunks.push(d.toString()));
+  child.stdout?.on('data', () => {});
+
+  try {
+    const initStart = performance.now();
+    let lastMtime: number;
+    try {
+      lastMtime = await waitForFile(outFile, INITIAL_BUILD_TIMEOUT_MS);
+    } catch (e) {
+      return {
+        error: `initial build failed: ${stderrChunks.join('').slice(0, 300)}`,
+      };
+    }
+    const initialMs = performance.now() - initStart;
+
+    await sleep(POST_BUILD_SETTLE_MS);
+
+    const iters: number[] = [];
+    for (let i = 0; i < ITERATIONS; i++) {
+      // emit 결과물에 반영되는 변경 — esbuild 의 unchanged-skip 회피.
+      // 변수 1개 추가 후 console.log 인자로 사용해 dead-code elim 도 회피.
+      appendFileSync(entry, `export const _iter${i} = ${i};\nconsole.log(_iter${i});\n`);
+      const t0 = performance.now();
+      try {
+        const newMtime = await waitForMtimeChange(outFile, lastMtime, REBUILD_TIMEOUT_MS);
+        const dt = performance.now() - t0;
+        iters.push(dt);
+        lastMtime = newMtime;
+      } catch (e) {
+        return { error: `rebuild ${i} timeout` };
+      }
+      await sleep(POST_BUILD_SETTLE_MS);
+    }
+
+    return { iters, initialMs };
+  } finally {
+    child.kill('SIGTERM');
+    await sleep(100);
+    if (!child.killed) child.kill('SIGKILL');
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function pad(s: string | number, n: number): string {
+  return String(s).padStart(n);
+}
+
+function fmt(n: number): string {
+  if (n < 10) return n.toFixed(2);
+  if (n < 100) return n.toFixed(1);
+  return n.toFixed(0);
+}
+
+async function main() {
+  console.log('# Incremental rebuild benchmark\n');
+  console.log(
+    `Watch mode + file touch → output mtime 변화까지 시간 (ms).\n` +
+      `Iterations per tool/fixture: ${ITERATIONS}, post-build settle: ${POST_BUILD_SETTLE_MS}ms.\n` +
+      `폴링 간격 ${POLL_INTERVAL_MS}ms 가 측정 하한 (≈ noise floor).\n`,
+  );
+
+  if (!existsSync(ZNTC_BIN)) {
+    console.error(`ZNTC 바이너리 없음: ${ZNTC_BIN}\n  먼저 \`zig build\` 실행`);
+    process.exit(1);
+  }
+
+  for (const fx of fixtures) {
+    console.log(`\n## ${fx.name} — ${fx.description}\n`);
+    console.log(`| Tool     | Initial | Rebuild median | min   | max   | mean  |`);
+    console.log(`|----------|--------:|---------------:|------:|------:|------:|`);
+    for (const tool of tools) {
+      if (!tool.enabled) {
+        console.log(
+          `| ${tool.name.padEnd(8)} | n/a     | n/a            | -     | -     | -     |`,
+        );
+        continue;
+      }
+      try {
+        const r = await measureTool(tool, fx);
+        if ('error' in r) {
+          console.log(
+            `| ${tool.name.padEnd(8)} | FAIL    | ${r.error.slice(0, 30).padEnd(14)} | -     | -     | -     |`,
+          );
+          continue;
+        }
+        const s = summarize(r.iters);
+        console.log(
+          `| ${tool.name.padEnd(8)} | ${pad(fmt(r.initialMs), 6)}ms | ${pad(fmt(s.median), 12)}ms | ${pad(fmt(s.min), 4)}ms | ${pad(fmt(s.max), 4)}ms | ${pad(fmt(s.mean), 4)}ms |`,
+        );
+      } catch (e) {
+        console.log(
+          `| ${tool.name.padEnd(8)} | ERROR   | ${String(e).slice(0, 20).padEnd(14)} | -     | -     | -     |`,
+        );
+      }
+    }
+  }
+  console.log();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tests/benchmark/inprocess-rebuild.ts
+++ b/tests/benchmark/inprocess-rebuild.ts
@@ -1,0 +1,273 @@
+#!/usr/bin/env bun
+/**
+ * In-process rebuild benchmark — fair comparison.
+ *
+ * 모든 도구를 *programmatic API* 로 호출해 spawn/polling overhead 제거.
+ *   - ZNTC: `@zntc/core` watch(opts) + onRebuild (NAPI worker thread)
+ *   - esbuild: context().rebuild()
+ *   - rolldown: watch().on('event')
+ *
+ * 실행: bun run inprocess-rebuild.ts
+ *
+ * Note(이력): 예전엔 bun 이 rolldown import 에서 crash 해 node+mjs 우회가 필요했으나,
+ * 현재 bun/rolldown 조합에선 `bun run` 으로 바로 동작한다. (node 로 직접 돌리면 `@zntc/core`
+ * 의 extensionless ESM import 가 strict resolver 에서 막히고, `bun build` 로 번들하면 rolldown
+ * 네이티브 바인딩 resolution 이 깨져 둘 다 부적합 → bun 직접 실행이 가장 단순.)
+ */
+
+import { watch as zntcWatch } from '../../packages/core/index.ts';
+import { context as esbuildContext } from 'esbuild';
+import { watch as rolldownWatch } from 'rolldown';
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const ITERATIONS = 10;
+const READY_TIMEOUT_MS = 15_000;
+const REBUILD_TIMEOUT_MS = 10_000;
+const SETTLE_MS = 200;
+
+interface Fixture {
+  name: string;
+  build(dir: string): { entry: string };
+}
+
+const fixtures: Fixture[] = [
+  {
+    name: 'tiny',
+    build(dir) {
+      const entry = join(dir, 'entry.ts');
+      writeFileSync(entry, `export const x = 1;\nconsole.log(x);\n`);
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', type: 'module' }));
+      return { entry };
+    },
+  },
+  {
+    name: 'medium',
+    build(dir) {
+      for (let i = 0; i < 10; i++) {
+        writeFileSync(join(dir, `m${i}.ts`), `export function fn${i}(x){return x+${i};}\n`);
+      }
+      const entry = join(dir, 'entry.ts');
+      const imps = Array.from({ length: 10 }, (_, i) => `import { fn${i} } from './m${i}';`).join(
+        '\n',
+      );
+      const calls = Array.from({ length: 10 }, (_, i) => `fn${i}(1)`).join('+');
+      writeFileSync(entry, `${imps}\nconsole.log(${calls});\n`);
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', type: 'module' }));
+      return { entry };
+    },
+  },
+  {
+    name: 'lodash',
+    build(dir) {
+      const benchNm = join(__dirname, 'node_modules');
+      try {
+        symlinkSync(benchNm, join(dir, 'node_modules'), 'dir');
+      } catch {}
+      const entry = join(dir, 'entry.ts');
+      writeFileSync(
+        entry,
+        `import { groupBy, sortBy, uniq, map, filter, reduce } from 'lodash-es';\nconsole.log(groupBy, sortBy, uniq, map, filter, reduce);\n`,
+      );
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', type: 'module' }));
+      return { entry };
+    },
+  },
+];
+
+const sleep = (ms: number) => new Promise<void>((res) => setTimeout(res, ms));
+
+function summarize(arr: number[]) {
+  const s = [...arr].sort((a, b) => a - b);
+  const n = s.length;
+  const median = n % 2 === 1 ? s[(n - 1) >> 1] : (s[n / 2 - 1] + s[n / 2]) / 2;
+  const mean = s.reduce((a, b) => a + b, 0) / n;
+  return { min: s[0], max: s[n - 1], median, mean };
+}
+
+async function measureZntc(fx: Fixture) {
+  const dir = mkdtempSync(join(tmpdir(), `inp-zntc-${fx.name}-`));
+  const { entry } = fx.build(dir);
+  const out = join(dir, 'out.js');
+  const iters: number[] = [];
+  let t0 = 0;
+  let rebuildResolve: (() => void) | null = null;
+  let readyResolve!: () => void;
+  const readyP = new Promise<void>((res, rej) => {
+    readyResolve = res;
+    setTimeout(() => rej(new Error('ready timeout')), READY_TIMEOUT_MS);
+  });
+  const initStart = performance.now();
+  const handle = zntcWatch({
+    entryPoints: [entry],
+    outfile: out,
+    bundle: true,
+    write: true,
+    onReady: () => readyResolve(),
+    onRebuild: () => {
+      if (rebuildResolve) {
+        iters.push(performance.now() - t0);
+        const r = rebuildResolve;
+        rebuildResolve = null;
+        r();
+      }
+    },
+  });
+  try {
+    await readyP;
+    const initialMs = performance.now() - initStart;
+    await sleep(SETTLE_MS);
+    for (let i = 0; i < ITERATIONS; i++) {
+      const p = new Promise<void>((res, rej) => {
+        rebuildResolve = res;
+        setTimeout(() => {
+          if (rebuildResolve) {
+            rebuildResolve = null;
+            rej(new Error(`rebuild ${i} timeout`));
+          }
+        }, REBUILD_TIMEOUT_MS);
+      });
+      appendFileSync(entry, `export const _i${i}=${i};console.log(_i${i});\n`);
+      t0 = performance.now();
+      await p;
+      await sleep(SETTLE_MS);
+    }
+    return { initialMs, iters };
+  } finally {
+    try {
+      handle.stop();
+    } catch {}
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function measureEsbuild(fx: Fixture) {
+  const dir = mkdtempSync(join(tmpdir(), `inp-esb-${fx.name}-`));
+  const { entry } = fx.build(dir);
+  const out = join(dir, 'out.js');
+  const iters: number[] = [];
+  const initStart = performance.now();
+  const ctx = await esbuildContext({
+    entryPoints: [entry],
+    outfile: out,
+    bundle: true,
+    write: true,
+    loader: { '.ts': 'ts' },
+    format: 'iife',
+  });
+  await ctx.rebuild();
+  const initialMs = performance.now() - initStart;
+  try {
+    await sleep(SETTLE_MS);
+    for (let i = 0; i < ITERATIONS; i++) {
+      appendFileSync(entry, `export const _i${i}=${i};console.log(_i${i});\n`);
+      const t0 = performance.now();
+      await ctx.rebuild();
+      iters.push(performance.now() - t0);
+      await sleep(SETTLE_MS);
+    }
+    return { initialMs, iters };
+  } finally {
+    await ctx.dispose();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function measureRolldown(fx: Fixture) {
+  const dir = mkdtempSync(join(tmpdir(), `inp-rd-${fx.name}-`));
+  const { entry } = fx.build(dir);
+  const out = join(dir, 'out.js');
+  const iters: number[] = [];
+  let t0 = 0;
+  let rebuildResolve: (() => void) | null = null;
+  let readyResolve!: () => void;
+  const readyP = new Promise<void>((res, rej) => {
+    readyResolve = res;
+    setTimeout(() => rej(new Error('rolldown ready timeout')), READY_TIMEOUT_MS);
+  });
+  const initStart = performance.now();
+  const watcher = rolldownWatch({
+    input: entry,
+    output: { file: out, format: 'esm' },
+  });
+  watcher.on('event', (e: any) => {
+    if (e.code === 'BUNDLE_END' || e.code === 'END') {
+      if (rebuildResolve) {
+        iters.push(performance.now() - t0);
+        const r = rebuildResolve;
+        rebuildResolve = null;
+        r();
+      } else {
+        readyResolve();
+      }
+    }
+  });
+  try {
+    await readyP;
+    const initialMs = performance.now() - initStart;
+    await sleep(SETTLE_MS);
+    for (let i = 0; i < ITERATIONS; i++) {
+      const p = new Promise<void>((res, rej) => {
+        rebuildResolve = res;
+        setTimeout(() => {
+          if (rebuildResolve) {
+            rebuildResolve = null;
+            rej(new Error(`rebuild ${i} timeout`));
+          }
+        }, REBUILD_TIMEOUT_MS);
+      });
+      appendFileSync(entry, `export const _i${i}=${i};console.log(_i${i});\n`);
+      t0 = performance.now();
+      await p;
+      await sleep(SETTLE_MS);
+    }
+    return { initialMs, iters };
+  } finally {
+    try {
+      await watcher.close();
+    } catch {}
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function fmt(n: number) {
+  if (n < 10) return n.toFixed(2);
+  if (n < 100) return n.toFixed(1);
+  return n.toFixed(0);
+}
+function pad(s: string | number, n: number) {
+  return String(s).padStart(n);
+}
+
+async function main() {
+  console.log('# In-process rebuild benchmark (fair, no spawn/polling)\n');
+  console.log(`Iter ${ITERATIONS}, settle ${SETTLE_MS}ms.\n`);
+  for (const fx of fixtures) {
+    console.log(`\n## ${fx.name}\n`);
+    console.log(`| Tool      | Initial   | Rebuild median | min   | max   | mean  |`);
+    console.log(`|-----------|----------:|---------------:|------:|------:|------:|`);
+    for (const [name, fn] of [
+      ['zntc(NAPI)', measureZntc],
+      ['esbuild', measureEsbuild],
+      ['rolldown', measureRolldown],
+    ] as const) {
+      try {
+        const r = await fn(fx);
+        const s = summarize(r.iters);
+        console.log(
+          `| ${name.padEnd(9)} | ${pad(fmt(r.initialMs), 7)}ms | ${pad(fmt(s.median), 12)}ms | ${pad(fmt(s.min), 4)}ms | ${pad(fmt(s.max), 4)}ms | ${pad(fmt(s.mean), 4)}ms |`,
+        );
+      } catch (e) {
+        console.log(
+          `| ${name.padEnd(9)} | FAIL      | ${String(e).slice(0, 30).padEnd(14)} | -     | -     | -     |`,
+        );
+      }
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tests/benchmark/napi-watch.ts
+++ b/tests/benchmark/napi-watch.ts
@@ -1,0 +1,210 @@
+#!/usr/bin/env bun
+/**
+ * NAPI watch rebuild benchmark — `@zntc/core`의 `watch(options)` 측정.
+ *
+ * CLI `--bundle --watch` 는 500ms 폴링 (src/main.zig:904) → measurement 가
+ * 폴링 대기에 묻힘. NAPI watch 는 별도 path — onReady/onRebuild 콜백 + worker
+ * thread + 진짜 file watcher (kqueue/inotify 가능).
+ *
+ * 실행: bun run napi-watch.ts
+ */
+
+import { watch } from '../../packages/core/index.ts';
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+
+const ITERATIONS = 10;
+const READY_TIMEOUT_MS = 15_000;
+const REBUILD_TIMEOUT_MS = 10_000;
+const POST_BUILD_SETTLE_MS = 200;
+
+interface Fixture {
+  name: string;
+  description: string;
+  build(dir: string): { entry: string };
+}
+
+const fixtures: Fixture[] = [
+  {
+    name: 'tiny',
+    description: 'single 2-line file',
+    build(dir) {
+      const entry = join(dir, 'entry.ts');
+      writeFileSync(entry, `export const x = 1;\nconsole.log(x);\n`);
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', type: 'module' }));
+      return { entry };
+    },
+  },
+  {
+    name: 'medium',
+    description: '10 local modules',
+    build(dir) {
+      for (let i = 0; i < 10; i++) {
+        writeFileSync(
+          join(dir, `m${i}.ts`),
+          `export function fn${i}(x: number) { return x + ${i}; }\n`,
+        );
+      }
+      const imports = Array.from(
+        { length: 10 },
+        (_, i) => `import { fn${i} } from './m${i}';`,
+      ).join('\n');
+      const calls = Array.from({ length: 10 }, (_, i) => `fn${i}(1)`).join(' + ');
+      const entry = join(dir, 'entry.ts');
+      writeFileSync(entry, `${imports}\nconsole.log(${calls});\n`);
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', type: 'module' }));
+      return { entry };
+    },
+  },
+  {
+    name: 'lodash',
+    description: 'lodash-es subset',
+    build(dir) {
+      const benchNm = join(__dirname, 'node_modules');
+      try {
+        symlinkSync(benchNm, join(dir, 'node_modules'), 'dir');
+      } catch {}
+      const entry = join(dir, 'entry.ts');
+      writeFileSync(
+        entry,
+        `import { groupBy, sortBy, uniq, map, filter, reduce } from 'lodash-es';\nconsole.log(groupBy, sortBy, uniq, map, filter, reduce);\n`,
+      );
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'fx', type: 'module' }));
+      return { entry };
+    },
+  },
+];
+
+async function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function summarize(arr: number[]) {
+  const sorted = [...arr].sort((a, b) => a - b);
+  const n = sorted.length;
+  const median = n % 2 === 1 ? sorted[(n - 1) >> 1] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
+  const mean = sorted.reduce((a, b) => a + b, 0) / n;
+  return { min: sorted[0], max: sorted[n - 1], median, mean };
+}
+
+async function measureFixture(fx: Fixture): Promise<
+  | {
+      initialMs: number;
+      iters: number[];
+    }
+  | { error: string }
+> {
+  const dir = mkdtempSync(join(tmpdir(), `napi-${fx.name}-`));
+  const { entry } = fx.build(dir);
+  const outFile = join(dir, 'out.js');
+
+  let readyResolve!: () => void;
+  const readyP = new Promise<void>((res, rej) => {
+    readyResolve = res;
+    setTimeout(() => rej(new Error('ready timeout')), READY_TIMEOUT_MS);
+  });
+  let rebuildResolve: (() => void) | null = null;
+  let t0 = 0;
+  const rebuildTimes: number[] = [];
+
+  const initStart = performance.now();
+  const handle = watch({
+    entryPoints: [entry],
+    outfile: outFile,
+    bundle: true,
+    write: true,
+    onReady: () => readyResolve(),
+    onRebuild: () => {
+      if (rebuildResolve) {
+        const dt = performance.now() - t0;
+        rebuildTimes.push(dt);
+        const r = rebuildResolve;
+        rebuildResolve = null;
+        r();
+      }
+    },
+  });
+
+  try {
+    await readyP;
+    const initialMs = performance.now() - initStart;
+    await sleep(POST_BUILD_SETTLE_MS);
+
+    for (let i = 0; i < ITERATIONS; i++) {
+      const p = new Promise<void>((res, rej) => {
+        rebuildResolve = res;
+        setTimeout(() => {
+          if (rebuildResolve) {
+            rebuildResolve = null;
+            rej(new Error(`rebuild ${i} timeout`));
+          }
+        }, REBUILD_TIMEOUT_MS);
+      });
+      appendFileSync(entry, `export const _iter${i} = ${i};\nconsole.log(_iter${i});\n`);
+      t0 = performance.now();
+      try {
+        await p;
+      } catch (e) {
+        return { error: String(e) };
+      }
+      await sleep(POST_BUILD_SETTLE_MS);
+    }
+
+    return { initialMs, iters: rebuildTimes };
+  } finally {
+    try {
+      handle.stop();
+    } catch {}
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function fmt(n: number): string {
+  if (n < 10) return n.toFixed(2);
+  if (n < 100) return n.toFixed(1);
+  return n.toFixed(0);
+}
+
+function pad(s: string | number, n: number): string {
+  return String(s).padStart(n);
+}
+
+async function main() {
+  console.log('# NAPI watch rebuild benchmark\n');
+  console.log(
+    `@zntc/core 의 watch(opts) + onRebuild 콜백 측정 (in-process, CLI 와 다른 path).\n` +
+      `Iterations: ${ITERATIONS}, settle: ${POST_BUILD_SETTLE_MS}ms.\n`,
+  );
+
+  console.log(`| Fixture  | Initial   | Rebuild median | min   | max   | mean  |`);
+  console.log(`|----------|----------:|---------------:|------:|------:|------:|`);
+
+  for (const fx of fixtures) {
+    try {
+      const r = await measureFixture(fx);
+      if ('error' in r) {
+        console.log(
+          `| ${fx.name.padEnd(8)} | FAIL      | ${r.error.slice(0, 30).padEnd(14)} | -     | -     | -     |`,
+        );
+        continue;
+      }
+      const s = summarize(r.iters);
+      console.log(
+        `| ${fx.name.padEnd(8)} | ${pad(fmt(r.initialMs), 7)}ms | ${pad(fmt(s.median), 12)}ms | ${pad(fmt(s.min), 4)}ms | ${pad(fmt(s.max), 4)}ms | ${pad(fmt(s.mean), 4)}ms |`,
+      );
+    } catch (e) {
+      console.log(
+        `| ${fx.name.padEnd(8)} | ERROR     | ${String(e).slice(0, 30).padEnd(14)} | -     | -     | -     |`,
+      );
+    }
+  }
+  console.log();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tests/benchmark/package.json
+++ b/tests/benchmark/package.json
@@ -10,6 +10,9 @@
     "bench:const-prepass": "bun run const-prepass.ts",
     "bench:monorepo": "bun run monorepo-perf.ts",
     "bench:minify": "bun run minify-bench.ts",
+    "bench:rebuild:incremental": "bun run incremental-rebuild.ts",
+    "bench:rebuild:inprocess": "bun run inprocess-rebuild.ts",
+    "bench:rebuild:napi": "bun run napi-watch.ts",
     "pipeline": "bun run pipeline.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## 배경

기존 벤치는 **cold build** 우위만 측정합니다(메모리에도 "dev cold-start만 ZNTC 우세"로 정리). 빠진 차원인 **warm/incremental rebuild + watch** 를 esbuild/rolldown 대비 세 각도로 측정하는 standalone 벤치를 추가합니다. (`tests/benchmark/` 의 기존 28개 standalone 벤치와 동일 관례)

> 참고: 이 3개 파일은 PR #4125(#4120) 머지 때 `git add -A` 로 실수로 휩쓸렸다가 정리 PR #4126 으로 추적 해제된 untracked WIP 였습니다. 이번엔 **실제 실행 검증 후 의도적으로** 정식 편입합니다.

## 추가하는 것

| 파일 | 측정 | 실행 |
|---|---|---|
| `incremental-rebuild.ts` | CLI `--bundle --watch` + 파일 touch → output mtime 변화 (spawn/polling 포함, 실사용 watch 경로) | `bun run bench:rebuild:incremental` |
| `inprocess-rebuild.ts` | programmatic API(`@zntc/core` watch / esbuild `context()` / rolldown `watch()`) — spawn/polling overhead 제거한 공정 비교 | `bun run bench:rebuild:inprocess` |
| `napi-watch.ts` | `@zntc/core` NAPI watch 단독(worker thread + 진짜 file watcher) | `bun run bench:rebuild:napi` |

`package.json` 에 `bench:rebuild:*` 스크립트 3개 등록.

## 검증 (3개 모두 실측 통과, exit 0)

`inprocess-rebuild.ts` 헤더의 "bun 이 rolldown 에서 crash → mjs 변환 필요" 경고는 **outdated** 였습니다(현재 bun/rolldown 조합은 `bun run` 으로 바로 동작) — 헤더를 실제 동작 명령으로 정정했습니다.

## 측정으로 드러난 사실 (정직 기록)

**ZNTC 의 CLI watch 는 경쟁사 대비 크게 느립니다** — 500ms 폴링(`src/main.zig`) + 풀 리빌드 때문:

```
incremental-rebuild (CLI, rebuild median):
  tiny    zntc 346ms  | esbuild 20.5ms | rolldown 19.1ms
  lodash  zntc 2283ms | esbuild 55.8ms | rolldown 39.6ms
```

반면 **NAPI watch 경로는 격차가 작습니다**(worker thread + 진짜 watcher):

```
inprocess (NAPI, rebuild median):
  tiny    zntc 53ms | esbuild 15ms | rolldown 25ms
  lodash  zntc 68ms | esbuild 56ms | rolldown 54ms
```

→ dev 모드 incremental 은 NAPI 경로가 정답이고, **CLI 폴링 경로는 개선 여지가 크다**는 걸 데이터로 보여줍니다(후속 최적화 타깃). 측정값은 머신/부하 의존이라 절대치보다 *경로 간 격차*가 신호입니다.

소스/빌드 영향 없음(벤치 스크립트 + package.json 스크립트뿐).

🤖 Generated with [Claude Code](https://claude.com/claude-code)