### PR TITLE
perf(graph): HMR 위상 보존 인프라 (Phase A — 정확성 토대, byte-identical)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1175,6 +1175,17 @@ pub const Bundler = struct {
             owned_graph_storage = ModuleGraph.init(self.allocator, self.getResolveCache());
         }
         const graph: *ModuleGraph = if (self.external_graph) |g| g else &owned_graph_storage;
+        // perf/hmr-graph-topology-reuse Phase A — 보존된 external_graph 재사용 훅.
+        // external_graph 가 *이미 모듈을 가진* 상태(=직전 빌드의 결과)면, 이번 빌드 전에
+        // 반드시 reset 해야 stale 모듈/edge 가 새 빌드를 오염시키지 않는다. Phase A 의
+        // prepareForPreservedRebuild 는 모듈을 전량 비워 매 빌드 fresh graph 와 byte-identical
+        // 출력을 보장한다(graph struct/backing/path_arena 만 재사용 — 객체 수명 안정 + alloc 절감).
+        // 위상 보존(edge/exec_index 재사용)은 transferModulesToStore 소유권 재설계가 필요해
+        // Phase B 로 분리. 따라서 여기 reset 은 빌드 종류(plugin/MF/glob/splitting 등)와 무관하게
+        // 항상 안전.
+        if (has_external_graph and graph.moduleCount() > 0) {
+            graph.prepareForPreservedRebuild();
+        }
         // this.emitFile (PR5): plugin 이 emit 한 asset 수집소. graph build 가 plugin hook 을
         // 호출하기 *전* 에 연결해야 한다. emit 된 asset 은 아래에서 OutputFile(kind=.asset)로
         // 복사되어 final_asset_outputs 에 합쳐지고, store 는 scratch 라 bundle() 종료 시 해제.

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -291,6 +291,9 @@ pub const ModuleGraph = struct {
     /// RFC_GRAPH_PERSISTENCE Sub-PR-B.1 — 단일 모듈 invalidate (path 보존).
     /// 호출자 없음 (Sub-PR-B.3 에서 wire-up).
     pub const invalidateModule = graph_lifecycle.invalidateModule;
+    /// perf/hmr-graph-topology-reuse Phase A — persistent_graph 재사용 빌드 직전 reset.
+    /// 현재는 fresh 와 byte-identical(모듈 전량 clear). bundler.zig external_graph 훅이 호출.
+    pub const prepareForPreservedRebuild = graph_lifecycle.prepareForPreservedRebuild;
 
     const ensureBuiltinPlugins = graph_plugins.ensureBuiltinPlugins;
     pub const pluginRunnerWithBuiltins = graph_plugins.pluginRunnerWithBuiltins;

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -716,6 +716,144 @@ fn checkSelfReExport(self: *ModuleGraph) void {
     }
 }
 
