### PR TITLE
test(codegen): load-bearing 괄호 회귀 하네스 + semantic-equiv oracle (#4042 PR3)

### DIFF
--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -27,4 +27,5 @@ comptime {
     _ = @import("codegen_test/skip_nodes_blank.zig");
     _ = @import("codegen_test/import_attributes.zig");
     _ = @import("codegen_test/class_expr_anonymize.zig");
+    _ = @import("codegen_test/load_bearing_paren.zig");
 }

--- a/src/codegen/codegen_test/load_bearing_paren.zig
+++ b/src/codegen/codegen_test/load_bearing_paren.zig
@@ -1,0 +1,83 @@
+//! load-bearing 괄호 회귀 매트릭스 (#4042) — 문자열 생존(빠른 1차 방어).
+//! 의미(throw vs undefined, SyntaxError 회피)까지의 런타임 검증은
+//! tests/integration/tests/load-bearing-paren.test.ts 가 담당한다.
+//!
+//! 입력은 괄호가 *의미를 갖는*(= 빼면 다른 프로그램이 되거나 invalid 가 되는)
+//! 최소 표현이다. 현재(precedence 전환 전)는 parenthesized_expression 노드로
+//! 보존하고, 전환(PR4) 후에는 emitExpr 가 precedence 로 재유도한다 — 어느 쪽이든
+//! 괄호가 살아있어야 한다. indexOf 로 핵심 괄호 부분문자열 생존만 보므로
+//! minify/공백 정책 변화에 영향받지 않고 PR3·PR4 양쪽에서 통과한다.
+//!
+//! TODO(PR4): 아래 두 케이스는 현재 codegen 갭(이슈 #4042 인스턴스 6·7)이라
+//! precedence 전환에서 비로소 해소된다 — 그때 매트릭스에 추가한다.
+//!   - `({x:1} as T).c` (TS as strip 후 statement-start `{` 유실)
+//!   - es2019 optional-chain lowering 의 이중괄호 정리
+
+const std = @import("std");
+const helpers = @import("helpers.zig");
+const e2e = helpers.e2e;
+
+fn expectParenSurvives(output: []const u8, needle: []const u8) !void {
+    if (std.mem.indexOf(u8, output, needle) == null) {
+        std.debug.print("\nload-bearing 괄호 유실: \"{s}\" 가 출력에 없음:\n{s}\n", .{ needle, output });
+        return error.LoadBearingParenLost;
+    }
+}
+
+test "load-bearing: optional-chain 끊기 (a?.b).c" {
+    var r = try e2e(std.testing.allocator, "(a?.b).c;");
+    defer r.deinit();
+    // 괄호 유실 시 `a?.b.c` 는 a 가 nullish 면 전체 short-circuit(undefined),
+    // 보존 시 `.c` 에서 throw — 의미가 다르다.
+    try expectParenSurvives(r.output, "(a?.b)");
+}
+
+test "load-bearing: numeric-then-dot (42).toString()" {
+    var r = try e2e(std.testing.allocator, "(42).toString();");
+    defer r.deinit();
+    // 괄호 유실 시 `42.toString` 은 `42.` 가 float 로 오파싱되어 invalid.
+    try expectParenSurvives(r.output, "(42)");
+}
+
+test "load-bearing: 음수 단항이 ** 의 좌측 (-a)**b" {
+    var r = try e2e(std.testing.allocator, "(-a) ** b;");
+    defer r.deinit();
+    // 괄호 유실 시 `-a**b` 는 SyntaxError(단항이 ** 좌측에 직접 못 옴).
+    try expectParenSurvives(r.output, "(-a)");
+}
+
+test "load-bearing: sequence 가 call callee (0,o.f)()" {
+    var r = try e2e(std.testing.allocator, "(0, o.f)();");
+    defer r.deinit();
+    // 괄호 유실 시 `0,o.f()` 는 sequence 의 마지막이 메서드 호출(this=o)이 되어
+    // indirect call(this=undefined)과 의미가 다르다.
+    try expectParenSurvives(r.output, "(0,o.f)");
+}
+
+test "load-bearing: ?? 와 || 혼용 (a||b)??c" {
+    var r = try e2e(std.testing.allocator, "(a || b) ?? c;");
+    defer r.deinit();
+    // 괄호 유실 시 `a||b??c` 는 SyntaxError(ECMAScript 가 괄호 없는 혼용 금지).
+    try expectParenSurvives(r.output, "(a||b)");
+}
+
+test "load-bearing: new callee 의 call-chain new (a().b)()" {
+    var r = try e2e(std.testing.allocator, "new (a().b)();");
+    defer r.deinit();
+    // 괄호 유실 시 `new a().b()` 는 `(new a()).b()` 로 결합이 깨진다(#1507).
+    try expectParenSurvives(r.output, "(a().b)");
+}
+
+test "load-bearing: assignment 가 binary 피연산자 (a=b)+c" {
+    var r = try e2e(std.testing.allocator, "(a = b) + c;");
+    defer r.deinit();
+    try expectParenSurvives(r.output, "(a=b)");
+}
+
+test "load-bearing: arrow 본문 object literal () => ({})" {
+    var r = try e2e(std.testing.allocator, "const f = () => ({ x: 1 });");
+    defer r.deinit();
+    // 괄호 유실 시 `() => {x:1}` 의 `{` 는 블록으로 파싱되어 객체를 반환하지 않는다.
+    // arrow `=>` 직후의 `({` 를 함께 봐 다른 위치 괄호와의 우연 매칭을 배제한다.
+    try expectParenSurvives(r.output, "=>({");
+}

--- a/tests/benchmark/paren-equiv.ts
+++ b/tests/benchmark/paren-equiv.ts
@@ -1,0 +1,44 @@
+/**
+ * Semantic-equivalence oracle — codegen precedence 전환(#4042)용.
+ *
+ * 전환은 byte-identical 을 의도적으로 깬다(군더더기 괄호 제거). 따라서 회귀
+ * 기준을 "두 출력이 괄호 차이를 빼면 같은 프로그램인가"(semantic equivalence)
+ * 로 둔다.
+ *
+ * esbuild 를 정규화기(normalizer)로 쓴다: `minify:false` 로 재파싱·재출력하면
+ * esbuild 자신의 최소-괄호 정책으로 redundant 괄호가 제거되고 형식이 통일되므로,
+ * 두 소스의 정규화 결과가 같으면 (불필요 괄호 차이만 있는) 같은 파스 트리다.
+ * load-bearing 괄호가 빠지면 파스가 달라져 정규화 결과도 달라진다. esbuild 가
+ * 정규화기로 적합한 이유는 이 전환의 목표 자체가 "esbuild/oxc 식 최소 괄호"이기
+ * 때문이다 — oracle 과 목표가 일치한다.
+ *
+ * 한쪽이 파싱 불가(invalid)면 비동등으로 본다 — load-bearing 괄호 유실로
+ * SyntaxError 가 된 출력을 잡아낸다.
+ */
+
+import { transformSync } from 'esbuild';
+
+/** esbuild 로 재파싱·재출력해 괄호/형식을 정규화한다. 입력은 트랜스파일된 JS 가정. */
+export function normalize(src: string): string {
+  return transformSync(src, { minify: false, loader: 'js' }).code;
+}
+
+/**
+ * 두 JS 소스가 (불필요 괄호 차이를 제외하고) 의미상 동일한가.
+ * 한쪽이라도 invalid 면 false (load-bearing 괄호 유실 → invalid 출력을 포착).
+ */
+export function astEquivalent(a: string, b: string): boolean {
+  let na: string;
+  let nb: string;
+  try {
+    na = normalize(a);
+  } catch {
+    return false;
+  }
+  try {
+    nb = normalize(b);
+  } catch {
+    return false;
+  }
+  return na === nb;
+}

--- a/tests/integration/tests/load-bearing-paren.test.ts
+++ b/tests/integration/tests/load-bearing-paren.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { transpileAndRun } from './helpers';
+
+// load-bearing 괄호 회귀 매트릭스(#4042) — 런타임 의미 검증.
+//
+// 문자열 생존(빠른 1차)은 src/codegen/codegen_test/load_bearing_paren.zig 가
+// 본다. 여기서는 transpile → 실제 실행으로 "괄호가 빠지면 throw 가 undefined 로
+// 바뀌거나, this 바인딩/평가순서가 달라지거나, SyntaxError 가 되는" 의미 자체를
+// 박제한다. 현재(precedence 전환 전)는 parenthesized_expression 노드로 보존되어
+// 전부 통과하고, 전환(PR4) 후에도 precedence 가 동일 괄호를 재유도해 통과해야
+// 한다 — 이 스위트가 그 가드다.
+//
+// 각 케이스는 괄호 유실 시 결과가 *관측 가능하게 달라지도록* 구성한다(비변별
+// 케이스는 가드 역할을 못 한다). cleanup 은 afterEach 로 등록해 expect 실패 시에도
+// temp dir 이 누수되지 않게 한다(downlevel-edge.test.ts 와 동일 패턴).
+describe('load-bearing 괄호 런타임 의미 보존 (#4042)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test('optional-chain 끊기: (a?.b).c 는 a=null 이면 throw (≠ undefined)', async () => {
+    const r = await transpileAndRun(`
+      const a = null;
+      let out = 'no-throw';
+      try { (a?.b).c; } catch { out = 'throw'; }
+      console.log(out);
+    `);
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    // 괄호 유실 시 a?.b.c → 전체 short-circuit → 'no-throw'.
+    expect(r.runOutput.trim()).toBe('throw');
+  });
+
+  test('indirect call: (0, o.m)() 는 this 가 o 가 아님', async () => {
+    const r = await transpileAndRun(`
+      const o = { m() { return this === o; } };
+      console.log((0, o.m)());
+    `);
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    // 괄호/sequence 유실 시 o.m() → this===o → true.
+    expect(r.runOutput.trim()).toBe('false');
+  });
+
+  test('numeric-then-dot: (42).toString()', async () => {
+    const r = await transpileAndRun(`console.log((42).toString());`);
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    expect(r.runOutput.trim()).toBe('42');
+  });
+
+  test('음수 단항이 ** 좌측: (-2) ** 2 === 4 (괄호 유실 시 SyntaxError)', async () => {
+    const r = await transpileAndRun(`console.log((-2) ** 2);`);
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    expect(r.runStderr).toBe('');
+    expect(r.runOutput.trim()).toBe('4');
+  });
+
+  test('?? 와 || 혼용: (a || b) ?? c (괄호 유실 시 SyntaxError)', async () => {
+    const r = await transpileAndRun(`
+      const a = 0, b = 2, c = 3;
+      console.log((a || b) ?? c);
+    `);
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    expect(r.runStderr).toBe('');
+    expect(r.runOutput.trim()).toBe('2'); // (0||2)??3 → 2
+  });
+
+  test('arrow 본문 object literal: () => ({}) 는 객체를 반환', async () => {
+    const r = await transpileAndRun(`
+      const f = () => ({ x: 1 });
+      console.log(f().x);
+    `);
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    // 괄호 유실 시 () => {x:1} 의 {는 블록 → undefined.
+    expect(r.runOutput.trim()).toBe('1');
+  });
+
+  test('new callee call-chain: new (factory().Ctor)()', async () => {
+    const r = await transpileAndRun(`
+      function factory() { return { Ctor: class { constructor() { this.ok = true; } } }; }
+      console.log(new (factory().Ctor)().ok);
+    `);
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    // 괄호 유실 시 new factory().Ctor() → (new factory()).Ctor() 로 결합이 깨짐.
+    expect(r.runOutput.trim()).toBe('true');
+  });
+
+  test('assignment 가 binary 피연산자: (a = 2) + 3 — 부수효과로 변별', async () => {
+    const r = await transpileAndRun(`
+      let a = 0;
+      const v = (a = 2) + 3;
+      // (a=2)+3: a===2, v===5.  괄호 유실 a=2+3: a===5, v===5(값은 우연히 동일).
+      // a 의 부수효과를 관측해 괄호 유실을 변별한다(값만 보면 둘 다 5라 무의미).
+      console.log(a === 2 ? v : 'BROKEN');
+    `);
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    expect(r.runOutput.trim()).toBe('5'); // a===2 → v(5). 괄호 유실 시 'BROKEN'.
+  });
+});

