### PR TITLE
fix(transpile): #4123 마지막 6개 재귀 AST walker 반복화 (PR-2c)

### DIFF
--- a/scripts/audit-recursive-ast-walkers.mjs
+++ b/scripts/audit-recursive-ast-walkers.mjs
@@ -35,6 +35,7 @@ const srcRoot = join(root, "src");
 const ALLOWLIST = {
   // --- sanctioned 헬퍼 / 명시 스택·큐·collector (깊이 무관 안전) ---
   "src/parser/ast_walk.zig::walkPreorderIterative": { class: "iterative_safe", note: "the sanctioned iterative helper" },
+  "src/parser/ast_walk.zig::collectChildrenInto": { class: "iterative_safe", note: "sanctioned child-collection entry point for iterative worklists (#4123 PR-2c)" },
   "src/parser/ast_walk.zig::collectReachableNodeIndices": { class: "iterative_safe", note: "explicit stack worklist" },
   "src/transformer/minify.zig::markReachableNodes": { class: "iterative_safe", note: "BFS queue" },
   "src/transformer/es2015_block_scoping.zig::collectChildIndices": { class: "iterative_safe", note: "one-level collector feeding caller stack" },
@@ -47,13 +48,12 @@ const ALLOWLIST = {
   "src/bundler/runtime_polyfills.zig::markSkippedIdentifiers": { class: "one_level", note: "import/export specifiers only, flat outer loop" },
   "src/bundler/constant_facts.zig::markMinifySensitiveIdentifierRefs": { class: "one_level", note: "one level, flat outer for" },
 
-  // --- 아직 재귀 (#4123 PR-2c 에서 walkPreorderIterative 로 전환 예정) ---
-  "src/transpile.zig::walkFunctionVarBindingPatterns": { class: "recursive_tracked", note: "#4123 PR-2c — binding-shadow scan" },
-  "src/transpile.zig::scanChildrenForUnsupportedBindingLiteShadow": { class: "recursive_tracked", note: "#4123 PR-2c — binding-lite shadow scan (scope-threaded)" },
-  "src/transpile.zig::markBindingLiteValueUses": { class: "recursive_tracked", note: "#4123 PR-2c — binding-lite value-use mark" },
-  "src/transformer/es2017.zig::rewriteAwaitToYieldAwait": { class: "recursive_tracked", note: "#4123 PR-2c — post-order + mutation" },
-  "src/semantic/analyzer.zig::visitTypeContextNode": { class: "recursive_tracked", note: "#4123 PR-2c — type-context generic descent (low-risk)" },
-  "src/parser/ast_walk.zig::hasRawPrivateSyntax": { class: "recursive_tracked", note: "#4123 PR-2c — Debug/ReleaseSafe-only assert (ReleaseFast 에선 compiled out)" },
+  // --- recursive_tracked: 없음 ---
+  // #4123 PR-2c 에서 마지막 6개 재귀 walker(walkFunctionVarBindingPatterns / scanChildrenForUnsupportedBindingLiteShadow /
+  // markBindingLiteValueUses / rewriteAwaitToYieldAwait / visitTypeContextNode / hasRawPrivateSyntax)를 전부 반복화했다.
+  // 이들은 이제 children() 을 직접 호출하지 않고 `ast_walk.collectChildrenInto`(또는 walkPreorderIterative)를 경유하므로
+  // 이 audit 의 children() 호출처 목록에서 사라진다 → recursive_tracked=0. 새 재귀 walker 가 children() 을 직접 돌면
+  // 미분류 violation 으로 다시 잡힌다.
 };
 
 function listZigFiles(dir) {

--- a/src/parser/ast_walk.zig
+++ b/src/parser/ast_walk.zig
@@ -268,21 +268,26 @@ pub fn bindingIdentifiers(
 /// `root` 서브트리에 raw `#x` private syntax (`private_field_expression` /
 /// `private_identifier`) 가 남아 있는지 검사. transformer 가 lowering 했어야 할 노드가
 /// codegen 까지 도달했는지 검증하는 debug invariant 용도 — 정상 코드 경로에서는 항상 false.
-pub fn hasRawPrivateSyntax(ast: *const Ast, root: NodeIndex) bool {
-    if (root.isNone()) return false;
-    if (@intFromEnum(root) >= ast.nodes.items.len) return false;
+const RawPrivateCtx = struct { found: bool };
 
-    const node = ast.nodes.items[@intFromEnum(root)];
+fn rawPrivateVisit(ctx: *RawPrivateCtx, idx: NodeIndex, node: Node) WalkAction {
+    _ = idx;
     switch (node.tag) {
-        .private_field_expression, .private_identifier => return true,
-        else => {},
+        .private_field_expression, .private_identifier => {
+            ctx.found = true;
+            return .stop;
+        },
+        else => return .descend,
     }
+}
 
-    var it = children(ast, node);
-    while (it.next()) |child_idx| {
-        if (hasRawPrivateSyntax(ast, child_idx)) return true;
-    }
-    return false;
+pub fn hasRawPrivateSyntax(ast: *const Ast, root: NodeIndex) bool {
+    // 반복 순회(#4123): 깊은 좌결합 체인에서 재귀 시 스택 오버플로우. 이건 Debug/ReleaseSafe
+    // 전용 invariant(`assert(!hasRawPrivateSyntax(...))`) — OOM 시 false 반환(검사 skip, false
+    // panic 회피; ReleaseFast 에선 assert 자체가 compiled out).
+    var c = RawPrivateCtx{ .found = false };
+    walkPreorderIterative(ast.allocator, ast, root, &c, rawPrivateVisit) catch return false;
+    return c.found;
 }
 
 /// AST 루트(마지막 program 노드)에서 도달 가능한 노드 인덱스를 pre-order로 수집한다.
@@ -384,4 +389,22 @@ pub fn walkPreorderIterative(
             try stack.append(allocator, child_buf.items[i]);
         }
     }
+}
+
+/// `node` 의 직계 자식을 `children` iterator 순서(좌→우) 그대로 `out` 에 수집한다(`out` 은 먼저
+/// 비워짐). 반복 순회(#4123) 변환의 **sanctioned 공용 진입점** — 직접 `children()` 재귀가
+/// 재유입되지 않도록 트리 순회 호출을 한 곳에 모은다(durability audit 의 iterative_safe 단일
+/// 호출처). worklist(LIFO 스택)에 넣을 땐 호출자가 역순으로 push 해 소스 순서를 보존한다
+/// (NodeIndex 스택이든 {idx,post} 같은 frame 스택이든 호출자가 wrapping 을 결정). `out` 은
+/// none NodeIndex 도 그대로 담으므로(필터링 안 함), 호출자가 pop 시 `isNone` 가드를 둔다 —
+/// `walkPreorderIterative`/`children` 의 의미와 일치.
+pub fn collectChildrenInto(
+    ast: *const Ast,
+    node: Node,
+    out: *std.ArrayList(NodeIndex),
+    allocator: std.mem.Allocator,
+) std.mem.Allocator.Error!void {
+    out.clearRetainingCapacity();
+    var it = children(ast, node);
+    while (it.next()) |c| try out.append(allocator, c);
 }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1844,18 +1844,107 @@ pub const SemanticAnalyzer = struct {
         }
     }
 
+    /// visitNode switch 의 TS type-node group(`ts_qualified_name` … `ts_class_implements`,
+    /// 모두 `visitTypeContextNode` 로 위임해 자식만 descend)과 **동기 유지 필수**.
+    /// visitTypeContextNode 의 worklist 가 이 group 을 만나면 visitNode 재귀(=visitTypeContextNode
+    /// 재진입) 대신 자식을 직접 평탄화해 깊은 타입 중첩(#4123)에서 스택오버플로우를 막는다.
+    /// 신규 ts_* type node 를 그 switch group 에 추가하면 여기에도 반드시 추가할 것: 빠지면 그
+    /// 노드는 visitNode 위임 → visitNode 가 다시 visitTypeContextNode 호출(dispatch 재귀)이라
+    /// 깊은 중첩에서 *깊이 안전*만 잃고(스택 재귀 재유입), **출력 의미는 동일**하다
+    /// (type_context_depth 는 boolean). 이 dispatch 재귀는 새 children() 호출처가 아니라
+    /// durability audit 이 못 잡고, 출력 불변이라 byte-identical 도 못 잡으므로 — 이 목록은
+    /// visitNode group 과 **수동으로** 동기 유지해야 한다(자동 가드 없음).
+    fn isTypeContextGenericNode(tag: Node.Tag) bool {
+        return switch (tag) {
+            .ts_qualified_name,
+            .ts_array_type,
+            .ts_tuple_type,
+            .ts_named_tuple_member,
+            .ts_union_type,
+            .ts_intersection_type,
+            .ts_conditional_type,
+            .ts_type_operator,
+            .ts_optional_type,
+            .ts_rest_type,
+            .ts_indexed_access_type,
+            .ts_type_literal,
+            .ts_function_type,
+            .ts_constructor_type,
+            .ts_mapped_type,
+            .ts_template_literal_type,
+            .ts_infer_type,
+            .ts_parenthesized_type,
+            .ts_import_type,
+            .ts_literal_type,
+            .ts_type_predicate,
+            .ts_type_alias_declaration,
+            .ts_interface_declaration,
+            .ts_interface_body,
+            .ts_property_signature,
+            .ts_method_signature,
+            .ts_call_signature,
+            .ts_construct_signature,
+            .ts_index_signature,
+            .ts_getter_signature,
+            .ts_setter_signature,
+            .ts_type_parameter,
+            .ts_type_parameter_declaration,
+            .ts_type_parameter_instantiation,
+            .ts_class_implements,
+            => true,
+            else => false,
+        };
+    }
+
     /// TS type node 의 children 을 `type_context_depth` 를 올린 채 순회.
-    /// `ast_walk.children` iterator 로 각 child NodeIndex 를 얻어 재귀 visit —
     /// 내부에 도달한 `identifier_reference` 는 `resolveIdentifier` 가 type_context
     /// flag 와 함께 Reference 에 기록.
+    ///
+    /// 반복 worklist(#4123): 원본은 children 을 그냥 `visitNode` 로 재귀했는데, 깊게 중첩된
+    /// 타입(`number[][]…[]`, `keyof keyof …`, 긴 `A|B|C…`)에서 visitNode ↔ visitTypeContextNode
+    /// 상호재귀가 스택오버플로우. type_context_depth 는 line 889 에서 boolean(`>0`)으로만 쓰여
+    /// 중첩 depth 값 자체가 무의미하므로, generic type-node group(isTypeContextGenericNode)은
+    /// 자식을 worklist 로 평탄화하고 그 외(ts_type_reference, ts_type_query=value_as_type, 또는
+    /// 타입 안의 value 식·identifier)는 visitNode 로 위임한다. 그 위임은 얕다 — value 식의 깊은
+    /// 체인은 visitNode 의 binary/logical arm 이 자체 평탄화(#4123 PR-1).
     fn visitTypeContextNode(self: *SemanticAnalyzer, idx: NodeIndex, node: Node) AllocError!void {
         _ = idx;
         self.type_context_depth += 1;
         defer self.type_context_depth -= 1;
-        var it = ast_walk.children(self.ast, node);
-        while (it.next()) |child| {
-            if (child.isNone()) continue;
-            try self.visitNode(child);
+
+        const Push = struct {
+            fn go(
+                a: *Ast,
+                n: Node,
+                st: *std.ArrayListUnmanaged(NodeIndex),
+                cb: *std.ArrayListUnmanaged(NodeIndex),
+                alloc: std.mem.Allocator,
+            ) AllocError!void {
+                try ast_walk.collectChildrenInto(a, n, cb, alloc);
+                var i = cb.items.len; // 소스 순서 보존: 역순 push → LIFO pop 이 forward
+                while (i > 0) {
+                    i -= 1;
+                    try st.append(alloc, cb.items[i]);
+                }
+            }
+        };
+
+        var stack: std.ArrayListUnmanaged(NodeIndex) = .empty;
+        defer stack.deinit(self.allocator);
+        var child_buf: std.ArrayListUnmanaged(NodeIndex) = .empty;
+        defer child_buf.deinit(self.allocator);
+
+        try Push.go(self.ast, node, &stack, &child_buf, self.allocator);
+        while (stack.pop()) |cur| {
+            // children() 는 extra_data 값을 그대로 yield 하므로(범위 검증 안 함) none 외에
+            // out-of-range 도 가능 → getNode 전 bounds 가드(walkPreorderIterative/scanChildren 동일).
+            if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) continue;
+            const cnode = self.ast.getNode(cur);
+            if (isTypeContextGenericNode(cnode.tag)) {
+                try Push.go(self.ast, cnode, &stack, &child_buf, self.allocator);
+            } else {
+                try self.visitNode(cur);
+            }
         }
     }
 

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -13,6 +13,7 @@
 
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
+const ast_walk = @import("../parser/ast_walk.zig");
 const es_helpers = @import("es_helpers.zig");
 const es2015_arrow = @import("es2015_arrow.zig");
 const es2015_generator = @import("es2015_generator.zig");
@@ -27,42 +28,68 @@ pub fn ES2017(comptime Transformer: type) type {
         /// 변환. nested function/arrow scope 는 traversal 안 함 (own this/await context 가짐).
         /// (#1911)
         fn rewriteAwaitToYieldAwait(self: *Transformer, node_idx: NodeIndex) Transformer.Error!void {
-            if (node_idx.isNone()) return;
-            const node = self.ast.getNode(node_idx);
-            switch (node.tag) {
-                .await_expression => {
-                    // 자식 먼저 — nested await 도 변환.
-                    try rewriteAwaitToYieldAwait(self, node.data.unary.operand);
-                    // __await(operand) call 만들기.
+            // 반복 post-order worklist(#4123): 원본은 generic else 에서 자식을, await_expression
+            // 에서 operand 를 재귀해, async-generator body 안 깊은 식(`await (a+b+c+…)`, 깊은
+            // statement 중첩, `await await …`)에서 스택오버플로우였다. await_expression 만 operand
+            // 를 **먼저** 변환한 뒤 자신을 yield 로 replace 해야 하므로(post-order + mutation),
+            // await 노드에 한해 post 프레임을 둔다. generic/boundary 는 mutation 이 없어 자식
+            // push(또는 skip)만 한다. operand subtree 의 in-place 변환은 NodeIndex 가 불변이라
+            // 보존되고, post 프레임이 스택 더 깊은 곳에 있어 operand 처리 완료 후에만 replace 된다.
+            const Frame = struct { idx: NodeIndex, post: bool };
+            var stack: std.ArrayListUnmanaged(Frame) = .empty;
+            defer stack.deinit(self.allocator);
+            var child_buf: std.ArrayListUnmanaged(NodeIndex) = .empty;
+            defer child_buf.deinit(self.allocator);
+
+            try stack.append(self.allocator, .{ .idx = node_idx, .post = false });
+            while (stack.pop()) |frame| {
+                if (frame.post) {
+                    // operand 는 이미 변환 완료. 이제 이 await 를 `yield __await(operand)` 로 replace.
+                    const node = self.ast.getNode(frame.idx);
                     self.runtime_helpers.await_helper = true;
                     const await_ref = try es_helpers.makeRuntimeHelperRef(self, "__await");
                     const await_call = try es_helpers.makeCallExpr(self, await_ref, &.{node.data.unary.operand}, node.span);
                     // span 보존하면서 await_expression → yield __await(value).
-                    self.ast.replaceNode(node_idx, .{
+                    self.ast.replaceNode(frame.idx, .{
                         .tag = .yield_expression,
                         .span = node.span,
                         .data = .{ .unary = .{ .operand = await_call, .flags = 0 } },
                     });
-                },
-                // 자체 async/await context 를 가진 nested scope — skip. `es2022_tla.hasTopLevelAwait`
-                // 의 boundary set 과 동일 (function/method/class 모두). class body 안 method
-                // 도 자체 컨텍스트라 await rewrite 에서 제외.
-                .function_declaration,
-                .function_expression,
-                .function,
-                .arrow_function_expression,
-                .method_definition,
-                .class_declaration,
-                .class_expression,
-                => {},
-                else => {
-                    // 일반 노드 — child iterator 로 모든 자식 traversal.
-                    const ast_walk = @import("../parser/ast_walk.zig");
-                    var it = ast_walk.children(self.ast, node);
-                    while (it.next()) |child| {
-                        try rewriteAwaitToYieldAwait(self, child);
-                    }
-                },
+                    continue;
+                }
+                // pre 프레임: children() 는 extra_data 값을 그대로 yield 하므로(범위 검증 안 함)
+                // none 외에 out-of-range 도 가능 → getNode 전 bounds 가드(post 프레임 idx 는 이미
+                // 검증된 await 노드라 안전). walkPreorderIterative/scanChildren 동일.
+                if (frame.idx.isNone() or @intFromEnum(frame.idx) >= self.ast.nodes.items.len) continue;
+                const node = self.ast.getNode(frame.idx);
+                switch (node.tag) {
+                    .await_expression => {
+                        // post-order: operand 를 먼저 변환(push post=false)한 뒤 자신을 replace.
+                        // LIFO 라 post 를 먼저 push 해야 operand 처리 *후* 실행된다.
+                        try stack.append(self.allocator, .{ .idx = frame.idx, .post = true });
+                        try stack.append(self.allocator, .{ .idx = node.data.unary.operand, .post = false });
+                    },
+                    // 자체 async/await context 를 가진 nested scope — skip. `es2022_tla.hasTopLevelAwait`
+                    // 의 boundary set 과 동일 (function/method/class 모두). class body 안 method
+                    // 도 자체 컨텍스트라 await rewrite 에서 제외.
+                    .function_declaration,
+                    .function_expression,
+                    .function,
+                    .arrow_function_expression,
+                    .method_definition,
+                    .class_declaration,
+                    .class_expression,
+                    => {},
+                    else => {
+                        // 일반 노드 — 모든 자식을 push (소스 순서 보존 위해 역순).
+                        try ast_walk.collectChildrenInto(self.ast, node, &child_buf, self.allocator);
+                        var i = child_buf.items.len;
+                        while (i > 0) {
+                            i -= 1;
+                            try stack.append(self.allocator, .{ .idx = child_buf.items[i], .post = false });
+                        }
+                    },
+                }
             }
         }
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -265,32 +265,46 @@ fn walkFunctionVarBindingPatterns(
     ctx: anytype,
     comptime onBindingPattern: fn (@TypeOf(ctx), ast_mod.NodeIndex) error{OutOfMemory}!bool,
 ) error{OutOfMemory}!bool {
-    if (idx.isNone()) return false;
-    const node = ast.getNode(idx);
-    switch (node.tag) {
-        .function_declaration,
-        .function_expression,
-        .function,
-        .arrow_function_expression,
-        => return false,
-        .variable_declaration => if (!ast.variableDeclarationKind(node).isLexical()) {
-            const list_start = ast.extra_data.items[node.data.extra + 1];
-            const list_len = ast.extra_data.items[node.data.extra + 2];
-            var i: u32 = 0;
-            while (i < list_len) : (i += 1) {
-                const decl_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[list_start + i]);
-                if (decl_idx.isNone()) continue;
-                const decl = ast.getNode(decl_idx);
-                if (decl.tag != .variable_declarator) continue;
-                if (try onBindingPattern(ctx, @enumFromInt(ast.extra_data.items[decl.data.extra]))) return true;
-            }
-        },
-        else => {},
-    }
+    // 반복 worklist(#4123): 깊은 좌결합 체인을 재귀로 내려가면 스택 오버플로우. scope state 가
+    // 없어(function 경계 prune + var-decl 콜백 + else descend) 단순 NodeIndex 스택이면 충분.
+    // comptime 콜백 + error 전파 때문에 walkPreorderIterative(비-erroring visit) 대신 inline.
+    var stack: std.ArrayListUnmanaged(ast_mod.NodeIndex) = .empty;
+    defer stack.deinit(ast.allocator);
+    try stack.append(ast.allocator, idx);
+    var child_buf: std.ArrayListUnmanaged(ast_mod.NodeIndex) = .empty;
+    defer child_buf.deinit(ast.allocator);
 
-    var it = ast_walk.children(ast, node);
-    while (it.next()) |child_idx| {
-        if (try walkFunctionVarBindingPatterns(ast, child_idx, ctx, onBindingPattern)) return true;
+    while (stack.pop()) |cur| {
+        if (cur.isNone() or @intFromEnum(cur) >= ast.nodes.items.len) continue;
+        const node = ast.getNode(cur);
+        switch (node.tag) {
+            // function/arrow scope 경계 — var 는 함수 밖으로 안 샘. prune(자식 안 봄).
+            .function_declaration,
+            .function_expression,
+            .function,
+            .arrow_function_expression,
+            => continue,
+            .variable_declaration => if (!ast.variableDeclarationKind(node).isLexical()) {
+                const list_start = ast.extra_data.items[node.data.extra + 1];
+                const list_len = ast.extra_data.items[node.data.extra + 2];
+                var i: u32 = 0;
+                while (i < list_len) : (i += 1) {
+                    const decl_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[list_start + i]);
+                    if (decl_idx.isNone()) continue;
+                    const decl = ast.getNode(decl_idx);
+                    if (decl.tag != .variable_declarator) continue;
+                    if (try onBindingPattern(ctx, @enumFromInt(ast.extra_data.items[decl.data.extra]))) return true;
+                }
+                // var-decl 도 자식(init 등) 계속 descend — 아래 child push 로 (원본 fall-through).
+            },
+            else => {},
+        }
+        try ast_walk.collectChildrenInto(ast, node, &child_buf, ast.allocator);
+        var i = child_buf.items.len;
+        while (i > 0) {
+            i -= 1;
+            try stack.append(ast.allocator, child_buf.items[i]);
+        }
     }
     return false;
 }
@@ -328,6 +342,34 @@ fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
     return !inside_function;
 }
 
+/// scanForUnsupportedBindingLiteShadow 의 switch 가 tag 별로 특수 처리(=scope state 변경 또는
+/// bespoke binding 검사)하는 노드인지. 이 노드들은 반복 평탄화에서 recursive scanForUnsupported
+/// 로 위임한다(scope 중첩은 얕음). 그 외(generic expression 등)는 scanForUnsupported 가 곧
+/// scanChildren(같은 state) 이므로 worklist 가 자식을 직접 push 해 평탄화.
+///
+/// ⚠️ 이 집합은 scanForUnsupportedBindingLiteShadow switch 의 **non-`else` arm 전부**와 정확히
+/// 일치해야 한다. 빠지면(과거 .variable_declaration/.binding_identifier 누락) 그 노드가 generic
+/// 으로 처리돼 top-level lexical shadow / binding-name 검사를 건너뛴다(→ `.bindings` 오판,
+/// `import { Foo } from …; const Foo = 1` 가 full semantic 으로 안 올라감). 단위 테스트
+/// "ambiguous or overflowing named import shadows keep full semantic" 가 drift 를 잡는다.
+fn isScopeOrSpecialForBindingLite(tag: ast_mod.Node.Tag) bool {
+    return switch (tag) {
+        .program,
+        .block_statement,
+        .function_body,
+        .formal_parameters,
+        .catch_clause,
+        .function_declaration,
+        .function_expression,
+        .function,
+        .arrow_function_expression,
+        .variable_declaration,
+        .binding_identifier,
+        => true,
+        else => false,
+    };
+}
+
 fn scanChildrenForUnsupportedBindingLiteShadow(
     ast: *const Ast,
     node: ast_mod.Node,
@@ -336,9 +378,43 @@ fn scanChildrenForUnsupportedBindingLiteShadow(
     inside_function: bool,
     fn_shadow_count: ?*usize,
 ) error{OutOfMemory}!bool {
-    var it = ast_walk.children(ast, node);
-    while (it.next()) |child_idx| {
-        if (try scanForUnsupportedBindingLiteShadow(ast, child_idx, names, child_scope_depth, inside_function, fn_shadow_count)) return true;
+    // 반복 worklist(#4123): 원본은 scanForUnsupported↔scanChildren 상호재귀라 깊은 좌결합 체인
+    // (`+` 등, 같은 scope state)에서 스택 오버플로우였다(실측 — named-import + 40000항). generic
+    // 노드는 scanForUnsupported(generic)=scanChildren(같은 state) 이므로 자식을 직접 push 해
+    // 평탄화하고, scope/special 노드만 recursive scanForUnsupported 로 위임(scope 중첩=얕음).
+    // worklist state(child_scope_depth/inside_function/fn_shadow_count)는 generic descent 내내
+    // 불변이라 단순 NodeIndex 스택으로 충분(scope 노드는 자체 재귀로 state 재유도).
+    const Push = struct {
+        fn go(
+            a: *const Ast,
+            n: ast_mod.Node,
+            st: *std.ArrayListUnmanaged(ast_mod.NodeIndex),
+            cb: *std.ArrayListUnmanaged(ast_mod.NodeIndex),
+        ) error{OutOfMemory}!void {
+            try ast_walk.collectChildrenInto(a, n, cb, a.allocator);
+            var i = cb.items.len; // 소스 순서 보존: 역순 push → LIFO pop 이 forward
+            while (i > 0) {
+                i -= 1;
+                try st.append(a.allocator, cb.items[i]);
+            }
+        }
+    };
+
+    var stack: std.ArrayListUnmanaged(ast_mod.NodeIndex) = .empty;
+    defer stack.deinit(ast.allocator);
+    var child_buf: std.ArrayListUnmanaged(ast_mod.NodeIndex) = .empty;
+    defer child_buf.deinit(ast.allocator);
+
+    try Push.go(ast, node, &stack, &child_buf); // seed: node 의 직계 자식 (원본 순회 대상)
+
+    while (stack.pop()) |cur| {
+        if (cur.isNone() or @intFromEnum(cur) >= ast.nodes.items.len) continue;
+        const cnode = ast.getNode(cur);
+        if (isScopeOrSpecialForBindingLite(cnode.tag)) {
+            if (try scanForUnsupportedBindingLiteShadow(ast, cur, names, child_scope_depth, inside_function, fn_shadow_count)) return true;
+        } else {
+            try Push.go(ast, cnode, &stack, &child_buf);
+        }
     }
     return false;
 }
@@ -950,17 +1026,59 @@ fn markBindingLiteFunctionScope(
 }
 
 fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite, value_context: bool, shadowed_names: []const []const u8) error{OutOfMemory}!void {
-    if (idx.isNone()) return;
+    // 반복 worklist(#4123): 원본은 generic descent(switch 의 else / value_context=true 인
+    // assignment_expression)에서 같은 (value_context, shadowed_names)로 자식을 재귀 → 깊은
+    // 좌결합 체인(`+` 등)에서 스택 오버플로우(실측 — named-import + 40000항). switch 본체를
+    // markBindingLiteValueUsesNode(special→handled/true, generic→false)로 추출하고 generic
+    // 노드만 worklist 로 평탄화한다. special 케이스의 sub-part 재귀(binding pattern/scope/value
+    // 식)는 다시 이 wrapper 를 타며, 깊은 value 식은 generic→worklist 로 평탄화되어 얕다.
+    // generic descent 동안 (value_context, shadowed_names)는 불변 → 단순 NodeIndex 스택으로 충분.
+    const Push = struct {
+        fn go(
+            a: *const Ast,
+            n: ast_mod.Node,
+            st: *std.ArrayListUnmanaged(ast_mod.NodeIndex),
+            cb: *std.ArrayListUnmanaged(ast_mod.NodeIndex),
+        ) error{OutOfMemory}!void {
+            try ast_walk.collectChildrenInto(a, n, cb, a.allocator);
+            var i = cb.items.len; // 소스 순서 보존: 역순 push → LIFO pop 이 forward
+            while (i > 0) {
+                i -= 1;
+                try st.append(a.allocator, cb.items[i]);
+            }
+        }
+    };
+
+    var stack: std.ArrayListUnmanaged(ast_mod.NodeIndex) = .empty;
+    defer stack.deinit(ast.allocator);
+    var child_buf: std.ArrayListUnmanaged(ast_mod.NodeIndex) = .empty;
+    defer child_buf.deinit(ast.allocator);
+
+    try stack.append(ast.allocator, idx);
+    while (stack.pop()) |cur| {
+        if (try markBindingLiteValueUsesNode(ast, cur, lite, value_context, shadowed_names)) continue; // special: 자체 처리됨
+        // generic 노드: 자식을 같은 (value_context, shadowed_names)로 descend.
+        try Push.go(ast, ast.getNode(cur), &stack, &child_buf);
+    }
+}
+
+/// markBindingLiteValueUses 의 per-node 처리. special 케이스(자체적으로 sub-part 를 적절한
+/// value_context 로 재귀)는 true 를, generic(자식을 같은 state 로 내려가야 하는 노드)은 false 를
+/// 반환한다. wrapper(markBindingLiteValueUses)가 false 노드의 자식 descent 를 worklist 로 평탄화한다.
+fn markBindingLiteValueUsesNode(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite, value_context: bool, shadowed_names: []const []const u8) error{OutOfMemory}!bool {
+    // children() 는 extra_data 값을 그대로 yield 하므로(범위 검증 안 함) none 외에 out-of-range 도
+    // 가능 → getNode 전 bounds 가드(true=처리됨 취급, wrapper 는 자식 push 안 함). scanChildren 동일.
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return true;
     const node = ast.getNode(idx);
 
-    if (Transformer.isTypeOnlyNode(node.tag) or node.tag.isTypeOnlyDeclaration()) return;
+    if (Transformer.isTypeOnlyNode(node.tag) or node.tag.isTypeOnlyDeclaration()) return true;
 
     switch (node.tag) {
         .identifier_reference,
         .assignment_target_identifier,
         => {
             if (value_context) markBindingLiteUse(lite, ast.getText(node.span), shadowed_names);
-            return;
+            return true;
         },
         .binding_identifier,
         .import_declaration,
@@ -968,12 +1086,12 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
         .import_default_specifier,
         .import_namespace_specifier,
         .import_attribute,
-        => return,
+        => return true,
         .block_statement,
         .function_body,
         => {
             try markBindingLiteBlockScope(ast, node, lite, shadowed_names);
-            return;
+            return true;
         },
         .catch_clause => {
             var shadow_buf: [binding_lite_max_shadows][]const u8 = undefined;
@@ -981,34 +1099,34 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
             for (shadowed_names) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
             try collectBindingLitePatternShadows(ast, node.data.binary.left, lite, &shadow_buf, &shadow_len);
             try markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadow_buf[0..shadow_len]);
-            return;
+            return true;
         },
         .try_statement => {
             try markBindingLiteValueUses(ast, node.data.ternary.a, lite, true, shadowed_names);
             try markBindingLiteValueUses(ast, node.data.ternary.b, lite, true, shadowed_names);
             try markBindingLiteValueUses(ast, node.data.ternary.c, lite, true, shadowed_names);
-            return;
+            return true;
         },
         .export_specifier => {
             try markBindingLiteValueUses(ast, node.data.binary.left, lite, true, shadowed_names);
-            return;
+            return true;
         },
         .export_named_declaration => {
             const x = module_parser.readExportNamedExtras(ast, node.data.extra);
             try markBindingLiteValueUses(ast, x.decl, lite, true, shadowed_names);
             try markBindingLiteListValueUses(ast, .{ .start = x.specs_start, .len = x.specs_len }, lite, true, shadowed_names);
-            return;
+            return true;
         },
         .variable_declaration => {
             const list_start = ast.extra_data.items[node.data.extra + 1];
             const list_len = ast.extra_data.items[node.data.extra + 2];
             try markBindingLiteListValueUses(ast, .{ .start = list_start, .len = list_len }, lite, true, shadowed_names);
-            return;
+            return true;
         },
         .variable_declarator => {
             try markBindingPatternDefaultValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite, shadowed_names);
             try markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra + 2]), lite, true, shadowed_names);
-            return;
+            return true;
         },
         .function_declaration,
         .function_expression,
@@ -1023,7 +1141,7 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
                 @enumFromInt(ast.extra_data.items[e + 1]),
                 @enumFromInt(ast.extra_data.items[e + 2]),
             );
