### PR TITLE
perf(graph): RN asset 모듈 위상 보존 reparse — fallback 제거 (PR-1 후속)

### DIFF
--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -1234,14 +1234,6 @@ pub fn buildIncrementalPreserved(
             if (graph_requested_exports.isLazyBarrelCandidate(self, self.modules.at(ui))) {
                 return fallbackFullRebuild(self, io, entry_points, store, changed_files);
             }
-            // **asset 가드**: asset 모듈(이미지 등)은 emit 후 loader=.javascript 로 굳는다. 보존 reparse
-            // 가 그 loader 를 복원하면 parseModule 의 isAsset() 분기를 우회 → parseAssetModule 미실행으로
-            // rn_asset_metadata 가 재생성되지 않고(누락) 바이너리를 raw JS 로 오파싱(source corruption).
-            // 직전 빌드 asset_data 로 감지해 보수적 full fallback(fresh 가 재스캔). asset 파일 자체
-            // 변경(.png 교체) 시나리오를 정확성 우선으로 처리.
-            if (self.modules.at(ui).asset_data != null) {
-                return fallbackFullRebuild(self, io, entry_points, store, changed_files);
-            }
             try changed_indices.append(self.allocator, ui);
         }
     }
@@ -1488,6 +1480,13 @@ fn reparseChangedModulePreserveEdges(self: *ModuleGraph, io: std.Io, mod_idx: us
     const saved_module_type = m.module_type;
     const saved_loader = m.loader;
     const saved_resolve_dir = m.resolve_dir;
+    // asset 모듈(asset_registry 모드 .file/.copy)은 emit 후 loader 가 .javascript 로 굳는다.
+    // 그 .javascript 를 그대로 복원하면 parseModule 의 isAsset() 분기를 못 타 parseAssetModule 이
+    // 미실행되어 metadata 손실 + 바이너리를 raw JS 로 오파싱한다. asset_data.original_loader(원본
+    // .file/.copy)를 복원해 재파싱이 asset 로 다시 해석되게 한다 — source 는 Module.init 의 빈 값으로
+    // 둬 분기 진입(parse_module:62). 새 hash/scales/metadata + AssetRegistry import(specifier 불변)로
+    // 보존 경로 유지(fallback 불요).
+    const saved_asset_loader: ?types.Loader = if (m.asset_data) |ad| ad.original_loader else null;
     m.dependencies = .empty;
     m.importers = .empty;
     m.dynamic_imports = .empty;
@@ -1502,7 +1501,7 @@ fn reparseChangedModulePreserveEdges(self: *ModuleGraph, io: std.Io, mod_idx: us
     m.dynamic_imports = saved_dyn;
     m.dynamic_importers = saved_dyn_importers;
     m.module_type = saved_module_type;
-    m.loader = saved_loader;
+    m.loader = if (saved_asset_loader) |al| al else saved_loader;
     m.resolve_dir = saved_resolve_dir;
 
     // 재파싱(새 parse_arena + ast + import_records). mtime=0 → parseModule 이

--- a/src/bundler/graph/loaders.zig
+++ b/src/bundler/graph/loaders.zig
@@ -148,6 +148,9 @@ pub fn parseAssetModule(self: *ModuleGraph, io: std.Io, module: *Module) void {
                 .ext = ext,
                 .scales = scales_result.scales,
                 .scale_variants = scales_result.variants,
+                // 이 시점 module.loader 는 아직 원본(.file/.copy) — 아래 asset_registry 분기가
+                // .javascript 로 전환하기 전이다. reparse 가 복원할 원본 loader 를 보존.
+                .original_loader = module.loader,
             };
 
             const url = if (self.public_path.len > 0)

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -2467,7 +2467,7 @@ test "PR-1 RN: A→B→A 반복 body-only edit → 매 회 output+metadata == fr
     }
 }
 
-test "PR-1 RN: asset(.png) 파일 자체 변경 → asset 가드로 fallback + == fresh full" {
+test "PR-1 RN: asset(.png) 파일 자체 변경 → 보존 reparse + == fresh full (fallback 없이)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "registry.js",
@@ -2497,10 +2497,12 @@ test "PR-1 RN: asset(.png) 파일 자체 변경 → asset 가드로 fallback + =
         defer r1.deinit(std.testing.allocator);
         try std.testing.expect(!r1.hasErrors());
     }
+    const hits_before = graph.topology_preserved_hits;
     const fb_before = graph.topology_fallback_count;
 
     // logo.png 자체 교체(다른 bytes) + changed_files=logo.png → asset 모듈 직접 변경.
-    // asset 가드(asset_data != null)가 보존을 거부하고 fallback(fresh 재스캔)해야 한다.
+    // 이제 보존 reparse 가 asset_data.original_loader(원본 .file)를 복원해 parseAssetModule 을
+    // 재실행하므로, fallback 없이 그 asset 모듈만 재파싱(새 hash/metadata)하고 위상을 보존한다.
     std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "logo.png", .data = &.{ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x01, 0x02 } });
     const logo_abs = try absPath(&tmp, "logo.png");
@@ -2513,11 +2515,16 @@ test "PR-1 RN: asset(.png) 파일 자체 변경 → asset 가드로 fallback + =
     defer preserved.deinit(std.testing.allocator);
     try std.testing.expect(!preserved.hasErrors());
 