--- a/tests/integration/tests/paren-equiv.test.ts
+++ b/tests/integration/tests/paren-equiv.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { astEquivalent, normalize } from '../../benchmark/paren-equiv';
+
+// Layer 0 oracle 자가검증(positive control) — 검사기가 실제로 load-bearing 괄호
+// 유실을 잡고, 군더더기 괄호 차이는 무시함을 증명한다. 이 self-test 가 없으면
+// oracle 이 (망가져서) 늘 true 를 반환해도 회귀 스위트가 silent pass 한다.
+// 패턴: src/codegen/codegen_test/helpers.zig 의 assertNoAsyncSelfLoop positive
+// control 과 동일 사상.
+describe('paren-equiv oracle (positive control)', () => {
+  test('load-bearing 괄호 차이 → 비동등(false)', () => {
+    expect(astEquivalent('(a + b) * c', 'a + b * c')).toBe(false); // precedence
+    expect(astEquivalent('(a?.b).c', 'a?.b.c')).toBe(false); // optional-chain 끊기
+    expect(astEquivalent('(function(){})()', 'function(){}()')).toBe(false); // stmt-start(후자 invalid)
+    expect(astEquivalent('(-a) ** b', '-a ** b')).toBe(false); // ** 좌단항(후자 invalid)
+  });
+
+  test('군더더기 괄호 차이 → 동등(true)', () => {
+    expect(astEquivalent('(a) + (b)', 'a + b')).toBe(true);
+    expect(astEquivalent('((a + b)) * c', '(a + b) * c')).toBe(true);
+    expect(astEquivalent('x = (a + b)', 'x = a + b')).toBe(true);
+  });
+
+  test('자기 자신과 동등', () => {
+    expect(astEquivalent('(a?.b).c', '(a?.b).c')).toBe(true);
+  });
+
+  test('invalid 출력은 비동등으로 처리', () => {
+    expect(astEquivalent('a + b', 'a +')).toBe(false); // 후자 SyntaxError
+  });
+
+  test('normalize 는 deterministic', () => {
+    const s = 'x = a + b * c - d / e';
+    expect(normalize(s)).toBe(normalize(s));
+  });
+});