-            return;
+            return true;
         },
         .arrow_function_expression => {
             const e = node.data.extra;
@@ -1035,35 +1153,35 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
                 @enumFromInt(ast.extra_data.items[e]),
                 @enumFromInt(ast.extra_data.items[e + 1]),
             );
-            return;
+            return true;
         },
         .formal_parameters => {
             try markBindingLiteListValueUses(ast, node.data.list, lite, false, shadowed_names);
-            return;
+            return true;
         },
         .assignment_pattern,
         .assignment_target_with_default,
         => {
             try markBindingLiteValueUses(ast, node.data.binary.left, lite, false, shadowed_names);
             try markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
-            return;
+            return true;
         },
         // `(Foo = Bar()) =>` 같이 cover-grammar 로 패턴 자리에 남은 assignment_expression 은
         // value_context=false (formal_parameters 진입) 에서만 LHS=binding/RHS=value 로 쪼갠다.
         // expression context (`Foo = expr;`) 는 LHS 가 assignment_target_identifier 라 default
-        // child walk 로 그대로 value_context=true 가 전파돼야 import 가 use 마킹된다.
+        // child walk 로 그대로 value_context=true 가 전파돼야 import 가 use 마킹된다(generic descent).
         .assignment_expression => {
             if (!value_context) {
                 try markBindingLiteValueUses(ast, node.data.binary.left, lite, false, shadowed_names);
                 try markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
-                return;
+                return true;
             }
         },
         .formal_parameter => {
             const e = node.data.extra;
             try markBindingPatternDefaultValueUses(ast, @enumFromInt(ast.extra_data.items[e]), lite, shadowed_names);
             try markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 2]), lite, true, shadowed_names);
