### PR TITLE
feat(codegen): emitExpr(level,flags) 스캐폴드 + statement-start 필드 (#4042 PR2)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -84,6 +84,17 @@ pub const Codegen = struct {
     /// `(void 0)` 으로 재작성할 때, lvalue 위치(`ns.x = 1` → `(void 0)=1`)면 SyntaxError
     /// 가 되므로 그 경우엔 재작성을 건너뛴다.
     member_assign_target: bool = false,
+    /// statement-start 모호성 추적 (esbuild `stmtStart`/`exportDefaultStart`/
+    /// `arrowExprStart`/`forOfInitStart`). 각 컨텍스트의 첫 토큰을 출력하기 직전
+    /// 현재 `buf.items.len` 으로 마킹하고, expression emitter 가 진입 시
+    /// `buf.items.len` 이 마크와 같으면 "내가 그 컨텍스트의 첫 토큰" 으로 판정해
+    /// 괄호를 친다 (`({}).x`, `(function(){})()`, `(class{})`, `(let)[x]`).
+    /// `maxInt` = 미마킹(절대 매치 안 됨). (PR2: 필드만 도입. 실제 마킹/판정은
+    /// statement-start 를 다루는 후속 PR.)
+    stmt_start: usize = std.math.maxInt(usize),
+    export_default_start: usize = std.math.maxInt(usize),
+    arrow_expr_start: usize = std.math.maxInt(usize),
+    for_of_init_start: usize = std.math.maxInt(usize),
     pub fn init(allocator: std.mem.Allocator, ast: *const Ast) Codegen {
         return initWithOptions(allocator, ast, .{});
     }
@@ -304,6 +315,7 @@ pub const Codegen = struct {
     pub const Error = std.mem.Allocator.Error;
     const node_dispatch_emit = @import("node_dispatch.zig");
     pub const emitNode = node_dispatch_emit.emitNode;
+    pub const emitExpr = node_dispatch_emit.emitExpr;
 
     /// identifier 노드의 symbol_id를 해결.
     /// symbol_ids[node_i]에서 직접 조회 (트랜스포머의 propagateSymbolId로 전파된 값).

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -12,6 +12,9 @@ const expression_emit = @import("expressions.zig");
 const call_emit = @import("calls.zig");
 const function_class_emit = @import("function_class.zig");
 const binding_emit = @import("bindings.zig");
+const precedence = @import("precedence.zig");
+const Level = precedence.Level;
+const ExprFlags = precedence.ExprFlags;
 
 const Error = std.mem.Allocator.Error;
 
@@ -226,36 +229,37 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
             try self.write("super");
         },
 
-        // Expressions
-        .unary_expression => try expression_emit.emitUnary(self, node),
-        .update_expression => try expression_emit.emitUpdate(self, node),
-        .binary_expression, .logical_expression => try expression_emit.emitBinary(self, node),
-        .assignment_expression => try expression_emit.emitAssignment(self, node),
-        .conditional_expression => try expression_emit.emitConditional(self, node),
-        .sequence_expression => try expression_emit.emitSequence(self, node),
-        .parenthesized_expression => try expression_emit.emitParen(self, node),
-        .spread_element => try expression_emit.emitSpread(self, node),
-        .await_expression => try expression_emit.emitAwait(self, node),
-        .yield_expression => try expression_emit.emitYield(self, node),
-        .array_expression => try expression_emit.emitArray(self, node),
-        .object_expression => try expression_emit.emitObject(self, node),
-        .object_property => try expression_emit.emitObjectProperty(self, node),
-        .computed_property_key => try expression_emit.emitComputedKey(self, node),
-        .static_member_expression => try expression_emit.emitStaticMember(self, node),
-        .computed_member_expression => try expression_emit.emitComputedMember(self, node),
-        .private_field_expression => try expression_emit.emitStaticMember(self, node),
-        .call_expression => try call_emit.emitCall(self, node),
-        .new_expression => try call_emit.emitNew(self, node),
-        .template_literal => try function_class_emit.emitTemplateLiteral(self, node),
-        .template_element => {
-            try self.addSourceMapping(node.span);
-            try self.writeNodeSpan(node);
-        },
-        .tagged_template_expression => try function_class_emit.emitTaggedTemplate(self, node),
-        .import_expression => try call_emit.emitImportExpr(self, node),
-        .meta_property => try call_emit.emitMetaProperty(self, node),
-        // chain_expression / TS·Flow type-cast: transparent wrapper — operand 가 자기 매핑 발행.
-        .chain_expression => try self.emitNode(node.data.unary.operand),
+        // Expressions — precedence-aware 경로(emitExpr)로 위임한다.
+        // (PR2: emitNode 는 항상 level=.lowest / flags=.{} 로 호출하므로 출력은
+        //  기존 paren 노드 기반과 동일=byte-identical. 후속 PR 에서 부모가 적절한
+        //  level/flags 를 내려보내고 emitExpr 가 precedence 로 괄호를 재유도한다.)
+        .unary_expression,
+        .update_expression,
+        .binary_expression,
+        .logical_expression,
+        .assignment_expression,
+        .conditional_expression,
+        .sequence_expression,
+        .parenthesized_expression,
+        .spread_element,
+        .await_expression,
+        .yield_expression,
+        .array_expression,
+        .object_expression,
+        .object_property,
+        .computed_property_key,
+        .static_member_expression,
+        .computed_member_expression,
+        .private_field_expression,
+        .call_expression,
+        .new_expression,
+        .template_literal,
+        .template_element,
+        .tagged_template_expression,
+        .import_expression,
+        .meta_property,
+        .chain_expression,
+        => try emitExpr(self, idx, .lowest, .{}),
 
         // Functions / Classes
         .function_declaration, .function_expression, .function => try function_class_emit.emitFunction(self, node),
@@ -351,5 +355,55 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
             try self.addSourceMapping(node.span);
             try self.writeNodeSpan(node);
         },
