### PR TITLE
perf(graph): HMR 위상 보존 edge-reuse (Phase B — web graph 절감 + /code-review max 수정)

### DIFF
--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -923,6 +923,21 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     var persistent_store = module_store_mod.PersistentModuleStore.init(allocator);
     defer persistent_store.deinit();
 
+    // perf/hmr-graph-topology-reuse Phase B — RN watch worker 의 보존 graph + resolve cache.
+    // RN 은 IncrementalBundler 를 거치지 않고 Bundler 를 직접 구동하므로, 보존 graph 를 worker
+    // 함수 스코프에 직접 보유해 빌드 간 유지한다(initWithGraph). 초기/rebuild 모두 같은 graph +
+    // 같은 resolve_cache 를 재사용 → rebuild 에서 preserve_topology=true 로 buildIncrementalPreserved
+    // (edge-reuse) 진입. 위상 변화/feature(runtime polyfill·asset 등) 시 graph 내부에서 full fallback.
+    //
+    // **수명/소유권 (defer LIFO)**: persistent_resolve_cache → persistent_graph 순서로 선언해
+    // graph.deinit 이 resolve_cache.deinit *전에* 실행되도록 한다(graph 가 resolve_cache 포인터
+    // 보유). graph 가 parse_arena 단독 owner(transferModulesToStore 비활성, bundler.zig) 라
+    // persistent_store 는 비어 double-free 없음. store/graph 둘 다 같은 함수 스코프 defer.
+    var persistent_resolve_cache = Bundler.initResolveCacheFromOptions(allocator, bundle_opts);
+    defer persistent_resolve_cache.deinit();
+    var persistent_graph = bundler_mod.ModuleGraph.init(allocator, &persistent_resolve_cache);
+    defer persistent_graph.deinit();
+
     var initial_opts = bundle_opts;
     initial_opts.module_store = &persistent_store;
     initial_opts.compiled_cache = &async_data.compiled_cache;
@@ -936,12 +951,24 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     // (BundleResult.rename_snapshot 으로 반환). preserved_renames 는 첫 빌드에 주입 대상이
     // 없으므로 여기서 주지 않는다.
     initial_opts.reuse_renames = bundle_opts.dev_mode;
+    // Phase B: 초기 빌드도 preserve_topology=true. graph 가 비어있어 buildIncrementalPreserved 의
+    // cold 분기(modules.count()==0)가 full discovery(buildIncremental)로 처리하지만, 빌드 끝의
+    // transferModulesToStore 가 비활성(bundler.zig, preserve_topology) 되어 parse_arena 가 store 로
+    // 양도되지 않고 graph 에 남는다 → 다음 rebuild 의 보존 경로가 그 arena 를 재사용. preserve_topology
+    // 없이 module_store 만 주면 transferModulesToStore 가 graph 를 비워 다음 rebuild 보존이 깨진다.
+    initial_opts.preserve_topology = true;
     // Lazy sourcemap (Issue #1727 Phase B): dev watch 세션에서는 initial/rebuild 모두
     // builder 를 handle 에 캐시해 `/bundle.js.map`, `/hmr-map/:id` 요청을 즉석 서빙.
     // rebuild 경로의 `emit_sourcemap_finalize` 29ms 를 HMR latency 밖으로 빼낸다.
     if (bundle_opts.dev_mode and bundle_opts.sourcemap.enable) initial_opts.sourcemap.lazy = true;
 
-    var bundler = Bundler.init(allocator, initial_opts);
+    // Phase B: 초기 빌드도 보존 graph + resolve cache 로 구동(initWithGraph). preserve_topology
+    // 는 set 하지 않는다(graph 비어있음 = cold discovery). 이 빌드가 graph 를 warm 으로 만들어
+    // 다음 rebuild 가 buildIncrementalPreserved(edge-reuse)로 진입할 수 있게 한다. transfer
+    // ModulesToStore 비활성(preserve_topology=false 라 여기선 store 로 양도되지만, 첫 빌드는
+    // 위상 변화 가드 무관 — 다음 rebuild 가 preserve_topology=true 면 store 양도가 비활성되어
+    // graph 가 단독 owner 로 굳는다).
+    var bundler = Bundler.initWithGraph(allocator, initial_opts, &persistent_resolve_cache, &persistent_graph);
     defer bundler.deinit();
     var result = bundler.bundle(common.io()) catch |err| {
         // 초기 빌드 실패 — rebuild 이벤트로 에러 전달
@@ -1013,8 +1040,8 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         result.sourcemap_builder = null;
     }
 
-    var persistent_resolve_cache = Bundler.initResolveCacheFromOptions(allocator, bundle_opts);
-    defer persistent_resolve_cache.deinit();
+    // persistent_resolve_cache 는 Phase B 보존 graph 와 함께 worker 초입(persistent_store 직후)
+    // 에서 선언됐다 — 초기 빌드도 같은 cache 를 쓰도록 앞당겼다(과거엔 여기서 별도 선언).
 
     // Issue #1223 Phase 1: 이벤트 기반 파일 워처 (kqueue/inotify, mtime 폴백).
     // 실패 시 워치 스레드 진입 직전에 종료한다.
@@ -1333,7 +1360,13 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             force_snapshot_buf = snap;
             break :blk snap;
         };
