### PR TITLE
fix(test): RN react-refresh prelude 의 stale injectIntoGlobalHook count 단언 정밀화

### DIFF
--- a/tests/integration/tests/rn-refresh-prelude.test.ts
+++ b/tests/integration/tests/rn-refresh-prelude.test.ts
@@ -372,11 +372,17 @@ describe('RN react-refresh prelude', () => {
 
     const bundle = readFileSync(outFile, 'utf-8');
 
-    // 실제 코드(injectIntoGlobalHook)는 1번만 포함되어야 함 (정의 + 호출)
-    const injectMatches = bundle.match(/injectIntoGlobalHook/g) || [];
-    // mock InitializeCore에 injectIntoGlobalHook이 1번, react-refresh/runtime에 정의가 1번
-    // = 총 2번 (정의 + 호출). 중복 주입 시 4번이 됨.
-    expect(injectMatches.length).toBeLessThanOrEqual(3);
+    // 이 테스트의 의도: --run-before-main 으로 InitializeCore 를 명시해도 *중복 추가하지 않음*.
+    // 과거엔 전체 문자열 `injectIntoGlobalHook` count(≤3)를 proxy 로 썼으나, HMR 프렐류드의
+    // __zntc_resolveRefresh 가 registry 에서 runtime 을 꺼내 호출하는 정적 참조
+    // (`__re.injectIntoGlobalHook(...)`, 4d3c5c17)와 mock 의 로깅 리터럴까지 세어 중복과
+    // 무관히 늘어나는 fragile 신호였다. 진짜 중복 여부는 다음 두 정의 사이트가 각각 1번:
+    //  (1) react-refresh/runtime 정의(`exports.injectIntoGlobalHook = function`) — 런타임 1회 포함
+    //  (2) InitializeCore 프렐류드 호출(`ReactRefreshRuntime.injectIntoGlobalHook`) — 프렐류드 1회
+    const runtimeDefs = bundle.match(/injectIntoGlobalHook\s*=\s*function/g) || [];
+    expect(runtimeDefs.length).toBe(1); // 런타임 중복 번들 아님
+    const initCoreCalls = bundle.match(/ReactRefreshRuntime\.injectIntoGlobalHook/g) || [];
+    expect(initCoreCalls.length).toBe(1); // InitializeCore 프렐류드 중복 추가 아님
   });
 
   test('HMR 런타임에 디버그 console.log가 없다', async () => {


### PR DESCRIPTION
## 무엇 / 왜

main 의 **Integration & E2E CI 가 red** 였습니다. 단일 원인은 `RN react-refresh prelude > 사용자가 --run-before-main 으로 이미 InitializeCore 를 지정하면 중복 추가하지 않는다` 테스트 1건:

```
expect(injectMatches.length).toBeLessThanOrEqual(3);  // Received: 5
```

### 근본 원인 (실측 확정)

이 테스트는 `injectIntoGlobalHook` **전체 문자열 count ≤3** 을 "중복 주입 안 됨" 의 proxy 로 썼습니다. 그런데 커밋 `4d3c5c17`(*RN Fast Refresh — registry 에서 react-refresh/runtime resolve*)이 HMR 프렐류드의 `__zntc_resolveRefresh` 에 다음 **정적 참조 2개**를 추가했습니다:

```js
if (__re && __re.injectIntoGlobalHook) { ...; __re.injectIntoGlobalHook(__zntc_g); return __re }
```

그 결과 **무중복** 번들의 count 가 2→5 로 올라 임계값을 넘겼습니다. 번들을 직접 덤프해 5개 위치를 확인했습니다:

| # | 위치 | 정체 |
|---|------|------|
| 1·2 | `__re.injectIntoGlobalHook(...)` | HMR 프렐류드 정적 참조 (4d3c5c17 신규, 중복과 무관) |
| 3 | `exports.injectIntoGlobalHook = function` | react-refresh/runtime **정의 — 1번뿐** |
| 4 | `action: 'injectIntoGlobalHook'` | mock 의 로깅 리터럴 |
| 5 | `ReactRefreshRuntime.injectIntoGlobalHook(...)` | InitializeCore 프렐류드 **호출 — 1번뿐** |

→ 런타임도 InitializeCore 프렐류드도 **중복 포함이 아님**. 번들은 정상이고, 테스트의 `≤3` 단언이 stale 였습니다.

## 수정

전체 문자열 count(프렐류드 참조·로깅 리터럴 포함)는 fragile → 진짜 중복 신호인 **두 정의 사이트를 각각 정확히 1번** 으로 단언:

```ts
const runtimeDefs = bundle.match(/injectIntoGlobalHook\s*=\s*function/g) || [];
expect(runtimeDefs.length).toBe(1);           // 런타임 1회 포함 (중복 번들 아님)
const initCoreCalls = bundle.match(/ReactRefreshRuntime\.injectIntoGlobalHook/g) || [];
expect(initCoreCalls.length).toBe(1);         // InitializeCore 프렐류드 1회 (테스트 *제목* 의도 직접 가드)
```

런타임 코드 변경 없음 — **테스트 단언만**. 중복 시 어느 쪽이든 2가 되어 `toBe(1)` 이 실패하므로 진짜 회귀를 잡습니다.

## 검증

- `rn-refresh-prelude.test.ts` **8/8 pass** (로컬, napi 빌드).
- 레포 전체에서 동일 fragile count 패턴은 이곳이 유일(grep 확인) — 4d3c5c17 로 추가로 깨질 테스트 없음.
- `/code-review max`(9-angle): 차단 결함 0. 회귀 포착 CONFIRMED, false neg/pos REFUTED(`exports.` 리네임 없음, `\s*` 가 `\n` 포함, `ReactRefreshRuntime` 은 스코프 지역변수). 프로덕션 프렐류드는 `__re.injectIntoGlobalHook` 형태라 두 정규식 어느 쪽도 매치 안 함(카운트 오염 없음).

## Zig 초보자용 메모

이건 Zig 가 아니라 통합 테스트(TypeScript/bun:test)의 단언만 고친 PR입니다. 번들러가 RN dev 빌드에서 만드는 *문자열 출력*을 정규식으로 세어 "중복 포함 안 됐나" 를 검사하는데, 검사 기준이 오래돼 무관한 코드 추가에 깨졌던 것을 정확한 기준으로 교체했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)