### PR TITLE
fix(test): dev HMR new-css-import 테스트의 watcher arm-race flake 제거

### DIFF
--- a/packages/core/test/cli/app-builder/dev-hmr/new-css-import.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/new-css-import.ts
@@ -39,20 +39,50 @@ describe('CLI: Vite-style app builder > dev HMR > new CSS import (#3813)', () =>
     try {
       const reloadOrUpdate = new Promise<{ type: string }>((resolve) => {
         const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
-        const timeout = setTimeout(() => resolve({ type: 'timeout' }), 8000);
+        let retry: ReturnType<typeof setInterval> | undefined;
+        let settled = false;
+        // 모든 종료 경로(broadcast 수신 / timeout / ws error)를 단일 teardown 으로 통합한다.
+        // 한 경로라도 retry(setInterval) clear 를 빠뜨리면, finally 의 rmSync(dir) 이후에도
+        // interval 이 살아 삭제된 dir 에 write → ENOENT 가 *다음 테스트*에 오귀속되는 누수 flake.
+        const settle = (result: { type: string }) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          if (retry) clearInterval(retry);
+          try {
+            ws.close();
+          } catch {
+            /* already closing */
+          }
+          resolve(result);
+        };
+        const timeout = setTimeout(() => settle({ type: 'timeout' }), 15000);
+        // arm-race 방어: waitForServer 는 HTTP listen 만 확인하고 native 파일 watcher 의
+        // arm 은 기다리지 않는다(별도 subsystem). watcher arm 전에 쓴 변경은 fsevents/inotify
+        // 가 *영구히* 놓쳐(이미 지난 이벤트) broadcast 가 영영 안 온다 — 드물게 8s 타임아웃.
+        // 정상 경로는 write→broadcast ~60ms 라 첫 write 로 끝나고, 희귀 miss 만 재트리거가 구제.
+        // (broadcast 가 진짜 깨지면 모든 재시도가 유실 → 여전히 timeout → silent-drop 가드 유지.)
+        let n = 1;
+        const writeTrigger = () => {
+          n += 1;
+          writeFileSync(join(dir, 'src', 'styles.css'), `body { background: lime; /* ${n} */ }`);
+          writeFileSync(
+            join(dir, 'src', 'main.ts'),
+            `import "./styles.css"; console.log("v${n}");`,
+          );
+        };
         ws.onopen = async () => {
           await new Promise((r) => setTimeout(r, 300));
-          writeFileSync(join(dir, 'src', 'styles.css'), 'body { background: lime; }');
-          writeFileSync(join(dir, 'src', 'main.ts'), 'import "./styles.css"; console.log("v2");');
+          if (settled) return; // 300ms 대기 중 error/timeout 으로 종료됐으면 interval 안 건다
+          writeTrigger();
+          retry = setInterval(writeTrigger, 1500);
         };
         ws.onmessage = (event) => {
           const msg = JSON.parse(String(event.data));
-          if (msg.type === 'full-reload' || msg.type === 'update-done') {
-            clearTimeout(timeout);
-            ws.close();
-            resolve(msg);
-          }
+          if (msg.type === 'full-reload' || msg.type === 'update-done') settle(msg);
         };
+        // 형제 dev-HMR 테스트 관례 — ws 에러도 종료 경로로 처리(누수 차단 + 명확한 실패).
+        ws.onerror = () => settle({ type: 'error' });
       });
       const msg = await reloadOrUpdate;
       // broadcast 자체 수신 가드 — pre-#3779 회귀 (silent drop) 방지
@@ -61,5 +91,5 @@ describe('CLI: Vite-style app builder > dev HMR > new CSS import (#3813)', () =>
       proc.kill();
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 });


### PR DESCRIPTION
## 무엇 / 왜

`CLI: Vite-style app builder > dev HMR > new CSS import (#3813)` 테스트가 전체 스위트 부하 하에서 **드물게 8s 타임아웃**(broadcast 미수신)으로 실패했습니다.

## 루트커즈 (measure-first 확정)

번들에 계측을 넣어 측정한 결과, **정상 경로의 write→broadcast 지연은 ~60ms**(50ms watch debounce + ~12ms rebuild)로 일관적이었습니다. 즉 실패는 "부하로 느려짐"이 아니라 broadcast 가 **영영 안 옴**(130배 miss). 원인은 **watcher arm-race**:

- `waitForServer()` 는 HTTP listen 만 확인하고 native 파일 watcher 의 arm 은 기다리지 않습니다(별도 subsystem).
- 테스트는 `ws.onopen` 후 고정 300ms 뒤 트리거 파일을 쓰는데, 부하 시 watcher 가 300ms 안에 arm 안 되면 그 write 를 fsevents/inotify 가 **영구히 놓칩니다**(이미 지난 이벤트는 watcher 가 arm 후 보고하지 않음) → rebuild 없음 → broadcast 없음 → 8s 타임아웃.

→ broadcast 가 영영 안 오는 **영구 miss** 라서 타임아웃을 늘려도 소용없습니다.

## 수정

broadcast 도착 전까지 트리거를 **1.5s 간격으로 재기록**(내용 변주로 매번 실제 변경 보장):
- **정상 경로**: 첫 write 가 ~60ms 에 broadcast 받아 1회로 끝(추가 write 없음, 속도 불변).
- **희귀 arm-race miss**: watcher arm 후 첫 재시도 write 가 잡혀 구제.
- broadcast 가 진짜 깨지면(silent drop) 모든 재시도가 유실 → 여전히 timeout → 이 테스트의 #3779 **silent-drop 가드 의미 유지**.

### teardown 통합 (`/code-review max` 가 적발한 누수 차단)

모든 종료 경로(broadcast 수신 / timeout / ws error)를 **단일 `settle()` 헬퍼**로 통합했습니다. 한 경로라도 `retry`(setInterval) clear 를 빠뜨리면 `finally` 의 `rmSync(dir)` 이후에도 interval 이 살아 삭제된 dir 에 write → **ENOENT 가 *다음 테스트*에 오귀속되는 새 누수 flake** 가 됩니다(리뷰가 bun 1.3.11 에서 실증). `settle` 은 `settled` 가드로 1회만 실행되며 timeout/retry clear + ws.close 를 모든 경로에서 보장하고, `onopen` 은 300ms 대기 후 `settled` 가드로 종료 후 interval 재무장을 차단합니다. 형제 dev-HMR 테스트 관례대로 `ws.onerror` 도 추가했습니다.

## 검증

- 첫 write 를 일부러 생략(arm-race miss 시뮬)해도 **재시도만으로 ~2.5s 통과** — 구제 실증.
- 강제 timeout 후 **settle 이후 write 0회 + 후행 테스트 ENOENT 없음** — 누수 차단 실증.
- 전체 스위트(312 테스트) **3회 연속 310 pass / 0 fail**. 정상 경로 ~60ms 불변.
- oxfmt/oxlint/tsc clean. **런타임/제품 코드 변경 없음**(테스트만).

## Zig 초보자용 메모

Zig 가 아니라 통합 테스트(TypeScript/bun:test)의 타이밍 수정입니다. dev 서버가 파일 변경을 감지해 브라우저에 "새로고침해라" 신호(broadcast)를 보내는지 검사하는 테스트인데, 파일 감시기가 준비되기 *전에* 테스트가 파일을 바꿔 신호가 안 오는 경쟁 상태가 드물게 있었습니다. 신호가 올 때까지 파일 변경을 재시도하도록 고쳤고, 타이머 정리를 한 곳(`settle`)으로 모아 다른 테스트로 새는 것을 막았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)