### PR DESCRIPTION
## 배경 (에픽 #4042, PR3/7)

PR4부터 precedence 기반 괄호 재유도를 켜면 **byte-identical 이 의도적으로 깨집니다**(군더더기 괄호가 esbuild 처럼 제거됨). 따라서 회귀 기준을 byte 가 아니라 **semantic equivalence**(의미 동등)로 바꿔야 합니다. 이 PR은 그 전환을 안전하게 하기 위한 **TDD 테스트 하네스를 전환 전에 먼저** 깝니다. **코드 무변경(테스트만)** 이라 그 자체로 byte-identical 입니다.

> 원래 계획의 PR3(컨텍스트 괄호 byte-identical 재표현)는, 코드를 보니 현재 zntc 가 optional-chain 끊기·컨텍스트 괄호를 precedence 가 아니라 `parenthesized_expression` 노드에 의존해 처리하고 있어 emitParen 투명화(PR4)와 분리가 불가능함을 확인했습니다. 그래서 PR3 를 "테스트 하네스 선행"으로 조정했습니다(사용자 승인).

## 이 PR이 하는 일

**1. semantic-equivalence oracle** (`tests/benchmark/paren-equiv.ts`)
`astEquivalent(a, b)` = 양쪽을 `esbuild.transformSync({minify:false})`로 재파싱·재출력해 정규화한 뒤 비교. 군더더기 괄호 차이는 정규화로 사라지고, load-bearing 괄호 유실은 파스가 달라져 정규화도 달라집니다. esbuild 가 정규화기로 적합한 이유는 전환의 목표 자체가 "esbuild/oxc 식 최소 괄호"이기 때문입니다(oracle 과 목표 일치).

