### PR TITLE
refactor(codegen): makeParenExpr 합성 제거 + IIFE auto-paren + cleanup (#4042 PR8)

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -3185,7 +3185,8 @@ test "#1621 minify+es5: async → $aS/$gn 축약" {
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "$aS=function") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "$gn=function") != null);
+    // $gn(__generator helper)은 IIFE 정의 → #4042 IIFE auto-paren 으로 `(function` (esbuild parity).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$gn=(function") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__async(") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__generator(") == null);
 }

--- a/src/codegen/calls.zig
+++ b/src/codegen/calls.zig
@@ -14,18 +14,21 @@ const ExprFlags = precedence.ExprFlags;
 const IMPORT_META_URL_NODE = "require(\"url\").pathToFileURL(__filename).href";
 const IMPORT_META_NODE_OBJECT = "{url:" ++ IMPORT_META_URL_NODE ++ ",dirname:__dirname,filename:__filename}";
 
-/// transparent TYPE wrapper(TS `as T`/`<T>x`/`!`, Flow cast, chain_expression)만 벗긴다.
-/// **paren 은 벗기지 않는다** — paren 은 optional chain 을 끊는 경계이므로
-/// (`(a?.b).c` 의 `.c` 는 None, `a?.b!.c` 의 `.c` 는 Continue). objectContinuesOptionalChain 전용.
-fn skipTypeWrappers(self: anytype, idx: NodeIndex) NodeIndex {
+/// transparent wrapper 를 벗겨 실제 노드를 반환. chain_expression + TS/Flow type cast
+/// (`as T`/`<T>x`/`!`)는 항상 벗긴다. `include_paren=true` 면 parenthesized_expression 도
+/// 벗긴다(출력 토큰 기준 — emitParen 투명). `false` 면 paren 은 경계로 남긴다 —
+/// optional chain 을 끊으므로(`(a?.b).c` 의 `.c` 는 None, `a?.b!.c` 의 `.c` 는 Continue).
+/// codegen 의 wrapper-skip 3종(투명검사/type-only/optional-chain)을 단일화.
+pub fn skipWrappers(self: anytype, idx: NodeIndex, comptime include_paren: bool) NodeIndex {
     var cur = idx;
     var depth: u8 = 0;
     while (depth < 32) : (depth += 1) {
         if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return cur;
         const n = self.ast.getNode(cur);
-        if (n.tag == .chain_expression or ast_mod.Node.Tag.isTransparentTypeWrapper(n.tag)) {
-            cur = n.data.unary.operand;
-        } else return cur;
+        const transparent = n.tag == .chain_expression or
+            ast_mod.Node.Tag.isTransparentTypeWrapper(n.tag) or
+            (include_paren and n.tag == .parenthesized_expression);
+        if (transparent) cur = n.data.unary.operand else return cur;
     }
     return cur;
 }
@@ -39,7 +42,7 @@ pub fn objectContinuesOptionalChain(self: anytype, idx: NodeIndex) bool {
     var cur = idx;
     var depth: u8 = 0;
     while (depth < 64) : (depth += 1) {
-        cur = skipTypeWrappers(self, cur);
+        cur = skipWrappers(self, cur, false); // paren 은 체인 경계로 남긴다
         if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return false;
         const n = self.ast.getNode(cur);
         switch (n.tag) {
@@ -66,18 +69,8 @@ pub fn objectContinuesOptionalChain(self: anytype, idx: NodeIndex) bool {
 /// 한다 (esbuild ETemplate: `IsOptionalChain(tag)` → wrap). paren 까지 벗기는 이유는 emit 시
 /// 투명 paren 이 사라져 `(a?.b)`x`` 가 `a?.b`x``(invalid)로 깨지기 때문.
 pub fn isOptionalChainExpr(self: anytype, idx: NodeIndex) bool {
-    var cur = idx;
-    var depth: u8 = 0;
-    while (depth < 32) : (depth += 1) {
-        if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return false;
-        const n = self.ast.getNode(cur);
-        if (n.tag == .parenthesized_expression or n.tag == .chain_expression or
-            ast_mod.Node.Tag.isTransparentTypeWrapper(n.tag))
-        {
-            cur = n.data.unary.operand;
-        } else break;
-    }
-    return objectContinuesOptionalChain(self, cur);
+    // paren 까지 벗긴(출력 토큰 기준) 실제 노드가 chain 인지.
+    return objectContinuesOptionalChain(self, skipWrappers(self, idx, true));
 }
 
 /// `undefined` peephole 의 callee/object/new.callee 슬롯 paren 검사.

--- a/src/codegen/calls.zig
+++ b/src/codegen/calls.zig
@@ -96,6 +96,18 @@ pub fn isUndefinedPeephole(self: anytype, idx: NodeIndex) bool {
     return std.mem.eql(u8, self.ast.getText(n.span), "undefined");
 }
 
+/// callee 가 (래퍼 없이) 직접 function expression 인지 — IIFE auto-paren 대상.
+/// esbuild 가 `ECall` 의 target 이 `EFunction` 이면 `IsParenthesized=true` 로 마킹하는 것과
+/// 동형. paren(function)(source IIFE)은 emitParen 이 보존하므로 *직접* 노드만 검사해
+/// 이중괄호를 피한다. arrow 는 .postfix(call-target) level 로 이미 wrap 돼 여기 불필요.
+fn calleeIsBareFunctionExpr(self: anytype, idx: NodeIndex) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return false;
+    return switch (self.ast.getNode(idx).tag) {
+        .function_expression, .function => true,
+        else => false,
+    };
+}
+
 /// `void 0` peephole 가 적용될 자식 노드를 paren 으로 감싸 emit. 자식이 그 외엔 그대로 emit.
 /// callee/object/new.callee 슬롯 4곳에서 공유 — 정책은 [[isUndefinedPeephole]].
 pub fn emitNodeMaybeUndefParen(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) !void {
@@ -137,7 +149,14 @@ pub fn emitCall(self: anytype, node: Node, level: Level, flags: ExprFlags) !void
     // 전파 안 함 — call 이 자기 wrap 에서 소진(esbuild ECall parity).
     const self_in_chain = is_optional or objectContinuesOptionalChain(self, callee);
     const callee_flags = ExprFlags{ .has_non_optional_chain_parent = !self_in_chain };
+    // IIFE: callee 가 *직접* function expression 이면 괄호로 감싼다 (esbuild 가 ECall target
+    // 이 EFunction 이면 IsParenthesized 자동 마킹하는 것과 동형, `function(){}()`→`(function(){})()`).
+    // source `(function(){})()` 는 callee=paren(function)이라 직접 노드가 아니어서 emitParen 이
+    // 보존(이중괄호 회피). arrow 는 .postfix(call-target) level 로 exprNeedsParens 가 이미 wrap.
+    const iife_wrap = calleeIsBareFunctionExpr(self, callee);
+    if (iife_wrap) try self.writeByte('(');
     try emitNodeMaybeUndefParen(self, callee, Level.postfix, callee_flags);
+    if (iife_wrap) try self.writeByte(')');
     if (is_optional) try self.write("?.");
     try self.writeByte('(');
     try self.emitExpressionNodeList(args_start, args_len, self.listSep());

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -85,16 +85,15 @@ pub const Codegen = struct {
     /// 가 되므로 그 경우엔 재작성을 건너뛴다.
     member_assign_target: bool = false,
     /// statement-start 모호성 추적 (esbuild `stmtStart`/`exportDefaultStart`/
-    /// `arrowExprStart`/`forOfInitStart`). 각 컨텍스트의 첫 토큰을 출력하기 직전
-    /// 현재 `buf.items.len` 으로 마킹하고, expression emitter 가 진입 시
-    /// `buf.items.len` 이 마크와 같으면 "내가 그 컨텍스트의 첫 토큰" 으로 판정해
-    /// 괄호를 친다 (`({}).x`, `(function(){})()`, `(class{})`, `(let)[x]`).
-    /// `maxInt` = 미마킹(절대 매치 안 됨). (PR2: 필드만 도입. 실제 마킹/판정은
-    /// statement-start 를 다루는 후속 PR.)
+    /// `arrowExprStart`). 각 컨텍스트의 첫 토큰을 출력하기 직전 현재 `buf.items.len`
+    /// 으로 마킹하고, expression emitter 가 진입 시 `buf.items.len` 이 마크와 같으면
+    /// "내가 그 컨텍스트의 첫 토큰" 으로 판정해 괄호를 친다 (`({}).x`,
+    /// `(function(){})()`, `(class{})`). `maxInt` = 미마킹(절대 매치 안 됨).
+    /// (for-of init `let`/`async` wrap 은 sloppy `.js` 전용 + identifier early-return
+    ///  충돌로 미구현 — 필요 시 `for_of_init_start` 필드 재도입.)
     stmt_start: usize = std.math.maxInt(usize),
     export_default_start: usize = std.math.maxInt(usize),
     arrow_expr_start: usize = std.math.maxInt(usize),
-    for_of_init_start: usize = std.math.maxInt(usize),
     /// 직전에 출력한 numeric literal 이 정수 형태(`42`)라 바로 뒤 `.` 가 소수점으로
     /// 오파싱될 수 있는 위치. emit 직후 `buf.items.len` 으로 마킹하고, static member
     /// 의 `.` emit 직전 위치가 일치하면 공백을 끼운다(`42 .toString()`). esbuild
@@ -370,7 +369,6 @@ pub const Codegen = struct {
         stmt_start: bool = false,
         export_default_start: bool = false,
         arrow_expr_start: bool = false,
-        for_of_init_start: bool = false,
     };
 
     /// 현재 출력 위치에서 어떤 statement-start 마크가 활성인지 캡처 (esbuild
@@ -381,7 +379,6 @@ pub const Codegen = struct {
             .stmt_start = self.stmt_start == n,
             .export_default_start = self.export_default_start == n,
             .arrow_expr_start = self.arrow_expr_start == n,
-            .for_of_init_start = self.for_of_init_start == n,
         };
     }
 
@@ -392,7 +389,6 @@ pub const Codegen = struct {
         if (flags.stmt_start) self.stmt_start = n;
         if (flags.export_default_start) self.export_default_start = n;
         if (flags.arrow_expr_start) self.arrow_expr_start = n;
-        if (flags.for_of_init_start) self.for_of_init_start = n;
     }
 
     /// 현재 위치가 statement-start 또는 arrow expression body-start 마크와 일치하는지.

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -137,19 +137,9 @@ fn binaryChildLevels(self: anytype, node: Node) BinaryChildLevels {
 /// emitParen 투명화(#4042) 후, 자식 노드 구조를 *직접* 검사하는 헬퍼들(`??`/`||` 혼용,
 /// `**` 좌단항, RHS 부호 토큰)은 래퍼 너머의 실제 노드를 봐야 정확하다 — 래퍼는 더 이상
 /// `(` 를 출력하지 않으므로 출력 시작 토큰이 안쪽 operand 의 것이 된다.
+/// 단일 구현 `calls.skipWrappers(.., include_paren=true)` 에 위임.
 fn skipTransparent(self: anytype, idx: NodeIndex) NodeIndex {
-    var cur = idx;
-    var depth: u8 = 0;
-    while (depth < 32) : (depth += 1) {
-        if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return cur;
-        const n = self.ast.getNode(cur);
-        if (n.tag == .parenthesized_expression or n.tag == .chain_expression or
-            ast_mod.Node.Tag.isTransparentTypeWrapper(n.tag))
-        {
-            cur = n.data.unary.operand;
-        } else return cur;
-    }
-    return cur;
+    return calls.skipWrappers(self, idx, true);
 }
 
 /// 노드가 (transparent wrapper 너머로) `||`(.pipe2) 또는 `&&`(.amp2) logical_expression 인지.

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -272,16 +272,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 none,
             });
             const wrapper_fn = try self.ast.addNode(.{ .tag = .function_expression, .span = span, .data = .{ .extra = wrapper_extra } });
-            const paren = try es_helpers.makeParenExpr(self, wrapper_fn, span);
 
             // (function(_super) { ... })(ParentClass) 또는 (function() { ... })()
+            // IIFE callee paren 은 emitCall 자동 wrap 이 처리 (#4042 PR8)
             const iife_call = if (has_super and super_span != null) blk: {
                 const parent_arg = if (!super_expr_node.isNone())
                     super_expr_node // 표현식: 이미 visit된 AST 노드 (e.g. React.Component)
                 else
                     try self.makeIdentifierRefWithSymbol(super_span.?, super_idx); // 식별자
-                break :blk try es_helpers.makeCallExpr(self, paren, &.{parent_arg}, span);
-            } else try es_helpers.makeCallExpr(self, paren, &.{}, span);
+                break :blk try es_helpers.makeCallExpr(self, wrapper_fn, &.{parent_arg}, span);
+            } else try es_helpers.makeCallExpr(self, wrapper_fn, &.{}, span);
 
             // var ClassName = IIFE;
             const declarator = try es_helpers.makeDeclarator(self, new_name, iife_call, span);
@@ -529,16 +529,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const wrapper_params_node2 = try self.ast.addFormalParameters(wrapper_params, span);
             const wrapper_extra = try self.ast.addExtras(&.{ none, @intFromEnum(wrapper_params_node2), @intFromEnum(iife_body), 0, none });
             const wrapper_fn = try self.ast.addNode(.{ .tag = .function_expression, .span = span, .data = .{ .extra = wrapper_extra } });
-            const paren = try es_helpers.makeParenExpr(self, wrapper_fn, span);
 
             // (function(_super) { ... })(ParentClass) 또는 (function() { ... })()
+            // IIFE callee paren 은 emitCall 자동 wrap 이 처리 (#4042 PR8)
             return if (has_super and super_span != null) blk: {
                 const parent_arg = if (!expr_super_node.isNone())
                     expr_super_node
                 else
                     try self.makeIdentifierRefWithSymbol(super_span.?, super_idx);
-                break :blk try es_helpers.makeCallExpr(self, paren, &.{parent_arg}, span);
-            } else es_helpers.makeCallExpr(self, paren, &.{}, span);
+                break :blk try es_helpers.makeCallExpr(self, wrapper_fn, &.{parent_arg}, span);
+            } else es_helpers.makeCallExpr(self, wrapper_fn, &.{}, span);
         }
 
         // super() / super.property lowering — es2015_class/super_props.zig로 위임

--- a/src/transformer/es2015_class/derived_constructors.zig
+++ b/src/transformer/es2015_class/derived_constructors.zig
@@ -291,15 +291,14 @@ pub fn DerivedConstructors(comptime Transformer: type) type {
                     .span = node.span,
                     .data = .{ .list = list },
                 });
