### PR TITLE
fix(bench): inprocess 가 esbuild 도 watch 경로로 측정하도록 공정화

### DIFF
--- a/tests/benchmark/inprocess-rebuild.ts
+++ b/tests/benchmark/inprocess-rebuild.ts
@@ -2,10 +2,20 @@
 /**
  * In-process rebuild benchmark — fair comparison.
  *
- * 모든 도구를 *programmatic API* 로 호출해 spawn/polling overhead 제거.
+ * 모든 도구를 in-process programmatic API 의 **file-watch 경로**로 동일하게 측정:
+ * 파일 touch → 각 도구의 watch 콜백/이벤트 fire 까지의 시간(감지+rebuild+콜백 dispatch).
  *   - ZNTC: `@zntc/core` watch(opts) + onRebuild (NAPI worker thread)
- *   - esbuild: context().rebuild()
+ *   - esbuild: context().watch() + onEnd 플러그인
  *   - rolldown: watch().on('event')
+ *
+ * ⚠️ esbuild 를 `ctx.rebuild()`(watch 미경유 직접 호출)로 재면 파일감지/콜백 오버헤드를
+ * 건너뛰어 zntc/rolldown(file-watch)보다 부당하게 빨라진다 → 반드시 watch 로 통일.
+ * (zntc 는 incremental rebuild 를 watch() 로만 노출 — 직접 rebuild API 없음.)
+ *
+ * ⚠️ 결과 해석: zntc(NAPI) rebuild ~53ms floor(tiny≈medium, 모듈 수 무관)는 *컴파일* 이
+ * 아니라 NAPI watch 의 **고정 50ms 디바운스**(napi/watch.zig `watch_debounce_ms`). 세 도구
+ * 모두 watch 디바운스가 있으나 zntc 의 50ms 가 esbuild/rolldown 보다 커 더 느리게 보인다.
+ * 실제 컴파일 속도는 incremental-rebuild.ts(CLI, 디바운스 0)의 ~16ms 가 더 가깝다.
  *
  * 실행: bun run inprocess-rebuild.ts
  *
@@ -147,7 +157,10 @@ async function measureEsbuild(fx: Fixture) {
   const { entry } = fx.build(dir);
   const out = join(dir, 'out.js');
   const iters: number[] = [];
-  const initStart = performance.now();
+  // ⚠️ 공정성: zntc/rolldown 은 file-watch(touch→onRebuild)로 재므로 esbuild 도 직접
+  // `ctx.rebuild()`(watch 미경유, 감지/콜백 오버헤드 0) 대신 **watch API**(`ctx.watch()` +
+  // onEnd 플러그인)로 측정한다. 안 그러면 esbuild 만 파일감지 latency 를 건너뛰어 유리.
+  let onEndResolve: (() => void) | null = null;
   const ctx = await esbuildContext({
     entryPoints: [entry],
     outfile: out,
@@ -155,15 +168,43 @@ async function measureEsbuild(fx: Fixture) {
     write: true,
     loader: { '.ts': 'ts' },
     format: 'iife',
+    plugins: [
+      {
+        name: 'bench-onend',
+        setup(build) {
+          build.onEnd(() => {
+            if (onEndResolve) {
+              const r = onEndResolve;
+              onEndResolve = null;
+              r();
+            }
+          });
+        },
+      },
+    ],
   });
-  await ctx.rebuild();
+  const firstBuild = new Promise<void>((res) => {
+    onEndResolve = res;
+  });
+  const initStart = performance.now();
+  await ctx.watch(); // 초기 빌드 트리거 → onEnd
+  await firstBuild;
   const initialMs = performance.now() - initStart;
   try {
     await sleep(SETTLE_MS);
     for (let i = 0; i < ITERATIONS; i++) {
+      const p = new Promise<void>((res, rej) => {
+        onEndResolve = res;
+        setTimeout(() => {
+          if (onEndResolve) {
+            onEndResolve = null;
+            rej(new Error(`rebuild ${i} timeout`));
+          }
+        }, REBUILD_TIMEOUT_MS);
+      });
       appendFileSync(entry, `export const _i${i}=${i};console.log(_i${i});\n`);
       const t0 = performance.now();
-      await ctx.rebuild();
+      await p;
       iters.push(performance.now() - t0);
       await sleep(SETTLE_MS);
     }

--- a/tests/benchmark/napi-watch.ts
+++ b/tests/benchmark/napi-watch.ts
@@ -9,6 +9,12 @@
  * (FSEvents/inotify) + `--watch-delay` debounce 를 쓴다 — 둘 다 *폴링 아님*. (내부 Zig
  * 바이너리 `zig-out/bin/zntc` 만 500ms mtime 폴링 fallback 이며 사용자 경로가 아니다.)
  *
+ * ⚠️ 결과 해석: rebuild median 의 ~50ms 는 *실제 컴파일* 이 아니라 NAPI watch 워커의
+ * **고정 50ms 디바운스**(packages/core/src/napi/watch.zig `watch_debounce_ms` — 연속 저장
+ * 병합용)다. tiny≈medium≈53ms(모듈 수 무관)가 그 증거. 실제 rebuild 컴파일은 ~3~16ms
+ * (incremental-rebuild.ts 의 CLI 경로 참고). 즉 이 수치는 "watch 반응성"(디바운스 포함)이지
+ * 컴파일 속도가 아니다.
+ *
  * 실행: bun run napi-watch.ts
  */
 


