### PR TITLE
feat(codegen): precedence wrap 발동 (연산자) + 잔여 자식 배선 (#4042 PR6)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -408,7 +408,14 @@ pub const Codegen = struct {
             first = false;
             const wrap = wrap_sequences and self.ast.getNode(node_idx).tag == .sequence_expression;
             if (wrap) try self.writeByte('(');
-            try self.emitNode(node_idx);
+            // expression list(call args/array items)는 argument 위치 → .comma.
+            // (PR5: emitExpr 가 아직 wrap 미발동이라 byte-identical. wrap_sequences ad-hoc 은
+            //  PR6 에서 .comma wrap 으로 대체되며 제거.) statement list 등은 emitNode(.lowest) 유지.
+            if (wrap_sequences) {
+                try self.emitExpr(node_idx, .comma, .{});
+            } else {
+                try self.emitNode(node_idx);
+            }
             if (wrap) try self.writeByte(')');
         }
     }

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -406,17 +406,15 @@ pub const Codegen = struct {
             if (self.isSkipped(node_idx)) continue;
             if (!first) try self.write(sep);
             first = false;
-            const wrap = wrap_sequences and self.ast.getNode(node_idx).tag == .sequence_expression;
-            if (wrap) try self.writeByte('(');
             // expression list(call args/array items)는 argument 위치 → .comma.
-            // (PR5: emitExpr 가 아직 wrap 미발동이라 byte-identical. wrap_sequences ad-hoc 은
-            //  PR6 에서 .comma wrap 으로 대체되며 제거.) statement list 등은 emitNode(.lowest) 유지.
+            // sequence(.comma) 는 .comma wrap 으로 괄호(`f((a,b))`, esbuild parity) — 이전의
+            // wrap_sequences ad-hoc 괄호는 precedence wrap 으로 대체되어 제거(이중괄호 방지).
+            // statement list(formal params/function body 등)는 emitNode(.lowest) 유지.
             if (wrap_sequences) {
                 try self.emitExpr(node_idx, .comma, .{});
             } else {
                 try self.emitNode(node_idx);
             }
-            if (wrap) try self.writeByte(')');
         }
     }
 };

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -158,7 +158,9 @@ fn powLeftNeedsParen(self: anytype, idx: NodeIndex) bool {
 /// (#4123) → 좌 스파인을 명시 스택으로 평탄화해 반복 emit 한다. 출력 텍스트와 addSourceMapping
 /// 순서(root → 스파인 top-down → 최좌단 leaf → operator+right bottom-up)는 재귀판과 동일.
 pub fn emitBinary(self: anytype, node: Node, level: Level, flags: ExprFlags) !void {
-    _ = level; // PR6: wrap = level.gte(entry) || (op==.kw_in && flags.forbid_in)
+    // wrap 은 emitExpr 진입부 exprNeedsParens 가 담당(중앙 집중). level 은 단락 폴드 시
+    // 살아남는 분기를 부모 level 로 투과해, 폴드로 wrap 을 위임받은 그 분기가 자기 wrap 을
+    // 정확히 걸 수 있게 한다(.lowest 로 투과하면 고-precedence 슬롯에서 괄호 유실).
     try self.addSourceMapping(node.span);
     const op: Kind = @enumFromInt(node.data.binary.flags);
     // 괄호 안이 아니면 자식에 forbid_in 전파(`for ((a in b);;)` 헤더 오파싱 방지).
@@ -172,8 +174,9 @@ pub fn emitBinary(self: anytype, node: Node, level: Level, flags: ExprFlags) !vo
                 try self.write(if (left_val) "true" else "false");
                 return;
             }
-            // 단락 폴드: logical 이 사라지고 right 가 그 자리 → 부모 flags 투과.
-            try self.emitExpr(node.data.binary.right, .lowest, flags);
+            // 단락 폴드: logical 이 사라지고 right 가 그 자리 → 부모 level/flags 투과
+            // (자식이 부모 level 로 자기 wrap → exprNeedsParens 의 wrap-위임이 정확해짐).
+            try self.emitExpr(node.data.binary.right, level, flags);
             return;
         }
     }
@@ -304,13 +307,13 @@ pub fn emitAssignment(self: anytype, node: Node, level: Level, flags: ExprFlags)
 }
 
 pub fn emitConditional(self: anytype, node: Node, level: Level, flags: ExprFlags) !void {
-    _ = level; // PR6: wrap = level.gte(.conditional)
+    // wrap 은 emitExpr 진입부가 담당. level 은 상수 폴드 시 살아남는 분기를 부모 level 로
+    // 투과해 그 분기가 자기 wrap 을 정확히 걸게 한다(.lowest 투과 시 고-precedence 슬롯 유실).
     try self.addSourceMapping(node.span);
     const t = node.data.ternary;
     if (self.options.linking_metadata != null) {
         if (self.evalBooleanCondition(t.a)) |cond| {
-            // 폴드된 분기는 conditional 이 사라지므로 부모 flags 그대로 투과(level 은 wrap 발동 후 정의).
-            try self.emitExpr(if (cond) t.b else t.c, .lowest, flags);
+            try self.emitExpr(if (cond) t.b else t.c, level, flags);
             return;
         }
     }

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -439,9 +439,10 @@ pub fn emitObjectProperty(self: anytype, node: Node) !void {
                 if (self.pending_fn_name) |s| self.allocator.free(s);
                 self.pending_fn_name = saved;
             }
-            try self.emitNode(value);
+            // object property value 는 argument 위치 → .comma (esbuild Property.Value=LComma)
+            try self.emitExpr(value, .comma, .{});
         } else {
-            try self.emitNode(value);
+            try self.emitExpr(value, .comma, .{});
         }
     }
 }

