### PR TITLE
perf(linker): HMR rename_table 보존 — computeRenames skip (lRen 106→0)

### DIFF
--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -929,6 +929,13 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     // rebuild 루프와 동일한 collect_module_codes 로 맞춘다 — options_hash 가 같아야
     // first-build 의 cache put 이 첫 rebuild 에서 그대로 hit 된다.
     initial_opts.collect_module_codes = bundle_opts.dev_mode;
+    // perf/hmr-link-rename-reuse (incremental.zig 와 동형): initial build 도 rename 재사용에
+    // *참여* 한다. capture_eligible 게이트(bundler.zig)는 reuse_renames + dev_mode +
+    // collect_module_codes + !code_splitting + !minify 로 평가되는데, initial 은
+    // skip_bundle_output=false 라 reuse(inject) 는 막히고 *snapshot capture 만* 수행된다
+    // (BundleResult.rename_snapshot 으로 반환). preserved_renames 는 첫 빌드에 주입 대상이
+    // 없으므로 여기서 주지 않는다.
+    initial_opts.reuse_renames = bundle_opts.dev_mode;
     // Lazy sourcemap (Issue #1727 Phase B): dev watch 세션에서는 initial/rebuild 모두
     // builder 를 handle 에 캐시해 `/bundle.js.map`, `/hmr-map/:id` 요청을 즉석 서빙.
     // rebuild 경로의 `emit_sourcemap_finalize` 29ms 를 HMR latency 밖으로 빼낸다.
@@ -1155,6 +1162,22 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         }
     }
 
+    // perf/hmr-link-rename-reuse — RN dev 서버 rebuild 경로(이 worker)는 IncrementalBundler
+    // 를 거치지 않고 Bundler 를 직접 호출하므로, IncrementalBundler.doBuild 가 하던 스냅샷
+    // 보존을 여기서 직접 한다 (incremental.zig:254~319 와 동형). persistent_store 와 같은
+    // 수명(worker 함수 스코프) — rebuild 루프 밖에서 선언해 빌드 간 보존. arena 소유라
+    // deinit 한 번이 일괄 해제.
+    var preserved_renames: ?bundler_mod.symbol.PreservedRenames = null;
+    defer if (preserved_renames) |*pr| pr.deinit();
+    // initial build 가 (skip_bundle_output=false 라) full computeRenames 를 돌고 스냅샷을
+    // 캡처했으면 보존본으로 move-out 한다. result.deinit(함수 스코프 defer, line ~975)이
+    // arena 를 다시 해제하지 않도록 result.rename_snapshot 을 null 로 — double-free 방지.
+    // 이전 preserved_renames 는 null 이라 그냥 대입.
+    if (result.rename_snapshot) |snap| {
+        preserved_renames = snap;
+        result.rename_snapshot = null;
+    }
+
     // Issue #1223 Phase 1: 이벤트 기반 워처 + 디바운스 + content hash 필터링.
     while (!async_data.stop_flag.load(.acquire)) {
         const first_events = tracked.waitForChanges(watch_poll_timeout_ms) catch &[_]zntc_lib.server.ChangeEvent{};
@@ -1286,6 +1309,14 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         // 조합은 incremental rebuild 시 module_dev_codes 도 비어있어 HMR client 가 받을 데이터 없음
         // — 그 조합은 그 자체로 비정상 사용 (caller responsibility).
         if (bundle_opts.skip_initial_output) incremental_opts.skip_bundle_output = true;
+        // perf/hmr-link-rename-reuse — 보존 스냅샷 주입(incremental.zig:251~256 와 동형).
+        // reuse_renames=true 로 bundler 의 capture/reuse 게이트에 참여시키고, 보존본이 있으면
+        // borrow 로 넘긴다. rebuild 는 위에서 dev_mode + collect_module_codes + skip_bundle_output
+        // 가 켜지므로(그리고 code_splitting/minify 비활성) reuse_eligible — 가드 통과 시
+        // computeRenames(전체 top-level deconflict, ~80~99ms 의 주범) 를 skip 한다. 가드 실패
+        // 시엔 bundler 가 full computeRenames 로 fallback 하며 새 스냅샷을 재캡처한다.
+        incremental_opts.reuse_renames = true;
+        if (preserved_renames) |*pr| incremental_opts.preserved_renames = pr;
         // #4079 PR-2 — requestLazySeed 로 누적된 force-parse 집합을 이번 rebuild 에 주입(초기
         // 옵션 set ∪ 누적). 헤더 배열만 복사(string 은 accum/options 소유) — 동시 append(realloc)
         // 에도 스냅샷 안정. snapshot 은 이 rebuild 동안만 유효(pathInForceParse=eql 비교, 미보관).
@@ -1319,6 +1350,33 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             continue;
         };
         defer rebuild_result.deinit(allocator);
