### PR TITLE
fix(parser): #4142 깊은 prefix 타입연산자(keyof keyof…) 반복 파싱

### DIFF
--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -1074,6 +1074,33 @@ test "Parser: TS typeof and keyof" {
     try std.testing.expect(parser.errors.items.len == 0);
 }
 
+test "Parser: deep keyof chain does not overflow the stack (#4142)" {
+    // `keyof keyof … T` (수만 중첩) 는 parseTypeOperatorOrHigher 가 operand 를 **재귀** 파싱해
+    // 파서 스택 오버플로우(SIGSEGV)였다(#4142). 접두 연산자 반복 수집 → operand 1회 → 안쪽부터
+    // wrap 으로 전환해 해소(임의 깊이 파싱). 재귀로 되돌리면 이 테스트가 스택 오버플로우로 fail.
+    const n: usize = 50000; // 재귀판 크래시 임계(~수만)를 넉넉히 초과.
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(std.testing.allocator);
+    try src.appendSlice(std.testing.allocator, "type X = ");
+    var i: usize = 0;
+    while (i < n) : (i += 1) try src.appendSlice(std.testing.allocator, "keyof ");
+    try src.appendSlice(std.testing.allocator, "T;\n");
+
+    var scanner = try Scanner.init(std.testing.allocator, src.items);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    // 크래시 없이 파싱 완료 + 진단 0 + 정확히 N 개의 ts_type_operator wrapper 생성(AST 정확성).
+    try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
+    var ops: usize = 0;
+    for (parser.ast.nodes.items) |node| {
+        if (node.tag == .ts_type_operator) ops += 1;
+    }
+    try std.testing.expectEqual(n, ops);
+}
+
 // ============================================================
 // TypeScript declaration tests
 // ============================================================

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -773,66 +773,83 @@ fn parseIntersectionType(self: *Parser) ParseError2!NodeIndex {
 }
 
 /// oxc parse_type_operator_or_higher: keyof/unique/readonly/infer → postfix
