### PR TITLE
docs(benchmarks): GitHub Pages 벤치에 cold build·증분 rebuild 차트 추가

### DIFF
--- a/documents/src/components/BenchmarkChartsImpl.tsx
+++ b/documents/src/components/BenchmarkChartsImpl.tsx
@@ -270,6 +270,18 @@ export default function BenchmarkCharts() {
       entries: benchmarkData.results.bundleCli,
     },
     {
+      title: "Cold Build (in-process)",
+      description:
+        "Cache-less initial full build via each tool's in-process programmatic API (in-memory). esbuild's small-fixture numbers are dominated by its Node↔Go service IPC round-trip; ZNTC/rolldown are napi (no IPC).",
+      entries: benchmarkData.results.coldBuild,
+    },
+    {
+      title: "Incremental Rebuild (in-process)",
+      description:
+        "Pure incremental rebuild compute (cache reuse, debounce/watch latency excluded): ZNTC watch({watchDelay:0}), esbuild ctx.rebuild(), rolldown bundle.generate().",
+      entries: benchmarkData.results.incrementalRebuild,
+    },
+    {
       title: "Bundle Size — Tree-shake + Minify",
       description:
         "Real npm libraries bundled and minified with the same input. Raw output bytes — lower is better. Tree-shaking + minifier quality, not speed.",

--- a/documents/src/content/docs/en/reference/benchmarks.mdx
+++ b/documents/src/content/docs/en/reference/benchmarks.mdx
@@ -14,6 +14,7 @@ ZNTC compares transpile and bundle performance — and final bundle size (tree-s
 - **CLI**: `bench.ts`, 50-run median, direct CLI binary execution without npx overhead
 - **NAPI / WASM / CLI**: `napi-bench.ts`, 10 warmups + 100-run median
 - **Bundle perf**: `bundle-perf.ts`, 5 warmups + 50-run median, CI-style same-run ZNTC/Rolldown/Rspack comparison
+- **Cold build / incremental rebuild**: `cold-build.ts` / `inprocess-rebuild.ts` — same fixtures (tiny/medium/lodash-es) compared against esbuild/rolldown via **in-process programmatic APIs**. Cold = cache-less initial full build; incremental = pure rebuild with cache reuse (debounce/watch latency excluded).
 - **Pipeline**: `pipeline.ts`, 15-run median, profile total
 - **Bundle size**: `smoke.ts --minify-all`, 2026-05-30, 9 real npm libraries bundled + minified, raw output bytes
 
@@ -32,6 +33,8 @@ bun run tests/benchmark/bench.ts
 bun run tests/benchmark/napi-bench.ts
 bun run tests/benchmark/bundle-perf.ts --no-fail --output bundle-perf.json
 bun run tests/benchmark/pipeline.ts
+bun run tests/benchmark/cold-build.ts
+bun run tests/benchmark/inprocess-rebuild.ts
 
 bun run tests/benchmark/smoke.ts --minify-all \
   --filter=zod,effect,lodash-es,preact,immer,date-fns,rxjs,mobx,three \

--- a/documents/src/content/docs/reference/benchmarks.mdx
+++ b/documents/src/content/docs/reference/benchmarks.mdx
@@ -14,6 +14,7 @@ ZNTC의 트랜스파일/번들 성능과 최종 번들 크기(tree-shaking + min
 - **CLI**: `bench.ts` median 50회, 직접 CLI 바이너리 실행 (npx 오버헤드 제거)
 - **NAPI / WASM / CLI**: `napi-bench.ts` warmup 10회 + median 100회
 - **Bundle perf**: `bundle-perf.ts` warmup 5회 + median 50회, CI와 같은 ZNTC/Rolldown/Rspack same-run 비교
+- **Cold build / 증분 rebuild**: `cold-build.ts` / `inprocess-rebuild.ts` — 같은 fixture(tiny/medium/lodash-es)를 esbuild/rolldown 과 **in-process programmatic API** 로 비교. cold = 캐시 없는 초기 full build, 증분 = 캐시 재사용 순수 rebuild(디바운스/watch latency 제외).
 - **Pipeline**: `pipeline.ts` median 15회, profile total 기준
 - **번들 크기**: `smoke.ts --minify-all`, 2026-05-30, 실제 npm 라이브러리 9종을 번들 + minify 한 raw 출력 바이트
 
@@ -32,6 +33,8 @@ bun run tests/benchmark/bench.ts
 bun run tests/benchmark/napi-bench.ts
 bun run tests/benchmark/bundle-perf.ts --no-fail --output bundle-perf.json
 bun run tests/benchmark/pipeline.ts
+bun run tests/benchmark/cold-build.ts
+bun run tests/benchmark/inprocess-rebuild.ts
 
 bun run tests/benchmark/smoke.ts --minify-all \
   --filter=zod,effect,lodash-es,preact,immer,date-fns,rxjs,mobx,three \

--- a/documents/src/data/benchmark-data.json
+++ b/documents/src/data/benchmark-data.json
@@ -46,6 +46,32 @@
       { "tool": "rolldown", "scale": "large (5000 modules)", "medianMs": 119, "minMs": 115, "maxMs": 126, "p95Ms": 121 },
       { "tool": "rspack", "scale": "large (5000 modules)", "medianMs": 173, "minMs": 167, "maxMs": 187, "p95Ms": 180 }
     ],
+    "coldBuild": [
+      { "tool": "ZNTC", "scale": "tiny (1 file)", "medianMs": 0.11, "minMs": 0.1, "maxMs": 0.16, "p95Ms": 0.16 },
+      { "tool": "rolldown", "scale": "tiny (1 file)", "medianMs": 0.66, "minMs": 0.58, "maxMs": 0.81, "p95Ms": 0.81 },
+      { "tool": "esbuild", "scale": "tiny (1 file)", "medianMs": 4.34, "minMs": 4.13, "maxMs": 5.02, "p95Ms": 5.02 },
+
+      { "tool": "ZNTC", "scale": "medium (10 modules)", "medianMs": 0.28, "minMs": 0.25, "maxMs": 0.32, "p95Ms": 0.32 },
+      { "tool": "rolldown", "scale": "medium (10 modules)", "medianMs": 1.09, "minMs": 0.99, "maxMs": 1.43, "p95Ms": 1.43 },
+      { "tool": "esbuild", "scale": "medium (10 modules)", "medianMs": 4.68, "minMs": 4.37, "maxMs": 4.92, "p95Ms": 4.92 },
+
+      { "tool": "ZNTC", "scale": "lodash-es (real dep)", "medianMs": 11.0, "minMs": 10.4, "maxMs": 11.5, "p95Ms": 11.5 },
+      { "tool": "rolldown", "scale": "lodash-es (real dep)", "medianMs": 12.9, "minMs": 12.5, "maxMs": 14.2, "p95Ms": 14.2 },
+      { "tool": "esbuild", "scale": "lodash-es (real dep)", "medianMs": 22.9, "minMs": 20.7, "maxMs": 24.1, "p95Ms": 24.1 }
+    ],
+    "incrementalRebuild": [
+      { "tool": "ZNTC", "scale": "tiny (1 file)", "medianMs": 1.93, "minMs": 0.47, "maxMs": 2.56, "p95Ms": 2.56 },
+      { "tool": "rolldown", "scale": "tiny (1 file)", "medianMs": 4.55, "minMs": 2.98, "maxMs": 5.39, "p95Ms": 5.39 },
+      { "tool": "esbuild", "scale": "tiny (1 file)", "medianMs": 20.0, "minMs": 9.57, "maxMs": 21.2, "p95Ms": 21.2 },
+
+      { "tool": "ZNTC", "scale": "medium (10 modules)", "medianMs": 2.77, "minMs": 0.66, "maxMs": 3.23, "p95Ms": 3.23 },
+      { "tool": "rolldown", "scale": "medium (10 modules)", "medianMs": 5.84, "minMs": 4.89, "maxMs": 14.3, "p95Ms": 14.3 },
+      { "tool": "esbuild", "scale": "medium (10 modules)", "medianMs": 21.6, "minMs": 11.0, "maxMs": 25.1, "p95Ms": 25.1 },
+
+      { "tool": "ZNTC", "scale": "lodash-es (real dep)", "medianMs": 13.1, "minMs": 5.22, "maxMs": 22.0, "p95Ms": 22.0 },
+      { "tool": "rolldown", "scale": "lodash-es (real dep)", "medianMs": 42.2, "minMs": 18.2, "maxMs": 47.8, "p95Ms": 47.8 },
+      { "tool": "esbuild", "scale": "lodash-es (real dep)", "medianMs": 46.3, "minMs": 24.3, "maxMs": 57.8, "p95Ms": 57.8 }
+    ],
     "napiWasmCli": [
       { "tool": "NAPI (.node)", "scale": "small (100 lines)", "medianMs": 0.049, "minMs": 0.048, "maxMs": 0.061, "p95Ms": 0.054 },
       { "tool": "WASM (.wasm)", "scale": "small (100 lines)", "medianMs": 0.13, "minMs": 0.108, "maxMs": 0.942, "p95Ms": 0.343 },


### PR DESCRIPTION
## 무엇

벤치마크 페이지(`/reference/benchmarks`)에 esbuild/rolldown 대비 **in-process** 비교 2종을 차트로 추가합니다.

- **Cold Build (in-process)**: 캐시 없는 초기 full build (tiny/medium/lodash-es), in-memory.
- **Incremental Rebuild (in-process)**: 캐시 재사용 순수 rebuild 컴파일(디바운스/watch latency 제외) — ZNTC `watch({watchDelay:0})`, esbuild `ctx.rebuild()`, rolldown `bundle.generate()`.

## 변경
- `benchmark-data.json`: `coldBuild` / `incrementalRebuild` 결과(각 9 entry).
- `BenchmarkChartsImpl.tsx`: ChartDefinition 2개 추가.
- `benchmarks.mdx`(ko/en): 측정 환경 + 실행법(`cold-build.ts` / `inprocess-rebuild.ts`).

## 수치 (median)

| | zntc | esbuild | rolldown |
|---|---|---|---|
| Cold lodash | **11.0ms** | 22.9ms | 12.9ms |
| Incremental lodash | **13.1ms** | 46.3ms | 42.2ms |

ZNTC 가 cold·증분 모두 최고속. 작은 fixture 의 esbuild ~4ms cold 는 Node↔Go 서비스 IPC 오버헤드라 차트 설명에 명시했습니다.

`bun run build`(astro) green. dist/ 는 gitignore 라 소스 4파일만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)