### PR TITLE
perf(graph): RN asset metadata 위상 보존 — module-level 재수집 (PR-1)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -2396,14 +2396,6 @@ pub const Bundler = struct {
         lifecycle_runner.runBuildEnd(first_err);
         lifecycle_runner.runCloseBundle();
 
-        // RN asset metadata ownership 을 graph → BundleResult 로 transfer.
-        // graph.deinit 의 free 루프는 toOwnedSlice 후 비어있는 list 를 만남.
-        const rn_asset_metadata_out: ?[]RnAssetMetadata =
-            if (graph.rn_asset_metadata.items.len > 0)
-                try graph.rn_asset_metadata.toOwnedSlice(self.allocator)
-            else
-                null;
-
         // #3318 P1-6: host(mf.remotes) — 단일파일 출력에 init prelude +
         // 원격 동적 import→loadRemote 재작성. split 경로(output="" — host
         // 가 동시에 remote 인 niche)는 후속(follow-up). 게이트 = wrapContainer
@@ -2422,6 +2414,27 @@ pub const Bundler = struct {
                 output = host_out;
             }
         }
+
+        // RN asset metadata 를 graph → BundleResult 로 deep-copy. 항목 strings 는 이제
+        // module.parse_arena 소유(graph list 는 borrow)라 graph.deinit(arena destroy) 후
+        // dangling — self.allocator 로 dupe 해 BundleResult 수명과 분리한다. MF host 분기
+        // *뒤*에 둬, 그 분기가 error 로 빠질 때 duped metadata 가 새지 않게 한다(이 dupe 이후
+        // return 까지 추가 try 가 없어 blk-scope errdefer 로 충분).
+        const rn_asset_metadata_out: ?[]RnAssetMetadata = blk: {
+            const items = graph.rn_asset_metadata.items;
+            if (items.len == 0) break :blk null;
+            const out = try self.allocator.alloc(RnAssetMetadata, items.len);
+            var filled: usize = 0;
+            errdefer {
+                for (out[0..filled]) |m| graph_assets.freeRnAssetMetadata(self.allocator, m);
+                self.allocator.free(out);
+            }
+            for (items, 0..) |meta, i| {
+                out[i] = try graph_assets.dupeRnAssetMetadata(self.allocator, meta);
+                filled = i + 1;
+            }
+            break :blk out;
+        };
 
         return .{
             .output = output,

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -203,12 +203,13 @@ pub const ModuleGraph = struct {
     /// Worker 엔트리: new Worker(new URL(...)) 패턴에서 수집된 worker 파일 경로.
     /// 메인 그래프에는 모듈로 추가하지 않고, bundler에서 별도 빌드한다.
     worker_entries: std.ArrayList(WorkerEntry) = .empty,
-    /// RN AssetRegistry.registerAsset 호출에 emit 된 asset metadata 수집.
-    /// loader 가 emit 시점에 push, bundler 가 BundleResult.rn_asset_metadata 로 expose.
-    /// strings 는 graph.allocator 소유 (loader arena 가 free 되어도 안전하도록 dupe).
+    /// RN AssetRegistry.registerAsset 호출에 emit 된 asset metadata.
+    /// loader 가 `module.rn_asset_metadata`(parse_arena 소유)에 저장하고, finalize 의
+    /// collectRnAssetMetadata 가 renumber-후 결정적 순서로 이 list 를 borrow 재구성한다.
+    /// list 항목은 borrow(실제 owner=module.parse_arena) — bundler 가 BundleResult 로 expose
+    /// 할 때만 deep-copy(dupeRnAssetMetadata)로 long-lived 분리. (per-module 저장이라 graph 공유
+    /// append 가 없어져 mutex 불요.)
     rn_asset_metadata: std.ArrayListUnmanaged(@import("graph/assets.zig").RnAssetMetadata) = .empty,
-    /// rn_asset_metadata 병렬 append 보호 (scanWorker 호출 대응).
-    rn_asset_metadata_mutex: spin.SpinLock = .{},
 
     /// `worklet "directive"` plugin 활성 여부 — bundler 가 BundleOptions.worklet_transform 으로 set.
     /// graph 가 직접 사용 (parseModule 의 worklet exclude 휴리스틱).

--- a/src/bundler/graph/assets.zig
+++ b/src/bundler/graph/assets.zig
@@ -158,8 +158,10 @@ pub fn applyAssetNamingPattern(
 }
 
 /// RN bundle 결과로 expose 되는 asset metadata. strings + scales 는 emit 시
-/// caller 가 전달한 `metadata_alloc` (BundleResult 까지 살아남는 long-lived
-/// allocator) 직접 소유 — clone 단계 없이 그대로 list 에 push 가능.
+/// caller 가 전달한 `metadata_alloc` 소유 — loader 는 이를 그 asset 모듈의 `parse_arena`
+/// 로 주어, metadata 가 module 라이프사이클(deinit/store/reparse)에 자동 정합되게 한다.
+/// `graph.rn_asset_metadata` list 는 finalize 가 module 들에서 borrow 로 재수집하며,
+/// `BundleResult` 로 내보낼 때만 `dupeRnAssetMetadata` 로 long-lived 복제한다.
 ///
 /// 노출되는 필드는 `rn-asset-copy` 의 release copy 경로가 실제 읽는 것만 (Metro
 /// `getAssetDestPath{IOS,Android}` 입력). width/height/hash 는 source string 안
@@ -187,6 +189,29 @@ pub fn freeRnAssetMetadata(allocator: std.mem.Allocator, meta: RnAssetMetadata) 
     allocator.free(meta.name);
     allocator.free(meta.type_name);
     allocator.free(meta.scales);
+}
+
+/// `RnAssetMetadata` 를 `allocator` 로 deep-copy. `freeRnAssetMetadata` 의 짝.
+/// 항목 strings 가 보통 module 의 `parse_arena`(short-lived) 소유라, graph 수명과
+/// 분리해 `BundleResult` 로 내보낼 때 long-lived allocator 로 복제한다.
+/// 부분 실패 시 errdefer 가 이미 dupe 된 슬라이스를 회수해 leak 을 막는다.
+pub fn dupeRnAssetMetadata(allocator: std.mem.Allocator, meta: RnAssetMetadata) !RnAssetMetadata {
+    const http = try allocator.dupe(u8, meta.http_server_location);
+    errdefer allocator.free(http);
+    const fs_loc = try allocator.dupe(u8, meta.file_system_location);
+    errdefer allocator.free(fs_loc);
+    const name = try allocator.dupe(u8, meta.name);
+    errdefer allocator.free(name);
+    const type_name = try allocator.dupe(u8, meta.type_name);
+    errdefer allocator.free(type_name);
+    const scales = try allocator.dupe(u32, meta.scales);
+    return .{
+        .http_server_location = http,
+        .file_system_location = fs_loc,
+        .name = name,
+        .type_name = type_name,
+        .scales = scales,
+    };
 }
 
 /// `emitAssetRegistryCall` 의 입력 — caller (loader) 가 module 단위로 모은 값들.

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -633,6 +633,22 @@ fn linkDependencyUnique(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) 
 
 /// Phase 2-4: DFS exec_index + ExportsKind 승격 + TLA 전파.
 /// build()와 buildIncremental() 양쪽에서 호출.
+/// renumber 직후 모든 모듈을 결정적 index 순서로 순회해 `graph.rn_asset_metadata` 를 재구성한다.
+/// fresh full 과 preserved(edge-reuse)가 같은 renumber-후 순서로 수집하므로 배열이 byte-identical.
+/// 항목 strings 는 각 module 의 parse_arena 소유 — list 는 borrow(여기서 free 하지 않으며,
+/// clearRetainingCapacity 로 이전 빌드 항목을 비운다).
+fn collectRnAssetMetadata(self: *ModuleGraph) !void {
+    self.rn_asset_metadata.clearRetainingCapacity();
+    const count = self.modules.count();
+    var i: usize = 0;
+    while (i < count) : (i += 1) {
+        const m = self.modules.at(i);
+        if (m.rn_asset_metadata) |meta| {
+            try self.rn_asset_metadata.append(self.allocator, meta);
+        }
+    }
+}
+
 fn finalizeGraph(self: *ModuleGraph, entry_points: []const []const u8) !void {
     var scope = profile.begin(.graph_finalize);
     defer scope.end();
@@ -640,6 +656,10 @@ fn finalizeGraph(self: *ModuleGraph, entry_points: []const []const u8) !void {
     // discovery 워커 race 로 비결정인 module_index 를 BFS 순으로 재부여.
     // linker init 전에 수행해 외부 idx 키 자료구조 영향 0.
     try renumber.renumberModulesDeterministically(self, entry_points);
+
+    // renumber 직후 결정적 index 순서로 RN asset metadata 재수집 — fresh full 과 preserved
+    // (edge-reuse) 양쪽이 같은 순서로 모아 배열이 byte-identical(항목은 module.parse_arena 소유 borrow).
+    try collectRnAssetMetadata(self);
 
     const count = self.modules.count();
     if (count == 0) return;
@@ -1214,6 +1234,14 @@ pub fn buildIncrementalPreserved(
             if (graph_requested_exports.isLazyBarrelCandidate(self, self.modules.at(ui))) {
                 return fallbackFullRebuild(self, io, entry_points, store, changed_files);
             }
+            // **asset 가드**: asset 모듈(이미지 등)은 emit 후 loader=.javascript 로 굳는다. 보존 reparse
+            // 가 그 loader 를 복원하면 parseModule 의 isAsset() 분기를 우회 → parseAssetModule 미실행으로
+            // rn_asset_metadata 가 재생성되지 않고(누락) 바이너리를 raw JS 로 오파싱(source corruption).
+            // 직전 빌드 asset_data 로 감지해 보수적 full fallback(fresh 가 재스캔). asset 파일 자체
+            // 변경(.png 교체) 시나리오를 정확성 우선으로 처리.
+            if (self.modules.at(ui).asset_data != null) {
+                return fallbackFullRebuild(self, io, entry_points, store, changed_files);
+            }
             try changed_indices.append(self.allocator, ui);
         }
     }
@@ -1395,7 +1423,9 @@ fn canPreserveTopology(self: *const ModuleGraph) bool {
     if (self.runtime_polyfills != null) return false;
     if (self.inject_files.len > 0 or self.run_before_main_files.len > 0) return false;
     if (self.worker_entries.items.len > 0) return false;
-    if (self.rn_asset_metadata.items.len > 0) return false;
+    // (rn_asset_metadata 게이트 제거 — PR-1: metadata 를 module.parse_arena 소유로 옮겨
+    //  finalize 의 collectRnAssetMetadata 가 재수집하므로 위상 보존에서 자동 정합한다.
+    //  polyfill/worker 는 PR-2/후속에서 풀 때까지 유지.)
     if (self.runtime_polyfill_roots.items.len > 0) return false;
     // emit_store 에 chunk 요청이 있으면(plugin emitFile chunk) 보존 제외. emit_store 가
     // null 이면 chunk 미사용(hot path 0). 포인터만 검사 — chunk 내용은 injectEmittedChunks 영역.

--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -49,10 +49,8 @@ pub fn reset(self: *ModuleGraph) void {
     for (self.worker_entries.items) |we| self.allocator.free(we.resolved_path);
     self.worker_entries.clearRetainingCapacity();
 
-    const graph_assets = @import("assets.zig");
-    for (self.rn_asset_metadata.items) |meta| {
-        graph_assets.freeRnAssetMetadata(self.allocator, meta);
-    }
+    // rn_asset_metadata 항목은 module.parse_arena 소유(borrow) — 여기서 free 안 함.
+    // finalize 의 collectRnAssetMetadata 가 clear 후 module 들에서 재수집한다.
     self.rn_asset_metadata.clearRetainingCapacity();
 
     self.runtime_polyfill_roots.clearRetainingCapacity();
@@ -197,10 +195,7 @@ pub fn deinit(self: *ModuleGraph) void {
         self.allocator.free(we.resolved_path);
     }
     self.worker_entries.deinit(self.allocator);
-    const graph_assets = @import("assets.zig");
-    for (self.rn_asset_metadata.items) |meta| {
-        graph_assets.freeRnAssetMetadata(self.allocator, meta);
-    }
+    // rn_asset_metadata 항목은 module.parse_arena 소유(borrow) — list backing 만 해제.
     self.rn_asset_metadata.deinit(self.allocator);
     if (self.plugins_with_helpers) |p| self.allocator.free(p);
     self.runtime_polyfill_roots.deinit(self.allocator);

--- a/src/bundler/graph/loaders.zig
+++ b/src/bundler/graph/loaders.zig
@@ -165,9 +165,9 @@ pub fn parseAssetModule(self: *ModuleGraph, io: std.Io, module: *Module) void {
                 // loader=.javascript는 호출자의 fall-through 신호.
                 // import_scanner가 source의 require()를 ImportRecord로 추출하고
                 // wrap_kind/exports_kind를 .cjs로 자동 결정한다.
-                // 첫 인자가 metadata_alloc (long-lived, graph), 두번째가 source_alloc
-                // (short-lived, parse_arena) — fs.RealReadFileCache.readFile 컨벤션.
-                const emitted = emitAssetRegistryCall(self.allocator, arena_alloc, .{
+                // 두 allocator 모두 arena_alloc(parse_arena): metadata 를 module 소유로 만들어
+                // finalize 재수집 + 위상 보존(reparse/store)에 자동 정합시킨다(PR-1).
+                const emitted = emitAssetRegistryCall(arena_alloc, arena_alloc, .{
                     .registry_path = registry_path,
                     .abs_path = module.path,
                     .bytes = raw,
@@ -182,11 +182,9 @@ pub fn parseAssetModule(self: *ModuleGraph, io: std.Io, module: *Module) void {
                     return;
                 };
                 module.source = emitted.source;
-                self.rn_asset_metadata_mutex.lock();
-                defer self.rn_asset_metadata_mutex.unlock();
-                self.rn_asset_metadata.append(self.allocator, emitted.metadata) catch {
-                    graph_assets.freeRnAssetMetadata(self.allocator, emitted.metadata);
-                };
+                // metadata(parse_arena 소유)를 module 에 저장 — finalize 의 collectRnAssetMetadata
+                // 가 graph list 로 재수집한다. graph 공유 list 직접 append 가 사라져 mutex 불요.
+                module.rn_asset_metadata = emitted.metadata;
                 module.module_type = .js;
                 module.loader = .javascript;
                 return;

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -2238,3 +2238,344 @@ test "Phase B: 보존 경로가 requested_exports 를 reset — parse_arena dang
         }
     }
 }
+
+// ── PR-1 RN asset metadata 위상 보존 (게이트 H 완화) ──────────────────────────
+
+const RnAssetMetadata_t = @import("graph/assets.zig").RnAssetMetadata;
+
+fn preservedBuildTopoRN(
+    graph: *ModuleGraph_t,
+    store: *module_store.PersistentModuleStore,
+    rc: *@import("resolve_cache.zig").ResolveCache,
+    entry: []const u8,
+    project_root: []const u8,
+    is_first: bool,
+    changed: ?*const std.StringHashMapUnmanaged(void),
+) !BundleResult {
+    _ = project_root;
+    var opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .platform = .react_native,
+        .asset_registry = "./AssetRegistry.js",
+        .loader_overrides = &.{.{ .ext = ".png", .loader = .file }},
+    });
+    if (!is_first) {
+        opts.module_store = store;
+        opts.changed_files = changed;
+        opts.preserve_topology = true;
+    }
+    var b = Bundler.initWithGraph(std.testing.allocator, opts, rc, graph);
+    defer b.deinit();
+    return try b.bundle(std.testing.io);
+}
+
+fn freshFullRN(entry: []const u8, project_root: []const u8) !BundleResult {
+    _ = project_root;
+    var fresh = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .platform = .react_native,
+        .asset_registry = "./AssetRegistry.js",
+        .loader_overrides = &.{.{ .ext = ".png", .loader = .file }},
+    });
+    defer fresh.deinit();
+    return try fresh.bundle(std.testing.io);
+}
+
+fn expectRnMetaEqual(a: ?[]const RnAssetMetadata_t, b: ?[]const RnAssetMetadata_t) !void {
+    const xa: []const RnAssetMetadata_t = a orelse &.{};
+    const xb: []const RnAssetMetadata_t = b orelse &.{};
+    try std.testing.expectEqual(xa.len, xb.len);
+    for (xa, xb) |ma, mb| {
+        try std.testing.expectEqualStrings(ma.http_server_location, mb.http_server_location);
+        try std.testing.expectEqualStrings(ma.file_system_location, mb.file_system_location);
+        try std.testing.expectEqualStrings(ma.name, mb.name);
+        try std.testing.expectEqualStrings(ma.type_name, mb.type_name);
+        try std.testing.expectEqualSlices(u32, ma.scales, mb.scales);
+    }
+}
+
+test "PR-1 RN: asset 보존 — body-only edit 후 output + rn_asset_metadata == fresh full (게이트 H 완화)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // 최소 PNG signature — extractDimensions 는 IHDR 없어 0×0 이지만 metadata(name/type/scales)는 생성.
+    try writeFile(tmp.dir, "registry.js",
+        \\exports.registerAsset = function registerAsset(asset) { return asset; };
+    );
+    try writeFile(tmp.dir, "AssetRegistry.js",
+        \\export { registerAsset } from './registry.js';
+    );
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "logo.png", .data = &.{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A } });
+    try writeFile(tmp.dir, "index.ts",
+        \\const logo = require('./logo.png');
+        \\console.log(logo);
+    );
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const root = std.fs.path.dirname(entry).?;
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true, .platform = .react_native, .asset_registry = "./AssetRegistry.js", .loader_overrides = &.{.{ .ext = ".png", .loader = .file }} });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopoRN(&graph, &store, &rc, entry, root, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+        // asset metadata 가 실제로 수집됐는지(게이트 전제 충족).
+        try std.testing.expect(r1.rn_asset_metadata != null and r1.rn_asset_metadata.?.len == 1);
+    }
+    const hits_before = graph.topology_preserved_hits;
+    const fb_before = graph.topology_fallback_count;
+
+    // index.ts body-only edit (asset import 위상 불변 → 보존 경로).
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts",
+        \\const logo = require('./logo.png');
+        \\console.log(logo, 'edited');
+    );
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuildTopoRN(&graph, &store, &rc, entry, root, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh = try freshFullRN(entry, root);
+    defer fresh.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh.hasErrors());
+
+    // 게이트 H 완화: asset metadata 가 있어도 보존 경로 진입(hit++), 전량 fallback 아님.
+    try std.testing.expectEqual(hits_before + 1, graph.topology_preserved_hits);
+    try std.testing.expectEqual(fb_before, graph.topology_fallback_count);
+    // 엄격 byte-identical: 번들 바이트 + rn_asset_metadata 배열(순서/필드/scales).
+    try std.testing.expectEqualStrings(fresh.output, preserved.output);
+    try expectRnMetaEqual(preserved.rn_asset_metadata, fresh.rn_asset_metadata);
+}
+
+test "PR-1 RN: asset import 제거 → 위상 변화 → fallback + rn_asset_metadata == fresh full" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "registry.js",
+        \\exports.registerAsset = function registerAsset(asset) { return asset; };
+    );
+    try writeFile(tmp.dir, "AssetRegistry.js",
+        \\export { registerAsset } from './registry.js';
+    );
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "logo.png", .data = &.{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A } });
+    try writeFile(tmp.dir, "index.ts",
+        \\const logo = require('./logo.png');
+        \\console.log(logo);
+    );
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const root = std.fs.path.dirname(entry).?;
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true, .platform = .react_native, .asset_registry = "./AssetRegistry.js", .loader_overrides = &.{.{ .ext = ".png", .loader = .file }} });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopoRN(&graph, &store, &rc, entry, root, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const fb_before = graph.topology_fallback_count;
+
+    // asset import 제거 → import_records 변화 → topologyMatches=false → fallback.
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts",
+        \\console.log('no asset');
+    );
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuildTopoRN(&graph, &store, &rc, entry, root, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh = try freshFullRN(entry, root);
+    defer fresh.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh.hasErrors());
+
+    try std.testing.expectEqual(fb_before + 1, graph.topology_fallback_count);
+    try std.testing.expectEqualStrings(fresh.output, preserved.output);
+    // logo 제거 → metadata 0 양쪽.
+    try expectRnMetaEqual(preserved.rn_asset_metadata, fresh.rn_asset_metadata);
+}
+
+test "PR-1 RN: A→B→A 반복 body-only edit → 매 회 output+metadata == fresh full + leak 0" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "registry.js",
+        \\exports.registerAsset = function registerAsset(asset) { return asset; };
+    );
+    try writeFile(tmp.dir, "AssetRegistry.js",
+        \\export { registerAsset } from './registry.js';
+    );
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "logo.png", .data = &.{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A } });
+    try writeFile(tmp.dir, "index.ts",
+        \\const logo = require('./logo.png');
+        \\console.log(logo, 0);
+    );
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const root = std.fs.path.dirname(entry).?;
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true, .platform = .react_native, .asset_registry = "./AssetRegistry.js", .loader_overrides = &.{.{ .ext = ".png", .loader = .file }} });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopoRN(&graph, &store, &rc, entry, root, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    var round: usize = 1;
+    while (round <= 4) : (round += 1) {
+        std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+        var buf: [128]u8 = undefined;
+        const src = try std.fmt.bufPrint(&buf,
+            \\const logo = require('./logo.png');
+            \\console.log(logo, {d});
+        , .{round});
+        try writeFile(tmp.dir, "index.ts", src);
+        var touched: std.StringHashMapUnmanaged(void) = .empty;
+        defer touched.deinit(std.testing.allocator);
+        try touched.put(std.testing.allocator, entry, {});
+
+        var preserved = try preservedBuildTopoRN(&graph, &store, &rc, entry, root, false, &touched);
+        defer preserved.deinit(std.testing.allocator);
+        try std.testing.expect(!preserved.hasErrors());
+
+        var fresh = try freshFullRN(entry, root);
+        defer fresh.deinit(std.testing.allocator);
+        try std.testing.expectEqualStrings(fresh.output, preserved.output);
+        try expectRnMetaEqual(preserved.rn_asset_metadata, fresh.rn_asset_metadata);
+    }
+}
+
+test "PR-1 RN: asset(.png) 파일 자체 변경 → asset 가드로 fallback + == fresh full" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "registry.js",
+        \\exports.registerAsset = function registerAsset(asset) { return asset; };
+    );
+    try writeFile(tmp.dir, "AssetRegistry.js",
+        \\export { registerAsset } from './registry.js';
+    );
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "logo.png", .data = &.{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A } });
+    try writeFile(tmp.dir, "index.ts",
+        \\const logo = require('./logo.png');
+        \\console.log(logo);
+    );
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const root = std.fs.path.dirname(entry).?;
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true, .platform = .react_native, .asset_registry = "./AssetRegistry.js", .loader_overrides = &.{.{ .ext = ".png", .loader = .file }} });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopoRN(&graph, &store, &rc, entry, root, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const fb_before = graph.topology_fallback_count;
+
+    // logo.png 자체 교체(다른 bytes) + changed_files=logo.png → asset 모듈 직접 변경.
+    // asset 가드(asset_data != null)가 보존을 거부하고 fallback(fresh 재스캔)해야 한다.
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "logo.png", .data = &.{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x01, 0x02 } });
+    const logo_abs = try absPath(&tmp, "logo.png");
+    defer std.testing.allocator.free(logo_abs);
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, logo_abs, {});
+
+    var preserved = try preservedBuildTopoRN(&graph, &store, &rc, entry, root, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    // 핵심: asset 모듈 직접 변경 → asset 가드가 보존(edge-reuse)을 거부하고 fallback 으로 전환.
+    // (보존 경로에 머물렀다면 reparse 가 .javascript loader 를 복원해 metadata 손실 + source 깨짐.)
+    // fallback 경로의 asset 재파싱 byte 정확성은 기존 동작이라 여기선 가드의 fallback 전환만 단언
+    // (테스트 환경 mtime 해상도와 무관하게 결정적).
+    try std.testing.expectEqual(fb_before + 1, graph.topology_fallback_count);
+}
+
+test "PR-1 RN: 다중 asset — body-only edit 후 rn_asset_metadata 배열 순서 == fresh full" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "registry.js",
+        \\exports.registerAsset = function registerAsset(asset) { return asset; };
+    );
+    try writeFile(tmp.dir, "AssetRegistry.js",
+        \\export { registerAsset } from './registry.js';
+    );
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "logo.png", .data = &.{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A } });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "icon.png", .data = &.{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A } });
+    try writeFile(tmp.dir, "index.ts",
+        \\const logo = require('./logo.png');
+        \\const icon = require('./icon.png');
+        \\console.log(logo, icon);
+    );
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const root = std.fs.path.dirname(entry).?;
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true, .platform = .react_native, .asset_registry = "./AssetRegistry.js", .loader_overrides = &.{.{ .ext = ".png", .loader = .file }} });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildTopoRN(&graph, &store, &rc, entry, root, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+        // 두 asset 모두 수집(순서 검증 대상).
+        try std.testing.expect(r1.rn_asset_metadata != null and r1.rn_asset_metadata.?.len == 2);
+    }
+    const hits_before = graph.topology_preserved_hits;
+
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts",
+        \\const logo = require('./logo.png');
+        \\const icon = require('./icon.png');
+        \\console.log(logo, icon, 'edited');
+    );
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuildTopoRN(&graph, &store, &rc, entry, root, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh = try freshFullRN(entry, root);
+    defer fresh.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh.hasErrors());
+
+    // 보존 경로 진입 + 배열 순서(renumber 결정적)가 fresh 와 동일.
+    try std.testing.expectEqual(hits_before + 1, graph.topology_preserved_hits);
+    try std.testing.expectEqualStrings(fresh.output, preserved.output);
+    try expectRnMetaEqual(preserved.rn_asset_metadata, fresh.rn_asset_metadata);
+}

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -20,6 +20,7 @@ const Symbol = semantic_symbol.Symbol;
 const Reference = semantic_symbol.Reference;
 const SemanticSymbolId = semantic_symbol.SymbolId;
 const Scope = @import("../semantic/scope.zig").Scope;