+
+        // perf/hmr-link-rename-reuse — 보존 스냅샷 갱신(incremental.zig:304~331 와 동형).
+        // 넷 중 하나:
+        //  (a) 에러 빌드: stale 스냅샷이 고친 뒤 첫 빌드에 잘못 주입되지 않도록 보존본 drop
+        //      → 다음 rebuild 가 from-scratch 재캡처. (rebuild_result.rename_snapshot 은
+        //      에러 경로에서 null 이라 별도 move-out 불필요, deinit 가 정리.)
+        //  (b) 가드 fallback 으로 computeRenames 재실행: rebuild_result.rename_snapshot 이
+        //      non-null → 기존 보존본 deinit 후 새 것으로 교체. move-out 했으니 null 처리해
+        //      rebuild_result.deinit 의 double-free 방지.
+        //  (c) F5 capture 실패(invalidated): fallback 재계산했으나 buildRenameSnapshot 이
+        //      불완전 스냅샷을 폐기 → 기존(stale) 보존본 drop. reuse-hit 의 null 과 구분.
+        //  (d) reuse-hit: rebuild_result.rename_snapshot 이 null → 기존 보존본 유지.
+        if (rebuild_result.hasErrors()) {
+            if (preserved_renames) |*pr| {
+                pr.deinit();
+                preserved_renames = null;
+            }
+        } else if (rebuild_result.rename_snapshot) |new_snap| {
+            if (preserved_renames) |*pr| pr.deinit();
+            preserved_renames = new_snap;
+            rebuild_result.rename_snapshot = null;
+        } else if (rebuild_result.rename_snapshot_invalidated) {
+            if (preserved_renames) |*pr| {
+                pr.deinit();
+                preserved_renames = null;
+            }
+        }
 
         // #3799 root-cause fix — rebuild_result.hasErrors() 면 이전 코드는 별도 early-event +
         // continue 였다. 그러나 그러면 module_code_cache / file output / lazy sourcemap swap 등

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -389,6 +389,14 @@ pub const BundleOptions = struct {
     /// Compiled output cache. HMR/watch 에서 변경 안 된 모듈의 emit 을 스킵.
     /// IncrementalBundler 가 소유.
     compiled_cache: ?*@import("compiled_cache.zig").CompiledOutputCache = null,
+    /// HMR rename 재사용 활성 (perf/hmr-link-rename-reuse). true + `preserved_renames`
+    /// present + 가드 통과 시 `computeRenames`(전체 모듈 top-level 이름 deconflict, ~106ms)
+    /// 를 skip 하고 초기 빌드의 rename_table 을 재주입한다. IncrementalBundler 가
+    /// HMR-incremental 브랜치에서만 set — 초기/비-dev/splitting 경로는 영향 0(additive+gated).
+    reuse_renames: bool = false,
+    /// 재사용할 보존 스냅샷 (borrowed, IncrementalBundler 소유). `reuse_renames=true`
+    /// 일 때만 의미. null 이면 가드 평가 없이 기존 computeRenames.
+    preserved_renames: ?*const @import("symbol.zig").PreservedRenames = null,
     /// 활성화할 디버그 로그 카테고리 (ZNTC_DEBUG env 와 합집합).
     /// 예: `&.{"compiled_cache", "hmr"}`. 카테고리 enum 은 `src/debug_log.zig` 참조.
     debug: []const []const u8 = &.{},
@@ -476,6 +484,23 @@ pub const BundleResult = struct {
     /// 비결정성으로 rebuild 간 emit 이 달라지는 phantom update 방지.
     reparsed_paths: ?[]const []const u8 = null,
 
+    /// HMR rename 재사용 스냅샷 (perf/hmr-link-rename-reuse). `computeRenames` 가
+    /// **실제로 실행된** 빌드(초기 빌드 / 가드 fallback)에서만 채워진다 — 재사용-hit
+    /// 빌드는 새 deconflict 를 안 했으니 기존 스냅샷을 그대로 유지(여기 null)한다.
+    /// 소유권은 caller(IncrementalBundler)로 이전 — `result.deinit` 전에 move 하지 않으면
+    /// `deinit` 이 arena 를 해제한다. `rename_snapshot.?.deinit()` 으로 정리.
+    rename_snapshot: ?@import("symbol.zig").PreservedRenames = null,
+
+    /// F5 보수적 fail-safe: `computeRenames` 가 실제로 실행됐으나(초기/fallback)
+    /// `buildRenameSnapshot` 이 불완전 스냅샷을 폐기(null 반환)한 빌드를 표시한다.
+    /// 이 경우 `rename_snapshot` 은 null 이지만 **reuse-hit 의 null 과 의미가 정반대** —
+    /// reuse-hit 은 "새 deconflict 없음 → 기존 보존본 유지", invalidated 는 "fallback
+    /// 재계산했는데 capture 실패 → 기존(stale) 보존본을 **drop** 해야 함"이다. caller
+    /// (IncrementalBundler/watch)가 이 둘을 구분해, invalidated 면 preserved_renames 를
+    /// 버려 다음 빌드가 또 fallback→capture 를 시도하게 한다. 이 플래그가 없으면 stale
+    /// 보존본이 살아남아 다음 reuse-hit 에 잘못 주입될 수 있다(silent wrong-binding).
+    rename_snapshot_invalidated: bool = false,
+
     /// 단계별 빌드 시간 (나노초).
     pub const BundleTimings = struct {
         /// resolve + parse + finalize (graph build)
@@ -558,6 +583,12 @@ pub const BundleResult = struct {
             allocator.free(metas);
         }
         if (self.metafile_json) |mf| allocator.free(mf);
+        if (self.rename_snapshot) |snap| {
+            // arena 소유 — caller 가 move 하지 않았으면 여기서 해제. const-self 라 로컬
+            // 복사본에 대고 deinit (arena 핸들은 값이라 복사돼도 같은 backing 을 가리킴).
+            var s = snap;
+            s.deinit();
+        }
     }
 
     pub fn hasErrors(self: *const BundleResult) bool {
@@ -1343,6 +1374,14 @@ pub const Bundler = struct {
         // binding 이 짧은 이름 풀(54자)을 잠식해 candidate-emit 비율이 떨어지는
         // 회귀 방지. TreeShaker 생성 조건과 동일 predicate.
         const will_tree_shake = !self.options.dev_mode and self.options.scope_hoist and self.options.tree_shaking;
+        // perf/hmr-link-rename-reuse: computeRenames 가 *실제 실행* 되면 그 결과를 박제해
+        // BundleResult 로 이전한다 (재사용-hit 빌드는 null — 기존 스냅샷 유지). 초기/fallback
+        // 빌드에서만 채워진다.
+        var rename_snapshot_out: ?@import("symbol.zig").PreservedRenames = null;
+        errdefer if (rename_snapshot_out) |*s| s.deinit();
+        // F5: computeRenames 가 돌았지만 buildRenameSnapshot 이 불완전 스냅샷을 폐기(null)
+        // 했을 때 true. caller 가 stale preserved 를 drop 하도록 신호.
+        var rename_snapshot_invalidated = false;
         var link_scope = profile.begin(.link);
         var linker: ?Linker = if (self.options.scope_hoist or self.options.dev_mode) blk: {
             var l = Linker.initWithGlobalIdentifiers(self.allocator, graph, self.options.format, self.options.global_identifiers);
@@ -1370,13 +1409,56 @@ pub const Bundler = struct {
             });
             if (mangle_report_enabled) l.mangle_report = &mangle_collector;
             try l.link();
+
+            // perf/hmr-link-rename-reuse: HMR-incremental 경로에서 가드 통과 시
+            // computeRenames 를 skip 하고 초기 빌드 rename_table 을 재주입한다.
+            //
+            // - capture_eligible: 스냅샷을 *만들* 수 있는 빌드(초기 dev 빌드 포함). 초기
+            //   빌드는 `skip_bundle_output=false`(full output 필요)라 capture 는 여기서 허용하되
+            //   reuse(inject)는 막는다. minify(prod-deconflict→mangle)는 rename_table 의미가
+            //   달라 제외 — dev_mode 는 minify 비활성이라 실질 무관.
+            // - reuse_eligible: 스냅샷을 *주입* 할 수 있는 빌드(skip_bundle_output=HMR-incremental).
+            // 비-dev/splitting/RN prod 는 `reuse_renames=false` 라 두 경로 모두 비활성 →
+            // 기존 computeRenames 경로 byte-identical(회귀 0).
+            const capture_eligible = self.options.reuse_renames and
+                self.options.dev_mode and
+                self.options.collect_module_codes and
+                !self.options.code_splitting and
+                !self.options.minify_identifiers;
+            const reuse_eligible = capture_eligible and self.options.skip_bundle_output;
+            var can_reuse = false;
+            if (reuse_eligible) {
+                if (self.options.preserved_renames) |snap| {
+                    if (l.renameReuseGuard(snap)) {
+                        try l.injectPreservedRenames(snap);
+                        can_reuse = true;
+                    }
+                }
+            }
+
             // Phase 3b (#1328): populateReExportAliases 가 canonical_name 을 채우려면
             // computeRenames 이후여야 한다. populateImportSymbols / NamespaceAccesses /
             // SymbolRefCounts (tree-shaking companion metric) 까지 한 번에 묶어 emit.
+            // 재사용 시 compute_renames=false — injectPreservedRenames 가 이미 rename_table 을
+            // 채웠고, populate* 는 fresh graph 대상으로 그대로 실행(cross-module 이름 생성에 필요).
+            const did_compute_renames = !self.options.code_splitting and !can_reuse;
             try l.finalize(.{
-                .compute_renames = !self.options.code_splitting,
+                .compute_renames = did_compute_renames,
                 .compute_mangling = self.options.minify_identifiers and !will_tree_shake,
             });
+
+            // computeRenames 가 실제 실행됐을 때만 스냅샷 박제(초기/fallback). 재사용-hit 는
+            // 새 deconflict 가 없으니 caller 의 기존 스냅샷을 유지(여기 null).
+            // F5: buildRenameSnapshot 이 null 을 반환하면(불완전 스냅샷 폐기) capture 실패다.
+            // 이때 rename_snapshot_out 은 null 로 두되 invalidated 플래그를 켜, caller 가
+            // reuse-hit(=유지)과 구분해 stale preserved 를 drop 하게 한다.
+            if (did_compute_renames and capture_eligible) {
+                if (try l.buildRenameSnapshot(self.allocator)) |snap| {
+                    rename_snapshot_out = snap;
+                } else {
+                    rename_snapshot_invalidated = true;
+                }
+            }
             break :blk l;
         } else null;
         defer if (linker) |*l| l.deinit();
@@ -2323,6 +2405,8 @@ pub const Bundler = struct {
             },
             .reparsed_modules = reparsed_count,
             .reparsed_paths = reparsed_paths_out,
+            .rename_snapshot = rename_snapshot_out,
+            .rename_snapshot_invalidated = rename_snapshot_invalidated,
         };
     }
 };

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -16,6 +16,7 @@ const module_store = @import("module_store.zig");
 const CompiledModule = @import("compiled_module.zig").CompiledModule;
 const CompiledOutputCache = @import("compiled_cache.zig").CompiledOutputCache;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
