### PR TITLE
feat(napi): watch 디바운스를 watchDelay 옵션으로 노출 (하드코딩 50ms 제거)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1300,6 +1300,14 @@ interface BuildOptionsCommon {
   /** watch-mode rebuild callback. */
   onRebuild?: (event: WatchRebuildEvent) => void | Promise<void>;
   /**
+   * watch debounce window in milliseconds — after the first file event, the
+   * watcher waits this long for idle before rebuilding, merging rapid saves
+   * into one rebuild. Default `50`. Set `0` to rebuild immediately (no debounce;
+   * lower latency, but rapid saves may trigger multiple rebuilds). Mirrors the
+   * CLI `--watch-delay` flag. Only affects the NAPI `watch()` path.
+   */
+  watchDelay?: number;
+  /**
    * Whether to write the `.map` file to disk (Issue #1727 Phase B).
    *
    * - Default `true` — save `bundle.js.map` to the `output_filename + ".map"`

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -34,6 +34,7 @@ const unwrapNapi = common.unwrapNapi;
 const getStringArg = common.getStringArg;
 const getNamedProperty = common.getNamedProperty;
 const getObjectBool = common.getObjectBool;
+const getObjectUint32 = common.getObjectUint32;
 const getObjectStringArray = common.getObjectStringArray;
 const parseBuildOptions = options_mod.parseBuildOptions;
 const freeOptionsTypedSlices = options_mod.freeOptionsTypedSlices;
@@ -114,6 +115,10 @@ const WatchAsyncData = struct {
     /// false 로 보내 rebuild 경로의 디스크 I/O 를 완전히 제거할 수 있다. CLI 빌드는
     /// 기본 true 유지.
     emit_disk_sourcemap: bool = true,
+
+    /// watch 디바운스(ms) — 첫 이벤트 후 idle 대기 윈도우(연속 저장 병합). JS `watchDelay`
+    /// 옵션으로 override(기본 `watch_debounce_ms`=50). 0 이면 디바운스 없이 즉시 rebuild.
+    debounce_ms: u32 = watch_debounce_ms,
 
     /// #4079 PR-2 — `requestLazySeed(path)` 로 런타임에 누적되는 force-parse 경로 집합
     /// (각 string 은 native_alloc owned dupe). main thread(NAPI 콜백)와 worker thread 가
@@ -1150,11 +1155,12 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         const force_dirty = async_data.lazy_force_dirty.swap(false, .acq_rel);
         if (touched.count() == 0 and !force_dirty) continue;
 
-        // 디바운스: idle 50ms 확보까지 드레인. 지속 변경되는 파일로 인한 기아를 막기 위해
-        // 첫 이벤트로부터 watch_debounce_max_ms 초과 시 강제 종료.
+        // 디바운스: idle `debounce_ms`(watchDelay, 기본 50) 확보까지 드레인. 지속 변경되는
+        // 파일로 인한 기아를 막기 위해 첫 이벤트로부터 watch_debounce_max_ms 초과 시 강제 종료.
+        // debounce_ms==0 이면 drain 자체를 건너뛰어 즉시 rebuild(저지연).
         var debounce_timer: ?IoTimer = IoTimer.start(common.io());
-        while (!async_data.stop_flag.load(.acquire)) {
-            const more = tracked.waitForChanges(watch_debounce_ms) catch break;
+        while (async_data.debounce_ms > 0 and !async_data.stop_flag.load(.acquire)) {
+            const more = tracked.waitForChanges(async_data.debounce_ms) catch break;
             if (more.len == 0) break;
             collectTouched(&touched, allocator, more);
             if (debounce_timer) |*t| {
@@ -1827,6 +1833,9 @@ pub fn napiWatch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
     // `emitDiskSourcemap` 옵션 (기본 true) — bungae 등 lazy 라우트를 갖춘 dev server 는
     // false 로 보내 rebuild 경로의 `.map` 디스크 I/O 를 완전히 제거한다.
     async_data.emit_disk_sourcemap = getObjectBool(env, argv[0], "emitDiskSourcemap", true);
+    // watch 디바운스(ms) — `watchDelay` 옵션(CLI `--watch-delay` 와 동명). 기본 50ms 유지(연속
+    // 저장 병합 공개 계약). 0 이면 디바운스 drain skip → 즉시 rebuild(저지연, 빠른 저장 다중 rebuild).
+    async_data.debounce_ms = getObjectUint32(env, argv[0], "watchDelay", watch_debounce_ms);
 
     // onReady 콜백 추출
     const on_ready_fn = getNamedProperty(env, argv[0], "onReady");

--- a/tests/benchmark/napi-watch.ts
+++ b/tests/benchmark/napi-watch.ts
@@ -9,11 +9,11 @@
  * (FSEvents/inotify) + `--watch-delay` debounce 를 쓴다 — 둘 다 *폴링 아님*. (내부 Zig
  * 바이너리 `zig-out/bin/zntc` 만 500ms mtime 폴링 fallback 이며 사용자 경로가 아니다.)
  *
- * ⚠️ 결과 해석: rebuild median 의 ~50ms 는 *실제 컴파일* 이 아니라 NAPI watch 워커의
- * **고정 50ms 디바운스**(packages/core/src/napi/watch.zig `watch_debounce_ms` — 연속 저장
- * 병합용)다. tiny≈medium≈53ms(모듈 수 무관)가 그 증거. 실제 rebuild 컴파일은 ~3~16ms
- * (incremental-rebuild.ts 의 CLI 경로 참고). 즉 이 수치는 "watch 반응성"(디바운스 포함)이지
- * 컴파일 속도가 아니다.
+ * ⚠️ 결과 해석: rebuild median 의 ~50ms 는 *실제 컴파일* 이 아니라 NAPI watch 의 디바운스
+ * (기본 50ms, 연속 저장 병합용)다. tiny≈medium≈53ms(모듈 수 무관)가 그 증거. 이제 `watchDelay`
+ * 옵션으로 조절 가능 — `watch({…, watchDelay: 0})` 면 디바운스 없이 **진짜 incremental rebuild
+ * ~3ms** 가 드러난다(persistent_store 캐시 재사용). 즉 이 기본 수치는 "watch 반응성(디바운스
+ * 포함)"이지 컴파일 속도가 아니다.
  *
  * 실행: bun run napi-watch.ts
  */


### PR DESCRIPTION
## 배경 (벤치 추적에서 발견)

NAPI `watch()` 워커가 첫 파일 이벤트 후 idle 구간을 **`watch_debounce_ms = 50` 하드코딩**으로 기다립니다(연속 저장 병합용). 그래서 작은 변경에도 rebuild latency 가 ~53ms floor 였는데, 추적해보니 실제 incremental 컴파일은 **~3ms** 이고 나머지는 전부 디바운스였습니다.

> inprocess/napi-watch 벤치의 zntc 53ms 가 "느린 컴파일"로 오해됐던 정체.

## 변경

- `packages/core/index.ts`: `BuildOptions` 에 `watchDelay?: number` 추가. `prepareNapiOptions` 가 `{...options}` spread 라 native 로 자동 전달.
- `packages/core/src/napi/watch.zig`: `getObjectUint32(env, opts, "watchDelay", 50)` 로 파싱 → `WatchAsyncData.debounce_ms` → 워커가 그 값으로 디바운스 drain. `0` 이면 drain 자체를 skip(즉시 rebuild).

CLI 의 `--watch-delay` 와 동명이고, **기본 50ms 유지**(연속 저장 병합 공개 계약 불변).

## 실측 (디바운스가 watchDelay 로 조절됨)

| `watchDelay` | rebuild median |
|---|---|
| (default) | 52.9ms |
| **0** | **3.0ms** ← 디바운스 제거 시 진짜 incremental rebuild |
| 50 | 52.9ms |
| 150 | 152.9ms |

→ 50ms floor 가 디바운스였음이 증명되고, `watchDelay: 0` 이면 **~3ms** incremental rebuild 가 드러납니다(persistent_store 캐시 재사용 — CLI 의 buildSync 16ms 보다도 빠름).

## 사용

```ts
import { watch } from '@zntc/core';
watch({ entryPoints: ['src/index.ts'], outfile: 'out.js', bundle: true,
        watchDelay: 0,  // 디바운스 없이 즉시 rebuild (저지연)
        onRebuild: () => {} });
```

## 검증
- `watchDelay` 0/50/150 디바운스 제어 실측 확인, 기본 동작(50ms) 보존.
- napi-lazy-dev-hmr / napi-lazy-primitives / watch-json / hmr 통합 **36개 green**, `tsc --noEmit` green, `zig build napi` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)