-                return es_helpers.makeParenExpr(self, seq, node.span);
+                // sequence paren 은 precedence 재유도가 처리 (#4042 PR8)
+                return seq;
             }
 
             switch (node.tag) {
-                .parenthesized_expression => return es_helpers.makeParenExpr(
-                    self,
-                    try injectInstanceFieldsAfterSuperExpr(self, node.data.unary.operand, instance_fields, span),
-                    node.span,
-                ),
+                // 이미 parenthesized_expression 인 입력의 inner 만 재귀 변환 후 반환.
+                // paren 은 precedence 재유도가 처리 (#4042 PR8)
+                .parenthesized_expression => return try injectInstanceFieldsAfterSuperExpr(self, node.data.unary.operand, instance_fields, span),
                 .sequence_expression, .array_expression => {
                     const scratch_top = self.scratch.items.len;
                     defer self.scratch.shrinkRetainingCapacity(scratch_top);

--- a/src/transformer/es2015_class/private_fields.zig
+++ b/src/transformer/es2015_class/private_fields.zig
@@ -336,7 +336,8 @@ pub fn PrivateFields(comptime Transformer: type) type {
                     .span = span,
                     .data = .{ .list = seq_list },
                 });
-                return es_helpers.makeParenExpr(self, seq, span);
+                // sequence paren 은 precedence 재유도가 처리 (#4042 PR8)
+                return seq;
             }
 
             // prefix: set(get() + 1) — expression 값이 새 값이라 세팅 결과 그대로 사용