+const PreservedRenames = @import("symbol.zig").PreservedRenames;
 
 /// JSON 문자열 값 내부의 특수 문자를 이스케이프한다 (RFC 8259 준수).
 fn writeJsonEscaped(writer: anytype, s: []const u8) !void {
@@ -98,6 +99,12 @@ pub const IncrementalBundler = struct {
     /// `deinit` 가 일괄 해제. caller 는 직접 접근 금지 — `doBuild` 만이 lifetime 관리.
     persistent_graph: ?ModuleGraph = null,
 
+    /// HMR rename 재사용 스냅샷 (perf/hmr-link-rename-reuse). 초기 빌드(또는 가드
+    /// fallback 빌드)가 만든 rename_table 보존본을 빌드 간 유지했다가, 다음 HMR rebuild
+    /// 의 `computeRenames` 를 skip 하는 데 쓴다. `deinit`/`reset`/`needs_full_rebuild` 에서
+    /// drop. arena 소유라 `deinit()` 한 번이 일괄 해제.
+    preserved_renames: ?PreservedRenames = null,
+
     /// 모듈 단위 dev/HMR 캐시 엔트리.
     /// `code` = `__zntc_register` wrapper (HMR 경로).
     /// `compiled` / `input_hash` = compiled output cache 재사용용 (populate 는 별도 PR).
@@ -125,6 +132,7 @@ pub const IncrementalBundler = struct {
         self.compiled_cache.deinit();
         if (self.resolve_cache) |*rc| rc.deinit();
         if (self.persistent_graph) |*g| g.deinit();
+        if (self.preserved_renames) |*pr| pr.deinit();
     }
 
     /// 외부에서 캐시 전체 무효화 (Control API `/reset-cache` 등).
@@ -143,6 +151,11 @@ pub const IncrementalBundler = struct {
         }
         self.rebuild_count = 0;
         self.needs_full_rebuild = true;
+        // 보존 스냅샷도 drop — 다음 빌드는 초기 빌드처럼 from-scratch deconflict 후 재캡처.
+        if (self.preserved_renames) |*pr| {
+            pr.deinit();
+            self.preserved_renames = null;
+        }
     }
 
     fn clearCache(self: *IncrementalBundler) void {
@@ -231,10 +244,16 @@ pub const IncrementalBundler = struct {
         // 가 sourcemap.enable=false default 라 dormant — sourcemap 활성화 시 sourcemap_builder
         // wire-up 또는 lazy 비활성화 follow-up 필수.
         if (opts.dev_mode and opts.sourcemap.enable) opts.sourcemap.lazy = true;
+        // perf/hmr-link-rename-reuse: dev 빌드는 항상 rename 재사용에 *참여* 한다.
+        // - 초기 빌드: reuse_renames=true 지만 skip_bundle_output=false 라 bundler 가 inject 는
+        //   막고 스냅샷 capture 만 한다 (BundleResult.rename_snapshot 으로 반환).
+        // - HMR rebuild: preserved_renames 를 주입 → bundler 가 가드 통과 시 computeRenames skip.
+        opts.reuse_renames = opts.dev_mode and opts.collect_module_codes;
         if (!is_first) {
             opts.module_store = &self.persistent_store;
             opts.changed_files = changed_files;
             if (opts.dev_mode and opts.collect_module_codes) opts.skip_bundle_output = true;
+            if (self.preserved_renames) |*pr| opts.preserved_renames = pr;
         }
 
         // RFC #3933 Sub-PR-B.2 — enable_persistence opt-in path. Bundler.initWithGraph wire-up.
@@ -282,7 +301,34 @@ pub const IncrementalBundler = struct {
             // 파일이 고쳐지면 full rebuild 가 에러 없이 끝나며 doBuild 의 `if (is_first)`
             // 분기에서 flag 가 자동 해제된다.
             self.needs_full_rebuild = true;
+            // 보존 스냅샷도 drop — full rebuild 가 from-scratch 재캡처. stale 스냅샷이
+            // 고친 후 첫 빌드에 잘못 주입되는 일 방지.
+            if (self.preserved_renames) |*pr| {
+                pr.deinit();
+                self.preserved_renames = null;
+            }
             return .{ .build_error = err_json };
+        }
+
+        // perf/hmr-link-rename-reuse: 새 스냅샷이 캡처됐으면(초기/fallback 빌드) 교체.
+        // 재사용-hit 빌드는 result.rename_snapshot=null 이라 기존 스냅샷 유지. result.deinit
+        // 이 arena 를 해제하기 전에 move out (소유권 이전).
+        //
+        // F5: result.rename_snapshot 이 null 인 경우는 두 가지로 갈린다 —
+        //  - reuse-hit: 새 deconflict 없음 → 기존 보존본 유지 (아래 두 분기 모두 skip).
+        //  - invalidated: fallback 재계산했으나 buildRenameSnapshot 이 불완전 스냅샷을
+        //    폐기 → 기존(stale) 보존본을 **drop**. 안 그러면 stale 이 다음 reuse-hit 에
+        //    잘못 주입(silent wrong-binding). "fallback 했는데 capture 실패 = preserved 없음"
+        //    상태가 일관되도록 보장한다.
+        if (result.rename_snapshot) |new_snap| {
+            if (self.preserved_renames) |*pr| pr.deinit();
+            self.preserved_renames = new_snap;
+            result.rename_snapshot = null; // double-free 방지 (result.deinit 가 안 건드리게)
+        } else if (result.rename_snapshot_invalidated) {
+            if (self.preserved_renames) |*pr| {
+                pr.deinit();
+                self.preserved_renames = null;
+            }
         }
 
         const graph_changed = is_first or !self.pathSetsEqual(result.module_paths);

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -35,6 +35,7 @@ const shared_namespace = @import("linker/shared_namespace.zig");
 pub const PreambleWriter = preamble_writer.PreambleWriter;
 pub const cjsImportNeedsToEsmInterop = preamble_writer.cjsImportNeedsToEsmInterop;
 pub const LinkingMetadata = @import("linker/metadata_types.zig").LinkingMetadata;
+pub const PreservedRenames = bundler_symbol.PreservedRenames;
 pub const MangleReportCollector = @import("linker/mangle_report.zig").MangleReportCollector;
 pub const MfStaticRemotes = @import("federation.zig").MfStaticRemotes;
 
@@ -576,14 +577,21 @@ pub const Linker = struct {
         try entry.value_ptr.append(self.allocator, owner);
     }
 
-    /// 단일 모듈의 top-level 심볼 이름을 name_to_owners에 수집한다.
-    /// 모듈 스코프의 모든 심볼 + export default 합성 _default 이름을 등록.
-    /// import binding은 다른 모듈의 심볼을 참조하므로 건너뛴다.
-    fn collectModuleNames(
+    /// 모듈의 top-level owner 이름을 **단일 출처**로 열거한다 (perf/hmr-link-rename-reuse).
+    ///
+    /// `collectModuleNames`(deconflict 입력 수집) 와 `buildRenameSnapshot` 의 fingerprint
+    /// 빌더(G2 이름집합 해시) 가 *정확히 같은 필터* 를 봐야 한다 — 한쪽만 어떤 이름을
+    /// 등록하면 가드가 거짓 통과/실패한다(드리프트=정확성 버그). 그래서 필터 로직을
+    /// 여기 한 곳에 두고 양쪽이 호출한다.
+    ///
+    /// `cb(ctx, name)` 를 등록 대상 이름마다 호출한다. 두 소비자(collectModuleNames /
+    /// fingerprint 빌더) 모두 이름만 필요하므로 sym_idx 는 노출하지 않는다.
+    fn forEachTopLevelOwnerName(
         self: *Linker,
         m: Module,
-        module_index: u32,
-        name_to_owners: *NameToOwnersMap,
+        comptime Ctx: type,
+        ctx: Ctx,
+        comptime cb: fn (Ctx, []const u8) anyerror!void,
     ) !void {
         const sem = m.semantic orelse return;
         if (sem.scope_maps.len == 0) return;
@@ -595,7 +603,7 @@ pub const Linker = struct {
             if (std.mem.eql(u8, sym_name, "default")) continue;
 
             // `_default` 합성 심볼은 scope_maps에도 등록되지만 owner 등록은 export_bindings
-            // 경로(line 394-)에서 전담한다. 여기서도 등록하면 같은 모듈의 같은 이름이
+            // 경로(아래)에서 전담한다. 여기서도 등록하면 같은 모듈의 같은 이름이
             // 이중 owner가 되어 collectModuleNames 충돌 처리가 `_default$1` 접미사를
             // 생성한다 (#1598).
             const sym_idx_for_kind = scope_entry.value_ptr.*;
@@ -658,29 +666,49 @@ pub const Linker = struct {
                 if (!generates_top_level_var) continue;
             }
 
-            try self.addNameOwner(name_to_owners, sym_name, .{
-                .module_index = module_index,
-                .exec_index = m.exec_index,
-                .path = m.path,
-            });
+            try cb(ctx, sym_name);
         }
 
         // codegen이 현재 모듈에 `_default` 합성 변수를 만드는 모든 export를 수집.
         // 충돌 시 _default$N으로 리네이밍되도록 등록한다.
-        const owner: NameOwner = .{ .module_index = module_index, .exec_index = m.exec_index, .path = m.path };
         for (m.export_bindings) |eb| {
             if (eb.hasSyntheticDefault(m.semanticSymbols())) {
-                try self.addNameOwner(name_to_owners, "_default", owner);
+                try cb(ctx, "_default");
                 continue;
             }
             if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
                 // export default function foo → foo 이름으로 등록
                 const local = m.exportBindingLocalName(eb);
                 if (module_scope.get(local) == null) {
-                    try self.addNameOwner(name_to_owners, local, owner);
+                    try cb(ctx, local);
                 }
             }
         }
+    }
+
+    /// 단일 모듈의 top-level 심볼 이름을 name_to_owners에 수집한다.
+    /// 모듈 스코프의 모든 심볼 + export default 합성 _default 이름을 등록.
+    /// import binding은 다른 모듈의 심볼을 참조하므로 건너뛴다.
+    fn collectModuleNames(
+        self: *Linker,
+        m: Module,
+        module_index: u32,
+        name_to_owners: *NameToOwnersMap,
+    ) !void {
+        const Ctx = struct {
+            linker: *Linker,
+            map: *NameToOwnersMap,
+            owner: NameOwner,
+            fn add(c: @This(), name: []const u8) anyerror!void {
+                try c.linker.addNameOwner(c.map, name, c.owner);
+            }
+        };
+        const owner: NameOwner = .{ .module_index = module_index, .exec_index = m.exec_index, .path = m.path };
+        try self.forEachTopLevelOwnerName(m, Ctx, .{
+            .linker = self,
+            .map = name_to_owners,
+            .owner = owner,
+        }, Ctx.add);
     }
 
     /// 후보 이름이 사용 가능한지 확인.
@@ -821,6 +849,232 @@ pub const Linker = struct {
         // 충돌하면 target module의 canonical name을 한 단계 더 rename.
         // 예: d3-color의 cubehelix와 d3-interpolate 내부의 function cubehelix 충돌.
         try self.resolveNestedShadowConflicts(&name_to_owners);
+    }
+
+    // ── HMR rename 보존/재사용 (perf/hmr-link-rename-reuse) ────────────────────
+
+    /// `computeRenames` 직후, 현재 `rename_table` + `reserved_globals` 를 owned
+    /// 스냅샷으로 박제한다. 다음 HMR rebuild 가 가드 통과 시 재주입해 computeRenames 를
+    /// skip 한다. fingerprint 도 한 번에 빌드 (scope_maps[0] 1-pass, import 스캔은
+    /// `forEachTopLevelOwnerName` 안에서만 — collectModuleNames 와 동일 비용).
+    ///
+    /// 모든 문자열은 스냅샷 arena 가 dupe 소유 — Linker.deinit 후에도 유효
+    /// (canonical_strings borrow 금지, RFC #3933 dangling 회피).
+    ///
+    /// **반환 null (F5 보수적 fail-safe)**: `symbolLocalName` 은 totality 가 정적으로
+    /// 보장되지 않는다(scope_maps[0] 역탐색 + synthetic fallback 둘 다 miss 하면 null).
+    /// rename_table 키 중 하나라도 local 이름을 못 얻으면 그 심볼의 rename 이 스냅샷에서
+    /// 조용히 누락된다 → reuse-hit rebuild 에서 그 rename 이 주입되지 않아 emit 이 원본
+    /// 이름을 써, 이미 로드된(renamed) 번들과 silent wrong-binding. 가드(G0~G6)는
+    /// 스냅샷 *자체* 의 불완전성은 못 잡는다. 그래서 불완전 스냅샷을 capture 하느니
+    /// **null 을 반환해 capture 를 폐기** — 그러면 caller 가 reuse 를 비활성화하고
+    /// 다음 rebuild 가 full computeRenames 를 돈다(정확성 > 성능). RN 8067 모듈 실측에선
+    /// null 발생이 0 이지만 코드가 totality 를 보장 못 하므로 정적 안전장치를 둔다.
+    pub fn buildRenameSnapshot(self: *Linker, gpa: std.mem.Allocator) !?PreservedRenames {
+        var snap: PreservedRenames = .{
+            .arena = std.heap.ArenaAllocator.init(gpa),
+            .entries = &.{},
+            .reserved_globals = &.{},
+            .fingerprint = &.{},
+            .module_count = @intCast(self.graph.moduleCount()),
+        };
+        errdefer snap.arena.deinit();
+        const a = snap.arena.allocator();
+
+        // 1. rename_table 엔트리 owned dupe. local_name 은 inject 시 by-name 재유도(G3)
+        //    의 lookup 키 — SymbolID.inner 로 심볼을 찾아 그 이름을 dupe 한다.
+        var entries: std.ArrayList(PreservedRenames.Entry) = .empty;
+        try entries.ensureTotalCapacity(a, self.rename_table.count());
+        var rit = self.rename_table.map.iterator();
+        while (rit.next()) |e| {
+            const id = e.key_ptr.*;
+            // 불완전 스냅샷 폐기: local 이름을 못 얻는 키가 하나라도 있으면 이 빌드의
+            // capture 를 통째로 무효화한다. 이미 alloc 한 arena 를 즉시 해제하고 null 반환
+            // → reuse 비활성, 다음 rebuild full 재계산 (위 doc 참고).
+            const local = self.symbolLocalName(id) orelse {
+                debug_log.print(.rename_reuse, "buildRenameSnapshot: symbolLocalName(module={d},inner={d}) null → 스냅샷 폐기(capture 실패), reuse 비활성\n", .{
+                    @intFromEnum(id.module),
+                    @intFromEnum(id.inner),
+                });
+                snap.arena.deinit();
+                return null;
+            };
+            entries.appendAssumeCapacity(.{
+                .id = id,
+                .local_name = try a.dupe(u8, local),
+                .canonical = try a.dupe(u8, e.value_ptr.*),
+            });
+        }
+        snap.entries = try entries.toOwnedSlice(a);
+
+        // 2. reserved_globals owned dupe.
+        var rg: std.ArrayList([]const u8) = .empty;
+        try rg.ensureTotalCapacity(a, self.reserved_globals.count());
+        var git = self.reserved_globals.keyIterator();
+        while (git.next()) |k| rg.appendAssumeCapacity(try a.dupe(u8, k.*));
+        snap.reserved_globals = try rg.toOwnedSlice(a);
+
+        // 3. per-index fingerprint 1-pass.
+        const mc = self.graph.moduleCount();
+        const fps = try a.alloc(PreservedRenames.ModuleFingerprint, mc);
+        for (0..mc) |i| {
+            const m = self.getModule(@intCast(i)) orelse {
+                fps[i] = .{
+                    .path_hash = 0,
+                    .exec_index = std.math.maxInt(u32),
+                    .toplevel_name_set_hash = 0,
+                    .unresolved_refs_hash = 0,
+                    .nested_name_set_hash = 0,
+                    .import_locals_wrap_hash = 0,
+                };
+                continue;
+            };
+            fps[i] = try self.moduleFingerprint(m.*);
+        }
+        snap.fingerprint = fps;
+
+        return snap;
+    }
+
+    /// 재사용 안전성 가드 (G0~G4). 현재(fresh) 그래프가 스냅샷과 "rename deconflict
+    /// 결과가 동일하게 나오는" 형태인지 판정한다. **하나라도 불확실하면 false → 호출자가
+    /// full computeRenames** (기존 경로). fail-safe: 가드 버그의 최악은 perf 회귀이지
+    /// 정확성 사고가 아니다 (G3 제외 — by-name 재유도가 테스트로 커버).
+    ///
+    /// per-index fingerprint 전체(path_hash/exec_index/toplevel_name_set_hash/
+    /// unresolved_refs_hash)를 비교한다. 변경 모듈만 골라 비교하는 대신 *모든* 모듈을
+    /// 비교 — 변경 안 된 모듈은 자명히 일치하고, 변경 모듈은 반드시 일치해야 하므로
+    /// 더 보수적이며 단순(graph_changed 사전계산 불필요).
+    /// - G0 모듈 추가/삭제: module_count 불일치 → false.
+    /// - G1 index/exec_index: per-index path_hash + exec_index 비교.
+    /// - G2 변경 모듈 이름집합: per-index toplevel_name_set_hash 비교.
+    /// - G3 inner idx: inject 의 by-name 재유도가 담당 (가드 아님).
+    /// - G4 reserved_globals: per-index unresolved_refs_hash 비교.
+    /// - G5 nested shadow 입력: per-index nested_name_set_hash 비교
+    ///   (scope_maps[1..] 이름이 import canonical 을 shadow → 추가 rename 유발).
+    /// - G6 import local + wrap: per-index import_locals_wrap_hash 비교
+    ///   (import local_name 집합 / ESM↔CJS wrap flip 시 synthetic 이름 landscape 변동).
+    pub fn renameReuseGuard(self: *Linker, snap: *const PreservedRenames) bool {
+        const mc = self.graph.moduleCount();
+        // G0: 모듈 수 동일.
+        if (mc != snap.module_count) return false;
+        if (snap.fingerprint.len != mc) return false;
+
+        for (0..mc) |i| {
+            const m = self.getModule(@intCast(i)) orelse return false;
+            const cur = self.moduleFingerprint(m.*) catch return false; // OOM → fail-safe
+            const old = snap.fingerprint[i];
+            // G1 + G0(per-index path): 같은 인덱스에 같은 경로/실행순서.
+            if (cur.path_hash != old.path_hash) return false;
+            if (cur.exec_index != old.exec_index) return false;
+            // G2: top-level owner 이름집합 불변 (body-only edit = 일치).
+            if (cur.toplevel_name_set_hash != old.toplevel_name_set_hash) return false;
+            // G4: unresolved_references (전역 참조) 불변.
+            if (cur.unresolved_refs_hash != old.unresolved_refs_hash) return false;
+            // G5: nested binding 이름집합 불변 (import shadow 결과 동일).
+            if (cur.nested_name_set_hash != old.nested_name_set_hash) return false;
+            // G6: import local_name 집합 + wrap_kind 불변.
+            if (cur.import_locals_wrap_hash != old.import_locals_wrap_hash) return false;
+        }
+        return true;
+    }
+
+    /// SymbolID 에 해당하는 module-local 이름 (scope_maps[0] reverse lookup → synthetic_name
+    /// fallback). `findSymbolIdx` 의 역방향 — idx 로 이름을 찾는다.
+    ///
+    /// **totality 미보장 (F5)**: 모듈이 그래프 밖이거나, semantic 이 없거나, idx 가
+    /// scope_maps[0] 역탐색·synthetic fallback 둘 다 miss 하면 null. `buildRenameSnapshot`
+    /// 이 이 null 을 만나면 스냅샷을 폐기한다(불완전 capture 방지). pub: linker_test.zig 가
+    /// 이 null 케이스를 직접 구성해 capture 폐기를 검증한다.
+    pub fn symbolLocalName(self: *const Linker, id: bundler_symbol.SymbolID) ?[]const u8 {
+        const m = self.getModule(@intFromEnum(id.module)) orelse return null;
+        const sem = m.semantic orelse return null;
+        const idx = @intFromEnum(id.inner);
+        if (sem.scope_maps.len > 0) {
+            var it = sem.scope_maps[0].iterator();
+            while (it.next()) |e| {
+                if (e.value_ptr.* == idx) return e.key_ptr.*;
+            }
+        }
+        if (idx < sem.symbols.items.len) {
+            const sym = sem.symbols.items[idx];
+            if (sym.synthetic_kind != null and sym.synthetic_name.len > 0) return sym.synthetic_name;
+        }
+        return null;
+    }
+
+    /// 모듈의 fingerprint 계산. order-independent 해시(sum)로 이름집합/unresolved 비교 —
+    /// scope_maps iteration 순서(비결정)에 무관해야 가드가 안정적이다.
+    /// pub: linker_test.zig 가 per-field 게이트 동작을 직접 대조 (which-gate 검증).
+    pub fn moduleFingerprint(self: *Linker, m: Module) !PreservedRenames.ModuleFingerprint {
+        var fp: PreservedRenames.ModuleFingerprint = .{
+            .path_hash = std.hash.Wyhash.hash(0x5a, m.path),
+            .exec_index = m.exec_index,
+            .toplevel_name_set_hash = 0,
+            .unresolved_refs_hash = 0,
+            .nested_name_set_hash = 0,
+            // wrap_kind 를 seed 로 접어 넣는다(빈 import 모듈도 wrap flip 을 감지).
+            .import_locals_wrap_hash = @intFromEnum(m.wrap_kind) +% 1,
+        };
+
+        // top-level owner 이름집합 (G2) — collectModuleNames 와 동일 필터 공유.
+        const Ctx = struct {
+            acc: *u64,
+            fn add(c: @This(), name: []const u8) anyerror!void {
+                // order-independent: 각 이름 해시를 wrapping-add. 같은 집합 → 같은 합.
+                c.acc.* +%= std.hash.Wyhash.hash(0xc0, name);
+            }
+        };
+        try self.forEachTopLevelOwnerName(m, Ctx, .{ .acc = &fp.toplevel_name_set_hash }, Ctx.add);
+
+        // nested binding 이름집합 (G5) — resolveNestedShadowConflicts/hasNestedBinding 입력.
+        // forEachNestedBindingName 으로 shadow pass 와 동일한 scope_maps[1..] 집합을 본다.
+        try forEachNestedBindingName(m, Ctx, .{ .acc = &fp.nested_name_set_hash }, Ctx.add);
+
+        // import binding local_name 집합 (G6) — nested shadow 비교의 다른 한쪽.
+        // 모든 binding 의 local_name 을 해시(namespace 포함, conservative superset).
+        for (m.import_bindings) |ib| {
+            fp.import_locals_wrap_hash +%= std.hash.Wyhash.hash(0xe0, ib.local_name);
+        }
+
+        // unresolved_references 집합 (G4) — collectReservedGlobals 입력.
+        if (m.semantic) |sem| {
+            var it = sem.unresolved_references.keyIterator();
+            while (it.next()) |k| fp.unresolved_refs_hash +%= std.hash.Wyhash.hash(0xd0, k.*);
+        }
+        return fp;
+    }
+
+    /// 보존 스냅샷을 현재(fresh) 그래프의 `rename_table`/`reserved_globals` 에 주입한다.
+    /// `renameReuseGuard` 통과 후에만 호출 — 이름집합/모듈순서 불변이 보장된 상태.
+    ///
+    /// **G3 (유일한 correctness-load-bearing)**: 변경 모듈은 재파싱돼 inner idx 가
+    /// 흔들릴 수 있으므로, 스냅샷 엔트리의 `id.inner` 를 신뢰하지 않고 *이름으로 재유도*
+    /// (`findSymbolIdx`, scope_maps[0] 대상) 해 fresh idx 로 재키잉한 뒤 주입한다. 이름은
+    /// G2 가 불변 보장하므로 모든 엔트리가 재유도 성공(total). 변경 안 된 모듈도 같은
+    /// 경로를 타 idx 가 그대로면 동일 결과 — 분기 없이 일관 처리.
+    ///
+    /// `assignSymbolCanonical` 싱크를 거쳐 rename_table/canonical_strings/canonical_names_used
+    /// 를 일관 갱신 (computeRenames 와 동일 sink).
+    pub fn injectPreservedRenames(self: *Linker, snap: *const PreservedRenames) !void {
+        // reserved_globals 복원 (collectReservedGlobals 를 skip 하므로 직접).
+        self.reserved_globals.clearRetainingCapacity();
+        for (snap.reserved_globals) |name| {
+            try self.reserved_globals.put(self.allocator, name, {});
+        }
+        // 외부 전달 전역 식별자도 동일하게 예약 (collectReservedGlobals 와 parity).
+        for (self.global_identifiers) |name| {
+            try self.reserved_globals.put(self.allocator, name, {});
+        }
+
+        for (snap.entries) |entry| {
+            const module_index = @intFromEnum(entry.id.module);
+            // by-name 재유도: 초기 idx 대신 fresh 그래프에서 이름으로 다시 찾는다.
+            const fresh_idx = self.findSymbolIdx(module_index, entry.local_name) orelse continue;
+            const id = bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(module_index)), fresh_idx);
+            const dup = try self.allocator.dupe(u8, entry.canonical);
+            try self.assignSymbolCanonical(id, dup);
+        }
     }
 
     /// import binding의 canonical name이 importer 모듈의 중첩 스코프에 같은 이름이
@@ -1446,10 +1700,32 @@ pub const Linker = struct {
         return null;
     }
 
+    /// nested-scope binding(scope_maps[1..]) 의 모든 이름을 1-pass 로 순회한다.
+    /// `hasNestedBinding`(단일 lookup) 과 `moduleFingerprint`(집합 해시) 의 **공유
+    /// 입력 소스** — 둘이 보는 nested 이름 집합이 정확히 같도록 단일 정의로 묶는다
+    /// (드리프트 = G5 가 shadow pass 가 실제로 보는 것과 어긋남 = 정확성 버그).
+    /// scope_maps[0](모듈 스코프)은 제외 — 그건 G2 toplevel 해시가 담당.
+    fn forEachNestedBindingName(
+        m: Module,
+        comptime Ctx: type,
+        ctx: Ctx,
+        comptime cb: fn (Ctx, []const u8) anyerror!void,
+    ) !void {
+        const sem = m.semantic orelse return;
+        for (sem.scope_maps, 0..) |scope_map, scope_idx| {
+            if (scope_idx == 0) continue;
+            var it = scope_map.iterator();
+            while (it.next()) |e| try cb(ctx, e.key_ptr.*);
+        }
+    }
+
     /// 모듈의 중첩 스코프 (비-모듈 스코프) 에 해당 이름이 존재하는지 확인.
     /// esbuild/rolldown/rollup 과 동일하게 semantic.scope_maps 직접 scan — scope 깊이는
     /// 보통 1~10 정도라 별도 cache 없이 충분.
     // pub: shared_namespace.zig (RFC #3399 PR-2) 가 동일 scan 을 재사용 (단일 소스 — 복제 제거).
+    // 순회하는 scope_maps[1..] 집합은 `forEachNestedBindingName` 과 동일해야 한다
+    // (moduleFingerprint G5 해시가 같은 집합을 본다). 여기는 early-return lookup 이라
+    // 별도 구현이지만 *순회 범위*(scope_idx != 0)는 한 군데서만 바뀌도록 주석으로 고정.
     pub fn hasNestedBinding(self: *const Linker, module_index: u32, name: []const u8) bool {
         const m = self.getModule(module_index) orelse return false;
         const sem = m.semantic orelse return false;

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -8,6 +8,8 @@ const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 const resolve_cache_mod = @import("resolve_cache.zig");
 const writeFile = @import("test_helpers.zig").writeFile;
+const bundler_symbol = @import("symbol.zig");
+const PreservedRenames = bundler_symbol.PreservedRenames;
 
 fn dirPath(tmp: *std.testing.TmpDir) ![:0]u8 {
     return try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
@@ -1710,4 +1712,310 @@ test "populateImportSymbols: named import의 local_symbol이 현재 모듈 seman
         }
     }
     try std.testing.expect(found);
+}
+
+// ============================================================
+// HMR rename 재사용 Tests (perf/hmr-link-rename-reuse)
+// ============================================================
+
+/// 두 rename_table 이 byte-identical 인지 (같은 SymbolID 집합 + 같은 이름) 단언.
+/// "재사용 ≡ recompute" 증명의 핵심 — 주입된 table 이 from-scratch computeRenames 와
+/// 완전히 동일해야 한다.
+fn expectRenameTablesEqual(a: *const Linker, b: *const Linker) !void {
+    try std.testing.expectEqual(a.rename_table.count(), b.rename_table.count());
+    var it = a.rename_table.map.iterator();
+    while (it.next()) |e| {
+        const other = b.rename_table.get(e.key_ptr.*) orelse {
+            std.debug.print("missing key in b: mod={d} inner={d}\n", .{
+                @intFromEnum(e.key_ptr.module), @intFromEnum(e.key_ptr.inner),
+            });
+            return error.MissingKey;
+        };
+        try std.testing.expectEqualStrings(e.value_ptr.*, other);
+    }
+}
+
+test "reuse: snapshot 주입 결과가 from-scratch recompute 와 byte-identical (다중 충돌)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // count 가 3개 모듈에서 충돌 → name$1, name$2 deconflict 발생.
+    try writeFile(tmp.dir, "a.ts", "import './b';\nimport './c';\nexport const count = 0;\nexport const name = 'a';");
+    try writeFile(tmp.dir, "b.ts", "export const count = 1;\nexport const name = 'b';");
+    try writeFile(tmp.dir, "c.ts", "export const count = 2;\nexport const name = 'c';");
+
+    // 1) 초기 빌드: computeRenames → 스냅샷 캡처.
+    var r = try buildLinkAndRename(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.destroyGraph();
+    defer r.cache.deinit();
+
+    // 정상 그래프 → capture 성공(non-null)이어야 한다. F5 null 폐기는 별도 테스트.
+    var snap = (try r.linker.buildRenameSnapshot(std.testing.allocator)).?;
+    defer snap.deinit();
+
+    // 2) 같은 그래프에 fresh Linker 를 link 만 하고(=deconflict 미실행), 스냅샷 주입.
+    var fresh = Linker.init(std.testing.allocator, r.graph, .esm);
+    defer fresh.deinit();
+    try fresh.link();
+    // 가드는 같은 그래프이므로 당연히 통과해야 한다.
+    try std.testing.expect(fresh.renameReuseGuard(&snap));
+    try fresh.injectPreservedRenames(&snap);
+
+    // 3) 주입 결과 == recompute 결과 (byte-identical).
+    try expectRenameTablesEqual(&r.linker, &fresh);
+    // sanity: 실제로 deconflict 가 일어났는지 (count$N 존재).
+    var saw_rename = false;
+    var it2 = fresh.rename_table.map.iterator();
+    while (it2.next()) |e| {
+        if (std.mem.indexOf(u8, e.value_ptr.*, "$") != null) saw_rename = true;
+    }
+    try std.testing.expect(saw_rename);
+}
+
+test "reuse: guard 통과 시 inject — single import 그래프" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './b';\nexport const count = 0;");
+    try writeFile(tmp.dir, "b.ts", "export const count = 1;");
+
+    var r = try buildLinkAndRename(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.destroyGraph();
+    defer r.cache.deinit();
+
+    var snap = (try r.linker.buildRenameSnapshot(std.testing.allocator)).?;
+    defer snap.deinit();
+
+    var fresh = Linker.init(std.testing.allocator, r.graph, .esm);
+    defer fresh.deinit();
+    try fresh.link();
+    try std.testing.expect(fresh.renameReuseGuard(&snap));
+    try fresh.injectPreservedRenames(&snap);
+    try expectRenameTablesEqual(&r.linker, &fresh);
+}
+
+test "reuse: G3 by-name 재유도 — 스냅샷의 inner idx 가 흔들려도 이름으로 복원" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './b';\nexport const count = 0;");
+    try writeFile(tmp.dir, "b.ts", "export const count = 1;");
+
+    var r = try buildLinkAndRename(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.destroyGraph();
+    defer r.cache.deinit();
+
+    var snap = (try r.linker.buildRenameSnapshot(std.testing.allocator)).?;
+    defer snap.deinit();
+
+    // 스냅샷의 모든 엔트리의 id.inner 를 의도적으로 망가뜨린다(maxInt-기반 가짜값).
+    // injectPreservedRenames 가 id.inner 를 신뢰하지 않고 local_name 으로 findSymbolIdx
+    // 재유도하므로, 망가진 idx 와 무관하게 동일 결과가 나와야 한다 (G3 핵심).
+    for (snap.entries) |*e| {
+        // local_name 은 유지, id.inner 만 손상.
+        e.id.inner = @enumFromInt(@as(u32, 0xFFFF));
+    }
+
+    var fresh = Linker.init(std.testing.allocator, r.graph, .esm);
+    defer fresh.deinit();
+    try fresh.link();
+    try fresh.injectPreservedRenames(&snap);
+    // by-name 재유도가 동작했으면 recompute 와 동일.
+    try expectRenameTablesEqual(&r.linker, &fresh);
+}
+
+test "reuse: fingerprint — 같은 그래프는 guard true, module_count 불일치는 false (G0)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './b';\nexport const count = 0;");
+    try writeFile(tmp.dir, "b.ts", "export const count = 1;");
+
+    var r = try buildLinkAndRename(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.destroyGraph();
+    defer r.cache.deinit();
+
+    var snap = (try r.linker.buildRenameSnapshot(std.testing.allocator)).?;
+    defer snap.deinit();
+
+    // 같은 그래프 → guard 통과.
+    try std.testing.expect(r.linker.renameReuseGuard(&snap));
+
+    // G0: 스냅샷의 module_count 를 조작해 불일치 유발 → fallback(false).
+    const real_count = snap.module_count;
+    snap.module_count = real_count + 1;
+    try std.testing.expect(!r.linker.renameReuseGuard(&snap));
+    snap.module_count = real_count;
+
+    // G2: 스냅샷의 첫 fingerprint 의 이름집합 해시를 조작 → fallback(false).
+    // fingerprint 는 []const 라 const-cast 로 한 엔트리만 손상(테스트 한정).
+    const fps = @constCast(snap.fingerprint);
+    const saved = fps[0].toplevel_name_set_hash;
+    fps[0].toplevel_name_set_hash = saved ^ 0xDEAD;
+    try std.testing.expect(!r.linker.renameReuseGuard(&snap));
+    fps[0].toplevel_name_set_hash = saved;
+
+    // 복원 후 다시 통과.
+    try std.testing.expect(r.linker.renameReuseGuard(&snap));
+}
+
+test "reuse: fingerprint — nested/import-local/wrap 해시 조작 시 fallback (G5/G6)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // a.ts 가 b.ts 의 foo 를 import 하고 nested 스코프(wrap 함수)를 가진다.
+    try writeFile(tmp.dir, "a.ts", "import { foo } from './b';\nexport function wrap(){ return foo; }");
+    try writeFile(tmp.dir, "b.ts", "export const foo = 1;");
+
+    var r = try buildLinkAndRename(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.destroyGraph();
+    defer r.cache.deinit();
+
+    var snap = (try r.linker.buildRenameSnapshot(std.testing.allocator)).?;
+    defer snap.deinit();
+
+    // baseline: 같은 그래프 → 통과.
+    try std.testing.expect(r.linker.renameReuseGuard(&snap));
+
+    const fps = @constCast(snap.fingerprint);
+
+    // G5: nested binding 이름집합 해시 조작 → fallback. (각 모듈 인덱스마다 검증)
+    for (fps) |*fp| {
+        const saved = fp.nested_name_set_hash;
+        fp.nested_name_set_hash = saved ^ 0xBEEF;
+        try std.testing.expect(!r.linker.renameReuseGuard(&snap));
+        fp.nested_name_set_hash = saved;
+    }
+    try std.testing.expect(r.linker.renameReuseGuard(&snap));
+
+    // G6: import local_name + wrap_kind 해시 조작 → fallback.
+    for (fps) |*fp| {
+        const saved = fp.import_locals_wrap_hash;
+        fp.import_locals_wrap_hash = saved ^ 0xBEEF;
+        try std.testing.expect(!r.linker.renameReuseGuard(&snap));
+        fp.import_locals_wrap_hash = saved;
+    }
+    try std.testing.expect(r.linker.renameReuseGuard(&snap));
+}
+
+test "reuse: nested shadow 추가 시 guard=false (toplevel 불변이라 G2 가 놓치는 hole)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // 빌드 A: 이미 존재하는 top-level 함수 wrap, 내부에 nested binding 없음.
+    try writeFile(tmp.dir, "a.ts", "import { foo } from './b';\nexport function wrap(){ return foo; }");
+    try writeFile(tmp.dir, "b.ts", "export const foo = 1;");
+
+    // 빌드 A → 스냅샷. (스냅샷은 자체 arena 로 dupe 하므로 teardown 후에도 유효)
+    var snap: PreservedRenames = blk: {
+        var rA = try buildLinkAndRename(std.testing.allocator, &tmp, "a.ts");
+        defer rA.linker.deinit();
+        defer rA.destroyGraph();
+        defer rA.cache.deinit();
+        break :blk (try rA.linker.buildRenameSnapshot(std.testing.allocator)).?;
+    };
+    defer snap.deinit();
+
+    // a.ts 의 nested 스코프에 import local 과 같은 이름(foo)을 const 로 추가.
+    // top-level 이름집합(wrap)은 그대로 — G2 는 이 변화를 못 잡는다.
+    try writeFile(tmp.dir, "a.ts", "import { foo } from './b';\nexport function wrap(){ const foo = 1; return foo; }");
+
+    // 빌드 B: 같은 tmpDir → 같은 경로(path_hash 동일) → G1 통과, nested 만 다름.
+    var rB = try buildLinkAndRename(std.testing.allocator, &tmp, "a.ts");
+    defer rB.linker.deinit();
+    defer rB.destroyGraph();
+    defer rB.cache.deinit();
+
+    // a.ts 모듈의 fresh fingerprint 와 스냅샷을 직접 대조해 어떤 게이트가 잡는지 확인:
+    // toplevel/import-local 은 일치, nested 만 불일치여야 한다.
+    const a_idx = findModuleIdx(rB.graph, "a.ts").?;
+    const ai: usize = @intFromEnum(a_idx);
+    const cur = try rB.linker.moduleFingerprint(rB.graph.getModule(a_idx).?.*);
+    const old = snap.fingerprint[ai];
+    try std.testing.expectEqual(old.path_hash, cur.path_hash); // 같은 파일
+    try std.testing.expectEqual(old.toplevel_name_set_hash, cur.toplevel_name_set_hash); // G2 놓침
+    try std.testing.expectEqual(old.import_locals_wrap_hash, cur.import_locals_wrap_hash); // G6 놓침
+    try std.testing.expect(old.nested_name_set_hash != cur.nested_name_set_hash); // G5 가 잡음
+
+    // 결과: 가드는 nested 변화를 감지해 fallback(false) → full computeRenames 로 안전.
+    try std.testing.expect(!rB.linker.renameReuseGuard(&snap));
+}
+
+test "reuse: wrap_kind flip (ESM→CJS) 시 guard=false" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // 빌드 A: b 가 ESM (wrap_kind=.none).
+    try writeFile(tmp.dir, "a.ts", "import { x } from './b';\nexport const y = x;");
+    try writeFile(tmp.dir, "b.js", "export const x = 1;");
+
+    var snap: PreservedRenames = blk: {
+        var rA = try buildLinkAndRename(std.testing.allocator, &tmp, "a.ts");
+        defer rA.linker.deinit();
+        defer rA.destroyGraph();
+        defer rA.cache.deinit();
+        // b 가 ESM 인지 sanity.
+        const b0 = findModuleIdx(rA.graph, "b.js").?;
+        try std.testing.expectEqual(types.WrapKind.none, rA.graph.getModule(b0).?.wrap_kind);
+        break :blk (try rA.linker.buildRenameSnapshot(std.testing.allocator)).?;
+    };
+    defer snap.deinit();
+
+    // b.js 를 CJS 로 교체 → wrap_kind=.cjs 로 바뀐다.
+    try writeFile(tmp.dir, "b.js", "module.exports = { x: 1 };");
+
+    var rB = try buildLinkAndRename(std.testing.allocator, &tmp, "a.ts");
+    defer rB.linker.deinit();
+    defer rB.destroyGraph();
+    defer rB.cache.deinit();
+
+    const b_idx = findModuleIdx(rB.graph, "b.js").?;
+    try std.testing.expectEqual(types.WrapKind.cjs, rB.graph.getModule(b_idx).?.wrap_kind);
+
+    // wrap_kind 가 import_locals_wrap_hash 의 seed 라 b 의 fingerprint 가 달라진다.
+    const bi: usize = @intFromEnum(b_idx);
+    const cur = try rB.linker.moduleFingerprint(rB.graph.getModule(b_idx).?.*);
+    try std.testing.expect(snap.fingerprint[bi].import_locals_wrap_hash != cur.import_locals_wrap_hash);
+
+    // 가드 fallback(false).
+    try std.testing.expect(!rB.linker.renameReuseGuard(&snap));
+}
+
+test "reuse: F5 — rename_table 키의 symbolLocalName 이 null 이면 스냅샷 폐기(capture null)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './b';\nexport const count = 0;");
+    try writeFile(tmp.dir, "b.ts", "export const count = 1;");
+
+    var r = try buildLinkAndRename(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.destroyGraph();
+    defer r.cache.deinit();
+
+    // 1) 대조군: 깨끗한 rename_table 은 capture 성공(non-null).
+    {
+        var ok = (try r.linker.buildRenameSnapshot(std.testing.allocator)).?;
+        ok.deinit();
+    }
+
+    // 2) symbolLocalName 이 null 을 반환하는 인위적 SymbolID 를 rename_table 에 주입한다.
+    //    module 인덱스를 모듈 수 밖(out-of-range)으로 잡으면 getModule→null →
+    //    symbolLocalName→null 이 된다. scope_maps 에도 없고 synthetic 도 아닌, totality 가
+    //    깨지는 정확한 케이스. value 는 borrow 라 별도 free 불필요(canonical_strings 소유가
+    //    아닌 string literal — RenameTable.deinit 은 map 만 해제).
+    const oob_module: types.ModuleIndex = @enumFromInt(@as(u32, @intCast(r.graph.moduleCount())) + 7);
+    const bad_id = bundler_symbol.SymbolID.make(oob_module, 0);
+    // sanity: 정말로 null 을 반환하는지 — buildRenameSnapshot 폐기 조건의 전제 확인.
+    try std.testing.expect(r.linker.symbolLocalName(bad_id) == null);
+    try r.linker.rename_table.put(std.testing.allocator, bad_id, "synthetic_should_not_leak");
+
+    // 3) 이제 capture 는 불완전 스냅샷을 폐기하고 null 을 반환해야 한다.
+    const captured = try r.linker.buildRenameSnapshot(std.testing.allocator);
+    try std.testing.expect(captured == null);
+
+    // 4) 가드 경로가 reuse 를 안 하는지: bundler 게이트는 `if (try buildRenameSnapshot()) |snap|`
+    //    형태라, capture 가 null 이면 그 분기 자체를 타지 않아 injectPreservedRenames 가
+    //    절대 호출되지 않는다(=reuse 비활성). 즉 reuse 의 *유일* 진입점인 non-null 스냅샷이
+    //    없으므로 구조적으로 재사용이 불가능하다. 아래는 그 불변식을 값 수준에서 재확인.
+    if (captured) |_| {
+        try std.testing.expect(false); // 도달 불가 — null 이어야 한다.
+    }
 }