**2. oracle positive-control self-test** (`tests/integration/tests/paren-equiv.test.ts`)
검사기가 실제로 load-bearing 유실을 잡고(`(a+b)*c` ≠ `a+b*c`) 군더더기는 무시함(`(a)+(b)` = `a+b`)을 증명. 이게 없으면 oracle 이 망가져도(늘 true) 회귀 스위트가 silent pass 합니다. (`assertNoAsyncSelfLoop` positive-control 과 동일 사상.)

**3. load-bearing 괄호 매트릭스 8종** — 두 계층:
- `src/codegen/codegen_test/load_bearing_paren.zig`: 괄호 문자열 생존(빠른 1차, `indexOf`).
- `tests/integration/tests/load-bearing-paren.test.ts`: **런타임 의미** 검증(transpile→실행).

| 케이스 | 괄호 유실 시 |
|---|---|
| `(a?.b).c` (a=null) | throw → **undefined** (short-circuit) |
| `(0, o.m)()` | this≠o → **this=o** (메서드 호출) |
| `(42).toString()` | float 오파싱 invalid |
| `(-2) ** 2` | **SyntaxError** (단항이 ** 좌측 불가) |
| `(a\|\|b) ?? c` | **SyntaxError** (괄호 없는 혼용 금지) |
| `() => ({x:1})` | `{`=블록 → undefined |
| `new (factory().Ctor)()` | `(new factory()).Ctor()` 결합 깨짐 |
| `(a = 2) + 3` | 부수효과 a 가 2≠5 (값 관측으로 변별) |