+    }
+}
+
+/// Expression 전용 emit 진입점 (esbuild `printExpr(expr, level, flags)`).
+/// `level` 은 "이 위치에서 괄호 없이 허용되는 최소 결합 강도", `flags` 는
+/// precedence 만으로 표현 못 하는 컨텍스트 괄호 조건이다.
+///
+/// PR2 단계: `level`/`flags` 를 받기만 하고 사용하지 않는다 — 괄호는 여전히 AST
+/// 의 `parenthesized_expression` 노드(emitParen)가 담당하므로 출력은 emitNode
+/// 시절과 byte-identical 하다. 후속 PR 에서 각 case 진입부에 `wrap` 계산이
+/// 추가되고, 자식 호출이 `emitNode` → `emitExpr(child, childLevel, childFlags)`
+/// 로 이행한다.
+///
+/// 진입 보장: emitNode 의 expression case 가 skip/comment/transparent-wrapper
+/// 처리를 마친 뒤 정확히 아래 tag 들로만 위임하므로, 다른 tag 는 `unreachable`.
+pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) Error!void {
+    _ = level;
+    _ = flags;
+    const node = self.ast.getNode(idx);
+    switch (node.tag) {
+        .unary_expression => try expression_emit.emitUnary(self, node),
+        .update_expression => try expression_emit.emitUpdate(self, node),
+        .binary_expression, .logical_expression => try expression_emit.emitBinary(self, node),
+        .assignment_expression => try expression_emit.emitAssignment(self, node),
+        .conditional_expression => try expression_emit.emitConditional(self, node),
+        .sequence_expression => try expression_emit.emitSequence(self, node),
+        .parenthesized_expression => try expression_emit.emitParen(self, node),
+        .spread_element => try expression_emit.emitSpread(self, node),
+        .await_expression => try expression_emit.emitAwait(self, node),
+        .yield_expression => try expression_emit.emitYield(self, node),
+        .array_expression => try expression_emit.emitArray(self, node),
+        .object_expression => try expression_emit.emitObject(self, node),
+        .object_property => try expression_emit.emitObjectProperty(self, node),
+        .computed_property_key => try expression_emit.emitComputedKey(self, node),
+        .static_member_expression => try expression_emit.emitStaticMember(self, node),
+        .computed_member_expression => try expression_emit.emitComputedMember(self, node),
+        .private_field_expression => try expression_emit.emitStaticMember(self, node),
+        .call_expression => try call_emit.emitCall(self, node),
+        .new_expression => try call_emit.emitNew(self, node),
+        .template_literal => try function_class_emit.emitTemplateLiteral(self, node),
+        .template_element => {
+            try self.addSourceMapping(node.span);
+            try self.writeNodeSpan(node);
+        },
+        .tagged_template_expression => try function_class_emit.emitTaggedTemplate(self, node),
+        .import_expression => try call_emit.emitImportExpr(self, node),
+        .meta_property => try call_emit.emitMetaProperty(self, node),
+        // chain_expression / TS·Flow type-cast: transparent wrapper — operand 가 자기 매핑 발행.
+        .chain_expression => try self.emitNode(node.data.unary.operand),
+        else => unreachable,
     }
 }

