### PR TITLE
fix(react-native): RN dev server 를 Bun 으로 실행 시 HMR WebSocket(/hot) 복구

### DIFF
--- a/packages/react-native/src/dev-server/bun-hmr.test.ts
+++ b/packages/react-native/src/dev-server/bun-hmr.test.ts
@@ -1,0 +1,182 @@
+// #RN-bun-hmr 회귀 테스트 — Bun 에서 `/hot` HMR WebSocket 이 OPEN 되는지.
+//
+// 배경: node:http 의 수동 RFC6455 핸드셰이크(socket.write("HTTP/1.1 101 ..."))는
+// Bun 의 node:http 호환층에서 101 응답이 TCP 로 전달 안 돼 client 가 OPEN/CLOSE
+// 둘 다 못 받고 timeout 한다(node 는 정상). 이 테스트는 그 최소 재현을 실제
+// dev http server(createBunDevHttpServer) 위에서 재현해, Bun.serve native
+// WebSocket 경로로 /hot 이 정상 연결되는지 검증한다.
+//
+// 이 테스트 파일은 bun:test 로만 실행된다(WebSocket 글로벌 + Bun.serve 필요).
+
+import { describe, expect, test } from 'bun:test';
+
+import { createBunDevHttpServer, type DevHttpServerHandle } from './http-server.ts';
+import { createHmrBridge } from './hmr-bridge.ts';
+import { buildRnDevServerOptions } from './options.ts';
+import type { PlatformStateRegistry } from './platform-state.ts';
+
+const BUNDLE = {
+  entry: '/proj/src/index.ts',
+  projectRoot: '/proj',
+  rnPlatform: 'ios' as const,
+  dev: true,
+};
+
+const noopPlatforms: PlatformStateRegistry = {
+  platforms: new Map(),
+  getOrCreate: () => {
+    throw new Error('not used');
+  },
+  async stopAll() {},
+};
+
+/** 첫 메시지 1개를 기다리거나 timeout. close/error 도 reject 로 surfacing. */
+function waitOpen(ws: WebSocket, ms: number): Promise<'open'> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('TIMEOUT: no open')), ms);
+    ws.onopen = () => {
+      clearTimeout(timer);
+      resolve('open');
+    };
+    ws.onclose = (e) => {
+      clearTimeout(timer);
+      reject(new Error(`CLOSE before open: ${e.code}`));
+    };
+    ws.onerror = () => {
+      clearTimeout(timer);
+      reject(new Error('WS error before open'));
+    };
+  });
+}
+
+/** 특정 type 의 메시지가 올 때까지 수집 후 첫 일치 메시지 반환. */
+function waitMessageType(
+  ws: WebSocket,
+  type: string,
+  ms: number,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`TIMEOUT: no '${type}' message`)), ms);
+    ws.addEventListener('message', (e: MessageEvent) => {
+      try {
+        const msg = JSON.parse(String(e.data));
+        if (msg && msg.type === type) {
+          clearTimeout(timer);
+          resolve(msg);
+        }
+      } catch {
+        /* ignore non-JSON */
+      }
+    });
+  });
+}
+
+describe('createBunDevHttpServer — /hot HMR WebSocket (#RN-bun-hmr)', () => {
+  test('client 가 /hot 에 OPEN + connected greeting 수신', async () => {
+    const hmrBridge = createHmrBridge({ path: '/hot', silent: true });
+    const handle: DevHttpServerHandle = await createBunDevHttpServer(
+      buildRnDevServerOptions({ bundle: BUNDLE, port: 0 }),
+      { broadcast: () => {}, platforms: noopPlatforms, hmrBridge },
+    );
+    try {
+      const wsUrl = `ws://localhost:${handle.port}/hot`;
+      const ws = new WebSocket(wsUrl);
+      // 핵심 단언: node:http 수동 핸드셰이크는 Bun 에서 여기서 timeout 한다.
+      await expect(waitOpen(ws, 3000)).resolves.toBe('open');
+      // greeting — connected + (initial) update-start/done sequence 중 connected 확인.
+      const connected = await waitMessageType(ws, 'connected', 3000);
+      expect(connected.type).toBe('connected');
+      ws.close();
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  test('register-entrypoints → bundle-registered ACK (client incoming dispatch)', async () => {
+    const hmrBridge = createHmrBridge({ path: '/hot', silent: true });
+    const handle = await createBunDevHttpServer(
+      buildRnDevServerOptions({ bundle: BUNDLE, port: 0 }),
+      { broadcast: () => {}, platforms: noopPlatforms, hmrBridge },
+    );
+    try {
+      const ws = new WebSocket(`ws://localhost:${handle.port}/hot`);
+      await waitOpen(ws, 3000);
+      const ack = waitMessageType(ws, 'bundle-registered', 3000);
+      ws.send(JSON.stringify({ type: 'register-entrypoints', entryPoints: [] }));
+      const msg = await ack;
+      expect(msg.type).toBe('bundle-registered');
+      ws.close();
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  test('broadcast 가 연결된 Bun client 에 도달 (hmr:reload)', async () => {
+    const hmrBridge = createHmrBridge({ path: '/hot', silent: true });
+    const handle = await createBunDevHttpServer(
+      buildRnDevServerOptions({ bundle: BUNDLE, port: 0 }),
+      { broadcast: () => {}, platforms: noopPlatforms, hmrBridge },
+    );
+    try {
+      const ws = new WebSocket(`ws://localhost:${handle.port}/hot`);
+      await waitOpen(ws, 3000);
+      // greeting 소비 대기 후 broadcast.
+      await waitMessageType(ws, 'connected', 3000);
+      const reload = waitMessageType(ws, 'hmr:reload', 3000);
+      hmrBridge.adapter.sendReload();
+      const msg = await reload;
+      expect(msg.type).toBe('hmr:reload');
+      ws.close();
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  test('plain HTTP route(/status) 도 어댑터로 정상 동작', async () => {
+    const handle = await createBunDevHttpServer(
+      buildRnDevServerOptions({ bundle: BUNDLE, port: 0 }),
+      { broadcast: () => {}, platforms: noopPlatforms },
+    );
+    try {
+      const res = await fetch(`http://localhost:${handle.port}/status`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('X-React-Native-Project-Root')).toBe('/proj');
+      expect(await res.text()).toBe('packager-status:running');
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  test('POST /open-url body 가 어댑터의 rawBody 경로로 파싱됨', async () => {
+    const handle = await createBunDevHttpServer(
+      buildRnDevServerOptions({ bundle: BUNDLE, port: 0 }),
+      { broadcast: () => {}, platforms: noopPlatforms },
+    );
+    try {
+      // 빈 body → 400 (open-url 핸들러가 url 누락 검증). body 가 어댑터로 전달돼
+      // 파싱까지 도달했다는 증거.
+      const res = await fetch(`http://localhost:${handle.port}/open-url`, {
+        method: 'POST',
+        body: '{}',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(res.status).toBe(400);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  test('미매치 path → 404 Not Found (terminal next)', async () => {
+    const handle = await createBunDevHttpServer(
+      buildRnDevServerOptions({ bundle: BUNDLE, port: 0 }),
+      { broadcast: () => {}, platforms: noopPlatforms },
+    );
+    try {
+      const res = await fetch(`http://localhost:${handle.port}/__nope`);
+      expect(res.status).toBe(404);
+      expect(await res.text()).toBe('Not Found');
+    } finally {
+      await handle.stop();
+    }
+  });
+});

--- a/packages/react-native/src/dev-server/bun-http-adapter.ts
+++ b/packages/react-native/src/dev-server/bun-http-adapter.ts
@@ -1,0 +1,194 @@
+// Bun.serve `fetch(Request)` ↔ node:http `(req, res)` 어댑터.
+//
+// 왜 필요한가:
+//   serveRn 의 모든 route handler / base middleware / enhanceMiddleware 는
+//   node:http 의 `IncomingMessage` / `ServerResponse` 모양으로 작성돼 있다.
+//   Bun 에서 dev server 를 띄울 때 HMR WebSocket(`/hot`)을 Bun.serve 의 native
+//   upgrade 로 처리해야 하는데(수동 RFC6455 핸드셰이크가 Bun node:http 호환층
+//   에서 깨짐, #RN-bun-hmr), Bun.serve 의 진입점은 `fetch(Request): Response`
+//   라서 기존 미들웨어 체인을 그대로 못 쓴다.
+//
+//   이 어댑터는 Bun `Request` 를 최소한의 node `req` 모양으로 감싸고, node `res`
+//   를 흉내내는 buffering shim 을 만들어 미들웨어를 그대로 실행한 뒤, 그 결과를
+//   하나의 Bun `Response` 로 변환한다. → route handler 코드는 한 줄도 안 바뀐다.
+//
+// Zig/JS 초보자 메모:
+//   - node:http 의 res 는 "쓰면 바로 소켓으로 흘러가는" 스트림이지만, 우리 route
+//     들은 항상 동기적으로 writeHead → write* → end 를 호출하고 끝낸다(진짜
+//     streaming 안 함). 그래서 write 청크를 배열에 모았다가 end 시점에 한 번에
+//     Response 로 만들면 동작이 동일하다.
+//   - body(POST)는 Bun Request 에서 미리 읽어 `req.rawBody` 로 넣어둔다. 기존
+//     `readJsonBody` 가 (스트림이 이미 drain 된 케이스로 보고) 이 캐시에서 복구
+//     하므로 `req.on('data')` 에뮬레이션 없이도 POST 가 동작한다.
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import type { Middleware } from './types.ts';
+
+/** node `res` 가 호출되며 모인 응답 상태. end 시 resolve 에 넘긴다. */
+interface CapturedResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  chunks: Array<Buffer>;
+}
+
+/**
+ * node `ServerResponse` 의 부분 구현 — route 들이 실제로 쓰는 표면만
+ * (writeHead/setHeader/write/end + headersSent/writableEnded/statusCode).
+ * end() 가 불리면 `done(captured)` 를 정확히 한 번 호출한다.
+ */
+function createResponseShim(done: (captured: CapturedResponse) => void): {
+  res: ServerResponse;
+  captured: CapturedResponse;
+} {
+  const captured: CapturedResponse = { statusCode: 200, headers: {}, chunks: [] };
+  let ended = false;
+  let headersSent = false;
+
+  const applyHeaders = (headers?: Record<string, unknown>): void => {
+    if (!headers) return;
+    for (const [k, v] of Object.entries(headers)) {
+      // node 는 header 값으로 number/array 도 허용 — Bun Response 는 string 필요.
+      captured.headers[k.toLowerCase()] = Array.isArray(v) ? v.join(', ') : String(v);
+    }
+  };
+
+  const shim = {
+    get statusCode(): number {
+      return captured.statusCode;
+    },
+    set statusCode(code: number) {
+      captured.statusCode = code;
+    },
+    get headersSent(): boolean {
+      return headersSent;
+    },
+    get writableEnded(): boolean {
+      return ended;
+    },
+    setHeader(name: string, value: unknown): void {
+      captured.headers[String(name).toLowerCase()] = Array.isArray(value)
+        ? value.join(', ')
+        : String(value);
+    },
+    getHeader(name: string): string | undefined {
+      return captured.headers[String(name).toLowerCase()];
+    },
+    writeHead(statusCode: number, headersOrReason?: unknown, maybeHeaders?: unknown): unknown {
+      captured.statusCode = statusCode;
+      // node 시그니처: writeHead(status, reasonPhrase?, headers?) — reason 은 무시.
+      const headers =
+        headersOrReason && typeof headersOrReason === 'object'
+          ? headersOrReason
+          : (maybeHeaders ?? undefined);
+      applyHeaders(headers as Record<string, unknown> | undefined);
+      headersSent = true;
+      return shim;
+    },
+    write(chunk: unknown): boolean {
+      if (chunk != null) {
+        captured.chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+      }
+      headersSent = true;
+      return true;
+    },
+    end(chunk?: unknown): unknown {
+      if (ended) return shim;
+      if (chunk != null) {
+        captured.chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+      }
+      ended = true;
+      headersSent = true;
+      done(captured);
+      return shim;
+    },
+  };
+
+  return { res: shim as unknown as ServerResponse, captured };
+}
+
+/**
+ * Bun `Request` → 최소 node `req` shim. `url` 은 path+query(`req.url` 관례),
+ * `headers` 는 소문자 키 객체, body 는 `rawBody` 캐시로 제공.
+ */
+function createRequestShim(req: Request, rawBody: string | null): IncomingMessage {
+  const u = new URL(req.url);
+  const headers: Record<string, string> = {};
+  req.headers.forEach((value, key) => {
+    headers[key.toLowerCase()] = value;
+  });
+  const shim: Record<string, unknown> = {
+    url: u.pathname + u.search,
+    method: req.method,
+    headers,
+    // readJsonBody 의 "stream 이미 drain됨" 분기를 타게 함 → rawBody 에서 복구.
+    complete: true,
+    readable: false,
+    rawBody,
+    // route 들이 직접 req.on 을 쓰진 않지만(readJsonBody 만 사용), 방어적으로 no-op.
+    on(): unknown {
+      return shim;
+    },
+  };
+  return shim as unknown as IncomingMessage;
+}
+
+/**
+ * 미들웨어 체인(node req/res 기반)을 Bun `Request` 에 대해 실행하고 단일
+ * `Response` 로 변환. terminal next() / next(err) 도 node 경로(chainToHandler)와
+ * 동일하게 404 / 500 으로 매핑한다.
+ *
+ * route handler 가 비동기로 res.end() 를 호출하는 경우(.catch(next) 패턴)도
+ * Promise 가 end / next 둘 중 먼저 오는 쪽에서 resolve 되도록 한다.
+ */
+export async function runMiddlewareForBun(middleware: Middleware, req: Request): Promise<Response> {
+  // POST body 미리 읽기 — readJsonBody 가 rawBody 캐시에서 파싱.
+  let rawBody: string | null = null;
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    try {
+      rawBody = await req.text();
+    } catch {
+      rawBody = null;
+    }
+  }
+  const reqShim = createRequestShim(req, rawBody);
+
+  return new Promise<Response>((resolve) => {
+    let settled = false;
+    const toResponse = (c: CapturedResponse): Response => {
+      // 빈 body 면 null, 아니면 합친 Buffer 를 Uint8Array 로(Response 가 허용).
+      const body = c.chunks.length === 0 ? null : new Uint8Array(Buffer.concat(c.chunks));
+      return new Response(body, { status: c.statusCode, headers: c.headers });
+    };
+    const { res } = createResponseShim((captured) => {
+      if (settled) return;
+      settled = true;
+      resolve(toResponse(captured));
+    });
+
+    try {
+      middleware(reqShim, res, (err?: unknown) => {
+        if (settled) return;
+        settled = true;
+        if (err) {
+          const msg = (err as Error)?.message ?? String(err);
+          resolve(new Response(`Internal Server Error: ${msg}`, { status: 500 }));
+          return;
+        }
+        // chainToHandler 의 terminal: 아직 응답 안 했으면 404.
+        if (!res.headersSent && !res.writableEnded) {
+          resolve(new Response('Not Found', { status: 404 }));
+          return;
+        }
+        // enhanceMiddleware 가 res.end() 후 next() 호출하는 케이스 — 위 done 콜백이
+        // 이미 resolve 했어야 하지만(settled), 방어적으로 빈 응답.
+        resolve(new Response(null, { status: res.statusCode }));
+      });
+    } catch (err) {
+      if (settled) return;
+      settled = true;
+      const msg = (err as Error)?.message ?? String(err);
+      resolve(new Response(`Internal Server Error: ${msg}`, { status: 500 }));
+    }
+  });
+}

--- a/packages/react-native/src/dev-server/hmr-bridge.ts
+++ b/packages/react-native/src/dev-server/hmr-bridge.ts
@@ -11,6 +11,8 @@ import type { Socket } from 'node:net';
 
 import type { WatchRebuildEvent } from '@zntc/core';
 
+import type { BunHmrClient } from '@zntc/server';
+
 import { createMetroHmrAdapter, type MetroHmrAdapter } from '../metro-hmr-adapter.ts';
 import { colors, formatLogBadge, logError, logInfo } from './logger.ts';
 import type { PlatformState, PlatformStateCallbacks } from './platform-state.ts';
@@ -28,8 +30,22 @@ export interface HmrBridge {
   readonly adapter: MetroHmrAdapter;
   readonly callbacks: PlatformStateCallbacks;
   readonly path: string;
-  /** http upgrade chain 안에서 호출 — channel.accept + initial greeting. */
+  /** http upgrade chain 안에서 호출 (Node) — channel.accept + initial greeting. */
   acceptUpgrade(req: IncomingMessage, socket: Socket): void;
+  /**
+   * Bun.serve websocket `open(ws)` 에서 호출 — Bun client 등록 + initial greeting.
+   * Node 의 `acceptUpgrade` 와 대칭이지만 raw socket 핸드셰이크가 없다 (Bun.serve
+   * 의 `server.upgrade(req)` 가 RFC6455 핸드셰이크를 native 로 처리하므로).
+   */
+  acceptBun(ws: BunHmrClient): void;
+  /** Bun.serve websocket `close(ws)` 에서 호출 — Bun client 정리. */
+  removeBun(ws: BunHmrClient): void;
+  /**
+   * Bun.serve websocket `message(ws, msg)` 에서 호출 — client → server text 를
+   * incoming 핸들러(register-entrypoints ACK / log forwarding)로 dispatch.
+   * Node 경로는 `channel.accept` 의 `socket.on('data')` 가 같은 역할.
+   */
+  handleBunMessage(ws: BunHmrClient, text: string): void;
   /** RN runtime console.log forwarding 출력 표시 toggle. 새 상태 반환. */
   toggleLogs(): boolean;
 }
@@ -91,7 +107,9 @@ function buildOnRebuild(adapter: MetroHmrAdapter, opts: { silent?: boolean } = {
  * 의 console.log → dev server 터미널). `getLogsEnabled` false 시 출력 skip.
  */
 function buildIncomingHandler(adapter: MetroHmrAdapter, getLogsEnabled: () => boolean) {
-  return (text: string, socket: import('node:net').Socket): void => {
+  // reply 는 channel 이 주입 — Node 는 raw socket 의 text frame, Bun 은 ws.send.
+  // 둘 다 plain text 만 받으므로 핸들러는 runtime 무관(ACK_TEXT 그대로 전달).
+  return (text: string, reply: (text: string) => void): void => {
     let msg: { type?: string; level?: string; data?: unknown } | null = null;
     try {
       msg = JSON.parse(text);
@@ -100,9 +118,8 @@ function buildIncomingHandler(adapter: MetroHmrAdapter, getLogsEnabled: () => bo
     }
     if (!msg || typeof msg.type !== 'string') return;
     if (msg.type === 'register-entrypoints') {
-      // single-client ACK — adapter.channel 의 nodeSockets[other] 에는 안 보내고
-      // 이 socket 에만 직접 send. text frame builder 사용.
-      socket.write(buildAckFrame());
+      // single-client ACK — broadcast 가 아니라 요청한 client 에게만 응답.
+      reply(ACK_TEXT);
       return;
     }
     if (msg.type === 'log') {
@@ -128,12 +145,9 @@ function buildIncomingHandler(adapter: MetroHmrAdapter, getLogsEnabled: () => bo
   };
 }
 
+// RN HMR client 의 register-entrypoints 에 대한 ACK payload. 프레이밍(RFC6455
+// text frame)은 channel 의 reply 가 담당 — 여기선 plain text 만.
 const ACK_TEXT = JSON.stringify({ type: 'bundle-registered' });
-function buildAckFrame(): Buffer {
-  // RFC 6455 §5.2 server→client text frame (FIN + opcode 0x1). short payload.
-  const payload = Buffer.from(ACK_TEXT);
-  return Buffer.concat([Buffer.from([0x81, payload.length]), payload]);
-}
 
 export function createHmrBridge(options: HmrBridgeOptions): HmrBridge {
   const adapter = createMetroHmrAdapter();
@@ -148,6 +162,16 @@ export function createHmrBridge(options: HmrBridgeOptions): HmrBridge {
     acceptUpgrade(req, socket) {
       adapter.channel.accept(req, socket);
       adapter.sendInitialGreeting();
+    },
+    acceptBun(ws) {
+      adapter.channel.addBunClient(ws);
+      adapter.sendInitialGreeting();
+    },
+    removeBun(ws) {
+      adapter.channel.removeBunClient(ws);
+    },
+    handleBunMessage(ws, text) {
+      adapter.channel.dispatchBunIncoming(ws, text);
     },
     toggleLogs() {
       logsEnabled = !logsEnabled;

--- a/packages/react-native/src/dev-server/http-server.ts
+++ b/packages/react-native/src/dev-server/http-server.ts
@@ -6,6 +6,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 
 import * as jscSafeUrl from 'jsc-safe-url';
 
+import { runMiddlewareForBun } from './bun-http-adapter.ts';
 import type { HmrBridge } from './hmr-bridge.ts';
 import { parseRequestUrl, sendText } from './http-utils.ts';
 import type { CliServerApi } from './middleware/cli-server-api.ts';
@@ -245,6 +246,142 @@ export async function createDevHttpServer(
         server.removeListener('request', requestHandler);
         if (upgradeHandler) server.removeListener('upgrade', upgradeHandler);
         server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+// ─── Bun runtime 전용 dev http server ────────────────────────────────────────
+//
+// 배경(#RN-bun-hmr): Bun 에서 `zntc dev --platform=react-native` 를 띄우면
+// HMR WebSocket(`/hot`)이 연결되지 않는다. 원인은 node:http `server.on('upgrade')`
+// + 수동 RFC6455 핸드셰이크(`socket.write("HTTP/1.1 101 ...")`)가 Bun 의 node:http
+// 호환층에서 깨지는 것: socket.write 가 throw 없이 "성공"하지만 101 응답이 실제로
+// TCP 로 전달되지 않아 client 가 OPEN 도 CLOSE 도 못 받는다(node 에선 정상).
+//
+// 해결: Bun 에선 Bun.serve 의 native WebSocket(`server.upgrade(req)` + `websocket`
+// handler)으로 `/hot` 을 처리한다. 나머지 HTTP 요청(bundle/asset/symbolicate/
+// status 등)과 enhanceMiddleware 는 Bun `Request` → node req/res 어댑터
+// (runMiddlewareForBun)로 기존 미들웨어 체인을 *그대로* 재사용한다.
+//
+// 한계(코드 코멘트로 명시):
+//   - cli-server-api(`/message` `/events`)와 dev-middleware(`/inspector` 등)의
+//     WebSocket endpoint 는 `ws` 라이브러리의 `handleUpgrade(req, socket, head)`
+//     가 raw Node socket(실제 fd) 을 요구한다. Bun.serve 의 fetch 는 raw socket 을
+//     노출하지 않으므로 이 endpoint 들의 ws upgrade 는 Bun 에서 동작하지 않는다.
+//     → HMR(`/hot`)만 Bun.serve 로 보장. cli-server-api 의 broadcast(터미널 r/d)는
+//       그 client 가 연결돼야 동작하므로 Bun 에선 제한될 수 있다.
+//   - enhanceMiddleware(ctx.httpServer)의 `.on('upgrade')` 도 같은 이유로 동작
+//     불가 — no-op shim 을 넘겨 Rozenite 등이 crash 하지 않게만 한다(WS 의존
+//     기능은 degrade).
+
+/** Bun.serve websocket handler 가 받는 ws 객체의 최소 표면. */
+interface BunServerWebSocket {
+  send(data: string): void;
+  readonly data?: unknown;
+}
+
+/** Bun.serve 가 반환하는 server 객체의 최소 표면(우리가 쓰는 부분만). */
+interface BunServer {
+  port: number;
+  stop(closeActiveConnections?: boolean): void;
+  upgrade(req: Request, options?: { data?: unknown }): boolean;
+}
+
+/**
+ * enhanceMiddleware 에 넘길 httpServer shim. Bun.serve 는 listen 전 instance 가
+ * 없고 `.on('upgrade')` 도 지원 안 하므로, node Server 인터페이스 흉내만 내고
+ * upgrade 등록은 1회 경고 후 무시한다(한계 — 위 코멘트 참고).
+ */
+function createBunHttpServerShim(): Server {
+  let warned = false;
+  const shim: Record<string, unknown> = {
+    on(event: string): unknown {
+      if (event === 'upgrade' && !warned) {
+        warned = true;
+        process.stderr.write(
+          `[zntc:rn-dev] Bun runtime: enhanceMiddleware 의 httpServer.on('upgrade') 는 ` +
+            `Bun.serve 에서 지원되지 않습니다(raw socket 미노출). HMR(/hot)은 정상 동작하나 ` +
+            `WebSocket upgrade 에 의존하는 enhanceMiddleware 기능(Rozenite 등)은 제한됩니다.\n`,
+        );
+      }
+      return shim;
+    },
+    once(): unknown {
+      return shim;
+    },
+    removeListener(): unknown {
+      return shim;
+    },
+    off(): unknown {
+      return shim;
+    },
+    address(): { port: number } {
+      return { port: 0 };
+    },
+  };
+  return shim as unknown as Server;
+}
+
+export async function createBunDevHttpServer(
+  options: RnDevServerOptions,
+  deps: DevHttpServerDeps,
+): Promise<DevHttpServerHandle> {
+  const Bun = (globalThis as { Bun?: { serve(opts: unknown): BunServer } }).Bun;
+  if (!Bun) throw new Error('createBunDevHttpServer는 Bun runtime에서만 호출 가능합니다.');
+
+  const baseMiddleware = createBaseMiddleware(options, deps);
+  // enhanceMiddleware 는 node Server 모양의 httpServer 를 기대 — shim 전달.
+  const enhanced = options.enhanceMiddleware
+    ? options.enhanceMiddleware(baseMiddleware, { httpServer: createBunHttpServerShim() })
+    : baseMiddleware;
+
+  const hmr = deps.hmrBridge;
+
+  const serveOpts: Record<string, unknown> = {
+    port: options.port,
+    hostname: options.host,
+    // fetch 는 동기적으로 server.upgrade(req) 를 먼저 시도(첫 await 전)해야 native
+    // WebSocket 업그레이드가 성립한다. /hot 이외는 어댑터로 미들웨어 체인 실행.
+    async fetch(req: Request, server: BunServer): Promise<Response | undefined> {
+      const url = new URL(req.url);
+      if (hmr && (url.pathname === hmr.path || url.pathname.startsWith(`${hmr.path}?`))) {
+        // server.upgrade 성공 시 undefined 반환(Bun 이 101 native 처리).
+        if (server.upgrade(req)) return undefined;
+        return new Response('Upgrade required', { status: 426 });
+      }
+      return runMiddlewareForBun(enhanced, req);
+    },
+  };
+
+  if (hmr) {
+    serveOpts.websocket = {
+      open(ws: BunServerWebSocket): void {
+        hmr.acceptBun(ws);
+      },
+      message(ws: BunServerWebSocket, message: string | Buffer): void {
+        // RN HMR client 의 register-entrypoints / log 처리. Buffer 면 문자열화.
+        const text = typeof message === 'string' ? message : message.toString('utf-8');
+        hmr.handleBunMessage(ws, text);
+      },
+      close(ws: BunServerWebSocket): void {
+        hmr.removeBun(ws);
+      },
+    };
+  }
+
+  const server = Bun.serve(serveOpts);
+
+  return {
+    // node Server 가 아니라 Bun server — DevHttpServerHandle.server 타입과 다르지만
+    // serve.ts 는 url/port/stop 만 사용한다. 타입 호환을 위해 cast.
+    server: server as unknown as Server,
+    url: `http://${options.host}:${server.port}`,
+    port: server.port,
+    stop: () =>
+      new Promise<void>((resolve) => {
+        // true = active connection(WS 포함)도 강제 종료 → 포트 즉시 해제(restart 대비).
+        server.stop(true);
+        resolve();
       }),
   };
 }

--- a/packages/react-native/src/dev-server/index.ts
+++ b/packages/react-native/src/dev-server/index.ts
@@ -15,6 +15,7 @@ export {
 } from './middleware/dev-middleware.ts';
 export {
   createBaseMiddleware,
+  createBunDevHttpServer,
   createDevHttpServer,
   type DevHttpServerDeps,
   type DevHttpServerHandle,

--- a/packages/react-native/src/dev-server/serve.ts
+++ b/packages/react-native/src/dev-server/serve.ts
@@ -2,7 +2,11 @@
 // 가 RnDevServerOptions 만 만들면 cli-server-api / dev-middleware 부가 lazy
 // 로드 + per-platform watch + HMR bridge + terminal actions 까지 자동 통합.
 
-import { createDevHttpServer, type DevHttpServerHandle } from './http-server.ts';
+import {
+  createBunDevHttpServer,
+  createDevHttpServer,
+  type DevHttpServerHandle,
+} from './http-server.ts';
 import { createHmrBridge, type HmrBridge } from './hmr-bridge.ts';
 import { logBundle, logError, logInfo, printZntcRnBanner } from './logger.ts';
 import { loadCliServerApi } from './middleware/cli-server-api.ts';
@@ -97,7 +101,12 @@ export async function serveRn(
     : undefined;
   const platforms = createPlatformStateRegistry(options, hmrBridge?.callbacks);
 
-  const httpHandle: DevHttpServerHandle = await createDevHttpServer(options, {
+  // #RN-bun-hmr — Bun 에선 node:http 의 수동 WS upgrade(socket.write 101)가
+  // 깨져 /hot 이 연결 안 됨. Bun.serve 의 native WebSocket 경로로 분기한다.
+  // node 는 기존 createDevHttpServer 그대로(회귀 없음).
+  const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined';
+  const createHttpServer = isBun ? createBunDevHttpServer : createDevHttpServer;
+  const httpHandle: DevHttpServerHandle = await createHttpServer(options, {
     broadcast,
     platforms,
     hmrBridge,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -22,6 +22,7 @@ export {
   type Broadcast,
   buildRnDevServerOptions,
   createBaseMiddleware,
+  createBunDevHttpServer,
   createDevHttpServer,
   createHmrBridge,
   createPlatformState,

--- a/packages/server/src/hmr-channel.ts
+++ b/packages/server/src/hmr-channel.ts
@@ -19,8 +19,13 @@ export interface BunHmrClient {
   send(text: string): void;
 }
 
-/** Client → server 메시지 callback. socket 은 individual response 가능. */
-export type HmrIncomingHandler = (text: string, socket: Socket) => void;
+/**
+ * Client → server 메시지 callback. 두 번째 인자 `reply` 로 *그 client 에게만*
+ * 단일 응답을 보낼 수 있다 (예: `register-entrypoints` ACK). Node 든 Bun 이든
+ * 동일 시그니처 — runtime 차이(raw socket frame vs Bun ws.send)는 channel 이
+ * reply 구현으로 흡수한다. caller 는 plain text 만 넘기면 됨.
+ */
+export type HmrIncomingHandler = (text: string, reply: (text: string) => void) => void;
 
 export interface HmrChannel {
   /** Node `http.Server` 의 `'upgrade'` 이벤트 핸들러로 사용. */
@@ -28,6 +33,13 @@ export interface HmrChannel {
   /** Bun.serve 의 WebSocket client 등록. */
   addBunClient(ws: BunHmrClient): void;
   removeBunClient(ws: BunHmrClient): void;
+  /**
+   * Bun.serve websocket 의 `message(ws, msg)` 에서 호출 — client → server text
+   * 를 등록된 incoming 핸들러로 dispatch. reply 는 `ws.send` 로 연결돼 단일
+   * client 응답(ACK 등)이 그 Bun client 에게만 간다. Node 경로는 `accept` 의
+   * `socket.on('data')` 가 동일 역할 — 이쪽은 Bun 전용 진입점.
+   */
+  dispatchBunIncoming(ws: BunHmrClient, text: string): void;
   /**
    * Client → server text frame 핸들러 등록. RN HMR client 가 보내는
    * `register-entrypoints` / `log` 메시지 처리에 사용. 한 channel 에 여러 핸들러
@@ -107,13 +119,16 @@ export function createHmrChannel(): HmrChannel {
         recvBuffer = (
           recvBuffer.length === 0 ? chunk : Buffer.concat([recvBuffer, chunk])
         ) as Buffer;
+        // Node 경로의 reply — 이 socket 에만 text frame 으로 단일 응답. Bun 경로
+        // (dispatchBunIncoming) 의 ws.send 와 동일 역할이라 핸들러는 runtime 무관.
+        const reply = (text: string): void => writeTextFrame(socket, text);
         while (recvBuffer.length > 0) {
           const parsed = parseTextFrame(recvBuffer);
           if (!parsed) break;
           recvBuffer = recvBuffer.subarray(parsed.consumed);
           for (const handler of incomingHandlers) {
             try {
-              handler(parsed.text, socket);
+              handler(parsed.text, reply);
             } catch {
               /* swallow user errors */
             }
@@ -130,6 +145,18 @@ export function createHmrChannel(): HmrChannel {
     },
     removeBunClient(ws) {
       bunClients.delete(ws);
+    },
+    dispatchBunIncoming(ws, text) {
+      if (incomingHandlers.length === 0) return;
+      // reply → 이 Bun client 에게만 plain text send (Node 의 socket frame 과 대칭).
+      const reply = (out: string): void => ws.send(out);
+      for (const handler of incomingHandlers) {
+        try {
+          handler(text, reply);
+        } catch {
+          /* swallow user errors */
+        }
+      }
     },
     onIncoming(handler) {
       incomingHandlers.push(handler);


### PR DESCRIPTION
## 문제
`zntc dev --platform=react-native` dev server(serveRn)를 **`bun`으로 실행하면** 앱 HMR client가 `/hot` WebSocket에 연결 못 해 HMR이 전혀 안 됩니다. **`node`로 실행하면 정상.**

## 원인
serveRn(`createDevHttpServer`)은 `node:http` `server.on('upgrade')` + **수동 RFC6455 핸드셰이크**(`socket.write("HTTP/1.1 101 ...")`)로 `/hot`을 처리합니다. Bun의 node:http 호환층에서 이 upgrade `socket.write`는 **throw 없이 "성공"하지만 101 응답이 실제 TCP로 전달 안 됨** → client가 OPEN/CLOSE 둘 다 못 받고 timeout(1006).

최소 재현(bun): `UPGRADE_EVENT` 발화 + write callback `err=null`인데도 client TIMEOUT. node로는 동일 코드가 OPEN.

## 수정
Bun일 때 **`Bun.serve`의 native WebSocket**(`server.upgrade(req)` + `websocket` 핸들러)으로 `/hot`을 처리하도록 우회 (zntc.mjs의 appDev `/__hmr`와 동일 패턴).

| 파일 | 내용 |
|---|---|
| `hmr-channel.ts` | incoming 핸들러 2번째 인자를 raw Socket → `reply(text)` 콜백으로 추상화. node는 `reply=writeTextFrame(socket)`로 **기존 바이트 동일**. Bun 진입점 `dispatchBunIncoming` |
| `hmr-bridge.ts` | `acceptBun`/`removeBun`/`handleBunMessage` |
| `http-server.ts` | 신규 `createBunDevHttpServer`. 기존 `createDevHttpServer`(node) **무수정** |
| `bun-http-adapter.ts`(신규) | Bun Request ↔ node req/res 어댑터 (route 코드 변경 0) |
| `serve.ts` | `globalThis.Bun` 분기 |

## 한계 (코드 코멘트 명시)
cli-server-api(`/message`,`/events`) · dev-middleware WS · enhanceMiddleware(Rozenite)의 `httpServer.on('upgrade')`는 Bun.serve가 raw socket을 안 노출해 동작 불가 → **no-op shim**(throw 안 함, 1회 경고). HTTP 미들웨어/route는 정상, **HMR(`/hot`)은 보장**.

## 검증
- **실앱(mobile-seller) bun dev → `/hot` OPEN** + `connected`/`update-start`/`update-done` greeting (수정 전 1006 → OPEN)
- **node 회귀 0**: node OPEN, 기존 server 테스트 95 pass, tsc/oxlint/oxfmt clean
- `bun-hmr.test.ts` 신규 회귀 테스트 6건 (코드 리뷰 통과, blocker 0)

## 배경
PR #4155(RN Fast Refresh) 검증 중 dev server를 bun으로 띄우면 HMR이 깨지는 걸 발견 → 분리 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