+// ============================================================
+// perf/hmr-graph-topology-reuse Phase A — 위상(topology) 스냅샷 + 가드 primitive
+//
+// 이 함수들은 "body-only edit(모듈 집합·import 위상 불변)이면 보존, 아니면 full" 판정의
+// **corruption-defense 핵심**이다. 변경 모듈을 invalidate(=deinit) *하기 전에* 그 모듈의
+// (specifier, kind) 집합 + import_records[].resolved 가 가리키는 타겟 모듈 path 집합을
+// 스냅샷한다. import_records 는 parse_arena 소유라 재파싱 시 backing 이 사라지므로 **반드시
+// deinit 전에** 떠 둬야 한다(스냅샷은 자체 allocator 로 dupe → arena 수명 독립).
+//
+// Phase A 에서는 persistent_graph 가 매 빌드 fresh discovery(prepareForPreservedRebuild)라
+// 이 primitive 가 *판정 경로에 강제 연결되어 있지는 않다*. 하지만 (1) 단위 테스트로 정확성을
+// 못박아 두고 (2) Phase B 의 selective edge-reuse 가 그대로 호출할 가드 표면을 확정한다.
+// (Phase B: invalidateModule 전 snapshot → 재파싱 후 topologyMatches → 일치 시 보존, 불일치
+// 시 full BFS.)
+// ============================================================
+
+/// 한 import record 의 위상 식별자: specifier + kind + (resolve 된) 타겟 모듈 path.
+/// resolved_target_path = null 은 "아직 미해석 / external / disabled(specifier 기반)" 를 뜻하며
+/// resolve target diff 가드에서 specifier 와 함께 비교된다.
+pub const ImportTopologyEntry = struct {
+    specifier: []const u8,
+    kind: types.ImportKind,
+    /// resolve 결과 타겟 모듈의 절대 path (snapshot allocator 소유 — dupe). null = 미해석.
+    resolved_target_path: ?[]const u8,
+    /// 동적 import 여부(`dynamic_import` kind). dynamic_import diff 가드용 — kind 에 이미
+    /// 포함되지만 가드 가독성을 위해 명시 필드로도 노출.
+    is_dynamic: bool,
+};
+
+/// 변경 모듈의 위상 스냅샷. `entries` 와 각 `specifier`/`resolved_target_path` 문자열은
+/// 모두 `allocator` 소유 — `deinit` 으로 일괄 해제. invalidate(deinit) 전에 떠 둬야 한다.
+pub const ModuleTopologySnapshot = struct {
+    entries: []ImportTopologyEntry,
+    /// 변경 모듈이 그 시점에 가졌던 import record 개수(= entries.len). count 비교 fast-path.
+    record_count: usize,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *ModuleTopologySnapshot) void {
+        for (self.entries) |e| {
+            self.allocator.free(e.specifier);
+            if (e.resolved_target_path) |p| self.allocator.free(p);
+        }
+        self.allocator.free(self.entries);
+    }
+};
+
+/// 변경 모듈(mod_idx)의 import 위상을 스냅샷한다. **invalidateModule 호출 전**에 부른다.
+/// specifier/kind 는 import_records(parse_arena 소유)에서, resolved target path 는
+/// import_records[].resolved 가 가리키는 모듈의 path(path_arena 소유)에서 떠 dupe 한다.
+/// glob/require_context 같은 *동적 확장* record 는 위상 보존 대상이 아니므로(plan §30 잔존
+/// 위험) 스냅샷 자체를 거부(null 반환) → caller 가 full 로 폴백.
+pub fn snapshotModuleTopology(
+    self: *const ModuleGraph,
+    allocator: std.mem.Allocator,
+    mod_idx: usize,
+) !?ModuleTopologySnapshot {
+    if (mod_idx >= self.modules.count()) return null;
+    const mod = self.modules.at(mod_idx);
+
+    var entries: std.ArrayListUnmanaged(ImportTopologyEntry) = .empty;
+    errdefer {
+        for (entries.items) |e| {
+            allocator.free(e.specifier);
+            if (e.resolved_target_path) |p| allocator.free(p);
+        }
+        entries.deinit(allocator);
+    }
+
+    for (mod.import_records) |rec| {
+        // glob / require.context 는 build-time FS 확장이라 specifier-set 만으로 위상 불변을
+        // 증명할 수 없다 → 보존 거부(보수적 full). (plan §12 제외 빌드와 동형.)
+        if (rec.kind == .glob or rec.kind == .require_context) {
+            for (entries.items) |e| {
+                allocator.free(e.specifier);
+                if (e.resolved_target_path) |p| allocator.free(p);
+            }
+            entries.deinit(allocator);
+            return null;
+        }
+        const spec_copy = try allocator.dupe(u8, rec.specifier);
+        var target_path: ?[]const u8 = null;
+        errdefer allocator.free(spec_copy);
+        if (!rec.resolved.isNone()) {
+            const ti = rec.resolved.toUsize();
+            if (ti < self.modules.count()) {
+                target_path = try allocator.dupe(u8, self.modules.at(ti).path);
+            }
+        }
+        try entries.append(allocator, .{
+            .specifier = spec_copy,
+            .kind = rec.kind,
+            .resolved_target_path = target_path,
+            .is_dynamic = rec.kind == .dynamic_import,
+        });
+    }
+
+    return ModuleTopologySnapshot{
+        .entries = try entries.toOwnedSlice(allocator),
+        .record_count = mod.import_records.len,
+        .allocator = allocator,
+    };
+}
+
+/// 재파싱 후의 모듈 위상이 `old` 스냅샷과 **위상 동일**한지 판정. 동일 = body-only edit
+/// (보존 가능). 다음 중 하나라도 다르면 false(=full 폴백):
+///   - import record 개수 변화
+///   - specifier 변화 (추가/삭제/수정) — 순서 포함 엄격 비교(parser 가 source 순서 보존)
+///   - kind 변화 (static ↔ dynamic ↔ require ↔ re_export 등)
+///   - resolve target path 변화 (같은 specifier 가 다른 파일로 해석 — resolve-diff)
+///   - dynamic_import diff
+///
+/// glob/require_context 가 새로 등장하면 new 쪽 record 의 kind 비교에서 자동으로 불일치.
+pub fn topologyMatches(old: *const ModuleTopologySnapshot, new_mod: *const ModuleGraph, new_idx: usize) bool {
+    if (new_idx >= new_mod.modules.count()) return false;
+    const mod = new_mod.modules.at(new_idx);
+    if (old.record_count != mod.import_records.len) return false;
+    if (old.entries.len != mod.import_records.len) return false;
+
+    for (old.entries, mod.import_records) |oe, rec| {
+        if (rec.kind == .glob or rec.kind == .require_context) return false;
+        if (oe.kind != rec.kind) return false;
+        if (oe.is_dynamic != (rec.kind == .dynamic_import)) return false;
+        if (!std.mem.eql(u8, oe.specifier, rec.specifier)) return false;
+        // resolve target diff: 새 resolved 타겟 path 를 구해 old 와 비교.
+        const new_target: ?[]const u8 = blk: {
+            if (rec.resolved.isNone()) break :blk null;
+            const ti = rec.resolved.toUsize();
+            if (ti >= new_mod.modules.count()) break :blk null;
+            break :blk new_mod.modules.at(ti).path;
+        };
+        const old_target = oe.resolved_target_path;
+        if (old_target == null and new_target == null) continue;
+        if (old_target == null or new_target == null) return false;
+        if (!std.mem.eql(u8, old_target.?, new_target.?)) return false;
+    }
+    return true;
+}
+
 /// 증분 빌드 결과.
 pub const IncrementalBuildResult = struct {
     /// 그래프 구조 또는 내용이 변경되었는지
@@ -1176,4 +1314,133 @@ test "F4 watch: entry 가 한 개로 축소되면 entry_dir 가 그 dirname 으�
 
     const single_entry = [_][]const u8{"/repo/src/a/index.ts"};
     try std.testing.expectEqualStrings("/repo/src/a", computeEntryDir(&single_entry));
+}
+
+// ============================================================
+// perf/hmr-graph-topology-reuse Phase A — topology snapshot/guard primitive 단위 테스트
+//
+// 이 테스트들이 corruption 방어의 핵심: snapshot 이 deinit 전에 (specifier,kind,target)을
+// 정확히 떠서, 재파싱 후 위상 동일/변화를 정확히 판정하는지 검증한다. graph 는 직접 조립
+// (addModule + parse_arena 소유 import_records) 해 resolve 파이프라인 없이 primitive 만 격리.
+// ============================================================
+
+const ResolveCache_t = @import("../resolve_cache.zig").ResolveCache;
+const ImportRecord_t = types.ImportRecord;
+const Span_t = @import("../../lexer/token.zig").Span;
+
+/// 테스트 헬퍼: 모듈의 import_records 를 parse_arena 소유로 세팅한다.
+/// (specifier, kind, resolved) 튜플 리스트로부터 record 를 만든다.
+fn tSetRecords(
+    graph: *ModuleGraph,
+    idx: usize,
+    recs: []const struct { spec: []const u8, kind: types.ImportKind, resolved: i64 },
+) !void {
+    const m = graph.modules.at(idx);
+    if (m.parse_arena == null) {
+        m.parse_arena = @import("../module.zig").createParseArena(graph.allocator) orelse return error.OutOfMemory;
+    }
+    const pa = m.parse_arena.?.allocator();
+    const out = try pa.alloc(ImportRecord_t, recs.len);
+    for (recs, 0..) |r, i| {
+        out[i] = .{
+            .specifier = try pa.dupe(u8, r.spec),
+            .kind = r.kind,
+            .span = Span_t.EMPTY,
+            .resolved = if (r.resolved < 0) types.ModuleIndex.none else types.ModuleIndex.fromUsize(@intCast(r.resolved)),
+        };
+    }
+    m.import_records = out;
+}
+
+test "topology: body-only edit 는 위상 동일 판정(보존 가능)" {
+    var cache = ResolveCache_t.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    // 0=index, 1=util. index → util (static). util → (none).
+    _ = try graph.addModule(std.testing.io, "/p/index.ts");
+    _ = try graph.addModule(std.testing.io, "/p/util.ts");
+    try tSetRecords(&graph, 0, &.{.{ .spec = "./util", .kind = .static_import, .resolved = 1 }});
+
+    var snap = (try snapshotModuleTopology(&graph, std.testing.allocator, 0)).?;
+    defer snap.deinit();
+
+    // body-only: 같은 record 로 재구성 (재파싱 시뮬레이션) → 위상 동일.
+    try tSetRecords(&graph, 0, &.{.{ .spec = "./util", .kind = .static_import, .resolved = 1 }});
+    try std.testing.expect(topologyMatches(&snap, &graph, 0));
+}
+
+test "topology: import specifier 추가 → 위상 변화(full)" {
+    var cache = ResolveCache_t.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    _ = try graph.addModule(std.testing.io, "/p/index.ts");
+    _ = try graph.addModule(std.testing.io, "/p/util.ts");
+    _ = try graph.addModule(std.testing.io, "/p/extra.ts");
+    try tSetRecords(&graph, 0, &.{.{ .spec = "./util", .kind = .static_import, .resolved = 1 }});
+
+    var snap = (try snapshotModuleTopology(&graph, std.testing.allocator, 0)).?;
+    defer snap.deinit();
+
+    // specifier 1 개 추가 → record_count 변화 → 불일치.
+    try tSetRecords(&graph, 0, &.{
+        .{ .spec = "./util", .kind = .static_import, .resolved = 1 },
+        .{ .spec = "./extra", .kind = .static_import, .resolved = 2 },
+    });
+    try std.testing.expect(!topologyMatches(&snap, &graph, 0));
+}
+
+test "topology: 같은 specifier 가 다른 파일로 resolve → resolve-diff(full)" {
+    var cache = ResolveCache_t.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    // 0=index, 1=util-old, 2=util-new. 같은 './util' specifier 가 1→2 로 타겟 변경.
+    _ = try graph.addModule(std.testing.io, "/p/index.ts");
+    _ = try graph.addModule(std.testing.io, "/p/util-old.ts");
+    _ = try graph.addModule(std.testing.io, "/p/util-new.ts");
+    try tSetRecords(&graph, 0, &.{.{ .spec = "./util", .kind = .static_import, .resolved = 1 }});
+
+    var snap = (try snapshotModuleTopology(&graph, std.testing.allocator, 0)).?;
+    defer snap.deinit();
+
+    // specifier 동일하지만 resolve 타겟 path 가 다름 → resolve-diff → 불일치.
+    try tSetRecords(&graph, 0, &.{.{ .spec = "./util", .kind = .static_import, .resolved = 2 }});
+    try std.testing.expect(!topologyMatches(&snap, &graph, 0));
+}
+
+test "topology: static → dynamic kind 변화 → 위상 변화(full)" {
+    var cache = ResolveCache_t.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    _ = try graph.addModule(std.testing.io, "/p/index.ts");
+    _ = try graph.addModule(std.testing.io, "/p/util.ts");
+    try tSetRecords(&graph, 0, &.{.{ .spec = "./util", .kind = .static_import, .resolved = 1 }});
+
+    var snap = (try snapshotModuleTopology(&graph, std.testing.allocator, 0)).?;
+    defer snap.deinit();
+
+    // 같은 specifier/target 이지만 static → dynamic → 불일치(dynamic_import diff).
+    try tSetRecords(&graph, 0, &.{.{ .spec = "./util", .kind = .dynamic_import, .resolved = 1 }});
+    try std.testing.expect(!topologyMatches(&snap, &graph, 0));
+}
+
+test "topology: glob record 는 스냅샷 거부(null → 보수적 full)" {
+    var cache = ResolveCache_t.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+
+    _ = try graph.addModule(std.testing.io, "/p/index.ts");
+    try tSetRecords(&graph, 0, &.{.{ .spec = "./pages/*.ts", .kind = .glob, .resolved = -1 }});
+
+    // glob 는 build-time FS 확장이라 위상 보존 대상 아님 → snapshot=null.
+    const snap = try snapshotModuleTopology(&graph, std.testing.allocator, 0);
+    try std.testing.expect(snap == null);
 }

