### PR TITLE
feat(codegen): precedence Level enum + 연산자 테이블 추가 (#4042 PR1)

### DIFF
--- a/src/codegen/mod.zig
+++ b/src/codegen/mod.zig
@@ -23,6 +23,7 @@ pub const function_map = @import("function_map.zig");
 pub const FunctionMapBuilder = function_map.FunctionMapBuilder;
 pub const mangler = @import("mangler.zig");
 pub const unified_mangler = @import("unified_mangler.zig");
+pub const precedence = @import("precedence.zig");
 
 test {
     _ = codegen;
@@ -31,9 +32,11 @@ test {
     _ = function_map;
     _ = mangler;
     _ = unified_mangler;
+    _ = precedence;
 
     // test files
     _ = @import("codegen_test.zig");
     _ = @import("sourcemap_test.zig");
     _ = @import("mangler_test.zig");
+    _ = @import("precedence_test.zig");
 }

--- a/src/codegen/precedence.zig
+++ b/src/codegen/precedence.zig
@@ -1,0 +1,96 @@
+//! Operator precedence levels for the code generator's parenthesization model.
+//!
+//! esbuild `internal/js_ast/js_ast.go` 의 `L` enum / `OpTable` 과 **동일한 상대
+//! 순서**를 따른다 (oxc `oxc_syntax::precedence::Precedence` 도 같은 값을 복제).
+//! 값이 클수록 더 강하게 묶인다(tighter binding). codegen 의
+//! `emitExpr(node, level, flags)` 가 부모→자식으로 "이 위치에서 괄호 없이
+//! 허용되는 최소 결합 강도" 를 내려보내고, 자식은 `자기 level <= 부모가 요구한
+//! level` 이면(= `level.gte(entry)`) 괄호로 감싼다. 결합성은 자식에 내려보내는
+//! level 을 ±1(`entry.lower()`) 로 인코딩한다.
+//!
+//! 주의 — parser 의 `expression/type_args.zig:getBinaryPrecedence` 와 **별개
+//! 도메인**이다. 그쪽은 Pratt 파싱 전용(이항 11단계, `||`/`??` 를 동일 레벨 1
+//! 로 둠)이고, 여기 Level 은 단항/postfix/new/call/member 까지 포함하는 23단계
+//! 이며 `??` 와 `||`/`&&` 를 분리한다(ECMAScript 가 괄호 없는 혼용을 금지하므로
+//! codegen 은 둘을 구분해야 한다). 두 표를 통합하면 양쪽 제약이 섞여 버그를
+//! 유발하므로 통합하지 않는다. 이 파일은 PR1 시점에는 호출처가 없는 인프라이며,
+//! emitExpr 전환(후속 PR)에서 사용된다.
+
+const Kind = @import("../lexer/token.zig").Kind;
+
+/// 연산자/표현식 결합 강도. esbuild `L` 과 동일 순서이므로 `@intFromEnum` 정수
+/// 비교로 강도를 잰다 (값이 클수록 더 강하게 묶임).
+pub const Level = enum(u8) {
+    lowest = 0,
+    comma,
+    spread,
+    yield,
+    assign,
+    conditional,
+    nullish_coalescing,
+    logical_or,
+    logical_and,
+    bitwise_or,
+    bitwise_xor,
+    bitwise_and,
+    equals,
+    compare,
+    shift,
+    add,
+    multiply,
+    exponentiation,
+    prefix,
+    postfix,
+    new,
+    call,
+    member,
+
+    /// 한 단계 약하게(괄호를 더 잘 침). 결합성 인코딩에서
+    /// `leftLevel`/`rightLevel = entry.lower()` 로 쓴다. `lowest` 는 0 에서
+    /// 멈춰 underflow 를 막는다(0 아래로 내려갈 일은 없다).
+    pub fn lower(self: Level) Level {
+        const v = @intFromEnum(self);
+        return @enumFromInt(if (v == 0) 0 else v - 1);
+    }
+
+    /// `self >= other` (자기 결합 강도가 부모가 요구한 최소 강도 이상인가).
+    /// codegen 의 `wrap := level >= entry.Level` 한 줄에 대응한다.
+    pub fn gte(self: Level, other: Level) bool {
+        return @intFromEnum(self) >= @intFromEnum(other);
+    }
+};
+
+/// `binary_expression` / `logical_expression` 의 연산자 Kind → Level.
+/// 이항/논리 연산자가 아니면 null (assignment 는 별도 노드, comma 는 sequence
+/// 노드로 따로 처리). esbuild `OpTable` 의 `BinOp*` 항목과 1:1.
+pub fn binaryOpLevel(op: Kind) ?Level {
+    return switch (op) {
+        .star2 => .exponentiation, // **  (우결합)
+        .star, .slash, .percent => .multiply, // * / %
+        .plus, .minus => .add, // + -
+        .shift_left, .shift_right, .shift_right3 => .shift, // << >> >>>
+        .l_angle, .r_angle, .lt_eq, .gt_eq, .kw_in, .kw_instanceof => .compare, // < <= > >= in instanceof
+        .eq2, .neq, .eq3, .neq2 => .equals, // == != === !==
+        .amp => .bitwise_and, // &
+        .caret => .bitwise_xor, // ^
+        .pipe => .bitwise_or, // |
+        .amp2 => .logical_and, // &&
+        .pipe2 => .logical_or, // ||
+        .question2 => .nullish_coalescing, // ??
+        else => null,
+    };
+}
+
+/// 이항 연산자가 좌결합인지. `**`(우결합)와 비-이항만 false.
+/// esbuild `IsLeftAssociative`: `BinOpAdd <= op < BinOpComma && op != BinOpPow`.
+pub fn isLeftAssociative(op: Kind) bool {
+    return binaryOpLevel(op) != null and op != .star2;
+}
+
+/// 이항 연산자가 우결합인지. esbuild `IsRightAssociative`:
+/// `op >= BinOpAssign || op == BinOpPow`. zntc 에서 assignment 는 별도 노드
+/// (`assignment_expression`)라 binary 연산자 Kind 에는 들어오지 않으므로
+/// 여기서는 `**` 만 해당한다.
+pub fn isRightAssociative(op: Kind) bool {
+    return op == .star2;
+}

--- a/src/codegen/precedence_test.zig
+++ b/src/codegen/precedence_test.zig
@@ -1,0 +1,101 @@
+//! precedence.zig 단위 검증 — Level 순서/매핑이 esbuild `OpTable` 과 1:1 인지.
+//! (PR1: 인프라만. 호출처는 후속 emitExpr 전환 PR 에서 생긴다.)
+
+const std = @import("std");
+const p = @import("precedence.zig");
+const Level = p.Level;
+const Kind = @import("../lexer/token.zig").Kind;
+
+test "precedence: Level enum 순서가 esbuild L 과 동일 (lowest=0 .. member=22)" {
+    const order = [_]Level{
+        .lowest,      .comma,          .spread,             .yield,
+        .assign,      .conditional,    .nullish_coalescing, .logical_or,
+        .logical_and, .bitwise_or,     .bitwise_xor,        .bitwise_and,
+        .equals,      .compare,        .shift,              .add,
+        .multiply,    .exponentiation, .prefix,             .postfix,
+        .new,         .call,           .member,
+    };
+    try std.testing.expectEqual(@as(usize, 23), order.len);
+    for (order, 0..) |lvl, i| {
+        try std.testing.expectEqual(@as(u8, @intCast(i)), @intFromEnum(lvl));
+    }
+}
+
+test "precedence: binaryOpLevel 가 esbuild OpTable 과 1:1" {
+    const cases = [_]struct { Kind, Level }{
+        .{ .star2, .exponentiation },
+        .{ .star, .multiply },
+        .{ .slash, .multiply },
+        .{ .percent, .multiply },
+        .{ .plus, .add },
+        .{ .minus, .add },
+        .{ .shift_left, .shift },
+        .{ .shift_right, .shift },
+        .{ .shift_right3, .shift },
+        .{ .l_angle, .compare },
+        .{ .r_angle, .compare },
+        .{ .lt_eq, .compare },
+        .{ .gt_eq, .compare },
+        .{ .kw_in, .compare },
+        .{ .kw_instanceof, .compare },
+        .{ .eq2, .equals },
+        .{ .neq, .equals },
+        .{ .eq3, .equals },
+        .{ .neq2, .equals },
+        .{ .amp, .bitwise_and },
+        .{ .caret, .bitwise_xor },
+        .{ .pipe, .bitwise_or },
+        .{ .amp2, .logical_and },
+        .{ .pipe2, .logical_or },
+        .{ .question2, .nullish_coalescing },
+    };
+    for (cases) |c| {
+        try std.testing.expectEqual(@as(?Level, c[1]), p.binaryOpLevel(c[0]));
+    }
+}
+
+test "precedence: 비-이항 Kind 는 null" {
+    try std.testing.expectEqual(@as(?Level, null), p.binaryOpLevel(.identifier));
+    try std.testing.expectEqual(@as(?Level, null), p.binaryOpLevel(.kw_function));
+}
+
+test "precedence: 이항 상대 순서 (** > * > + > << > < > == > & > ^ > | > && > || > ??)" {
+    const gt = struct {
+        fn f(a: Kind, b: Kind) bool {
+            return @intFromEnum(p.binaryOpLevel(a).?) > @intFromEnum(p.binaryOpLevel(b).?);
+        }
+    }.f;
+    try std.testing.expect(gt(.star2, .star)); // ** > *
+    try std.testing.expect(gt(.star, .plus)); // * > +
+    try std.testing.expect(gt(.plus, .shift_left)); // + > <<
+    try std.testing.expect(gt(.shift_left, .l_angle)); // << > <
+    try std.testing.expect(gt(.l_angle, .eq2)); // < > ==
+    try std.testing.expect(gt(.eq2, .amp)); // == > &
+    try std.testing.expect(gt(.amp, .caret)); // & > ^
+    try std.testing.expect(gt(.caret, .pipe)); // ^ > |
+    try std.testing.expect(gt(.pipe, .amp2)); // | > &&
+    try std.testing.expect(gt(.amp2, .pipe2)); // && > ||
+    try std.testing.expect(gt(.pipe2, .question2)); // || > ??
+}
+
+test "precedence: 결합성 — 이항은 좌결합, ** 만 우결합" {
+    try std.testing.expect(p.isLeftAssociative(.plus));
+    try std.testing.expect(p.isLeftAssociative(.star));
+    try std.testing.expect(p.isLeftAssociative(.pipe2));
+    try std.testing.expect(!p.isLeftAssociative(.star2)); // ** 는 우결합
+    try std.testing.expect(!p.isLeftAssociative(.identifier)); // 비-이항
+
+    try std.testing.expect(p.isRightAssociative(.star2));
+    try std.testing.expect(!p.isRightAssociative(.plus));
+    try std.testing.expect(!p.isRightAssociative(.identifier));
+}
+
+test "precedence: lower/gte" {
+    try std.testing.expectEqual(Level.lowest, Level.lowest.lower()); // 0 에서 멈춤(underflow 방지)
+    try std.testing.expectEqual(Level.comma, Level.spread.lower());
+    try std.testing.expectEqual(Level.multiply, Level.exponentiation.lower());
+
+    try std.testing.expect(Level.member.gte(Level.lowest));
+    try std.testing.expect(Level.multiply.gte(Level.multiply)); // 같으면 true (>=)
+    try std.testing.expect(!Level.add.gte(Level.multiply));
+}


### PR DESCRIPTION
## 배경 (에픽 #4042)

zntc의 codegen은 지금 **paren-node 기반**입니다 — parser가 만든 `parenthesized_expression`(괄호) 노드를 만나면 `(` `)`를 그대로 출력할 뿐, 연산자 우선순위로 괄호를 출력 시점에 다시 만들어내지 않습니다. 반면 esbuild·oxc·swc·babel·tsc·terser 등 메이저 도구는 전부 **precedence 기반**(출력할 때 `needsParens(부모, 자식, 위치)`로 괄호를 삽입)입니다.

이 차이가 "load-bearing 괄호 유실" 버그 부류를 낳습니다. 노드를 떼거나 재구성하는 변환(타입 strip, optional-chain/class lowering, minify)이 괄호 노드를 제거하면 codegen이 **그 괄호를 되살릴 능력이 없어** 잘못된 코드가 나옵니다. 예: `(a?.b).c`는 `a`가 nullish면 `.c`에서 throw인데, 괄호를 잃은 `a?.b.c`는 전체 short-circuit → `undefined`라 의미가 달라집니다. 같은 뿌리의 버그가 5건 이상 적발됐습니다(#4042 참조).

해결 방향은 **esbuild/oxc와 동일한 풀 precedence 전환**(괄호 정확성을 codegen 한 곳에 집중)이며, 이 PR은 그 전환의 **첫 인프라 단계**입니다.

## 이 PR이 하는 일

`src/codegen/precedence.zig` (신규)에 esbuild `internal/js_ast/js_ast.go`의 `L` enum / `OpTable`을 1:1 이식합니다.

- `Level` enum: `lowest`(0) ~ `member`(22)의 23단계 결합 강도. **값이 클수록 더 강하게 묶입니다**(tighter binding). 후속 PR의 `emitExpr(node, level, flags)`가 부모→자식으로 "이 위치에서 괄호 없이 허용되는 최소 결합 강도"를 내려보내고, 자식은 `자기 level <= 부모 요구 level`이면 괄호로 감쌉니다.
- `binaryOpLevel(Kind)`: 이항/논리 연산자 token `Kind` → `Level` 매핑.
- `isLeftAssociative` / `isRightAssociative`: 결합성(좌결합 전부 + `**`만 우결합).
- `lower()` / `gte()`: 결합성 인코딩(자식 level ±1)과 `level >= entry` 비교 헬퍼.

> **Zig 초보자 메모**: Zig의 `enum(u8)`은 각 멤버에 정수 값을 줍니다(`lowest=0`부터 자동 증가). `@intFromEnum`으로 정수를 꺼내 비교하면 esbuild Go 코드의 `level >= entry.Level` 한 줄과 똑같이 동작합니다. `@enumFromInt`은 반대로 정수→enum인데, `lower()`에서 0 미만으로 내려가지 않도록 `if (v == 0) 0 else v - 1`로 막아 ReleaseSafe에서도 패닉이 없습니다.

## 별개 도메인으로 분리한 이유

parser에도 `expression/type_args.zig:getBinaryPrecedence`라는 우선순위 함수가 있지만, 그건 **Pratt 파싱 전용**(이항 11단계, `||`와 `??`를 같은 레벨로 둠)입니다. codegen Level은 단항/postfix/new/call/member까지 포함하는 23단계이고 `??`와 `||`/`&&`를 분리합니다(ECMAScript가 괄호 없는 혼용을 금지하므로 codegen은 둘을 구분해야 함). 두 표를 통합하면 양쪽 제약이 섞여 버그를 유발하므로 **의도적으로 분리**했습니다(파일 주석에 명시).

## 안전성 / 게이트

- **byte-identical**: 아직 호출처가 없는 dead code입니다. 출력은 전혀 바뀌지 않습니다.
- ✅ `zig build test` 전체 통과 (회귀 0)
- ✅ `precedence_test.zig`: esbuild `OpTable`과 1:1 매핑, JS 우선순위 상대순서(`** > * > + > << > < > == > & > ^ > | > && > || > ??`), 결합성, `lower/gte`를 독립 작성한 기댓값으로 교차검증
- token `Kind` 의미는 `src/lexer/token.zig` + 검증된 parser `getBinaryPrecedence` 양쪽으로 대조 확인

## 다음 단계

PR2(emitExpr 스캐폴드 + statement-start 마킹, byte-identical) → PR3(new/call/optional-chain 컨텍스트 괄호) → PR4+5(이항/단항 precedence wrap + paren 투명화, 여기서 처음으로 스냅샷 변경) → PR6(statement-start) → PR7(transformer 합성 제거). 회귀는 byte 대신 **semantic equivalence**(esbuild 재파싱 정규화 oracle + 런타임 동작 + load-bearing 괄호 매트릭스)로 검증합니다.

Refs #4042

🤖 Generated with [Claude Code](https://claude.com/claude-code)