--- a/src/transformer/es2015_class/super_props.zig
+++ b/src/transformer/es2015_class/super_props.zig
@@ -100,7 +100,7 @@ pub fn SuperProps(comptime Transformer: type) type {
             self.runtime_helpers.call_super = true;
             self.runtime_helpers.derived_constructor = true;
 
-            return es_helpers.makeParenExpr(self, seq, span);
+            return seq;
         }
 
         /// call_expression의 callee가 super.method (static_member_expression + super) 인지 확인.
@@ -268,7 +268,7 @@ pub fn SuperProps(comptime Transformer: type) type {
                 .span = span,
                 .data = .{ .list = seq_list },
             });
-            return es_helpers.makeParenExpr(self, seq, span);
+            return seq;
         }
 
         /// ClassName.prototype static_member_expression 생성.
@@ -513,8 +513,7 @@ pub fn SuperProps(comptime Transformer: type) type {
                     .span = span,
                     .data = .{ .list = seq_list },
                 });
-                const paren = try es_helpers.makeParenExpr(self, seq, span);
-                return wrapSuperPropInit(self, prop_ref, paren, span);
+                return wrapSuperPropInit(self, prop_ref, seq, span);
             }
 
             const get_call = try buildSuperPropGet(self, prop_ref.read, span);

