### PR TITLE
feat(codegen): emitParen 투명화 + precedence 기반 괄호 재유도 (#4042 PR7)

### DIFF
--- a/scripts/audit-codegen-sourcemap.ts
+++ b/scripts/audit-codegen-sourcemap.ts
@@ -47,6 +47,7 @@ const SKIP_FUNCS = new Map<string, string>([
 	["emitStaticBlock", "container — body carries mappings"],
 	["emitNamespaceIIFE", "delegates to emitNamespaceIIFEInner"],
 	["emitExportSpecifier", "leaf-token mapping at local_node.span (not outer node.span)"],
+	["emitParen", "transparent (#4042) — operand 이 자기 매핑 발행, paren 노드는 토큰 미출력"],
 ]);
 
 /** `pub fn emit<Name>(self: anytype, node: Node, ...)` 시그니처 매치. */

--- a/scripts/classify-paren-diff.ts
+++ b/scripts/classify-paren-diff.ts
@@ -1,0 +1,124 @@
+/**
+ * classify-paren-diff — #4042 precedence 전환 스냅샷 변화 분류기.
+ *
+ * codegen 의 paren-node→precedence 전환은 byte 를 의도적으로 바꾼다(군더더기 괄호
+ * 제거 + load-bearing 재유도). 회귀 기준은 byte 가 아니라 **semantic equivalence**
+ * 이므로, 스냅샷 변화를 무지성 `--update` 하기 전에 각 변화가 EQUIVALENT(군더더기
+ * 괄호 차이) 인지 SUSPECT(load-bearing 유실 의심) 인지 기계 분류한다.
+ *
+ * 방법: 각 bun `.snap` 파일을 git HEAD(old) 와 working tree(new) 로 파싱해 key 별
+ * 값을 비교하고, 바뀐 값마다 esbuild 정규화(paren-equiv) 로 astEquivalent 를 잰다.
+ * SUSPECT(비동등) 가 0 이어야 스냅샷 갱신이 안전하다.
+ *
+ * 사용: `bun scripts/classify-paren-diff.ts [snapshot_glob_dir]`
+ *   기본 dir = tests/integration/tests/tsc/__snapshots__
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { normalize as esbuildNormalize } from '../tests/benchmark/paren-equiv.ts';
+
+/** esbuild 로 재파싱·재출력해 정규화. 실패(파싱 불가)면 null. */
+function normalize(src: string): string | null {
+  try {
+    return esbuildNormalize(src);
+  } catch {
+    return null;
+  }
+}
+
+type Verdict = 'EQUIVALENT' | 'SUSPECT' | 'UNPARSEABLE';
+/** old/new 코드를 esbuild 정규화 비교. 둘 다 파싱 불가면 UNPARSEABLE(이미-transpiled 산출물에
+ *  esbuild-js 가 못 다루는 구문 — 보통 paren 차이만, 수동 확인 버킷). 한쪽만 깨지면 SUSPECT. */
+function classify(oldCode: string, newCode: string): Verdict {
+  const no = normalize(oldCode);
+  const nn = normalize(newCode);
+  if (no === null && nn === null) return 'UNPARSEABLE';
+  if (no === null || nn === null) return 'SUSPECT';
+  return no === nn ? 'EQUIVALENT' : 'SUSPECT';
+}
+
+const REPO = execSync('git rev-parse --show-toplevel').toString().trim();
+const snapDir = process.argv[2] ?? 'tests/integration/tests/tsc/__snapshots__';
+
+/** bun snapshot 파일을 {key: value} 로 파싱. value 는 ``...`` 안의 raw 문자열. */
+function parseSnap(content: string): Map<string, string> {
+  const map = new Map<string, string>();
+  // exports[`key`] = `value`;  — value 는 multiline, 백틱은 \` 로 escape.
+  const re = /exports\[`((?:[^`\\]|\\.)*)`\] = `((?:[^`\\]|\\.)*)`;/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    map.set(m[1].replace(/\\`/g, '`'), m[2]);
+  }
+  return map;
+}
+
+/** snapshot 값(`\n"<code>"\n` 형태)에서 실제 코드 문자열을 추출. */
+function extractCode(raw: string): string {
+  let s = raw.replace(/^\n/, '').replace(/\n$/, '');
+  // 문자열 스냅샷은 `"..."` 로 감싸짐 — 벗기고 escape 해제.
+  if (s.startsWith('"') && s.endsWith('"')) {
+    s = s.slice(1, -1);
+  }
+  return s
+    .replace(/\\\$/g, '$') // bun 은 template 의 `${` 를 `\${` 로 escape
+    .replace(/\\`/g, '`')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\');
+}
+
+function gitShow(relPath: string): string | null {
+  try {
+    return execSync(`git show HEAD:${relPath}`, { cwd: REPO, maxBuffer: 64 * 1024 * 1024 }).toString();
+  } catch {
+    return null; // 신규 파일
+  }
+}
+
+const changed = execSync(`git diff --name-only -- ${snapDir}`, { cwd: REPO })
+  .toString().trim().split('\n').filter(Boolean);
+
+let equivalent = 0;
+let suspect = 0;
+let unparseable = 0;
+const suspects: { file: string; key: string; old: string; neu: string }[] = [];
+const unparse: { file: string; key: string }[] = [];
+
+for (const rel of changed) {
+  const abs = join(REPO, rel);
+  if (!existsSync(abs)) continue;
+  const oldRaw = gitShow(rel);
+  if (oldRaw === null) continue;
+  const oldMap = parseSnap(oldRaw);
+  const newMap = parseSnap(readFileSync(abs, 'utf8'));
+  for (const [key, newVal] of newMap) {
+    const oldVal = oldMap.get(key);
+    if (oldVal === undefined || oldVal === newVal) continue;
+    const oldCode = extractCode(oldVal);
+    const newCode = extractCode(newVal);
+    const v = classify(oldCode, newCode);
+    if (v === 'EQUIVALENT') equivalent++;
+    else if (v === 'UNPARSEABLE') {
+      unparseable++;
+      unparse.push({ file: rel.split('/').pop()!, key });
+    } else {
+      suspect++;
+      suspects.push({ file: rel.split('/').pop()!, key, old: oldCode, neu: newCode });
+    }
+  }
+}
+
+console.log(`\n=== classify-paren-diff (#4042) ===`);
+console.log(`changed snap files : ${changed.length}`);
+console.log(`EQUIVALENT (군더더기 괄호 제거, 정상): ${equivalent}`);
+console.log(`UNPARSEABLE (esbuild-js 미파싱 양쪽 동일, 수동확인): ${unparseable}`);
+console.log(`SUSPECT    (load-bearing 유실 의심)   : ${suspect}`);
+
+for (const u of unparse) console.log(`  · UNPARSEABLE [${u.file}] ${u.key}`);
+for (const s of suspects) {
+  console.log(`\n──── SUSPECT [${s.file}] ${s.key} ────`);
+  console.log(`OLD:\n${s.old.slice(0, 600)}`);
+  console.log(`NEW:\n${s.neu.slice(0, 600)}`);
+}
+
+process.exit(suspect === 0 ? 0 : 1);

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -1817,8 +1817,11 @@ test "Minify: new (CallExpression)() keeps parens — safety (#1586)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "new (") != null);
 }
 
-test "Minify: redundant parens removal preserved without minify_syntax (#1586)" {
-    // minify_syntax 비활성화 시 원본 parens 유지 (관찰 불변성).
+test "Minify: redundant parens removed for new-callee even without minify_syntax (#1586/#4042)" {
+    // #4042: precedence 기반 전환으로 *전 모드 통일* — minify_syntax 여부와 무관하게
+    // 군더더기 괄호 제거. `new (class Foo extends Error {})()` 의 callee 괄호는
+    // `new class Foo extends Error {}()` 로 떨어진다(class expression 은 PrimaryExpression
+    // 이라 new callee 슬롯에 직접 가능, 의미 동일 — esbuild parity).
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts",
@@ -1839,8 +1842,9 @@ test "Minify: redundant parens removal preserved without minify_syntax (#1586)" 
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // parens 유지
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "new (class") != null);
+    // 군더더기 괄호 제거(esbuild parity): `new class` (괄호 없음).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new class") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new (class") == null);
 }
 
 test "Minify: default export has no synthetic variable — no regression (#1585)" {

--- a/src/bundler/bundler_test/typescript_format.zig
+++ b/src/bundler/bundler_test/typescript_format.zig
@@ -960,7 +960,8 @@ test "Complex: destructuring imports used in complex expressions" {
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "const area = 200") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "2 * (30)") != null);
+    // 군더더기 괄호 제거(#4042): `2 * (30)` → `2 * 30` (동등). const-fold 후 단일 리터럴.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "2 * 30") != null);
 }
 
 // ============================================================

--- a/src/codegen/bindings.zig
+++ b/src/codegen/bindings.zig
@@ -5,6 +5,7 @@ const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const writer = @import("writer.zig");
 const expressions = @import("expressions.zig");
+const ExprFlags = @import("precedence.zig").ExprFlags;
 
 const writeNewline = writer.writeNewline;
 const writeSpace = writer.writeSpace;
@@ -54,7 +55,9 @@ pub fn emitBindingProperty(self: anytype, node: Node) !void {
             try self.writeByte(':');
             try self.writeSpan(key_node.span);
             try self.writeByte('=');
-            try self.emitNode(node.data.binary.right);
+            // default value level = .comma: 최상위 sequence(`({x=(a,b)}=o)`)가 괄호로 감싸진다
+            // (default 는 AssignmentExpression 이라 `x=a,b` 는 다른 의미 — silent miscompile).
+            try self.emitExpr(node.data.binary.right, .comma, .{});
         } else {
             try self.writeByte(':');
             try self.emitNode(node.data.binary.right);
@@ -150,7 +153,10 @@ pub fn emitVariableDeclarator(self: anytype, node: Node) !void {
         try self.writeByte('=');
         try writeSpace(self);
         // init level = .comma (esbuild SLocal declarator value = LComma): 최상위 sequence
-        // (`let x=(a,b)`)가 괄호로 감싸져 declarator 구분 콤마와 섞이지 않게 한다.
+        // (`let x=(a,b)`)가 괄호로 감싸져 declarator 구분 콤마와 섞이지 않게 한다. for-init
+        // 안(`for(var x=(a in b);;)`)이면 forbid_in 전파 — top-level `in` 이 for-in 헤더로
+        // 오파싱되지 않게 괄호 (array/call 등 중첩에선 자식 emit 이 flag clear).
+        const init_flags = ExprFlags{ .forbid_in = self.in_for_init };
         // contextual name: binding_identifier = function/arrow/class → 변수명을 이름으로
         if (self.fn_map_builder != null and self.isFunctionLike(init_val)) {
             const saved = self.pending_fn_name;
@@ -159,9 +165,9 @@ pub fn emitVariableDeclarator(self: anytype, node: Node) !void {
                 if (self.pending_fn_name) |s| self.allocator.free(s);
                 self.pending_fn_name = saved;
             }
-            try self.emitExpr(init_val, .comma, .{});
+            try self.emitExpr(init_val, .comma, init_flags);
         } else {
-            try self.emitExpr(init_val, .comma, .{});
+            try self.emitExpr(init_val, .comma, init_flags);
         }
     }
 }

--- a/src/codegen/bindings.zig
+++ b/src/codegen/bindings.zig
@@ -17,7 +17,9 @@ pub fn emitAssignmentPattern(self: anytype, node: Node) !void {
     try self.addSourceMapping(node.span);
     try self.emitNode(node.data.binary.left);
     try self.writeByte('=');
-    try self.emitNode(node.data.binary.right);
+    // default value level = .comma: 최상위 sequence(`[x=(a,b)]`)가 콤마 구분자와 섞이지
+    // 않게 괄호로 감싼다 (esbuild binding default = LComma).
+    try self.emitExpr(node.data.binary.right, .comma, .{});
 }
 
 pub fn emitBindingProperty(self: anytype, node: Node) !void {
@@ -147,6 +149,8 @@ pub fn emitVariableDeclarator(self: anytype, node: Node) !void {
         try writeSpace(self);
         try self.writeByte('=');
         try writeSpace(self);
+        // init level = .comma (esbuild SLocal declarator value = LComma): 최상위 sequence
+        // (`let x=(a,b)`)가 괄호로 감싸져 declarator 구분 콤마와 섞이지 않게 한다.
         // contextual name: binding_identifier = function/arrow/class → 변수명을 이름으로
         if (self.fn_map_builder != null and self.isFunctionLike(init_val)) {
             const saved = self.pending_fn_name;
@@ -155,9 +159,9 @@ pub fn emitVariableDeclarator(self: anytype, node: Node) !void {
                 if (self.pending_fn_name) |s| self.allocator.free(s);
                 self.pending_fn_name = saved;
             }
-            try self.emitNode(init_val);
+            try self.emitExpr(init_val, .comma, .{});
         } else {
-            try self.emitNode(init_val);
+            try self.emitExpr(init_val, .comma, .{});
         }
     }
 }
@@ -174,6 +178,8 @@ pub fn emitFormalParam(self: anytype, node: Node) !void {
     try self.emitNode(pattern);
     if (!default_val.isNone()) {
         try self.writeByte('=');
-        try self.emitNode(default_val);
+        // default value level = .comma: 최상위 sequence(`f(x=(a,b))`)가 파라미터 구분
+        // 콤마와 섞이지 않게 괄호로 감싼다 (esbuild fn arg default = LComma).
+        try self.emitExpr(default_val, .comma, .{});
     }
 }

--- a/src/codegen/calls.zig
+++ b/src/codegen/calls.zig
@@ -14,6 +14,72 @@ const ExprFlags = precedence.ExprFlags;
 const IMPORT_META_URL_NODE = "require(\"url\").pathToFileURL(__filename).href";
 const IMPORT_META_NODE_OBJECT = "{url:" ++ IMPORT_META_URL_NODE ++ ",dirname:__dirname,filename:__filename}";
 
+/// transparent TYPE wrapper(TS `as T`/`<T>x`/`!`, Flow cast, chain_expression)만 벗긴다.
+/// **paren 은 벗기지 않는다** — paren 은 optional chain 을 끊는 경계이므로
+/// (`(a?.b).c` 의 `.c` 는 None, `a?.b!.c` 의 `.c` 는 Continue). objectContinuesOptionalChain 전용.
+fn skipTypeWrappers(self: anytype, idx: NodeIndex) NodeIndex {
+    var cur = idx;
+    var depth: u8 = 0;
+    while (depth < 32) : (depth += 1) {
+        if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return cur;
+        const n = self.ast.getNode(cur);
+        if (n.tag == .chain_expression or ast_mod.Node.Tag.isTransparentTypeWrapper(n.tag)) {
+            cur = n.data.unary.operand;
+        } else return cur;
+    }
+    return cur;
+}
+
+/// `object` 가 (paren 을 건너지 않고 type-wrapper 만 건너서) optional `?.` 로 시작/연속되는
+/// 체인인지 — 이 멤버/호출이 esbuild 의 OptionalChainContinue(체인 연속)인지 판정한다.
+/// zntc 파서는 chain_expression 없이 paren 노드로만 체인을 끊으므로(transformer/define.zig
+/// 주석) 트리 구조에서 유도한다: `a?.b.c` 의 `.c` 는 object(`a?.b`)가 optional → Continue
+/// (끊지 않음), `(a?.b).c` 의 `.c` 는 object 가 paren → 체인 끊김 → None(끊음).
+pub fn objectContinuesOptionalChain(self: anytype, idx: NodeIndex) bool {
+    var cur = idx;
+    var depth: u8 = 0;
+    while (depth < 64) : (depth += 1) {
+        cur = skipTypeWrappers(self, cur);
+        if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return false;
+        const n = self.ast.getNode(cur);
+        switch (n.tag) {
+            .static_member_expression, .computed_member_expression, .private_field_expression => {
+                const e = n.data.extra;
+                if (!self.ast.hasExtra(e, 2)) return false;
+                if ((self.ast.readExtra(e, 2) & ast_mod.MemberFlags.optional_chain) != 0) return true;
+                cur = self.ast.readExtraNode(e, 0); // object — Continue 여부 재귀
+            },
+            .call_expression => {
+                const e = n.data.extra;
+                if (!self.ast.hasExtra(e, 3)) return false;
+                if ((self.ast.readExtra(e, 3) & ast_mod.CallFlags.optional_chain) != 0) return true;
+                cur = self.ast.readExtraNode(e, 0); // callee
+            },
+            else => return false, // paren/identifier/literal 등 → 체인 끊김
+        }
+    }
+    return false;
+}
+
+/// expression 이 (paren 포함 transparent wrapper 를 벗긴 뒤) optional chain(Start/Continue)인지.
+/// tagged template 의 tag 가 optional chain 이면 ECMAScript 상 SyntaxError 라 괄호로 감싸야
+/// 한다 (esbuild ETemplate: `IsOptionalChain(tag)` → wrap). paren 까지 벗기는 이유는 emit 시
+/// 투명 paren 이 사라져 `(a?.b)`x`` 가 `a?.b`x``(invalid)로 깨지기 때문.
+pub fn isOptionalChainExpr(self: anytype, idx: NodeIndex) bool {
+    var cur = idx;
+    var depth: u8 = 0;
+    while (depth < 32) : (depth += 1) {
+        if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return false;
+        const n = self.ast.getNode(cur);
+        if (n.tag == .parenthesized_expression or n.tag == .chain_expression or
+            ast_mod.Node.Tag.isTransparentTypeWrapper(n.tag))
+        {
+            cur = n.data.unary.operand;
+        } else break;
+    }
+    return objectContinuesOptionalChain(self, cur);
+}
+
 /// `undefined` peephole 의 callee/object/new.callee 슬롯 paren 검사.
 /// node_dispatch.zig 가 `void 0` (no paren) 으로 출력하므로, member/call/new 슬롯의
 /// caller 가 paren 으로 감싸 `void 0.x` → `void (0.x)` 오파싱 방지.
@@ -40,8 +106,9 @@ pub fn emitNodeMaybeUndefParen(self: anytype, idx: NodeIndex, level: Level, flag
 }
 
 pub fn emitCall(self: anytype, node: Node, level: Level, flags: ExprFlags) !void {
-    _ = level; // PR6: wrap = level.gte(.new) || flags.forbid_call
-    _ = flags; // forbid_call 은 callee 로 전파 안 함(call 이 자기 wrap 에서 소진) — esbuild ECall parity.
+    _ = level; // wrap(level>=.new | forbid_call | optional-chain | pure) 은 exprNeedsParens 중앙 처리.
+    _ = flags; // callee 의 has_non_optional_chain_parent 는 call 자신의 optional-ness 로 계산
+    // (incoming flags 전파 안 함). forbid_call 도 callee 로 전파 안 함 — esbuild ECall parity.
     try self.addSourceMapping(node.span);
     const e = node.data.extra;
     if (!self.ast.hasExtra(e, 3)) return;
@@ -57,10 +124,19 @@ pub fn emitCall(self: anytype, node: Node, level: Level, flags: ExprFlags) !void
     if (try tryEmitGlobObject(self, callee, args_start, args_len)) return;
     if (try tryEmitRequireContextObject(self, node)) return;
 
-    if (is_pure and !self.options.minify_whitespace) try self.write("/* @__PURE__ */ ");
-    // callee level = .postfix. non-optional call 은 callee 에 has_non_optional_chain_parent
-    // set(PR6 에서 callee 가 optional-chain start 면 wrap). forbid_call 은 전파 안 함(위 참조).
-    const callee_flags = ExprFlags{ .has_non_optional_chain_parent = !is_optional };
+    // pure-comment 가 버퍼 위치를 밀면 callee(예: stmt-start 의 function expression)가
+    // statement-start 마크와 어긋난다 → save/restore 로 마크를 comment 뒤로 옮긴다
+    // (esbuild ECall). 그래야 `/* @__PURE__ */ (function(){})()` 의 괄호가 살아난다.
+    if (is_pure and !self.options.minify_whitespace) {
+        const start_flags = self.saveExprStartFlags();
+        try self.write("/* @__PURE__ */ ");
+        self.restoreExprStartFlags(start_flags);
+    }
+    // callee level = .postfix. self 가 None(체인 밖)이면 callee 에 has_non_optional_chain_parent
+    // set(callee 가 optional-chain start/continue 면 exprNeedsParens 가 wrap). forbid_call 은
+    // 전파 안 함 — call 이 자기 wrap 에서 소진(esbuild ECall parity).
+    const self_in_chain = is_optional or objectContinuesOptionalChain(self, callee);
+    const callee_flags = ExprFlags{ .has_non_optional_chain_parent = !self_in_chain };
     try emitNodeMaybeUndefParen(self, callee, Level.postfix, callee_flags);
     if (is_optional) try self.write("?.");
     try self.writeByte('(');
@@ -321,36 +397,24 @@ fn tryRewriteRequire(self: anytype, callee: ast_mod.NodeIndex, args_start: u32, 
     return false;
 }
 
-/// `new MemberExpression Arguments` 문법상 callee 는 MemberExpression 이어야 함.
-/// callee 의 member chain 안에 call_expression 이 있으면 `new A(x)` 가 `new (A)(x)` 로
-/// 잘못 파싱되어 뒤따르는 `()` 가 외부 call 로 붙음 (#1507). 감싸서 Primary 로 승격.
-fn newCalleeNeedsParens(self: anytype, idx: NodeIndex) bool {
+/// `new Animated.Value()` 처럼 callee 자체엔 call 이 없어도 linker rename 후
+/// `Animated`가 `require_x().Animated` 같은 call 포함 표현식으로 바뀌면 `new` 의 첫
+/// `()` 가 그 call 에 붙어 `(new require_x()).Animated.Value()` 로 결합이 달라진다 →
+/// member chain 의 leaf 식별자가 rename→call 이면 callee 전체를 괄호로 감싼다.
+/// AST 노드로는 식별자(identifier_reference)라 precedence(AST 기반)가 못 잡는 유일한
+/// new-callee 케이스이므로 ad-hoc 으로 유지 (#4042 PR7). 나머지(callee 안의 call/
+/// binary/conditional/sequence/… )는 precedence(.new + forbid_call)가 재유도한다.
+fn newCalleeNeedsRenameParens(self: anytype, idx: NodeIndex) bool {
     var cur = idx;
     while (true) {
         const n = self.ast.getNode(cur);
         switch (n.tag) {
-            .call_expression => return true,
-            // `undefined` 가 `void 0` peephole 적용 후 `new void 0` → `new void (0)` 로 오파싱.
-            .identifier_reference => return identifierRenameContainsCall(self, cur) or isUndefinedPeephole(self, cur),
+            .identifier_reference => return identifierRenameContainsCall(self, cur),
             .static_member_expression, .computed_member_expression, .private_field_expression => {
                 cur = self.ast.readExtraNode(n.data.extra, 0);
             },
-            // `new MemberExpression` callee 슬롯이 아닌 expression: paren 을 벗기면 결합이 깨진다.
-            // `new (a||b)()` → `new a||b()` 가 `(new a)||b()` 로 결합 (#2960).
-            // function/class expression 은 PrimaryExpression 이라 callee 슬롯에 직접 가능 (#1586).
-            .logical_expression,
-            .binary_expression,
-            .conditional_expression,
-            .assignment_expression,
-            .sequence_expression,
-            .arrow_function_expression,
-            .new_expression,
-            .yield_expression,
-            .await_expression,
-            .import_expression,
-            .unary_expression,
-            .update_expression,
-            => return true,
+            // paren 은 투명(codegen 이 괄호 미출력) — 안쪽으로 따라가 rename leaf 검사.
+            .parenthesized_expression => cur = n.data.unary.operand,
             else => return false,
         }
     }
@@ -415,12 +479,12 @@ fn tryEmitWorkerURL(self: anytype, callee: ast_mod.NodeIndex, args_start: u32, a
 }
 
 pub fn emitNew(self: anytype, node: Node, level: Level, flags: ExprFlags) !void {
-    _ = level; // PR6: wrap = level.gte(.call)
+    _ = level; // wrap(level>=.call | pure-comment) 은 exprNeedsParens 중앙 처리.
     _ = flags;
     try self.addSourceMapping(node.span);
     const e = node.data.extra;
     if (!self.ast.hasExtra(e, 3)) return;
-    var callee = self.ast.readExtraNode(e, 0);
+    const callee = self.ast.readExtraNode(e, 0);
     const args_start = self.ast.readExtra(e, 1);
     const args_len = self.ast.readExtra(e, 2);
     const new_flags = self.ast.readExtra(e, 3);
@@ -432,23 +496,14 @@ pub fn emitNew(self: anytype, node: Node, level: Level, flags: ExprFlags) !void 
     if (try tryEmitWorkerURL(self, callee, args_start, args_len)) return;
 
     try self.write("new ");
-    // 원본의 잉여 parens 제거 (#1586): callee가 `(inner)` 형태이고 inner를
-    // 직접 새 callee로 써도 `new MemberExpression` 문법이 깨지지 않으면 벗긴다.
-    // newCalleeNeedsParens가 이미 call-chain 안전성을 판정하므로 재사용.
-    if (self.options.minify_syntax) {
-        while (true) {
-            const cn = self.ast.getNode(callee);
-            if (cn.tag != .parenthesized_expression) break;
-            const inner = cn.data.unary.operand;
-            if (newCalleeNeedsParens(self, inner)) break;
-            callee = inner;
-        }
-    }
-    const needs_parens = newCalleeNeedsParens(self, callee);
+    // callee 의 군더더기 괄호(`new (a)()`)는 emitParen 투명화가 제거하고, callee 안에
+    // call/binary/conditional/sequence 등이 섞이면 precedence(.new + forbid_call)가
+    // 괄호를 재유도한다. precedence 가 못 잡는 건 rename→call 체인(식별자)뿐이라 그것만 ad-hoc.
+    const needs_parens = newCalleeNeedsRenameParens(self, callee);
     if (needs_parens) try self.writeByte('(');
-    // callee level = .new + forbid_call(set) — `new (foo())` 보존. ad-hoc 괄호는 PR6 에서
-    // precedence 로 대체될 때까지 유지(byte-identical).
-    try self.emitExpr(callee, Level.new, .{ .forbid_call = true });
+    // callee = .new + forbid_call(set): `new (foo())` 보존. `undefined`→`void 0`
+    // peephole 슬롯이라 emitNodeMaybeUndefParen 경유(`new void 0`→`new void(0)` 오파싱 방지).
+    try emitNodeMaybeUndefParen(self, callee, Level.new, .{ .forbid_call = true });
     if (needs_parens) try self.writeByte(')');
     try self.writeByte('(');
     try self.emitExpressionNodeList(args_start, args_len, self.listSep());

--- a/src/codegen/calls.zig
+++ b/src/codegen/calls.zig
@@ -501,9 +501,11 @@ pub fn emitNew(self: anytype, node: Node, level: Level, flags: ExprFlags) !void 
     // 괄호를 재유도한다. precedence 가 못 잡는 건 rename→call 체인(식별자)뿐이라 그것만 ad-hoc.
     const needs_parens = newCalleeNeedsRenameParens(self, callee);
     if (needs_parens) try self.writeByte('(');
-    // callee = .new + forbid_call(set): `new (foo())` 보존. `undefined`→`void 0`
-    // peephole 슬롯이라 emitNodeMaybeUndefParen 경유(`new void 0`→`new void(0)` 오파싱 방지).
-    try emitNodeMaybeUndefParen(self, callee, Level.new, .{ .forbid_call = true });
+    // callee = .new + forbid_call + has_non_optional_chain_parent(set): `new (foo())` 보존 +
+    // optional chain 끊기(`new (a?.b)()`/`new (a?.b.c)()`/`new (a?.[b])()` — new 의 첫 `()` 가
+    // optional chain 안으로 들어가면 SyntaxError). new 타겟은 member object 처럼 non-optional
+    // 체인 부모다. `undefined`→`void 0` peephole 슬롯이라 emitNodeMaybeUndefParen 경유.
+    try emitNodeMaybeUndefParen(self, callee, Level.new, .{ .forbid_call = true, .has_non_optional_chain_parent = true });
     if (needs_parens) try self.writeByte(')');
     try self.writeByte('(');
     try self.emitExpressionNodeList(args_start, args_len, self.listSep());

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -95,6 +95,11 @@ pub const Codegen = struct {
     export_default_start: usize = std.math.maxInt(usize),
     arrow_expr_start: usize = std.math.maxInt(usize),
     for_of_init_start: usize = std.math.maxInt(usize),
+    /// 직전에 출력한 numeric literal 이 정수 형태(`42`)라 바로 뒤 `.` 가 소수점으로
+    /// 오파싱될 수 있는 위치. emit 직후 `buf.items.len` 으로 마킹하고, static member
+    /// 의 `.` emit 직전 위치가 일치하면 공백을 끼운다(`42 .toString()`). esbuild
+    /// `needSpaceBeforeDot`. `maxInt` = 미마킹(절대 매치 안 됨).
+    need_space_before_dot: usize = std.math.maxInt(usize),
     pub fn init(allocator: std.mem.Allocator, ast: *const Ast) Codegen {
         return initWithOptions(allocator, ast, .{});
     }

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -357,6 +357,53 @@ pub const Codegen = struct {
     pub const emitRewriteValue = call_emit.emitRewriteValue;
     pub const emitRequireRewriteOrCall = call_emit.emitRequireRewriteOrCall;
 
+    /// statement-start 모호성 마크 4종의 현재 활성 여부 스냅샷 (esbuild
+    /// `exprStartFlags`). prefix(주석/`/* @__PURE__ */`)를 출력해 버퍼 위치가
+    /// 밀리기 전에 캡처하고, 출력 직후 `restoreExprStartFlags` 로 마크를 새 위치로
+    /// 옮겨 prefix 뒤의 expression 이 여전히 "그 컨텍스트의 첫 토큰" 으로 판정되게 한다.
+    pub const ExprStartFlags = packed struct {
+        stmt_start: bool = false,
+        export_default_start: bool = false,
+        arrow_expr_start: bool = false,
+        for_of_init_start: bool = false,
+    };
+
+    /// 현재 출력 위치에서 어떤 statement-start 마크가 활성인지 캡처 (esbuild
+    /// `saveExprStartFlags`).
+    pub fn saveExprStartFlags(self: *Codegen) ExprStartFlags {
+        const n = self.buf.items.len;
+        return .{
+            .stmt_start = self.stmt_start == n,
+            .export_default_start = self.export_default_start == n,
+            .arrow_expr_start = self.arrow_expr_start == n,
+            .for_of_init_start = self.for_of_init_start == n,
+        };
+    }
+
+    /// 캡처해 둔 마크를 현재 출력 위치로 복원 (esbuild `restoreExprStartFlags`).
+    /// prefix 출력 후 호출해 마크가 prefix 뒤 토큰을 가리키게 한다.
+    pub fn restoreExprStartFlags(self: *Codegen, flags: ExprStartFlags) void {
+        const n = self.buf.items.len;
+        if (flags.stmt_start) self.stmt_start = n;
+        if (flags.export_default_start) self.export_default_start = n;
+        if (flags.arrow_expr_start) self.arrow_expr_start = n;
+        if (flags.for_of_init_start) self.for_of_init_start = n;
+    }
+
+    /// 현재 위치가 statement-start 또는 arrow expression body-start 마크와 일치하는지.
+    /// object literal(`({})`)·destructuring 할당(`({a}=b)`) wrap 판정에 쓴다.
+    pub fn atStmtOrArrowStart(self: *Codegen) bool {
+        const n = self.buf.items.len;
+        return self.stmt_start == n or self.arrow_expr_start == n;
+    }
+
+    /// 현재 위치가 statement-start 또는 export-default-start 마크와 일치하는지.
+    /// function/class expression(`(function(){})`·`(class{})`) wrap 판정에 쓴다.
+    pub fn atStmtOrExportDefaultStart(self: *Codegen) bool {
+        const n = self.buf.items.len;
+        return self.stmt_start == n or self.export_default_start == n;
+    }
+
     // JSX 출력 함수 제거: Transformer의 jsx_lowering이 JSX → call_expression 변환을 담당.
     // emitJSXElement, emitJSXFragment, emitJSXTagName, emitJSXAttrsClassic,
     // emitJSXPropsAutomatic, emitJSXChildrenClassic, emitJSXChildrenAutomatic,

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -48,19 +48,19 @@ test "ES2020: ?? no transform on es2020" {
 test "ES2020: ?. member" {
     var r = try e2eTarget(std.testing.allocator, "a?.b;", .es2019);
     defer r.deinit();
-    try std.testing.expectEqualStrings("(a==null?void 0:a.b);", r.output);
+    try std.testing.expectEqualStrings("a==null?void 0:a.b;", r.output);
 }
 
 test "ES2020: ?. computed" {
     var r = try e2eTarget(std.testing.allocator, "a?.[0];", .es2019);
     defer r.deinit();
-    try std.testing.expectEqualStrings("(a==null?void 0:a[0]);", r.output);
+    try std.testing.expectEqualStrings("a==null?void 0:a[0];", r.output);
 }
 
 test "ES2020: ?. call" {
     var r = try e2eTarget(std.testing.allocator, "a?.();", .es2019);
     defer r.deinit();
-    try std.testing.expectEqualStrings("(a==null?void 0:a());", r.output);
+    try std.testing.expectEqualStrings("a==null?void 0:a();", r.output);
 }
 
 test "ES2020: optional eval call indirect eval 보존" {
@@ -72,13 +72,13 @@ test "ES2020: optional eval call indirect eval 보존" {
 test "ES2020: ?. side effect (temp var)" {
     var r = try e2eTarget(std.testing.allocator, "foo()?.bar;", .es2019);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var _a;((_a=foo())==null?void 0:_a.bar);", r.output);
+    try std.testing.expectEqualStrings("var _a;(_a=foo())==null?void 0:_a.bar;", r.output);
 }
 
 test "ES2020: ?. chain continuation" {
     var r = try e2eTarget(std.testing.allocator, "a?.b.c;", .es2019);
     defer r.deinit();
-    try std.testing.expectEqualStrings("(a==null?void 0:a.b.c);", r.output);
+    try std.testing.expectEqualStrings("a==null?void 0:a.b.c;", r.output);
 }
 
 test "ES2020: ?. no transform on esnext" {
@@ -98,13 +98,13 @@ test "ES2021: ??= to es2020" {
 test "ES2021: ??= to es2019 (double lowering)" {
     var r = try e2eTarget(std.testing.allocator, "a ??= b;", .es2019);
     defer r.deinit();
-    try std.testing.expectEqualStrings("a!=null?a:(a=b);", r.output);
+    try std.testing.expectEqualStrings("a!=null?a:a=b;", r.output);
 }
 
 test "ES2021: ??= member to es2019 captures to temp" {
     var r = try e2eTarget(std.testing.allocator, "obj.x ??= b;", .es2019);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var _a;(_a=obj.x)!=null?_a:(obj.x=b);", r.output);
+    try std.testing.expectEqualStrings("var _a;(_a=obj.x)!=null?_a:obj.x=b;", r.output);
 }
 
 test "ES2021: ??= no transform on esnext" {
@@ -156,7 +156,7 @@ test "ES2016: **= member receiver 1회 평가" {
 test "ES2016: **= computed member key 1회 평가" {
     var r = try e2eTarget(std.testing.allocator, "obj[getKey()] **= 3;", .es2015);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "obj[(_a=getKey())]=Math.pow(obj[_a],3)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "obj[_a=getKey()]=Math.pow(obj[_a],3)") != null);
 }
 
 test "ES2016: ** no transform on es2016" {
@@ -235,19 +235,19 @@ test "ES2022: static block with methods preserved" {
 test "ES2017: async function declaration" {
     var r = try e2eFull(std.testing.allocator, "export async function foo() { return await bar(); }", .{ .unsupported = TransformOptions.compat.fromESTarget(.es2016) }, .{ .minify_whitespace = true }, ".mts");
     defer r.deinit();
-    try std.testing.expectEqualStrings("export function foo(){return __async(function*(){return(yield bar());}).call(this);}", r.output);
+    try std.testing.expectEqualStrings("export function foo(){return __async(function*(){return yield bar();}).call(this);}", r.output);
 }
 
 test "ES2017: async arrow block body" {
     var r = try e2eFull(std.testing.allocator, "export const f = async () => { await x; };", .{ .unsupported = TransformOptions.compat.fromESTarget(.es2016) }, .{ .minify_whitespace = true }, ".mts");
     defer r.deinit();
-    try std.testing.expectEqualStrings("export const f=()=>__async(function*(){(yield x);}).call(this);", r.output);
+    try std.testing.expectEqualStrings("export const f=()=>__async(function*(){yield x;}).call(this);", r.output);
 }
 
 test "ES2017: async arrow expression body" {
     var r = try e2eFull(std.testing.allocator, "export const f = async () => await x;", .{ .unsupported = TransformOptions.compat.fromESTarget(.es2016) }, .{ .minify_whitespace = true }, ".mts");
     defer r.deinit();
-    try std.testing.expectEqualStrings("export const f=()=>__async(function*(){return(yield x);}).call(this);", r.output);
+    try std.testing.expectEqualStrings("export const f=()=>__async(function*(){return yield x;}).call(this);", r.output);
 }
 
 test "ES2017: no transform on es2017" {
@@ -1997,7 +1997,7 @@ test "ES2015: derived constructor return 값이 super를 먼저 평가" {
 test "ES2015: derived constructor return comma expression super 평가 순서" {
     var r = try e2eTarget(std.testing.allocator, "class C extends P{constructor(){return (super(),undefined);}}", .es5);
     defer r.deinit();
-    const helper_pos = std.mem.indexOf(u8, r.output, "__possibleConstructorReturn(((__assertThisUninitialized") orelse return error.TestExpectedEqual;
+    const helper_pos = std.mem.indexOf(u8, r.output, "__possibleConstructorReturn((__assertThisUninitialized") orelse return error.TestExpectedEqual;
     const this_pos = std.mem.indexOfPos(u8, r.output, helper_pos, "),_this)") orelse return error.TestExpectedEqual;
     try std.testing.expect(helper_pos < this_pos);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__possibleConstructorReturn(_this,((__assertThisUninitialized") == null);
@@ -2730,13 +2730,13 @@ test "ES2020: ?. with method call" {
 test "ES2020: optional method call this 바인딩 보존" {
     var r = try e2eTarget(std.testing.allocator, "obj.method?.(1,2);", .es2019);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var _a;((_a=obj.method)==null?void 0:_a.call(obj,1,2));", r.output);
+    try std.testing.expectEqualStrings("var _a;(_a=obj.method)==null?void 0:_a.call(obj,1,2);", r.output);
 }
 
 test "ES2020: optional method call 복잡 receiver 1회 평가" {
     var r = try e2eTarget(std.testing.allocator, "getObj().method?.();", .es2019);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var _a,_b;((_b=(_a=getObj()).method)==null?void 0:_b.call(_a));", r.output);
+    try std.testing.expectEqualStrings("var _a,_b;(_b=(_a=getObj()).method)==null?void 0:_b.call(_a);", r.output);
 }
 
 test "ES2020: optional super method call this 바인딩 보존" {
@@ -2864,7 +2864,7 @@ test "ES2021: logical assignment computed super member key 1회 평가" {
     var r = try e2eTarget(std.testing.allocator, "class C extends B{m(){super[getKey()] ||= 1;}}", .es2020);
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "=super") == null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "super[(_a=getKey())]||") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "super[_a=getKey()]||") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "super[_a]=1") != null);
 }
 
@@ -2891,7 +2891,7 @@ test "ES2021: &&= member receiver 1회 평가" {
 test "ES2021: ??= computed member key 1회 평가" {
     var r = try e2eTarget(std.testing.allocator, "obj[getKey()] ??= 5;", .es2019);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=getKey())") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_a=getKey()") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "obj[_a]=5") != null);
 }
 

--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -1420,15 +1420,15 @@ test "Flow: trailing %checks 선언문 회귀 가드 (#3527)" {
 test "Flow: object type `proto` property modifier stripped" {
     var r = try e2eFlow(std.testing.allocator, "type T = { proto p: string }; let v: T = ({});");
     defer r.deinit();
-    try std.testing.expectEqualStrings("let v=({});", r.output);
+    try std.testing.expectEqualStrings("let v={};", r.output);
 }
 
 test "Flow: `proto` with variance + `proto` as key (회귀 가드)" {
     var r1 = try e2eFlow(std.testing.allocator, "type U = { proto +q: number }; let w: U = ({});");
     defer r1.deinit();
-    try std.testing.expectEqualStrings("let w=({});", r1.output);
+    try std.testing.expectEqualStrings("let w={};", r1.output);
     // `proto` 자체가 키인 경우는 modifier 아님 — 정상 strip 유지.
     var r2 = try e2eFlow(std.testing.allocator, "type P = { proto: string }; let z: P = ({});");
     defer r2.deinit();
-    try std.testing.expectEqualStrings("let z=({});", r2.output);
+    try std.testing.expectEqualStrings("let z={};", r2.output);
 }

--- a/src/codegen/codegen_test/load_bearing_paren.zig
+++ b/src/codegen/codegen_test/load_bearing_paren.zig
@@ -3,15 +3,13 @@
 //! tests/integration/tests/load-bearing-paren.test.ts 가 담당한다.
 //!
 //! 입력은 괄호가 *의미를 갖는*(= 빼면 다른 프로그램이 되거나 invalid 가 되는)
-//! 최소 표현이다. 현재(precedence 전환 전)는 parenthesized_expression 노드로
-//! 보존하고, 전환(PR4) 후에는 emitExpr 가 precedence 로 재유도한다 — 어느 쪽이든
-//! 괄호가 살아있어야 한다. indexOf 로 핵심 괄호 부분문자열 생존만 보므로
-//! minify/공백 정책 변화에 영향받지 않고 PR3·PR4 양쪽에서 통과한다.
+//! 최소 표현이다. precedence 전환 후 emitExpr 가 괄호를 재유도한다 — 다만 군더더기
+//! 제거로 *형태*가 바뀔 수 있어(예: `(42)`→`42 .`, `(a().b)`→`(a())`) 의미를 보존하는
+//! 한 핵심 부분문자열을 갱신한다. indexOf 로 핵심 보존 부분문자열만 본다.
 //!
-//! TODO(PR4): 아래 두 케이스는 현재 codegen 갭(이슈 #4042 인스턴스 6·7)이라
-//! precedence 전환에서 비로소 해소된다 — 그때 매트릭스에 추가한다.
-//!   - `({x:1} as T).c` (TS as strip 후 statement-start `{` 유실)
-//!   - es2019 optional-chain lowering 의 이중괄호 정리
+//! 인스턴스 6·7(#4042)도 precedence 전환에서 해소되어 아래에 포함:
+//!   - 6: `({x:1} as T).c` (TS as strip 후 object literal statement-start 괄호 재유도)
+//!   - 7: es2019 optional-chain lowering 의 이중괄호 정리는 es_downlevel `?.` 테이블이 커버.
 
 const std = @import("std");
 const helpers = @import("helpers.zig");
@@ -35,8 +33,10 @@ test "load-bearing: optional-chain 끊기 (a?.b).c" {
 test "load-bearing: numeric-then-dot (42).toString()" {
     var r = try e2e(std.testing.allocator, "(42).toString();");
     defer r.deinit();
-    // 괄호 유실 시 `42.toString` 은 `42.` 가 float 로 오파싱되어 invalid.
-    try expectParenSurvives(r.output, "(42)");
+    // 괄호 유실 시 `42.toString` 은 `42.` 가 float 로 오파싱되어 invalid. precedence 전환
+    // 후에는 괄호 대신 공백(`42 .toString`, esbuild needSpaceBeforeDot)으로 끊는다 —
+    // 둘 다 의미 보존. `42.` 로 붙는 invalid 출력만 회귀.
+    try expectParenSurvives(r.output, "42 .toString");
 }
 
 test "load-bearing: 음수 단항이 ** 의 좌측 (-a)**b" {
@@ -61,11 +61,13 @@ test "load-bearing: ?? 와 || 혼용 (a||b)??c" {
     try expectParenSurvives(r.output, "(a||b)");
 }
 
-test "load-bearing: new callee 의 call-chain new (a().b)()" {
+test "load-bearing: new callee 의 call-chain new (a()).b()" {
     var r = try e2e(std.testing.allocator, "new (a().b)();");
     defer r.deinit();
-    // 괄호 유실 시 `new a().b()` 는 `(new a()).b()` 로 결합이 깨진다(#1507).
-    try expectParenSurvives(r.output, "(a().b)");
+    // 괄호 유실 시 `new a().b()` 는 `(new a()).b()` 로 new 가 첫 call 에 결합돼 깨진다(#1507).
+    // precedence 전환 후 forbid_call 전파로 inner call 만 감싼다(`new (a()).b()`, esbuild parity)
+    // — `(a().b)` 전체 대신 `(a())` 로 동등 보존.
+    try expectParenSurvives(r.output, "new (a()).b()");
 }
 
 test "load-bearing: assignment 가 binary 피연산자 (a=b)+c" {
@@ -80,4 +82,20 @@ test "load-bearing: arrow 본문 object literal () => ({})" {
     // 괄호 유실 시 `() => {x:1}` 의 `{` 는 블록으로 파싱되어 객체를 반환하지 않는다.
     // arrow `=>` 직후의 `({` 를 함께 봐 다른 위치 괄호와의 우연 매칭을 배제한다.
     try expectParenSurvives(r.output, "=>({");
+}
+
+test "load-bearing: 인스턴스6 — TS as strip 후 object statement-start ({x:1} as T).c" {
+    var r = try e2e(std.testing.allocator, "({x:1} as any).c;");
+    defer r.deinit();
+    // `as any` 타입 래퍼를 벗겨도 object literal 이 statement-start 라 괄호 재유도 필요.
+    // 유실 시 `{x:1}.c` 의 `{` 가 블록으로 오파싱(이슈 #4042 인스턴스 6).
+    try expectParenSurvives(r.output, "({x:1})");
+}
+
+test "load-bearing: optional-chain 끊기 타입래퍼 통과 (a?.b as T).c" {
+    var r = try e2e(std.testing.allocator, "(a?.b as any).c;");
+    defer r.deinit();
+    // 타입 래퍼를 벗길 때 괄호까지 떼면 `a?.b.c` 로 체인이 이어져 의미가 바뀐다
+    // (a nullish 시 throw vs undefined). precedence 가 체인 끊기 괄호를 재유도.
+    try expectParenSurvives(r.output, "(a?.b)");
 }

--- a/src/codegen/codegen_test/load_bearing_paren.zig
+++ b/src/codegen/codegen_test/load_bearing_paren.zig
@@ -14,6 +14,7 @@
 const std = @import("std");
 const helpers = @import("helpers.zig");
 const e2e = helpers.e2e;
+const e2eWithOptions = helpers.e2eWithOptions;
 
 fn expectParenSurvives(output: []const u8, needle: []const u8) !void {
     if (std.mem.indexOf(u8, output, needle) == null) {
@@ -128,4 +129,27 @@ test "load-bearing: assignment shorthand default sequence ({x=(a,b)}=o)" {
     defer r.deinit();
     // 괄호 유실 시 `x=a,b` 는 default 가 `a` 로 바뀌고 `b` 가 별도 평가 → silent miscompile.
     try expectParenSurvives(r.output, "(a,b)");
+}
+
+test "load-bearing: 주석이 statement-start object 마크 무력화 (/*c*/{a:1}).b" {
+    var r = try e2eWithOptions(std.testing.allocator, "(/*c*/{a:1}).b;", .{});
+    defer r.deinit();
+    // 주석이 buf 위치를 밀어 stmt_start 마크와 어긋나면 `{a:1}.b` 의 `{` 가 block 으로
+    // 오파싱(legal 주석은 minify 에서도 생존 → 프로덕션 깨짐). save/restore 로 재앵커.
+    try expectParenSurvives(r.output, "({ a: 1 })");
+}
+
+test "load-bearing: 주석이 arrow body object 마크 무력화 ()=>(/*c*/{a:1})" {
+    var r = try e2eWithOptions(std.testing.allocator, "var f = () => (/*c*/{a:1});", .{});
+    defer r.deinit();
+    // 유실 시 `() => {a:1}` 의 `{` 가 block body → 객체 미반환(silent runtime miscompile).
+    try expectParenSurvives(r.output, "({ a: 1 })");
+}
+
+test "load-bearing: for-init sequence 의 in 누수 for((a in b),c;;)" {
+    var r = try e2e(std.testing.allocator, "for ((a in b), c;;) {}");
+    defer r.deinit();
+    // 유실 시 `for (a in b,c;;)` 는 for-in 헤더 오파싱 → SyntaxError. forbid_in 시드된
+    // sequence 는 통째로 감싼다(emitList 가 원소 flag clear 하므로 sequence 레벨 처리).
+    try expectParenSurvives(r.output, "(a in b,c)");
 }

--- a/src/codegen/codegen_test/load_bearing_paren.zig
+++ b/src/codegen/codegen_test/load_bearing_paren.zig
@@ -99,3 +99,33 @@ test "load-bearing: optional-chain 끊기 타입래퍼 통과 (a?.b as T).c" {
     // (a nullish 시 throw vs undefined). precedence 가 체인 끊기 괄호를 재유도.
     try expectParenSurvives(r.output, "(a?.b)");
 }
+
+test "load-bearing: new callee 가 optional chain new (a?.b)()" {
+    var r = try e2e(std.testing.allocator, "new (a?.b)();");
+    defer r.deinit();
+    // 괄호 유실 시 `new a?.b()` 는 SyntaxError(new 의 첫 `()` 가 optional chain 안으로
+    // 들어갈 수 없음). new 타겟에 has_non_optional_chain_parent set 으로 체인 끊기.
+    try expectParenSurvives(r.output, "(a?.b)");
+}
+
+test "load-bearing: 정수-점 numeric separator 100_000 .toString()" {
+    var r = try e2e(std.testing.allocator, "(100_000).toString();");
+    defer r.deinit();
+    // `100_000.toString` 은 `100_000.` 가 float 로 오파싱되어 invalid → 공백 보존
+    // (needSpaceBeforeDot, all-digit 만 보면 구분자 `_` 가 누락되던 회귀).
+    try expectParenSurvives(r.output, "100_000 .toString");
+}
+
+test "load-bearing: for-init top-level in 은 for-in 헤더 오파싱 방지 for((a in b);;)" {
+    var r = try e2e(std.testing.allocator, "for ((a in b);;) {}");
+    defer r.deinit();
+    // 괄호 유실 시 `for (a in b;;)` 는 for-in 헤더로 오파싱 → SyntaxError. forbid_in 시드.
+    try expectParenSurvives(r.output, "(a in b)");
+}
+
+test "load-bearing: assignment shorthand default sequence ({x=(a,b)}=o)" {
+    var r = try e2e(std.testing.allocator, "({x = (a, b)} = obj);");
+    defer r.deinit();
+    // 괄호 유실 시 `x=a,b` 는 default 가 `a` 로 바뀌고 `b` 가 별도 평가 → silent miscompile.
+    try expectParenSurvives(r.output, "(a,b)");
+}

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -85,8 +85,9 @@ test "private method: conditional nullish temp is hoisted into standalone functi
     , .es5);
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "function _compute_fn(){var _a;") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=(typeof this.options.refetchInterval===\"function\"") != null or
-        std.mem.indexOf(u8, r.output, "(_a=(typeof this.options.refetchInterval==\"function\"") != null);
+    // 군더더기 괄호 제거(#4042): `(_a = typeof ... ? ... : ...)` — 조건식 둘레의 inner 괄호 불필요.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=typeof this.options.refetchInterval===\"function\"") != null or
+        std.mem.indexOf(u8, r.output, "(_a=typeof this.options.refetchInterval==\"function\"") != null);
 }
 
 test "private method: multiple methods" {

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -133,24 +133,46 @@ fn binaryChildLevels(self: anytype, node: Node) BinaryChildLevels {
     return .{ .left = left_level, .right = right_level };
 }
 
-/// 노드가 `||`(.pipe2) 또는 `&&`(.amp2) logical_expression 인지.
+/// transparent wrapper(paren/chain/TS·Flow type cast)를 벗겨 실제 피연산자 노드를 반환.
+/// emitParen 투명화(#4042) 후, 자식 노드 구조를 *직접* 검사하는 헬퍼들(`??`/`||` 혼용,
+/// `**` 좌단항, RHS 부호 토큰)은 래퍼 너머의 실제 노드를 봐야 정확하다 — 래퍼는 더 이상
+/// `(` 를 출력하지 않으므로 출력 시작 토큰이 안쪽 operand 의 것이 된다.
+fn skipTransparent(self: anytype, idx: NodeIndex) NodeIndex {
+    var cur = idx;
+    var depth: u8 = 0;
+    while (depth < 32) : (depth += 1) {
+        if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return cur;
+        const n = self.ast.getNode(cur);
+        if (n.tag == .parenthesized_expression or n.tag == .chain_expression or
+            ast_mod.Node.Tag.isTransparentTypeWrapper(n.tag))
+        {
+            cur = n.data.unary.operand;
+        } else return cur;
+    }
+    return cur;
+}
+
+/// 노드가 (transparent wrapper 너머로) `||`(.pipe2) 또는 `&&`(.amp2) logical_expression 인지.
 fn binaryChildIsLogical(self: anytype, idx: NodeIndex) bool {
-    if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return false;
-    const n = self.ast.getNode(idx);
+    const real = skipTransparent(self, idx);
+    if (real.isNone() or @intFromEnum(real) >= self.ast.nodes.items.len) return false;
+    const n = self.ast.getNode(real);
     if (n.tag != .logical_expression) return false;
     const cop: Kind = @enumFromInt(n.data.binary.flags);
     return cop == .pipe2 or cop == .amp2;
 }
 
-/// `**` 좌측이 출력 시 prefix 단항으로 시작해 직접 올 수 없는 형태인지.
-/// esbuild BinOpPow: unary(비-update)/await/undefined(`void 0`)/number(음수)/(minify)boolean.
+/// `**` 좌측이 출력 시 prefix 단항으로 시작해 직접 올 수 없는 형태인지 (transparent
+/// wrapper 너머). esbuild BinOpPow: unary(비-update)/await/undefined(`void 0`)/number(음수)/
+/// (minify)boolean.
 fn powLeftNeedsParen(self: anytype, idx: NodeIndex) bool {
-    if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return false;
-    const n = self.ast.getNode(idx);
+    const real = skipTransparent(self, idx);
+    if (real.isNone() or @intFromEnum(real) >= self.ast.nodes.items.len) return false;
+    const n = self.ast.getNode(real);
     return switch (n.tag) {
         .unary_expression, .await_expression, .numeric_literal => true,
         .boolean_literal => self.options.minify_syntax, // !0/!1 peephole
-        else => calls.isUndefinedPeephole(self, idx), // undefined → void 0
+        else => calls.isUndefinedPeephole(self, real), // undefined → void 0
     };
 }
 
@@ -233,6 +255,9 @@ fn rhsLeadingSignChar(self: anytype, idx: NodeIndex) ?u8 {
     var cur = idx;
     var depth: u8 = 0;
     while (depth < 32) : (depth += 1) {
+        // transparent wrapper(paren 등)는 `(` 미출력 → 안쪽 토큰이 시작 (#4042).
+        cur = skipTransparent(self, cur);
+        if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return null;
         const n = self.ast.getNode(cur);
         switch (n.tag) {
             .unary_expression => return switch (unaryOpKind(self, n.data.extra) orelse return null) {
@@ -335,11 +360,33 @@ pub fn emitSequence(self: anytype, node: Node) !void {
     try self.emitList(node, ",");
 }
 
-pub fn emitParen(self: anytype, node: Node) !void {
-    try self.addSourceMapping(node.span);
-    try self.writeByte('(');
-    try self.emitNode(node.data.unary.operand);
-    try self.writeByte(')');
+/// `parenthesized_expression` 은 대체로 투명 — 괄호를 출력하지 않고 operand 를 부모의
+/// `level`/`flags` 그대로 재귀한다. 괄호가 필요하면 operand 의 precedence(exprNeedsParens)
+/// 가 재유도한다 (esbuild/oxc 는 paren 노드를 AST 에 두지 않고 precedence 로만 괄호를 낸다).
+/// 군더더기 괄호는 제거하고 load-bearing 만 재유도한다 — 전 모드 통일(#4042). `level`/
+/// `flags` 전파로 `(a?.b as T).c` 같은 타입래퍼 통과 optional-chain 끊기 괄호도 보존된다.
+///
+/// 예외 — function/arrow expression 둘레의 괄호는 *보존*한다 (esbuild 가 EFunction/EArrow
+/// 의 `IsParenthesized` 를 출력에 반영하는 것과 동일). IIFE(`(function(){})()`)·
+/// `var x=(function(){})`·`export default (function(){})` 형태가 유지된다. object/array 는
+/// esbuild 도 IsParenthesized 를 무시하므로 투명 처리한다(`({a:1})`→`{a:1}`).
+pub fn emitParen(self: anytype, node: Node, level: Level, flags: ExprFlags) !void {
+    const inner = node.data.unary.operand;
+    const real = skipTransparent(self, inner);
+    if (!real.isNone() and @intFromEnum(real) < self.ast.nodes.items.len) {
+        switch (self.ast.getNode(real).tag) {
+            .function_expression, .function, .arrow_function_expression => {
+                // 중첩 transparent wrapper 의 이중 괄호 방지 위해 skip 한 실제 노드를
+                // 새 .lowest 컨텍스트로 직접 emit (괄호가 precedence 를 리셋).
+                try self.writeByte('(');
+                try self.emitExpr(real, .lowest, .{});
+                try self.writeByte(')');
+                return;
+            },
+            else => {},
+        }
+    }
+    try self.emitExpr(inner, level, flags);
 }
 
 pub fn emitSpread(self: anytype, node: Node, level: Level, flags: ExprFlags) !void {
@@ -589,13 +636,22 @@ pub fn emitStaticMember(self: anytype, node: Node, level: Level, flags: ExprFlag
         }
     }
 
-    // object level = .postfix. non-optional member 는 object 에 has_non_optional_chain_parent
-    // set(PR6 에서 object 가 optional-chain start 면 `(a?.b).c` 처럼 wrap). forbid_call 보존.
-    const obj_flags = ExprFlags{ .forbid_call = flags.forbid_call, .has_non_optional_chain_parent = (member_flags & MemberFlags.optional_chain) == 0 };
+    // object level = .postfix. self 가 None(체인 밖: optional 아니고 object 도 체인 아님)이면
+    // object 에 has_non_optional_chain_parent set → object 가 optional chain start/continue 면
+    // `(a?.b).c` 처럼 끊는다. Start/Continue 면 clear. forbid_call 보존(esbuild EDot target flags).
+    const self_in_chain = (member_flags & MemberFlags.optional_chain) != 0 or
+        calls.objectContinuesOptionalChain(self, object);
+    const obj_flags = ExprFlags{
+        .forbid_call = flags.forbid_call,
+        .has_non_optional_chain_parent = !self_in_chain,
+    };
     try calls.emitNodeMaybeUndefParen(self, object, Level.postfix, obj_flags);
     if (member_flags & MemberFlags.optional_chain != 0) {
         try self.write("?.");
     } else {
+        // object 가 정수 리터럴로 끝나면 `42.x` 가 `42.`(소수점)으로 오파싱됨 → 공백
+        // (`42 .toString()`). esbuild needSpaceBeforeDot. `?.` 는 소수점 모호성 없어 제외.
+        if (self.need_space_before_dot == self.buf.items.len) try self.writeByte(' ');
         try self.writeByte('.');
     }
     // property name 슬롯은 reserved word 도 valid identifier 로 취급되므로 peephole
@@ -616,7 +672,12 @@ pub fn emitComputedMember(self: anytype, node: Node, level: Level, flags: ExprFl
     const property = self.ast.readExtraNode(e, 1);
     const member_flags = self.ast.readExtra(e, 2);
     const MemberFlags = ast_mod.MemberFlags;
-    const obj_flags = ExprFlags{ .forbid_call = flags.forbid_call, .has_non_optional_chain_parent = (member_flags & MemberFlags.optional_chain) == 0 };
+    const self_in_chain = (member_flags & MemberFlags.optional_chain) != 0 or
+        calls.objectContinuesOptionalChain(self, object);
+    const obj_flags = ExprFlags{
+        .forbid_call = flags.forbid_call,
+        .has_non_optional_chain_parent = !self_in_chain,
+    };
     try calls.emitNodeMaybeUndefParen(self, object, Level.postfix, obj_flags);
     if (member_flags & MemberFlags.optional_chain != 0) {
         try self.write("?.");

--- a/src/codegen/function_class.zig
+++ b/src/codegen/function_class.zig
@@ -318,7 +318,10 @@ pub fn emitClass(self: anytype, node: Node) !void {
     }
     if (!super_class.isNone()) {
         try self.write(" extends ");
-        try self.emitNode(super_class);
+        // extends 절은 LeftHandSideExpression 만 허용 → .postfix(esbuild LNew-1)로 emit해
+        // yield/conditional/logical/sequence 등 그 아래 결합강도는 괄호로 감싼다
+        // (`class C extends (yield 0)`, `extends (a?B:C)`). member/call/new 는 그대로.
+        try self.emitExpr(super_class, .postfix, .{});
     }
     try emitNestedExecutionBody(self, body);
 
@@ -410,6 +413,9 @@ pub fn emitPropertyDef(self: anytype, node: Node) !void {
         try self.writeSpace();
         try self.writeByte('=');
         try self.writeSpace();
+        // init level = .comma (esbuild class field init = LComma): 최상위 sequence
+        // (`f = (a,b)`)가 괄호로 감싸진다 — class field init 은 AssignmentExpression 이라
+        // 콤마를 직접 못 받는다(`f = a,b` 는 SyntaxError).
         // contextual name: class property = function-like → key 이름 사용
         if (self.fn_map_builder != null and self.isFunctionLike(value)) {
             const saved = self.pending_fn_name;
@@ -418,9 +424,9 @@ pub fn emitPropertyDef(self: anytype, node: Node) !void {
                 if (self.pending_fn_name) |s| self.allocator.free(s);
                 self.pending_fn_name = saved;
             }
-            try self.emitNode(value);
+            try self.emitExpr(value, .comma, .{});
         } else {
-            try self.emitNode(value);
+            try self.emitExpr(value, .comma, .{});
         }
     }
     try self.writeByte(';');
@@ -463,7 +469,8 @@ pub fn emitAccessorProp(self: anytype, node: Node) !void {
         try self.writeSpace();
         try self.writeByte('=');
         try self.writeSpace();
-        try self.emitNode(value);
+        // init level = .comma: 최상위 sequence 가 콤마 구분과 안 섞이게 (위 emitPropertyDef 참조).
+        try self.emitExpr(value, .comma, .{});
     }
     try self.writeByte(';');
 }

--- a/src/codegen/function_class.zig
+++ b/src/codegen/function_class.zig
@@ -6,6 +6,7 @@ const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const debug_metadata = @import("debug_metadata.zig");
 const statement_emit = @import("statements.zig");
+const call_emit = @import("calls.zig");
 
 fn emitNestedExecutionBody(self: anytype, body: NodeIndex) !void {
     const saved_for_init = self.in_for_init;
@@ -77,8 +78,17 @@ pub fn emitTaggedTemplate(self: anytype, node: Node) !void {
         const is_pure = (flags & TaggedTemplateFlags.is_pure) != 0;
         if (is_pure and !self.options.minify_whitespace) try self.write("/* @__PURE__ */ ");
     }
-    // tag 는 .postfix (esbuild ETemplate tag = LPostfix; optional-chain tag 강제괄호는 PR6 wrap).
-    try self.emitExpr(@enumFromInt(extras[e]), .postfix, .{});
+    // tag 는 .postfix (esbuild ETemplate tag = LPostfix). 단 tag 가 optional chain 이면
+    // ECMAScript 상 tagged template tag 로 불가(`a?.b`x`` = SyntaxError) → 괄호로 감싼다
+    // (esbuild `IsOptionalChain(tag)` 분기). 투명 paren 이 사라져도 체인이 끊긴 채 보존된다.
+    const tag: NodeIndex = @enumFromInt(extras[e]);
+    if (call_emit.isOptionalChainExpr(self, tag)) {
+        try self.writeByte('(');
+        try self.emitExpr(tag, .lowest, .{});
+        try self.writeByte(')');
+    } else {
+        try self.emitExpr(tag, .postfix, .{});
+    }
     try self.emitNode(@enumFromInt(extras[e + 1]));
 }
 
@@ -186,14 +196,26 @@ pub fn emitArrow(self: anytype, node: Node) !void {
     const is_block_body = !body.isNone() and self.ast.getNode(body).tag == .block_statement;
     if (!is_block_body) try self.writeSpace();
 
-    // expression body 의 leftmost token 이 `{` 면 paren wrap (#2964): constant
-    // inline 으로 \`x => ({obj})[x]\` 가 \`x => {obj}[x]\` 로 변환되면 \`{\` 가
-    // block body 로 해석되어 SyntaxError. object_expression 이 leftmost 인 모든
-    // expression (member/binary/conditional 의 left chain) 을 검사.
-    const needs_paren = !is_block_body and !body.isNone() and expressionStartsWithBrace(self, body);
-    if (needs_paren) try self.writeByte('(');
-    try emitNestedExecutionBody(self, body);
-    if (needs_paren) try self.writeByte(')');
+    // arrow expression body: leftmost token 이 `{`(object literal)이면 block body 로
+    // 오파싱되는 것을 막아야 한다 (`x => ({obj})`). arrow_expr_start 를 body 출력 직전
+    // 위치로 마킹하면, leftmost object literal 이 그 위치에서 EObject wrap(exprNeedsParens)
+    // 으로 괄호를 친다 — member/binary/conditional left-chain 을 타고 내려간 object 도
+    // 그 사이 아무것도 안 써서 자동 커버 (esbuild EArrow: `p.arrowExprStart = len(p.js)`).
+    // body level = .comma (esbuild EArrow body = LComma).
+    const saved_for_init = self.in_for_init;
+    const saved_skip_var_init = self.skip_var_init;
+    self.in_for_init = false;
+    self.skip_var_init = false;
+    defer {
+        self.in_for_init = saved_for_init;
+        self.skip_var_init = saved_skip_var_init;
+    }
+    if (is_block_body or body.isNone()) {
+        try self.emitNode(body);
+    } else {
+        self.arrow_expr_start = self.buf.items.len;
+        try self.emitExpr(body, .comma, .{});
+    }
 }
 
 /// 파라미터 노드가 단순 식별자 1개(이름만 출력) 인지 — `binding_identifier` 또는
@@ -220,34 +242,8 @@ fn arrowParamsOmittable(self: anytype, params_idx: NodeIndex) bool {
     return isPlainIdentifierParam(self.ast.getNode(self.ast.readExtraNode(elem.data.extra, FP.pattern)).tag);
 }
 
-fn expressionStartsWithBrace(self: anytype, node_idx: ast_mod.NodeIndex) bool {
-    return expressionStartsWithBraceDepth(self, node_idx, 0);
-}
-
-fn expressionStartsWithBraceDepth(self: anytype, node_idx: ast_mod.NodeIndex, depth: u32) bool {
-    if (depth >= 32) return false;
-    if (node_idx.isNone() or @intFromEnum(node_idx) >= self.ast.nodes.items.len) return false;
-    const n = self.ast.getNode(node_idx);
-    return switch (n.tag) {
-        .object_expression => true,
-        // member: extra = [object(0), property(1), flags(2)]
-        .static_member_expression, .computed_member_expression, .private_field_expression => blk: {
-            const ex = n.data.extra;
-            if (ex >= self.ast.extra_data.items.len) break :blk false;
-            const obj_idx: ast_mod.NodeIndex = @enumFromInt(self.ast.extra_data.items[ex]);
-            break :blk expressionStartsWithBraceDepth(self, obj_idx, depth + 1);
-        },
-        .binary_expression, .logical_expression, .assignment_expression => expressionStartsWithBraceDepth(self, n.data.binary.left, depth + 1),
-        .conditional_expression => expressionStartsWithBraceDepth(self, n.data.ternary.a, depth + 1),
-        .sequence_expression => blk: {
-            const list = n.data.list;
-            const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
-            if (indices.len == 0) break :blk false;
-            break :blk expressionStartsWithBraceDepth(self, @enumFromInt(indices[0]), depth + 1);
-        },
-        else => false,
-    };
-}
+// (expressionStartsWithBrace 제거: arrow expression body 의 `{` 모호성은 이제
+//  arrow_expr_start 마킹 + EObject wrap(precedence)이 처리한다 — #4042 PR7.)
 
 /// class: extra = [name, super, body, type_params, impl_start, impl_len, deco_start, deco_len]
 pub fn emitClass(self: anytype, node: Node) !void {

--- a/src/codegen/modules.zig
+++ b/src/codegen/modules.zig
@@ -533,6 +533,12 @@ pub fn emitExportDefault(self: anytype, node: Node) !void {
     }
     try self.write("export default ");
     const inner_idx = node.data.unary.operand;
+    // export-default-start 마킹: `export default (function(){})` / `export default
+    // (class{})` 처럼 식 형태의 function/class 가 선언문(`export default function(){}`)
+    // 으로 오파싱되지 않도록 expression emitter 가 괄호를 친다 (esbuild exportDefaultStart).
+    // 선언 노드(function_declaration/class_declaration)는 exprNeedsParens 가 제외하므로
+    // 마크가 걸려도 영향 없음.
+    self.export_default_start = self.buf.items.len;
     // contextual name: 익명 function/arrow/class → "default"
     if (self.fn_map_builder != null and self.isFunctionLike(inner_idx)) {
         const saved = self.pending_fn_name;

--- a/src/codegen/modules.zig
+++ b/src/codegen/modules.zig
@@ -539,6 +539,8 @@ pub fn emitExportDefault(self: anytype, node: Node) !void {
     // 선언 노드(function_declaration/class_declaration)는 exprNeedsParens 가 제외하므로
     // 마크가 걸려도 영향 없음.
     self.export_default_start = self.buf.items.len;
+    // value level = .comma (esbuild SExportDefault SExpr = LComma): 최상위 sequence
+    // (`export default (a,b)`)가 괄호로 감싸진다. function/class 선언은 wrap 안 됨(exprNeedsParens 제외).
     // contextual name: 익명 function/arrow/class → "default"
     if (self.fn_map_builder != null and self.isFunctionLike(inner_idx)) {
         const saved = self.pending_fn_name;
@@ -547,9 +549,9 @@ pub fn emitExportDefault(self: anytype, node: Node) !void {
             if (self.pending_fn_name) |s| self.allocator.free(s);
             self.pending_fn_name = saved;
         }
-        try self.emitNode(inner_idx);
+        try self.emitExpr(inner_idx, .comma, .{});
     } else {
-        try self.emitNode(inner_idx);
+        try self.emitExpr(inner_idx, .comma, .{});
     }
     // class/function 선언 뒤에는 세미콜론 불필요
     if (!inner_idx.isNone()) {

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -495,12 +495,17 @@ fn exprNeedsParens(self: anytype, node: ast_mod.Node, level: Level, flags: ExprF
     };
 }
 
-/// numeric literal 텍스트가 정수 형태(ASCII 숫자만)인지 — 바로 뒤 `.` 가 소수점으로
-/// 오파싱되는 형태. `1.5`/`0xff`/`1e3`/`0b1`/`0o7`/`42n` 등은 false(그 뒤 `.` 안전).
+/// numeric literal 텍스트가 (소수점/지수/radix prefix/bigint 없는) 십진 정수 형태인지
+/// — 바로 뒤 `.` 가 소수점으로 오파싱되는 형태. `1.5`/`0xff`/`1e3`/`0b1`/`0o7`/`42n` 은
+/// false(`.`/`e`/`x`/`b`/`o`/`n` 이 `.` 를 멤버로 안전하게 만듦). 숫자 구분자(`100_000`)는
+/// 십진 정수라 true — `_` 만으로는 `.` 안전성이 안 생겨 공백 필요. esbuild needSpaceBeforeDot.
 fn numericIsPlainInteger(text: []const u8) bool {
     if (text.len == 0) return false;
     for (text) |c| {
-        if (c < '0' or c > '9') return false;
+        switch (c) {
+            '.', 'e', 'E', 'x', 'X', 'b', 'B', 'o', 'O', 'n', 'N' => return false,
+            else => {},
+        }
     }
     return true;
 }

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -124,8 +124,18 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
                 try self.writeNodeSpan(node);
             }
         },
+        .numeric_literal => {
+            try self.addSourceMapping(node.span);
+            try self.writeNodeSpan(node);
+            // 정수 형태(`42`)면 바로 뒤 `.` 가 소수점으로 오파싱됨 → member 의 `.` 가
+            // 공백을 끼우도록 위치 마킹 (`42 .toString()`). `.`/`e`/`x`/`b`/`o` 가 있는
+            // float/hex/exp/radix(`1.5`/`0xff`/`1e3`)는 `.` 가 멤버로 안전 → 마킹 안 함.
+            // esbuild needSpaceBeforeDot (정수만). bigint(`42n`)는 별도 노드라 제외.
+            if (numericIsPlainInteger(self.ast.getText(node.span))) {
+                self.need_space_before_dot = self.buf.items.len;
+            }
+        },
         .null_literal,
-        .numeric_literal,
         .bigint_literal,
         .regexp_literal,
         => {
@@ -261,7 +271,7 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
         .assignment_expression => try expression_emit.emitAssignment(self, node, level, flags),
         .conditional_expression => try expression_emit.emitConditional(self, node, level, flags),
         .sequence_expression => try expression_emit.emitSequence(self, node),
-        .parenthesized_expression => try expression_emit.emitParen(self, node),
+        .parenthesized_expression => try expression_emit.emitParen(self, node, level, flags),
         .spread_element => try expression_emit.emitSpread(self, node, level, flags),
         .await_expression => try expression_emit.emitAwait(self, node, level, flags),
         .yield_expression => try expression_emit.emitYield(self, node, level, flags),
@@ -385,14 +395,18 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
     if (wrap) try self.writeByte(')');
 }
 
-/// 이 expression 노드가 부모가 요구한 `level` 에서 괄호가 필요한지 (esbuild
+/// 이 expression 노드가 부모가 요구한 `level`/`flags` 에서 괄호가 필요한지 (esbuild
 /// `printExpr` 진입부의 `wrap := level >= entry.Level`). wrap 을 emitExpr 한 곳에
-/// 모으기 위한 술어.
+/// 모아, emitter 내부 early-return 과 무관하게 정확히 여닫는다.
 ///
-/// PR6a 범위: 연산자(binary/unary/update/conditional/assignment/sequence/yield/
-/// await)만. member/call/new 의 precedence·optional-chain 끊기 wrap 과 primary 의
-/// statement-start wrap 은 ad-hoc 괄호(newCalleeNeedsParens/`(void 0)`) 제거 및
-/// emitParen 투명화와 함께 PR6b 에서 켠다 (지금 켜면 ad-hoc 과 이중괄호).
+/// 전 표현식 커버: 연산자(unary/update/binary/conditional/assignment/sequence/yield/
+/// await) + statement-start primary(object/function/class/destructuring) + member/
+/// call/new/import optional-chain·precedence wrap + arrow. precedence 로 표현 불가한
+/// 잔여 ad-hoc 은 newCalleeNeedsRenameParens(rename→call 체인)·emitNodeMaybeUndefParen
+/// (`void 0` peephole)·emitStaticMember 의 ns 미존재 `(void 0)` 뿐.
+///
+/// 주의 — identifier_reference 처럼 dispatch case 안에 early-return 이 있는 노드는
+/// 여기서 wrap 을 켜면 닫는 `)` 가 누락된다(전부 별도 fn 으로 dispatch 되는 노드만 안전).
 fn exprNeedsParens(self: anytype, node: ast_mod.Node, level: Level, flags: ExprFlags) bool {
     return switch (node.tag) {
         .unary_expression, .await_expression => level.gte(.prefix),
@@ -434,11 +448,61 @@ fn exprNeedsParens(self: anytype, node: ast_mod.Node, level: Level, flags: ExprF
         // 선언 노드(function_declaration/class_declaration)는 제외 — 그쪽은 마킹이
         // 안 걸리고, 걸려도 선언을 식으로 바꾸면 안 된다. esbuild EFunction/EClass wrap.
         .function_expression, .function, .class_expression => self.atStmtOrExportDefaultStart(),
-        // member/call/new optical-chain·precedence wrap 은 PR7(이 PR) 후속 커밋에서.
+        // arrow 는 .assign 미만에서만 괄호 없이 올 수 있다 (esbuild EArrow:
+        // `level >= LAssign`). `new (()=>{})()`, `(()=>{}).x`, `a ? ()=>b : c` 등.
+        .arrow_function_expression => level.gte(.assign),
+        // member optional-chain 끊기: 이 멤버가 체인 내부(Start=`?.` 또는 Continue=체인 안
+        // `.`)이고 부모가 non-optional 이면 괄호로 끊어 보존 (`(a?.b).c`). `a?.b.c` 의 `.c`
+        // 는 Continue 라 끊지 않는다. 그 외 멤버는 precedence 최고(member)라 wrap 없음 (esbuild EDot/EIndex).
+        .static_member_expression, .computed_member_expression, .private_field_expression => blk: {
+            if (!flags.has_non_optional_chain_parent) break :blk false;
+            const e = node.data.extra;
+            if (!self.ast.hasExtra(e, 2)) break :blk false;
+            const member_flags = self.ast.readExtra(e, 2);
+            // self 가 체인 내부(Start=`?.` 또는 Continue=object 가 체인)이고 부모가 None 이면 끊는다.
+            const self_in_chain = (member_flags & ast_mod.MemberFlags.optional_chain) != 0 or
+                call_emit.objectContinuesOptionalChain(self, self.ast.readExtraNode(e, 0));
+            break :blk self_in_chain;
+        },
+        // call wrap = level>=new(즉 new 의 callee) | forbid_call | optional-chain 끊기
+        // | pure-comment at postfix (esbuild ECall). `new (foo())`, `(a?.())()` 등.
+        .call_expression => blk: {
+            const e = node.data.extra;
+            if (!self.ast.hasExtra(e, 3)) break :blk false;
+            const call_flags = self.ast.readExtra(e, 3);
+            const is_pure = (call_flags & ast_mod.CallFlags.is_pure) != 0;
+            const chain_break = flags.has_non_optional_chain_parent and
+                ((call_flags & ast_mod.CallFlags.optional_chain) != 0 or
+                    call_emit.objectContinuesOptionalChain(self, self.ast.readExtraNode(e, 0)));
+            break :blk level.gte(.new) or flags.forbid_call or chain_break or
+                (is_pure and !self.options.minify_whitespace and level.gte(.postfix));
+        },
+        // new wrap = level>=call (member/call 의 타겟) | pure-comment at postfix
+        // (esbuild ENew). `(new X).y`, `(new X)()` 처럼 뒤에 `.`/`()` 가 붙는 경우.
+        .new_expression => blk: {
+            const e = node.data.extra;
+            if (!self.ast.hasExtra(e, 3)) break :blk false;
+            const new_flags = self.ast.readExtra(e, 3);
+            const is_pure = (new_flags & ast_mod.CallFlags.is_pure) != 0;
+            break :blk level.gte(.call) or
+                (is_pure and !self.options.minify_whitespace and level.gte(.postfix));
+        },
+        // import() call (esbuild EImportCall): call 과 동일 (level>=new | forbid_call).
+        .import_expression => level.gte(.new) or flags.forbid_call,
         // (for-of init `let`/`async` 식별자 wrap 은 identifier_reference 의 inline
         //  early-return 들과 충돌하므로 중앙 wrap 으로 처리하지 않는다.)
         else => false,
     };
+}
+
+/// numeric literal 텍스트가 정수 형태(ASCII 숫자만)인지 — 바로 뒤 `.` 가 소수점으로
+/// 오파싱되는 형태. `1.5`/`0xff`/`1e3`/`0b1`/`0o7`/`42n` 등은 false(그 뒤 `.` 안전).
+fn numericIsPlainInteger(text: []const u8) bool {
+    if (text.len == 0) return false;
+    for (text) |c| {
+        if (c < '0' or c > '9') return false;
+    }
+    return true;
 }
 
 /// 할당식의 좌변(lvalue 타겟)이 object destructuring 패턴인지. `({a}=b)` 처럼

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -420,10 +420,34 @@ fn exprNeedsParens(self: anytype, node: ast_mod.Node, level: Level, flags: ExprF
             }
             break :blk level.gte(.conditional);
         },
-        .assignment_expression => level.gte(.assign),
+        .assignment_expression => level.gte(.assign) or
+            // destructuring 할당(`({a}=b)`)이 statement-start / arrow body-start 면 괄호
+            // 필수 — `{` 가 block 으로 오파싱되는 것을 막는다 (esbuild binaryExprVisitor).
+            (self.atStmtOrArrowStart() and assignTargetIsObject(self, node.data.binary.left)),
         .sequence_expression => level.gte(.comma),
         .yield_expression => level.gte(.assign),
-        // member/call/new + primary(object/array/function/class/literal/...) 는 PR6b.
+        // object literal 이 statement-start / arrow body-start 면 `{` block 오파싱 방지
+        // 괄호 (`({})`, `()=>({})`). esbuild EObject wrap.
+        .object_expression => self.atStmtOrArrowStart(),
+        // function/class expression 이 statement-start / export-default-start 면 선언문
+        // 형태와의 혼동을 막는 괄호 (`(function(){})()`, `export default (class{})`).
+        // 선언 노드(function_declaration/class_declaration)는 제외 — 그쪽은 마킹이
+        // 안 걸리고, 걸려도 선언을 식으로 바꾸면 안 된다. esbuild EFunction/EClass wrap.
+        .function_expression, .function, .class_expression => self.atStmtOrExportDefaultStart(),
+        // member/call/new optical-chain·precedence wrap 은 PR7(이 PR) 후속 커밋에서.
+        // (for-of init `let`/`async` 식별자 wrap 은 identifier_reference 의 inline
+        //  early-return 들과 충돌하므로 중앙 wrap 으로 처리하지 않는다.)
+        else => false,
+    };
+}
+
+/// 할당식의 좌변(lvalue 타겟)이 object destructuring 패턴인지. `({a}=b)` 처럼
+/// statement-start 에서 `{` 가 block 으로 오파싱되는 것을 막는 wrap 판정용.
+/// 배열 패턴(`[a]=b`)은 `[` 가 statement-start 에서 모호하지 않아 제외 (esbuild 동일).
+fn assignTargetIsObject(self: anytype, left: NodeIndex) bool {
+    if (left.isNone() or @intFromEnum(left) >= self.ast.nodes.items.len) return false;
+    return switch (self.ast.getNode(left).tag) {
+        .object_expression, .object_pattern, .object_assignment_target => true,
         else => false,
     };
 }

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -47,7 +47,13 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
     // STRING_TABLE_BIT가 설정된 span은 합성 노드(string_table 참조)이므로
     // 원본 소스 위치가 아님 → 주석 위치 비교를 건너뛴다.
     if (node.span.start != node.span.end and node.span.start & Ast.STRING_TABLE_BIT == 0) {
+        // 주석이 buf 위치를 밀면 statement-start 마크(stmt_start/arrow_expr_start 등)와
+        // 어긋나 `(/*c*/{a:1}).b` 같은 object/class/destructuring 의 wrap 이 유실된다
+        // (legal 주석은 minify 에서도 살아남아 프로덕션 깨짐). save/restore 로 마크를 주석
+        // 뒤(실제 첫 토큰 위치)로 재앵커한다 (esbuild printExprComments + start-flag 보존).
+        const start_flags = self.saveExprStartFlags();
         try statement_emit.emitComments(self, node.span.start);
+        self.restoreExprStartFlags(start_flags);
     }
 
     // 소스맵 매핑은 각 emitter / inline case 가 명시 발행 (oxc/esbuild 패턴).
@@ -438,7 +444,10 @@ fn exprNeedsParens(self: anytype, node: ast_mod.Node, level: Level, flags: ExprF
             // destructuring 할당(`({a}=b)`)이 statement-start / arrow body-start 면 괄호
             // 필수 — `{` 가 block 으로 오파싱되는 것을 막는다 (esbuild binaryExprVisitor).
             (self.atStmtOrArrowStart() and assignTargetIsObject(self, node.data.binary.left)),
-        .sequence_expression => level.gte(.comma),
+        // sequence 가 for-init(forbid_in)이면 top-level `in`(`for((a in b),c;;)`)이 원소로
+        // 누수돼 for-in 헤더 오파싱되는 것을 막아 통째로 감싼다 — emitList 가 원소에 .{} 를
+        // 줘 forbid_in 이 끊기므로 sequence 레벨에서 처리(esbuild 는 원소별 wrap, 여기선 전체).
+        .sequence_expression => level.gte(.comma) or flags.forbid_in,
         .yield_expression => level.gte(.assign),
         // object literal 이 statement-start / arrow body-start 면 `{` block 오파싱 방지
         // 괄호 (`({})`, `()=>({})`). esbuild EObject wrap.

--- a/src/codegen/precedence.zig
+++ b/src/codegen/precedence.zig
@@ -106,7 +106,12 @@ pub const ExprFlags = packed struct {
     /// for-loop init 절 안 — `in` 연산자가 for-in 헤더로 오파싱되지 않도록
     /// 괄호 필요. esbuild `forbidIn`.
     forbid_in: bool = false,
-    /// 부모가 non-optional 멤버/호출 — 자식이 optional chain 의 시작이면 괄호로
+    /// 부모가 non-optional 멤버/호출 — 자식이 optional chain 의 시작/연속이면 괄호로
     /// 체인을 끊어 보존 (`(a?.b).c`). esbuild `hasNonOptionalChainParent`.
+    ///
+    /// zntc 파서는 chain_expression 없이 paren 노드로만 optional chain 을 끊으므로(esbuild 의
+    /// OptionalChainContinue 를 노드로 표현 안 함), 멤버/호출이 "체인 연속(Continue)"인지는
+    /// object 를 구조적으로 본다(`calls.objectContinuesOptionalChain`). None(체인 밖)만
+    /// 이 flag 를 set 한다.
     has_non_optional_chain_parent: bool = false,
 };

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -344,6 +344,11 @@ pub fn emitBracedList(self: anytype, node: Node) !void {
 
 pub fn emitExpressionStatement(self: anytype, node: Node) !void {
     try self.addSourceMapping(node.span);
+    // statement-start 마킹: operand 의 첫 토큰이 `{`(object)·`function`·`class`·
+    // destructuring `{` 면 expression emitter 가 괄호로 감싸 block/선언문 오파싱을
+    // 막는다 (esbuild printStmt SExpr: `p.stmtStart = len(p.js)`). 출력 직전 위치를
+    // 마킹하므로, 그 사이 아무것도 안 쓴 expression 만 매치된다.
+    self.stmt_start = self.buf.items.len;
     try self.emitNode(node.data.unary.operand);
     try self.writeByte(';');
 }

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -885,7 +885,9 @@ pub fn emitFor(self: anytype, node: Node) !void {
     // 내부 for가 끝날 때 plain assignment로 되돌리지 않도록 해야 한다. (#1564 Case 1)
     const saved_for_init = self.in_for_init;
     self.in_for_init = true;
-    try self.emitNode(@enumFromInt(extras[0]));
+    // init 식의 top-level `in`(`for((a in b);;)`)이 for-in 헤더로 오파싱되지 않게 forbid_in.
+    // var_decl init 은 emitVariableDeclarator 가 self.in_for_init 로 별도 전파(flag 미투과 경로).
+    try self.emitExpr(@enumFromInt(extras[0]), .lowest, .{ .forbid_in = true });
     if (self.options.minify_whitespace) try self.writeByte(';') else try self.write("; ");
     self.in_for_init = saved_for_init;
     try self.emitNode(@enumFromInt(extras[1]));

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -393,10 +393,16 @@ fn operandStartsIdentifierLikeDepth(self: anytype, idx: ast_mod.NodeIndex, depth
     if (depth >= 32) return true;
     if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return true;
     const n = self.ast.getNode(idx);
+    // TS/Flow type cast 래퍼(`x as T`/`<T>x`)는 strip 후 안쪽이 시작 토큰 → 따라간다.
+    if (ast_mod.Node.Tag.isTransparentTypeWrapper(n.tag)) {
+        return operandStartsIdentifierLikeDepth(self, n.data.unary.operand, depth + 1);
+    }
     return switch (n.tag) {
-        // S3 + S3b: paren / string / template / array / object / unary punctuator 처리.
-        // esbuild/rolldown/rspack 동일 정책.
-        .parenthesized_expression,
+        // transparent wrapper(paren/chain)는 codegen 이 `(` 미출력 → 안쪽 operand 의 시작
+        // 토큰이 출력 시작 토큰 (#4042 emitParen 투명화). 따라간다.
+        .parenthesized_expression, .chain_expression => operandStartsIdentifierLikeDepth(self, n.data.unary.operand, depth + 1),
+        // S3 + S3b: string / template / array / object 는 punctuator(`"`/`` ` ``/`[`/`{`)
+        // 로 시작 → identifier-like 아님. esbuild/rolldown/rspack 동일 정책.
         .string_literal,
         .template_literal,
         .array_expression,

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -275,7 +275,7 @@ test "minify_whitespace: return + paren expression — space 제거" {
     try expectMinifyFull(
         \\function f() { return (a + b); }
     ,
-        \\function f(){return(a+b)}
+        \\function f(){return a+b}
     );
 }
 
@@ -310,7 +310,7 @@ test "minify_whitespace: return + binary 의 left=paren — recursive 검출" {
     try expectMinifyFull(
         \\function f(t, x) { return (1 - t) * x; }
     ,
-        \\function f(t,x){return(1-t)*x}
+        \\function f(t,x){return (1-t)*x}
     );
 }
 
@@ -334,7 +334,7 @@ test "minify_whitespace: throw + paren — 공백 제거" {
     try expectMinifyFull(
         \\function f() { throw (a + b); }
     ,
-        \\function f(){throw(a+b)}
+        \\function f(){throw a+b}
     );
 }
 
@@ -637,14 +637,14 @@ test "minify: literal === literal still folds" {
 // ================================================================
 
 test "minify: comma operator with literal lhs" {
-    try expectMinify("const x = (0, foo);", "const x = (foo);");
+    try expectMinify("const x = (0, foo);", "const x = foo;");
 }
 
 test "minify: comma operator with string lhs" {
     try expectMinify(
         \\const x = ("unused", bar);
     ,
-        "const x = (bar);",
+        "const x = bar;",
     );
 }
 
@@ -653,7 +653,7 @@ test "minify: comma operator with non-literal lhs preserved" {
 }
 
 test "minify: comma operator with 3+ literal items simplified" {
-    try expectMinify("const x = (0, 1, foo);", "const x = (foo);");
+    try expectMinify("const x = (0, 1, foo);", "const x = foo;");
 }
 
 test "minify: comma operator mixed keeps non-literal" {
@@ -2109,7 +2109,7 @@ test "unused: (foo.bar)(); — call callee 자리 paren 은 minify 범위 밖" {
     // expression_statement 의 operand 자리 paren 만 대상 → 이 paren 은 그대로.
     try expectMinifyDead(
         "(foo.bar)();",
-        "function run() {\n\t(foo.bar)();\n}\nrun();",
+        "function run() {\n\tfoo.bar();\n}\nrun();",
     );
 }
 
@@ -2131,7 +2131,7 @@ test "unused: ({v} = o); — object destructuring assignment 은 paren 유지 ({
 test "unused: ([a] = arr); — array destructuring assignment 은 paren 유지" {
     try expectMinifyDead(
         "let a, arr = [1]; ([a] = arr); console.log(a);",
-        "function run() {\n\tlet a,arr = [1];\n\t([a] = arr);\n\tconsole.log(a);\n}\nrun();",
+        "function run() {\n\tlet a,arr = [1];\n\t[a] = arr;\n\tconsole.log(a);\n}\nrun();",
     );
 }
 
@@ -2506,7 +2506,7 @@ test "iife: returning call expression" {
 test "iife: returning object — paren-wrapped to keep statement-context safe" {
     try expectMinify(
         "const o = (() => { return { value: 3 }; })();",
-        "const o = ({ value: 3 });",
+        "const o = { value: 3 };",
     );
 }
 
@@ -2516,7 +2516,7 @@ test "iife: returning paren-wrapped object — paren preserved (codegen lifts la
     // simplification 이 별도로 lift 가능.
     try expectMinify(
         "const o = (() => ({ value: 3 }))();",
-        "const o = ({ value: 3 });",
+        "const o = { value: 3 };",
     );
 }
 
@@ -2567,7 +2567,7 @@ test "inline: precedence 보존 — chained binary inline" {
     // 정답: `((x+1)*2)-3`. node 실행: g(2) → 3.
     try expectMinifyDead(
         "function g(x) { const a = x+1; const b = a*2; const c = b-3; return c; } g(2);",
-        "function run() {\n\tfunction g(x) {\n\t\t;\n\t\t;\n\t\t;\n\t\treturn ((x + 1) * 2) - 3;\n\t}\n\tg(2);\n}\nrun();",
+        "function run() {\n\tfunction g(x) {\n\t\t;\n\t\t;\n\t\t;\n\t\treturn (x + 1) * 2 - 3;\n\t}\n\tg(2);\n}\nrun();",
     );
 }
 

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1484,11 +1484,12 @@ test "codegen: TS `(X as T)` 괄호 — numeric/statement-start/arrow 등 load-b
     //   - arrow/function callee: `(function(){} as T)()` 등
     const Keep = struct { src: []const u8, want: []const u8 };
     const keep = [_]Keep{
-        .{ .src = "(42 as number).toFixed(2);", .want = "(42).toFixed(2)" },
-        .{ .src = "(255 as number).toString(16);", .want = "(255).toString(16)" },
+        // numeric-then-dot: 괄호 대신 `42 .x` 공백(esbuild needSpaceBeforeDot)으로 보존.
+        .{ .src = "(42 as number).toFixed(2);", .want = "42 .toFixed(2)" },
+        .{ .src = "(255 as number).toString(16);", .want = "255 .toString(16)" },
         .{ .src = "({x:1} as any).c;", .want = "({ x: 1 }).c" },
         .{ .src = "(function(){} as any)();", .want = "(function() {" },
-        .{ .src = "(<any>42).x;", .want = "(42).x" },
+        .{ .src = "(<any>42).x;", .want = "42 .x" },
     };
     for (keep) |c| {
         var r = try parseAndTransform(std.testing.allocator, c.src);
@@ -1524,9 +1525,9 @@ test "codegen: Flow colon-cast `(expr: T)` 는 load-bearing 괄호만 보존 (pa
         .{ .src = "// @flow\n(c ? x : y: any).z;", .want = "(c ? x : y).z" },
         // statement-start 모호성 (object literal / new)
         .{ .src = "// @flow\n({x:1}: any).c;", .want = "({ x: 1 }).c" },
-        .{ .src = "// @flow\n(new C: any).x;", .want = "(new C()).x" },
-        // numeric-then-dot: `42.x` 는 float 오파싱 → invalid. 괄호 보존.
-        .{ .src = "// @flow\n(42: any).x;", .want = "(42).x" },
+        .{ .src = "// @flow\n(new C: any).x;", .want = "new C().x" },
+        // numeric-then-dot: `42.x` 는 float 오파싱 → invalid. `42 .x` 공백으로 보존.
+        .{ .src = "// @flow\n(42: any).x;", .want = "42 .x" },
     };
     for (keep) |c| {
         var r = try parseAndTransform(std.testing.allocator, c.src);
@@ -1567,7 +1568,7 @@ test "codegen: TS `<T>(expr)` prefix-assertion 도 load-bearing 괄호만 제거
     const keep = [_]Keep{
         .{ .src = "<T>(a + b) * c;", .want = "(a + b) * c" },
         .{ .src = "(<T>(a?.b)).c;", .want = "(a?.b).c" },
-        .{ .src = "<T>(a, b);", .want = "(a,b)" }, // sequence
+        .{ .src = "<T>(a, b);", .want = "a,b" }, // sequence: statement-level 이라 괄호 불필요
     };
     for (keep) |c| {
         var r = try parseAndTransform(std.testing.allocator, c.src);

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -143,13 +143,14 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       const clientTemp = output.match(/(_[a-z]+) = client;/)?.[1];
       expect(clientTemp).toBeDefined();
       const clientRead = output.indexOf(`${clientTemp} = client;`);
-      const andGuard = output.indexOf(`if (!(${clientTemp}))`, clientRead);
+      // #4042: 군더더기 괄호 제거 — `!(_a)` → `!_a` (단항 operand 가 식별자, 동등).
+      const andGuard = output.indexOf(`if (!${clientTemp})`, clientRead);
       const clientEnd = output.indexOf('client.end();');
       const skipOrMatch = output.match(/(_[a-z]+) = true;[\s\S]*?if \(\1\)[\s\S]*?skipOr\(\)/);
       const skipNullishMatch = output.match(
         /(_[a-z]+) = "value";[\s\S]*?if \(\1 != null\)[\s\S]*?skipNullish\(\)/,
       );
-      const conditionalGuard = output.indexOf('if (!(flag))');
+      const conditionalGuard = output.indexOf('if (!flag)');
       const thenBranch = output.indexOf('thenBranch()');
       const elseBranch = output.indexOf('elseBranch()');
 

--- a/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
@@ -587,12 +587,12 @@ class C7 extends foo {
 exports[`TSC: classes classExtendingNull 1`] = `
 "class C1 extends null {
 }
-class C2 extends (null) {
+class C2 extends null {
 }
 class C3 extends null {
 	x = 1;
 }
-class C4 extends (null) {
+class C4 extends null {
 	x = 1;
 }
 "
@@ -993,7 +993,7 @@ exports[`TSC: classes classExpression4 1`] = `
 		return new C();
 	}
 };
-let x = (new C()).foo();
+let x = new C().foo();
 "
 `;
 
@@ -1128,7 +1128,7 @@ function B3() {
 class K extends B1() {
 	namae;
 }
-class C extends (new B2().anon) {
+class C extends new B2().anon {
 	name;
 }
 let b3Number = B3();
@@ -2873,20 +2873,20 @@ class DerivedWithFunctionExpression extends Base {
 class DerivedWithParenthesis extends Base {
 	prop = true;
 	constructor() {
-		(super());
+		super();
 	}
 }
 class DerivedWithParenthesisAfterStatement extends Base {
 	prop = true;
 	constructor() {
 		this.prop;
-		(super());
+		super();
 	}
 }
 class DerivedWithParenthesisBeforeStatement extends Base {
 	prop = true;
 	constructor() {
-		(super());
+		super();
 		this.prop;
 	}
 }
@@ -5265,8 +5265,8 @@ exports[`TSC: classes thisAndSuperInStaticMembers1 1`] = `
 	static y1 = this.x;
 	static y2 = this.x();
 	static y3 = this?.x();
-	static y4 = this[("x")]();
-	static y5 = this?.[("x")]();
+	static y4 = this["x"]();
+	static y5 = this?.["x"]();
 	static z1 = super.a;
 	static z2 = super["a"];
 	static z3 = super.f();
@@ -5284,7 +5284,7 @@ exports[`TSC: classes thisAndSuperInStaticMembers1 1`] = `
 	static z13 = { ...super.a } = { x: 0 };
 	static z14 = ++super.a;
 	static z15 = --super.a;
-	static z16 = ++super[("a")];
+	static z16 = ++super["a"];
 	static z17 = super.a++;
 	static z18 = super.a\`\`;
 	// these should be unaffected
@@ -5301,8 +5301,8 @@ exports[`TSC: classes thisAndSuperInStaticMembers2 1`] = `
 	static y1 = this.x;
 	static y2 = this.x();
 	static y3 = this?.x();
-	static y4 = this[("x")]();
-	static y5 = this?.[("x")]();
+	static y4 = this["x"]();
+	static y5 = this?.["x"]();
 	static z1 = super.a;
 	static z2 = super["a"];
 	static z3 = super.f();
@@ -5320,7 +5320,7 @@ exports[`TSC: classes thisAndSuperInStaticMembers2 1`] = `
 	static z13 = { ...super.a } = { x: 0 };
 	static z14 = ++super.a;
 	static z15 = --super.a;
-	static z16 = ++super[("a")];
+	static z16 = ++super["a"];
 	static z17 = super.a++;
 	static z18 = super.a\`\`;
 	// these should be unaffected
@@ -5337,8 +5337,8 @@ exports[`TSC: classes thisAndSuperInStaticMembers3 1`] = `
 	static y1 = this.x;
 	static y2 = this.x();
 	static y3 = this?.x();
-	static y4 = this[("x")]();
-	static y5 = this?.[("x")]();
+	static y4 = this["x"]();
+	static y5 = this?.["x"]();
 	static z3 = super.f();
 	static z4 = super["f"]();
 	// these should be unaffected
@@ -5355,8 +5355,8 @@ exports[`TSC: classes thisAndSuperInStaticMembers4 1`] = `
 	static y1 = this.x;
 	static y2 = this.x();
 	static y3 = this?.x();
-	static y4 = this[("x")]();
-	static y5 = this?.[("x")]();
+	static y4 = this["x"]();
+	static y5 = this?.["x"]();
 	static z3 = super.f();
 	static z4 = super["f"]();
 	// these should be unaffected
@@ -5827,7 +5827,7 @@ exports[`TSC: classes typeOfThisInStaticMembers7 1`] = `
 class D extends C {
 	static c = 2;
 	static d = this.c + 1;
-	static e = 1 + (super.a) + (this.c + 1) + 1;
+	static e = 1 + super.a + (this.c + 1) + 1;
 }
 "
 `;
@@ -6880,7 +6880,7 @@ exports[`TSC: classes privateNameFieldDestructuredBinding 1`] = `
 	constructor() {
 		let y;
 		({ x:this.#field, y } = this.testObject());
-		([this.#field, y] = this.testArray());
+		[this.#field, y] = this.testArray();
 		({ a:this.#field, b:[this.#field] } = { a: 1, b: [2] });
 		[this.#field, [this.#field]] = [1, [2]];
 		({ a:this.#field=1, b:[this.#field=1] } = { b: [] });
@@ -6912,13 +6912,13 @@ exports[`TSC: classes privateNameFieldParenthesisLeftAssignment 1`] = `
 		this.#p = p;
 	}
 	t2(p) {
-		((this.#p)) = p;
+		this.#p = p;
 	}
 	t3(p) {
-		(this.#p) = p;
+		this.#p = p;
 	}
 	t4(p) {
-		(((this.#p))) = p;
+		this.#p = p;
 	}
 }
 "
@@ -6962,17 +6962,17 @@ exports[`TSC: classes privateNameFieldUnaryMutation 1`] = `
 		}
 		for (this.#test = 0; this.#test < 10; this.#test++) {
 		}
-		(this.#test)++;
-		(this.#test)--;
-		++(this.#test);
-		--(this.#test);
-		const e = (this.#test)++;
-		const f = (this.#test)--;
-		const g = ++(this.#test);
-		const h = --(this.#test);
-		for (this.#test = 0; this.#test < 10; ++(this.#test)) {
+		this.#test++;
+		this.#test--;
+		++this.#test;
+		--this.#test;
+		const e = this.#test++;
+		const f = this.#test--;
+		const g = ++this.#test;
+		const h = --this.#test;
+		for (this.#test = 0; this.#test < 10; ++this.#test) {
 		}
-		for (this.#test = 0; this.#test < 10; (this.#test)++) {
+		for (this.#test = 0; this.#test < 10; this.#test++) {
 		}
 	}
 	test() {
@@ -6988,17 +6988,17 @@ exports[`TSC: classes privateNameFieldUnaryMutation 1`] = `
 		}
 		for (this.getInstance().#test = 0; this.getInstance().#test < 10; this.getInstance().#test++) {
 		}
-		(this.getInstance().#test)++;
-		(this.getInstance().#test)--;
-		++(this.getInstance().#test);
-		--(this.getInstance().#test);
-		const e = (this.getInstance().#test)++;
-		const f = (this.getInstance().#test)--;
-		const g = ++(this.getInstance().#test);
-		const h = --(this.getInstance().#test);
-		for (this.getInstance().#test = 0; this.getInstance().#test < 10; ++(this.getInstance().#test)) {
+		this.getInstance().#test++;
+		this.getInstance().#test--;
+		++this.getInstance().#test;
+		--this.getInstance().#test;
+		const e = this.getInstance().#test++;
+		const f = this.getInstance().#test--;
+		const g = ++this.getInstance().#test;
+		const h = --this.getInstance().#test;
+		for (this.getInstance().#test = 0; this.getInstance().#test < 10; ++this.getInstance().#test) {
 		}
-		for (this.getInstance().#test = 0; this.getInstance().#test < 10; (this.getInstance().#test)++) {
+		for (this.getInstance().#test = 0; this.getInstance().#test < 10; this.getInstance().#test++) {
 		}
 	}
 	getInstance() {
@@ -7036,14 +7036,14 @@ exports[`TSC: classes privateNameInLhsReceiverExpression 1`] = `
 "class Test {
 	#y = 123;
 	static something(obj) {
-		obj[(new class {
+		obj[new class {
 			#x = 1;
 			s = "prop";
-		}()).s].#y = 1;
-		obj[(new class {
+		}().s].#y = 1;
+		obj[new class {
 			#x = 1;
 			s = "prop";
-		}()).s].#y += 1;
+		}().s].#y += 1;
 	}
 }
 "
@@ -7180,7 +7180,7 @@ exports[`TSC: classes privateNameMethodAsync 1`] = `
 		yield 42;
 	}
 	async *#qux() {
-		yield (await Promise.resolve(42));
+		yield await Promise.resolve(42);
 	}
 };
 new C().foo().then(console.log);
@@ -7207,7 +7207,7 @@ exports[`TSC: classes privateNameMethodCallExpression 1`] = `
 		const str = this.#method2\`head\${1}middle\${2}tail\`;
 		this.getInstance().#method2\`test\${1}and\${2}\`;
 		this.getInstance().#method2(0, ...arr, 3);
-		const b2 = new (this.getInstance().#method2)(0, ...arr, 3);
+		const b2 = new (this.getInstance()).#method2(0, ...arr, 3);
 		//Error 
 		const str2 = this.getInstance().#method2\`head\${1}middle\${2}tail\`;
 	}
@@ -7724,7 +7724,7 @@ exports[`TSC: classes privateNameSetterExprReturnValue 1`] = `
 	set #foo(a) {
 	}
 	bar() {
-		let x = (this.#foo = 42 * 2);
+		let x = this.#foo = 42 * 2;
 		console.log(x);
 	}
 }
@@ -8194,7 +8194,7 @@ exports[`TSC: classes privateNameStaticFieldDestructuredBinding 1`] = `
 	constructor() {
 		let y;
 		({ x:A.#field, y } = this.testObject());
-		([A.#field, y] = this.testArray());
+		[A.#field, y] = this.testArray();
 		({ a:A.#field, b:[A.#field] } = { a: 1, b: [2] });
 		[A.#field, [A.#field]] = [1, [2]];
 		({ a:A.#field=1, b:[A.#field=1] } = { b: [] });
@@ -8325,7 +8325,7 @@ exports[`TSC: classes privateNameStaticMethodCallExpression 1`] = `
 		const str = AA.#method2\`head\${1}middle\${2}tail\`;
 		AA.getClass().#method2\`test\${1}and\${2}\`;
 		AA.getClass().#method2(0, ...arr, 3);
-		const b2 = new (AA.getClass().#method2)(0, ...arr, 3);
+		const b2 = new (AA.getClass()).#method2(0, ...arr, 3);
 		//Error 
 		const str2 = AA.getClass().#method2\`head\${1}middle\${2}tail\`;
 	}

--- a/tests/integration/tests/tsc/__snapshots__/es2021.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es2021.test.ts.snap
@@ -56,9 +56,9 @@ c.foo.bar().baz ??= result.foo.bar().baz;
 `;
 
 exports[`TSC: es2021 logicalAssignment3 1`] = `
-"(a.baz) &&= result.baz;
-(b.baz) ||= result.baz;
-(c.baz) ??= result.baz;
+"a.baz &&= result.baz;
+b.baz ||= result.baz;
+c.baz ??= result.baz;
 "
 `;
 
@@ -132,13 +132,13 @@ function bar3(f) {
 
 exports[`TSC: es2021 logicalAssignment6 1`] = `
 "function foo1(results,results1) {
-	(results ||= (results1 ||= [])).push(100);
+	(results ||= results1 ||= []).push(100);
 }
 function foo2(results,results1) {
-	(results ??= (results1 ??= [])).push(100);
+	(results ??= results1 ??= []).push(100);
 }
 function foo3(results,results1) {
-	(results &&= (results1 &&= [])).push(100);
+	(results &&= results1 &&= []).push(100);
 }
 "
 `;

--- a/tests/integration/tests/tsc/__snapshots__/es6-Symbols.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-Symbols.test.ts.snap
@@ -485,8 +485,8 @@ exports[`TSC: es6/Symbols symbolProperty46 1`] = `
 	set [Symbol.hasInstance](x) {
 	}
 }
-(new C())[Symbol.hasInstance] = 0;
-(new C())[Symbol.hasInstance] = "";
+new C()[Symbol.hasInstance] = 0;
+new C()[Symbol.hasInstance] = "";
 "
 `;
 
@@ -499,8 +499,8 @@ exports[`TSC: es6/Symbols symbolProperty47 1`] = `
 	set [Symbol.hasInstance](x) {
 	}
 }
-(new C())[Symbol.hasInstance] = 0;
-(new C())[Symbol.hasInstance] = "";
+new C()[Symbol.hasInstance] = 0;
+new C()[Symbol.hasInstance] = "";
 "
 `;
 
@@ -712,7 +712,7 @@ s ^= s;
 s ^= 0;
 s |= s;
 s |= 0;
-str += (s || str);
+str += s || str;
 "
 `;
 

--- a/tests/integration/tests/tsc/__snapshots__/es6-classDeclaration.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-classDeclaration.test.ts.snap
@@ -192,7 +192,7 @@ exports[`TSC: es6/classDeclaration emitClassDeclarationWithPropertyAccessInHerit
 function foo() {
 	return { B: B };
 }
-class C extends (foo()).B {
+class C extends foo().B {
 }
 "
 `;

--- a/tests/integration/tests/tsc/__snapshots__/es6-destructuring.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-destructuring.test.ts.snap
@@ -153,7 +153,7 @@ function f19() {
 	[a, b] = [b, a];
 	({ a, b } = { b, a });
 	[[a, b]=[1, 2]] = [[2, 3]];
-	var x = ([a, b] = [1, 2]);
+	var x = [a, b] = [1, 2];
 }
 function f20(v) {
 	var x;
@@ -491,14 +491,14 @@ function f2(obj) {
 	let a1 = obj[1];
 	// string | null
 	let [b0, b1] = obj;
-	([a0, a1] = obj);
+	[a0, a1] = obj;
 	if (obj[0] && obj[1]) {
 		let c0 = obj[0];
 		// number
 		let c1 = obj[1];
 		// string
 		let [d0, d1] = obj;
-		([c0, c1] = obj);
+		[c0, c1] = obj;
 	}
 }
 function f3(obj) {
@@ -641,7 +641,7 @@ exports[`TSC: es6/destructuring destructuringObjectBindingPatternAndAssignment5 
 "function a() {
 	let x;
 	let y;
-	({ x, ...y } = ({}));
+	({ x, ...y } = {});
 }
 "
 `;
@@ -1259,7 +1259,7 @@ exports[`TSC: es6/destructuring destructuringParameterProperties2 1`] = `
 class C1 {
 	constructor(k,[a, b, c]) {
 		this.k = k;
-		if ((b === undefined && c === undefined) || (this.b === undefined && this.c === undefined)) {
+		if (b === undefined && c === undefined || this.b === undefined && this.c === undefined) {
 			this.a = a || k;
 		}
 	}
@@ -1287,7 +1287,7 @@ exports[`TSC: es6/destructuring destructuringParameterProperties3 1`] = `
 class C1 {
 	constructor(k,[a, b, c]) {
 		this.k = k;
-		if ((b === undefined && c === undefined) || (this.b === undefined && this.c === undefined)) {
+		if (b === undefined && c === undefined || this.b === undefined && this.c === undefined) {
 			this.a = a || k;
 		}
 	}
@@ -1317,7 +1317,7 @@ exports[`TSC: es6/destructuring destructuringParameterProperties4 1`] = `
 class C1 {
 	constructor(k,[a, b, c]) {
 		this.k = k;
-		if ((b === undefined && c === undefined) || (this.b === undefined && this.c === undefined)) {
+		if (b === undefined && c === undefined || this.b === undefined && this.c === undefined) {
 			this.a = a || k;
 		}
 	}
@@ -1728,7 +1728,7 @@ exports[`TSC: es6/destructuring emptyArrayBindingPatternParameter04 1`] = `
 exports[`TSC: es6/destructuring emptyAssignmentPatterns01_ES5 1`] = `
 "var a;
 ({} = a);
-([] = a);
+[] = a;
 var [] = [1, 2];
 "
 `;
@@ -1736,14 +1736,14 @@ var [] = [1, 2];
 exports[`TSC: es6/destructuring emptyAssignmentPatterns01_ES5iterable 1`] = `
 "var a;
 ({} = a);
-([] = a);
+[] = a;
 "
 `;
 
 exports[`TSC: es6/destructuring emptyAssignmentPatterns01_ES6 1`] = `
 "var a;
 ({} = a);
-([] = a);
+[] = a;
 "
 `;
 
@@ -1751,7 +1751,7 @@ exports[`TSC: es6/destructuring emptyAssignmentPatterns02_ES5 1`] = `
 "var a;
 let x,y,z,a1,a2,a3;
 ({} = { x, y, z } = a);
-([] = [a1, a2, a3] = a);
+[] = [a1, a2, a3] = a;
 "
 `;
 
@@ -1759,7 +1759,7 @@ exports[`TSC: es6/destructuring emptyAssignmentPatterns02_ES5iterable 1`] = `
 "var a;
 let x,y,z,a1,a2,a3;
 ({} = { x, y, z } = a);
-([] = [a1, a2, a3] = a);
+[] = [a1, a2, a3] = a;
 "
 `;
 
@@ -1767,28 +1767,28 @@ exports[`TSC: es6/destructuring emptyAssignmentPatterns02_ES6 1`] = `
 "var a;
 let x,y,z,a1,a2,a3;
 ({} = { x, y, z } = a);
-([] = [a1, a2, a3] = a);
+[] = [a1, a2, a3] = a;
 "
 `;
 
 exports[`TSC: es6/destructuring emptyAssignmentPatterns03_ES5 1`] = `
 "var a;
 ({} = {} = a);
-([] = [] = a);
+[] = [] = a;
 "
 `;
 
 exports[`TSC: es6/destructuring emptyAssignmentPatterns03_ES5iterable 1`] = `
 "var a;
 ({} = {} = a);
-([] = [] = a);
+[] = [] = a;
 "
 `;
 
 exports[`TSC: es6/destructuring emptyAssignmentPatterns03_ES6 1`] = `
 "var a;
 ({} = {} = a);
-([] = [] = a);
+[] = [] = a;
 "
 `;
 
@@ -1796,7 +1796,7 @@ exports[`TSC: es6/destructuring emptyAssignmentPatterns04_ES5 1`] = `
 "var a;
 let x,y,z,a1,a2,a3;
 ({ x, y, z } = {} = a);
-([a1, a2, a3] = [] = a);
+[a1, a2, a3] = [] = a;
 "
 `;
 
@@ -1804,7 +1804,7 @@ exports[`TSC: es6/destructuring emptyAssignmentPatterns04_ES5iterable 1`] = `
 "var a;
 let x,y,z,a1,a2,a3;
 ({ x, y, z } = {} = a);
-([a1, a2, a3] = [] = a);
+[a1, a2, a3] = [] = a;
 "
 `;
 
@@ -1812,7 +1812,7 @@ exports[`TSC: es6/destructuring emptyAssignmentPatterns04_ES6 1`] = `
 "var a;
 let x,y,z,a1,a2,a3;
 ({ x, y, z } = {} = a);
-([a1, a2, a3] = [] = a);
+[a1, a2, a3] = [] = a;
 "
 `;
 

--- a/tests/integration/tests/tsc/__snapshots__/es6-spread.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-spread.test.ts.snap
@@ -61,19 +61,19 @@ f1(...[1], 2, 3, 4, 5, 6);
 f1(1, 2, ...[3, 4], 5, 6);
 f1(1, 2, ...[3], 4, ...[5, 6]);
 f1(...[1, 2], ...[3, 4], ...[5, 6]);
-f1(...(([1, 2])), ...(((([3, 4])))), ...([5, 6]));
+f1(...[1, 2], ...[3, 4], ...[5, 6]);
 const x21 = f2(...[1, "foo"]);
 const x22 = f2(true, ...[1, "foo"]);
-const x23 = f2(...([1, "foo"]));
-const x24 = f2(true, ...([1, "foo"]));
+const x23 = f2(...[1, "foo"]);
+const x24 = f2(true, ...[1, "foo"]);
 const x31 = f3(...[1, "foo"]);
 const x32 = f3(true, ...[1, "foo"]);
-const x33 = f3(...([1, "foo"]));
-const x34 = f3(true, ...([1, "foo"]));
+const x33 = f3(...[1, "foo"]);
+const x34 = f3(true, ...[1, "foo"]);
 const x41 = f4(...[1, "foo"]);
 const x42 = f4(true, ...[1, "foo"]);
-const x43 = f4(...([1, "foo"]));
-const x44 = f4(true, ...([1, "foo"]));
+const x43 = f4(...[1, "foo"]);
+const x44 = f4(true, ...[1, "foo"]);
 // dicovered in #52845#issuecomment-1459132562
 action.run(...[100, "foo"]);
 // error

--- a/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
@@ -229,14 +229,14 @@ f.thisIsNotATag(\`abc\${1}def\${2}ghi\`);
 exports[`TSC: es6/templates taggedTemplateStringsWithManyCallAndMemberExpressions 1`] = `
 "// @target: es2015
 var f;
-var x = new (new (new f())())()\`abc\${0}def\`.member("hello")(42) === true;
+var x = new new new f()()()\`abc\${0}def\`.member("hello")(42) === true;
 "
 `;
 
 exports[`TSC: es6/templates taggedTemplateStringsWithManyCallAndMemberExpressionsES6 1`] = `
 "// @target: ES6
 var f;
-var x = new (new (new f())())()\`abc\${0}def\`.member("hello")(42) === true;
+var x = new new new f()()()\`abc\${0}def\`.member("hello")(42) === true;
 "
 `;
 
@@ -1171,13 +1171,13 @@ var x = new \`abc\${1}def\`();
 
 exports[`TSC: es6/templates templateStringInParentheses 1`] = `
 "// @target: es2015
-var x = (\`abc\${0}abc\`);
+var x = \`abc\${0}abc\`;
 "
 `;
 
 exports[`TSC: es6/templates templateStringInParenthesesES6 1`] = `
 "// @target: ES6
-var x = (\`abc\${0}abc\`);
+var x = \`abc\${0}abc\`;
 "
 `;
 
@@ -1684,13 +1684,13 @@ var x = \`123\${\`456 \${" | "} 654\`}321 123\${\`456 \${" | "} 654\`}321\`;
 
 exports[`TSC: es6/templates templateStringWithEmbeddedTypeAssertionOnAddition 1`] = `
 "// @target: es2015
-var x = \`abc\${(10 + 10)}def\`;
+var x = \`abc\${10 + 10}def\`;
 "
 `;
 
 exports[`TSC: es6/templates templateStringWithEmbeddedTypeAssertionOnAdditionES6 1`] = `
 "// @target: ES6
-var x = \`abc\${(10 + 10)}def\`;
+var x = \`abc\${10 + 10}def\`;
 "
 `;
 

--- a/tests/integration/tests/tsc/__snapshots__/es6-yieldExpressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-yieldExpressions.test.ts.snap
@@ -603,7 +603,7 @@ function* g() {
 			}
 			static {
 				const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
-				_m_decorators = [(yield "")];
+				_m_decorators = [yield ""];
 				__esDecorate(this, null, _m_decorators, { kind: "method", name: "m", static: false, private: false, access: { has: (obj) => "m" in obj, get: (obj) => obj.m }, metadata: _metadata }, null, _instanceExtraInitializers);
 				if (_metadata) {
 					Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
@@ -681,7 +681,7 @@ var __propKey = function(x) {
 function* g() {
 	let C = (() => {
 		let _classThis;
-		let _classDecorators = [(yield 0)];
+		let _classDecorators = [yield 0];
 		let _classDescriptor;
 		let _classExtraInitializers = [];
 		var C = class {
@@ -798,7 +798,7 @@ exports[`TSC: es6/yieldExpressions generatorTypeCheck9 1`] = `
 
 exports[`TSC: es6/yieldExpressions YieldExpression10_es6 1`] = `
 "var v = { *foo() {
-	yield (foo);
+	yield foo;
 } };
 "
 `;
@@ -806,7 +806,7 @@ exports[`TSC: es6/yieldExpressions YieldExpression10_es6 1`] = `
 exports[`TSC: es6/yieldExpressions YieldExpression11_es6 1`] = `
 "class C {
 	*foo() {
-		yield (foo);
+		yield foo;
 	}
 }
 "
@@ -823,7 +823,7 @@ exports[`TSC: es6/yieldExpressions YieldExpression19_es6 1`] = `
 "function* foo() {
 	function bar() {
 		function* quux() {
-			yield (foo);
+			yield foo;
 		}
 	}
 }
@@ -869,7 +869,7 @@ exports[`TSC: es6/yieldExpressions YieldExpression7_es6 1`] = `
 
 exports[`TSC: es6/yieldExpressions YieldExpression9_es6 1`] = `
 "var v = function*() {
-	yield (foo);
+	yield foo;
 };
 "
 `;

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -285,12 +285,12 @@ var x3;
 x3.a = value;
 x3["a"] = value;
 // parentheses, the contained expression is reference
-(x1) = value;
+x1 = value;
 function fn2(x4) {
-	(x4) = value;
+	x4 = value;
 }
-(x3.a) = value;
-(x3["a"]) = value;
+x3.a = value;
+x3["a"] = value;
 "
 `;
 
@@ -495,16 +495,16 @@ x3.a += value;
 x3["a"] *= value;
 x3["a"] += value;
 // parentheses, the contained expression is reference
-(x1) *= value;
-(x1) += value;
+x1 *= value;
+x1 += value;
 function fn2(x4) {
-	(x4) *= value;
-	(x4) += value;
+	x4 *= value;
+	x4 += value;
 }
-(x3.a) *= value;
-(x3.a) += value;
-(x3["a"]) *= value;
-(x3["a"]) += value;
+x3.a *= value;
+x3.a += value;
+x3["a"] *= value;
+x3["a"] += value;
 "
 `;
 
@@ -6383,10 +6383,10 @@ var resultIsStringOrBoolean1 = condObject ? exprString1 : exprBoolean1;
 // union
 var resultIsAny2 = ((a) => a.length) ? exprAny1 : exprAny2;
 var resultIsBoolean2 = ((a) => a.length) ? exprBoolean1 : exprBoolean2;
-var resultIsNumber2 = ({}) ? exprNumber1 : exprNumber2;
-var resultIsString2 = ({ a: 1, b: "s" }) ? exprString1 : exprString2;
-var resultIsObject2 = ({ a: 1, b: "s" }) ? exprIsObject1 : exprIsObject2;
-var resultIsStringOrBoolean2 = ({ a: 1, b: "s" }) ? exprString1 : exprBoolean1;
+var resultIsNumber2 = {} ? exprNumber1 : exprNumber2;
+var resultIsString2 = { a: 1, b: "s" } ? exprString1 : exprString2;
+var resultIsObject2 = { a: 1, b: "s" } ? exprIsObject1 : exprIsObject2;
+var resultIsStringOrBoolean2 = { a: 1, b: "s" } ? exprString1 : exprBoolean1;
 // union
 var resultIsAny3 = foo() ? exprAny1 : exprAny2;
 var resultIsBoolean3 = new Date() ? exprBoolean1 : exprBoolean2;
@@ -8040,6 +8040,119 @@ var b;
 "
 `;
 
+exports[`TSC: expressions parenthesizedContexualTyping1 1`] = `
+"function fun(g,x) {
+	return g(x);
+}
+var a = fun((x) => x, 10);
+var b = fun(((x) => x), 10);
+var c = fun(((x) => x), 10);
+var d = fun(((x) => x), 10);
+var e = fun((x) => x, (x) => x, 10);
+var f = fun(((x) => x), ((x) => x), 10);
+var g = fun(((x) => x), ((x) => x), 10);
+var h = fun(((x) => x), ((x) => x), 10);
+// Ternaries in parens
+var i = fun(Math.random() < 0.5 ? (x) => x : (x) => undefined, 10);
+var j = fun(Math.random() < 0.5 ? ((x) => x) : ((x) => undefined), 10);
+var k = fun(Math.random() < 0.5 ? ((x) => x) : ((x) => undefined), (x) => x, 10);
+var l = fun(Math.random() < 0.5 ? ((x) => x) : ((x) => undefined), ((x) => x), 10);
+var lambda1 = (x) => x;
+var lambda2 = ((x) => x);
+var obj1 = { x: (x) => (x,undefined), y: (y) => (y,undefined) };
+var obj2 = { x: (x) => (x,undefined), y: (y) => (y,undefined) };
+"
+`;
+
+exports[`TSC: expressions parenthesizedContexualTyping2 1`] = `
+"// These tests ensure that in cases where it may *appear* that a value has a type,
+// they actually are properly being contextually typed. The way we test this is
+// that we invoke contextually typed arguments with type arguments.
+// Since 'any' cannot be invoked with type arguments, we should get errors
+// back if contextual typing is not taking effect.
+function fun(...rest) {
+	return undefined;
+}
+var a = fun((x) => {
+	x(undefined);
+	return x;
+}, 10);
+var b = fun(((x) => {
+	x(undefined);
+	return x;
+}), 10);
+var c = fun(((x) => {
+	x(undefined);
+	return x;
+}), 10);
+var d = fun(((x) => {
+	x(undefined);
+	return x;
+}), 10);
+var e = fun((x) => {
+	x(undefined);
+	return x;
+}, (x) => {
+	x(undefined);
+	return x;
+}, 10);
+var f = fun(((x) => {
+	x(undefined);
+	return x;
+}), ((x) => {
+	x(undefined);
+	return x;
+}), 10);
+var g = fun(((x) => {
+	x(undefined);
+	return x;
+}), ((x) => {
+	x(undefined);
+	return x;
+}), 10);
+var h = fun(((x) => {
+	x(undefined);
+	return x;
+}), ((x) => {
+	x(undefined);
+	return x;
+}), 10);
+// Ternaries in parens
+var i = fun(Math.random() < 0.5 ? (x) => {
+	x(undefined);
+	return x;
+} : (x) => undefined, 10);
+var j = fun(Math.random() < 0.5 ? ((x) => {
+	x(undefined);
+	return x;
+}) : ((x) => undefined), 10);
+var k = fun(Math.random() < 0.5 ? ((x) => {
+	x(undefined);
+	return x;
+}) : ((x) => undefined), (x) => {
+	x(undefined);
+	return x;
+}, 10);
+var l = fun(Math.random() < 0.5 ? ((x) => {
+	x(undefined);
+	return x;
+}) : ((x) => undefined), ((x) => {
+	x(undefined);
+	return x;
+}), 10);
+var lambda1 = (x) => {
+	x(undefined);
+	return x;
+};
+var lambda2 = ((x) => {
+	x(undefined);
+	return x;
+});
+var obj1 = { x: (x) => (x,undefined), y: (y) => (y,undefined) };
+var obj2 = { x: (x) => (x,undefined), y: (y) => (y,undefined) };
+"
+`;
+
 exports[`TSC: expressions parenthesizedContexualTyping3 1`] = `
 "// Contextual typing for parenthesized substitution expressions in tagged templates.
 /**
@@ -8050,12 +8163,12 @@ function tempFun(tempStrs,g,x) {
 }
 var a = tempFun\`\${(x) => x}  \${10}\`;
 var b = tempFun\`\${((x) => x)}  \${10}\`;
-var c = tempFun\`\${(((x) => x))} \${10}\`;
+var c = tempFun\`\${((x) => x)} \${10}\`;
 var d = tempFun\`\${(x) => x} \${(x) => x} \${10}\`;
 var e = tempFun\`\${(x) => x} \${((x) => x)} \${10}\`;
-var f = tempFun\`\${(x) => x} \${(((x) => x))} \${10}\`;
-var g = tempFun\`\${((x) => x)} \${((((x) => x)))} \${10}\`;
-var h = tempFun\`\${((x) => x)} \${((((x) => x)))} \${undefined}\`;
+var f = tempFun\`\${(x) => x} \${((x) => x)} \${10}\`;
+var g = tempFun\`\${((x) => x)} \${((x) => x)} \${10}\`;
+var h = tempFun\`\${((x) => x)} \${((x) => x)} \${undefined}\`;
 "
 `;
 
@@ -8319,12 +8432,12 @@ obj.foo(1, 2, ...a, "abc");
 obj.foo(1, 2, ...a).foo(1, 2, "abc");
 obj.foo(1, 2, ...a).foo(1, 2, ...a);
 obj.foo(1, 2, ...a).foo(1, 2, ...a, "abc");
-(obj.foo)(1, 2, "abc");
-(obj.foo)(1, 2, ...a);
-(obj.foo)(1, 2, ...a, "abc");
-((obj.foo)(1, 2, ...a).foo)(1, 2, "abc");
-((obj.foo)(1, 2, ...a).foo)(1, 2, ...a);
-((obj.foo)(1, 2, ...a).foo)(1, 2, ...a, "abc");
+obj.foo(1, 2, "abc");
+obj.foo(1, 2, ...a);
+obj.foo(1, 2, ...a, "abc");
+obj.foo(1, 2, ...a).foo(1, 2, "abc");
+obj.foo(1, 2, ...a).foo(1, 2, ...a);
+obj.foo(1, 2, ...a).foo(1, 2, ...a, "abc");
 xa[1].foo(1, 2, "abc");
 xa[1].foo(1, 2, ...a);
 xa[1].foo(1, 2, ...a, "abc");
@@ -8439,9 +8552,9 @@ foo(1, 2, ...a, "abc");
 obj.foo(1, 2, "abc");
 obj.foo(1, 2, ...a);
 obj.foo(1, 2, ...a, "abc");
-(obj.foo)(1, 2, "abc");
-(obj.foo)(1, 2, ...a);
-(obj.foo)(1, 2, ...a, "abc");
+obj.foo(1, 2, "abc");
+obj.foo(1, 2, ...a);
+obj.foo(1, 2, ...a, "abc");
 xa[1].foo(1, 2, "abc");
 xa[1].foo(1, 2, ...a);
 xa[1].foo(1, 2, ...a, "abc");
@@ -8511,7 +8624,7 @@ var A,B;
 f(g(7));
 f(g < A, B > 7);
 // Should error
-f(g < A, B > +(7));
+f(g < A, B > +7);
 // Should error
 "
 `;
@@ -8549,9 +8662,9 @@ new b.f(1, 2, "string");
 new b.f(1, 2, ...a);
 new b.f(1, 2, ...a, "string");
 // Parenthesised expression
-new (b.f)(1, 2, "string");
-new (b.f)(1, 2, ...a);
-new (b.f)(1, 2, ...a, "string");
+new b.f(1, 2, "string");
+new b.f(1, 2, ...a);
+new b.f(1, 2, ...a, "string");
 // Element access expression
 new d[1].f(1, 2, "string");
 new d[1].f(1, 2, ...a);
@@ -8569,9 +8682,9 @@ new c["a-b"](1, 2, "string");
 new c["a-b"](1, 2, ...a);
 new c["a-b"](1, 2, ...a, "string");
 // Parenthesised expression
-new (c["a-b"])(1, 2, "string");
-new (c["a-b"])(1, 2, ...a);
-new (c["a-b"])(1, 2, ...a, "string");
+new c["a-b"](1, 2, "string");
+new c["a-b"](1, 2, ...a);
+new c["a-b"](1, 2, ...a, "string");
 // Element access expression
 new g[1]["a-b"](1, 2, "string");
 new g[1]["a-b"](1, 2, ...a);
@@ -8620,9 +8733,9 @@ new b.f(1, 2, "string");
 new b.f(1, 2, ...a);
 new b.f(1, 2, ...a, "string");
 // Parenthesised expression
-new (b.f)(1, 2, "string");
-new (b.f)(1, 2, ...a);
-new (b.f)(1, 2, ...a, "string");
+new b.f(1, 2, "string");
+new b.f(1, 2, ...a);
+new b.f(1, 2, ...a, "string");
 // Element access expression
 new d[1].f(1, 2, "string");
 new d[1].f(1, 2, ...a);
@@ -8640,9 +8753,9 @@ new c["a-b"](1, 2, "string");
 new c["a-b"](1, 2, ...a);
 new c["a-b"](1, 2, ...a, "string");
 // Parenthesised expression
-new (c["a-b"])(1, 2, "string");
-new (c["a-b"])(1, 2, ...a);
-new (c["a-b"])(1, 2, ...a, "string");
+new c["a-b"](1, 2, "string");
+new c["a-b"](1, 2, ...a);
+new c["a-b"](1, 2, ...a, "string");
 // Element access expression
 new g[1]["a-b"](1, 2, "string");
 new g[1]["a-b"](1, 2, ...a);
@@ -8691,9 +8804,9 @@ new b.f(1, 2, "string");
 new b.f(1, 2, ...a);
 new b.f(1, 2, ...a, "string");
 // Parenthesised expression
-new (b.f)(1, 2, "string");
-new (b.f)(1, 2, ...a);
-new (b.f)(1, 2, ...a, "string");
+new b.f(1, 2, "string");
+new b.f(1, 2, ...a);
+new b.f(1, 2, ...a, "string");
 // Element access expression
 new d[1].f(1, 2, "string");
 new d[1].f(1, 2, ...a);
@@ -8711,9 +8824,9 @@ new c["a-b"](1, 2, "string");
 new c["a-b"](1, 2, ...a);
 new c["a-b"](1, 2, ...a, "string");
 // Parenthesised expression
-new (c["a-b"])(1, 2, "string");
-new (c["a-b"])(1, 2, ...a);
-new (c["a-b"])(1, 2, ...a, "string");
+new c["a-b"](1, 2, "string");
+new c["a-b"](1, 2, ...a);
+new c["a-b"](1, 2, ...a, "string");
 // Element access expression
 new g[1]["a-b"](1, 2, "string");
 new g[1]["a-b"](1, 2, ...a);
@@ -9492,9 +9605,9 @@ exports[`TSC: expressions contextuallyTypedIife 1`] = `
 })("lol");
 // Lots of Irritating Superfluous Parentheses
 (function(x) {
-}("!"));
-((((function(y) {
-}))))("-");
+})("!");
+(function(y) {
+})("-");
 // multiple arguments
 ((a, b, c) => {
 })("foo", 101, false);
@@ -9538,9 +9651,9 @@ exports[`TSC: expressions contextuallyTypedIifeStrict 1`] = `
 })("lol");
 // Lots of Irritating Superfluous Parentheses
 (function(x) {
-}("!"));
-((((function(y) {
-}))))("-");
+})("!");
+(function(y) {
+})("-");
 // multiple arguments
 ((a, b, c) => {
 })("foo", 101, false);
@@ -9680,7 +9793,7 @@ function fnVoid() {
 var t = new fnVoid();
 var t;
 // Chained new expressions
-var nested = new (new (new nestedCtor())())();
+var nested = new new new nestedCtor()()();
 var n = new nested();
 var n = new nested();
 "
@@ -9840,7 +9953,7 @@ exports[`TSC: expressions nullishCoalescingOperator6 1`] = `
 exports[`TSC: expressions nullishCoalescingOperator7 1`] = `
 "const foo1 = a ? 1 : 2;
 const foo2 = a ?? "foo" ? 1 : 2;
-const foo3 = a ?? "foo" ? (b ?? "bar") : (c ?? "baz");
+const foo3 = a ?? "foo" ? b ?? "bar" : c ?? "baz";
 function f() {
 	const foo4 = a ?? "foo" ? b ?? "bar" : c ?? "baz";
 }
@@ -10177,7 +10290,7 @@ class Derived extends Base {
 `;
 
 exports[`TSC: expressions parentheses 1`] = `
-"(o1)(o1 ?? 1);
+"o1(o1 ?? 1);
 (o2?.b)(o1 ?? 1);
 (o3?.b())(o1 ?? 1);
 (o4?.b().c)(o1 ?? 1);
@@ -10213,18 +10326,18 @@ exports[`TSC: expressions thisMethodCall 1`] = `
 
 exports[`TSC: expressions deleteChain 1`] = `
 "delete o1?.b;
-delete (o1?.b);
+delete o1?.b;
 delete o2?.b.c;
-delete (o2?.b.c);
+delete o2?.b.c;
 delete o3.b?.c;
-delete (o3.b?.c);
+delete o3.b?.c;
 delete o4.b?.c.d?.e;
-delete (o4.b?.c.d)?.e;
-delete (o4.b?.c.d?.e);
+delete o4.b?.c.d?.e;
+delete o4.b?.c.d?.e;
 delete o5.b?.().c.d?.e;
-delete (o5.b?.().c.d?.e);
+delete o5.b?.().c.d?.e;
 delete o6.b?.["c"].d?.["e"];
-delete (o6.b?.["c"].d?.["e"]);
+delete o6.b?.["c"].d?.["e"];
 "
 `;
 
@@ -11032,9 +11145,9 @@ let o9 = { x: 10, foo() {
 	this.x = 20;
 } };
 // Error
-let p1 = (10);
-let p2 = ((-10));
-let p3 = ([(10)]);
+let p1 = 10;
+let p2 = -10;
+let p3 = [10];
 let p4 = [[[[10]]]];
 let x1 = { x: 10, y: [20, 30], z: { a: { b: 42 } } };
 let q1 = 10;
@@ -11044,7 +11157,7 @@ let q4 = [1, 2, 3];
 let q5 = { x: 10, y: 20 };
 let e1 = v1;
 // Error
-let e2 = (true ? 1 : 0);
+let e2 = true ? 1 : 0;
 // Error
 let e3 = id(1);
 // Error
@@ -11491,17 +11604,17 @@ if (isFoo(value)) {
 
 exports[`TSC: expressions typeGuardNesting 1`] = `
 "let strOrBool;
-if ((typeof strOrBool === "boolean" && !strOrBool) || typeof strOrBool === "string") {
-	let label = (typeof strOrBool === "string") ? strOrBool : "string";
-	let bool = (typeof strOrBool === "boolean") ? strOrBool : false;
-	let label2 = (typeof strOrBool !== "boolean") ? strOrBool : "string";
-	let bool2 = (typeof strOrBool !== "string") ? strOrBool : false;
+if (typeof strOrBool === "boolean" && !strOrBool || typeof strOrBool === "string") {
+	let label = typeof strOrBool === "string" ? strOrBool : "string";
+	let bool = typeof strOrBool === "boolean" ? strOrBool : false;
+	let label2 = typeof strOrBool !== "boolean" ? strOrBool : "string";
+	let bool2 = typeof strOrBool !== "string" ? strOrBool : false;
 }
-if ((typeof strOrBool !== "string" && !strOrBool) || typeof strOrBool !== "boolean") {
-	let label = (typeof strOrBool === "string") ? strOrBool : "string";
-	let bool = (typeof strOrBool === "boolean") ? strOrBool : false;
-	let label2 = (typeof strOrBool !== "boolean") ? strOrBool : "string";
-	let bool2 = (typeof strOrBool !== "string") ? strOrBool : false;
+if (typeof strOrBool !== "string" && !strOrBool || typeof strOrBool !== "boolean") {
+	let label = typeof strOrBool === "string" ? strOrBool : "string";
+	let bool = typeof strOrBool === "boolean" ? strOrBool : false;
+	let label2 = typeof strOrBool !== "boolean" ? strOrBool : "string";
+	let bool2 = typeof strOrBool !== "string" ? strOrBool : false;
 }
 "
 `;
@@ -12515,7 +12628,7 @@ function positiveTestClassesWithOptionalProperties(x) {
 	}
 }
 function inParenthesizedExpression(x) {
-	if ("a" in (x)) {
+	if ("a" in x) {
 		let y = x.a;
 	} else {
 		let z = x.b;
@@ -12817,29 +12930,29 @@ function foo(x) {
 }
 // number
 function foo2(x) {
-	return typeof x === "string" ? ((x = "hello") && x) : // string
+	return typeof x === "string" ? (x = "hello") && x : // string
 	x;
 }
 // number
 function foo3(x) {
-	return typeof x === "string" ? ((x = 10) && x) : // number
+	return typeof x === "string" ? (x = 10) && x : // number
 	x;
 }
 // number
 function foo4(x) {
 	return typeof x === "string" ? x : // string
-	((x = 10) && x);
+	(x = 10) && x;
 }
 // number
 function foo5(x) {
 	return typeof x === "string" ? x : // string
-	((x = "hello") && x);
+	(x = "hello") && x;
 }
 // string
 function foo6(x) {
 	// Modify in both branches
-	return typeof x === "string" ? ((x = 10) && x) : // number
-	((x = "hello") && x);
+	return typeof x === "string" ? (x = 10) && x : // number
+	(x = "hello") && x;
 }
 // string
 function foo7(x) {
@@ -12850,15 +12963,15 @@ function foo7(x) {
 // boolean
 function foo8(x) {
 	var b;
-	return typeof x === "string" ? x === "hello" : ((b = x) && //  number | boolean
+	return typeof x === "string" ? x === "hello" : (b = x) && //  number | boolean
 	(typeof x === "boolean" ? x : // boolean
-	x == 10));
+	x == 10);
 }
 // boolean
 function foo9(x) {
 	var y = 10;
 	// usage of x or assignment to separate variable shouldn't cause narrowing of type to stop
-	return typeof x === "string" ? ((y = x.length) && x === "hello") : // boolean
+	return typeof x === "string" ? (y = x.length) && x === "hello" : // boolean
 	x === 10;
 }
 // boolean
@@ -12866,25 +12979,25 @@ function foo10(x) {
 	// Mixing typeguards
 	var b;
 	return typeof x === "string" ? x : // string
-	((b = x) && // x is number | boolean
-	typeof x === "number" && x.toString());
+	(b = x) && // x is number | boolean
+	typeof x === "number" && x.toString();
 }
 // x is number
 function foo11(x) {
 	// Mixing typeguards
 	var b;
 	return typeof x === "string" ? x : // string
-	((b = x) && // x is number | boolean
+	(b = x) && // x is number | boolean
 	typeof x === "number" && (x = 10) && // assignment to x
-	x);
+	x;
 }
 // x is number
 function foo12(x) {
 	// Mixing typeguards
 	var b;
-	return typeof x === "string" ? ((x = 10) && x.toString().length) : // number
-	((b = x) && // x is number | boolean
-	typeof x === "number" && x);
+	return typeof x === "string" ? (x = 10) && x.toString().length : // number
+	(b = x) && // x is number | boolean
+	typeof x === "number" && x;
 }
 // x is number
 "
@@ -13300,10 +13413,10 @@ function foo11(x) {
 		var y;
 		var b = x;
 		// number | boolean | string - because below we are changing value of x in if statement
-		return typeof x === "number" ? (// change value of x
-		x = 10 && x.toString()) : // number | boolean | string
-		(// do not change value
-		y = x && x.toString());
+		return typeof x === "number" ? // change value of x
+		x = 10 && x.toString() : // number | boolean | string
+		// do not change value
+		y = x && x.toString();
 	}
 }
 // number | boolean | string
@@ -13470,9 +13583,9 @@ function foo7(x) {
 	// Mixing typeguard narrowing
 	return typeof x !== "string" && ((z = x) && // number | boolean
 	(typeof x === "number" ? // change value of x
-	((x = 10) && x.toString()) : // x is number
+	(x = 10) && x.toString() : // x is number
 	// do not change value
-	((y = x) && x.toString())));
+	(y = x) && x.toString()));
 }
 // x is boolean
 "
@@ -13524,9 +13637,9 @@ function foo7(x) {
 	// Mixing typeguard narrowing
 	return typeof x === "string" || ((z = x) || // number | boolean
 	(typeof x === "number" ? // change value of x
-	((x = 10) && x.toString()) : // number | boolean | string
+	(x = 10) && x.toString() : // number | boolean | string
 	// do not change value
-	((y = x) && x.toString())));
+	(y = x) && x.toString()));
 }
 // number | boolean | string
 "
@@ -14215,7 +14328,7 @@ function fn6() {
 (() => ({ a: 1 }))();
 (() => obj1)();
 (() => ({}))();
-(() => (({})))();
+(() => ({}))();
 "
 `;
 
@@ -15739,201 +15852,88 @@ exports[`TSC: expressions assignmentToParenthesizedIdentifiers 1`] = `
 "var x;
 x = 3;
 // OK
-(x) = 3;
+x = 3;
 // OK
 x = "";
 // Error
-(x) = "";
+x = "";
 // Error
 var M;((M) => {})(M || (M = {}));
 M.y = 3;
 // OK
-(M).y = 3;
+M.y = 3;
 // OK
-(M.y) = 3;
+M.y = 3;
 // OK
 M.y = "";
 // Error
-(M).y = "";
+M.y = "";
 // Error
-(M.y) = "";
+M.y = "";
 // Error
 M = { y: 3 };
 // Error
-(M) = { y: 3 };
+M = { y: 3 };
 // Error
 var M2;((M2) => {let M3;((M3) => {})(M3 = M2.M3 || (M2.M3 = {}));M3 = { x: 3 };})(M2 || (M2 = {}));
 // Error
 M2.M3 = { x: 3 };
 // OK
-(M2).M3 = { x: 3 };
+M2.M3 = { x: 3 };
 // OK
-(M2.M3) = { x: 3 };
+M2.M3 = { x: 3 };
 // OK
 M2.M3 = { x: "" };
 // Error
-(M2).M3 = { x: "" };
+M2.M3 = { x: "" };
 // Error
-(M2.M3) = { x: "" };
+M2.M3 = { x: "" };
 // Error
 function fn() {
 }
 fn = () => 3;
 // Bug 823548: Should be error (fn is not a reference)
-(fn) = () => 3;
+fn = () => 3;
 // Should be error
 function fn2(x,y) {
 	x = 3;
-	(x) = 3;
+	x = 3;
 	// OK
 	x = "";
 	// Error
-	(x) = "";
+	x = "";
 	// Error
-	(y).t = 3;
+	y.t = 3;
 	// OK
-	(y.t) = 3;
+	y.t = 3;
 	// OK
-	(y).t = "";
+	y.t = "";
 	// Error
-	(y.t) = "";
+	y.t = "";
 	// Error
 	y["t"] = 3;
 	// OK
-	(y)["t"] = 3;
+	y["t"] = 3;
 	// OK
-	(y["t"]) = 3;
+	y["t"] = 3;
 	// OK
 	y["t"] = "";
 	// Error
-	(y)["t"] = "";
+	y["t"] = "";
 	// Error
-	(y["t"]) = "";
+	y["t"] = "";
 }
 // Error
 var E = /* @__PURE__ */ ((E) => {E[E["A"]=0]="A";return E;})(E || {});
 E = undefined;
 // Error
-(E) = undefined;
+E = undefined;
 // Error
 class C {
 }
 C = undefined;
 // Error
-(C) = undefined;
+C = undefined;
 // Error
-"
-`;
-
-exports[`TSC: expressions parenthesizedContexualTyping1 1`] = `
-"function fun(g,x) {
-	return g(x);
-}
-var a = fun((x) => x, 10);
-var b = fun(((x) => x), 10);
-var c = fun((((x) => x)), 10);
-var d = fun(((((x) => x))), 10);
-var e = fun((x) => x, (x) => x, 10);
-var f = fun(((x) => x), ((x) => x), 10);
-var g = fun((((x) => x)), (((x) => x)), 10);
-var h = fun(((((x) => x))), (((x) => x)), 10);
-// Ternaries in parens
-var i = fun((Math.random() < 0.5 ? (x) => x : (x) => undefined), 10);
-var j = fun((Math.random() < 0.5 ? ((x) => x) : ((x) => undefined)), 10);
-var k = fun((Math.random() < 0.5 ? ((x) => x) : ((x) => undefined)), (x) => x, 10);
-var l = fun(((Math.random() < 0.5 ? (((x) => x)) : (((x) => undefined)))), (((x) => x)), 10);
-var lambda1 = (x) => x;
-var lambda2 = ((x) => x);
-var obj1 = { x: (x) => (x,undefined), y: (y) => (y,undefined) };
-var obj2 = ({ x: (x) => (x,undefined), y: (y) => (y,undefined) });
-"
-`;
-
-exports[`TSC: expressions parenthesizedContexualTyping2 1`] = `
-"// These tests ensure that in cases where it may *appear* that a value has a type,
-// they actually are properly being contextually typed. The way we test this is
-// that we invoke contextually typed arguments with type arguments.
-// Since 'any' cannot be invoked with type arguments, we should get errors
-// back if contextual typing is not taking effect.
-function fun(...rest) {
-	return undefined;
-}
-var a = fun((x) => {
-	x(undefined);
-	return x;
-}, 10);
-var b = fun(((x) => {
-	x(undefined);
-	return x;
-}), 10);
-var c = fun((((x) => {
-	x(undefined);
-	return x;
-})), 10);
-var d = fun(((((x) => {
-	x(undefined);
-	return x;
-}))), 10);
-var e = fun((x) => {
-	x(undefined);
-	return x;
-}, (x) => {
-	x(undefined);
-	return x;
-}, 10);
-var f = fun(((x) => {
-	x(undefined);
-	return x;
-}), ((x) => {
-	x(undefined);
-	return x;
-}), 10);
-var g = fun((((x) => {
-	x(undefined);
-	return x;
-})), (((x) => {
-	x(undefined);
-	return x;
-})), 10);
-var h = fun(((((x) => {
-	x(undefined);
-	return x;
-}))), (((x) => {
-	x(undefined);
-	return x;
-})), 10);
-// Ternaries in parens
-var i = fun((Math.random() < 0.5 ? (x) => {
-	x(undefined);
-	return x;
-} : (x) => undefined), 10);
-var j = fun((Math.random() < 0.5 ? ((x) => {
-	x(undefined);
-	return x;
-}) : ((x) => undefined)), 10);
-var k = fun((Math.random() < 0.5 ? ((x) => {
-	x(undefined);
-	return x;
-}) : ((x) => undefined)), (x) => {
-	x(undefined);
-	return x;
-}, 10);
-var l = fun(((Math.random() < 0.5 ? (((x) => {
-	x(undefined);
-	return x;
-})) : (((x) => undefined)))), (((x) => {
-	x(undefined);
-	return x;
-})), 10);
-var lambda1 = (x) => {
-	x(undefined);
-	return x;
-};
-var lambda2 = ((x) => {
-	x(undefined);
-	return x;
-});
-var obj1 = { x: (x) => (x,undefined), y: (y) => (y,undefined) };
-var obj2 = ({ x: (x) => (x,undefined), y: (y) => (y,undefined) });
 "
 `;

--- a/tests/integration/tests/tsc/__snapshots__/generators.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/generators.test.ts.snap
@@ -120,9 +120,9 @@ function* g4() {
 	// ok, result is unused
 	noop(),yield,noop();
 	// ok, result is unused
-	(yield);
+	yield;
 	// ok, result is unused
-	(yield,noop()),noop();
+	yield,noop(),noop();
 	// ok, result is unused
 	for (yield; false; yield);
 	// ok, results are unused


### PR DESCRIPTION
## 개요 (#4042 PR7 — THE FLIP)

codegen 의 괄호 처리를 **paren-node 의존 → esbuild/oxc 식 precedence 기반 재유도**로 전환하는 핵심 PR입니다. 군더더기 괄호를 전 모드에서 제거하고 load-bearing 괄호만 연산자 우선순위로 정확히 재유도합니다.

### 왜 (전환 동기 = 버그부류 근절)
기존 codegen 은 `(a?.b).c`(optional-chain 끊기)·`({})`(statement-start) 같은 괄호를 **precedence 가 아니라 `parenthesized_expression` 노드에 의존**해 출력했습니다. 그래서 타입 strip·optional-chain/class lowering·minify 재결합 같은 변환이 괄호 노드를 떼면 codegen 이 **살릴 능력이 없어** silent miscompile / invalid 출력이 났습니다(`/code-review max` 가 같은 뿌리의 버그를 5+ 인스턴스 적발). precedence 한 곳으로 모아 이 부류를 근절합니다.

> **회귀 기준**: 의도적으로 byte 를 바꿉니다(군더더기 괄호 제거). 따라서 기준은 byte-identical 이 아니라 **semantic equivalence** 입니다.

## 변경 (커밋별)
1. **`65e1b8a8` statement-start 마킹 인프라** (byte-identical) — `saveExprStartFlags`/`atStmtOrArrowStart` + object/function/class statement-start wrap 토대. paren 노드가 아직 괄호를 담당해 출력 불변.
2. **`031954a6` emitParen 투명화 + member/call/new/optional-chain wrap** (THE FLIP) — 아래 핵심 로직.
3. **`58e8382a` class field/extends sequence·yield 래핑 + TSC 스냅샷 재생성 + classifier**.
4. **`5bae95d7` code-review max 적발 엣지 4건 수정**.

## 핵심 로직 (Zig 초보 설명 포함)
- **emitParen 투명화**: `parenthesized_expression` 노드를 만나면 `(`·`)` 를 그대로 찍던 것을, **operand 를 부모의 결합강도(`level`)/플래그(`flags`) 로 재귀**하도록 바꿨습니다. 괄호가 필요하면 안쪽 노드의 precedence 가 다시 만들어냅니다. (단, function/arrow 식 둘레 괄호는 esbuild `IsParenthesized` 처럼 보존 — IIFE `(function(){})()` 등.)
- **중앙 wrap 술어 `exprNeedsParens`**: 각 노드가 `level.gte(entry)` 면 `(`…`)` 로 감쌉니다. Zig 에는 클로저가 없어 esbuild Go 처럼 `if (wrap) writeByte('(')` 인라인 패턴입니다.
- **optional-chain Continue vs None** (가장 까다로운 함정): zntc 파서는 esbuild 의 `OptionalChainContinue` 를 노드로 표현하지 않고 **paren 노드로 체인을 끊습니다**. 그래서 `a?.b.c`(체인 연속, 안 끊음)와 `(a?.b).c`(끊음)를 구분하려 `objectContinuesOptionalChain` 으로 object 를 **구조적으로** 검사합니다.
- **잔여 ad-hoc 유지**: rename→`()` 식별자(`newCalleeNeedsRenameParens`)·`void 0` peephole(`emitNodeMaybeUndefParen`)은 AST 기반 precedence 가 못 잡아 유지. `needSpaceBeforeDot`(`(42).x`→`42 .x`)·comma-context level(`let x=(a,b)`)·class extends `.postfix`·tagged-template optional tag 강제괄호도 추가.

## 검증 (semantic equivalence)
| 항목 | 결과 |
|------|------|
| **classifier** (scripts/classify-paren-diff.ts, TSC 스냅샷 old/new esbuild 정규화 분류) | **81 EQUIVALENT / 0 SUSPECT** (2 UNPARSEABLE=esbuild-js 미파싱 양쪽 동일, yield 격리 동등) |
| test262 (parse 정합성 바닥) | **100%** (23384/23384) |
| zig 단위 테스트 | **0 fail** (+ load-bearing 매트릭스 9행) |
| integration | **4039 pass** (잔여 3 = watch/dev-server TLS handshake + Hermes hermesc 타임아웃 = **환경 문제, codegen 무관**) |
| **smoke 144-lib** (번들 실행 stdout = esbuild/rolldown 동일) | **144/144 MATCH**, size 0.87x avg (회귀 없음) |
| `/code-review max` (3-finder 병렬) | 5 엣지 적발 → 4 수정 + 1 문서화 |

### code-review 적발·수정
- `new (a?.b)()` → `new a?.b()` SyntaxError (실제 zod `new (params?.Err)(x)` 패턴) → new callee 에 `has_non_optional_chain_parent`.
- `100_000.toString()` numeric separator 공백 누락 → `numericIsPlainInteger` 보정.
- `({x=(a,b)}=o)` shorthand default sequence silent miscompile → `.comma`.
- `for((a in b);;)` for-in 오파싱 → `forbid_in` 시드.
- (deferred) for-of head 의 literal `let`/`async` 식별자 = sloppy `.js` 전용(strict/.ts 거부, test262 100%) → PR8 후보.

## 잔여 (별도 PR)
- **PR8**: transformer `makeParenExpr` 합성 제거(투명화 후 precedence 가 동일 재유도) + for-of `let` 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)