-    // 핵심: asset 모듈 직접 변경 → asset 가드가 보존(edge-reuse)을 거부하고 fallback 으로 전환.
-    // (보존 경로에 머물렀다면 reparse 가 .javascript loader 를 복원해 metadata 손실 + source 깨짐.)
-    // fallback 경로의 asset 재파싱 byte 정확성은 기존 동작이라 여기선 가드의 fallback 전환만 단언
-    // (테스트 환경 mtime 해상도와 무관하게 결정적).
-    try std.testing.expectEqual(fb_before + 1, graph.topology_fallback_count);
+    var fresh = try freshFullRN(entry, root);
+    defer fresh.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh.hasErrors());
+
+    // asset 파일 자체 변경도 fallback 없이 보존 경로(reparse)로 처리 — hit++, fallback 불변.
+    try std.testing.expectEqual(hits_before + 1, graph.topology_preserved_hits);
+    try std.testing.expectEqual(fb_before, graph.topology_fallback_count);
+    // 새 bytes 의 hash/metadata 가 fresh full 과 byte-identical.
+    try std.testing.expectEqualStrings(fresh.output, preserved.output);
+    try expectRnMetaEqual(preserved.rn_asset_metadata, fresh.rn_asset_metadata);
 }
 
 test "PR-1 RN: 다중 asset — body-only edit 후 rn_asset_metadata 배열 순서 == fresh full" {

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -449,6 +449,10 @@ pub const Module = struct {
         /// scale > 1 variant 파일들. 각 항목이 별개 OutputFile로 emit되어
         /// RN 네이티브가 `logo@2x.png` 등의 이름으로 로드 가능하다.
         scale_variants: []const ScaleVariant = &.{},
+        /// asset 파싱 시점의 원본 loader(.file/.copy). asset_registry 모드는 emit 후 loader 를
+        /// .javascript 로 전환하므로, HMR 위상 보존 reparse 가 이 값으로 원본 loader 를 복원해
+        /// parseAssetModule 재실행을 유도한다(없으면 바이너리를 raw JS 로 오파싱).
+        original_loader: types.Loader = .file,
     };
 
     pub const ScaleVariant = struct {


### PR DESCRIPTION
## 요약
PR #4164 는 asset 파일(.png) 자체가 changed 되면, 보존 reparse 가 emit-후 굳은 `loader=.javascript` 를 복원해 `parseAssetModule` 을 우회한다(metadata 손실 + 바이너리를 raw JS 로 오파싱)는 이유로 **보수적 full fallback** 하는 가드를 뒀다.

이 PR 은 그 가드를 제거하고 **asset 모듈을 보존 경로에서 제대로 reparse** 한다 — asset 파일 편집도 fallback 없이 그 모듈만 재파싱하며 위상을 보존한다. (`@ohah` 의 "fallback 없이 안 되냐" 지적 반영.)

## 근본 원인 & 해법 (Zig 초보 설명)
asset_registry 모드 `.file`/`.copy` 모듈은 첫 파싱 때 `parseAssetModule` 이 source 를 `registerAsset({...})` 호출식으로 만든 뒤 **loader 를 `.javascript` 로 전환**한다(그래야 일반 JS 파이프라인이 `require("./AssetRegistry.js")` 를 import_record 로 뽑음). 문제는 reparse 가 이 굳은 `.javascript` 를 복원해 `parseModule` 의 `isAsset()` 분기(parse_module:62)를 못 탄다는 것뿐이다.

→ asset 파싱 시점의 **원본 loader 를 저장**했다가 reparse 가 복원하면 `parseAssetModule` 이 재실행되어, 그 모듈만 보존 경로에서 새 hash/scales/metadata 로 재파싱된다. asset 모듈은 leaf 가 아니라 AssetRegistry 를 import 하지만 specifier 불변이라 보존된 edge 와 정합한다.

## 변경
- `Module.AssetData.original_loader`(원본 `.file`/`.copy`) 추가. `parseAssetModule` 이 asset_data 설정 시(`.javascript` 전환 *전*) 저장.
- `reparseChangedModulePreserveEdges`: asset 모듈이면 `original_loader` 복원(source 는 `Module.init` 의 빈 값) → `isAsset()` 분기 재진입 → `parseAssetModule` 재실행.
- changed_indices 의 `asset_data != null → fallback` 가드 제거.

## `/code-review max`
메모리 안전 견고 — `original_loader` 는 enum value copy, `saved_asset_loader` 추출이 `m.deinit` *전*, asset_data struct 는 store round-trip 에 value 캐리. asset_registry 모드 byte-identical 핵심 경로 정합 확인. 비-asset 모듈 회귀 0(`asset_data==null` → 기존 `saved_loader` 복원).

## 테스트
T4(asset `.png` 자체 변경 → 보존 reparse + `output`/`rn_asset_metadata` == fresh full, hit++/fallback 불변). `zig build test` + `zig build napi` 통과, 전체 회귀 0.

## 한계 (후속)
- URL 출력 모드(asset_registry 없는 web `.file`)도 동일 메커니즘으로 보존되나 별도 테스트 미커버.
- scale variant(@2x/@3x) 파일 단독 변경은 watcher 가 본체 asset 모듈을 changed 로 올려야 정합(본체가 changed 면 재스캔으로 정합).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
