### PR TITLE
fix(ast-walk): flag-gated 재귀 walker 4곳 반복 순회 — 깊은 이항 체인 (#4123 PR-2a)

### DIFF
--- a/src/codegen/private_mangler.zig
+++ b/src/codegen/private_mangler.zig
@@ -141,33 +141,37 @@ fn applyRenames(ast: *Ast, idx: NodeIndex, renames: *const std.StringHashMapUnma
 /// Direct `eval("...")` 호출이 class body 안에 있는지 보수적 탐지. 있으면 private mangle
 /// 전체 skip (eval 이 private name 을 동적으로 재작성할 가능성에 대비 — 실제 runtime 에선
 /// eval 안에서 private 접근이 language level 로 금지되어 있지만 안전 측면 보수 유지).
-fn containsDirectEval(ast: *const Ast, idx: NodeIndex) bool {
-    const ni = @intFromEnum(idx);
-    if (ni >= ast.nodes.items.len) return false;
-    const node = ast.nodes.items[ni];
+const DirectEvalCtx = struct { ast: *const Ast, found: bool };
 
+fn directEvalVisit(ctx: *DirectEvalCtx, idx: NodeIndex, node: Node) ast_walk.WalkAction {
+    _ = idx;
     if (node.tag == .call_expression) {
         // callee 가 identifier_reference "eval" 인지
         const e = node.data.extra;
-        if (ast.hasExtra(e, 0)) {
-            const callee_ni = ast.readExtra(e, 0);
-            if (callee_ni < ast.nodes.items.len) {
-                const callee = ast.nodes.items[callee_ni];
+        if (ctx.ast.hasExtra(e, 0)) {
+            const callee_ni = ctx.ast.readExtra(e, 0);
+            if (callee_ni < ctx.ast.nodes.items.len) {
+                const callee = ctx.ast.nodes.items[callee_ni];
                 if (callee.tag == .identifier_reference and
-                    std.mem.eql(u8, ast.getText(callee.span), "eval")) return true;
+                    std.mem.eql(u8, ctx.ast.getText(callee.span), "eval"))
+                {
+                    ctx.found = true;
+                    return .stop;
+                }
             }
         }
     }
+    // Nested class 는 자체 eval 이 있어도 그 class 의 처리 문제 — outer 에 영향 없음. prune.
+    if (node.tag == .class_declaration or node.tag == .class_expression) return .skip_children;
+    return .descend;
+}
 
-    // Nested class 는 자체 eval 이 있어도 그 class 의 처리 문제 — outer 에 영향 없음.
-    if (node.tag == .class_declaration or node.tag == .class_expression) return false;
-
-    var it = ast_walk.children(ast, node);
-    while (it.next()) |child| {
-        if (child.isNone()) continue;
-        if (containsDirectEval(ast, child)) return true;
-    }
-    return false;
+fn containsDirectEval(ast: *const Ast, idx: NodeIndex) bool {
+    // 반복 순회(#4123): 클래스 body 안 깊은 좌결합 체인에서 재귀 시 스택 오버플로우.
+    // OOM 시 보수적으로 true(=eval 있다고 가정 → private mangling 생략) → 안전.
+    var c = DirectEvalCtx{ .ast = ast, .found = false };
+    ast_walk.walkPreorderIterative(ast.allocator, ast, idx, &c, directEvalVisit) catch return true;
+    return c.found;
 }
 
 /// counter -> `#a`, `#b`, ..., `#z`, `#A`, ..., `#Z`, `#a0`, `#a1`, ...

--- a/src/parser/ast_walk.zig
+++ b/src/parser/ast_walk.zig
@@ -333,3 +333,55 @@ pub fn collectReachableNodeIndices(allocator: std.mem.Allocator, ast: *const Ast
 
     return result.toOwnedSlice(allocator);
 }
+
+/// `walkPreorderIterative` 의 노드별 콜백 반환값.
+pub const WalkAction = enum {
+    /// 이 노드의 자식들을 마저 방문(일반 pre-order 하강).
+    descend,
+    /// 이 노드의 서브트리를 건너뜀(prune — 자식 push 안 함). 재귀판의 early `return` 대응.
+    skip_children,
+    /// 순회 전체를 즉시 종료. predicate short-circuit(첫 매치에서 멈춤) 대응.
+    stop,
+};
+
+/// `root` 서브트리를 pre-order(자식 좌→우)로 **반복** 순회한다. 재귀 대신 명시 스택을 써서
+/// 깊은 좌결합 체인(`a+b+c+…` 수천 항, #4123)에서도 스택 오버플로우가 없다.
+/// `visit(ctx, idx, node)` 가 각 노드에서 호출돼 `WalkAction` 을 반환:
+///   - `.descend` → 자식 방문, `.skip_children` → 서브트리 prune, `.stop` → 전체 종료.
+/// 방문 순서와 prune 의미는 `var it = children(...); while(it.next())|c| recurse(c)` 재귀판과
+/// 동일하다(스택에 자식을 역순 push → 좌→우 pop). `allocator` 는 스택 전용(보통
+/// `ast.allocator`=parse_arena; 함수 종료 시 deinit). OOM 시 `error.OutOfMemory` 전파 —
+/// 무한루프/부분상태 없음(호출자가 catch 로 보수적 처리 가능).
+pub fn walkPreorderIterative(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    root: NodeIndex,
+    ctx: anytype,
+    comptime visit: fn (@TypeOf(ctx), NodeIndex, Node) WalkAction,
+) std.mem.Allocator.Error!void {
+    var stack: std.ArrayList(NodeIndex) = .empty;
+    defer stack.deinit(allocator);
+    try stack.append(allocator, root);
+
+    var child_buf: std.ArrayList(NodeIndex) = .empty;
+    defer child_buf.deinit(allocator);
+
+    while (stack.pop()) |idx| {
+        if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) continue;
+        const node = ast.nodes.items[@intFromEnum(idx)];
+        switch (visit(ctx, idx, node)) {
+            .stop => return,
+            .skip_children => continue,
+            .descend => {},
+        }
+        // 자식을 좌→우 pop 하도록 역순으로 push.
+        child_buf.clearRetainingCapacity();
+        var it = children(ast, node);
+        while (it.next()) |c| try child_buf.append(allocator, c);
+        var i = child_buf.items.len;
+        while (i > 0) {
+            i -= 1;
+            try stack.append(allocator, child_buf.items[i]);
+        }
+    }
+}

--- a/src/transformer/es2022_tla.zig
+++ b/src/transformer/es2022_tla.zig
@@ -54,12 +54,12 @@ fn isModuleDeclaration(tag: Tag) bool {
 }
 
 /// 서브트리(statement)에 top-level await (함수 경계를 넘지 않는 await) 가 있는지 검사.
-fn hasTopLevelAwait(ast: *const ast_mod.Ast, idx: NodeIndex) bool {
-    if (idx.isNone()) return false;
-    const node = ast.getNode(idx);
+const TopLevelAwaitCtx = struct { found: bool };
 
-    // 함수/메서드 경계를 만나면 await 는 해당 함수 소속 — 더 내려가지 않음.
+fn topLevelAwaitVisit(ctx: *TopLevelAwaitCtx, idx: NodeIndex, node: Node) ast_walk.WalkAction {
+    _ = idx;
     switch (node.tag) {
+        // 함수/메서드/클래스 경계 → 그 안의 await 는 top-level 아님. prune.
         .function_declaration,
         .function_expression,
         .function,
@@ -67,17 +67,22 @@ fn hasTopLevelAwait(ast: *const ast_mod.Ast, idx: NodeIndex) bool {
         .method_definition,
         .class_declaration,
         .class_expression,
-        => return false,
-        .await_expression => return true,
-        else => {},
+        => return .skip_children,
+        .await_expression => {
+            ctx.found = true;
+            return .stop;
+        },
+        else => return .descend,
     }
+}
 
-    // 자식 재귀 — 공통 ChildIterator (ast_walk) 로 predicate 탐색.
-    var it = ast_walk.children(ast, node);
-    while (it.next()) |child| {
-        if (hasTopLevelAwait(ast, child)) return true;
-    }
-    return false;
+fn hasTopLevelAwait(ast: *const ast_mod.Ast, idx: NodeIndex) std.mem.Allocator.Error!bool {
+    // 반복 순회(#4123): top-level 깊은 좌결합 체인에서 재귀 시 스택 오버플로우. OOM 은
+    // 호출자(lowerProgram=Error!)로 전파한다 — true/false 어느 기본값도 안전하지 않으므로
+    // (false=미지원 타깃에 unwrapped await / true=불필요 IIFE wrap) 추측 대신 에러 전파.
+    var c = TopLevelAwaitCtx{ .found = false };
+    try ast_walk.walkPreorderIterative(ast.allocator, ast, idx, &c, topLevelAwaitVisit);
+    return c.found;
 }
 
 /// program 의 top-level 에 TLA 가 있으면 async IIFE 로 wrap.
@@ -96,7 +101,7 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
         const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
         const child_node = self.ast.getNode(child);
         if (isModuleDeclaration(child_node.tag)) continue;
-        if (hasTopLevelAwait(self.ast, child)) {
+        if (try hasTopLevelAwait(self.ast, child)) {
             has_tla = true;
             break;
         }

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -669,24 +669,21 @@ pub fn decrementRefsShallow(ast: *const Ast, ctx: MinifyCtx, idx: NodeIndex) voi
     decrementRefsImpl(ast, ctx, idx, true);
 }
 
-fn decrementRefsImpl(ast: *const Ast, ctx: MinifyCtx, idx: NodeIndex, comptime skip_fn_body: bool) void {
-    if (idx.isNone()) return;
-    const ni = @intFromEnum(idx);
-    if (ni >= ast.nodes.items.len) return;
-    const node = ast.nodes.items[ni];
+const DecrementRefsCtx = struct { mc: MinifyCtx, skip_fn_body: bool };
 
+fn decrementRefsVisit(ctx: *DecrementRefsCtx, idx: NodeIndex, node: Node) ast_walk.WalkAction {
     if (node.tag == .identifier_reference) {
-        if (ni < ctx.symbol_ids.len) {
-            if (ctx.symbol_ids[ni]) |sid| {
-                if (sid < ctx.ref_deltas.len and ctx.effectiveRefCount(sid) > 0) {
-                    ctx.ref_deltas[sid] += 1;
+        const ni = @intFromEnum(idx);
+        if (ni < ctx.mc.symbol_ids.len) {
+            if (ctx.mc.symbol_ids[ni]) |sid| {
+                if (sid < ctx.mc.ref_deltas.len and ctx.mc.effectiveRefCount(sid) > 0) {
+                    ctx.mc.ref_deltas[sid] += 1;
                 }
             }
         }
-        return;
+        return .skip_children; // identifier_reference 는 자식 없음
     }
-
-    if (skip_fn_body) switch (node.tag) {
+    if (ctx.skip_fn_body) switch (node.tag) {
         // 함수/클래스 body 는 호출/인스턴스화 시점에 평가. dead branch 안에 함수
         // declaration 이 있어도 그 함수가 외부 ref 면 body 안 read 는 살아 있음.
         .function_declaration,
@@ -694,14 +691,17 @@ fn decrementRefsImpl(ast: *const Ast, ctx: MinifyCtx, idx: NodeIndex, comptime s
         .arrow_function_expression,
         .class_declaration,
         .class_expression,
-        => return,
+        => return .skip_children,
         else => {},
     };
+    return .descend;
+}
 
-    var it = ast_walk.children(ast, node);
-    while (it.next()) |child| {
-        decrementRefsImpl(ast, ctx, child, skip_fn_body);
-    }
+fn decrementRefsImpl(ast: *const Ast, ctx: MinifyCtx, idx: NodeIndex, comptime skip_fn_body: bool) void {
+    // 반복 순회(#4123): 깊은 좌결합 체인(`if(false) a+b+c+…`)의 dead branch 를 감산할 때
+    // 재귀면 스택 오버플로우. OOM 시 일부 감산 누락 → 해당 심볼이 보수적으로 live 유지 → 출력 정상.
+    var c = DecrementRefsCtx{ .mc = ctx, .skip_fn_body = skip_fn_body };
+    ast_walk.walkPreorderIterative(ast.allocator, ast, idx, &c, decrementRefsVisit) catch {};
 }
 
 // ================================================================
@@ -1047,27 +1047,37 @@ inline fn isImmutableSymbol(ctx: MinifyCtx, sid: u32) bool {
 /// pure compound expression inline 안전성 — `const a = x+1; b = a*2;` 에서
 /// `x` 가 mutable 이면 inline 후 `b = (x+1)*2;` 의 `x` 평가 시점이 declaration
 /// 위치에서 read 위치로 옮겨가 ordering 의미 변경 위험.
+const ImmutableRefsCtx = struct { mc: MinifyCtx, decl_sym_id: u32, all_immutable: bool };
+
+fn immutableRefsVisit(ctx: *ImmutableRefsCtx, idx: NodeIndex, node: Node) ast_walk.WalkAction {
+    if (node.tag == .identifier_reference) {
+        const ni = @intFromEnum(idx);
+        // 원본과 동일: ni 범위 밖 / symbol_id 없음 / decl 자기참조 / mutable 심볼 → 즉시 false.
+        const immutable = ni < ctx.mc.symbol_ids.len and blk: {
+            const sid = ctx.mc.symbol_ids[ni] orelse break :blk false;
+            if (sid == ctx.decl_sym_id) break :blk false;
+            break :blk isImmutableSymbol(ctx.mc, sid);
+        };
+        if (!immutable) {
+            ctx.all_immutable = false;
+            return .stop;
+        }
+        return .skip_children; // identifier_reference 는 자식 없음
+    }
+    return .descend;
+}
+
 fn allInnerReferencesImmutable(
     ast: *const Ast,
     ctx: MinifyCtx,
     idx: NodeIndex,
     decl_sym_id: u32,
 ) bool {
-    if (idx.isNone()) return true;
-    const ni = @intFromEnum(idx);
-    if (ni >= ast.nodes.items.len) return true;
-    const node = ast.nodes.items[ni];
-    if (node.tag == .identifier_reference) {
-        if (ni >= ctx.symbol_ids.len) return false;
-        const sid = ctx.symbol_ids[ni] orelse return false;
-        if (sid == decl_sym_id) return false;
-        if (!isImmutableSymbol(ctx, sid)) return false;
-    }
-    var it = ast_walk.children(ast, node);
-    while (it.next()) |child| {
-        if (!allInnerReferencesImmutable(ast, ctx, child, decl_sym_id)) return false;
-    }
-    return true;
+    // 반복 순회(#4123): 단일-use inline 대상 init(`const x = a+b+c+…`)이 깊은 체인이면
+    // 재귀 시 스택 오버플로우. OOM 시 보수적으로 false(=inline 안 함) 반환 → 출력 정상.
+    var c = ImmutableRefsCtx{ .mc = ctx, .decl_sym_id = decl_sym_id, .all_immutable = true };
+    ast_walk.walkPreorderIterative(ast.allocator, ast, idx, &c, immutableRefsVisit) catch return false;
+    return c.all_immutable;
 }
 
 /// init 이 식별자 의존성 없는 constant expression 인지 판정.

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1671,6 +1671,31 @@ test "deep left-assoc binary chain does not overflow the stack (#4123)" {
     try std.testing.expectEqual(n - 1, std.mem.count(u8, result.code, "+"));
 }
 
+test "deep binary chain with minify does not overflow (#4123 flag-gated walkers)" {
+    // `const x = a + a + … (N항)` (a=immutable const, x single-use) 를 minify_syntax 로 처리하면
+    // single-use inline 판정이 `allInnerReferencesImmutable` 로 깊은 체인을 순회한다(주 커버 대상).
+    // 재귀판이면 여기서 스택 오버플로우(#4123). 반복(walkPreorderIterative) 변환 후 정상.
+    // (decrementRefs/containsDirectEval/hasTopLevelAwait 의 깊은-체인 비크래시는 CLI e2e 로 확인.)
+    const n: usize = 20000;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(std.testing.allocator);
+    try src.appendSlice(std.testing.allocator, "const a = 1;\nconst x = a");
+    var i: usize = 1;
+    while (i < n) : (i += 1) try src.appendSlice(std.testing.allocator, " + a");
+    try src.appendSlice(std.testing.allocator, ";\nconsole.log(x);\n");
+
+    var result = try transpileWithCallbackInternal(
+        std.testing.allocator,
+        src.items,
+        "input.js",
+        .{ .minify_syntax = true },
+        null,
+        true,
+    );
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+}
+
 test "TransformPlan: simple TypeScript strip skips semantic" {
     const plan = try testTransformPlan(
         "export const x: number = 1;\nexport function f(v: string): string { return v; }\ninterface Foo { x: number }\ntype Bar = string;\n",


### PR DESCRIPTION
> **Stacked PR**: base 가 `fix/deep-binary-stack-overflow-4123`(#4124, PR-1)입니다. **#4124 머지 후** GitHub 가 자동으로 base 를 `main` 으로 재지정합니다 — #4124 를 먼저 머지해 주세요.

## 무엇을 / 왜

#4123(깊은 좌결합 이항 체인 → 재귀 visitor 스택 오버플로우)의 **PR-2a**. PR-1(#4124)이 기본(무옵션) 경로 3곳을 고쳤고, audit 으로 찾은 flag-gated 재귀 site 중 **읽기 전용 walker 4곳**을 공용 반복 헬퍼로 전환합니다. (가드 없이 완전 커버 — 누락 site = 거기서 여전히 크래시하므로 전수 변환.)

## 신규: `ast_walk.walkPreorderIterative`

```
walkPreorderIterative(allocator, ast, root, ctx, visit)
```
`root` 서브트리를 **명시 스택**으로 pre-order(자식 좌→우) 반복 순회. `visit(ctx, idx, node)` 가 `.descend`(자식 방문) / `.skip_children`(서브트리 prune) / `.stop`(전체 종료)을 반환 — 재귀판의 하강/early-return/short-circuit 에 1:1 대응. 방문 순서·prune 의미는 `while(children) recurse` 재귀판과 동일(기존 `collectReachableNodeIndices` 의 worklist 패턴 일반화).

## 전환한 walker (전부 읽기 전용)

| walker | 플래그 | OOM 시 |
|---|---|---|
| minify `decrementRefsImpl` | --minify dead-branch ref 감산 | `catch {}` (감산 누락→심볼 보존=보수적, 출력 정상) |
| minify `allInnerReferencesImmutable` | --minify single-use inline 판정 | `catch false` (inline 안 함) |
| codegen `private_mangler.containsDirectEval` | `#private` mangle 전 eval 검사 | `catch true` (mangle 생략) |
| transformer `es2022_tla.hasTopLevelAwait` | 저ES TLA 검출 | **error 전파** (true/false 둘 다 비-안전 → 추측 대신 전파, code-review max 반영) |

스택은 `ast.allocator`(AST 가 사는 그 allocator — walk 중 항상 유효, 함수 종료 시 즉시 deinit).

## 검증 (PR-1 위 stack; fix vs main 직접 대조)

- **크래시 해소**: 깊은 체인 30000항 + `--minify`(allInner/decrementRefs), `class #private`+체인+`--minify`(containsDirectEval) 전부 exit 0.
- **byte-identical**: lodash-es·date-fns plain+minify 모두 pre-fix == fix (동작 보존).
- `zig build test` 통과(TLA 단위 테스트 포함) + minify 깊은 체인 회귀 유닛 테스트 추가.
- `/code-review max`(3 finder): 4개 전환 모두 재귀 원본과 1:1 동치 확인, critical 0. 지적(hasTopLevelAwait 비-보수 기본값)은 error 전파로 수정.

## 남은 #4123 (PR-2b 예정)

mutation/할당 walker — codegen `collectPrivateNames`(할당 콜백), `private_mangler.applyRenames`·es2017 `rewriteAwaitToYieldAwait`(ast mutation, `*Ast` + post-order 필요) + transpile binding-shadow scanner 2곳. mutation walker 는 `*const Ast` 헬퍼로 안 되어 별도 변형 필요.

Refs #4123

🤖 Generated with [Claude Code](https://claude.com/claude-code)