--- a/src/bundler/symbol.zig
+++ b/src/bundler/symbol.zig
@@ -195,6 +195,77 @@ pub const RenameTable = struct {
     }
 };
 
+/// HMR rename 보존 스냅샷 (perf/hmr-link-rename-reuse).
+///
+/// **문제**: HMR rebuild 는 매번 `Linker` 를 새로 만들고 `computeRenames`(전체 모듈
+/// top-level 이름 deconflict, RN 8067 모듈에서 ~106ms)를 재계산한다. 그러나 body-only
+/// 수정 (HMR 절대다수) 에서는 모든 모듈의 top-level 이름 집합이 불변이라 deconflict
+/// 결과 (rename_table) 도 byte-identical 하다. → 초기 빌드의 결과를 owned 스냅샷으로
+/// 보존했다가 다음 rebuild 에서 가드 통과 시 재주입하고 computeRenames 를 skip.
+///
+/// **소유권 (RFC #3933 dangling 클래스 회피)**: 스냅샷 안의 모든 문자열 (rename name,
+/// reserved global, fingerprint path) 은 `arena` 가 dupe 해 소유한다. `Linker` 의
+/// `canonical_strings` 에서 borrow 하면 Linker.deinit 후 dangling 이 되므로 **금지**.
+/// `arena.deinit()` 한 번이 일괄 해제 (CLAUDE.md 메모리 규약).
+///
+/// **fingerprint**: 재사용 안전성 가드(G0~G4)의 비교 기준. 초기 빌드 시점의 그래프
+/// 형태(모듈 수/순서/이름집합/전역참조)를 per-index 로 박제한다. rebuild 시 현재
+/// 그래프와 대조해 "이름 deconflict 결과가 바뀔 수 있는 변화"가 있었는지 판정한다.
+pub const PreservedRenames = struct {
+    /// 스냅샷 전용 arena — 모든 owned 문자열의 backing. `deinit` 이 일괄 해제.
+    arena: std.heap.ArenaAllocator,
+
+    /// 보존된 rename_table 엔트리. `SymbolID → owned name`. inner idx 는 *초기 빌드*
+    /// 의 module-local 인덱스라, 재파싱된 모듈은 idx 가 흔들릴 수 있어 inject 시
+    /// 이름으로 재유도(G3)한다. 변경 안 된 모듈은 idx 가 그대로라 직접 재키잉.
+    entries: []Entry,
+
+    /// 보존된 `reserved_globals` 키 집합 (owned). inject 시 Linker.reserved_globals 복원.
+    /// `computeRenames` 의 `collectReservedGlobals` 를 skip 하므로 직접 복원해야 한다.
+    reserved_globals: []const []const u8,
+
+    /// per-index fingerprint. 인덱스 = ModuleIndex 정수. 가드가 현재 그래프와 대조.
+    fingerprint: []const ModuleFingerprint,
+
+    /// 초기 빌드 모듈 수. 가드 G0 (모듈 추가/삭제) 1차 비교.
+    module_count: u32,
+
+    pub const Entry = struct {
+        /// 초기 빌드 시점의 SymbolID (module, inner). inner 는 by-name 재유도 전 키.
+        id: SymbolID,
+        /// 초기 빌드 시점의 module-local 이름 (재유도용 lookup 키, owned).
+        local_name: []const u8,
+        /// 최종 rename 결과 (owned).
+        canonical: []const u8,
+    };
+
+    /// 모듈 단위 fingerprint. 가드가 "이 모듈의 rename 결과에 영향을 주는 입력"이
+    /// 초기 빌드와 같은지 1-pass 로 판정한다.
+    pub const ModuleFingerprint = struct {
+        /// 경로 해시 (G0/G1 — 모듈 동일성). path 문자열 자체는 보관 안 함(해시로 충분).
+        path_hash: u64,
+        /// 실행 순서 (G1 — deconflict 는 exec_index 오름차순 tie-break 라 순서 변경 = 결과 변경).
+        exec_index: u32,
+        /// top-level owner 이름 집합의 order-independent 해시 (G2 — body-only edit 불변).
+        toplevel_name_set_hash: u64,
+        /// unresolved_references 집합의 order-independent 해시 (G4 — 새 전역참조 = reserved 변화).
+        unresolved_refs_hash: u64,
+        /// nested-scope binding(scope_maps[1..]) 이름 집합의 order-independent 해시.
+        /// G5 — `resolveNestedShadowConflicts`/`hasNestedBinding` 가 보는 shadow 입력.
+        /// body edit 으로 nested binding *이름* 이 추가/변경되면 import target rename 이
+        /// 달라질 수 있는데 toplevel 해시는 이를 못 잡는다(scope_maps[0] 만 봄).
+        nested_name_set_hash: u64,
+        /// import binding local_name 집합의 order-independent 해시 + wrap_kind.
+        /// G6 — nested shadow 비교의 다른 한쪽(import local name)과 wrap synthetic
+        /// landscape(ESM↔CJS wrap flip 시 init_/exports_/require_ 이름 변동) 변화 감지.
+        import_locals_wrap_hash: u64,
+    };
+
+    pub fn deinit(self: *PreservedRenames) void {
+        self.arena.deinit();
+    }
+};
+
 /// Re-export alias 레코드.
 /// `name`은 exported_name(barrel 기준). `canonical_name`은 체인 resolve 후
 /// linker가 주입한 최종 참조 이름. `ref_count`는 symbol-level tree-shaking 용.