--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -96,6 +96,61 @@ pub fn invalidateModule(self: *ModuleGraph, idx: ModuleIndex) void {
     mod_ptr.* = @import("../module.zig").Module.init(saved_index, saved_path);
 }
 
+/// perf/hmr-graph-topology-reuse Phase A — persistent_graph 재사용 빌드 직전 호출.
+///
+/// **현재(Phase A) 의미 = "fresh 와 byte-identical 한 안전 reset"**:
+/// graph 인스턴스(SegmentedList backing, path_to_module backing, path_arena, 옵션,
+/// pkg_info_cache)는 보존하되, **모든 모듈 슬롯을 비우고**(`modules` clear) graph-global
+/// state 를 reset 한다. 이후 `buildIncremental` 이 entry 부터 다시 discovery 하며 슬롯을
+/// 새로 append → 출력은 매 빌드 fresh graph 와 동일.
+///
+/// **왜 슬롯 in-place 보존(invalidateModule)이 아니라 전량 clear 인가 (정확성 근거):**
+///   1. body-only edit 의 위상 보존(edge/exec_index 재사용)은 `transferModulesToStore`
+///      (build_flow:transferModulesToStore)가 매 빌드 graph 모듈의 parse_arena /
+///      import_records / resolved_deps 소유권을 store 로 *이전*(=graph 쪽을 비움)하는 한
+///      불가능하다. 그 소유권 재설계는 plan 의 **Phase B(최대 리스크)** 라 Phase A 범위 밖.
+///   2. invalidateModule 로 슬롯만 `.reserved` 로 되돌리고 보존하면, **모듈이 제거되는
+///      위상 변화**에서 옛 슬롯이 orphan 으로 남는다. `buildIncremental` 의 sequential
+///      루프는 `parse_start..modules.count()` 전 범위를 돌며 `.reserved` 슬롯을 무조건
+///      reparse → emitter(emitter.zig:400 `m.ast != null` 필터)가 *더 이상 import 되지
+///      않는 제거된 모듈을 그대로 emit* → silent corruption. `path_to_module` 도 그 orphan
+///      을 가리켜 다음 빌드 dedup 이 stale 슬롯을 hit.
+///   → 따라서 Phase A 는 슬롯을 보존하지 않는다. clear 후 fresh discovery 가 유일하게
+///      byte-identical 을 보장하는 경로다. (slot/edge 재사용은 Phase B 에서
+///      transferModulesToStore 비활성 + orphan prune 과 함께 도입.)
+///
+/// **보존 영역**: graph struct 자체(call-site 가 deinit/재init 을 피함 — 객체 수명 안정),
+/// modules SegmentedList 의 *backing chunk*(clearRetainingCapacity 로 재사용),
+/// path_to_module *backing*(clear 후 재채움), path_arena.
+///
+/// **재설정(reset) 영역**: reset() 가 비우는 graph-global state 전체 + modules + path_to_module.
+///
+/// path_arena: clearRetainingCapacity 로 **메모리 보존 + 논리적 비움**. 이전 빌드 path
+/// 슬라이스는 modules/path_to_module 가 비워져 더 이상 참조되지 않으므로 재사용 안전
+/// (monotonic 누적 없이 capacity 재활용). retainCapacity 라 RSS 단방향 증가 없음.
+pub fn prepareForPreservedRebuild(self: *ModuleGraph) void {
+    // 1) 모든 모듈 슬롯 해제 (parse_arena 가 아직 graph 소유면 함께 해제 —
+    //    transferModulesToStore 가 이미 store 로 넘긴 경우 parse_arena=null 이라 no-op).
+    var mod_it = self.modules.iterator(0);
+    while (mod_it.next()) |m| {
+        m.deinit(self.allocator);
+    }
+    self.modules.clearRetainingCapacity();
+
+    // 2) path → idx 인덱스 비움 (backing 재사용).
+    self.path_to_module.clearRetainingCapacity();
+
+    // 3) path_arena 논리적 비움 + capacity 보존 (위 doc: 더 이상 참조 없음).
+    _ = self.path_arena.reset(.retain_capacity);
+
+    // 4) entry_dir 은 graph-owned dupe — buildIncremental 의 entry_dir 재계산이 free 후
+    //    재dupe 하므로 여기서 건드리지 않는다(이중 free 방지). project_root 자동 추론도 동일.
+
+    // 5) graph-global per-build state reset (diagnostics / worker_entries / lazy_seeds /
+    //    requested_exports / source_read_cache / exec/cycle counter).
+    reset(self);
+}
+
 pub fn deinit(self: *ModuleGraph) void {
     // 0.16: entry_dir 는 graph-owned dupe (build_flow). project_root 는 entry_dir
     // 로의 borrow 또는 user-set borrow 라 별도 free 안 함.

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -256,15 +256,24 @@ pub const IncrementalBundler = struct {
             if (self.preserved_renames) |*pr| opts.preserved_renames = pr;
         }
 
-        // RFC #3933 Sub-PR-B.2 — enable_persistence opt-in path. Bundler.initWithGraph wire-up.
+        // RFC #3933 Sub-PR-B.2 + perf/hmr-graph-topology-reuse Phase A — enable_persistence
+        // opt-in path. Bundler.initWithGraph wire-up.
         //
-        // **정확성 가드 (본 PR scope 제한)**: graph state 의 selective invalidate 는 Sub-PR-B.3
-        // 영역. 본 PR 은 매 빌드 graph 를 *fresh init* (이전 graph 는 deinit) — 즉 실측 효과 0,
-        // API path 만 작동. persistent_graph 의 *진짜 reuse + replay short-circuit* 은 B.3 에서.
+        // **Phase A 의미**: persistent_graph 를 빌드 *간* 보존한다(매 빌드 deinit/재init 폐기).
+        // 첫 빌드는 init, 이후 빌드는 같은 graph 를 재사용 — bundle() 의 external_graph 훅
+        // (bundler.zig)이 빌드 직전 `prepareForPreservedRebuild` 로 모듈을 비워 fresh 와
+        // byte-identical 출력을 보장한다(graph struct/backing/path_arena 재사용 → 객체 수명
+        // 안정 + alloc 절감). 위상 보존(edge/exec_index 재사용)은 transferModulesToStore
+        // 소유권 재설계가 필요해 Phase B 로 분리.
+        //
+        // **정확성 가드**: graph_changed(아래 pathSetsEqual)가 위상 변화(모듈 추가/삭제)를
+        // 감지하면 그 빌드 자체는 prepareForPreservedRebuild 로 fresh discovery 라 정확하다.
+        // (Phase B 의 selective edge-reuse 도입 시 여기서 추가 fallback 가드가 필요.)
         var bundler = blk: {
             if (!self.enable_persistence) break :blk Bundler.initWithResolveCache(self.allocator, opts, &self.resolve_cache.?);
-            if (self.persistent_graph) |*pg| pg.deinit();
-            self.persistent_graph = ModuleGraph.init(self.allocator, &self.resolve_cache.?);
+            if (self.persistent_graph == null) {
+                self.persistent_graph = ModuleGraph.init(self.allocator, &self.resolve_cache.?);
+            }
             break :blk Bundler.initWithGraph(self.allocator, opts, &self.resolve_cache.?, &self.persistent_graph.?);
         };
         defer bundler.deinit(); // resolve_cache_external=true이므로 resolve_cache는 해제 안 됨

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -1176,3 +1176,327 @@ test "IncrementalBundler enable_persistence=false: default off, persistent_graph
     // default off 면 persistent_graph 미사용
     try std.testing.expect(ib.persistent_graph == null);
 }