+///
+/// 접두 타입연산자(keyof/readonly/unique symbol)는 원래 operand 를 **재귀** 파싱해
+/// `keyof keyof … T`(수만 중첩)에서 파서 스택 오버플로우였다(#4142, parseTypeOperatorOrHigher
+/// self-recursion). 접두 연산자를 반복 수집해 operand 를 1회 파싱하고 안쪽→바깥쪽으로 wrapper
+/// 노드를 만든다(재귀 제거 = postfix `T[]`/이항식과 동일한 비재귀 전략). `infer` 는 체인 대상이
+/// 아니라(자체 노드로 종료) operand 파서(parseTypeOperatorOperand)가 처리.
 fn parseTypeOperatorOrHigher(self: *Parser) ParseError2!NodeIndex {
-    if (self.current() == .identifier) {
+    // 접두 연산자 체인의 span.start 를 source 순(바깥→안쪽)으로 수집. 연산자가 없으면(대부분의
+    // 타입) append 가 안 일어나 무할당(.empty deinit=no-op) — 비-연산자 타입에 오버헤드 없음.
+    var op_starts: std.ArrayListUnmanaged(u32) = .empty;
+    defer op_starts.deinit(self.allocator);
+    while (self.current() == .identifier) {
         const text = self.tokenText();
-        // keyof T
         if (std.mem.eql(u8, text, "keyof") or std.mem.eql(u8, text, "readonly")) {
-            const span = self.currentSpan();
-            try self.advance();
-            const operand = try parseTypeOperatorOrHigher(self);
-            return try self.ast.addNode(.{
-                .tag = .ts_type_operator,
-                .span = .{ .start = span.start, .end = self.currentSpan().start },
-                .data = .{ .unary = .{ .operand = operand, .flags = 0 } },
-            });
-        }
-        // unique symbol → type operator. TS에서 unique는 symbol과만 결합 가능.
-        if (std.mem.eql(u8, text, "unique")) {
-            const next = try self.peekNextKind();
-            if (next == .identifier) {
-                const span = self.currentSpan();
-                try self.advance();
-                const operand = try parseTypeOperatorOrHigher(self);
-                return try self.ast.addNode(.{
-                    .tag = .ts_type_operator,
-                    .span = .{ .start = span.start, .end = self.currentSpan().start },
-                    .data = .{ .unary = .{ .operand = operand, .flags = 0 } },
-                });
+            // keyof T / readonly T
+        } else if (std.mem.eql(u8, text, "unique") and (try self.peekNextKind()) == .identifier) {
+            // unique symbol → type operator (TS 에서 unique 는 symbol 과만 결합). 뒤가 식별자가
+            // 아니면 연산자가 아니라 type reference 라 체인에서 제외(operand 로 흘려보냄).
+        } else break;
+        try op_starts.append(self.allocator, self.currentSpan().start);
+        try self.advance();
+    }
+
+    // 체인 끝의 operand (infer 또는 postfix). 접두 연산자가 없으면 이게 곧 결과.
+    const operand = try parseTypeOperatorOperand(self);
+    if (op_starts.items.len == 0) return operand;
+
+    // 안쪽(체인 끝 = op_starts 마지막)부터 바깥쪽(op_starts 처음)으로 wrap. 모든 wrapper 의
+    // span.end 는 operand 파싱 직후 위치 — 재귀판도 그 사이 advance 가 없어 전부 같은 값이었다.
+    const end = self.currentSpan().start;
+    var node = operand;
+    var i = op_starts.items.len;
+    while (i > 0) {
+        i -= 1;
+        node = try self.ast.addNode(.{
+            .tag = .ts_type_operator,
+            .span = .{ .start = op_starts.items[i], .end = end },
+            .data = .{ .unary = .{ .operand = node, .flags = 0 } },
+        });
+    }
+    return node;
+}
+
+/// 접두 타입연산자(parseTypeOperatorOrHigher) 체인 끝의 operand: `infer T (extends C)?` 또는
+/// disallow_conditional_types 해제 후 postfix 타입. (재귀판에서 parseTypeOperatorOrHigher 가
+/// 접두 연산자가 아닐 때 하던 일을 그대로 분리 — #4142.)
+fn parseTypeOperatorOperand(self: *Parser) ParseError2!NodeIndex {
+    // infer T (extends C)?
+    if (self.current() == .identifier and std.mem.eql(u8, self.tokenText(), "infer")) {
+        const span = self.currentSpan();
+        try self.advance(); // skip 'infer'
+        // infer의 타입 파라미터 이름
+        try self.advance(); // type param name
+        // 선택적 constraint: infer T extends U (TS 4.7+)
+        // oxc try_parse_constraint_of_infer_type 대응:
+        // speculative 파싱으로 constraint 시도. extends 뒤에 타입을 파싱하되,
+        // 외부가 disallow_conditional_types가 아닌데 ? 가 오면 rollback
+        // (그 extends는 조건부 타입의 extends이므로 infer constraint가 아님)
+        if (self.current() == .kw_extends) {
+            const infer_saved = self.saveState();
+            const infer_err_count = self.errors.items.len;
+            try self.advance(); // skip 'extends'
+            // constraint 타입: parseType with disallow_conditional_types=true
+            const ctx_saved = self.ctx;
+            self.ctx.disallow_conditional_types = true;
+            _ = try parseType(self);
+            self.ctx = ctx_saved;
+            // 외부 컨텍스트가 disallow가 아닌데 ? 가 오면 → extends는 조건부 타입의 것
+            if (!ctx_saved.disallow_conditional_types and self.current() == .question) {
+                self.restoreState(infer_saved);
+                self.rollbackErrors(infer_err_count);
             }
-            // unique 단독 — type reference로 처리 (아래 fallthrough)
         }
-        // infer T (extends C)?
-        if (std.mem.eql(u8, text, "infer")) {
-            const span = self.currentSpan();
-            try self.advance(); // skip 'infer'
-            // infer의 타입 파라미터 이름
-            try self.advance(); // type param name
-            // 선택적 constraint: infer T extends U (TS 4.7+)
-            // oxc try_parse_constraint_of_infer_type 대응:
-            // speculative 파싱으로 constraint 시도. extends 뒤에 타입을 파싱하되,
-            // 외부가 disallow_conditional_types가 아닌데 ? 가 오면 rollback
-            // (그 extends는 조건부 타입의 extends이므로 infer constraint가 아님)
-            if (self.current() == .kw_extends) {
-                const infer_saved = self.saveState();
-                const infer_err_count = self.errors.items.len;
-                try self.advance(); // skip 'extends'
-                // constraint 타입: parseType with disallow_conditional_types=true
-                const ctx_saved = self.ctx;
-                self.ctx.disallow_conditional_types = true;
-                _ = try parseType(self);
-                self.ctx = ctx_saved;
-                // 외부 컨텍스트가 disallow가 아닌데 ? 가 오면 → extends는 조건부 타입의 것
-                if (!ctx_saved.disallow_conditional_types and self.current() == .question) {
-                    self.restoreState(infer_saved);
-                    self.rollbackErrors(infer_err_count);
-                }
-            }
-            return try self.ast.addEmptyExtraNode(
-                .ts_infer_type,
-                .{ .start = span.start, .end = self.currentSpan().start },
-            );
-        }
+        return try self.ast.addEmptyExtraNode(
+            .ts_infer_type,
+            .{ .start = span.start, .end = self.currentSpan().start },
+        );
     }
 
     // disallow_conditional_types 해제하여 postfix 파싱 (oxc L274-277)


### PR DESCRIPTION
## 배경 (#4142)

`#4123`(재귀 AST visitor 스택 오버플로우)을 마무리하던 중 파생 발견된 **파서** 측 재귀 오버플로우입니다. AST visitor 가 아니라 `src/parser/ts.zig` 의 재귀-하강에서 발생합니다.

```ts
type X = keyof keyof keyof … (수만 개) … T;
```

`parseTypeOperatorOrHigher` 가 접두 타입연산자(`keyof`/`readonly`/`unique symbol`)의 operand 를 **재귀** 파싱해, 연산자가 깊게 중첩되면 파서 스택이 터졌습니다(SIGSEGV).

```
src/parser/ts.zig:783: parseTypeOperatorOrHigher
  const operand = try parseTypeOperatorOrHigher(self);   // ← self-recursion
… (수만 프레임) … → Segmentation fault
```

> 💡 **Zig 초보 설명**: 재귀 하강 파서는 문법 규칙마다 함수를 호출합니다. `keyof X` 를 만나면 "operand(X)를 파싱"하려고 자기 자신을 다시 호출하죠. `keyof` 가 N개 중첩되면 함수 호출이 N번 쌓여 스택(약 8MB) 초과 시 크래시. 해법은 **접두 연산자를 `while` 루프로 먼저 다 모으고**(`keyof`가 몇 개인지 세고), operand 는 **한 번만** 파싱한 뒤, 모아둔 연산자로 **안쪽부터 바깥쪽으로** AST 래퍼 노드를 만드는 것입니다 — 재귀가 사라져 임의 깊이를 견딥니다. (postfix `T[]` 와 이항식은 이미 이런 비재귀 방식이었습니다.)

## 변경

`parseTypeOperatorOrHigher` 를 재귀 → 반복으로 전환:
1. `while` 루프로 `keyof`/`readonly`/`unique symbol` 접두 연산자의 `span.start` 를 source 순(바깥→안쪽)으로 수집.
2. operand 를 **1회** 파싱 — `infer` 처리 + `disallow_conditional_types` 해제 후 postfix fallthrough 를 새 헬퍼 `parseTypeOperatorOperand` 로 분리(재귀판에서 접두 연산자가 아닐 때 하던 일 그대로).
3. 수집한 연산자를 **안쪽(체인 끝)→바깥쪽** 순으로 `ts_type_operator` 래퍼 노드로 wrap. 모든 래퍼의 `span.end` 는 operand 파싱 직후 위치(재귀판도 그 사이 advance 가 없어 전부 같은 값).

- **`infer` 는 접두 체인 대상이 아닙니다**(자체 노드로 종료) — operand 파서가 처리해 `keyof infer T` 같은 조합도 동일하게 동작.
- **비-연산자 타입은 무할당**: `op_starts` 는 빈 `ArrayList` 로 시작해 연산자가 있을 때만 append → 대부분의 타입 파싱엔 오버헤드 0.

## 검증

- **byte-identical** (baseline `cf7f1c76` 대비): **736 TS fixture runs** + `keyof`/`readonly`/`unique symbol`/`infer`/`typeof` 혼합 케이스 + lodash-es/date-fns 번들 — **전부 동일**. 순수 파서 리팩토링이라 유효 입력의 AST/출력은 불변.
- **crash → survive**:
  | fixture | baseline (cf7f1c76) | 본 PR |
  |---|---|---|
  | `keyof × 60000 T` | **SIGSEGV(139)** | exit 0 (출력 `export const v = 0;`) |
  | `keyof readonly × 40000 T` | **SIGSEGV(139)** | exit 0 |
- **회귀 유닛테스트**: `Parser: deep keyof chain does not overflow (#4142)` — `keyof × 50000` 파싱이 진단 0 + 정확히 N개의 `ts_type_operator` 래퍼 생성(AST 정확성). 재귀로 되돌리면 이 테스트가 스택 오버플로우로 fail.
- `zig build test` 통과, `/code-review max` 무발견.

## 범위

접두 타입연산자 체인(`keyof`/`readonly`/`unique symbol`)만 다룹니다. 다른 깊은-중첩 타입 구문(parenthesized `(((T)))`, conditional `A extends B ? … : …`, function `() => () => …`)의 파서 재귀가 별도로 존재할 수 있으나 #4142 범위 밖입니다 — 필요 시 별도 이슈로.

Closes #4142

🤖 Generated with [Claude Code](https://claude.com/claude-code)