--- a/src/codegen/precedence.zig
+++ b/src/codegen/precedence.zig
@@ -94,3 +94,19 @@ pub fn isLeftAssociative(op: Kind) bool {
 pub fn isRightAssociative(op: Kind) bool {
     return op == .star2;
 }
+
+/// 컨텍스트 의존 괄호 플래그 — precedence(Level)만으로 표현할 수 없는 괄호
+/// 조건을 부모→자식으로 전파한다. esbuild `printExprFlags`(js_printer.go) 의
+/// 부분 집합으로, 필요한 flag 는 후속 PR 에서 추가한다. (PR2: 정의만. 실제
+/// 발동은 new/call·optional-chain·for-init 을 다루는 후속 PR 에서.)
+pub const ExprFlags = packed struct {
+    /// `new X` 의 타겟 안 — 자식이 호출이면 괄호 (`new (foo())`). esbuild
+    /// `forbidCall`.
+    forbid_call: bool = false,
+    /// for-loop init 절 안 — `in` 연산자가 for-in 헤더로 오파싱되지 않도록
+    /// 괄호 필요. esbuild `forbidIn`.
+    forbid_in: bool = false,
+    /// 부모가 non-optional 멤버/호출 — 자식이 optional chain 의 시작이면 괄호로
+    /// 체인을 끊어 보존 (`(a?.b).c`). esbuild `hasNonOptionalChainParent`.
+    has_non_optional_chain_parent: bool = false,
+};


### PR DESCRIPTION
## 배경 (에픽 #4042, PR2/7)

codegen을 esbuild/oxc식 **precedence 기반 괄호 재유도**로 전환하는 인프라 2단계입니다. [PR1(#4148)](https://github.com/ohah/zntc/pull/4148)에서 `Level` enum/연산자 테이블을 깔았고, 이 PR은 그것을 나를 **진입점**을 만듭니다. 아직 괄호 동작은 바꾸지 않습니다.

## 이 PR이 하는 일

esbuild `printExpr(expr, level, flags)`와 동형으로 **expression 전용 emit 진입점** `emitExpr(idx, level, flags)`를 추가하고, `emitNode`의 expression dispatch(26개 tag)를 거기로 위임합니다.

- `node_dispatch.zig`: `emitExpr` 신설. `emitNode`의 expression case 26개를 한 묶음으로 `emitExpr(self, idx, .lowest, .{})` 위임. dispatch 로직(같은 emitter 호출)은 `emitExpr` 내부로 그대로 이동.
- `precedence.zig`: `ExprFlags` packed struct 정의 — precedence(Level)만으로 표현 못 하는 컨텍스트 괄호 조건(`forbid_call`/`forbid_in`/`has_non_optional_chain_parent`, esbuild `printExprFlags` 부분집합).
- `codegen.zig`: `Codegen`에 statement-start 추적 필드 4개(`stmt_start`/`export_default_start`/`arrow_expr_start`/`for_of_init_start`, `maxInt` sentinel) 추가 + `emitExpr` 노출.

> **Zig 초보자 메모**: `emitExpr`는 지금 `_ = level; _ = flags;`로 두 인자를 버립니다. 괄호는 여전히 AST의 `parenthesized_expression` 노드(`emitParen`)가 출력하므로 결과물이 한 글자도 안 바뀝니다(**byte-identical**). 후속 PR에서 각 case 진입부에 `wrap` 계산이 들어가고, 자식 호출이 `emitNode` → `emitExpr(child, 자식level, 자식flags)`로 바뀌면서 precedence가 괄호를 재유도하게 됩니다. statement-start 필드도 지금은 정의만 — 출력 버퍼 위치(`buf.items.len`)로 "내가 이 statement의 첫 토큰인가"를 판정하는 데 PR6에서 쓰입니다. `maxInt`는 "아직 마킹 안 됨"(절대 매치 안 되는 sentinel)이고, `buf`는 append-only라 그 길이가 `maxInt`에 닿을 일이 없어 안전합니다.

## 왜 진입점을 미리 분리하나 (altitude)

`emitExpr` 시그니처를 지금 확정해 두면, 이후 precedence wrap을 켜는 PR들이 **호출처를 건드리지 않고 본문만** 채울 수 있습니다. 인프라(시그니처/마킹)와 알고리즘(결합성/문법제약)을 시간축으로 분리해, 회귀가 나면 원인이 항상 직전 PR로 특정됩니다.

## 안전성 / 게이트 (byte-identical)

- `emitExpr`는 `emitNode`의 26개 expression case 위임으로만 호출 → `else => unreachable` 도달 불가. dispatch↔switch 태그를 3자 대조해 set-identical 확인.
- ✅ `zig build test` 전체 통과 (회귀 0)
- ✅ TSC conformance 스냅샷 **2211 pass / 0 fail / 1643 snapshots 전부 일치** (byte-identical 입증)
- ✅ `/code-review max` 2개 finder 모두 no findings

## 다음 단계

PR3: new/call/optional-chain 컨텍스트 괄호를 `level`/`flags` 기반으로 치환(byte-identical 목표). 이후 PR4+5에서 처음으로 baseline 스냅샷이 바뀌며, 그때부터 회귀는 byte 대신 **semantic equivalence**(esbuild 재파싱 정규화 oracle + 런타임 동작 + load-bearing 괄호 매트릭스)로 검증합니다.

Refs #4042

🤖 Generated with [Claude Code](https://claude.com/claude-code)