--- a/src/codegen/function_class.zig
+++ b/src/codegen/function_class.zig
@@ -57,7 +57,8 @@ pub fn emitTemplateLiteral(self: anytype, node: Node) !void {
         if (child_node.tag == .template_element) {
             try self.writeNodeSpan(child_node);
         } else {
-            try self.emitNode(child);
+            // `${}` substitution 은 괄호 안 → .lowest (esbuild ETemplate part = LLowest)
+            try self.emitExpr(child, .lowest, .{});
         }
     }
 }
@@ -76,7 +77,8 @@ pub fn emitTaggedTemplate(self: anytype, node: Node) !void {
         const is_pure = (flags & TaggedTemplateFlags.is_pure) != 0;
         if (is_pure and !self.options.minify_whitespace) try self.write("/* @__PURE__ */ ");
     }
-    try self.emitNode(@enumFromInt(extras[e]));
+    // tag 는 .postfix (esbuild ETemplate tag = LPostfix; optional-chain tag 강제괄호는 PR6 wrap).
+    try self.emitExpr(@enumFromInt(extras[e]), .postfix, .{});
     try self.emitNode(@enumFromInt(extras[e + 1]));
 }
 

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -15,6 +15,7 @@ const binding_emit = @import("bindings.zig");
 const precedence = @import("precedence.zig");
 const Level = precedence.Level;
 const ExprFlags = precedence.ExprFlags;
+const Kind = @import("../lexer/token.zig").Kind;
 
 const Error = std.mem.Allocator.Error;
 
@@ -56,6 +57,13 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
     // TS/Flow type wrapper: operand 만 출력 (type 스트리핑, #3129 단일 source).
     // pre-visit body codegen 시 TS/Flow 노드가 남아있을 수 있어 명시 처리.
     if (ast_mod.Node.Tag.isTransparentTypeWrapper(node.tag)) return self.emitExpr(node.data.unary.operand, level, flags);
+
+    // precedence wrap: 자기 결합강도가 부모가 요구한 최소 level 이하면 괄호 (esbuild printExpr).
+    // wrap 을 emitExpr 한 곳에 집중해 emitter 내부 early-return 과 무관하게 정확히 닫는다.
+    // (PR6a: 연산자만. member/call/new wrap·emitParen 투명화·statement-start 는 ad-hoc 제거와
+    //  함께 PR6b. 소스 괄호는 paren 노드가 유지 → 합성 AST 에서만 괄호 추가.)
+    const wrap = exprNeedsParens(self, node, level, flags);
+    if (wrap) try self.writeByte('(');
 
     switch (node.tag) {
         .program => try statement_emit.emitProgram(self, node),
@@ -373,4 +381,49 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
             try self.writeNodeSpan(node);
         },
     }
+
+    if (wrap) try self.writeByte(')');
+}
+
+/// 이 expression 노드가 부모가 요구한 `level` 에서 괄호가 필요한지 (esbuild
+/// `printExpr` 진입부의 `wrap := level >= entry.Level`). wrap 을 emitExpr 한 곳에
+/// 모으기 위한 술어.
+///
+/// PR6a 범위: 연산자(binary/unary/update/conditional/assignment/sequence/yield/
+/// await)만. member/call/new 의 precedence·optional-chain 끊기 wrap 과 primary 의
+/// statement-start wrap 은 ad-hoc 괄호(newCalleeNeedsParens/`(void 0)`) 제거 및
+/// emitParen 투명화와 함께 PR6b 에서 켠다 (지금 켜면 ad-hoc 과 이중괄호).
+fn exprNeedsParens(self: anytype, node: ast_mod.Node, level: Level, flags: ExprFlags) bool {
+    return switch (node.tag) {
+        .unary_expression, .await_expression => level.gte(.prefix),
+        .update_expression => blk: {
+            const e = node.data.extra;
+            const extras = self.ast.extra_data.items;
+            if (e + 1 >= extras.len) break :blk false;
+            const is_postfix = (extras[e + 1] & ast_mod.UnaryFlags.postfix) != 0;
+            break :blk level.gte(if (is_postfix) Level.postfix else Level.prefix);
+        },
+        .binary_expression, .logical_expression => blk: {
+            const op: Kind = @enumFromInt(node.data.binary.flags);
+            const entry = precedence.binaryOpLevel(op) orelse break :blk false;
+            // logical 단락 폴드 시 right 가 logical 자리에 옴 → 자기(right) wrap 으로
+            // 위임하고 여기선 wrap 안 함(emitBinary 가 right 를 부모 level 로 투과).
+            if (node.tag == .logical_expression and self.options.linking_metadata != null) {
+                if (self.evalBooleanCondition(node.data.binary.left) != null) break :blk false;
+            }
+            break :blk level.gte(entry) or (op == .kw_in and flags.forbid_in);
+        },
+        .conditional_expression => blk: {
+            // conditional 폴드(상수 test) 시 분기가 그 자리 → 자기 wrap 으로 위임.
+            if (self.options.linking_metadata != null) {
+                if (self.evalBooleanCondition(node.data.ternary.a) != null) break :blk false;
+            }
+            break :blk level.gte(.conditional);
+        },
+        .assignment_expression => level.gte(.assign),
+        .sequence_expression => level.gte(.comma),
+        .yield_expression => level.gte(.assign),
+        // member/call/new + primary(object/array/function/class/literal/...) 는 PR6b.
+        else => false,
+    };
 }


