### PR TITLE
fix(test): dev HMR 형제 테스트 watcher arm-race 선제 견고화 — 공유 waitForHmrBroadcast

### DIFF
--- a/packages/core/test/cli/app-builder/dev-hmr/comprehensive-e2e.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/comprehensive-e2e.ts
@@ -24,40 +24,11 @@ import {
   waitForServer,
   writeFileSync,
 } from '../helpers';
+import { waitForHmrBroadcast } from './hmr-wait';
 
-interface HmrMessage {
-  type: string;
-  modules?: Array<{ id: string; code: string }>;
-}
-
-/**
- * WebSocket 으로 `/__hmr` 에 연결한 뒤 `predicate` 가 true 를 반환할 때까지 메시지 수집.
- * connected 메시지는 자동 무시. 받은 메시지 전체를 `received` 로 반환해 시퀀스 검증에 사용.
- */
-function listen(
-  port: number,
-  predicate: (msg: HmrMessage) => boolean,
-  timeoutMs = 8000,
-): Promise<{ result?: HmrMessage; received: HmrMessage[] }> {
-  return new Promise((resolve) => {
-    const received: HmrMessage[] = [];
-    const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
-    const t = setTimeout(() => resolve({ received }), timeoutMs);
-    ws.onmessage = (event) => {
-      const msg = JSON.parse(String(event.data)) as HmrMessage;
-      if (msg.type === 'connected') return;
-      received.push(msg);
-      if (predicate(msg)) {
-        clearTimeout(t);
-        ws.close();
-        resolve({ result: msg, received });
-      }
-    };
-    ws.onerror = () => {
-      clearTimeout(t);
-      resolve({ received });
-    };
-  });
+interface UpdateModule {
+  id: string;
+  code: string;
 }
 
 async function sleep(ms: number) {
@@ -101,20 +72,22 @@ describe('CLI: Vite-style app builder > dev HMR > 종합 E2E (#3779 → #3826)',
       // PR #3779 — broadcast 시퀀스. PR #3825 — multi-error root-cause (success 유지).
       // PR #3799 — sourceMappingURL append.
       const origGreet = readFileSync(join(dir, 'src', 'greet.ts'), 'utf8');
-      const jsEditP = listen(port, (m) => m.type === 'update-done');
-      await sleep(300);
-      writeFileSync(join(dir, 'src', 'greet.ts'), origGreet.replace('hello', 'hi'));
-      const { received: jsReceived, result: jsDone } = await jsEditP;
+      const { received: jsReceived, result: jsDone } = await waitForHmrBroadcast(
+        port,
+        () => writeFileSync(join(dir, 'src', 'greet.ts'), origGreet.replace('hello', 'hi')),
+        (m) => m.type === 'update-done',
+      );
       expect(jsDone).toBeDefined();
       const jsTypes = jsReceived.map((m) => m.type);
       expect(jsTypes).toEqual(expect.arrayContaining(['update-start', 'update', 'update-done']));
       const updateMsg = jsReceived.find((m) => m.type === 'update');
-      expect(updateMsg?.modules?.length ?? 0).toBeGreaterThan(0);
-      expect(updateMsg!.modules![0].code.length).toBeGreaterThan(0);
+      const updateModules = updateMsg?.modules as UpdateModule[] | undefined;
+      expect(updateModules?.length ?? 0).toBeGreaterThan(0);
+      expect(updateModules![0].code.length).toBeGreaterThan(0);
       // PR #3799 — sourceMappingURL 주석 append
-      expect(updateMsg!.modules![0].code).toMatch(/\/\/# sourceMappingURL=\/__zntc_hmr_map\//);
+      expect(updateModules![0].code).toMatch(/\/\/# sourceMappingURL=\/__zntc_hmr_map\//);
       // sourcemap endpoint route 응답 (200 또는 404 둘 다 valid — sourcemap enable 여부 dependent)
-      const smId = updateMsg!.modules![0].id;
+      const smId = updateModules![0].id;
       const smResp = await fetch(
         `http://localhost:${port}/__zntc_hmr_map/${encodeURIComponent(smId)}`,
       );
@@ -130,13 +103,15 @@ describe('CLI: Vite-style app builder > dev HMR > 종합 E2E (#3779 → #3826)',
       // (#3813 limitation) → update-done 도 acceptable.
       const origMain = readFileSync(join(dir, 'src', 'main.ts'), 'utf8');
       writeFileSync(join(dir, 'src', 'added.ts'), 'export const x = "new";\n');
-      const graphP = listen(port, (m) => m.type === 'full-reload' || m.type === 'update-done');
-      await sleep(300);
-      writeFileSync(
-        join(dir, 'src', 'main.ts'),
-        `${origMain}\nimport { x } from "./added.ts";\nconsole.log(x);`,
+      const { result: graphResult } = await waitForHmrBroadcast(
+        port,
+        () =>
+          writeFileSync(
+            join(dir, 'src', 'main.ts'),
+            `${origMain}\nimport { x } from "./added.ts";\nconsole.log(x);`,
+          ),
+        (m) => m.type === 'full-reload' || m.type === 'update-done',
       );
-      const { result: graphResult } = await graphP;
       expect(['full-reload', 'update-done']).toContain(graphResult?.type);
 
       // 원복
@@ -148,17 +123,19 @@ describe('CLI: Vite-style app builder > dev HMR > 종합 E2E (#3779 → #3826)',
 
       // ───── 시나리오 4: HTML 변경 → fallback FullReload (#3797 drain else) ─────
       const origHtml = readFileSync(join(dir, 'index.html'), 'utf8');
-      const htmlP = listen(port, (m) => m.type === 'full-reload');
-      await sleep(300);
-      writeFileSync(
-        join(dir, 'index.html'),
-        origHtml.replace('<body>', '<body><meta name="v" content="2">'),
+      const { result: htmlResult } = await waitForHmrBroadcast(
+        port,
+        () =>
+          writeFileSync(
+            join(dir, 'index.html'),
+            origHtml.replace('<body>', '<body><meta name="v" content="2">'),
+          ),
+        (m) => m.type === 'full-reload',
       );
-      const { result: htmlResult } = await htmlP;
       expect(htmlResult?.type).toBe('full-reload');
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }, 30000);
 });

--- a/packages/core/test/cli/app-builder/dev-hmr/css-updates/module-reload.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/css-updates/module-reload.ts
@@ -14,6 +14,7 @@ import {
   waitForServer,
   writeFileSync,
 } from '../../helpers';
+import { waitForHmrBroadcast } from '../hmr-wait';
 
 describe('CLI: Vite-style app builder > dev HMR CSS updates > module reload', () => {
   test('dev .module.scss edit triggers full reload (not css-update fast-path)', async () => {
@@ -30,25 +31,15 @@ describe('CLI: Vite-style app builder > dev HMR CSS updates > module reload', ()
     const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
     await waitForServer(port);
     try {
-      const messagePromise = new Promise<any>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
-        ws.onmessage = (event) => {
-          const msg = JSON.parse(String(event.data));
-          if (msg.type === 'css-update' || msg.type === 'full-reload') {
-            ws.close();
-            resolve(msg);
-          }
-        };
-        ws.onerror = () => resolve({ type: 'error' });
-        setTimeout(() => resolve({ type: 'timeout' }), 10000);
-      });
-      await new Promise((r) => setTimeout(r, 300));
-      writeFileSync(join(dir, 'src', 'card.module.scss'), '.card { color: rgb(7, 8, 9); }');
-      const msg = await messagePromise;
-      expect(msg.type).toBe('full-reload');
+      const { result } = await waitForHmrBroadcast(
+        port,
+        () => writeFileSync(join(dir, 'src', 'card.module.scss'), '.card { color: rgb(7, 8, 9); }'),
+        (m) => m.type === 'css-update' || m.type === 'full-reload',
+      );
+      expect(result?.type).toBe('full-reload');
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 });

--- a/packages/core/test/cli/app-builder/dev-hmr/css-updates/scss-fast-path.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/css-updates/scss-fast-path.ts
@@ -14,6 +14,7 @@ import {
   waitForServer,
   writeFileSync,
 } from '../../helpers';
+import { waitForHmrBroadcast } from '../hmr-wait';
 
 describe('CLI: Vite-style app builder > dev HMR CSS updates > SCSS fast path', () => {
   test('dev single SCSS edit takes the css-update fast-path', async () => {
@@ -38,28 +39,18 @@ describe('CLI: Vite-style app builder > dev HMR CSS updates > SCSS fast path', (
     try {
       expect(await fetchEmittedCss()).toContain('rgb(1, 2, 3)');
 
-      const messagePromise = new Promise<any>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
-        ws.onmessage = (event) => {
-          const msg = JSON.parse(String(event.data));
-          if (msg.type === 'css-update' || msg.type === 'full-reload') {
-            ws.close();
-            resolve(msg);
-          }
-        };
-        ws.onerror = () => resolve({ type: 'error' });
-        setTimeout(() => resolve({ type: 'timeout' }), 10000);
-      });
-      await new Promise((r) => setTimeout(r, 300));
-      writeFileSync(join(dir, 'src', 'style.scss'), '.box { color: rgb(4, 5, 6); }');
-      const msg = await messagePromise;
-      expect(msg.type).toBe('css-update');
-      expect(msg.href).toMatch(/\/src\/style\.css$/);
+      const { result: msg } = await waitForHmrBroadcast(
+        port,
+        () => writeFileSync(join(dir, 'src', 'style.scss'), '.box { color: rgb(4, 5, 6); }'),
+        (m) => m.type === 'css-update' || m.type === 'full-reload',
+      );
+      expect(msg?.type).toBe('css-update');
+      expect(msg?.href as string | undefined).toMatch(/\/src\/style\.css$/);
       await new Promise((r) => setTimeout(r, 300));
       expect(await fetchEmittedCss()).toContain('rgb(4, 5, 6)');
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 });

--- a/packages/core/test/cli/app-builder/dev-hmr/hmr-wait.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/hmr-wait.ts
@@ -1,0 +1,95 @@
+// dev HMR 테스트 공용 — `/__hmr` WebSocket broadcast 를 watcher arm-race 에 견고하게 대기.
+//
+// ## 왜 retry 가 필요한가 (watcher arm-race)
+// `waitForServer()` 는 HTTP listen 만 확인하고 native 파일 watcher 의 arm 은 기다리지 않는다
+// (별도 subsystem). watcher arm 전에 쓴 변경은 fsevents/inotify 가 *영구히* 놓쳐(이미 지난
+// 이벤트는 arm 후 보고되지 않음) broadcast 가 영영 안 온다 — 부하 하에서 드물게 타임아웃.
+// 타임아웃을 늘려도 소용없다(영구 miss). 그래서 broadcast 가 올 때까지 trigger 를 주기적으로
+// 재호출한다. 정상 경로는 write→broadcast ~60ms 라 첫 trigger 로 끝나고(추가 write 없음),
+// 희귀 arm-race miss 만 재시도가 구제한다. broadcast 가 진짜 깨지면(silent drop) 모든 재시도가
+// 유실 → 여전히 timeout → silent-drop 회귀 가드 의미 유지.
+//
+// trigger 는 *고정 내용* 을 다시 써도 된다: 첫 write 가 유실됐다면 bundler 의 last-built
+// baseline 은 변경 *전* 상태라, 재시도 write 가 정상 diff(baseline→new)로 잡힌다.
+//
+// ## teardown
+// 모든 종료 경로(predicate 충족 / timeout / ws error)를 단일 settle() 로 통합한다. 한 경로라도
+// retry(setInterval) clear 를 빠뜨리면, 호출부 finally 의 rmSync(dir) 이후에도 interval 이 살아
+// 삭제된 dir 에 write → ENOENT 가 *다음 테스트*에 오귀속되는 누수 flake 가 된다. settle 은
+// settled 가드로 1회만 실행되며 timeout/retry clear + ws.close 를 모든 경로에서 보장하고,
+// onopen 은 initialDelay 후 settled 가드로 종료 후 interval 재무장을 차단한다.
+
+export interface HmrMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface HmrWaitResult {
+  /** predicate 를 충족한 메시지. timeout / ws error 시 undefined. */
+  result?: HmrMessage;
+  /** `connected` 를 제외하고 수신한 메시지 전체(시퀀스 검증용). */
+  received: HmrMessage[];
+}
+
+export interface HmrWaitOptions {
+  /** ws.onopen 후 첫 trigger 까지 대기(ms). 기본 300. */
+  initialDelayMs?: number;
+  /** broadcast 미수신 시 trigger 재호출 간격(ms). 기본 1500. */
+  retryMs?: number;
+  /** 전체 대기 상한(ms). 기본 15000. */
+  timeoutMs?: number;
+}
+
+/**
+ * `/__hmr` WebSocket 에 연결해 `trigger()` 로 변경을 일으키고 `predicate` 를 충족하는
+ * broadcast 가 올 때까지 기다린다(watcher arm-race 에 견고). 파일 시스템 정리는 호출부가 담당.
+ */
+export function waitForHmrBroadcast(
+  port: number,
+  trigger: () => void,
+  predicate: (msg: HmrMessage) => boolean,
+  opts: HmrWaitOptions = {},
+): Promise<HmrWaitResult> {
+  const { initialDelayMs = 300, retryMs = 1500, timeoutMs = 15000 } = opts;
+  return new Promise<HmrWaitResult>((resolve) => {
+    const received: HmrMessage[] = [];
+    const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
+    let retry: ReturnType<typeof setInterval> | undefined;
+    let settled = false;
+    const settle = (out: HmrWaitResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (retry) clearInterval(retry);
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+      resolve(out);
+    };
+    const timeout = setTimeout(() => settle({ received }), timeoutMs);
+    // trigger() 가 throw 하면(예: 경로 문제) async onopen / setInterval 의 unhandled rejection
+    // 대신 settle 로 라우팅 → 호출부 단언이 명확히 실패한다.
+    const safeTrigger = () => {
+      try {
+        trigger();
+      } catch {
+        settle({ received });
+      }
+    };
+    ws.onopen = async () => {
+      await new Promise((r) => setTimeout(r, initialDelayMs));
+      if (settled) return; // 대기 중 error/timeout 으로 종료됐으면 interval 안 건다
+      safeTrigger();
+      retry = setInterval(safeTrigger, retryMs);
+    };
+    ws.onmessage = (event) => {
+      const msg = JSON.parse(String(event.data)) as HmrMessage;
+      if (msg.type === 'connected') return; // 핸드셰이크 무시
+      received.push(msg);
+      if (predicate(msg)) settle({ result: msg, received });
+    };
+    ws.onerror = () => settle({ received });
+  });
+}

--- a/packages/core/test/cli/app-builder/dev-hmr/new-css-import.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/new-css-import.ts
@@ -25,6 +25,7 @@ import {
   waitForServer,
   writeFileSync,
 } from '../helpers';
+import { waitForHmrBroadcast } from './hmr-wait';
 
 describe('CLI: Vite-style app builder > dev HMR > new CSS import (#3813)', () => {
   test('JS-only 변경이 새 CSS import 추가 → broadcast 수신 (FullReload 또는 Update)', async () => {
@@ -37,56 +38,18 @@ describe('CLI: Vite-style app builder > dev HMR > new CSS import (#3813)', () =>
     const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
     await waitForServer(port);
     try {
-      const reloadOrUpdate = new Promise<{ type: string }>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
-        let retry: ReturnType<typeof setInterval> | undefined;
-        let settled = false;
-        // 모든 종료 경로(broadcast 수신 / timeout / ws error)를 단일 teardown 으로 통합한다.
-        // 한 경로라도 retry(setInterval) clear 를 빠뜨리면, finally 의 rmSync(dir) 이후에도
-        // interval 이 살아 삭제된 dir 에 write → ENOENT 가 *다음 테스트*에 오귀속되는 누수 flake.
-        const settle = (result: { type: string }) => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timeout);
-          if (retry) clearInterval(retry);
-          try {
-            ws.close();
-          } catch {
-            /* already closing */
-          }
-          resolve(result);
-        };
-        const timeout = setTimeout(() => settle({ type: 'timeout' }), 15000);
-        // arm-race 방어: waitForServer 는 HTTP listen 만 확인하고 native 파일 watcher 의
-        // arm 은 기다리지 않는다(별도 subsystem). watcher arm 전에 쓴 변경은 fsevents/inotify
-        // 가 *영구히* 놓쳐(이미 지난 이벤트) broadcast 가 영영 안 온다 — 드물게 8s 타임아웃.
-        // 정상 경로는 write→broadcast ~60ms 라 첫 write 로 끝나고, 희귀 miss 만 재트리거가 구제.
-        // (broadcast 가 진짜 깨지면 모든 재시도가 유실 → 여전히 timeout → silent-drop 가드 유지.)
-        let n = 1;
-        const writeTrigger = () => {
-          n += 1;
-          writeFileSync(join(dir, 'src', 'styles.css'), `body { background: lime; /* ${n} */ }`);
-          writeFileSync(
-            join(dir, 'src', 'main.ts'),
-            `import "./styles.css"; console.log("v${n}");`,
-          );
-        };
-        ws.onopen = async () => {
-          await new Promise((r) => setTimeout(r, 300));
-          if (settled) return; // 300ms 대기 중 error/timeout 으로 종료됐으면 interval 안 건다
-          writeTrigger();
-          retry = setInterval(writeTrigger, 1500);
-        };
-        ws.onmessage = (event) => {
-          const msg = JSON.parse(String(event.data));
-          if (msg.type === 'full-reload' || msg.type === 'update-done') settle(msg);
-        };
-        // 형제 dev-HMR 테스트 관례 — ws 에러도 종료 경로로 처리(누수 차단 + 명확한 실패).
-        ws.onerror = () => settle({ type: 'error' });
-      });
-      const msg = await reloadOrUpdate;
+      // JS-only 변경이 새 CSS import 를 추가 → graphChanged 면 FullReload, 아니면 Update 시퀀스.
+      // (arm-race 방어/재시도/teardown 은 waitForHmrBroadcast 가 담당 — hmr-wait.ts 참고.)
+      const { result } = await waitForHmrBroadcast(
+        port,
+        () => {
+          writeFileSync(join(dir, 'src', 'styles.css'), 'body { background: lime; }');
+          writeFileSync(join(dir, 'src', 'main.ts'), 'import "./styles.css"; console.log("v2");');
+        },
+        (m) => m.type === 'full-reload' || m.type === 'update-done',
+      );
       // broadcast 자체 수신 가드 — pre-#3779 회귀 (silent drop) 방지
-      expect(['full-reload', 'update-done']).toContain(msg.type);
+      expect(['full-reload', 'update-done']).toContain(result?.type);
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });

--- a/packages/core/test/cli/app-builder/dev-hmr/non-graph-reload.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/non-graph-reload.ts
@@ -19,6 +19,7 @@ import {
   waitForServer,
   writeFileSync,
 } from '../helpers';
+import { waitForHmrBroadcast } from './hmr-wait';
 
 describe('CLI: Vite-style app builder > dev HMR > non-graph file reload', () => {
   test('index.html 변경 → FullReload broadcast 수신 (#3797)', async () => {
@@ -34,30 +35,20 @@ describe('CLI: Vite-style app builder > dev HMR > non-graph file reload', () => 
     const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
     await waitForServer(port);
     try {
-      const messagePromise = new Promise<{ type: string }>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
-        ws.onmessage = (event) => {
-          const msg = JSON.parse(String(event.data));
-          // connected 무시, full-reload 받으면 종료
-          if (msg.type === 'full-reload') {
-            ws.close();
-            resolve(msg);
-          }
-        };
-        ws.onerror = () => resolve({ type: 'error' });
-        setTimeout(() => resolve({ type: 'timeout' }), 5000);
-      });
-      await new Promise((r) => setTimeout(r, 300));
       // HTML 변경 — module graph 밖, CSS 도 아님 → drain 의 fallback FullReload 가 처리해야.
-      writeFileSync(
-        join(dir, 'index.html'),
-        '<!doctype html><meta name="v" content="2"><script type="module" src="/src/main.ts"></script>',
+      const { result } = await waitForHmrBroadcast(
+        port,
+        () =>
+          writeFileSync(
+            join(dir, 'index.html'),
+            '<!doctype html><meta name="v" content="2"><script type="module" src="/src/main.ts"></script>',
+          ),
+        (m) => m.type === 'full-reload',
       );
-      const msg = await messagePromise;
-      expect(msg.type).toBe('full-reload');
+      expect(result?.type).toBe('full-reload');
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 });

--- a/packages/core/test/cli/app-builder/dev-hmr/postcss.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/postcss.ts
@@ -14,6 +14,7 @@ import {
   waitForServer,
   writeFileSync,
 } from '../helpers';
+import { waitForHmrBroadcast } from './hmr-wait';
 
 describe('CLI: Vite-style app builder > dev HMR and overlay', () => {
   test('dev incremental PostCSS reprocesses only the changed CSS', async () => {
@@ -53,20 +54,11 @@ describe('CLI: Vite-style app builder > dev HMR and overlay', () => {
       stderrChunks.length = 0;
 
       // a.css 한 파일만 변경 → incremental, "processed 1 CSS file".
-      const messagePromise = new Promise<any>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
-        ws.onmessage = (event) => {
-          const msg = JSON.parse(String(event.data));
-          if (msg.type === 'css-update' || msg.type === 'full-reload') {
-            ws.close();
-            resolve(msg);
-          }
-        };
-        setTimeout(() => resolve({ type: 'timeout' }), 10000);
-      });
-      await new Promise((r) => setTimeout(r, 300));
-      writeFileSync(join(dir, 'src', 'a.css'), '.a{color:green}');
-      await messagePromise;
+      await waitForHmrBroadcast(
+        port,
+        () => writeFileSync(join(dir, 'src', 'a.css'), '.a{color:green}'),
+        (m) => m.type === 'css-update' || m.type === 'full-reload',
+      );
       // 이벤트 후 stderr flush 위해 잠시 대기.
       await new Promise((r) => setTimeout(r, 200));
       expect(stderrChunks.join('')).toContain('[postcss] processed 1 CSS file');
@@ -74,5 +66,5 @@ describe('CLI: Vite-style app builder > dev HMR and overlay', () => {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 });

--- a/packages/core/test/cli/app-builder/dev-hmr/sourcemap-endpoint.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/sourcemap-endpoint.ts
@@ -19,6 +19,7 @@ import {
   waitForServer,
   writeFileSync,
 } from '../helpers';
+import { waitForHmrBroadcast } from './hmr-wait';
 
 describe('CLI: Vite-style app builder > dev HMR > sourcemap endpoint (#3799)', () => {
   test('Update modules.code 에 sourceMappingURL 주석 + endpoint 응답', async () => {
@@ -31,28 +32,15 @@ describe('CLI: Vite-style app builder > dev HMR > sourcemap endpoint (#3799)', (
     const proc = spawn(RUNTIME, [CLI, 'dev', dir, `--port=${port}`], { cwd: dir });
     await waitForServer(port);
     try {
-      const updateMsg = await new Promise<{
-        type: string;
-        modules?: Array<{ id: string; code: string }>;
-      }>((resolve) => {
-        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
-        const timeout = setTimeout(() => resolve({ type: 'timeout' }), 8000);
-        ws.onopen = async () => {
-          await new Promise((r) => setTimeout(r, 300));
-          writeFileSync(join(dir, 'src', 'main.ts'), 'export const x = 2;');
-        };
-        ws.onmessage = (event) => {
-          const msg = JSON.parse(String(event.data));
-          if (msg.type === 'update') {
-            clearTimeout(timeout);
-            ws.close();
-            resolve(msg);
-          }
-        };
-      });
-      expect(updateMsg.type).toBe('update');
-      expect(updateMsg.modules?.length ?? 0).toBeGreaterThan(0);
-      const first = updateMsg.modules![0];
+      const { result: updateMsg } = await waitForHmrBroadcast(
+        port,
+        () => writeFileSync(join(dir, 'src', 'main.ts'), 'export const x = 2;'),
+        (m) => m.type === 'update',
+      );
+      expect(updateMsg?.type).toBe('update');
+      const modules = updateMsg?.modules as Array<{ id: string; code: string }> | undefined;
+      expect(modules?.length ?? 0).toBeGreaterThan(0);
+      const first = modules![0];
       // sourceMappingURL 주석 append 확인
       expect(first.code).toMatch(/\/\/# sourceMappingURL=\/__zntc_hmr_map\//);
 
@@ -67,5 +55,5 @@ describe('CLI: Vite-style app builder > dev HMR > sourcemap endpoint (#3799)', (
       proc.kill();
       rmSync(dir, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 });


### PR DESCRIPTION
## 무엇 / 왜

직전 PR(#4167)에서 고친 `new-css-import` 의 **watcher arm-race flake** 와 **동일한 패턴**을 공유하는 형제 dev-HMR 테스트들을 선제적으로 견고화합니다.

### arm-race (직전 PR 에서 확정)

`waitForServer()` 는 HTTP listen 만 확인하고 native 파일 watcher 의 arm 은 기다리지 않습니다(별도 subsystem). "ws.onopen 후 고정 300ms → 트리거 파일 write → broadcast 대기" 패턴의 테스트는, 부하 시 watcher 가 300ms 안에 arm 안 되면 그 write 를 fsevents/inotify 가 **영구히 놓쳐**(이미 지난 이벤트) broadcast 가 영영 안 와 드물게 타임아웃합니다.

같은 race 에 노출된 형제 6곳:
- `sourcemap-endpoint` · `postcss` · `non-graph-reload`
- `css-updates/module-reload` · `css-updates/scss-fast-path`
- `comprehensive-e2e` 의 3 시나리오(JS incremental / graph change / HTML fallback)

## 수정 — 메커니즘을 공유 헬퍼로 일반화

7곳에 복붙하면 teardown 누수 같은 실수가 반복되므로, arm-race 방어를 단일 헬퍼로 추출했습니다:

```ts
// test/cli/app-builder/dev-hmr/hmr-wait.ts
waitForHmrBroadcast(port, trigger, predicate, opts): Promise<{ result?, received }>
```

- **재시도**: broadcast 도착 전까지 `trigger()` 를 1.5s 간격으로 재호출. 정상은 ~60ms 라 1회로 끝나고(추가 write 없음), 희귀 arm-race miss 만 재시도가 구제. trigger 는 고정 내용 재기록으로 충분 — 첫 write 유실 시 bundler baseline 은 변경 *전* 이라 재시도가 정상 diff 로 잡힙니다.
- **단일 settle() teardown**: 모든 종료 경로(predicate 충족 / timeout / ws error / trigger throw)를 한 곳으로 통합. 한 경로라도 `setInterval` clear 를 빠뜨리면 `finally` 의 `rmSync(dir)` 이후 삭제된 dir 에 write → **ENOENT 가 다음 테스트에 오귀속되는 누수 flake**(직전 PR 리뷰가 실증). `settled` 가드 1회 실행 + `onopen` 의 `settled` 가드로 종료 후 interval 재무장 차단.
- **silent-drop 가드 유지**: broadcast 가 진짜 깨지면 모든 재시도가 유실 → 여전히 timeout → 실패.
- `received`(connected 제외 전체) 반환으로 `comprehensive-e2e` 의 시퀀스 단언 보존.

`new-css-import` 도 인라인 구현을 이 헬퍼 호출로 통일(DRY).

### 비대상

`overlay`(초기 빌드 에러 connect-replay) · `bun-runtime`(connect `connected`) · overlay client `fetch` 는 파일-트리거 arm-race 가 아니라 제외했습니다.

## 검증

- 헬퍼의 첫 trigger 를 일부러 생략(arm-race miss 시뮬)해도 **재시도만으로 통과** — 구제 실증.
- 강제 timeout 후 **settle 이후 write 0회** — 누수 차단 실증(동일 settle 구조).
- 전체 스위트(312) **3회 연속 310 pass / 0 fail**. tsc/oxfmt/oxlint clean.
- `/code-review max`(6 영역: 단언 동치 / dedup 안전 / 타이머 누수 / timeout 레이어링 / 시나리오 간 상태 / 헬퍼 자체) **차단 결함 0**, 리뷰 권고(trigger throw → settle 라우팅) 반영.
- **제품 코드 변경 없음**(테스트만).

## Zig 초보자용 메모

Zig 가 아니라 통합 테스트(TypeScript/bun:test)의 타이밍 견고화입니다. dev 서버가 파일 변경을 감지해 보내는 새로고침 신호를, 파일 감시기 준비 전 경쟁 상태에서도 안정적으로 받도록 "신호 올 때까지 변경 재시도 + 타이머 정리"를 공통 헬퍼 하나로 묶었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)