### PR TITLE
fix(bench): incremental-rebuild 가 실제 사용자 CLI(JS)를 측정하도록 수정

### DIFF
--- a/tests/benchmark/incremental-rebuild.ts
+++ b/tests/benchmark/incremental-rebuild.ts
@@ -18,7 +18,11 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 const ROOT = resolve(__dirname, '../..');
-const ZNTC_BIN = join(ROOT, 'zig-out/bin/zntc');
+// ⚠️ 실제 사용자 CLI = JS(`packages/core/bin/zntc.mjs`) — Node `fs.watch`(OS 네이티브:
+// macOS FSEvents / Linux inotify) + `--watch-delay` debounce 를 쓴다. 내부 Zig 바이너리
+// (`zig-out/bin/zntc`)는 500ms mtime 폴링 fallback 이라 watch 벤치에 쓰면 안 된다(폴링
+// 지연이 측정을 지배 → "ZNTC 느림" 거짓 결론). esbuild/rolldown 도 진짜 CLI 라 공정 비교.
+const ZNTC_CLI = join(ROOT, 'packages/core/bin/zntc.mjs');
 const ESBUILD_BIN = join(__dirname, 'node_modules/.bin/esbuild');
 const ROLLDOWN_BIN = join(__dirname, 'node_modules/.bin/rolldown');
 