> **Zig 초보자 메모**: `indexOf` 로 핵심 괄호 부분문자열 생존만 보므로 minify/공백 정책 변화에 영향받지 않고 PR3(paren 노드 보존)·PR4(precedence 재유도) 양쪽에서 통과합니다. 런타임 매트릭스는 *값이 아니라 의미*를 박제합니다 — 예컨대 `(a=2)+3` 은 괄호를 떼도 식의 값은 5로 같으므로, `a` 의 부수효과(2인지 5인지)를 관측해야 괄호 유실을 변별할 수 있습니다.

## 검증 / `/code-review max` 반영

- ✅ oracle self-test 5 pass / load-bearing 런타임 8 pass / `zig build test` 전체 통과(매트릭스 8 포함, 회귀 0)
- `/code-review max` 2 finder → 3건 수정: (1) `(a=2)+3` 비변별 → 부수효과 관측형, (2) `cleanup()` → `afterEach`(expect 실패 시 temp 누수 방지), (3) arrow needle `({` → `=>({` 강화

## 다음 단계

PR4+5: binary/unary/conditional/assignment precedence wrap 켜기 + emitParen 투명화. **이 하네스가 그 전환의 안전망** — load-bearing 괄호 유실은 런타임 매트릭스가, 군더더기 제거의 의미 보존은 oracle 이 보장합니다. 인스턴스 6·7(`({x:1} as T).c`, es2019 이중괄호)은 PR4 에서 해소 후 매트릭스에 추가합니다.

Refs #4042

🤖 Generated with [Claude Code](https://claude.com/claude-code)