--- a/src/transformer/es2015_computed.zig
+++ b/src/transformer/es2015_computed.zig
@@ -190,7 +190,7 @@ pub fn ES2015Computed(comptime Transformer: type) type {
             // 마지막에 _a 반환
             try self.scratch.append(self.allocator, try es_helpers.makeTempVarRef(self, temp_span, temp_span));
 
-            // (sequence_expression) — 괄호로 감싸야 올바른 우선순위
+            // sequence_expression — paren 은 precedence 재유도가 처리 (#4042 PR8)
             const seq_list = try self.ast.addNodeList(self.scratch.items[seq_scratch_top..]);
             self.scratch.shrinkRetainingCapacity(seq_scratch_top);
 
@@ -199,7 +199,7 @@ pub fn ES2015Computed(comptime Transformer: type) type {
                 .span = span,
                 .data = .{ .list = seq_list },
             });
-            return es_helpers.makeParenExpr(self, seq, span);
+            return seq;
         }
 
         /// member의 key NodeIndex를 반환. object_property는 binary.left, method_definition은 extra[0].

--- a/src/transformer/es2015_for_of.zig
+++ b/src/transformer/es2015_for_of.zig
@@ -130,10 +130,9 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
                 .data = .{ .binary = .{ .left = step_ref_assign, .right = iter_next_call, .flags = 0 } },
             });
 
-            // (_e = _d.next()).done
-            const paren_step = try es_helpers.makeParenExpr(self, step_assign, span);
+            // (_e = _d.next()).done — paren 은 precedence 재유도가 처리 (#4042 PR8)
             const done_prop = try es_helpers.makeIdentifierRef(self, "done");
-            const step_done = try es_helpers.makeStaticMember(self, paren_step, done_prop, span);
+            const step_done = try es_helpers.makeStaticMember(self, step_assign, done_prop, span);
 
             // _a = (...).done
             const inc_ref_assign = try makeRefFromSpan(self, inc_span);
@@ -143,9 +142,8 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
                 .data = .{ .binary = .{ .left = inc_ref_assign, .right = step_done, .flags = 0 } },
             });
 
-            // !(_a = ...)
-            const paren_inc = try es_helpers.makeParenExpr(self, inc_assign, span);
-            const not_inc = try es_helpers.makeUnaryNot(self, paren_inc, span);
+            // !(_a = ...) — paren 은 precedence 재유도가 처리 (#4042 PR8)
+            const not_inc = try es_helpers.makeUnaryNot(self, inc_assign, span);
 
             // --- update: _a = true ---
             const inc_ref_update = try makeRefFromSpan(self, inc_span);

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1403,11 +1403,8 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 .span = span,
                 .data = .{ .binary = .{ .left = lhs, .right = rhs, .flags = 0 } },
             });
-            const expr = if (lhs_node.tag == .object_pattern)
-                try es_helpers.makeParenExpr(self, assign, span)
-            else
-                assign;
-            return es_helpers.makeExprStmt(self, expr, span);
+            // object_pattern assign 의 paren 은 precedence 재유도가 처리 (#4042 PR8)
+            return es_helpers.makeExprStmt(self, assign, span);
         }
 
         /// yield가 있는 variable_declaration의 각 declarator를 개별 연산으로 변환.
@@ -1504,10 +1501,9 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 return self.visitNode(expr_idx);
             }
 
-            // parenthesized_expression: 내부 재귀
+            // parenthesized_expression: 내부 재귀. paren 은 precedence 재유도가 처리 (#4042 PR8)
             if (node.tag == .parenthesized_expression) {
-                const inner = try visitExprWithYieldExtraction(self, node.data.unary.operand, ops, next_label);
-                return es_helpers.makeParenExpr(self, inner, node.span);
+                return visitExprWithYieldExtraction(self, node.data.unary.operand, ops, next_label);
             }
 
             // TS/Flow 타입 wrapper 는 런타임상 noop 이므로 통과한다. 그러지 않으면 타입 스트립