### PR DESCRIPTION
## 문제 (리뷰 지적 — "인프로세스는 왜 이리 차이나? 다른 번들러도 같은 기준으로 비교 가능하잖아")

`inprocess-rebuild.ts` 가 도구마다 **다른 측정 경로**를 썼습니다:
- zntc: `@zntc/core` watch() + onRebuild → file-watch(파일감지+rebuild+콜백 dispatch)
- rolldown: `watch().on('event')` → file-watch
- **esbuild: `ctx.rebuild()` → watch 미경유 직접 호출** ← 파일감지/콜백 오버헤드 0

→ esbuild 만 watch 비용을 건너뛰어 부당하게 빨라졌습니다(esbuild 16ms vs zntc 53ms = 사과-오렌지).

## 수정

- esbuild 를 `ctx.watch()` + `onEnd` 플러그인으로 측정 → **세 도구 모두 touch→rebuilt file-watch 경로로 통일**. (zntc 는 incremental rebuild 를 watch() 로만 노출 — 직접 rebuild API 없음.)
- 두 벤치 헤더에 결과 해석 주석 추가.

## 공정화 후 (median, 모두 file-watch)

| Fixture | zntc(NAPI) | esbuild | rolldown |
|---|---|---|---|
| tiny | 53.6ms | 28.1ms (이전 16) | 26.5ms |
| medium | 54.6ms | 40.2ms (이전 23) | 25.1ms |
| lodash | 69.4ms | 58.8ms (이전 50) | 49.8ms |

esbuild 가 16→28ms 로 오른 게 불공정의 증거입니다.

## ⚠️ zntc ~53ms floor 의 정체 (버그 아님)

공정 비교에서도 zntc(NAPI)가 ~53ms 로 더 느린데, 이 floor 는 **컴파일이 아니라 NAPI watch 워커의 고정 50ms 디바운스**입니다:

```zig
// packages/core/src/napi/watch.zig
const watch_debounce_ms: u32 = 50;  // 첫 이벤트 후 50ms idle 대기(연속 저장 병합, "공개 계약")
```

- `tiny ≈ medium ≈ 53ms`(모듈 수 1 vs 10 무관)가 디바운스 floor 의 증거. lodash 만 +15ms(실제 컴파일).
- 파일 감지는 kqueue(macOS)라 즉시 — 폴링 아님.
- 실제 컴파일 속도는 `incremental-rebuild.ts`(실제 CLI, `--watch-delay=0`)의 **~16ms** 가 더 정확. 거긴 NAPI watch 가 아니라 fs.watch + 직접 빌드라 디바운스 0.

즉 inprocess/napi-watch 수치는 **"watch 반응성(디바운스 포함)"** 이지 컴파일 속도가 아닙니다. esbuild/rolldown 의 watch 디바운스가 zntc 의 50ms 보다 작아 더 빠르게 보입니다.

> follow-up 후보: NAPI watch 디바운스(50ms 하드코딩)를 JS CLI 의 `--watch-delay` 처럼 옵션화하면 사용자 튜닝 + 벤치가 순수 rebuild 측정 가능. 단 50ms 병합 "공개 계약" 이라 별도 논의 필요.

소스/빌드 영향 없음(벤치 스크립트뿐).

🤖 Generated with [Claude Code](https://claude.com/claude-code)