### PR TITLE
perf(emitter): HMR 변경분만 방출 — cache hit 모듈 emit/전송 skip

### DIFF
--- a/packages/core/src/napi/result.zig
+++ b/packages/core/src/napi/result.zig
@@ -181,6 +181,12 @@ pub fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult,
     }
 
     if (result.module_dev_codes) |codes| {
+        // NOTE(durability): one-shot build() 는 compiled_cache 를 주입하지 않으므로 emit 의
+        // dev_code hit-skip 분기(ModuleDevCode.changed=false, 빈 code placeholder)가 발생하지
+        // 않는다 — 여기 codes 는 항상 전부 changed=true(실제 code). 향후 build() 에
+        // compiled_cache 를 연결하면 changed=false 빈 placeholder 가 섞이므로, 그 PR 에서
+        // `if (!mc.changed) continue` 필터 + array 길이 보정을 추가해야 한다(현재는 dead path).
+        // watch.zig / incremental.zig 의 HMR 소비처는 이미 changed 를 필터한다.
         var js_codes: c.napi_value = undefined;
         _ = c.napi_create_array_with_length(env, codes.len, &js_codes);
         for (codes, 0..) |mc, i| {

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -1444,6 +1444,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
                 // 단일 패스: 캐시와 비교하여 변경된 모듈만 수집
                 var update_list: std.ArrayList(WatchRebuildEvent.ModuleUpdate) = .empty;
                 for (dev_codes) |dc| {
+                    if (!dc.changed) continue; // cache hit(id-only 항목, code 빈 placeholder) — update 아님
                     const cached = module_code_cache.get(dc.id);
                     if (cached == null or !std.mem.eql(u8, cached.?, dc.code)) {
                         // 재파싱 목록이 있을 때만 필터 적용. 첫 증분 빌드 이후 캐시가
@@ -1476,25 +1477,57 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
                 }
             }
 
-            // 캐시 업데이트
+            // 캐시 정합: dev_codes 는 변경분(changed=true, 새 code) + cache hit(changed=false, 빈
+            // placeholder) 의 합집합이라 전체 모듈 id 를 담는다. 과거의 clear-후-전체-rebuild 는 hit 의
+            // 빈 code 로 캐시를 덮어 다음 rebuild 의 비교를 깨뜨리므로, 키 정합 + changed 선택 갱신으로 바꾼다.
             {
+                // 1) dev_codes 에 없는 키 제거 — 모듈 삭제 반영(없으면 count 불일치로 graph_changed 영구 true).
+                var live_ids = std.StringHashMap(void).init(allocator);
+                defer live_ids.deinit();
+                for (dev_codes) |dc| live_ids.put(dc.id, {}) catch {};
+                var stale: std.ArrayList([]const u8) = .empty;
+                defer stale.deinit(allocator);
                 var it = module_code_cache.iterator();
                 while (it.next()) |entry| {
-                    allocator.free(entry.key_ptr.*);
-                    allocator.free(entry.value_ptr.*);
+                    if (!live_ids.contains(entry.key_ptr.*)) stale.append(allocator, entry.key_ptr.*) catch {};
                 }
-                module_code_cache.clearRetainingCapacity();
+                for (stale.items) |k| {
+                    if (module_code_cache.fetchRemove(k)) |kv| {
+                        allocator.free(kv.key);
+                        allocator.free(kv.value);
+                    }
+                }
             }
+            // 2) changed=true 만 새 code 로 value 갱신/추가. changed=false(빈 code)는 기존 실제 code 를
+            //    유지해 캐시 오염을 막는다(initial 은 전부 changed=true 라 채워짐 — 방어적으로 빈 추가).
             for (dev_codes) |dc| {
-                const id_copy = allocator.dupe(u8, dc.id) catch continue;
-                const code_copy = allocator.dupe(u8, dc.code) catch {
-                    allocator.free(id_copy);
-                    continue;
-                };
-                module_code_cache.put(id_copy, code_copy) catch {
-                    allocator.free(id_copy);
-                    allocator.free(code_copy);
-                };
+                if (dc.changed) {
+                    if (module_code_cache.getPtr(dc.id)) |vp| {
+                        const code_copy = allocator.dupe(u8, dc.code) catch continue;
+                        allocator.free(vp.*);
+                        vp.* = code_copy;
+                    } else {
+                        const id_copy = allocator.dupe(u8, dc.id) catch continue;
+                        const code_copy = allocator.dupe(u8, dc.code) catch {
+                            allocator.free(id_copy);
+                            continue;
+                        };
+                        module_code_cache.put(id_copy, code_copy) catch {
+                            allocator.free(id_copy);
+                            allocator.free(code_copy);
+                        };
+                    }
+                } else if (!module_code_cache.contains(dc.id)) {
+                    const id_copy = allocator.dupe(u8, dc.id) catch continue;
+                    const code_copy = allocator.dupe(u8, "") catch {
+                        allocator.free(id_copy);
+                        continue;
+                    };
+                    module_code_cache.put(id_copy, code_copy) catch {
+                        allocator.free(id_copy);
+                        allocator.free(code_copy);
+                    };
+                }
             }
         }
         const delta_ns: u64 = if (delta_timer) |*t| t.read() else 0;

--- a/packages/react-native/src/dev-server/hmr-bridge.ts
+++ b/packages/react-native/src/dev-server/hmr-bridge.ts
@@ -88,8 +88,18 @@ function buildOnRebuild(adapter: MetroHmrAdapter, opts: { silent?: boolean } = {
       );
       adapter.sendUpdate(annotated);
       if (!opts.silent) {
+        // ZNTC_PROFILE 활성 시에만 phase breakdown(det/grph/lnk/...) 노출. 일반 dev 출력은
+        // 간결하게 유지하고, 성능 진단 시 ZNTC_PROFILE=all 로 띄우면 단계별 ms 를 함께 본다.
+        const profileOn = process.env.ZNTC_PROFILE != null && process.env.ZNTC_PROFILE !== '';
+        const pd = profileOn
+          ? (event as unknown as { phaseDurations?: Record<string, number> }).phaseDurations
+          : undefined;
+        const r = (n?: number) => (n == null ? '-' : n.toFixed(0));
+        const bd = pd
+          ? ` ${colors.dim}[det=${r(pd.detect)} grph=${r(pd.graph)} lnk=${r(pd.link)} shk=${r(pd.shake)} emt=${r(pd.emit)} dlt=${r(pd.delta)} | gDisc=${r(pd.graphDiscover)} gBld=${r(pd.graphBuild)} eOut=${r(pd.emitOutput)} eMod=${r(pd.emitModulePass)} eCat=${r(pd.emitConcat)}]${colors.reset}`
+          : '';
         logInfo(
-          `HMR update ${colors.dim}[${state.platform}] ${event.updates.length} module(s) (${ms}ms)${colors.reset}`,
+          `HMR update ${colors.dim}[${state.platform}] ${event.updates.length} module(s) (${ms}ms)${colors.reset}${bd}`,
         );
       }
       return;

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -909,6 +909,19 @@ pub fn emitWithTreeShaking(
         if (options.dev_mode and options.collect_module_codes) {
             const mod_id = makeModuleId(m.path, options.root_dir);
 
+            // compiled cache hit(소스 불변) 모듈은 id 만 방출하고 wrap+sourcemap+code 복사를 skip.
+            // watch 는 id 로 graph_changed 감지·캐시 키 정합만 하고(changed=false), HMR update 에는
+            // 변경분(아래 miss 경로, changed=true)만 올린다. 변경 1개인데 8067 모듈 전부 wrap 하던
+            // eCat(~70ms→~6ms) 병목 제거. id-only 항목이라 code 는 빈 placeholder.
+            if (hit_mask[i]) {
+                try dev_module_codes.append(allocator, .{
+                    .id = try allocator.dupe(u8, mod_id),
+                    .code = try allocator.dupe(u8, ""),
+                    .changed = false,
+                });
+                continue;
+            }
+
             // wrap 형식(IIFE + 런타임 alias + sourceURL)은 split 경로와 공유 — 한 곳에서 정의.
             const hmr_code = try wrapDevModuleCode(allocator, code, mod_id, options.sourcemap.enable);
 
@@ -954,6 +967,7 @@ pub fn emitWithTreeShaking(
                 .code = hmr_code,
                 .map = module_map,
                 .sm_builder = module_sm_builder,
+                .changed = true,
             });
         }
     }

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -301,6 +301,7 @@ pub const IncrementalBundler = struct {
                 try actually_changed.ensureTotalCapacity(self.allocator, new_codes.len);
 
                 for (new_codes) |nc| {
+                    if (!nc.changed) continue; // cache hit(id-only, 빈 code) — changed_modules 제외
                     const cached = self.module_cache.get(nc.id);
                     const code_changed = if (cached) |c| !std.mem.eql(u8, c.code, nc.code) else true;
                     if (!code_changed) continue;
@@ -367,8 +368,13 @@ pub const IncrementalBundler = struct {
     }
 
     fn updateCache(self: *IncrementalBundler, result: *const BundleResult) void {
-        self.clearCache();
-
+        // last_paths 는 매 빌드 새 module_paths 로 교체(기존 동작). module_cache 는 아래에서
+        // changed 선택 갱신하므로 clearCache(전체 비움) 대신 last_paths 만 직접 교체한다.
+        if (self.last_paths) |paths| {
+            for (paths) |p| self.allocator.free(p);
+            self.allocator.free(paths);
+            self.last_paths = null;
+        }
         if (result.module_paths) |paths| {
             const copied = self.allocator.alloc([]const u8, paths.len) catch {
                 self.needs_full_rebuild = true;
@@ -380,17 +386,60 @@ pub const IncrementalBundler = struct {
             self.last_paths = copied;
         }
 
+        // module_cache 정합: dev_codes 는 변경분(changed=true, 새 code) + cache hit(changed=false,
+        // 빈 placeholder)의 합집합이다. hit 의 빈 code 로 캐시를 덮으면 다음 rebuild 의 diff 비교가
+        // 깨져(phantom update) 안 변한 모듈이 changed_modules 에 섞이므로, 키 정합 + changed 선택
+        // 갱신으로 hit 모듈의 기존 실제 code 를 유지한다.
         if (result.module_dev_codes) |codes| {
+            // 1) dev_codes 에 없는 키 제거 — 모듈 삭제 반영.
+            var live: std.StringHashMapUnmanaged(void) = .empty;
+            defer live.deinit(self.allocator);
+            for (codes) |c| live.put(self.allocator, c.id, {}) catch {};
+            var stale: std.ArrayList([]const u8) = .empty;
+            defer stale.deinit(self.allocator);
+            var it = self.module_cache.iterator();
+            while (it.next()) |e| {
+                if (!live.contains(e.key_ptr.*)) stale.append(self.allocator, e.key_ptr.*) catch {};
+            }
+            for (stale.items) |k| {
+                if (self.module_cache.fetchRemove(k)) |kv| {
+                    self.allocator.free(kv.value.id);
+                    self.allocator.free(kv.value.code);
+                    if (kv.value.compiled) |c| c.deinit(self.allocator);
+                }
+            }
+            // 2) changed=true 만 새 code 로 갱신/추가. changed=false 는 기존 실제 code 유지
+            //    (없으면 — first 빌드는 전부 changed=true — 빈 placeholder 추가).
             for (codes) |c| {
-                const id = self.allocator.dupe(u8, c.id) catch continue;
-                const code = self.allocator.dupe(u8, c.code) catch {
-                    self.allocator.free(id);
-                    continue;
-                };
-                self.module_cache.put(self.allocator, id, .{ .id = id, .code = code }) catch {
-                    self.allocator.free(id);
-                    self.allocator.free(code);
-                };
+                if (c.changed) {
+                    if (self.module_cache.getPtr(c.id)) |vp| {
+                        const code = self.allocator.dupe(u8, c.code) catch continue;
+                        self.allocator.free(vp.code);
+                        if (vp.compiled) |cc| cc.deinit(self.allocator);
+                        vp.code = code;
+                        vp.compiled = null;
+                    } else {
+                        const id = self.allocator.dupe(u8, c.id) catch continue;
+                        const code = self.allocator.dupe(u8, c.code) catch {
+                            self.allocator.free(id);
+                            continue;
+                        };
+                        self.module_cache.put(self.allocator, id, .{ .id = id, .code = code }) catch {
+                            self.allocator.free(id);
+                            self.allocator.free(code);
+                        };
+                    }
+                } else if (!self.module_cache.contains(c.id)) {
+                    const id = self.allocator.dupe(u8, c.id) catch continue;
+                    const code = self.allocator.dupe(u8, "") catch {
+                        self.allocator.free(id);
+                        continue;
+                    };
+                    self.module_cache.put(self.allocator, id, .{ .id = id, .code = code }) catch {
+                        self.allocator.free(id);
+                        self.allocator.free(code);
+                    };
+                }
             }
         }
     }

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -21,6 +21,11 @@ pub const ModuleDevCode = struct {
     /// NAPI getter (`getHmrSourceMap(moduleId)`) 호출 시점에 generateJSON 을 수행한다.
     /// `map` 과 상호 배타 — lazy 경로에선 `sm_builder` 만, eager 경로에선 `map` 만 채워진다.
     sm_builder: ?*SourceMapBuilder = null,
+    /// emit 이 이 항목을 변경분으로 표시했는지. false = compiled cache hit(소스 불변) 모듈로,
+    /// `code` 는 빈 placeholder 이고 `id` 만 watch 의 graph_changed 감지·캐시 키 정합에 쓰인다.
+    /// watch 는 changed=true 만 HMR update 로 올려 변경 안 된 모듈의 phantom update 를 막는다.
+    /// 기본 true — initial 빌드/전체 방출(splitting 등 비-게이트 경로) 과 하위호환.
+    changed: bool = true,
 
     /// 각 항목의 소유 메모리만 해제 (백킹 slice 는 호출자 소유 — 예: ArrayList).
     pub fn freeItems(codes: []const ModuleDevCode, allocator: std.mem.Allocator) void {


### PR DESCRIPTION
8067 모듈 RN 앱에서 모듈 1개 수정 시 HMR이 ~512ms 걸렸고, 그 중 emit 의
dev_code 수집(eCat ~70ms)이 "변경 1개인데 8067 모듈을 전부 wrap+sourcemap+복사"
하는 게 병목이었다.

emit 이 compiled_cache hit(소스 불변) 모듈은 id placeholder(changed=false, 빈 code)만
방출하고, 변경(miss) 모듈만 실제 dev_code 를 생성하도록 바꾼다. HMR 소비처
(watch.zig napi, incremental.zig)는 changed=true 만 전송하고, module 캐시는
clear-후-전체-rebuild 대신 키 정합 + changed 선택 갱신으로 hit 모듈의 기존
실제 code 를 유지한다(빈 placeholder 오염 방지).

ModuleDevCode 에 changed:bool=true 필드 추가. graph_changed 감지는 전체 id
(hit placeholder 포함)로 그대로 동작. split 경로는 changed 기본 true 라 전체 전송 유지.

효과(실측, warm): eCat 70→8ms, emit 104→50ms, 전체 HMR 512→~430ms.
정확성: A→B→A 반복 수정도 매번 전송(compiled_cache 는 path 당 직전 결과만 보관),
zig build test 5790 통과(incremental_test 의 changed_modules 검증 포함).

graph(170ms)/link(119ms)는 범위 밖(graph 위상 보존은 renumber 좌표 위험으로 보류).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
