### PR TITLE
fix(bench): 증분 rebuild 변동 안정화 — iteration 50 + 파일크기 일정(in-place)

### DIFF
--- a/documents/src/components/BenchmarkChartsImpl.tsx
+++ b/documents/src/components/BenchmarkChartsImpl.tsx
@@ -278,7 +278,7 @@ export default function BenchmarkCharts() {
     {
       title: "Incremental Rebuild (in-process)",
       description:
-        "Pure incremental rebuild compute (cache reuse, debounce/watch latency excluded): ZNTC watch({watchDelay:0}), esbuild ctx.rebuild(), rolldown bundle.generate(). Median of 5 runs (each 10 iterations) — single-rebuild timings have notable run-to-run variance (GC).",
+        "Pure incremental rebuild compute (cache reuse, debounce/watch latency excluded): ZNTC watch({watchDelay:0}), esbuild ctx.rebuild(), rolldown bundle.generate(). Median of 50 in-process rebuilds (constant-size in-place edit) — stable across runs.",
       entries: benchmarkData.results.incrementalRebuild,
     },
     {

--- a/documents/src/data/benchmark-data.json
+++ b/documents/src/data/benchmark-data.json
@@ -60,17 +60,17 @@
       { "tool": "esbuild", "scale": "lodash-es (real dep)", "medianMs": 22.9, "minMs": 20.5, "maxMs": 25.1, "p95Ms": 25.1 }
     ],
     "incrementalRebuild": [
-      { "tool": "ZNTC", "scale": "tiny (1 file)", "medianMs": 2.1, "minMs": 0.24, "maxMs": 2.4, "p95Ms": 2.4 },
-      { "tool": "rolldown", "scale": "tiny (1 file)", "medianMs": 4.17, "minMs": 0.97, "maxMs": 4.38, "p95Ms": 4.38 },
-      { "tool": "esbuild", "scale": "tiny (1 file)", "medianMs": 17.8, "minMs": 4.83, "maxMs": 22.2, "p95Ms": 22.2 },
+      { "tool": "ZNTC", "scale": "tiny (1 file)", "medianMs": 2.23, "minMs": 0.58, "maxMs": 3.16, "p95Ms": 3.16 },
+      { "tool": "rolldown", "scale": "tiny (1 file)", "medianMs": 4.18, "minMs": 1.13, "maxMs": 6.49, "p95Ms": 6.49 },
+      { "tool": "esbuild", "scale": "tiny (1 file)", "medianMs": 21.0, "minMs": 5.71, "maxMs": 28.4, "p95Ms": 28.4 },
 
-      { "tool": "ZNTC", "scale": "medium (10 modules)", "medianMs": 2.57, "minMs": 0.35, "maxMs": 2.82, "p95Ms": 2.82 },
-      { "tool": "rolldown", "scale": "medium (10 modules)", "medianMs": 5.99, "minMs": 1.46, "maxMs": 6.44, "p95Ms": 6.44 },
-      { "tool": "esbuild", "scale": "medium (10 modules)", "medianMs": 21.9, "minMs": 5.63, "maxMs": 24.8, "p95Ms": 24.8 },
+      { "tool": "ZNTC", "scale": "medium (10 modules)", "medianMs": 2.73, "minMs": 0.76, "maxMs": 4.57, "p95Ms": 4.57 },
+      { "tool": "rolldown", "scale": "medium (10 modules)", "medianMs": 6.5, "minMs": 1.86, "maxMs": 12.3, "p95Ms": 12.3 },
+      { "tool": "esbuild", "scale": "medium (10 modules)", "medianMs": 22.9, "minMs": 8.75, "maxMs": 29.8, "p95Ms": 29.8 },
 
-      { "tool": "ZNTC", "scale": "lodash-es (real dep)", "medianMs": 10.5, "minMs": 3.62, "maxMs": 17.8, "p95Ms": 17.8 },
-      { "tool": "rolldown", "scale": "lodash-es (real dep)", "medianMs": 38.9, "minMs": 14.2, "maxMs": 44.5, "p95Ms": 44.5 },
-      { "tool": "esbuild", "scale": "lodash-es (real dep)", "medianMs": 47.1, "minMs": 23.5, "maxMs": 54.6, "p95Ms": 54.6 }
+      { "tool": "ZNTC", "scale": "lodash-es (real dep)", "medianMs": 20.0, "minMs": 3.61, "maxMs": 24.2, "p95Ms": 24.2 },
+      { "tool": "rolldown", "scale": "lodash-es (real dep)", "medianMs": 43.7, "minMs": 17.5, "maxMs": 52.4, "p95Ms": 52.4 },
+      { "tool": "esbuild", "scale": "lodash-es (real dep)", "medianMs": 55.5, "minMs": 30.4, "maxMs": 60.8, "p95Ms": 60.8 }
     ],
     "napiWasmCli": [
       { "tool": "NAPI (.node)", "scale": "small (100 lines)", "medianMs": 0.049, "minMs": 0.048, "maxMs": 0.061, "p95Ms": 0.054 },

--- a/tests/benchmark/inprocess-rebuild.ts
+++ b/tests/benchmark/inprocess-rebuild.ts
@@ -22,11 +22,14 @@
 import { watch as zntcWatch } from '../../packages/core/index.ts';
 import { context as esbuildContext } from 'esbuild';
 import { rolldown } from 'rolldown';
-import { appendFileSync, mkdtempSync, rmSync, writeFileSync, symlinkSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const ITERATIONS = 10;
+// 단일 rebuild 가 GC 로 run-to-run 변동이 커, median 샘플 수를 늘려 안정화(10→50). 50 샘플
+// median 은 GC outlier 에 강건. 매 iteration 은 entry 를 append 가 아니라 baseSrc + 마커 1줄로
+// in-place 덮어써 파일 크기를 일정 유지(append 면 누적으로 파일이 커져 rebuild 가 무거워지는 confound 제거).
+const ITERATIONS = 50;
 const READY_TIMEOUT_MS = 15_000;
 const REBUILD_TIMEOUT_MS = 10_000;
 const SETTLE_MS = 200;
@@ -93,6 +96,7 @@ function summarize(arr: number[]) {
 async function measureZntc(fx: Fixture) {
   const dir = mkdtempSync(join(tmpdir(), `inp-zntc-${fx.name}-`));
   const { entry } = fx.build(dir);
+  const baseSrc = readFileSync(entry, 'utf8');
   const out = join(dir, 'out.js');
   const iters: number[] = [];
   let t0 = 0;
@@ -135,7 +139,7 @@ async function measureZntc(fx: Fixture) {
           }
         }, REBUILD_TIMEOUT_MS);
       });
-      appendFileSync(entry, `export const _i${i}=${i};console.log(_i${i});\n`);
+      writeFileSync(entry, `${baseSrc}\nexport const _b${i} = ${i};\nconsole.log(_b${i});\n`);
       t0 = performance.now();
       await p;
       await sleep(SETTLE_MS);
@@ -152,6 +156,7 @@ async function measureZntc(fx: Fixture) {
 async function measureEsbuild(fx: Fixture) {
   const dir = mkdtempSync(join(tmpdir(), `inp-esb-${fx.name}-`));
   const { entry } = fx.build(dir);
+  const baseSrc = readFileSync(entry, 'utf8');
   const out = join(dir, 'out.js');
   const iters: number[] = [];
   // 순수 rebuild — esbuild 의 documented incremental API `ctx.rebuild()`(컨텍스트 캐시 재사용).
@@ -169,7 +174,7 @@ async function measureEsbuild(fx: Fixture) {
   try {
     await sleep(SETTLE_MS);
     for (let i = 0; i < ITERATIONS; i++) {
-      appendFileSync(entry, `export const _i${i}=${i};console.log(_i${i});\n`);
+      writeFileSync(entry, `${baseSrc}\nexport const _b${i} = ${i};\nconsole.log(_b${i});\n`);
       const t0 = performance.now();
       await ctx.rebuild();
       iters.push(performance.now() - t0);
@@ -185,6 +190,7 @@ async function measureEsbuild(fx: Fixture) {
 async function measureRolldown(fx: Fixture) {
   const dir = mkdtempSync(join(tmpdir(), `inp-rd-${fx.name}-`));
   const { entry } = fx.build(dir);
+  const baseSrc = readFileSync(entry, 'utf8');
   const iters: number[] = [];
   // 순수 rebuild — rolldown() 빌드 객체 재사용 + generate() 재호출(변경 파일 re-read 후
   // incremental 재번들; lodash initial 20ms→re-gen 13ms 로 캐시 재사용 확인). watch 미경유.
@@ -195,7 +201,7 @@ async function measureRolldown(fx: Fixture) {
   try {
     await sleep(SETTLE_MS);
     for (let i = 0; i < ITERATIONS; i++) {
-      appendFileSync(entry, `export const _i${i}=${i};console.log(_i${i});\n`);
+      writeFileSync(entry, `${baseSrc}\nexport const _b${i} = ${i};\nconsole.log(_b${i});\n`);
       const t0 = performance.now();
       await bundle.generate({ format: 'esm' });
       iters.push(performance.now() - t0);


### PR DESCRIPTION
## 문제

증분 rebuild 벤치(`inprocess-rebuild.ts`)의 median 이 GC 로 run-to-run 변동이 컸습니다(zntc lodash 3.6~21ms 회마다). 또 매 iteration 이 entry 에 `appendFileSync` 로 누적해 파일이 커지는 confound + lodash 가 4회 중 3회 누락되는 flakiness 도 있었습니다.

## 수정

- **ITERATIONS 10→50**: median 샘플 5배 → GC 가 친 소수 iteration outlier 에 강건.
- **append → in-place `writeFileSync`**(baseSrc + 마커 1줄): 파일 크기를 일정하게 유지. 누적 증가 confound + lodash flakiness 의 원인이었습니다.

## 검증 (4회 연속)

- **lodash 누락 0** (4/4 모두 9 rows) — flakiness 해소.
- **median run-to-run <5%** 안정: zntc lodash 20.2/20.2/20.0/19.5, esbuild 55.2/55.8/55.8/55.3.

## 페이지 수치 갱신

이전 10-iter median-of-5 는 GC-lucky 저값이라, 50-iter 정직한 steady-state 로 교체:

| Fixture | zntc | esbuild | rolldown |
|---|---|---|---|
| tiny | **2.23** | 21.0 | 4.18 |
| medium | **2.73** | 22.9 | 6.50 |
| lodash | **20.0** | 55.5 | 43.7 |

ZNTC 여전히 최고속. 차트 설명 "median of 50 in-process rebuilds (constant-size in-place edit) — stable across runs". `astro build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)