-        var rebundler = Bundler.initWithResolveCache(allocator, incremental_opts, &persistent_resolve_cache);
+        // Phase B: 보존 graph + preserve_topology 로 buildIncrementalPreserved(edge-reuse) 진입.
+        // 변경 모듈만 재파싱하고 나머지 위상/edge/parse_arena 를 보존(graphDiscover 절감). 위상 변화
+        // (모듈 추가/삭제, specifier/resolve 변화, 동적 import) 또는 feature(plugin/MF/splitting/
+        // runtime polyfill/asset/worker) 시 graph 내부에서 prepareForPreservedRebuild + full
+        // discovery 로 fallback → 셋(보존 hit / fallback / 원래 fresh) 다 byte-identical.
+        incremental_opts.preserve_topology = true;
+        var rebundler = Bundler.initWithGraph(allocator, incremental_opts, &persistent_resolve_cache, &persistent_graph);
         defer rebundler.deinit();
 
         var rebuild_result = rebundler.bundle(common.io()) catch |err| {

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -962,12 +962,12 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     // rebuild 경로의 `emit_sourcemap_finalize` 29ms 를 HMR latency 밖으로 빼낸다.
     if (bundle_opts.dev_mode and bundle_opts.sourcemap.enable) initial_opts.sourcemap.lazy = true;
 
-    // Phase B: 초기 빌드도 보존 graph + resolve cache 로 구동(initWithGraph). preserve_topology
-    // 는 set 하지 않는다(graph 비어있음 = cold discovery). 이 빌드가 graph 를 warm 으로 만들어
-    // 다음 rebuild 가 buildIncrementalPreserved(edge-reuse)로 진입할 수 있게 한다. transfer
-    // ModulesToStore 비활성(preserve_topology=false 라 여기선 store 로 양도되지만, 첫 빌드는
-    // 위상 변화 가드 무관 — 다음 rebuild 가 preserve_topology=true 면 store 양도가 비활성되어
-    // graph 가 단독 owner 로 굳는다).
+    // Phase B: 초기 빌드도 보존 graph + resolve cache 로 구동(initWithGraph). 위(959)에서 이미
+    // preserve_topology=true 로 설정했으므로 빌드 끝의 transferModulesToStore 가 비활성되어
+    // parse_arena 가 store 로 양도되지 않고 graph 에 남는다 → graph 가 단독 owner 로 굳어, 다음
+    // rebuild 가 그 warm graph 로 buildIncrementalPreserved(edge-reuse)에 진입한다. (cold 빌드는
+    // graph 가 비어 buildIncrementalPreserved 가 modules.count()==0 분기로 full discovery 폴백 —
+    // 위상 변화 가드 무관.)
     var bundler = Bundler.initWithGraph(allocator, initial_opts, &persistent_resolve_cache, &persistent_graph);
     defer bundler.deinit();
     var result = bundler.bundle(common.io()) catch |err| {

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -397,6 +397,13 @@ pub const BundleOptions = struct {
     /// 재사용할 보존 스냅샷 (borrowed, IncrementalBundler 소유). `reuse_renames=true`
     /// 일 때만 의미. null 이면 가드 평가 없이 기존 computeRenames.
     preserved_renames: ?*const @import("symbol.zig").PreservedRenames = null,
+    /// perf/hmr-graph-topology-reuse Phase B — 위상(topology) 보존 모드.
+    /// `external_graph` (initWithGraph) 와 함께일 때만 의미. true 면 (1) bundle() 이 매
+    /// 빌드 graph 를 전량 clear(prepareForPreservedRebuild)하지 않고 graph.buildIncrementalPreserved
+    /// 가 변경 모듈만 선택 재파싱(edge-reuse short-circuit, 위상 변화 시 내부 full fallback),
+    /// (2) `transferModulesToStore` 를 비활성(graph 가 parse_arena 단독 owner — store 양도 0).
+    /// IncrementalBundler.enable_persistence / RN watch worker 가 set. default false → Phase A 동작.
+    preserve_topology: bool = false,
     /// 활성화할 디버그 로그 카테고리 (ZNTC_DEBUG env 와 합집합).
     /// 예: `&.{"compiled_cache", "hmr"}`. 카테고리 enum 은 `src/debug_log.zig` 참조.
     debug: []const []const u8 = &.{},
@@ -1175,17 +1182,22 @@ pub const Bundler = struct {
             owned_graph_storage = ModuleGraph.init(self.allocator, self.getResolveCache());
         }
         const graph: *ModuleGraph = if (self.external_graph) |g| g else &owned_graph_storage;
-        // perf/hmr-graph-topology-reuse Phase A — 보존된 external_graph 재사용 훅.
+        // perf/hmr-graph-topology-reuse — 보존된 external_graph 재사용 훅.
         // external_graph 가 *이미 모듈을 가진* 상태(=직전 빌드의 결과)면, 이번 빌드 전에
-        // 반드시 reset 해야 stale 모듈/edge 가 새 빌드를 오염시키지 않는다. Phase A 의
-        // prepareForPreservedRebuild 는 모듈을 전량 비워 매 빌드 fresh graph 와 byte-identical
-        // 출력을 보장한다(graph struct/backing/path_arena 만 재사용 — 객체 수명 안정 + alloc 절감).
-        // 위상 보존(edge/exec_index 재사용)은 transferModulesToStore 소유권 재설계가 필요해
-        // Phase B 로 분리. 따라서 여기 reset 은 빌드 종류(plugin/MF/glob/splitting 등)와 무관하게
-        // 항상 안전.
-        if (has_external_graph and graph.moduleCount() > 0) {
+        // stale 모듈/edge 가 새 빌드를 오염시키지 않도록 처리해야 한다. 두 모드:
+        //
+        // - **Phase A (preserve_topology=false)**: prepareForPreservedRebuild 로 모듈을 전량
+        //   비워 매 빌드 fresh discovery → byte-identical(graph struct/backing/path_arena 만 재사용).
+        //
+        // - **Phase B (preserve_topology=true)**: 여기서 clear 하지 *않는다*. graph 가 직전 빌드의
+        //   모듈/edge/parse_arena 를 그대로 보유한 채 buildIncrementalPreserved 로 진입 →
+        //   변경 모듈만 선택 재파싱(edge-reuse). 위상 변화 가드 위반 시 그 함수 내부에서
+        //   prepareForPreservedRebuild + full fresh discovery 로 fallback(byte-identical full).
+        //   따라서 Phase B 에선 여기서 graph 를 비우면 안 된다(보존이 무효화됨).
+        if (has_external_graph and graph.moduleCount() > 0 and !self.options.preserve_topology) {
             graph.prepareForPreservedRebuild();
         }
+        graph.preserve_topology = self.options.preserve_topology;
         // this.emitFile (PR5): plugin 이 emit 한 asset 수집소. graph build 가 plugin hook 을
         // 호출하기 *전* 에 연결해야 한다. emit 된 asset 은 아래에서 OutputFile(kind=.asset)로
         // 복사되어 final_asset_outputs 에 합쳐지고, store 는 scratch 라 bundle() 종료 시 해제.
@@ -1260,7 +1272,14 @@ pub const Bundler = struct {
             var gb_scope = profile.begin(.graph_build);
             defer gb_scope.end();
             if (self.options.module_store) |store| {
-                const inc_result = try graph.buildIncremental(io, self.options.entry_points, store, self.options.changed_files);
+                // Phase B: preserve_topology(+external_graph) 면 위상 보존 증분 빌드(edge-reuse).
+                // 아니면 기존 buildIncremental(store cache-hit 기반). external_graph 없이
+                // preserve_topology 만 켜는 건 무의미(graph 보존이 없으면 매 빌드 cold) — 그
+                // 경우 owned graph 라 buildIncrementalPreserved 의 cold 분기가 full 로 처리.
+                const inc_result = if (self.options.preserve_topology and has_external_graph)
+                    try graph.buildIncrementalPreserved(io, self.options.entry_points, store, self.options.changed_files)
+                else
+                    try graph.buildIncremental(io, self.options.entry_points, store, self.options.changed_files);
                 reparsed_count = inc_result.reparsed_indices.len;
                 if (inc_result.reparsed_indices.len > 0) {
                     const list = try self.allocator.alloc([]const u8, inc_result.reparsed_indices.len);
@@ -2349,8 +2368,17 @@ pub const Bundler = struct {
         // 증분 빌드: graph.deinit() 전에 모듈을 store로 이전.
         // putModule이 parse_arena 소유권을 store로 가져가므로
         // graph.deinit()에서 이중 해제가 발생하지 않는다.
+        //
+        // **Phase B (preserve_topology)**: transferModulesToStore 비활성. 보존 모드에선 graph 가
+        // 빌드 사이 parse_arena 를 단독 소유(다음 빌드 buildIncrementalPreserved 가 보존된 arena 를
+        // 그대로 재사용)한다. 여기서 store 로 양도하면 graph(external_graph 라 deinit 안 됨)와 store 가
+        // 같은 parse_arena 를 동시에 참조 → store.deinit + 다음 빌드 graph 의 reuse 사이에서
+        // double-free/UAF. 보존 모드에선 store 를 채우지 않아 buildIncrementalPreserved 의 cache-hit
+        // 경로(있다면 fallback 의 buildIncremental)도 전량 cache-miss = full parse 로 정합을 맞춘다.
         if (self.options.module_store) |store| {
-            graph.transferModulesToStore(io, store);
+            if (!self.options.preserve_topology) {
+                graph.transferModulesToStore(io, store);
+            }
         }
 
         var first_err: ?*const types.BundlerDiagnostic = null;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -125,6 +125,25 @@ pub const ModuleGraph = struct {
     /// (CLI / 첫 빌드 외부) 에서는 false — caller 자체가 없어 fstat 불필요.
     /// 5000-module 합성 벤치에서 fstat ~5000 회 절감.
     incremental_mode: bool = false,
+    /// perf/hmr-graph-topology-reuse Phase B — 위상(topology) 보존 모드.
+    /// true 면 (1) `transferModulesToStore` 가 비활성(graph 가 parse_arena 단독 owner —
+    /// store 로 양도하지 않음), (2) bundler external_graph 훅이 매 빌드 graph 를 전량 clear
+    /// (prepareForPreservedRebuild) 하지 않고 `buildIncrementalPreserved` 가 변경 모듈만
+    /// 선택적으로 재파싱(edge-reuse short-circuit)한다. 위상 변화(모듈 추가/삭제, specifier/
+    /// resolve target 변화)면 안에서 full fallback. enable_persistence(IncrementalBundler) /
+    /// RN watch worker 가 set. default false → 기존 경로(Phase A) 영향 0.
+    preserve_topology: bool = false,
+    /// Phase B 관측용 카운터(누적). edge-reuse short-circuit 가 성공(보존-hit)한 빌드 수와
+    /// 위상 변화/불확실로 full fallback 한 빌드 수. ZNTC_DEBUG / 단위 테스트가 "이번 rebuild 가
+    /// 실제 보존 경로를 탔는지(전량 fallback 이 아닌지)" 검증하는 데 사용. 빌드 정확성과 무관.
+    topology_preserved_hits: usize = 0,
+    topology_fallback_count: usize = 0,
+    /// Phase B edge-reuse 내부 플래그 — 변경 모듈 *재resolve* 중에만 일시적으로 true.
+    /// true 면 `linkDependency`/`linkDynamicImport` 가 no-op (보존된 edge 리스트를 그대로 두고
+    /// import_records[].resolved + resolved_deps 만 재구성하기 위함). 보존 모드에서 변경 모듈의
+    /// edge 를 unlink/relink 하면 dep.importers 내 위치가 바뀌어 byte-identical 이 깨지므로,
+    /// edge 는 invalidate 전 스냅샷으로 보존하고 link 단계만 억제한다. 재resolve 종료 즉시 false 복구.
+    suppress_edge_link: bool = false,
     /// dev mode: HMR을 위해 모든 모듈을 강제 래핑 (__esm).
     dev_mode: bool = false,
     /// `output.inlineDynamicImports` 런타임 부분. true 면 dynamic-import target 모듈을
@@ -356,6 +375,9 @@ pub const ModuleGraph = struct {
 
     pub const IncrementalBuildResult = graph_build_flow.IncrementalBuildResult;
     pub const buildIncremental = graph_build_flow.buildIncremental;
+    /// perf/hmr-graph-topology-reuse Phase B — 위상 보존 증분 빌드(edge-reuse short-circuit).
+    /// `preserve_topology=true` 일 때 bundler 가 buildIncremental 대신 호출.
+    pub const buildIncrementalPreserved = graph_build_flow.buildIncrementalPreserved;
     pub const getMtime = graph_build_flow.getMtime;
     pub const transferModulesToStore = graph_build_flow.transferModulesToStore;
 

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -1203,12 +1203,14 @@ pub fn buildIncrementalPreserved(
             if (ui >= self.modules.count()) {
                 return fallbackFullRebuild(self, io, entry_points, store, changed_files);
             }
-            // **lazy-barrel 가드 (requested_exports over-approx 회피)**: topologyMatches 는
-            // specifier/kind/resolve-target 만 보고 *imported 이름 집합* 은 안 본다. 보존 경로는
-            // requested_exports 를 reset 하지 않으므로, sideEffects:false re-export barrel 에서
-            // named import 가 *제거* 되면 옛 요청이 남아(over-approx) link 결정이 fresh 와 달라질
-            // 수 있다(shouldLinkResolvedRecordForModule). 변경 모듈이 그런 barrel 후보면 보수적
-            // full fallback. (일반 모듈은 isLazyBarrelCandidate=false → 항상 link → 영향 없음.)
+            // **lazy-barrel 가드**: topologyMatches 는 specifier/kind/resolve-target 만 보고
+            // *imported 이름 집합* 은 안 본다. resetPerBuildStateForPreserved 가 requested_exports 를
+            // 전량 reset 하므로 over-approx(옛 요청 잔존)는 사라졌지만, 보존 경로는 unchanged barrel
+            // importer 를 재resolve 하지 않아 그 요청이 *under-approx*(비어 있음) 될 수 있다 — 비-dev
+            // 에서 sideEffects:false re-export barrel 의 link 결정(shouldLinkResolvedRecordForModule)
+            // 이 fresh 와 달라질 위험. 변경 모듈이 그런 barrel 후보면 보수적 full fallback. 현재
+            // canPreserveTopology 의 `!dev_mode` 게이트 + isLazyBarrelCandidate 의 dev=false 로 dev
+            // 보존 경로에선 dead 지만, 비-dev 보존이 미래에 켜질 때를 위한 방어로 유지.
             if (graph_requested_exports.isLazyBarrelCandidate(self, self.modules.at(ui))) {
                 return fallbackFullRebuild(self, io, entry_points, store, changed_files);
             }
@@ -1405,13 +1407,22 @@ fn canPreserveTopology(self: *const ModuleGraph) bool {
 }
 
 /// 보존 경로 진입 시 per-build global state 만 reset(modules/edges/resolved_deps/parse_arena/
-/// requested_exports/pkg_info_cache 는 보존). `lifecycle.reset()` 의 부분집합:
+/// pkg_info_cache 는 보존). `lifecycle.reset()` 의 부분집합:
 ///   - diagnostics + owned_diagnostic_strings (변경 모듈 재파싱이 자기 diag 재생성)
 ///   - source_read_cache (변경 파일 fresh read 강제)
 ///   - exec_counter / cycle_counter (finalizeGraph DFS 가 0 부터 재부여 → fresh 와 동일 exec_index)
-/// requested_exports 는 reset 하지 *않는다* — unchanged 모듈의 export 요청 상태를 보존(변경 모듈
-/// 재resolve 가 자기 deps 요청을 idempotent 재등록). worker_entries/rn_asset_metadata/
-/// runtime_polyfill_roots 는 feature gate 가 비어있음을 보장하므로 reset 불요(누적 0).
+///   - requested_exports (아래 UAF 방어로 전량 deinit)
+/// **requested_exports 를 반드시 reset(전량 deinit)** 해야 한다 — `RequestedExports.names`(state.zig)
+/// 는 `[]const u8` 을 *dupe 없이 borrow* 하며, 그 slice 는 importer 의 `ib.imported_name`/
+/// `eb.local_name`(parse_arena 소유, requested_exports.zig requestNamed). 변경 모듈을
+/// `reparseChangedModulePreserveEdges` 가 deinit(=parse_arena free)하면, 그 모듈이 dep 의
+/// `requested_exports[dep].names` 에 기여한 slice 가 dangling 된다(dep 는 unchanged 라 안 건드림).
+/// 다음 재resolve 의 `requestNamed`→`contains`(std.mem.eql)가 freed 메모리를 읽어 **UAF**(#4123 PR-3
+/// /code-review max HIGH). reset 해도 변경 모듈 재resolve 가 자기 deps 요청을 다시 채우고,
+/// requested_exports 소비처(lazy-barrel link/tree-shake)는 보존 경로의 dev 게이트(canPreserveTopology
+/// 의 `!dev_mode` + isLazyBarrelCandidate 의 dev=false)에서 비활성이라 정확성 영향 0.
+/// worker_entries/rn_asset_metadata/runtime_polyfill_roots 는 feature gate 가 비어있음을 보장하므로
+/// reset 불요(누적 0).
 fn resetPerBuildStateForPreserved(self: *ModuleGraph) void {
     for (self.owned_diagnostic_strings.items) |s| self.allocator.free(s);
     self.owned_diagnostic_strings.clearRetainingCapacity();
@@ -1420,6 +1431,9 @@ fn resetPerBuildStateForPreserved(self: *ModuleGraph) void {
     self.source_read_cache = .{};
     self.exec_counter = 0;
     self.cycle_counter = 0;
+    var req_it = self.requested_exports.valueIterator();
+    while (req_it.next()) |req| req.deinit(self.allocator);
+    self.requested_exports.clearRetainingCapacity();
 }
 
 /// 변경 모듈을 **edge 보존**하며 재파싱한다. dependencies/importers/dynamic_imports/

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -1113,6 +1113,363 @@ pub fn buildIncremental(
     };
 }
 
+// ============================================================
+// perf/hmr-graph-topology-reuse Phase B — edge-reuse short-circuit (위상 보존 빌드)
+//
+// **목표**: body-only edit(모듈 집합·import 위상 불변)이면 변경 모듈만 재파싱+재resolve 하고
+// 나머지 모듈의 edge/exec_index/resolved_deps/parse_arena 를 **보존**(재discovery/재replay skip).
+// graphDiscover 170→~40ms 의 본체. 위상 변화면 full fallback(전량 clear + fresh discovery).
+//
+// **정확성(byte-identical) 핵심**:
+//   1. renumber 미수정 — 위상 불변이면 renumber=identity(SymbolRef 에 박힌 module index 안전).
+//      위상 변화는 topologyMatches=false → full fallback(renumber 정상 실행).
+//   2. 변경 모듈의 edge(dependencies/importers/dynamic_*) 는 invalidate 전에 스냅샷해 그대로
+//      복원 — unlink/relink 하면 dep.importers 내 위치가 바뀌어 출력이 fresh 와 달라진다.
+//      재resolve 는 `suppress_edge_link=true` 로 link 단계만 억제하고 import_records[].resolved
+//      + resolved_deps 만 새 parse_arena 기준으로 재구성한다(.specifier PathRef UAF 회피 —
+//      옛 resolved_deps 를 보존하지 않고 새 arena 로 새로 만든다).
+//   3. 위상 일치 = 모듈 추가/삭제 0 → orphan 없음(prune 불필요). 추가/삭제는 변경 모듈의
+//      specifier diff 로 topologyMatches=false → full fallback 에서 prepareForPreservedRebuild
+//      (전량 clear)가 처리.
+//
+// **parse_arena 단독 owner**: 보존 모드에선 transferModulesToStore 비활성(bundler.zig) →
+// graph 가 parse_arena 를 계속 소유. store 는 비어 cache-hit 경로를 타지 않는다. graph.deinit
+// (IncrementalBundler.deinit / RN worker defer)이 parse_arena 를 단독 해제 → double-free 없음.
+// ============================================================
+
+/// 위상(topology) 보존 증분 빌드. `preserve_topology=true` 일 때 bundler 가 호출.
+///
+/// - cold(graph 비어있음) 또는 위상 변화 가드 위반 시 → full discovery(`buildIncremental`).
+///   단 보존 모드는 store 를 안 채우므로 store cache-hit 없이 전량 parse(byte-identical full).
+/// - warm(graph 보존) + 변경 모듈 전부 body-only(topologyMatches) → 변경 모듈만 재파싱+재resolve,
+///   나머지 보존. finalizeGraph(renumber identity + DFS) 후 reparsed=변경 모듈.
+pub fn buildIncrementalPreserved(
+    self: *ModuleGraph,
+    io: std.Io,
+    entry_points: []const []const u8,
+    store: *module_store.PersistentModuleStore,
+    changed_files: ?*const std.StringHashMapUnmanaged(void),
+) !IncrementalBuildResult {
+    // cold / 첫 빌드 / 직전 fallback 으로 graph 가 비워진 경우 → full discovery.
+    // (store 는 보존 모드에서 비어있어 전량 cache-miss = full parse → byte-identical full.)
+    if (self.modules.count() == 0) {
+        return buildIncremental(self, io, entry_points, store, changed_files);
+    }
+
+    // 변경 정보가 없으면(initial-after-warm / CLI) 보존 판정 불가 → full fallback.
+    const cf = changed_files orelse return fallbackFullRebuild(self, io, entry_points, store, changed_files);
+
+    // **feature gate** — 보존 경로는 "모듈 집합 전체에서 discovery 중 파생되는 per-build 상태"
+    // (worker_entries / rn_asset_metadata / runtime_polyfill_roots / emit chunk / lazy seed 등)를
+    // 가진 빌드를 다루지 못한다(변경 모듈만 재resolve 하면 *변경되지 않은* 모듈의 기여분을
+    // 재생성/보존할 수 없어 byte-identical 이 깨짐). 이런 빌드는 보수적으로 full fallback.
+    // plan §12/§29 의 "plugin/MF/glob/require.context/code_splitting 보존 경로 제외" 와 동형 +
+    // RN 의 runtime polyfill / asset 까지 확장. 정확성 우선 — 불확실하면 full.
+    if (!canPreserveTopology(self)) {
+        return fallbackFullRebuild(self, io, entry_points, store, changed_files);
+    }
+
+    // entry_dir/project_root 재계산(buildIncremental 와 동일 — 보존 경로도 entry 변경 반영).
+    // entry 변경(추가/삭제)은 아래 "변경 모듈 = 현재 graph 모듈" 가드에서 위상 변화로 잡힌다.
+    if (entry_points.len > 0) {
+        const ed = computeEntryDir(entry_points);
+        if (self.entry_dir.len > 0) self.allocator.free(self.entry_dir);
+        self.entry_dir = if (ed.len == 0) "" else (self.allocator.dupe(u8, ed) catch "");
+        if (self.project_root_auto) {
+            self.project_root = "";
+            self.project_root_auto = false;
+        }
+    }
+    if (self.project_root.len == 0 and self.entry_dir.len > 0) {
+        self.project_root = graph_project_root.findProjectRoot(self.allocator, io, self.entry_dir) catch self.entry_dir;
+        self.project_root_auto = true;
+    }
+    graph_plugins.ensureBuiltinPlugins(self);
+
+    // 변경 모듈 인덱스 수집 — changed path 가 *현재 graph 에 있는* 모듈이어야 한다.
+    // 그래프에 없는 changed path = 신규 파일(모듈 추가 후보) → 위상 변화 → full fallback.
+    // entry_points 가 graph 에 없으면(신규 entry) 역시 full fallback.
+    var changed_indices: std.ArrayListUnmanaged(usize) = .empty;
+    defer changed_indices.deinit(self.allocator);
+    {
+        var it = cf.iterator();
+        while (it.next()) |e| {
+            const path = e.key_ptr.*;
+            const idx = self.path_to_module.get(path) orelse {
+                // changed 파일이 graph 에 없음 → 신규 모듈 추가(위상 변화) 가능성 → full.
+                return fallbackFullRebuild(self, io, entry_points, store, changed_files);
+            };
+            const ui = @intFromEnum(idx);
+            if (ui >= self.modules.count()) {
+                return fallbackFullRebuild(self, io, entry_points, store, changed_files);
+            }
+            // **lazy-barrel 가드 (requested_exports over-approx 회피)**: topologyMatches 는
+            // specifier/kind/resolve-target 만 보고 *imported 이름 집합* 은 안 본다. 보존 경로는
+            // requested_exports 를 reset 하지 않으므로, sideEffects:false re-export barrel 에서
+            // named import 가 *제거* 되면 옛 요청이 남아(over-approx) link 결정이 fresh 와 달라질
+            // 수 있다(shouldLinkResolvedRecordForModule). 변경 모듈이 그런 barrel 후보면 보수적
+            // full fallback. (일반 모듈은 isLazyBarrelCandidate=false → 항상 link → 영향 없음.)
+            if (graph_requested_exports.isLazyBarrelCandidate(self, self.modules.at(ui))) {
+                return fallbackFullRebuild(self, io, entry_points, store, changed_files);
+            }
+            try changed_indices.append(self.allocator, ui);
+        }
+    }
+    // 모든 entry 가 graph 에 있어야(신규 entry = 위상 변화) 보존 안전.
+    for (entry_points) |ep| {
+        if (self.path_to_module.get(ep) == null) {
+            return fallbackFullRebuild(self, io, entry_points, store, changed_files);
+        }
+    }
+    // 변경 모듈이 없으면(force_dirty 등) 보존된 graph 그대로 finalize — 출력 불변.
+    if (changed_indices.items.len == 0) {
+        resetPerBuildStateForPreserved(self);
+        self.topology_preserved_hits += 1;
+        try finalizeGraph(self, entry_points);
+        return .{ .graph_changed = false, .reparsed_indices = try self.allocator.alloc(types.ModuleIndex, 0) };
+    }
+
+    var discover_scope = profile.begin(.graph_discover);
+
+    // ── 각 변경 모듈: snapshot → edge 보존 invalidate → 재파싱 → 재resolve(link 억제) ──
+    // snapshot 들은 모든 변경 모듈 재파싱이 끝난 뒤 일괄 topologyMatches 검사에 쓴다.
+    var snapshots: std.ArrayListUnmanaged(ModuleTopologySnapshot) = .empty;
+    defer {
+        for (snapshots.items) |*s| s.deinit();
+        snapshots.deinit(self.allocator);
+    }
+
+    // 1) 모든 변경 모듈의 위상 스냅샷을 *invalidate/재파싱 전에* 먼저 떠 둔다(import_records 는
+    //    parse_arena 소유라 deinit 시 backing 이 사라짐). glob/require_context record 면
+    //    snapshot=null → 보존 거부 → full fallback.
+    var fallback = false;
+    for (changed_indices.items) |ui| {
+        const snap_opt = snapshotModuleTopology(self, self.allocator, ui) catch {
+            fallback = true;
+            break;
+        };
+        const snap = snap_opt orelse {
+            fallback = true;
+            break;
+        };
+        snapshots.append(self.allocator, snap) catch {
+            var s = snap;
+            s.deinit();
+            fallback = true;
+            break;
+        };
+    }
+    if (fallback) {
+        discover_scope.end();
+        return fallbackFullRebuild(self, io, entry_points, store, changed_files);
+    }
+
+    // 2) per-build global state reset (diagnostics / source_read_cache / exec·cycle counter).
+    //    snapshot 을 뜬 *뒤*, 변경 모듈 재파싱 *전*에 수행한다:
+    //    - diagnostics: 이전 빌드의 stale diag 제거(변경 모듈 재파싱이 자기 diag 재생성).
+    //    - source_read_cache: 변경 파일의 stale source 캐시 무효화(fresh read 강제).
+    //    - exec_counter/cycle_counter: finalizeGraph 의 DFS 가 0 부터 재부여해야 fresh 와 동일.
+    //    KEEP: modules/edges/resolved_deps/parse_arena/requested_exports/pkg_info_cache
+    //    (보존이 본 PR 의 목적). feature gate 가 worker_entries/rn_asset_metadata/
+    //    runtime_polyfill_roots 가 비어있음을 이미 보장하므로 그 reset 은 불필요(누적 0).
+    resetPerBuildStateForPreserved(self);
+
+    // 3) 변경 모듈을 edge 보존하며 재파싱(invalidate). reparseChangedModulePreserveEdges 는
+    //    dependencies/importers/dynamic_* 를 떼어 보관 → module.deinit(parse_arena/ast/semantic/
+    //    resolved_deps 해제) → 빈 Module init → edge 리스트 복원 → 재파싱.
+    for (changed_indices.items) |ui| {
+        reparseChangedModulePreserveEdges(self, io, ui);
+    }
+
+    // 4) 변경 모듈 재resolve — edge link 억제(보존된 edge 유지), import_records[].resolved +
+    //    resolved_deps 만 새 parse_arena 기준으로 재구성. 새 모듈이 추가되면(addModule count
+    //    증가) 위상 변화이므로 그 즉시 fallback.
+    const count_before_resolve = self.modules.count();
+    self.suppress_edge_link = true;
+    for (changed_indices.items) |ui| {
+        const m = self.modules.at(ui);
+        if (m.is_disabled or m.is_external) continue;
+        graph_resolve_imports.resolveModuleImports(self, io, ModuleIndex.fromUsize(ui)) catch {
+            self.suppress_edge_link = false;
+            discover_scope.end();
+            return fallbackFullRebuild(self, io, entry_points, store, changed_files);
+        };
+    }
+    self.suppress_edge_link = false;
+
+    // 5) 위상 일치 검사. (a) 모듈이 추가됐거나(count 증가 = 신규 dep) (b) 어느 변경 모듈이라도
+    //    snapshot 과 위상 불일치(specifier/kind/resolve-target diff)면 → full fallback.
+    if (self.modules.count() != count_before_resolve) {
+        discover_scope.end();
+        return fallbackFullRebuild(self, io, entry_points, store, changed_files);
+    }
+    for (changed_indices.items, snapshots.items) |ui, *snap| {
+        if (!topologyMatches(snap, self, ui)) {
+            discover_scope.end();
+            return fallbackFullRebuild(self, io, entry_points, store, changed_files);
+        }
+    }
+
+    discover_scope.end();
+
+    // 6) 위상 보존 확정 — renumber(identity) + DFS exec_index 재부여.
+    self.topology_preserved_hits += 1;
+    try finalizeGraph(self, entry_points);
+
+    // 변경 모듈만 reparsed(HMR diff source-of-truth). renumber 가 module index 를 재배치하므로
+    // pre-renumber 인덱스는 stale — changed_files 의 path 로 post-renumber index 를 재조회한다
+    // (path slice 는 path_arena 소유라 renumber 후에도 path_to_module 키로 유효).
+    var reparsed: std.ArrayListUnmanaged(types.ModuleIndex) = .empty;
+    errdefer reparsed.deinit(self.allocator);
+    {
+        var it = cf.iterator();
+        while (it.next()) |e| {
+            if (self.path_to_module.get(e.key_ptr.*)) |idx| {
+                try reparsed.append(self.allocator, idx);
+            }
+        }
+    }
+
+    return .{
+        .graph_changed = false, // 위상 불변 = 그래프 구조 불변
+        .reparsed_indices = try reparsed.toOwnedSlice(self.allocator),
+    };
+}
+
+/// 위상 변화/불확실 시 fail-safe full rebuild.
+///
+/// **핵심(성능)**: clear 전에 graph 의 현재 모듈을 store 로 이전(transferModulesToStore)한 뒤
+/// clear + buildIncremental 한다. 그러면 buildIncremental 이 store cache-hit 으로 변경 안 된
+/// 모듈의 재파싱을 skip → fallback 도 *증분*(전량 reparse 가 아님)이다. 보존 모드는 평소
+/// transferModulesToStore 를 비활성(graph 단독 owner)하지만, fallback 직전 1회 이전은
+/// "graph→store 핸드오프" 로, 직후 buildIncremental 의 cache-hit 이 arena 를 store→graph 로
+/// 되돌린다(incremental.zig: cached.module.parse_arena=null). 빌드 끝의 transferModulesToStore
+/// 는 보존 모드라 다시 skip → graph 가 단독 owner 로 복귀. double-free 없음(이전 후 graph 쪽
+/// parse_arena=null → prepareForPreservedRebuild 의 m.deinit 가 arena no-op).
+///
+/// 출력은 fresh full 과 byte-identical(store cache-hit 모듈도 fresh 와 동일 — Phase A 검증됨).
+fn fallbackFullRebuild(
+    self: *ModuleGraph,
+    io: std.Io,
+    entry_points: []const []const u8,
+    store: *module_store.PersistentModuleStore,
+    changed_files: ?*const std.StringHashMapUnmanaged(void),
+) !IncrementalBuildResult {
+    self.topology_fallback_count += 1;
+    // graph→store 핸드오프: 현재 모듈의 parse_arena 를 store 로 이전(graph 쪽 parse_arena=null).
+    // 이후 buildIncremental 이 store cache-hit 으로 미변경 모듈 reparse 를 skip.
+    transferModulesToStore(self, io, store);
+    self.prepareForPreservedRebuild();
+    return buildIncremental(self, io, entry_points, store, changed_files);
+}
+
+/// 위상 보존(edge-reuse) 경로가 안전한 빌드인지 판정. false 면 full fallback.
+///
+/// 보존 경로는 *변경 모듈만* 재resolve 하므로, "모든 모듈에서 discovery 중 파생되는 per-build
+/// 상태"를 가진 빌드는 다루지 못한다 — 변경되지 않은 모듈의 기여분을 재생성할 수 없어
+/// byte-identical 이 깨진다. 다음 중 하나라도 활성이면 보수적으로 거부(full):
+///   - 사용자 plugin (resolveId/load/transform 비결정 — plan §12 제외)
+///   - code_splitting / preserve_modules (per-chunk 처리 — plan §12 제외)
+///   - lazy_compilation (동적 import seed materialize)
+///   - runtime_polyfills (usage-mode 는 모듈 전체 feature 스캔 — body edit 가 feature 변화 가능)
+///   - inject_files / run_before_main_files (execution root 합류 — 변경 모듈만으론 재배선 불가)
+///   - MF(emit_store) (federation/emit chunk)
+///   - 이미 누적된 per-build 파생물 보유: worker_entries / rn_asset_metadata /
+///     runtime_polyfill_roots (변경 모듈만 재resolve 하면 이들의 unchanged 기여분이 보존 안 됨)
+///
+/// glob/require_context 는 snapshotModuleTopology 가 record 단위로 null 반환 → 거기서 거부.
+///
+/// **dev_mode 전제**: 보존 경로는 dev/HMR(web IncrementalBundler.enable_persistence, RN watch
+/// worker)에서만 켜진다. 비-dev(prod tree-shaking)에선 requested_exports over-approximation
+/// (named import 제거 시 옛 요청 잔존)이 tree-shake 결과를 fresh 와 다르게 만들 수 있어 거부한다.
+/// dev_mode 는 tree-shaking 비활성(bundler.zig will_tree_shake) + 전 모듈 __esm 래핑이라 그 위험이
+/// 없다. lazy-barrel link 결정(requested_exports 의 다른 소비처)은 buildIncrementalPreserved 의
+/// 변경-모듈 lazy-barrel 가드가 별도 차단.
+fn canPreserveTopology(self: *const ModuleGraph) bool {
+    if (!self.dev_mode) return false;
+    if (self.has_user_resolve_id_plugins or self.has_user_load_plugins or self.has_transform_plugins) return false;
+    if (self.code_splitting or self.preserve_modules) return false;
+    if (self.lazy_compilation) return false;
+    if (self.runtime_polyfills != null) return false;
+    if (self.inject_files.len > 0 or self.run_before_main_files.len > 0) return false;
+    if (self.worker_entries.items.len > 0) return false;
+    if (self.rn_asset_metadata.items.len > 0) return false;
+    if (self.runtime_polyfill_roots.items.len > 0) return false;
+    // emit_store 에 chunk 요청이 있으면(plugin emitFile chunk) 보존 제외. emit_store 가
+    // null 이면 chunk 미사용(hot path 0). 포인터만 검사 — chunk 내용은 injectEmittedChunks 영역.
+    if (self.emit_store) |store_ptr| {
+        const store: *const @import("../emit_store.zig").EmitStore = @ptrCast(@alignCast(store_ptr));
+        if (store.chunks.items.len > 0) return false;
+    }
+    return true;
+}
+
+/// 보존 경로 진입 시 per-build global state 만 reset(modules/edges/resolved_deps/parse_arena/
+/// requested_exports/pkg_info_cache 는 보존). `lifecycle.reset()` 의 부분집합:
+///   - diagnostics + owned_diagnostic_strings (변경 모듈 재파싱이 자기 diag 재생성)
+///   - source_read_cache (변경 파일 fresh read 강제)
+///   - exec_counter / cycle_counter (finalizeGraph DFS 가 0 부터 재부여 → fresh 와 동일 exec_index)
+/// requested_exports 는 reset 하지 *않는다* — unchanged 모듈의 export 요청 상태를 보존(변경 모듈
+/// 재resolve 가 자기 deps 요청을 idempotent 재등록). worker_entries/rn_asset_metadata/
+/// runtime_polyfill_roots 는 feature gate 가 비어있음을 보장하므로 reset 불요(누적 0).
+fn resetPerBuildStateForPreserved(self: *ModuleGraph) void {
+    for (self.owned_diagnostic_strings.items) |s| self.allocator.free(s);
+    self.owned_diagnostic_strings.clearRetainingCapacity();
+    self.diagnostics.clearRetainingCapacity();
+    self.source_read_cache.deinit(self.allocator);
+    self.source_read_cache = .{};
+    self.exec_counter = 0;
+    self.cycle_counter = 0;
+}
+
+/// 변경 모듈을 **edge 보존**하며 재파싱한다. dependencies/importers/dynamic_imports/
+/// dynamic_importers 리스트(graph allocator 소유, parse_arena 와 독립)를 떼어 보관 →
+/// module.deinit(parse_arena/ast/semantic/resolved_deps + edge 리스트 해제) → 같은 index/path
+/// 로 빈 Module init → 보관한 edge 리스트 복원 → 재파싱. 재resolve 는 caller 가 suppress_edge_link
+/// 로 link 를 억제하므로 edge 가 중복/이동 없이 그대로 유지된다.
+fn reparseChangedModulePreserveEdges(self: *ModuleGraph, io: std.Io, mod_idx: usize) void {
+    const m = self.modules.at(mod_idx);
+    const saved_index = m.index;
+    const saved_path = m.path;
+    // edge 리스트 move-out (deinit 가 해제하지 않도록 빈 리스트로 치환).
+    const saved_deps = m.dependencies;
+    const saved_importers = m.importers;
+    const saved_dyn = m.dynamic_imports;
+    const saved_dyn_importers = m.dynamic_importers;
+    // **file-identity 필드 보존**: body edit 은 같은 파일(같은 확장자/loader)이므로 module_type/
+    // loader/resolve_dir 이 불변이다. Module.init 은 이들을 default(.unknown) 로 두므로(addModule
+    // WithResolveDir 가 확장자로 채우는 로직을 우회), 보존하지 않으면 parseModule 이 모듈을
+    // 비-JS 로 오인해 빈 source/0 record 로 끝난다(byte-identical 깨짐). resolve_dir 은 graph
+    // allocator 소유라 m.deinit 가 free 하므로 move-out 후 복원.
+    const saved_module_type = m.module_type;
+    const saved_loader = m.loader;
+    const saved_resolve_dir = m.resolve_dir;
+    m.dependencies = .empty;
+    m.importers = .empty;
+    m.dynamic_imports = .empty;
+    m.dynamic_importers = .empty;
+    m.resolve_dir = null; // move-out: m.deinit 가 free 하지 않게(아래에서 복원).
+    // 나머지(parse_arena/ast/semantic/resolved_deps/import_records/alias_table 등) 일괄 해제.
+    m.deinit(self.allocator);
+    // 같은 index/path 로 빈 Module — edge + file-identity 복원.
+    m.* = @import("../module.zig").Module.init(saved_index, saved_path);
+    m.dependencies = saved_deps;
+    m.importers = saved_importers;
+    m.dynamic_imports = saved_dyn;
+    m.dynamic_importers = saved_dyn_importers;
+    m.module_type = saved_module_type;
+    m.loader = saved_loader;
+    m.resolve_dir = saved_resolve_dir;
+
+    // 재파싱(새 parse_arena + ast + import_records). mtime=0 → parseModule 이
+    // readModuleSourceWithMtime 로 fresh source + mtime 을 채운다.
+    m.mtime = 0;
+    self.parseModule(io, ModuleIndex.fromUsize(mod_idx));
+    const m2 = self.modules.at(mod_idx);
+    self.applySideEffectsFromPackageJson(io, m2);
+    m2.state = .ready;
+}
+
 /// 파일의 mtime 을 나노초로 반환. virtual module / embedded null byte / overlong
 /// path 는 error 로 폴백해 호출부가 `catch 0` 으로 처리하도록 한다.
 ///

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -343,6 +343,20 @@ pub fn propagateTopLevelAwait(self: *ModuleGraph) void {
     const count = self.modules.count();
     if (count == 0) return;
 
+    // Base reset: `uses_top_level_await` 를 각 모듈의 self(자기 await) 값으로 되돌린 뒤 전파.
+    // 이 함수의 전파는 set-only(아래 BFS 는 true 만 set, 절대 demote 안 함)라, HMR 위상 보존
+    // (Phase B) 처럼 unchanged 모듈을 reparse 하지 않는 경로에서 직전 빌드의 transitive true 가
+    // stale 로 남는다 — 예: dep 가 await 를 제거했는데 그 importer 가 여전히 true → emit 이
+    // fresh(sync) 와 달리 async wrapper 를 박아 byte 가 갈린다. self 로 base 를 깔면 그 stale 이
+    // 지워진다. fresh full 빌드에선 모든 모듈이 reparse 되어 `uses==self` 라 이 loop 는 no-op.
+    {
+        var i: usize = 0;
+        while (i < count) : (i += 1) {
+            const m = self.modules.at(i);
+            m.uses_top_level_await = m.self_uses_top_level_await;
+        }
+    }
+
     // Fast path: TLA 모듈이 없으면 전파할 것도 없다.
     var has_tla = false;
     {

--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -128,6 +128,11 @@ pub fn invalidateModule(self: *ModuleGraph, idx: ModuleIndex) void {
 /// path_arena: clearRetainingCapacity 로 **메모리 보존 + 논리적 비움**. 이전 빌드 path
 /// 슬라이스는 modules/path_to_module 가 비워져 더 이상 참조되지 않으므로 재사용 안전
 /// (monotonic 누적 없이 capacity 재활용). retainCapacity 라 RSS 단방향 증가 없음.
+///
+/// **pkg_info_cache 무효화 (F1)**: path_arena 를 recycle 하면 pkg_info_cache 키
+/// (= module_path 의 substring, path_arena 소유)가 dangling 되므로 reset 직전에 비운다.
+/// reset() 는 path_arena 를 유지해 키가 살아있으니 pkg_info_cache 를 보존(doc 계약)하지만,
+/// 여기서는 path_arena 가 회수되므로 보존이 불가능 — value 메모리 해제 후 clearRetainingCapacity.
 pub fn prepareForPreservedRebuild(self: *ModuleGraph) void {
     // 1) 모든 모듈 슬롯 해제 (parse_arena 가 아직 graph 소유면 함께 해제 —
     //    transferModulesToStore 가 이미 store 로 넘긴 경우 parse_arena=null 이라 no-op).
@@ -139,6 +144,19 @@ pub fn prepareForPreservedRebuild(self: *ModuleGraph) void {
 
     // 2) path → idx 인덱스 비움 (backing 재사용).
     self.path_to_module.clearRetainingCapacity();
+
+    // 2.5) pkg_info_cache 비움 — **path_arena.reset 전에 반드시** (F1 dangling key).
+    //   키는 graph.zig:112 주석대로 module_path 의 substring(= path_arena 소유, dupe 없음).
+    //   아래 3) 에서 path_arena 를 recycle 하면 그 키 슬라이스가 회수된 arena 를 가리켜
+    //   dangling → 다음 빌드의 lookupPkgInfo(get) 가 stale is_module/side_effects 반환 →
+    //   잘못된 ESM/tree-shaking 판정(silent corruption). 보존 경로(prepareForPreservedRebuild)
+    //   에서만 path_arena 를 recycle 하므로, pkg_info_cache 무효화도 여기 한정이 맞다
+    //   (reset() 는 path_arena 를 유지해 키가 살아있으므로 pkg_info_cache 를 보존 — 그게 doc 계약).
+    //   value 소유 메모리(side_effects.patterns: graph.allocator dupe)는 graph.deinit
+    //   (graph.zig pkg_info_cache 해제 loop)과 **동일한 방식**으로 free 후 backing 재사용.
+    var pi_it = self.pkg_info_cache.valueIterator();
+    while (pi_it.next()) |info| info.side_effects.deinit(self.allocator);
+    self.pkg_info_cache.clearRetainingCapacity();
 
     // 3) path_arena 논리적 비움 + capacity 보존 (위 doc: 더 이상 참조 없음).
     _ = self.path_arena.reset(.retain_capacity);

--- a/src/bundler/graph/module_registry.zig
+++ b/src/bundler/graph/module_registry.zig
@@ -196,8 +196,14 @@ pub fn addExternalModule(self: *ModuleGraph, specifier: []const u8) !ModuleIndex
 
 /// 양방향 의존성 등록. from → to (dependencies) + to → from (importers) 를 동시에 append.
 /// graph 가 양방향 관계 책임을 캡슐화. storage 가 SegmentedList 로 바뀌어도 caller 영향 없음.
+///
+/// **Phase B (suppress_edge_link)**: 위상 보존 모드의 변경 모듈 재resolve 중에는 no-op.
+/// edge(dependencies/importers)는 invalidate 전 스냅샷으로 이미 복원돼 있고, 여기서 다시
+/// append 하면 중복 + dep.importers 내 위치 변동(byte-identical 깨짐)이 발생하므로 억제한다.
+/// (resolved_deps/import_records[].resolved 재구성은 caller 가 별도로 수행 — link 만 건너뜀.)
 pub fn linkDependency(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) !void {
     if (to.isNone()) return;
+    if (self.suppress_edge_link) return;
     const from_mod = self.moduleAtMut(from) orelse return;
     const to_mod = self.moduleAtMut(to) orelse return;
     try from_mod.dependencies.append(self.allocator, to);
@@ -207,6 +213,7 @@ pub fn linkDependency(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) !v
 /// 양방향 dynamic import 등록. `linkDependency` 의 dynamic 버전.
 pub fn linkDynamicImport(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) !void {
     if (to.isNone()) return;
+    if (self.suppress_edge_link) return;
     const from_mod = self.moduleAtMut(from) orelse return;
     const to_mod = self.moduleAtMut(to) orelse return;
     try from_mod.dynamic_imports.append(self.allocator, to);

--- a/src/bundler/graph/parse_module.zig
+++ b/src/bundler/graph/parse_module.zig
@@ -210,6 +210,8 @@ pub fn parseModule(self: *ModuleGraph, io: std.Io, idx: ModuleIndex) void {
             };
             // TLA 감지: semantic analyzer가 스코프 체인을 추적하며 정확히 판별
             module.uses_top_level_await = analyzer.has_top_level_await;
+            // base(self) 값 보존 — propagateTopLevelAwait 가 매 빌드 이 값으로 reset 후 전파.
+            module.self_uses_top_level_await = analyzer.has_top_level_await;
 
             // Semantic Analyzer에서 사전 수집한 stmt↔symbol 매핑으로 StmtInfo 구축.
             // tree_shaker가 AST를 다시 순회하지 않아도 된다 (Phase 2 최적화).

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -327,6 +327,8 @@ fn refreshSemanticAndStmtInfoAfterAstMutation(
         }
         suppressRuntimeHelperInternalUnresolved(module);
         module.uses_top_level_await = analyzer.has_top_level_await;
+        // base(self) 값 보존 — propagateTopLevelAwait 가 매 빌드 이 값으로 reset 후 전파.
+        module.self_uses_top_level_await = analyzer.has_top_level_await;
         if (module.transform_cache) |*cache| {
             cache.symbol_ids = analyzer.symbol_ids.items;
         }

--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -256,19 +256,21 @@ pub const IncrementalBundler = struct {
             if (self.preserved_renames) |*pr| opts.preserved_renames = pr;
         }
 
-        // RFC #3933 Sub-PR-B.2 + perf/hmr-graph-topology-reuse Phase A — enable_persistence
+        // RFC #3933 Sub-PR-B.2 + perf/hmr-graph-topology-reuse Phase A/B — enable_persistence
         // opt-in path. Bundler.initWithGraph wire-up.
         //
-        // **Phase A 의미**: persistent_graph 를 빌드 *간* 보존한다(매 빌드 deinit/재init 폐기).
-        // 첫 빌드는 init, 이후 빌드는 같은 graph 를 재사용 — bundle() 의 external_graph 훅
-        // (bundler.zig)이 빌드 직전 `prepareForPreservedRebuild` 로 모듈을 비워 fresh 와
-        // byte-identical 출력을 보장한다(graph struct/backing/path_arena 재사용 → 객체 수명
-        // 안정 + alloc 절감). 위상 보존(edge/exec_index 재사용)은 transferModulesToStore
-        // 소유권 재설계가 필요해 Phase B 로 분리.
+        // **Phase A/B 의미**: persistent_graph 를 빌드 *간* 보존한다(매 빌드 deinit/재init 폐기).
+        // 첫 빌드는 init, 이후 빌드는 같은 graph 를 재사용.
         //
-        // **정확성 가드**: graph_changed(아래 pathSetsEqual)가 위상 변화(모듈 추가/삭제)를
-        // 감지하면 그 빌드 자체는 prepareForPreservedRebuild 로 fresh discovery 라 정확하다.
-        // (Phase B 의 selective edge-reuse 도입 시 여기서 추가 fallback 가드가 필요.)
+        // - **Phase B (preserve_topology=true)**: bundle() 이 graph 를 비우지 않고
+        //   buildIncrementalPreserved 로 진입 → 변경 모듈만 선택 재파싱(edge-reuse). 위상 변화면
+        //   그 함수 내부에서 prepareForPreservedRebuild + full fresh discovery 로 fallback.
+        //   transferModulesToStore 비활성 → graph 가 parse_arena 단독 owner(double-free 방지).
+        //   출력은 fresh full 과 byte-identical(보존 경로/fallback 경로/원래 fresh 셋 다 동일).
+        //
+        // is_first(첫 빌드)에는 module_store 를 주입하지 않으므로 preserve_topology 도 무의미 —
+        // initWithGraph 의 cold 분기(graph 비어있음)가 full discovery 후 graph 를 warm 으로 만든다.
+        opts.preserve_topology = self.enable_persistence and !is_first;
         var bundler = blk: {
             if (!self.enable_persistence) break :blk Bundler.initWithResolveCache(self.allocator, opts, &self.resolve_cache.?);
             if (self.persistent_graph == null) {

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -1419,6 +1419,126 @@ test "Phase A byte-identical: 모듈 제거(import 삭제) 후에도 보존 grap
     try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
 }
 
+test "Phase A F1: prepareForPreservedRebuild 가 pkg_info_cache 를 비운다 (dangling key 차단, deterministic)" {
+    // F1 의 **결정적** 회귀 가드. byte-identical 통합 테스트는 path_arena retain_capacity
+    // 가 stale 키 영역을 동일 패키지 경로로 덮어써 값이 우연히 일치할 수 있어(silent)
+    // divergence 가 비결정적이다. 여기선 불변식을 직접 검증한다:
+    //   pkg_info_cache 키 = module_path(path_arena 소유)의 substring(dupe 없음).
+    //   prepareForPreservedRebuild 가 path_arena 를 recycle 하기 *전에* 이 캐시를 비우지
+    //   않으면 모든 키가 dangling → 이후 lookupPkgInfo(get) 가 회수된 arena 를 읽는다.
+    // 따라서 "prepareForPreservedRebuild 후 pkg_info_cache.count()==0" 이 fix 의 핵심 계약.
+    // fix 없으면(=clear 누락) count 가 그대로라 이 테스트가 실패한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "node_modules/pure-pkg/package.json",
+        \\{"name":"pure-pkg","sideEffects":false}
+    );
+    try writeFile(tmp.dir, "node_modules/pure-pkg/index.js",
+        \\export const used = 1;
+    );
+    try writeFile(tmp.dir, "index.ts",
+        \\import { used } from 'pure-pkg';
+        \\console.log(used);
+    );
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    // 패키지 의존 모듈을 discovery → applySideEffectsFromPackageJson 가 lookupPkgInfo 로
+    // pkg_info_cache 를 채운다 (키 = pure-pkg 디렉토리 경로 = path_arena 소유 substring).
+    try graph.build(std.testing.io, &.{entry});
+    try std.testing.expect(graph.pkg_info_cache.count() > 0); // 전제: 캐시가 실제로 찬다.
+
+    // 핵심: 보존 rebuild 준비가 path_arena 를 recycle 하므로 그 전에 캐시를 비워야 한다.
+    graph.prepareForPreservedRebuild();
+
+    // F1 fix 검증 — 비우지 않으면(=clear 누락) 키가 dangling 인 채 entry 가 남는다.
+    try std.testing.expectEqual(@as(usize, 0), graph.pkg_info_cache.count());
+}
+
+test "Phase A byte-identical: node_modules sideEffects=false 패키지 의존 시 보존 rebuild == fresh (F1 pkg_info_cache dangling key)" {
+    // F1 통합 가드(보완). 기존 Phase A 테스트는 전부 상대경로(./util)뿐이라 pkg_info_cache 가
+    // 빈 채로 유지돼 F1 을 비켜간다. 여기선 node_modules 패키지(package.json
+    // "sideEffects":false)를 import 해 pkg_info_cache 가 채워지게 한다.
+    //
+    // pkg_info_cache 키는 module_path(= path_arena 소유)의 substring(dupe 없음). 보존
+    // rebuild 의 prepareForPreservedRebuild 가 path_arena 를 recycle 하면 그 키가 dangling
+    // → fix 전엔 다음 빌드 lookupPkgInfo(get) 가 stale side_effects 를 반환할 수 있어
+    // tree-shaking/ESM 판정이 fresh 와 어긋난다(silent corruption). fix(=reset 전 cache
+    // 무효화) 후엔 fresh 와 byte-identical.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // sideEffects:false 패키지: used + unused export 를 둬서 side-effects 판정이 stale 이면
+    // tree-shaking 결과(미사용 export/모듈 제거)가 fresh 와 갈리도록.
+    try writeFile(tmp.dir, "node_modules/pure-pkg/package.json",
+        \\{"name":"pure-pkg","sideEffects":false}
+    );
+    try writeFile(tmp.dir, "node_modules/pure-pkg/index.js",
+        \\export const used = 1;
+        \\export const unused = 2;
+    );
+    try writeFile(tmp.dir, "index.ts",
+        \\import { used } from 'pure-pkg';
+        \\console.log(used);
+    );
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    // build 1 (first): 보존 graph + pkg_info_cache 채움.
+    {
+        var r1 = try preservedBuild(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    // build 2 (warm seed). 이 빌드 직전 prepareForPreservedRebuild 가 path_arena 를 recycle
+    // → fix 전이면 pkg_info_cache 키가 dangling 된 상태로 재진입.
+    {
+        var r2 = try preservedBuild(&graph, &store, &rc, entry, false, null);
+        defer r2.deinit(std.testing.allocator);
+        try std.testing.expect(!r2.hasErrors());
+    }
+
+    // index.ts body-only edit (패키지 import 위상 불변 — pure-pkg 는 cache-hit/재resolve).
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts",
+        \\import { used } from 'pure-pkg';
+        \\console.log(used + 1);
+    );
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    // build 3 (보존 경로 rebuild): pkg_info_cache 가 fix 로 무효화돼 fresh re-parse →
+    // 올바른 sideEffects=false 판정 재획득.
+    var preserved = try preservedBuild(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    // fresh full (graph/store 없음 — pkg.json 매번 fresh parse).
+    var fresh = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer fresh.deinit();
+    var fresh_result = try fresh.bundle(std.testing.io);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    // 핵심: 보존 rebuild 출력 == fresh full (side_effects 판정이 stale 되지 않음).
+    try std.testing.expect(preserved.output.len > 0);
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+}
+
 test "Phase A: 보존 graph 반복 rebuild leak 0 (GPA) — IncrementalBundler enable_persistence" {
     // testing.allocator(GPA) 가 deinit 시 leak 검출. 보존 graph 를 여러 번 rebuild 해도
     // path_arena retain_capacity + 모듈 전량 deinit 이 정확해 leak 0 이어야 한다.

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -1620,3 +1620,510 @@ test "Phase A: enable_persistence + resolve_cache reset(interval) 교차 안전 
     }
     try std.testing.expect(ib.persistent_graph != null);
 }
+
+// ============================================================
+// perf/hmr-graph-topology-reuse Phase B — edge-reuse short-circuit byte-identical
+//
+// 보존(preserve_topology=true) 경로로 rebuild 한 full 번들 출력이 fresh full 과 **바이트 동일**
+// 한지 검증한다. Phase A 와 달리 graph 를 전량 clear 하지 않고 변경 모듈만 선택 재파싱(edge-reuse)
+// → exec_index/edge/resolved_deps 보존이 byte-identical 을 깨지 않는지가 핵심.
+// topology_preserved_hits / topology_fallback_count 로 "실제 보존 경로를 탔는지(전량 fallback 이
+// 아닌지)" 도 단언한다.
+// ============================================================
+
+/// 보존 경로(preserve_topology=true) 한 빌드 헬퍼. preservedBuild 와 동형이되 preserve_topology
+/// 를 켜 buildIncrementalPreserved(edge-reuse) 로 진입시킨다.
+fn preservedBuildTopo(
+    graph: *ModuleGraph_t,
+    store: *module_store.PersistentModuleStore,
+    rc: *@import("resolve_cache.zig").ResolveCache,
+    entry: []const u8,
+    is_first: bool,
+    changed: ?*const std.StringHashMapUnmanaged(void),
+) !BundleResult {
+    var opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+    });
+    if (!is_first) {
+        opts.module_store = store;
+        opts.changed_files = changed;
+        opts.preserve_topology = true;
+    }
+    var b = Bundler.initWithGraph(std.testing.allocator, opts, rc, graph);
+    defer b.deinit();
+    return try b.bundle(std.testing.io);
+}
+
+fn freshFull(entry: []const u8) !BundleResult {
+    var fresh = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer fresh.deinit();
+    return try fresh.bundle(std.testing.io);
+}
+
+test "Phase B byte-identical: edge-reuse short-circuit 출력 == fresh full (다중 dep + re-export + 동적 import)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // 그래프: index → barrel(re-export) → {a, b}; index → c(동적 import); 변경은 index body-only.
+    try writeFile(tmp.dir, "a.ts", "export const a = 1;");
+    try writeFile(tmp.dir, "b.ts", "export const b = 2;");
+    try writeFile(tmp.dir, "barrel.ts", "export { a } from './a';\nexport { b } from './b';");
+    try writeFile(tmp.dir, "c.ts", "export const c = 3;");
+    try writeFile(tmp.dir, "index.ts",
+        \\import { a, b } from './barrel';
+        \\console.log(a, b);
+        \\export async function load() { return import('./c'); }
+    );
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopo(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const mod_count_after_first = graph.modules.count();
+    const hits_before = graph.topology_preserved_hits;
+    const fb_before = graph.topology_fallback_count;
+
+    // index.ts body-only edit (import/동적 import 위상 불변).
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts",
+        \\import { a, b } from './barrel';
+        \\console.log(a, b, 'edited');
+        \\export async function load() { return import('./c'); }
+    );
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuildTopo(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh_result = try freshFull(entry);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    // 핵심 1: 보존(edge-reuse) 경로를 실제로 탔다(전량 fallback 아님) — preserved hit++ , fallback 불변.
+    try std.testing.expectEqual(hits_before + 1, graph.topology_preserved_hits);
+    try std.testing.expectEqual(fb_before, graph.topology_fallback_count);
+    // 핵심 2: 모듈 슬롯 보존(count 동일) + byte-identical.
+    try std.testing.expectEqual(mod_count_after_first, graph.modules.count());
+    try std.testing.expect(preserved.output.len > 0);
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+}
+
+test "Phase B byte-identical: A→B→A 반복 body-only edit 후에도 fresh full 과 동일(보존 경로)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "other.ts", "export const y = 9;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nimport { y } from './other';\nconsole.log(x, y, 'A');");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopo(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+
+    const variants = [_][]const u8{
+        "import { x } from './util';\nimport { y } from './other';\nconsole.log(x, y, 'B');",
+        "import { x } from './util';\nimport { y } from './other';\nconsole.log(x, y, 'A');",
+        "import { x } from './util';\nimport { y } from './other';\nconsole.log(x, y, 'B');",
+    };
+    var hits: usize = 0;
+    for (variants) |src| {
+        std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+        try writeFile(tmp.dir, "index.ts", src);
+        var touched: std.StringHashMapUnmanaged(void) = .empty;
+        defer touched.deinit(std.testing.allocator);
+        try touched.put(std.testing.allocator, entry, {});
+
+        const hits_before = graph.topology_preserved_hits;
+        var preserved = try preservedBuildTopo(&graph, &store, &rc, entry, false, &touched);
+        defer preserved.deinit(std.testing.allocator);
+        try std.testing.expect(!preserved.hasErrors());
+        if (graph.topology_preserved_hits > hits_before) hits += 1;
+
+        var fresh_result = try freshFull(entry);
+        defer fresh_result.deinit(std.testing.allocator);
+        try std.testing.expect(!fresh_result.hasErrors());
+        try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+    }
+    // 세 rebuild 모두 보존 경로(edge-reuse) hit.
+    try std.testing.expectEqual(@as(usize, 3), hits);
+}
+
+test "Phase B: 모듈 추가(import 신규) → 위상 변화 → full fallback + byte-identical" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "extra.ts", "export const y = 2;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopo(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const fb_before = graph.topology_fallback_count;
+
+    // 신규 import → extra.ts 모듈 추가(위상 변화) → fallback.
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts",
+        \\import { x } from './util';
+        \\import { y } from './extra';
+        \\console.log(x, y);
+    );
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuildTopo(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh_result = try freshFull(entry);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    // fallback 발생(위상 변화) + 모듈 추가 반영 + byte-identical.
+    try std.testing.expectEqual(fb_before + 1, graph.topology_fallback_count);
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+}
+
+test "Phase B: 모듈 제거(import 삭제) → fallback + orphan prune(제거 export 누수 0) + byte-identical" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "extra.ts", "export const REMOVED_MARKER_y = 222;");
+    try writeFile(tmp.dir, "index.ts",
+        \\import { x } from './util';
+        \\import { REMOVED_MARKER_y } from './extra';
+        \\console.log(x, REMOVED_MARKER_y);
+    );
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopo(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const fb_before = graph.topology_fallback_count;
+
+    // extra.ts import 제거(위상 변화: 모듈 제거) → fallback + orphan prune.
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuildTopo(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh_result = try freshFull(entry);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    // fallback + byte-identical + 제거된 모듈의 export 가 출력에 없어야 한다(orphan 누수 0).
+    try std.testing.expectEqual(fb_before + 1, graph.topology_fallback_count);
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+    try std.testing.expect(std.mem.indexOf(u8, preserved.output, "REMOVED_MARKER_y") == null);
+}
+
+// resolve-target-diff 가드는 build_flow.zig 의 결정적 단위 테스트
+// ("topology: 같은 specifier 가 다른 파일로 resolve → resolve-diff(full)") 에서 격리 검증한다.
+// 통합 레벨에서 같은 시나리오를 만들려면 *persistent resolve_cache* 의 sibling-file 무효화까지
+// 얽혀(plan §30 transitive resolve 잔존 위험) 비결정적이라 단위 테스트로 고정한다.
+
+test "Phase B: 동적 import 추가(위상 변화) → fallback + byte-identical" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "lazy.ts", "export const z = 7;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopo(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const fb_before = graph.topology_fallback_count;
+
+    // 동적 import 추가 → import record 추가(위상 변화) → fallback.
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts",
+        \\import { x } from './util';
+        \\console.log(x);
+        \\export async function load() { return import('./lazy'); }
+    );
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuildTopo(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh_result = try freshFull(entry);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    try std.testing.expectEqual(fb_before + 1, graph.topology_fallback_count);
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+}
+
+test "Phase B: dep(비변경 모듈) 만 수정해도 보존 경로 + byte-identical (importers 보존)" {
+    // 변경 모듈이 entry 가 아니라 leaf dep 인 경우. importers 보존이 정확해야 byte-identical.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const util_path = try absPath(&tmp, "util.ts");
+    defer std.testing.allocator.free(util_path);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopo(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const hits_before = graph.topology_preserved_hits;
+    const fb_before = graph.topology_fallback_count;
+
+    // util.ts body-only edit (leaf dep) — index.ts 는 그대로.
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "util.ts", "export const x = 42;");
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, util_path, {});
+
+    var preserved = try preservedBuildTopo(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh_result = try freshFull(entry);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    try std.testing.expectEqual(hits_before + 1, graph.topology_preserved_hits);
+    try std.testing.expectEqual(fb_before, graph.topology_fallback_count);
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+    // 변경값 반영 확인.
+    try std.testing.expect(std.mem.indexOf(u8, preserved.output, "42") != null);
+}
+
+test "Phase B: 보존 경로 반복 rebuild GPA leak 0 (transferModulesToStore 비활성 — parse_arena 단독 owner)" {
+    // 보존 모드에선 store 로 양도하지 않고 graph 가 parse_arena 를 단독 소유. 여러 번 rebuild
+    // 후 graph.deinit + store.deinit 가 double-free/leak 없이 끝나야 한다(GPA 검출).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "export const a = 1;");
+    try writeFile(tmp.dir, "b.ts", "export const b = 2;");
+    try writeFile(tmp.dir, "index.ts", "import { a } from './a';\nimport { b } from './b';\nconsole.log(a, b);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopo(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    // store 는 보존 모드에서 비어있어야 한다(transferModulesToStore 비활성).
+    try std.testing.expectEqual(@as(usize, 0), store.modules.count());
+
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        std.testing.io.sleep(std.Io.Duration.fromMilliseconds(20), .awake) catch {};
+        const src = try std.fmt.allocPrint(std.testing.allocator, "import {{ a }} from './a';\nimport {{ b }} from './b';\nconsole.log(a, b, {d});", .{i});
+        defer std.testing.allocator.free(src);
+        try writeFile(tmp.dir, "index.ts", src);
+        var touched: std.StringHashMapUnmanaged(void) = .empty;
+        defer touched.deinit(std.testing.allocator);
+        try touched.put(std.testing.allocator, entry, {});
+
+        var preserved = try preservedBuildTopo(&graph, &store, &rc, entry, false, &touched);
+        defer preserved.deinit(std.testing.allocator);
+        try std.testing.expect(!preserved.hasErrors());
+    }
+    // 보존 경로를 여러 번 탔고(전량 fallback 아님), store 는 끝까지 비어있다.
+    try std.testing.expect(graph.topology_preserved_hits >= 1);
+    try std.testing.expectEqual(@as(usize, 0), store.modules.count());
+}
+
+test "Phase B: 공유 dep 의 여러 importer — dep body edit 시 importers 순서 보존(byte-identical)" {
+    // shared.ts 를 a/b/c 셋이 import → shared.importers 에 [a,b,c] 순. shared body edit 시
+    // 보존 경로가 a/b/c 의 edge 를 건드리지 않아 importers 순서가 fresh 와 동일해야 한다
+    // (unlink/relink 했다면 shared 가 importers 끝으로 밀려 출력이 달라질 위험을 격리 검증).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "shared.ts", "export const s = 100;");
+    try writeFile(tmp.dir, "a.ts", "import { s } from './shared';\nexport const a = s + 1;");
+    try writeFile(tmp.dir, "b.ts", "import { s } from './shared';\nexport const b = s + 2;");
+    try writeFile(tmp.dir, "c.ts", "import { s } from './shared';\nexport const c = s + 3;");
+    try writeFile(tmp.dir, "index.ts",
+        \\import { a } from './a';
+        \\import { b } from './b';
+        \\import { c } from './c';
+        \\console.log(a, b, c);
+    );
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const shared_path = try absPath(&tmp, "shared.ts");
+    defer std.testing.allocator.free(shared_path);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopo(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const hits_before = graph.topology_preserved_hits;
+    const fb_before = graph.topology_fallback_count;
+
+    // shared.ts body-only edit (위상 불변 — 셋이 여전히 import).
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "shared.ts", "export const s = 999;");
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, shared_path, {});
+
+    var preserved = try preservedBuildTopo(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh_result = try freshFull(entry);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    // 보존 경로 hit(전량 fallback 아님) + importers 순서 보존 → byte-identical + 변경값 반영.
+    try std.testing.expectEqual(hits_before + 1, graph.topology_preserved_hits);
+    try std.testing.expectEqual(fb_before, graph.topology_fallback_count);
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+    try std.testing.expect(std.mem.indexOf(u8, preserved.output, "999") != null);
+}
+
+test "Phase B: fallback 도 store cache-hit 으로 증분(전량 reparse 아님) + byte-identical" {
+    // 모듈 추가(위상 변화) → fallback. fast-fallback(graph→store 핸드오프)으로 변경 안 된
+    // 모듈은 store cache-hit 이라 reparse 가 적어야 한다. 정확성(byte-identical)은 필수.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "x.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "y.ts", "export const y = 2;");
+    try writeFile(tmp.dir, "extra.ts", "export const EXTRA_ADDED_MARKER = 31337;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './x';\nimport { y } from './y';\nconsole.log(x, y);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopo(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const fb_before = graph.topology_fallback_count;
+
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts",
+        \\import { x } from './x';
+        \\import { y } from './y';
+        \\import { EXTRA_ADDED_MARKER } from './extra';
+        \\console.log(x, y, EXTRA_ADDED_MARKER);
+    );
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuildTopo(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh_result = try freshFull(entry);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    // fallback 발생 + byte-identical + 추가 모듈 반영(31337 값이 출력에 등장).
+    try std.testing.expectEqual(fb_before + 1, graph.topology_fallback_count);
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+    try std.testing.expect(std.mem.indexOf(u8, preserved.output, "31337") != null);
+}

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -2127,3 +2127,114 @@ test "Phase B: fallback 도 store cache-hit 으로 증분(전량 reparse 아님)
     try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
     try std.testing.expect(std.mem.indexOf(u8, preserved.output, "31337") != null);
 }
+
+// ── /code-review max 회귀 가드 (Phase B HIGH 2건) ────────────────────────────
+
+test "Phase B byte-identical: dep 의 top-level await 제거 → importer TLA demote (set-only stale 방지)" {
+    // B-F1: propagateTopLevelAwait 는 importer 에 set-only 전파(demote 없음)다. 보존 경로는
+    // unchanged importer 를 reparse 하지 않으므로, dep 가 await 를 제거하면 importer 의 stale
+    // uses_top_level_await=true 가 남아 emit 이 fresh(sync)와 달리 async wrapper 를 박는다.
+    // self_uses_top_level_await base reset 이 이를 demote 하는지 byte-identical 로 가드.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "dep.ts", "export const x = await Promise.resolve(1);");
+    try writeFile(tmp.dir, "index.ts",
+        \\import { x } from './dep';
+        \\console.log(x);
+    );
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopo(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const hits_before = graph.topology_preserved_hits;
+
+    // dep.ts body-only edit: top-level await 제거 (import 위상 불변 → 보존 경로).
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "dep.ts", "export const x = 1;");
+    const dep_abs = try absPath(&tmp, "dep.ts");
+    defer std.testing.allocator.free(dep_abs);
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, dep_abs, {});
+
+    var preserved = try preservedBuildTopo(&graph, &store, &rc, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh_result = try freshFull(entry);
+    defer fresh_result.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh_result.hasErrors());
+
+    // 보존 경로를 탔고(전량 fallback 아님), importer TLA 가 fresh 처럼 demote 되어 byte-identical.
+    try std.testing.expectEqual(hits_before + 1, graph.topology_preserved_hits);
+    try std.testing.expectEqualStrings(fresh_result.output, preserved.output);
+}
+
+test "Phase B: 보존 경로가 requested_exports 를 reset — parse_arena dangling slice 누적/UAF 방지" {
+    // A-F1: requested_exports[dep].names 는 importer 의 parse_arena slice 를 dupe 없이 borrow
+    // 한다. 변경 모듈(index) reparse 가 그 arena 를 free 하는데 reset 안 하면 names 가 dangling
+    // 되어 재resolve 의 contains(std.mem.eql)가 UAF read + (freed page mismatch 시) 매 rebuild
+    // append 누적한다. resetPerBuildStateForPreserved 의 전량 deinit 으로 names.len 이 항상 1
+    // (index 가 요청하는 'a' 하나)로 유지됨을 가드.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "dep.ts", "export const a = 1;\nexport const b = 2;");
+    try writeFile(tmp.dir, "index.ts",
+        \\import { a } from './dep';
+        \\console.log(a);
+    );
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const dep_abs = try absPath(&tmp, "dep.ts");
+    defer std.testing.allocator.free(dep_abs);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopo(&graph, &store, &rc, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const dep_idx = graph.path_to_module.get(dep_abs) orelse return error.DepNotFound;
+    const dep_key: u32 = @intFromEnum(dep_idx);
+
+    var round: usize = 0;
+    while (round < 3) : (round += 1) {
+        std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+        // index body-only edit (named import 'a' 유지) → 보존 경로 재진입.
+        var buf: [128]u8 = undefined;
+        const src = try std.fmt.bufPrint(&buf,
+            \\import {{ a }} from './dep';
+            \\console.log(a, {d});
+        , .{round});
+        try writeFile(tmp.dir, "index.ts", src);
+        var touched: std.StringHashMapUnmanaged(void) = .empty;
+        defer touched.deinit(std.testing.allocator);
+        try touched.put(std.testing.allocator, entry, {});
+        var r = try preservedBuildTopo(&graph, &store, &rc, entry, false, &touched);
+        defer r.deinit(std.testing.allocator);
+        try std.testing.expect(!r.hasErrors());
+
+        // reset 이 매 빌드 names 를 비우고 변경 모듈 재resolve 가 'a' 하나만 재등록 → len 1 유지.
+        // (reset 누락 시 dangling slice 가 0xaa fill 로 eql=false 되어 append 누적 → len 증가.)
+        if (graph.requested_exports.get(dep_key)) |req| {
+            try std.testing.expectEqual(@as(usize, 1), req.names.items.len);
+        }
+    }
+}

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -329,6 +329,13 @@ pub const Module = struct {
     def_format: types.ModuleDefFormat = .unknown,
     /// Top-Level Await 사용 여부. TLA 모듈을 static import하는 모듈도 전이적으로 true.
     uses_top_level_await: bool = false,
+    /// 이 모듈 *자신의* body 가 top-level await 를 쓰는지 — parse 가 설정하는 base 값
+    /// (`uses_top_level_await` 의 transitive 전파 *전* 상태). `propagateTopLevelAwait` 가
+    /// 매 빌드 시작 시 `uses_top_level_await = self_uses_top_level_await` 로 base 를 깐 뒤
+    /// 전파한다. HMR 위상 보존(Phase B) 에서 unchanged 모듈은 reparse 되지 않아 직전 빌드의
+    /// transitive true 가 stale 로 남는데(set-only 전파라 demote 없음), 이 base reset 이
+    /// 그 stale 을 지운다. fresh full 빌드에선 `uses==self` 라 no-op.
+    self_uses_top_level_await: bool = false,
     side_effects: bool,
     /// side_effects가 package.json `sideEffects` 필드에 의해 결정됐음을 표시.
     /// true면 tree-shaker의 auto-purity 분석이 이 값을 덮어쓸 수 없다.


### PR DESCRIPTION
## 요약
HMR graph 증분의 **Phase B**(edge-reuse). body-only edit(import 위상 불변)이면 `persistent_graph` 를 보존하고 **변경 모듈만 재파싱**해 graphDiscover 의 replay/edge 재구성을 skip 한다. Phase A(#4162, 전량 clear 후 fresh discovery)의 토대 위에서, 이번엔 변경 모듈 edge 만 부분 갱신한다.

- base = `origin/main`(82eddf12 = Phase A 머지 완료).
- 포함 커밋: `c3e5f154`(F1 보정) → `e4ca8bea`(Phase B) → `d67c49be`(/code-review max 수정).

## 성능
- **web 평이 빌드만 graph 절감**(170→~40 목표).
- **RN(mobile-seller)은 항상 full fallback** — `canPreserveTopology` 가 `runtime_polyfills`(core-js)/`rn_asset_metadata`(images)를 제외하기 때문. 이 per-build 파생물을 보존하면 byte-identical 이 깨지므로 **의도된 fail-safe**다. RN graph 절감은 정확성 위험을 동반해 후속 과제로 분리.
- 100ms 목표는 renumber+finalizeGraph(O(N) DFS) 잔존으로 도달 불가(별도 분석). 안전 천장 ~270ms.

## 동작 (Zig 초보 설명)
- `buildIncrementalPreserved`: 변경 모듈이 모두 graph 에 있고 위상 가드를 통과하면 진입. 아니면 `fallbackFullRebuild`(graph→store 핸드오프 후 `buildIncremental` — fallback 도 증분 유지).
- `reparseChangedModulePreserveEdges`: 변경 모듈의 edge 리스트(`dependencies`/`importers`/`dynamic_*`, graph allocator 소유)를 떼어 보관 → `module.deinit`(parse_arena 등 해제) → 빈 `init` → edge + file-identity(module_type/loader/resolve_dir) 복원 → 재파싱. 재resolve 는 `suppress_edge_link` 로 link 를 억제해 edge 중복/이동을 막는다.
- `transferModulesToStore`: 보존 모드에선 비활성 → graph 가 `parse_arena` 단독 owner(double-free 회피).
- `topologyMatches`: specifier/kind/resolve-target 비교. 불일치 시 full fallback.

## F1 (main 누락 보정)
Phase A 의 F1(`pkg_info_cache` 가 `path_arena` substring 키라 reset 전 무효화 필수)이 #4162 머지 시 auto-merge 타이밍 때문에 main 에 못 들어갔다. `c3e5f154` 로 재반영.

## /code-review max 수정 (d67c49be — 머지 차단급 2건 + 문서 1건)
- **A-F1 [UAF]**: `requested_exports[dep].names` 가 importer 의 `parse_arena` slice 를 dupe 없이 borrow → 변경 모듈 reparse(arena free) 후 dangling → 재resolve 의 `requestNamed→contains`(std.mem.eql)가 freed 메모리를 읽음. `resolveModuleImports` 는 dev 무관하게 `requestDependencyExports` 를 호출하므로 dev 보존 경로도 노출. → `resetPerBuildStateForPreserved` 에서 `requested_exports` 전량 deinit(dev 소비처는 게이트로 비활성이라 정확성 영향 0).
- **B-F1 [byte 갈림]**: `propagateTopLevelAwait` 가 importer 에 set-only 전파(demote 없음)라, 보존 경로에서 dep 가 top-level await 를 제거하면 unchanged importer 의 stale `uses_top_level_await=true` 가 잔존 → emit 이 fresh(sync)와 달리 async wrapper 를 박아 byte 가 갈림. → `module.self_uses_top_level_await`(parse base) 추가 + `propagateTopLevelAwait` 시작에 `uses=self` 로 base reset(fresh 엔 no-op).
- **C-F1 [문서]**: `watch.zig` 초기 빌드 둘째 주석 블록이 코드(`preserve_topology=true`)와 정반대인 stale 주석 → 정정.
- 회귀 테스트 2건 추가(TLA demote byte-identical, requested_exports 누적 0).

## known-limitation
- **B-F2**(`is_module_field` set-only stale): emit 소비처가 resolver/resolve_cache 뿐(emit/linker 부재)이라 byte 영향 미미 → 후속.
- **RN watch(napi) 경로**는 단위 테스트 미커버(코어 `IncrementalBundler` 경로로 정확성 담보) — 통합 스모크 후속.

## 검증
- `zig build test` + `zig build napi` RC=0.
- Phase B byte-identical 9 + topology 5 + 신규 회귀 2 green, GPA leak 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