### PR DESCRIPTION
## 배경 (에픽 #4042, PR6)

PR1~5로 precedence 인프라(Level/ExprFlags) + 단일 진입점(`emitExpr`) + 자식 level/flags 배선을 byte-identical로 깔았습니다. 이 PR에서 **처음으로 precedence `wrap`을 켜** 연산자 괄호를 재유도합니다.

## 이 PR이 하는 일

**1. 잔여 자식 배선** (byte-identical):
- `emitNodeListImpl` expression 원소(call args/array items)=`.comma`, object property value=`.comma`, template substitution=`.lowest`, tagged-template tag=`.postfix`.

**2. 연산자 wrap 발동** — `emitExpr` 진입부에 `exprNeedsParens(self, node, level, flags)` 술어 추가:
```
const wrap = exprNeedsParens(...);  // level.gte(entry)
if (wrap) try self.writeByte('(');
switch (node.tag) { ... }
if (wrap) try self.writeByte(')');
```
- wrap을 **`emitExpr` 한 곳에 집중** → emitter 내부 early-return(fold/peephole)과 무관하게 정확히 괄호를 닫습니다(esbuild `printExpr` 구조).
- 범위(PR6): **연산자만** — unary/await(`.prefix`), update(postfix `.postfix`), binary/logical(`binaryOpLevel`+`in`&forbid_in), conditional(`.conditional`), assignment(`.assign`), sequence(`.comma`), yield(`.assign`). member/call/new wrap·`emitParen` 투명화·statement-start는 ad-hoc 괄호 제거와 함께 **PR7**.
- `emitNodeListImpl`의 `wrap_sequences` ad-hoc 괄호 제거 — sequence(`.comma`)가 `.comma` wrap으로 괄호를 받으므로, 둘이 겹치면 `return[2,((seq))]` 이중괄호(ES5 async state machine에서 적발). precedence 단일 경로로 일원화.

> **Zig 초보자 메모**: 소스 코드의 괄호는 아직 `parenthesized_expression` 노드(`emitParen`, 투명화는 PR7)가 그대로 유지합니다. 그래서 이 PR의 wrap은 **transformer/minify가 괄호 노드 없이 합성한 AST**에서만 발동합니다 — 바로 거기서 기존 codegen이 괄호를 잃어 silent miscompile이 나던 부류(`(a+b)*c`를 합성하면 `a+b*c`로 출력)가 해소되기 시작합니다. 소스 괄호는 보존되므로 TSC 스냅샷은 byte-identical입니다.

## `/code-review max` 반영 (HIGH latent fix)

3 finder 중 1건 HIGH: **상수 폴드(logical 단락/conditional) 분기를 `.lowest`로 투과**하던 버그. `exprNeedsParens`는 fold 시 "자기 wrap에 위임"하며 wrap을 끄는데, 자식이 `.lowest`를 받으면 자기 wrap도 누락 → **PR7(`emitParen` 투명화) 시 `a ** (FLAG ? (b=1) : c)`→`a ** b = 1`(SyntaxError) miscompile** 시한폭탄. fold passthrough를 부모 `level`로 수정해 제거(`emitBinary`/`emitConditional`). 나머지는 no findings.

## 안전성 / 게이트

- ✅ `zig build test` 5781 pass (ES5 async sequence 이중괄호 해소 포함)
- ✅ load-bearing 런타임 매트릭스 13 pass (throw/undefined/this 의미 보존)
- ✅ TSC conformance **2211 pass / 0 fail** (소스 괄호 paren 노드 유지 → byte-identical)

## 다음 단계 (PR7)

`emitParen` 투명화(소스 괄호도 precedence로 재유도 = **군더더기 괄호 제거, 첫 대규모 스냅샷 변화**) + member/call/new wrap + statement-start 마킹(`({}).x`/IIFE) + ad-hoc 제거(`newCalleeNeedsParens`/`void 0` paren) + 잔여 배선(arrow body/class extends). 여기서 **인스턴스 6·7이 해소**됩니다. `classify-paren-diff.ts` 신설 + 하네스 전수 검증.

Refs #4042

🤖 Generated with [Claude Code](https://claude.com/claude-code)