@@ -98,12 +102,14 @@ import { basename } from 'node:path';
 const tools: ToolRunner[] = [
   {
     name: 'zntc',
-    enabled: existsSync(ZNTC_BIN),
+    enabled: existsSync(ZNTC_CLI),
     spawnWatch(dir, entry, outFile) {
-      // --watch-delay=0: debounce window 제거 (기본 50ms — 측정 차감 위해).
+      // 실제 사용자 CLI(JS) 를 그대로 실행 — `node zntc.mjs … --watch`. Node fs.watch
+      // (FSEvents/inotify) 기반. --watch-delay=0: debounce 제거(측정 차감). outFile 은
+      // watch 디렉토리(entry dir) 밖이라 self-trigger 피드백 루프 없음(아래 measureTool).
       return spawn(
-        ZNTC_BIN,
-        ['--bundle', basename(entry), '-o', basename(outFile), '--watch', '--watch-delay=0'],
+        'node',
+        [ZNTC_CLI, '--bundle', entry, '-o', outFile, '--watch', '--watch-delay=0'],
         { cwd: dir, stdio: ['ignore', 'pipe', 'pipe'] },
       );
     },
@@ -113,12 +119,13 @@ const tools: ToolRunner[] = [
     enabled: existsSync(ESBUILD_BIN),
     spawnWatch(dir, entry, outFile) {
       // `--watch=forever`: esbuild 는 stdin close 시 자동 stop 하므로 명시적 keep-alive.
+      // outFile 은 절대경로(watch dir 밖) — zntc 와 동일 조건.
       return spawn(
         ESBUILD_BIN,
         [
           basename(entry),
           '--bundle',
-          `--outfile=${basename(outFile)}`,
+          `--outfile=${outFile}`,
           '--watch=forever',
           '--loader:.ts=ts',
           '--format=iife',
@@ -131,7 +138,7 @@ const tools: ToolRunner[] = [
     name: 'rolldown',
     enabled: existsSync(ROLLDOWN_BIN),
     spawnWatch(dir, entry, outFile) {
-      return spawn(ROLLDOWN_BIN, [basename(entry), '-o', basename(outFile), '--watch'], {
+      return spawn(ROLLDOWN_BIN, [basename(entry), '-o', outFile, '--watch'], {
         cwd: dir,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
@@ -188,8 +195,13 @@ function summarize(arr: number[]): {
 
 async function measureTool(tool: ToolRunner, fx: Fixture): Promise<Stats | { error: string }> {
   const dir = mkdtempSync(join(tmpdir(), `inc-${tool.name}-${fx.name}-`));
+  // 출력은 watch 디렉토리(entry dir) *밖* 별도 디렉토리로 — 실제 사용자 CLI 는
+  // recursive fs.watch(entry dir)라, 출력이 watch dir 안이면 출력→재빌드 self-trigger
+  // 피드백 루프가 생겨 측정이 왜곡된다(esbuild/rolldown 은 출력을 안 watch 해 무관하나
+  // 조건 통일). entry-touch → output mtime 변화만 깨끗이 측정.
+  const outDir = mkdtempSync(join(tmpdir(), `inc-out-${tool.name}-${fx.name}-`));
   const { entry } = fx.build(dir);
-  const outFile = join(dir, `${tool.name}.out.js`);
+  const outFile = join(outDir, `${tool.name}.out.js`);
 
   const child = tool.spawnWatch(dir, entry, outFile);
   const stderrChunks: string[] = [];
@@ -212,6 +224,10 @@ async function measureTool(tool: ToolRunner, fx: Fixture): Promise<Stats | { err
 
     const iters: number[] = [];
     for (let i = 0; i < ITERATIONS; i++) {
+      // touch *직전* 에 lastMtime 을 현재 출력 mtime 으로 refresh — settle(200ms) 동안
+      // 일어난 noise rebuild(다중 fs.watch 이벤트 등)로 outFile mtime 이 앞서가 있으면,
+      // 다음 touch 측정이 그 stale mtime 으로 즉시 반환(≈0ms artifact)되는 걸 차단.
+      if (existsSync(outFile)) lastMtime = statSync(outFile).mtimeMs;
       // emit 결과물에 반영되는 변경 — esbuild 의 unchanged-skip 회피.
       // 변수 1개 추가 후 console.log 인자로 사용해 dead-code elim 도 회피.
       appendFileSync(entry, `export const _iter${i} = ${i};\nconsole.log(_iter${i});\n`);
@@ -233,6 +249,7 @@ async function measureTool(tool: ToolRunner, fx: Fixture): Promise<Stats | { err
     await sleep(100);
     if (!child.killed) child.kill('SIGKILL');
     rmSync(dir, { recursive: true, force: true });
+    rmSync(outDir, { recursive: true, force: true });
   }
 }
 
@@ -254,8 +271,8 @@ async function main() {
       `폴링 간격 ${POLL_INTERVAL_MS}ms 가 측정 하한 (≈ noise floor).\n`,
   );
 
-  if (!existsSync(ZNTC_BIN)) {
-    console.error(`ZNTC 바이너리 없음: ${ZNTC_BIN}\n  먼저 \`zig build\` 실행`);
+  if (!existsSync(ZNTC_CLI)) {
+    console.error(`ZNTC CLI 없음: ${ZNTC_CLI}\n  먼저 \`bun run build:js\`(또는 napi 빌드) 실행`);
     process.exit(1);
   }
 

--- a/tests/benchmark/napi-watch.ts
+++ b/tests/benchmark/napi-watch.ts
@@ -2,9 +2,12 @@
 /**
  * NAPI watch rebuild benchmark — `@zntc/core`의 `watch(options)` 측정.
  *
- * CLI `--bundle --watch` 는 500ms 폴링 (src/main.zig:904) → measurement 가
- * 폴링 대기에 묻힘. NAPI watch 는 별도 path — onReady/onRebuild 콜백 + worker
- * thread + 진짜 file watcher (kqueue/inotify 가능).
+ * 이 path 는 onReady/onRebuild 콜백 + NAPI worker thread + (NAPI 옵션 경유) 네이티브
+ * file watcher. spawn/IPC 없이 in-process 라 onRebuild 콜백 latency 만 깨끗이 측정.
+ *
+ * cf. 실제 사용자 CLI(JS `bin/zntc.mjs`, incremental-rebuild.ts)는 Node `fs.watch`
+ * (FSEvents/inotify) + `--watch-delay` debounce 를 쓴다 — 둘 다 *폴링 아님*. (내부 Zig
+ * 바이너리 `zig-out/bin/zntc` 만 500ms mtime 폴링 fallback 이며 사용자 경로가 아니다.)
  *
  * 실행: bun run napi-watch.ts
  */


### PR DESCRIPTION
## 문제 (리뷰 지적 — "CLI watch 폴링 안 쓰는 옵션 있지 않나? 테스트 설정 잘못된 듯")

직전 PR #4127 의 `incremental-rebuild.ts` 가 **잘못된 바이너리**를 측정했습니다.

- 실제 사용자 CLI 는 **JS**(`packages/core/bin/zntc.mjs`) — Node `fs.watch`(OS 네이티브: macOS FSEvents / Linux inotify) + `--watch-delay` debounce. **폴링 아님.**
- 그런데 벤치는 내부 Zig 바이너리(`zig-out/bin/zntc`)를 spawn — 이쪽은 `src/main.zig` 의 **500ms mtime 폴링 fallback**.

→ 폴링 지연(평균 250ms)이 측정을 지배해 **"ZNTC CLI 가 esbuild/rolldown 대비 10~100x 느리다"는 거짓 결론**(tiny 346ms / lodash 2283ms)이 나왔습니다. esbuild/rolldown 은 진짜 CLI(네이티브 watch)라 더 불공정했습니다.

## 수정

- ZNTC tool 을 `node packages/core/bin/zntc.mjs … --watch` (**실제 사용자 CLI**)로 spawn.
- 출력을 watch 디렉토리(entry dir) **밖** 별도 dir 로 — 실제 CLI 의 recursive `fs.watch` 가 자기 출력에 self-trigger 하는 피드백 루프 제거(3-tool 조건 통일).
- touch 직전 `lastMtime` refresh — settle 중 noise rebuild 로 mtime 이 앞서가 다음 측정이 ≈0ms 로 즉시 반환되던 artifact 차단(lodash `0.02ms` → 정상 `~45ms`).
- `napi-watch.ts` 헤더의 "CLI 는 500ms 폴링" 주석 정정(그건 내부 Zig 바이너리 한정).

## 정정 후 실측 (median, 실제 CLI)

| Fixture | zntc | esbuild | rolldown |
|---|---|---|---|
| tiny | **16.9ms** | 18.0ms | 21.5ms |
| medium | **19.7ms** | 24.8ms | 24.2ms |
| lodash | **46.5ms** | 55.7ms | 56.9ms |

→ ZNTC CLI 는 실제로 **경쟁사와 동급, 이 실행에선 3개 모두 median 최고속**. 원래 "느림" 결론은 순수 측정 버그였습니다. (watch 벤치는 fs.watch/GC noise 로 run-to-run 변동이 크므로 median 기준, 절대치보다 *동급* 임이 신호.)

## 검증
- `bun run incremental-rebuild.ts` / `bun run napi-watch.ts` 둘 다 exit 0, 정상 테이블.

소스/빌드 영향 없음(벤치 스크립트 수정뿐).

🤖 Generated with [Claude Code](https://claude.com/claude-code)