### PR TITLE
feat(debug): HMR 위상 보존 게이트 + grph 분해 진단 로깅

### DIFF
--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -5,6 +5,7 @@ const bundler_mod = zntc_lib.bundler;
 const Bundler = bundler_mod.Bundler;
 const TrackedFileSet = zntc_lib.server.TrackedFileSet;
 const profile_mod = zntc_lib.profile;
+const debug_log = zntc_lib.debug_log;
 const BundleOptions = bundler_mod.BundleOptions;
 const SourceMap = zntc_lib.codegen.sourcemap;
 const types_mod = zntc_lib.bundler.types;
@@ -1670,6 +1671,20 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
             .link_populate_import_symbols_ms = nsToMs(profile_mod.totalNs(.link_populate_import_symbols)),
             .link_populate_namespace_accesses_ms = nsToMs(profile_mod.totalNs(.link_populate_namespace_accesses)),
         };
+        // 측정용(ZNTC_DEBUG=topology_preserve + ZNTC_PROFILE=all): grph(graph_discover) 분해 —
+        // fallback full discovery 의 lookup/miss_parse(plugin)/replay(edge 재구성)/miss_resolve 비중.
+        if (debug_log.enabled(.topology_preserve)) {
+            debug_log.print(.topology_preserve, "  grph sub(ms): lookup={d} miss_parse={d} replay={d}(add={d} reqExp={d} recDep={d} other={d}) miss_resolve={d}\n", .{
+                nsToMs(profile_mod.totalNs(.graph_discover_incr_cache_lookup)),
+                nsToMs(profile_mod.totalNs(.graph_discover_incr_miss_parse)),
+                nsToMs(profile_mod.totalNs(.graph_discover_incr_replay)),
+                nsToMs(profile_mod.totalNs(.graph_discover_incr_replay_add_module)),
+                nsToMs(profile_mod.totalNs(.graph_discover_incr_replay_request_exports)),
+                nsToMs(profile_mod.totalNs(.graph_discover_incr_replay_record_dep)),
+                nsToMs(profile_mod.totalNs(.graph_discover_incr_replay_other)),
+                nsToMs(profile_mod.totalNs(.graph_discover_incr_miss_resolve)),
+            });
+        }
         event.reparsed_modules = rebuild_result.reparsed_modules;
 
         // rebuild 이벤트 전송

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const types = @import("../types.zig");
 const ModuleIndex = types.ModuleIndex;
 const runtime_polyfills = @import("../runtime_polyfills.zig");
+const debug_log = @import("../../debug_log.zig");
 const module_store = @import("../module_store.zig");
 const fs = @import("../fs.zig");
 const MpscChannel = @import("../mpsc_channel.zig").MpscChannel;
@@ -1186,6 +1187,7 @@ pub fn buildIncrementalPreserved(
     // plan §12/§29 의 "plugin/MF/glob/require.context/code_splitting 보존 경로 제외" 와 동형 +
     // RN 의 runtime polyfill / asset 까지 확장. 정확성 우선 — 불확실하면 full.
     if (!canPreserveTopology(self)) {
+        logPreserveFallbackGates(self);
         return fallbackFullRebuild(self, io, entry_points, store, changed_files);
     }
 
@@ -1467,6 +1469,30 @@ fn canPreserveTopology(self: *const ModuleGraph) bool {
         if (store.chunks.items.len > 0) return false;
     }
     return true;
+}
+
+/// 측정용(ZNTC_DEBUG=topology_preserve): canPreserveTopology fallback 시 걸린 게이트를 전부 출력.
+/// `enabled` 가드라 비활성 시 비용 0. 무엇을 풀어야 보존 경로로 진입하는지 식별용
+/// (예: mobile-seller 가 plugin/splitting 등 어느 게이트로 fallback 하는지).
+fn logPreserveFallbackGates(self: *const ModuleGraph) void {
+    if (!debug_log.enabled(.topology_preserve)) return;
+    if (!self.dev_mode)
+        debug_log.print(.topology_preserve, "preserve-fallback gate: non-dev\n", .{});
+    if (self.has_user_resolve_id_plugins or self.has_user_load_plugins or self.has_transform_plugins)
+        debug_log.print(.topology_preserve, "preserve-fallback gate: plugin (resolveId={} load={} transform={})\n", .{ self.has_user_resolve_id_plugins, self.has_user_load_plugins, self.has_transform_plugins });
+    if (self.code_splitting or self.preserve_modules)
+        debug_log.print(.topology_preserve, "preserve-fallback gate: splitting={} preserve_modules={}\n", .{ self.code_splitting, self.preserve_modules });
+    if (self.lazy_compilation)
+        debug_log.print(.topology_preserve, "preserve-fallback gate: lazy_compilation\n", .{});
+    if (self.inject_files.len > 0)
+        debug_log.print(.topology_preserve, "preserve-fallback gate: inject_files ({d})\n", .{self.inject_files.len});
+    if (self.worker_entries.items.len > 0)
+        debug_log.print(.topology_preserve, "preserve-fallback gate: worker_entries ({d})\n", .{self.worker_entries.items.len});
+    if (self.emit_store) |store_ptr| {
+        const store: *const @import("../emit_store.zig").EmitStore = @ptrCast(@alignCast(store_ptr));
+        if (store.chunks.items.len > 0)
+            debug_log.print(.topology_preserve, "preserve-fallback gate: emit_chunks ({d})\n", .{store.chunks.items.len});
+    }
 }
 
 /// 보존 경로 진입 시 per-build global state 만 reset(modules/edges/resolved_deps/parse_arena/