-            return;
+            return true;
         },
         .object_property => {
             const key = node.data.binary.left;
@@ -1075,21 +1193,19 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
                 if (key_node.tag == .computed_property_key) try markBindingLiteValueUses(ast, key, lite, true, shadowed_names);
                 try markBindingLiteValueUses(ast, value, lite, true, shadowed_names);
             }
-            return;
+            return true;
         },
         .static_member_expression,
         .private_field_expression,
         => {
             try markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite, true, shadowed_names);
-            return;
+            return true;
         },
         else => {},
     }
 
-    var it = ast_walk.children(ast, node);
-    while (it.next()) |child_idx| {
-        try markBindingLiteValueUses(ast, child_idx, lite, value_context, shadowed_names);
-    }
+    // generic 노드(else, 또는 value_context=true 인 assignment_expression): wrapper 가 descend.
+    return false;
 }
 
 /// 소스 문자열을 트랜스파일한다. I/O 없음, 순수 함수.
@@ -1694,6 +1810,53 @@ test "deep binary chain with minify does not overflow (#4123 flag-gated walkers)
     );
     defer result.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+}
+
+test "deep chain under named-import binding-lite shadow scan does not overflow (#4123 PR-2c)" {
+    // `.ts` + named import → fast-path 의 buildTransformPlan 이 hasUnsupportedNamedImportLocalBindingShadow
+    // → scanForUnsupportedBindingLiteShadow ↔ scanChildrenForUnsupportedBindingLiteShadow 로 top-level
+    // 식을 순회한다. 깊은 좌결합 체인(`a + a + …`)이 그 generic descent 를 N-deep **상호재귀**시켜
+    // SIGSEGV 였다(#4123, named-import + 수만 항 실측). 반복 worklist 변환 후 정상 — shadow 없으니
+    // plan 은 `.bindings` 로 해소돼야 한다(크래시 없이 도달했다는 증거). fast_path_disabled=false 로
+    // 호출해야 이 스캔 경로를 탄다(true 면 buildTransformPlan 이 즉시 .full 반환하고 스캔 skip).
+    const n: usize = 20000; // pre-fix 크래시 임계(수천 항)를 넉넉히 초과.
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(std.testing.allocator);
+    try src.appendSlice(std.testing.allocator, "import { Foo, Bar } from \"./m\";\nconst a = 1;\nconst r = a");
+    var i: usize = 1;
+    while (i < n) : (i += 1) try src.appendSlice(std.testing.allocator, " + a");
+    try src.appendSlice(std.testing.allocator, ";\nFoo();\nBar(r);\n");
+
+    const plan = try testTransformPlan(src.items, "input.ts", .{});
+    try std.testing.expectEqual(SemanticRequirement.bindings, plan.semantic);
+    try std.testing.expectEqual(SemanticPlanReason.named_import_binding_elision, plan.reason);
+}
+
+test "deep chain using named import does not overflow value-use marking (#4123 PR-2c)" {
+    // semantic=.bindings 경로(named-import elision)는 markBindingLiteValueUses 로 import 사용처를
+    // 마킹하며 식 전체를 순회한다(generic descent = 같은 value_context 로 자식 재귀). import 를 깊은
+    // 좌결합 체인에서 쓰면 N-deep 재귀 → SIGSEGV 였다(#4123). switch 본체를 per-node 함수로 추출 후
+    // generic 노드만 worklist 로 평탄화해 해소. fast_path_disabled=false 로 호출해 .bindings 실행
+    // 경로(markBindingLiteValueUses)를 탄다. Foo 가 쓰이므로 import 는 보존(elision 안 됨).
+    const n: usize = 20000;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(std.testing.allocator);
+    try src.appendSlice(std.testing.allocator, "import { Foo } from \"./m\";\nexport const r = Foo");
+    var i: usize = 1;
+    while (i < n) : (i += 1) try src.appendSlice(std.testing.allocator, " + Foo");
+    try src.appendSlice(std.testing.allocator, ";\n");
+
+    var result = try transpileWithCallbackInternal(
+        std.testing.allocator,
+        src.items,
+        "input.ts",
+        .{},
+        null,
+        false, // fast-path enabled → .bindings 경로(markBindingLiteValueUses) 실행
+    );
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "Foo") != null);
 }
 
 test "TransformPlan: simple TypeScript strip skips semantic" {


### PR DESCRIPTION
## 배경 (#4123)

`a + b + c + … (수천 항)` 같은 깊은 좌결합 식이나 깊게 중첩된 타입은 AST 를 **재귀**로 내려가는 visitor 에서 스택 프레임을 그만큼 쌓아 **스택 오버플로우(SIGSEGV)** 를 냅니다. ReleaseFast 빌드에선 스택 가드페이지를 침범해 비결정 garbage 출력까지 났습니다.

이 문제는 단계적으로 잡아 왔습니다:
- **PR-1(#4124)**: 기본 경로 3곳(semantic/transformer/codegen 의 binary·logical) 좌 스파인 평탄화.
- **PR-2a(#4136)/PR-2b(#4131)**: 읽기 전용 walker + private mangler 반복화 (`ast_walk.walkPreorderIterative` 헬퍼 도입).
- **durability audit(#4133)**: `scripts/audit-recursive-ast-walkers.mjs` 가 모든 `ast_walk.children()` 호출처를 분류 강제 — 신규 재귀 walker 재유입을 CI 에서 차단.

이 PR(**PR-2c**)은 audit 이 `recursive_tracked` 로 추적하던 **마지막 6개** 재귀 walker 를 명시 스택 worklist 로 전환해 **#4123 의 AST-visitor 영역을 완결**합니다 (audit `recursive_tracked` → **0**).

> 💡 **Zig 초보 설명**: 재귀(함수가 자기 자신을 호출)는 호출마다 *스택*에 프레임이 쌓입니다. 입력이 N단계 깊으면 프레임도 N개 → 스택(보통 8MB) 초과 시 크래시. 해법은 "다음에 처리할 노드"를 힙에 있는 배열(`ArrayList`)에 담아 `while` 루프로 꺼내 처리하는 **worklist(명시 스택)** 방식입니다. 힙은 8MB 제한이 없어 임의 깊이를 견딥니다. 방문 순서를 보존하려면 자식을 **역순으로** push 합니다(LIFO 스택은 마지막에 넣은 걸 먼저 꺼내므로).

## 변환한 6개 walker

| 파일 | 함수 | 방식 |
|---|---|---|
| `transpile.zig` | `scanChildrenForUnsupportedBindingLiteShadow` | scope/special 노드는 재귀 `scanForUnsupported` 위임, generic 은 worklist 평탄화 |
| `transpile.zig` | `markBindingLiteValueUses` | switch 본체를 per-node 함수(`…Node`, special→handled/generic→descend)로 **추출**, generic 만 worklist 평탄화 |
| `transpile.zig` | `walkFunctionVarBindingPatterns` | inline worklist (comptime 콜백 + error 전파라 헬퍼 대신) |
| `semantic/analyzer.zig` | `visitTypeContextNode` | generic type-node group 은 worklist 평탄화, 그 외(ts_type_reference/ts_type_query/value 식)는 `visitNode` 위임 |
| `transformer/es2017.zig` | `rewriteAwaitToYieldAwait` | **post-order + mutation** — await 노드만 `{idx,post}` 2-state 프레임(operand 먼저 변환 후 replace) |
| `parser/ast_walk.zig` | `hasRawPrivateSyntax` | `walkPreorderIterative` 로 (PR-2a 에서 이관) |

### 핵심 설계 결정

- **`markBindingLiteValueUses`**: switch 의 special-tag 집합을 손으로 열거하면 누락 위험이 큽니다. 그래서 switch 본체를 `markBindingLiteValueUsesNode`(special 케이스 자체 처리 후 `true`, generic 은 `false`)로 추출하고, wrapper 는 `false` 일 때만 자식을 push 합니다. **switch 자체가 진실 소스**라 special-tag 드리프트가 원천 차단됩니다.
- **공용 헬퍼 `ast_walk.collectChildrenInto`**: 변환된 walker 들이 `children()` 을 *직접* 돌면 audit 키가 nested `Push.go` 의 generic 한 `::go` 로 뭉개져 동명 우회(false-negative)가 생깁니다. `children()` 순회 진입점을 sanctioned 공용 헬퍼 한 곳에 모아 audit 신뢰성을 강화했습니다 — 변환된 walker 는 이제 `collectChildrenInto`/`walkPreorderIterative` 경유라 audit 호출처 목록에서 사라지고 `recursive_tracked=0` 이 됩니다.
- **`isScopeOrSpecialForBindingLite`** 는 `scanForUnsupportedBindingLiteShadow` switch 의 non-`else` arm **전부**와 정확히 일치해야 합니다(초기 변환에서 `.variable_declaration`/`.binding_identifier` 누락 → top-level `const Foo` shadow 미검출 버그를 유닛 테스트로 잡고 수정). ⚠️ 주석으로 동기 유지 의무를 명시.

## 검증

- **byte-identical (origin/main 대비)**: 367 TS fixture × {plain, minify} = **734 runs** + lodash-es/date-fns 번들 + async-gen(`--target=es2015`) + nested-type — **전부 동일**.
- **crash → survive** (수만~수십만 항):
  | fixture | 경로 | origin/main | 본 PR |
  |---|---|---|---|
  | `import{Foo}; const r=a+a+…; Foo()` | scanChildren | **SIGSEGV(139)** | exit 0 |
  | `import{Foo}; export const r=Foo+Foo+…` | markBindingLiteValueUses | **SIGSEGV(139)** | exit 0 |
  | `async function*g(x){yield await(x+x+…)}` (es2015) | rewriteAwaitToYieldAwait | **SIGSEGV(139)** | exit 0 |
- **회귀 유닛테스트 2종** 추가(binding-lite scan / value-use, 20000 항) + 기존 PR-1/PR-2a deep-chain 테스트. `zig build test` 통과.
- **audit**: `recursive_tracked=0`, violation 0.

## `/code-review max` 반영

- (CONFIRMED) `visitTypeContextNode`/`markBindingLiteValueUsesNode`/`rewriteAwaitToYieldAwait` 의 pop 루프가 `getNode` 전 **bounds 가드** 누락 — `children()` 가 `extra_data` 값을 그대로 yield 하므로 sibling worklist(`walkPreorderIterative`/`scanChildren`)와 동일하게 `@intFromEnum(idx) >= nodes.len` 가드 추가.
- 존재하지 않는 테스트를 가리키던 주석을 정확히 수정(이 tag-list 드리프트는 출력 불변이라 audit/byte-identical 로는 못 잡고 수동 동기 유지가 필요함을 명시).

## 알려진 범위 밖 (별도 follow-up 예정)

깊은 prefix 타입연산자(`keyof keyof … T`)는 **파서**(`parseTypeOperatorOrHigher`)의 재귀-하강에서 오버플로우합니다 — AST visitor 가 아니라 파서라 이 audit/PR 범위 밖입니다. 별도 이슈로 추적합니다.

Closes #4123

🤖 Generated with [Claude Code](https://claude.com/claude-code)