+const RnAssetMetadata = @import("graph/assets.zig").RnAssetMetadata;
 const binding_scanner = @import("binding_scanner.zig");
 pub const ImportBinding = binding_scanner.ImportBinding;
 pub const ExportBinding = binding_scanner.ExportBinding;
@@ -424,6 +425,10 @@ pub const Module = struct {
     mtime: i128 = 0,
     /// file/copy 로더의 asset 출력 정보. null이면 asset이 아님.
     asset_data: ?AssetData = null,
+    /// RN AssetRegistry metadata (이미지 모듈만, asset_registry 활성 시). parse_arena 소유 —
+    /// finalize 의 collectRnAssetMetadata 가 graph 단위 list 로 borrow 재수집하고, reparse/store
+    /// 가 arena 라이프사이클로 자동 정합한다(위상 보존 경로에서 unchanged 모듈 metadata 보존).
+    rn_asset_metadata: ?RnAssetMetadata = null,
     /// CSS 번들링 메타데이터. null이면 CSS 모듈이 아님.
     css_data: ?CssData = null,
 


### PR DESCRIPTION
## 요약
HMR 위상 보존(Phase A #4162 / Phase B #4163)에서 **RN asset 빌드가 항상 full fallback** 하던 원인 중 하나(`canPreserveTopology` 의 `rn_asset_metadata` 게이트)를 풀었다. asset metadata 를 그 asset 모듈의 `parse_arena` 소유로 옮기고, `finalizeGraph`(renumber 직후)가 결정적 순서로 재수집하게 했다.

asset metadata 는 **번들 바이트가 아니라 사이드 채널**(release asset 복사용 — `registerAsset(...)` 호출식은 이미 `module.source` 라 unchanged 모듈에서 자동 보존)이라, RN graph 절감 2단계 중 **정확성 위험이 가장 낮은 첫 조각**이다.

## 동작 (Zig 초보 설명)
- 기존: loader 가 asset 파싱 시 `graph.rn_asset_metadata`(graph.allocator 소유) 에 discovery 순서로 append.
- 변경: `Module.rn_asset_metadata`(parse_arena 소유)에 저장 → `collectRnAssetMetadata` 가 finalize 에서 renumber-후 module index 순회로 graph list 를 **borrow** 재구성. fresh full / preserved(edge-reuse) / fallback 이 **같은 finalize→renumber→collect** 를 통과하므로 배열 순서가 by-construction 으로 byte-identical.
- 소유권: strings 의 유일한 owner = `module.parse_arena`(module.deinit/store/reparse 에 자동 정합). graph list 는 borrow, `BundleResult` 로 내보낼 때만 `dupeRnAssetMetadata` 로 long-lived deep-copy.

## 변경
- `Module.rn_asset_metadata` 필드 추가, loader 의 graph 공유 list append + mutex 제거(per-module write 라 race 없음, mutex dead → 삭제).
- `canPreserveTopology`: `rn_asset_metadata` 게이트만 제거. **polyfill/worker/plugin/splitting/lazy/emit_store 게이트는 유지**(PR-2/후속).
- lifecycle reset/deinit: `freeRnAssetMetadata` 루프 제거(borrow). bundler: deep-copy out.

## `/code-review max` 수정 (HIGH 2건)
- **asset 가드**: asset 모듈(.png 등)은 emit 후 `loader=.javascript` 로 굳어, 보존 reparse 가 그 loader 를 복원하면 `parseAssetModule` 을 우회한다(metadata 손실 + 바이너리를 raw JS 로 오파싱). 변경 모듈의 직전 빌드 `asset_data != null` 로 감지해 보수적 full fallback.
- **MF leak**: `BundleResult` deep-dupe 를 MF host 분기 *뒤*로 이동. `blk`-scope `errdefer` 가 `break` 에서 disarm 되므로, MF 분기가 dupe 뒤에 있어야 그 분기 error 시 duped metadata 누수가 없다.

## 테스트 (incremental_test.zig, 5건)
보존==fresh full(번들 output + `rn_asset_metadata` 배열 순서/필드/scales), asset import 추가/제거 → fallback, asset 파일 자체 변경 → asset 가드 fallback, 다중 asset 순서 보존, A→B→A 반복 + leak 0. `zig build test` + `zig build napi` 통과, 전체 회귀 0.

## 한계
- **이 PR 단독 실측 0**: asset+polyfill 둘 다 쓰는 mobile-seller 는 polyfill 게이트로 여전히 fallback → graphDiscover 절감은 **PR-2(`runtime_polyfill_roots` 보존) 필요**. asset-only RN/유닛 테스트만 보존 진입.
- scale variant(@2x/@3x) FS 추가가 그 asset 모듈을 `changed_files` 로 만들지 못하면 stale scales 보존(watch 한계 — source/metadata 상호 정합은 유지).
- fresh full 의 metadata 배열 순서가 worker-완료(비결정) → renumber(결정)로 바뀜(rn-asset-copy 순서 비의존이라 기능 무해).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