@@ -1944,12 +1940,12 @@ pub fn ES2015Generator(comptime Transformer: type) type {
         /// negate=true이면 조건을 !로 반전.
         fn buildConditionalBreak(self: *Transformer, label: u32, cond: NodeIndex, negate: bool, span: Span) Transformer.Error!NodeIndex {
             const final_cond = if (negate) blk: {
-                const paren_cond = try es_helpers.makeParenExpr(self, cond, span);
+                // !cond 의 paren 은 precedence 재유도가 처리 (#4042 PR8)
                 break :blk try self.ast.addNode(.{
                     .tag = .unary_expression,
                     .span = span,
                     .data = .{ .extra = try self.ast.addExtras(&.{
-                        @intFromEnum(paren_cond),
+                        @intFromEnum(cond),
                         @intFromEnum(token_mod.Kind.bang),
                     }) },
                 });

--- a/src/transformer/es2015_template.zig
+++ b/src/transformer/es2015_template.zig
@@ -97,10 +97,7 @@ pub fn ES2015Template(comptime Transformer: type) type {
                     if (!visited.isNone()) {
                         // 보간 표현식이 + 연산자 right에 올 때 우선순위 문제 방지.
                         // 예: `${1+2}` → "" + (1 + 2), `${x ? "a" : "b"}` → "" + (x ? "a" : "b")
-                        if (needsParenForConcat(self, visited)) {
-                            const es_helpers = @import("es_helpers.zig");
-                            visited = try es_helpers.makeParenExpr(self, visited, span);
-                        }
+                        // (paren removed) emitParen 투명화 + precedence 재유도가 괄호 처리 (#4042 PR8)
                         result = try buildBinaryPlus(self, result, visited, span);
                     }
                 }
@@ -321,43 +318,10 @@ pub fn buildStringLiteral(self: anytype, text: []const u8) !NodeIndex {
     });
 }
 
-/// a + b binary expression을 만든다.
-/// 보간 표현식이 string concat (+) right operand에 올 때 괄호가 필요한지 판별.
-/// +보다 낮은 우선순위(conditional, assignment, comma 등)나
-/// 같은 우선순위(+, -)는 left-to-right 결합으로 의미가 달라지므로 괄호 필요.
-/// 리터럴, identifier, call, member 등 원자적 표현식은 괄호 불필요.
-fn needsParenForConcat(self: anytype, idx: NodeIndex) bool {
-    if (idx.isNone()) return false;
-    const node = self.ast.getNode(idx);
-    return switch (node.tag) {
-        // 괄호 불필요: 원자적 표현식
-        .identifier_reference,
-        .this_expression,
-        .numeric_literal,
-        .string_literal,
-        .boolean_literal,
-        .null_literal,
-        .bigint_literal,
-        .regexp_literal,
-        .template_literal,
-        .array_expression,
-        .object_expression,
-        .call_expression,
-        .new_expression,
-        .static_member_expression,
-        .computed_member_expression,
-        .parenthesized_expression,
-        .tagged_template_expression,
-        .unary_expression,
-        .update_expression,
-        .await_expression,
-        .private_field_expression,
-        => false,
-        // 그 외(binary, conditional, assignment, sequence, yield 등)는 괄호 필요
-        else => true,
-    };
-}
+// needsParenForConcat 제거: 보간 표현식 paren 은 emitParen 투명화 + precedence
+// 재유도가 처리한다 (#4042 PR8). 합성 paren wrapper 가 불필요해짐.
 
+/// a + b binary expression을 만든다.
 fn buildBinaryPlus(self: anytype, left: NodeIndex, right: NodeIndex, span: Span) !NodeIndex {
     return self.ast.addNode(.{
         .tag = .binary_expression,

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -169,7 +169,7 @@ pub fn ES2017(comptime Transformer: type) type {
         pub fn lowerAwaitExpression(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
             const new_operand = try self.visitNode(node.data.unary.operand);
             const yield_node = try es_helpers.makeYieldExpression(self, new_operand, node.span);
-            return es_helpers.makeParenExpr(self, yield_node, node.span);
+            return yield_node;
         }
 
         /// async function foo() { ... } → function foo() { return __async(function*() { ... }); }

--- a/src/transformer/es2018_for_await.zig
+++ b/src/transformer/es2018_for_await.zig
@@ -105,9 +105,8 @@ pub fn ES2018ForAwait(comptime Transformer: type) type {
             });
 
             // (_step = await _iter.next()).done
-            const paren_step = try es_helpers.makeParenExpr(self, step_assign, span);
             const done_prop = try es_helpers.makeIdentifierRef(self, "done");
-            const step_done = try es_helpers.makeStaticMember(self, paren_step, done_prop, span);
+            const step_done = try es_helpers.makeStaticMember(self, step_assign, done_prop, span);
 
             // !(...)
             const not_done = try es_helpers.makeUnaryNot(self, step_done, span);
@@ -236,7 +235,6 @@ pub fn ES2018ForAwait(comptime Transformer: type) type {
                 .span = span,
                 .data = .{ .binary = .{ .left = ret_ref_assign, .right = iter_return, .flags = 0 } },
             });
-            const paren_ret_assign = try es_helpers.makeParenExpr(self, ret_assign, span);
 
             // (_step && !_step.done) && (_ret = _iter.return)
             const and2 = try self.ast.addNode(.{
@@ -244,7 +242,7 @@ pub fn ES2018ForAwait(comptime Transformer: type) type {
                 .span = span,
                 .data = .{ .binary = .{
                     .left = and1,
-                    .right = paren_ret_assign,
+                    .right = ret_assign,
                     .flags = @intFromEnum(token_mod.Kind.amp2),
                 } },
             });

--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -71,12 +71,11 @@ pub fn ES2020(comptime Transformer: type) type {
                         .flags = @intFromEnum(token_mod.Kind.eq),
                     } },
                 });
-                const paren_assign = try helpers.makeParenExpr(self, assign_node, node.span);
                 const neq_null = try self.ast.addNode(.{
                     .tag = .binary_expression,
                     .span = node.span,
                     .data = .{ .binary = .{
-                        .left = paren_assign,
+                        .left = assign_node,
                         .right = null_node,
                         .flags = @intFromEnum(token_mod.Kind.neq),
                     } },
@@ -178,7 +177,7 @@ pub fn ES2020(comptime Transformer: type) type {
             });
             // 괄호로 감싸서 binary expression 안에서 우선순위 보장
             // 예: a?.b !== c?.d → (a == null ? void 0 : a.b) !== (c == null ? void 0 : c.d)
-            return helpers.makeParenExpr(self, cond, node.span);
+            return cond;
         }
 
         /// `prepareOptionalMemberCall` 의 두 가지 반환 모드.
@@ -308,7 +307,7 @@ pub fn ES2020(comptime Transformer: type) type {
                 .span = root.span,
                 .data = .{ .ternary = .{ .a = outer_eq_null, .b = try helpers.makeVoidZero(self, root.span), .c = inner } },
             });