--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -74,6 +74,11 @@ pub const Category = enum {
     /// 패턴 vs esbuild/rolldown 의 arrow `__export(ns, {name:()=>val})` 패턴 격차
     /// 식별용. 큰 namespace 일수록 zntc 가 손해.
     ns_inline_audit,
+    /// HMR rename 재사용 스냅샷(perf/hmr-link-rename-reuse) 진단. 특히
+    /// `buildRenameSnapshot` 이 rename_table 키 중 `symbolLocalName` null 을 만나
+    /// 스냅샷을 폐기(capture 실패 → 다음 rebuild 가 full computeRenames)한 빈도를
+    /// 관측. 실앱(RN 8067 모듈)에서 null capture 가 실제로 0 인지 확인용 (F5).
+    rename_reuse,
 
     /// 카테고리 이름으로 enum 조회 (공백 제거 + 대소문자 무시).
     pub fn fromString(s: []const u8) ?Category {


### PR DESCRIPTION
> base: #4159(emit) 위에 쌓은 PR. #4159 머지 후 main 으로 rebase 예정.

## 문제

8067 모듈 RN 앱(payhere mobile-seller) HMR rebuild 가 ~430ms(emit PR #4159 후). `ZNTC_PROFILE=all` 실측에서 **link 119ms 중 `computeRenames`(lRen)가 76~106ms**로 압도적. dev single-bundle(code_splitting=false)은 매 rebuild 마다 전체 8067 모듈의 top-level 식별자 충돌을 deconflict(`x`,`x$1`).

## 해결 — rename_table 보존

**핵심 비대칭**: 초기 full bundle 은 모듈을 IIFE 없이 concat → 전역 충돌 → rename 필수. 하지만 **HMR rebuild 는 `skip_bundle_output`으로 concat 을 건너뛰고 `dev_module_codes`(IIFE wrap)만** 만든다. IIFE 격리면 변경 모듈 top-level 은 전역 충돌을 안 만들고, dev_code 가 참조하는 다른 모듈 이름은 "앱에 이미 로드된 초기 번들의 rename 된 이름"과 같아야 한다.

→ 초기 빌드의 rename_table 을 `PreservedRenames` 스냅샷(arena 소유)으로 보존했다가, HMR rebuild 에서 가드 통과 시 주입하고 `computeRenames`를 skip. 소비처 2곳(watch.zig RN dev napi, incremental.zig web dev) 모두 적용.

## 가드 (모두 통과해야 reuse; 하나라도 실패 → 기존 full computeRenames)
| 가드 | 검사 | 막는 것 |
|---|---|---|
| G0 | module_count | 모듈 추가/삭제 |
| G1 | per-index path+exec_index | 인덱스/순서 변화 |
| G2 | top-level 이름집합 해시 | 변경 모듈 export/식별자 추가 |
| G3 | inner idx by-name 재유도(findSymbolIdx) | 변경 모듈 재파싱 idx 흔들림 |
| G4 | unresolved_refs 해시 | 새 전역 참조 |
| G5 | nested binding 이름집합 | nested shadow(resolveNestedShadowConflicts) |
| G6 | wrap_kind+import locals | ESM↔CJS wrap flip(synthetic 이름) |
| F5 | symbolLocalName 완전성 | 불완전 스냅샷 → 폐기(reuse 안 함) |

`/code-review max`(메모리/정확성/cross-file) 2라운드로 G5·G6·F5 를 추가해 silent wrong-binding hole 을 닫았다.

## Zig 초보자용 설명
- `PreservedRenames` 는 모든 문자열을 자체 arena 에 dupe 소유 → 빌드의 Linker 가 사라져도 유효(borrow 금지, dangling 회피). `deinit` 은 `arena.deinit()` 한 번.
- 가드는 **fail-safe**: 안정성을 증명할 때만 reuse, 불확실하면 기존 full computeRenames. 가드 버그의 최악은 perf 회귀(불필요 재계산)이지 정확성 사고가 아니다(F5/G3 제외, 테스트로 커버).
- `BundleResult.rename_snapshot_invalidated` 플래그로 "reuse-hit(snapshot null)"과 "fallback 인데 capture 실패(이전 보존본 drop 필요)"를 구분.

## 효과 (실측 warm, 8067 모듈)
| 지표 | before | after |
|---|---|---|
| lRen(computeRenames) | 76~106ms | **0** |
| link | 119ms | **~68ms** |
| 전체 HMR | ~430ms | **~360ms (최저 355)** |

## 정확성 검증
- A→B→A·텍스트 edit → reuse-hit(lRen 0), nested/wrap edit → fallback, `ZNTC_DEBUG=rename_reuse` 폐기 로그 0.
- `zig build test` 통과 — byte-identical(reuse≡recompute)/G3 손상복구/nested shadow/wrap flip/F5 폐기 테스트 추가.
- 초기 빌드/비-dev/splitting/minify 는 gate 밖이라 byte-identical(회귀 0).

## known limitations (후속)
- code-review 의 F3/F4/F6/F7 — synthetic 이름이 user 식별자와 우연히 같은 adversarial-but-legal 케이스 등 극드문 round-trip 비대칭. 현재 fail-safe(F5)가 명백한 누락은 폐기하지만 "synthetic==user 동명" 같은 ambiguous 매핑은 미커버. 빈도가 극히 낮고 실앱 실측 정상이라 후속 이슈로 추적.
- graph(170ms) incremental — 100ms 최종 목표엔 이것도 필요. renumber 위험으로 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)