### PR TITLE
feat(cli): watch 폴링 간격을 --watch-delay 로 조절 (하드코딩 500ms 제거)

### DIFF
--- a/src/cli/watch.zig
+++ b/src/cli/watch.zig
@@ -2,8 +2,15 @@
 
 const std = @import("std");
 
+/// 폴링 fallback watch 의 mtime 확인 주기(ms). `--watch-delay`(기본 100) 값을 쓰되 0/과소값은
+/// busy-loop 방지로 10ms floor. JS CLI(bin/zntc.mjs)의 fs.watch debounce 와 같은 노브 —
+/// 거기선 이벤트 후 debounce, 폴링인 여기선 확인 주기. (예전엔 500ms 하드코딩이라 반응성 저하.)
+pub fn pollIntervalMs(delay_ms: u32) i64 {
+    return @max(@as(i64, delay_ms), 10);
+}
+
 /// 단일 파일을 폴링 방식으로 감시한다 (D048).
-/// 파일의 mtime을 500ms마다 확인하여 변경되면 재트랜스파일한다.
+/// 파일의 mtime을 `delay_ms`(--watch-delay, 기본 100ms)마다 확인하여 변경되면 재트랜스파일.
 /// Ctrl+C로 종료될 때까지 무한 루프를 돈다.
 pub fn watchFile(
     comptime transpileFn: anytype,
@@ -11,6 +18,7 @@ pub fn watchFile(
     io: std.Io,
     file_path: []const u8,
     output_path: ?[]const u8,
+    delay_ms: u32,
     options: anytype,
     stderr: anytype,
 ) !void {
@@ -25,8 +33,9 @@ pub fn watchFile(
 
     try stdout.print("[watch] Watching for file changes...\n", .{});
 
+    const poll_ms = pollIntervalMs(delay_ms);
     while (true) {
-        io.sleep(std.Io.Duration.fromMilliseconds(500), .awake) catch {};
+        io.sleep(std.Io.Duration.fromMilliseconds(poll_ms), .awake) catch {};
 
         const current_mtime = getFileMtime(io, file_path) catch continue;
 
@@ -41,14 +50,15 @@ pub fn watchFile(
 }
 
 /// 디렉토리를 폴링 방식으로 감시한다 (D048).
-/// 매 500ms마다 디렉토리를 재순회하여 .ts/.tsx 파일의 mtime을 확인하고,
-/// 변경된 파일만 재트랜스파일한다.
+/// 매 `delay_ms`(--watch-delay, 기본 100ms)마다 디렉토리를 재순회하여 .ts/.tsx 파일의
+/// mtime을 확인하고, 변경된 파일만 재트랜스파일한다.
 pub fn watchDirectory(
     comptime transpileFn: anytype,
     allocator: std.mem.Allocator,
     io: std.Io,
     input_dir: []const u8,
     output_dir: []const u8,
+    delay_ms: u32,
     options: anytype,
     stderr: anytype,
 ) !void {
@@ -70,8 +80,9 @@ pub fn watchDirectory(
 
     try stdout.print("[watch] Watching for file changes...\n", .{});
 
+    const poll_ms = pollIntervalMs(delay_ms);
     while (true) {
-        io.sleep(std.Io.Duration.fromMilliseconds(500), .awake) catch {};
+        io.sleep(std.Io.Duration.fromMilliseconds(poll_ms), .awake) catch {};
 
         // 현재 파일 상태 수집
         var current_mtimes: std.StringHashMapUnmanaged(i128) = .empty;

--- a/src/main.zig
+++ b/src/main.zig
@@ -993,9 +993,12 @@ pub fn main(init: std.process.Init) !void {
                 try stderr.print("[watch] Watching {d} files for changes...\n", .{mtime_map.count()});
             }
 
+            // 폴링 간격 = --watch-delay (기본 100ms). 과거엔 500ms 하드코딩이라 watch
+            // 반응성이 폴링 대기에 묻혔다(watch_cli.pollIntervalMs 가 0/과소값 floor).
+            const watch_poll_ms = watch_cli.pollIntervalMs(opts.watch_delay_ms);
             while (true) {
                 // 0.16: std.Thread.sleep 제거 → io.sleep(duration, clock).
-                io.sleep(std.Io.Duration.fromMilliseconds(500), .awake) catch {};
+                io.sleep(std.Io.Duration.fromMilliseconds(watch_poll_ms), .awake) catch {};
 
                 // mtime 변경 확인 + 변경 파일 수집
                 var changed = false;
@@ -1249,7 +1252,7 @@ pub fn main(init: std.process.Init) !void {
             };
             walkAndTranspile(allocator, io, input_path_str, out_dir, options) catch std.process.exit(1);
             if (opts.watch) {
-                try watch_cli.watchDirectory(transpileFile, allocator, io, input_path_str, out_dir, options, stderr);
+                try watch_cli.watchDirectory(transpileFile, allocator, io, input_path_str, out_dir, opts.watch_delay_ms, options, stderr);
             }
             return;
         };
@@ -1262,7 +1265,7 @@ pub fn main(init: std.process.Init) !void {
             };
             walkAndTranspile(allocator, io, input_path_str, out_dir, options) catch std.process.exit(1);
             if (opts.watch) {
-                try watch_cli.watchDirectory(transpileFile, allocator, io, input_path_str, out_dir, options, stderr);
+                try watch_cli.watchDirectory(transpileFile, allocator, io, input_path_str, out_dir, opts.watch_delay_ms, options, stderr);
             }
             return;
         }
@@ -1286,7 +1289,7 @@ pub fn main(init: std.process.Init) !void {
     } else {
         transpileFile(allocator, io, file_path, null, opts.output_file, options) catch std.process.exit(1);
         if (opts.watch) {
-            watch_cli.watchFile(transpileFile, allocator, io, file_path, opts.output_file, options, stderr) catch std.process.exit(1);
+            watch_cli.watchFile(transpileFile, allocator, io, file_path, opts.output_file, opts.watch_delay_ms, options, stderr) catch std.process.exit(1);
         }
     }
 }


### PR DESCRIPTION
## 배경

직전 벤치 작업(#4127·#4129)에서 드러난 것 — 내부 Zig 바이너리(`zig-out/bin/zntc`)의 watch fallback 이 mtime 폴링을 **500ms 하드코딩**으로 돌고 있었습니다(`src/main.zig`, `src/cli/watch.zig` 3곳). 그래서 watch 반응성이 폴링 대기에 묻혀 평균 ~250ms+ 지연이었고, `--watch-delay` 를 줘도 이 500ms 는 안 바뀌었습니다.

> 참고: 사용자가 실제 쓰는 CLI 는 JS(`bin/zntc.mjs`, Node `fs.watch` = 이벤트 기반)라 이 폴링 경로를 안 탑니다. 하지만 Zig 바이너리도 watch 를 지원하므로 노브를 통일합니다.

## 변경

- `src/cli/watch.zig`: `pollIntervalMs(delay_ms)` 헬퍼 추가 — `--watch-delay`(기본 100ms)를 폴링 간격으로. `0`/과소값은 **10ms floor**(busy-loop 방지). `watchFile`/`watchDirectory` 에 `delay_ms` 파라미터 추가.
- `src/main.zig`: `--bundle --watch` 루프 + transpile watch(파일/디렉토리) 3 호출부가 `opts.watch_delay_ms` 전달.

JS CLI 의 fs.watch debounce 와 같은 `--watch-delay` 노브로 통일했습니다(거기선 이벤트 후 debounce, 폴링 fallback 인 여기선 mtime 확인 주기). 기본값이 500→100ms 로 바뀌어 **5배 반응적**입니다.

## 검증 (실측, detection median)

| `--watch-delay` | 감지 지연 |
|---|---|
| 500 | 302ms (이전 하드코딩과 동일) |
| 100 (기본) | 121ms |
| 50 | 80ms |

→ 폴링 간격이 정상적으로 `--watch-delay` 로 조절됩니다.

`zig build test`(유닛 전체)·`napi`·`wasm` 빌드 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)