-            return try helpers.makeParenExpr(self, outer, root.span);
+            return outer;
         }
 
         fn lowerOptionalSuperMethodCall(
@@ -321,7 +320,7 @@ pub fn ES2020(comptime Transformer: type) type {
             const member = try makeSuperMethodMember(self, self.ast.getNode(base_idx).tag, old_prop, member_flags, root.span);
             const receiver = try makeThisOrAlias(self, root.span);
             const cond = try buildOptionalCallEpilogue(self, member, receiver, root.data.extra, root.span);
-            return helpers.makeParenExpr(self, cond, root.span);
+            return cond;
         }
 
         /// `(fn = member); fn == null ? void 0 : fn.call(receiver, ...args)` 의 inner ternary 를 만든다.
@@ -642,7 +641,7 @@ pub fn ES2020(comptime Transformer: type) type {
                 .span = span,
                 .data = .{ .list = seq_list },
             });
-            return helpers.makeParenExpr(self, seq, span);
+            return seq;
         }
 
         fn isEvalIdentifier(self: *Transformer, idx: NodeIndex) bool {

--- a/src/transformer/es2021.zig
+++ b/src/transformer/es2021.zig
@@ -25,7 +25,6 @@ pub fn ES2021(comptime Transformer: type) type {
             const target = (try es_helpers.prepareAssignmentTargetRef(self, node.data.binary.left, node.span)) orelse unreachable;
             const new_right = try self.visitNode(node.data.binary.right);
             const assign = try es_helpers.makeAssignExpr(self, target.write, new_right, node.span, @intFromEnum(token_mod.Kind.eq));
-            const paren_assign = try es_helpers.makeParenExpr(self, assign, node.span);
 
             if (self.options.unsupported.nullish_coalescing) {
                 // ternary lowering 은 condition 과 truthy branch 두 자리에 read 표현을 emit 한다.
@@ -37,7 +36,7 @@ pub fn ES2021(comptime Transformer: type) type {
                     return self.ast.addNode(.{
                         .tag = .conditional_expression,
                         .span = node.span,
-                        .data = .{ .ternary = .{ .a = neq_null, .b = target.value, .c = paren_assign } },
+                        .data = .{ .ternary = .{ .a = neq_null, .b = target.value, .c = assign } },
                     });
                 }
                 const captured = try es_helpers.captureToTemp(self, target.read, node.span);
@@ -46,7 +45,7 @@ pub fn ES2021(comptime Transformer: type) type {
                 return self.ast.addNode(.{
                     .tag = .conditional_expression,
                     .span = node.span,
-                    .data = .{ .ternary = .{ .a = neq_null, .b = captured_value, .c = paren_assign } },
+                    .data = .{ .ternary = .{ .a = neq_null, .b = captured_value, .c = assign } },
                 });
             }
 
@@ -55,7 +54,7 @@ pub fn ES2021(comptime Transformer: type) type {
                 .span = node.span,
                 .data = .{ .binary = .{
                     .left = target.read,
-                    .right = paren_assign,
+                    .right = assign,
                     .flags = @intFromEnum(token_mod.Kind.question2),
                 } },
             });
@@ -67,13 +66,12 @@ pub fn ES2021(comptime Transformer: type) type {
             const target = (try es_helpers.prepareAssignmentTargetRef(self, node.data.binary.left, node.span)) orelse unreachable;
             const new_right = try self.visitNode(node.data.binary.right);
             const assign = try es_helpers.makeAssignExpr(self, target.write, new_right, node.span, @intFromEnum(token_mod.Kind.eq));
-            const paren_assign = try es_helpers.makeParenExpr(self, assign, node.span);
             return self.ast.addNode(.{
                 .tag = .logical_expression,
                 .span = node.span,
                 .data = .{ .binary = .{
                     .left = target.read,
-                    .right = paren_assign,
+                    .right = assign,
                     .flags = @intFromEnum(logical_op),
                 } },
             });

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -817,13 +817,11 @@ pub fn ES2022(comptime Transformer: type) type {
                 .data = .{ .extra = arrow_extra },
             });
 
-            // 괄호로 감싸기: (arrow)
-            const paren_arrow = try es_helpers.makeParenExpr(self, arrow, span);
-
             // call_expression: extra = [callee, args_start, args_len, flags]
+            // arrow 는 call-target(.postfix) 위치에서 codegen 이 자동 wrap 한다.
             const empty_args = try self.ast.addNodeList(&.{});
             const call = try self.ast.addExtras(&.{
-                @intFromEnum(paren_arrow),
+                @intFromEnum(arrow),
                 empty_args.start,
                 empty_args.len,
                 0, // flags

--- a/src/transformer/es2022_tla.zig
+++ b/src/transformer/es2022_tla.zig
@@ -172,9 +172,8 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
         .data = .{ .extra = arrow_extra },
     });
 
-    // (arrow)() — 괄호 + 호출
-    const paren = try es_helpers.makeParenExpr(self, arrow, node.span);
-    const call = try es_helpers.makeCallExpr(self, paren, &.{}, node.span);
+    // (arrow)() — 호출 (arrow 는 call-target 위치에서 codegen 이 자동 wrap)
+    const call = try es_helpers.makeCallExpr(self, arrow, &.{}, node.span);
     const iife_stmt = try es_helpers.makeExprStmt(self, call, node.span);
 
     // async/await lowering 이 이 arrow 에 적용되어야 하므로 재방문이 필요한 경우가 있지만,

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -323,14 +323,8 @@ pub fn makeVoidZero(self: anytype, span: Span) !NodeIndex {
     });
 }
 
