### PR TITLE
docs(benchmarks): 증분 차트 설명에 median-of-runs 횟수 명시

### DIFF
--- a/documents/src/components/BenchmarkChartsImpl.tsx
+++ b/documents/src/components/BenchmarkChartsImpl.tsx
@@ -278,7 +278,7 @@ export default function BenchmarkCharts() {
     {
       title: "Incremental Rebuild (in-process)",
       description:
-        "Pure incremental rebuild compute (cache reuse, debounce/watch latency excluded): ZNTC watch({watchDelay:0}), esbuild ctx.rebuild(), rolldown bundle.generate(). Median of repeated runs — single-rebuild timings have notable run-to-run variance (GC).",
+        "Pure incremental rebuild compute (cache reuse, debounce/watch latency excluded): ZNTC watch({watchDelay:0}), esbuild ctx.rebuild(), rolldown bundle.generate(). Median of 5 runs (each 10 iterations) — single-rebuild timings have notable run-to-run variance (GC).",
       entries: benchmarkData.results.incrementalRebuild,
     },
     {


### PR DESCRIPTION
증분 rebuild 차트 설명에 측정 횟수를 명시: **"Median of 5 runs (each 10 iterations)"**.

단일 rebuild 가 GC 로 run-to-run 변동이 크므로, 5회 실행(각 10 iteration) 의 median-of-medians 를 채택했음을 독자가 알 수 있게 합니다. astro build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)