### PR TITLE
ci(audit): 신규 재귀 AST walker 재유입 차단 — durability tripwire (#4123)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,12 @@ jobs:
       - name: Audit codegen sourcemap mapping (#2983)
         run: bun scripts/audit-codegen-sourcemap.ts
 
+      # 신규 재귀 AST walker 가 깊은 좌결합 체인(#4123)에서 스택 오버플로우를 재유입하지
+      # 않도록, 모든 ast_walk.children() 호출처가 분류(iterative/one_level/tracked)됐는지 검사.
+      # 미분류 신규 walker → fail. (장기 root-cause: 새 순회는 walkPreorderIterative 강제.)
+      - name: Audit recursive AST walkers (#4123)
+        run: bun scripts/audit-recursive-ast-walkers.mjs
+
   napi:
     name: NAPI Build & Test
     runs-on: ${{ matrix.os }}

--- a/scripts/audit-recursive-ast-walkers.mjs
+++ b/scripts/audit-recursive-ast-walkers.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// 재귀 AST walker durability audit (#4123).
+//
+// 배경: `a + b + c + … (수천 항)` 같은 깊은 좌결합 트리를 AST visitor 가 재귀로 내려가면
+// 스택 오버플로우(#4123). 대책으로 핫패스/공통 walker 를 `ast_walk.walkPreorderIterative`
+// (명시 스택 반복 순회)로 전환했다. 문제는 **새 walker 가 또 재귀로 children() 을 돌면 버그가
+// 조용히 재유입**된다는 것. 이 audit 이 그 tripwire 다.
+//
+// 규칙: src/ 안의 모든 `ast_walk.children()` 호출처(주석/정의 제외)는 아래 ALLOWLIST 의
+// 한 분류에 *명시적으로* (file::fn 키로) 등록돼야 한다. 등록 안 된 신규 호출처가 있으면 CI 실패.
+//   - iterative_safe   : 명시 스택/큐/collector 또는 sanctioned 헬퍼(walkPreorderIterative).
+//                        깊이 무관 안전.
+//   - one_level        : 재귀 없이 직계 자식만 1단계 순회(flat). 깊이 무관 안전.
+//   - recursive_tracked: 아직 재귀라 깊은 체인서 overflow 가능. #4123 PR-2c 에서 반복화 예정.
+//                        (전환되면 children() 대신 walkPreorderIterative 를 써 이 목록에서 빠짐.)
+//
+// 신규 walker 작성자에게: 서브트리를 재귀 순회해야 하면 **반드시 walkPreorderIterative** 를
+// 써라(또는 명시 스택). 직계 1단계만 보면 one_level 로, 깊이 가드(cap)가 있으면 그 함수에
+// 가드 주석을 달고 iterative_safe 로 등록하라.
+//
+// 한계(정직히): 이 audit 은 `ast_walk.children()` 기반 일반 순회만 본다. binary/unary 노드의
+// left/right 를 *직접* 재귀(visitBinaryNode/emitBinary 식 rebuild/emit)하는 특수 패턴, 그리고
+// depth-cap 이 달린 direct-recursion evaluator(purity/import_scanner 등)는 이 audit 밖이다 —
+// 전자는 좌-스파인 평탄화(#4123 PR-1), 후자는 자체 depth guard 로 안전. 키를 file::fn 으로 둬
+// 동명 walker 우회를 막고, fn 선언이 여러 줄로 쪼개져도(`fn name(\n …)`) 잡도록 한다.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve, relative } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const srcRoot = join(root, "src");
+
+// "<relpath>::<fn>" → { class, note }. class ∈ {iterative_safe, one_level, recursive_tracked}.
+// 파일 경로로 스코프해 동명 walker 가 분류를 상속하는 false-negative 를 차단.
+const ALLOWLIST = {
+  // --- sanctioned 헬퍼 / 명시 스택·큐·collector (깊이 무관 안전) ---
+  "src/parser/ast_walk.zig::walkPreorderIterative": { class: "iterative_safe", note: "the sanctioned iterative helper" },
+  "src/parser/ast_walk.zig::collectReachableNodeIndices": { class: "iterative_safe", note: "explicit stack worklist" },
+  "src/transformer/minify.zig::markReachableNodes": { class: "iterative_safe", note: "BFS queue" },
+  "src/transformer/es2015_block_scoping.zig::collectChildIndices": { class: "iterative_safe", note: "one-level collector feeding caller stack" },
+  "src/transformer/transformer/worklet.zig::collectAllIdentifiers": { class: "iterative_safe", note: "explicit stack (worklet)" },
+  "src/transformer/transformer/worklet.zig::collectNewExpressionCallees": { class: "iterative_safe", note: "explicit stack (worklet)" },
+  "src/transformer/transformer/worklet.zig::walkBodyForClosureAnalysis": { class: "iterative_safe", note: "explicit stack; nested-fn depth bounded by source nesting" },
+  "src/bundler/tree_shaker/const_materialize.zig::anyReachableNode": { class: "iterative_safe", note: "numeric_dfs_stack" },
+
+  // --- 직계 1단계만 (재귀 없음) ---
+  "src/bundler/runtime_polyfills.zig::markSkippedIdentifiers": { class: "one_level", note: "import/export specifiers only, flat outer loop" },
+  "src/bundler/constant_facts.zig::markMinifySensitiveIdentifierRefs": { class: "one_level", note: "one level, flat outer for" },
+
+  // --- 아직 재귀 (#4123 PR-2c 에서 walkPreorderIterative 로 전환 예정) ---
+  "src/transpile.zig::walkFunctionVarBindingPatterns": { class: "recursive_tracked", note: "#4123 PR-2c — binding-shadow scan" },
+  "src/transpile.zig::scanChildrenForUnsupportedBindingLiteShadow": { class: "recursive_tracked", note: "#4123 PR-2c — binding-lite shadow scan (scope-threaded)" },
+  "src/transpile.zig::markBindingLiteValueUses": { class: "recursive_tracked", note: "#4123 PR-2c — binding-lite value-use mark" },
+  "src/transformer/es2017.zig::rewriteAwaitToYieldAwait": { class: "recursive_tracked", note: "#4123 PR-2c — post-order + mutation" },
+  "src/semantic/analyzer.zig::visitTypeContextNode": { class: "recursive_tracked", note: "#4123 PR-2c — type-context generic descent (low-risk)" },
+  "src/parser/ast_walk.zig::hasRawPrivateSyntax": { class: "recursive_tracked", note: "#4123 PR-2c — Debug/ReleaseSafe-only assert (ReleaseFast 에선 compiled out)" },
+};
+
+function listZigFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    const st = statSync(p);
+    if (st.isDirectory()) out.push(...listZigFiles(p));
+    else if (entry.endsWith(".zig")) out.push(p);
+  }
+  return out;
+}
+
+// fn 선언: 이름만 매칭(여는 괄호를 같은 줄에 요구하지 않음 → 여러 줄 시그니처도 잡음).
+// `fn (` (익명 fn 타입/포인터)은 이름이 없어 매칭 안 됨.
+const FN_DECL = /\bfn\s+([A-Za-z_][A-Za-z0-9_]*)/;
+// children( 호출. ast_walk.children( 또는 bare children(ast/children(self.ast.
+const CALL = /(?:ast_walk\.)?\bchildren\s*\(/;
+
+// Zig 은 라인 주석(`//`)만 있고 블록 주석이 없다. trailing 주석을 잘라 false-positive 차단.
+// (children() 가 문자열 리터럴 안에 등장하는 일은 없어 단순 strip 으로 충분.)
+function stripLineComment(line) {
+  const i = line.indexOf("//");
+  return i === -1 ? line : line.slice(0, i);
+}
+
+const callSites = [];
+for (const file of listZigFiles(srcRoot)) {
+  if (file.endsWith("_test.zig")) continue; // 테스트 파일만 제외(경로 substring 아님)
+  const rel = relative(root, file).split("\\").join("/");
+  const lines = readFileSync(file, "utf8").split("\n");
+  let curFn = "<file-scope>";
+  for (let i = 0; i < lines.length; i++) {
+    const code = stripLineComment(lines[i]);
+    const fnMatch = code.match(FN_DECL);
+    if (fnMatch) curFn = fnMatch[1];
+    if (!CALL.test(code)) continue;
+    if (/\bfn\s+children\s*\(/.test(code)) continue; // children() 정의 자체
+    callSites.push({ key: `${rel}::${curFn}`, file: rel, line: i + 1, fn: curFn });
+  }
+}
+
+const violations = [];
+const byClass = { iterative_safe: 0, one_level: 0, recursive_tracked: 0 };
+const matchedKeys = new Set();
+for (const site of callSites) {
+  const entry = ALLOWLIST[site.key];
+  if (!entry) {
+    violations.push(site);
+  } else {
+    byClass[entry.class]++;
+    matchedKeys.add(site.key);
+  }
+}
+
+console.log(`recursive-ast-walker audit: ${callSites.length} children() 호출처 검사`);
+console.log(
+  `  iterative_safe=${byClass.iterative_safe}  one_level=${byClass.one_level}  recursive_tracked=${byClass.recursive_tracked}`,
+);
+
+if (violations.length > 0) {
+  console.error("\n❌ 분류되지 않은 ast_walk.children() 호출처:");
+  for (const v of violations) console.error(`  ${v.file}:${v.line}  fn ${v.fn}`);
+  console.error(
+    "\n새 AST 서브트리 순회는 깊은 좌결합 체인(#4123)에서 스택 오버플로우를 일으킬 수 있습니다.\n" +
+      "- 재귀 순회면 `ast_walk.walkPreorderIterative` 로 쓰세요(명시 스택).\n" +
+      "- 직계 1단계만 보면, 또는 깊이 가드가 있으면, scripts/audit-recursive-ast-walkers.mjs 의\n" +
+      "  ALLOWLIST 에 `<relpath>::<fn>` 키로 분류(class)+근거(note)와 함께 등록하세요.",
+  );
+  process.exit(1);
+}
+
+// stale(매칭 0) ALLOWLIST 항목 알림 — PR-2c 전환으로 children() 미사용이 된 항목 정리용(실패 아님).
+const stale = Object.keys(ALLOWLIST).filter((k) => !matchedKeys.has(k));
+if (stale.length > 0) {
+  console.log(`\n  ℹ️ 매칭 0 인 ALLOWLIST 항목(전환 완료/이동 — 정리 가능):`);
+  for (const k of stale) console.log(`     ${k}`);
+}
+
+// 아직 재귀인 walker 가시화 — green CI 가 "재귀 walker 없음"으로 오인되지 않도록(실패 아님).
+if (byClass.recursive_tracked > 0) {
+  console.log(
+    `\n  ⚠️ recursive_tracked ${byClass.recursive_tracked}개 — 깊은 체인서 여전히 overflow 가능(#4123 PR-2c 대기). green=전환완료 아님.`,
+  );
+} else {
+  console.log("  ✅ recursive_tracked 0 — #4123 walker 전환 완료. ALLOWLIST 의 recursive_tracked 항목 정리 가능.");
+}
+
+console.log("✅ 모든 children() 호출처가 분류됨 (신규 재귀 walker 재유입 차단).");


### PR DESCRIPTION
> **Stacked PR**: base 가 `fix/deep-binary-private-mangler-4123`(#4131, PR-2b). 머지는 #4124→#4128→#4131→이 PR 순.

## 무엇을 / 왜 (장기 root-cause)

#4123(깊은 좌결합 체인 → 재귀 visitor 스택 오버플로우)의 **장기 대책**. "끝까지 처리(거부 없이 임의 깊이)" 방향을 지속가능하게 만들려면, 핫패스/walker 를 반복화하는 것만으론 부족합니다 — **새 walker 가 또 재귀로 `children()` 을 돌면 버그가 조용히 재유입**됩니다. 이 PR 은 그걸 막는 **CI tripwire** 입니다.

## 무엇을 한다

`scripts/audit-recursive-ast-walkers.mjs`: src/ 의 모든 `ast_walk.children()` 호출처(주석/정의 제외)가 ALLOWLIST(`<relpath>::<fn>` 키)의 한 분류에 명시 등록됐는지 검사. **미등록 신규 호출처 → CI fail.**

| class | 의미 |
|---|---|
| `iterative_safe` | 명시 스택/큐/collector 또는 sanctioned 헬퍼(`walkPreorderIterative`) — 깊이 무관 안전 |
| `one_level` | 재귀 없이 직계 1단계만 |
| `recursive_tracked` | 아직 재귀(#4123 PR-2c 전환 예정) — 전환되면 `children()` 미사용으로 자동 탈락 |

현재 16 호출처: **iterative_safe 8 / one_level 2 / recursive_tracked 6**. `ci.yml` 의 기존 정적 audit(addNode variants / sourcemap) 옆에 스텝 추가.

신규 walker 작성자는 재귀 순회 시 `walkPreorderIterative` 강제(self/mutual 재귀 모두 커버).

## 견고성 (code-review max 반영)

리뷰가 짚은 false-negative 경로 2건을 수정:
- **multi-line fn 시그니처**: `fn name(`을 한 줄로 가정하던 걸, 이름만 매칭(`\bfn\s+(\w+)`)으로 바꿔 줄바꿈 시그니처 신규 walker 도 잡음(load-bearing).
- **동명 우회**: fn-name only 키 → **`file::fn` 키**로. 다른 파일의 동명 walker 가 안전 분류를 상속하는 우회 차단.
- + test 필터 `_test.zig` 한정(`/test` substring 과대 제외 수정), trailing `//` 주석 strip(false-positive), `recursive_tracked>0` 가시 경고 + stale 키 알림.

## 검증

- 현재 src: 통과(16/16 분류), `recursive_tracked 6` 경고 출력.
- **tripwire 실측**: ① multi-line 시그니처 신규 재귀 walker → exit 1 ② 동명(`anyReachableNode`) 다른-파일 재사용 → exit 1 (file::fn 키로 차단) ③ probe 제거 → exit 0.
- bun 1.3.11 실행 확인, ci.yml YAML 유효.

## 한계 (정직히, 스크립트 헤더에 명시)

`children()` 기반 순회만 검사. binary/unary left/right **직접 재귀**(rebuild/emit)는 좌-스파인 평탄화(#4123 PR-1)로, depth-cap evaluator(purity/import_scanner 등)는 자체 가드로 별도 안전.

Refs #4123

🤖 Generated with [Claude Code](https://claude.com/claude-code)