-/// 식을 괄호로 감싼 parenthesized_expression 생성.
-pub fn makeParenExpr(self: anytype, inner: NodeIndex, span: Span) !NodeIndex {
-    return self.ast.addNode(.{
-        .tag = .parenthesized_expression,
-        .span = span,
-        .data = .{ .unary = .{ .operand = inner, .flags = 0 } },
-    });
-}
+// (makeParenExpr 제거 #4042 PR8: emitParen 투명화 + IIFE auto-wrap 후 합성 paren 은
+//  precedence 가 동일 재유도 — TSC byte-identical 로 확인. 합성 노드 자체가 불필요해짐.)
 
 /// 이름 문자열로 identifier_reference 노드 생성.
 /// addString + addNode를 한 번에 수행.
@@ -658,7 +652,9 @@ fn makeSingleEvalExpr(
         } },
     });
     return .{
-        .read = try makeParenExpr(self, assign, span),
+        // 합성 paren 제거(#4042 PR8): assign 을 직접 둔다 — 첫 사용 자리(member object/
+        // binary-left 등)의 precedence 가 `(temp = value)` 괄호를 재유도한다.
+        .read = assign,
         .value = try makeTempVarRef(self, temp_span, span),
         .write = try makeTempVarRef(self, temp_span, span),
     };
@@ -695,7 +691,8 @@ pub fn captureToTemp(self: anytype, value: NodeIndex, span: Span) !TempCapture {
     const assign = try makeAssignExpr(self, temp_lhs, value, span, @intFromEnum(token_mod.Kind.eq));
     return .{
         .span = temp_span,
-        .paren_assign = try makeParenExpr(self, assign, span),
+        // 합성 paren 제거(#4042 PR8): bare assign — 첫 사용 자리의 precedence 가 괄호 재유도.
+        .paren_assign = assign,
     };
 }
 

--- a/src/transformer/transformer/class_visit.zig
+++ b/src/transformer/transformer/class_visit.zig
@@ -458,8 +458,7 @@ pub fn wrapClassExprInIIFE(
     const arrow = try self.addExtraNode(.arrow_function_expression, span, &.{
         none, @intFromEnum(body_block), 0,
     });
-    const paren = try es_helpers.makeParenExpr(self, arrow, span);
-    return es_helpers.makeCallExpr(self, paren, &.{}, span);
+    return es_helpers.makeCallExpr(self, arrow, &.{}, span);
 }
 
 pub fn shouldDropClassExprName(self: *Transformer, tag: Tag, name_idx: NodeIndex) bool {

--- a/src/transformer/transformer/flow.zig
+++ b/src/transformer/transformer/flow.zig
@@ -382,12 +382,11 @@ pub fn visitFlowMatch(self: *Transformer, node: Node) Error!NodeIndex {
     });
 
     // (function(_m){...})(discriminant)
-    // function expression을 parenthesized로 감싸서 IIFE 형태로 만듦
-    const paren_fn = try es_helpers.makeParenExpr(self, fn_expr, span);
+    // function expression을 IIFE 형태로 호출 — emitCall이 callee를 자동으로 괄호 처리
     // call_expression extra: [callee, args_start, args_len, flags]
     const args_list = try self.ast.addNodeList(&.{new_discriminant});
     const call_extra = try self.ast.addExtras(&.{
-        @intFromEnum(paren_fn),
+        @intFromEnum(fn_expr),
         args_list.start,
         args_list.len,
         0, // flags

--- a/src/transformer/transformer/stage3_decorator_transform.zig
+++ b/src/transformer/transformer/stage3_decorator_transform.zig
@@ -826,7 +826,7 @@ fn buildPiggybackedInitCall(self: *Transformer, prev_extra_name: []const u8, ini
             .span = zero_span,
             .data = .{ .list = seq_list },
         });
-        return es_helpers.makeParenExpr(self, seq, zero_span);
+        return seq;
     } else {
         return prev_call;
     }

--- a/tests/integration/tests/tsc/__snapshots__/es6-yieldExpressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-yieldExpressions.test.ts.snap
@@ -288,9 +288,9 @@ exports[`TSC: es6/yieldExpressions generatorTypeCheck26 1`] = `
 
 exports[`TSC: es6/yieldExpressions generatorTypeCheck27 1`] = `
 "function* g() {
-	yield* function*() {
+	yield* (function*() {
 		yield (x) => x.length;
-	}();
+	})();
 }
 "
 `;
@@ -306,9 +306,9 @@ exports[`TSC: es6/yieldExpressions generatorTypeCheck28 1`] = `
 
 exports[`TSC: es6/yieldExpressions generatorTypeCheck29 1`] = `
 "function* g2() {
-	yield function*() {
+	yield (function*() {
 		yield (x) => x.length;
-	}();
+	})();
 }
 "
 `;
@@ -321,18 +321,18 @@ exports[`TSC: es6/yieldExpressions generatorTypeCheck3 1`] = `
 
 exports[`TSC: es6/yieldExpressions generatorTypeCheck30 1`] = `
 "function* g2() {
-	yield function*() {
+	yield (function*() {
 		yield (x) => x.length;
-	}();
+	})();
 }
 "
 `;
 
 exports[`TSC: es6/yieldExpressions generatorTypeCheck31 1`] = `
 "function* g2() {