--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -79,6 +79,10 @@ pub const Category = enum {
     /// 스냅샷을 폐기(capture 실패 → 다음 rebuild 가 full computeRenames)한 빈도를
     /// 관측. 실앱(RN 8067 모듈)에서 null capture 가 실제로 0 인지 확인용 (F5).
     rename_reuse,
+    /// HMR 위상 보존(canPreserveTopology) fallback 게이트 진단 — 보존 경로 진입이 거부될 때
+    /// 걸린 게이트(plugin/splitting/lazy/inject/run_before_main/worker/emit_chunk/non-dev)를
+    /// 전부 출력. mobile-seller 가 무엇 때문에 fallback 하는지 측정용.
+    topology_preserve,
 
     /// 카테고리 이름으로 enum 조회 (공백 제거 + 대소문자 무시).
     pub fn fromString(s: []const u8) ?Category {


### PR DESCRIPTION
## 요약
실앱(mobile-seller 등)에서 HMR 위상 보존이 **왜 fallback 하는지**와, fallback 시 **grph 시간이 어디 쏠리는지**를 측정하기 위한 진단 로깅. 모두 `enabled` 가드라 **비활성 시 비용 0**(hot path 영향 없음).

## 변경
- `debug_log.zig`: `topology_preserve` Category 추가.
- `build_flow.zig`: `canPreserveTopology` fallback 시 `logPreserveFallbackGates` 가 걸린 게이트(plugin/splitting/lazy/inject/worker/emit_chunk/non-dev)를 **전부** 출력. (canPreserveTopology 단축 평가는 유지, dispatch 에서만 호출.)
- `watch.zig`: HMR rebuild 후 grph(graph_discover) 분해 출력 — lookup / miss_parse(plugin transform) / replay(add/reqExp/recDep) / miss_resolve 비중. `profile_mod.totalNs` 재사용, `ZNTC_PROFILE=all` 병용.

## 사용법
```
ZNTC_DEBUG=topology_preserve ZNTC_PROFILE=all <zntc dev ...>
```
rebuild 시:
```
[topology_preserve] preserve-fallback gate: plugin (resolveId=true load=true transform=true)
[topology_preserve]   grph sub(ms): lookup=0.2 miss_parse=0.45 replay=152(add=112 reqExp=22 recDep=7 ...) miss_resolve=1.7
```

## 측정 결과 (mobile-seller, 8092 모듈)
- **fallback gate = plugin 단독** (PR-1/PR-2 로 asset/polyfill/rbm 게이트는 풀려 plugin 만 남음).
- **grph 188ms 중 replay 152ms(addModuleWithResolveDir 112ms)가 병목** — plugin transform 자체는 0.45ms 로 무관. 즉 plugin 이 보존을 막아 8091 cache-hit 모듈을 매 rebuild 재등록하는 게 진짜 비용.

`zig build test` + `zig build napi` 통과(회귀 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