+
+// ============================================================
+// perf/hmr-graph-topology-reuse Phase A — byte-identical 정확성 (corruption 방어 핵심)
+//
+// 보존(persistent_graph 재사용) 경로로 rebuild 한 *full 번들 출력* 이 같은 입력을 fresh full
+// 로 빌드한 출력과 **바이트 동일** 한지 검증한다. 이것이 silent corruption 방어의 핵심.
+// Bundler 를 직접 구동해(IncrementalBundler 는 rebuild 시 skip_bundle_output 이라 full output
+// 미생성) external_graph + module_store 보존 경로의 full output 을 fresh 와 대조한다.
+// ============================================================
+
+const ModuleGraph_t = @import("graph.zig").ModuleGraph;
+
+/// 보존 경로 한 빌드 헬퍼: 같은 graph/store/resolve_cache 를 재사용해 full output 빌드.
+/// changed 가 non-null 이면 그 set 을 changed_files 로 전달(web doBuild 와 동형). dev_mode
+/// full output(skip_bundle_output=false)으로 비교 가능한 result.output 을 만든다.
+fn preservedBuild(
+    graph: *ModuleGraph_t,
+    store: *module_store.PersistentModuleStore,
+    rc: *@import("resolve_cache.zig").ResolveCache,
+    entry: []const u8,
+    is_first: bool,
+    changed: ?*const std.StringHashMapUnmanaged(void),
+) !BundleResult {
+    var opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+    });
+    if (!is_first) {
+        opts.module_store = store;
+        opts.changed_files = changed;
+    }
+    var b = Bundler.initWithGraph(std.testing.allocator, opts, rc, graph);
+    defer b.deinit();
+    return try b.bundle(std.testing.io);
+}
+
+test "Phase A byte-identical: 보존 rebuild 출력 == fresh full (body-only edit)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    // 보존 graph + store + resolve_cache 세팅 (web doBuild 와 동형).
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    // build 1 (first): 보존 graph init 채움.
+    {
+        var r1 = try preservedBuild(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    // build 2 (warm seed, 변경 없음 — store/graph 워밍).
+    {
+        var r2 = try preservedBuild(&graph, &store, &rc, entry, false, null);
+        defer r2.deinit(std.testing.allocator);
+        try std.testing.expect(!r2.hasErrors());
+    }
+
+    // index.ts body-only edit (import 위상 불변).
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x + 1);");
+
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    // build 3 (보존 경로 rebuild) — full output.
+    var preserved = try preservedBuild(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    // fresh full (store/graph 없음, 수정된 파일 읽음).
+    var fresh = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer fresh.deinit();
+    var fresh_result = try fresh.bundle(std.testing.io);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    // 핵심: 보존 rebuild 출력 == fresh full 출력 (byte-identical).
+    try std.testing.expect(preserved.output.len > 0);
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+}
+
+test "Phase A byte-identical: A→B→A 반복 후에도 fresh full 과 동일" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x, 'A');");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuild(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+
+    const variants = [_][]const u8{
+        "import { x } from './util';\nconsole.log(x, 'B');",
+        "import { x } from './util';\nconsole.log(x, 'A');",
+        "import { x } from './util';\nconsole.log(x, 'B');",
+        "import { x } from './util';\nconsole.log(x, 'A');",
+    };
+    for (variants) |src| {
+        std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+        try writeFile(tmp.dir, "index.ts", src);
+        var touched: std.StringHashMapUnmanaged(void) = .empty;
+        defer touched.deinit(std.testing.allocator);
+        try touched.put(std.testing.allocator, entry, {});
+
+        var preserved = try preservedBuild(&graph, &store, &rc, entry, false, &touched);
+        defer preserved.deinit(std.testing.allocator);
+        try std.testing.expect(!preserved.hasErrors());
+
+        var fresh = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+        defer fresh.deinit();
+        var fresh_result = try fresh.bundle(std.testing.io);
+        defer fresh_result.deinit(std.testing.allocator);
+        try std.testing.expect(!fresh_result.hasErrors());
+
+        try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+    }
+}
+
+test "Phase A byte-identical: 모듈 추가(import 신규) 후에도 보존 graph 가 fresh 와 동일" {
+    // 위상 변화(모듈 추가): 보존 graph 가 prepareForPreservedRebuild 로 매 빌드 fresh
+    // discovery 라 추가/삭제도 정확. orphan slot 누수 없이 byte-identical 이어야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "extra.ts", "export const y = 2;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuild(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const mod_count_before = graph.modules.count();
+
+    // 새 import 추가 → extra.ts 가 그래프에 등장(모듈 추가, 위상 변화).
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts",
+        \\import { x } from './util';
+        \\import { y } from './extra';
+        \\console.log(x, y);
+    );
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuild(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer fresh.deinit();
+    var fresh_result = try fresh.bundle(std.testing.io);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    // 모듈 추가가 반영(보존 graph 가 fresh discovery)되고, 출력이 byte-identical.
+    try std.testing.expect(graph.modules.count() > mod_count_before);
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+}
+
+test "Phase A byte-identical: 모듈 제거(import 삭제) 후에도 보존 graph 가 fresh 와 동일 (orphan 누수 0)" {
+    // 위상 변화(모듈 제거): 제거된 모듈이 보존 graph 의 orphan slot 으로 남아 emit 에 새는
+    // corruption 을 차단하는지 검증. prepareForPreservedRebuild 의 modules 전량 clear 가
+    // 핵심 — fresh 와 byte-identical 이면 제거 모듈이 새지 않음을 증명.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "extra.ts", "export const y = 2;");
+    try writeFile(tmp.dir, "index.ts",
+        \\import { x } from './util';
+        \\import { y } from './extra';
+        \\console.log(x, y);
+    );
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuild(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+
+    // extra.ts import 제거 → extra.ts 가 그래프에서 빠져야 함(위상 변화: 제거).
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuild(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer fresh.deinit();
+    var fresh_result = try fresh.bundle(std.testing.io);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    // 핵심: 제거된 extra.ts 의 export(`const y = 2`) 가 보존 출력에 *없어야* 한다 + byte-identical.
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+}
+
+test "Phase A: 보존 graph 반복 rebuild leak 0 (GPA) — IncrementalBundler enable_persistence" {
+    // testing.allocator(GPA) 가 deinit 시 leak 검출. 보존 graph 를 여러 번 rebuild 해도
+    // path_arena retain_capacity + 모듈 전량 deinit 이 정확해 leak 0 이어야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var ib = IncrementalBundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .collect_module_codes = true,
+    });
+    ib.enable_persistence = true;
+    defer ib.deinit();
+
+    // 첫 빌드 + 여러 body-only rebuild.
+    {
+        const r = try ib.rebuild(std.testing.io);
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    const payloads = [_][]const u8{
+        "import { x } from './util';\nconsole.log(x, 1);",
+        "import { x } from './util';\nconsole.log(x, 2);",
+        "import { x } from './util';\nconsole.log(x, 3);",
+        "import { x } from './util';\nconsole.log(x, 4);",
+    };
+    for (payloads) |src| {
+        std.testing.io.sleep(std.Io.Duration.fromMilliseconds(20), .awake) catch {};
+        try writeFile(tmp.dir, "index.ts", src);
+        const r = try ib.rebuild(std.testing.io);
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    // 보존 graph 가 살아있고 leak 없이 deinit 가능(아래 defer ib.deinit + GPA 검출).
+    try std.testing.expect(ib.persistent_graph != null);
+}
+
+test "Phase A: enable_persistence + resolve_cache reset(interval) 교차 안전 (#3751 정합)" {
+    // 보존 graph 의 resolve_cache 포인터는 &self.resolve_cache.? (stable address). interval
+    // reset 으로 resolve_cache 가 deinit+재생성돼도 그 빌드 직전 prepareForPreservedRebuild 가
+    // 모듈을 전량 비워 stale interned ref 가 남지 않는다. UAF/double-free/leak 없이 진행.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var ib = IncrementalBundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .collect_module_codes = true,
+    });
+    ib.enable_persistence = true;
+    ib.rebuild_reset_interval = 2; // 빠른 reset 유도.
+    defer ib.deinit();
+
+    var i: usize = 0;
+    while (i < 6) : (i += 1) {
+        std.testing.io.sleep(std.Io.Duration.fromMilliseconds(20), .awake) catch {};
+        const src = try std.fmt.allocPrint(std.testing.allocator, "import {{ x }} from './util';\nconsole.log(x, {d});", .{i});
+        defer std.testing.allocator.free(src);
+        try writeFile(tmp.dir, "index.ts", src);
+        const r = try ib.rebuild(std.testing.io);
+        switch (r) {
+            .success => |s| freeChanged(s.changed_modules),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    try std.testing.expect(ib.persistent_graph != null);
+}

--- a/src/bundler/module_list.zig
+++ b/src/bundler/module_list.zig
@@ -63,6 +63,15 @@ pub fn StableSegmentedList(comptime T: type) type {
             self.len = 0;
         }
 
+        /// `len` 만 0 으로 — shelf chunk 할당은 보존(다음 append 가 재사용).
+        /// perf/hmr-graph-topology-reuse Phase A: persistent_graph 재사용 시
+        /// 모듈 슬롯을 논리적으로 비우되 backing 메모리를 재활용한다. caller 는 비우기
+        /// *전에* 각 element 의 deinit(Module.deinit) 을 직접 호출할 책임이 있다 —
+        /// 이 함수는 element 소유 리소스를 해제하지 않는다(len reset 만).
+        pub fn clearRetainingCapacity(self: *Self) void {
+            self.len = 0;
+        }
+
         pub fn append(self: *Self, allocator: Allocator, item: T) !void {
             const idx = self.len;
             const shelf_idx = shelfIndex(idx);


### PR DESCRIPTION
graph 170ms incremental 의 정확성 토대. enable_persistence 를 연결해
persistent_graph 를 빌드 간 보존하고, body-only edit 감지용 topology
snapshot/guard(specifier/kind/resolve-target diff)를 build_flow 에 추가.

핵심 제약 발견: web IncrementalBundler 는 매 빌드 transferModulesToStore 가
graph 모듈 소유권을 store 로 이전(graph 비움)해, 슬롯 in-place 보존 시 모듈
제거가 orphan 슬롯 → emitter 가 제거 모듈 emit → corruption. 따라서 Phase A 는
슬롯 보존 대신 전량 clear 후 fresh discovery(graph struct/backing/path_arena 만
재사용)로 byte-identical 을 보장한다. 실제 edge-reuse 절감은 Phase B
(transferModulesToStore 비활성 + orphan prune)에 분리.

renumber.zig 미수정(위상 불변=identity). 위상 변화는 full fallback(fail-safe).
byte-identical: body-only/A→B→A/모듈 추가/모듈 제거(orphan 누수 0) 전부 fresh
full 과 바이트 동일. leak 0. zig build napi + test 통과.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
