### PR TITLE
fix(private-mangler): collectPrivateNames/applyRenames 반복 순회 — 깊은 이항 체인 (#4123 PR-2b)

### DIFF
--- a/src/codegen/private_mangler.zig
+++ b/src/codegen/private_mangler.zig
@@ -92,49 +92,69 @@ fn processClass(ast: *Ast, class_ni: u32) void {
 
 /// class body 안의 private_identifier 이름 수집 (nested class 는 독립 scope 라 제외 —
 /// 재귀 `processClass` 에서 별도 처리).
-fn collectPrivateNames(ast: *const Ast, idx: NodeIndex, out: *std.StringArrayHashMapUnmanaged(void)) void {
-    const ni = @intFromEnum(idx);
-    if (ni >= ast.nodes.items.len) return;
-    const node = ast.nodes.items[ni];
+const PrivateNamesCtx = struct { ast: *const Ast, out: *std.StringArrayHashMapUnmanaged(void) };
 
+fn privateNamesVisit(ctx: *PrivateNamesCtx, idx: NodeIndex, node: Node) ast_walk.WalkAction {
+    _ = idx;
     if (node.tag == .private_identifier) {
-        const text = ast.getText(node.span);
-        out.put(ast.allocator, text, {}) catch {};
-        return;
+        const text = ctx.ast.getText(node.span);
+        ctx.out.put(ctx.ast.allocator, text, {}) catch {}; // 원본과 동일: put OOM 은 무시(미수집→unmangle)
+        return .skip_children;
     }
-
     // nested class / class expression 은 내부 private 이 독립 — skip.
-    if (node.tag == .class_declaration or node.tag == .class_expression) return;
+    if (node.tag == .class_declaration or node.tag == .class_expression) return .skip_children;
+    return .descend;
+}
 
-    var it = ast_walk.children(ast, node);
-    while (it.next()) |child| {
-        if (child.isNone()) continue;
-        collectPrivateNames(ast, child, out);
+fn collectPrivateNames(ast: *const Ast, idx: NodeIndex, out: *std.StringArrayHashMapUnmanaged(void)) void {
+    // 반복 순회(#4123). under-collection(OOM 으로 일부 이름 누락)은 일관: 누락된 #x 는
+    // rename 맵에 없어 applyRenames 가 전 occurrence 를 그대로 둔다 → unmangle, 안전.
+    var c = PrivateNamesCtx{ .ast = ast, .out = out };
+    ast_walk.walkPreorderIterative(ast.allocator, ast, idx, &c, privateNamesVisit) catch {};
+}
+
+const RenameTarget = struct { idx: NodeIndex, new_span: Span };
+
+const RenameCollectCtx = struct {
+    ast: *const Ast,
+    renames: *const std.StringHashMapUnmanaged(Span),
+    targets: *std.ArrayListUnmanaged(RenameTarget),
+    oom: bool,
+};
+
+fn renameCollectVisit(ctx: *RenameCollectCtx, idx: NodeIndex, node: Node) ast_walk.WalkAction {
+    if (node.tag == .private_identifier) {
+        const text = ctx.ast.getText(node.span);
+        if (ctx.renames.get(text)) |new_span| {
+            ctx.targets.append(ctx.ast.allocator, .{ .idx = idx, .new_span = new_span }) catch {
+                ctx.oom = true;
+                return .stop;
+            };
+        }
+        return .skip_children;
     }
+    // nested class 는 외부 rename 적용 안 함.
+    if (node.tag == .class_declaration or node.tag == .class_expression) return .skip_children;
+    return .descend;
 }
 
 fn applyRenames(ast: *Ast, idx: NodeIndex, renames: *const std.StringHashMapUnmanaged(Span)) void {
-    const ni = @intFromEnum(idx);
-    if (ni >= ast.nodes.items.len) return;
-    const node = ast.nodes.items[ni];
-
-    if (node.tag == .private_identifier) {
-        const text = ast.getText(node.span);
-        if (renames.get(text)) |new_span| {
-            // span 과 data.string_ref 둘 다 — codegen 은 string_ref 를 읽음.
-            ast.nodes.items[ni].span = new_span;
-            ast.nodes.items[ni].data = .{ .string_ref = new_span };
-        }
-        return;
-    }
-
-    // nested class 는 외부 rename 적용 안 함.
-    if (node.tag == .class_declaration or node.tag == .class_expression) return;
-
-    var it = ast_walk.children(ast, node);
-    while (it.next()) |child| {
-        if (child.isNone()) continue;
-        applyRenames(ast, child, renames);
+    // 2-phase atomic (#4123): 재귀판은 무할당이라 부분상태가 없었다(깊으면 overflow). 반복판은
+    // worklist 할당이 OOM 가능 → 도중 OOM 으로 "일부만 rename" 되면 #private 정의/사용 불일치
+    // (corruption). 이를 막으려 rename 대상을 먼저 모으고(읽기 전용 반복 순회), 수집이 완전히
+    // 성공했을 때만 일괄 적용한다. 수집 단계 실패(OOM)면 아무것도 적용 안 함 = 전 occurrence
+    // 가 원래 #이름 유지(unmangle, 일관) → 안전. mutation 은 leaf span/data 만 바꿔 트리 구조
+    // 불변이라 적용 순서·재진입 무관.
+    var targets: std.ArrayListUnmanaged(RenameTarget) = .empty;
+    defer targets.deinit(ast.allocator);
+    var c = RenameCollectCtx{ .ast = ast, .renames = renames, .targets = &targets, .oom = false };
+    ast_walk.walkPreorderIterative(ast.allocator, ast, idx, &c, renameCollectVisit) catch return;
+    if (c.oom) return;
+    for (targets.items) |t| {
+        const ni = @intFromEnum(t.idx);
+        // span 과 data.string_ref 둘 다 — codegen 은 string_ref 를 읽음.
+        ast.nodes.items[ni].span = t.new_span;
+        ast.nodes.items[ni].data = .{ .string_ref = t.new_span };
     }
 }
 


### PR DESCRIPTION
> **Stacked PR**: base 가 `fix/deep-binary-flag-gated-walkers-4123`(#4128, PR-2a). #4128 → #4124 순으로 머지하면 GitHub 가 base 를 자동 재지정합니다.

## 무엇을 / 왜

#4123 flag-gated walker 중 codegen private-field mangler 의 두 재귀 walker 를 `walkPreorderIterative`(PR-2a 신규)로 전환. `#private` 클래스 body 안 깊은 좌결합 체인(`m(){ return this.#x + 1 + 1 + … }`)에서 재귀 시 스택 오버플로우(#4123)였습니다.

## 전환

- **`collectPrivateNames`** (읽기 전용): 헬퍼 + `catch {}`. OOM(이름 일부 누락)은 일관 — 누락된 `#x` 는 rename 맵에 없어 `applyRenames` 가 전 occurrence 를 그대로 둠 → unmangle, 안전.
- **`applyRenames`** (mutation): **2-phase atomic**. 재귀판은 무할당이라 부분상태가 없었습니다(깊으면 그냥 overflow). 반복판의 worklist 는 OOM 가능 → 도중 OOM 으로 "일부만 rename" 하면 `#private` 정의/사용 불일치(corruption). 이를 막으려 **rename 대상을 먼저 모으고(읽기 전용 반복 순회) 수집이 완전히 성공했을 때만 일괄 적용**. 수집 실패(OOM)면 아무것도 적용 안 함 = 전 occurrence 가 원래 `#`이름 유지(unmangle, 일관) → 안전.

> mutation walker 라 `applyRenames` 만 2-phase(나머지 5개 walker 는 1-phase 읽기/predicate). leaf `span`/`data` 만 바꿔 트리 구조 불변 → 적용 순서·재진입 무관.

## 검증 (fix vs main)

- **byte-identical**: `#private` 클래스(plain+minify) mangle 결과 pre-fix == fix (동작 보존).
- **크래시 해소**: 깊은 체인 30000항 + `#private` + `--minify` exit 0.
- `zig build test` 통과.
- `/code-review max`(2 finder): collectPrivateNames 동치 + applyRenames 2-phase atomicity(모든 OOM 경로가 zero-apply → 부분-rename 불가) 확인, critical 0.

## 남은 #4123 (PR-2c — 마지막)

transpile binding-shadow scanner 2곳 + es2017 `rewriteAwaitToYieldAwait`(post-order + 구조 변경 → 헬퍼 post-order 변형 필요, 가장 복잡). 사용자 방향 = "끝까지 처리"(가드/거부 없이 임의 깊이 처리)이므로 PR-2c 에서 반복화 완결 예정 + 신규 재귀 walker 재유입 방지 audit 검토.

Refs #4123

🤖 Generated with [Claude Code](https://claude.com/claude-code)