-	yield function*() {
+	yield (function*() {
 		yield (x) => x.length;
-	}();
+	})();
 }
 "
 `;
@@ -766,9 +766,9 @@ export const Nothing3 = strategy("Nothing", function*(state) {
 
 exports[`TSC: es6/yieldExpressions generatorTypeCheck64 1`] = `
 "function* g3() {
-	yield function*() {
+	yield (function*() {
 		yield (x) => x.length;
-	}();
+	})();
 }
 function* g4() {
 	yield (function*() {

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -13143,7 +13143,7 @@ function f2(param) {
 	// variables in function declaration
 	var var2;
 	// variables in function expressions
-	var r = function(param1) {
+	var r = (function(param1) {
 		// global vars in function declaration
 		num = typeof var1 === "string" && var1.length;
 		// string
@@ -13158,7 +13158,7 @@ function f2(param) {
 		num = typeof var3 === "string" && var3.length;
 		// string
 		num = typeof param1 === "string" && param1.length;
-	}(// string
+	})(// string
 	param);
 }
 // Arrow expression
@@ -13199,21 +13199,21 @@ strOrNum = typeof f4() === "string" && f4();
 exports[`TSC: expressions typeGuardsInFunctionAndModuleBlock 1`] = `
 "// typeguards are scoped in function/module block
 function foo(x) {
-	return typeof x === "string" ? x : function f() {
+	return typeof x === "string" ? x : (function f() {
 		var b = x;
 		// number | boolean
 		return typeof x === "boolean" ? x.toString() : // boolean
 		x.toString();
-	}();
+	})();
 }
 // number
 function foo2(x) {
-	return typeof x === "string" ? x : function f(a) {
+	return typeof x === "string" ? x : (function f(a) {
 		var b = x;
 		// new scope - number | boolean
 		return typeof x === "boolean" ? x.toString() : // boolean
 		x.toString();
-	}(// number
+	})(// number
 	x);
 }
 // x here is narrowed to number | boolean


### PR DESCRIPTION
## 개요 (#4042 PR8 — 에픽 종결)

PR7(emitParen 투명화 + precedence 전환)의 마지막 단계입니다. transformer 의 합성 paren 노드(`makeParenExpr`)를 전부 제거해 **precedence 모델이 합성을 완전히 대체함을 byte-identical 로 증명**하고, code-review 가 적발한 debt 일부를 정리합니다.

## 커밋
### 1. `a47f591c` IIFE function auto-paren (esbuild IsParenthesized parity)
`emitCall` 의 **직접** callee 가 function expression 이면 괄호로 감쌉니다 — esbuild 가 `ECall` target 이 `EFunction` 이면 `IsParenthesized` 를 자동 마킹하는 것과 동형. yield/generator lowering 의 bare IIFE(`yield* function*(){}()`)·generator 런타임 helper(`$gn=function(){}()`)가 `(function(){})()` 로 esbuild parity 정렬됩니다(classifier 7 EQUIVALENT). source `(function(){})()` 는 callee 가 `paren(function)`(직접 노드 아님)이라 `emitParen` 이 보존(이중괄호 회피), arrow 는 `.postfix` call-target level 로 이미 wrap 됩니다. → **function IIFE 의 `makeParenExpr` 를 byte-identical 제거 가능케 하는 토대**.

### 2. `1132c496` makeParenExpr 합성 제거
30+ 호출처 + 정의 제거. 각 부류가 precedence 로 동일 재유도됩니다:
- **sequence/assignment/conditional** 래퍼 → `emitParen` 투명 → 배치 컨텍스트(member object/binary-left/comma)의 precedence 가 재유도.
- **arrow IIFE** → callee 가 `.postfix` call-target → `exprNeedsParens` 가 wrap.
- **function IIFE** → PR8-1 auto-wrap.
- **es_helpers `(temp=value)` 캡처**(optional-chain/logical-assign lowering 전반) → 첫 사용 자리의 precedence 가 재유도.

> **TSC 2211 스냅샷 byte-identical** — precedence 가 합성을 완전히 대체함을 기계 증명.

### 3. `72ec2ed0` code-review debt 정리 (순수 refactor)
- **dead `for_of_init_start` 제거**: Codegen 필드 + `ExprStartFlags` + save/restore. set/check 가 전혀 없는 닫힌 루프였습니다(for-of-let scaffold, 필요 시 재도입).
- **wrapper-skip 3중복 단일화**: `skipTypeWrappers`(chain+type)·`skipTransparent`(paren+chain+type)·`isOptionalChainExpr` inline → `calls.skipWrappers(idx, comptime include_paren)` 하나로. paren 경계 정책(optional chain 끊김)을 한 곳에 집중.

## 검증
| 항목 | 결과 |
|------|------|
| TSC (2211 스냅샷) | **byte-identical** (PR8-2/8-3) + 7 EQUIVALENT (PR8-1 auto-wrap, classifier) |
| test262 | **100%** (23384/23384) |
| 단위 테스트 | **0 fail** |
| integration | **4040 pass** (잔여 3 = Hermes hermesc 타임아웃 / dev-server·watch TLS handshake = 환경, codegen 무관) |
| smoke 144-lib | **144/144 MATCH**, size 0.87x |
| `/code-review max` (4 finder) | **0 confirmed defects** (1500-file differential = IIFE paren-only 변경) |

## 잔여 (별도 평가)
- `objectContinuesOptionalChain` ↔ transformer `spineHasOptionalChainThroughTypeWrappers` 중복(cross-layer 공유 모듈 이동 필요)
- `self_in_chain` exprNeedsParens+emitter 2회 계산 O(n²)(시그니처 threading invasive, 체인 짧아 bounded)
- for-of head `let`/`async` wrap(sloppy `.js` 전용, identifier early-return 충돌, test262 100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)