### PR TITLE
feat(hmr): plugin 게이트를 결정적 plugin 한정 완화 — RN preset opt-in (#4123)

### DIFF
--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -91,6 +91,9 @@ export function buildRnBundleExtra(config, opts = {}) {
     fallback: resolver.extraNodeModules ?? undefined,
     metroResolveRequest: resolver.resolveRequest ?? undefined,
     babelTransformerPath: transformer.babelTransformerPath ?? undefined,
+    // HMR 위상 보존 게이트 명시 override (config top-level). 사용자가 "내 resolveRequest/
+    // transformer 는 결정적"임을 보장하면 true 로 보존 강제 — preset 의 보수적 자동판정을 덮어쓴다.
+    preserveSafePlugins: cfg.preserveSafePlugins ?? undefined,
     polyfills: getSerializerPolyfills(serializer, opts),
     extraVars: serializer.extraVars ?? undefined,
     prelude: serializer.prelude ?? undefined,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1266,6 +1266,12 @@ interface BuildOptionsCommon {
    * Avoids the Fabric early-register race (`View config not found for
    * component 'X'`). */
   codegenTransform?: boolean;
+  /**
+   * PR-3: HMR 위상 보존에서 plugin 게이트를 완화하는 **빌드 수준** opt-in 신호(per-plugin 아님).
+   * 이 빌드의 모든 plugin 이 결정적·모듈별 순수(ModuleGraph 무접근, 전역 상태/lifecycle 출력 영향
+   * 없음)임을 호출자가 보장할 때만 true. RN preset 이 내장 plugin 구성에 대해 자동으로 켠다.
+   * 임의 custom plugin 은 비결정 가능하므로 default false. */
+  preserveSafePlugins?: boolean;
   /** Global identifiers to reserve during scope hoisting. */
   globalIdentifiers?: string[];
   /** Paths of polyfills to run immediately at bundle start. */

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -908,6 +908,9 @@ pub fn parseBuildOptions(
         // `codegenTransform: false` 명시하면 그게 우선 (escape hatch 동작 보장). OR 패턴은
         // false override 가 RN preset 의 true 에 묻혀 무력화되는 버그 있었음.
         .codegen_transform = getObjectBool(env, opts_obj, "codegenTransform", platform == .react_native and bundler_mod.RN_BOOL_PRESET.codegen_transform),
+        // PR-3: 호출자(RN preset)가 명시적으로 켜는 opt-in 신호. default false(보수적 — 임의 custom
+        // plugin 은 비결정 가능). preset 이 자기 plugin 구성이 결정적·모듈별 순수일 때만 true 로 보낸다.
+        .preserve_safe_plugins = getObjectBool(env, opts_obj, "preserveSafePlugins", false),
         .global_identifiers = global_identifiers orelse &.{},
         .polyfills = polyfills orelse &.{},
         .run_before_main = run_before_main orelse &.{},

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -500,6 +500,53 @@ describe('buildRnBundleOptions — plugins (asset/optional-babel/require-context
     expect(opts.plugins?.length).toBe(3);
     expect(opts.plugins?.[2]).toBe(userPlugin);
   });
+
+  // ── PR-3: HMR 위상 보존 plugin 게이트 ──────────────────────────────────────
+  test('preserveSafePlugins — 내장 plugin 만이면 자동 true(보존 안전)', () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.preserveSafePlugins).toBe(true);
+  });
+
+  test('preserveSafePlugins — metroResolveRequest(사용자 resolver) 있으면 false 강등', () => {
+    const opts = buildRnBundleOptions(
+      baseInput({ extra: { metroResolveRequest: () => ({ type: 'empty' }) } }),
+    );
+    expect(opts.preserveSafePlugins).toBe(false);
+  });
+
+  test('preserveSafePlugins — babelTransformerPath(사용자 transformer) 있으면 false 강등', () => {
+    const opts = buildRnBundleOptions(
+      baseInput({ extra: { babelTransformerPath: '/abs/svg-transformer.js' } }),
+    );
+    expect(opts.preserveSafePlugins).toBe(false);
+  });
+
+  test('preserveSafePlugins — additionalPlugins 있으면 false 강등', () => {
+    const userPlugin: ZntcPlugin = { name: 'user:custom2', setup() {} };
+    const opts = buildRnBundleOptions(
+      baseInput({ extra: { additionalPlugins: [userPlugin] } }),
+    );
+    expect(opts.preserveSafePlugins).toBe(false);
+  });
+
+  test('preserveSafePlugins — 명시 true override 가 보수 판정(metroResolveRequest)보다 우선', () => {
+    const opts = buildRnBundleOptions(
+      baseInput({
+        extra: {
+          metroResolveRequest: () => ({ type: 'empty' }),
+          preserveSafePlugins: true,
+        },
+      }),
+    );
+    expect(opts.preserveSafePlugins).toBe(true);
+  });
+
+  test('preserveSafePlugins — 명시 false override 가 내장-only(자동 true)보다 우선', () => {
+    const opts = buildRnBundleOptions(
+      baseInput({ extra: { preserveSafePlugins: false } }),
+    );
+    expect(opts.preserveSafePlugins).toBe(false);
+  });
 });
 
 describe('buildRnBundleOptions — extra (watchFolders / blockList / fallback)', () => {

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -95,6 +95,15 @@ export interface RnBundleInput {
     metroResolveRequest?: CustomResolver;
     /** Metro 호환 babel transformer path (svg-transformer 등). */
     babelTransformerPath?: string;
+    /**
+     * HMR 위상 보존 plugin 게이트 명시 override. 미지정(undefined)이면 preset 이 보수적으로
+     * 판정한다 — 내장 plugin 만이면 true, additionalPlugins/metroResolveRequest/
+     * babelTransformerPath 중 하나라도 있으면 false. 사용자가 "내 resolver/transformer 가
+     * 결정적·모듈별 순수(같은 입력→같은 출력, 전역 상태 무의존)"임을 보장할 수 있으면 true 로
+     * 명시해 보존을 강제(=HMR rebuild 가속)할 수 있다. 비결정이면 stale 번들 위험은 사용자 책임.
+     * false 명시로 강제 비활성도 가능.
+     */
+    preserveSafePlugins?: boolean;
     /** RN sourceExts override (default RN preset). */
     sourceExts?: string[];
     /** RN assetExts override (default RN preset). */
@@ -500,6 +509,22 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     inlineDynamicImports: true,
     workletTransform: true,
     codegenTransform: true,
+    // PR-3: RN preset 내장 plugin(asset/metro-resolve-request/require-context/codegen)은 전부
+    // 결정적·모듈별 순수 → HMR 위상 보존 안전. 단 "사용자 임의 코드"가 주입되는 경로가 하나라도
+    // 있으면 결정성(같은 입력→같은 출력)을 보장할 수 없어 false 로 강등(보존 끄고 종전 fallback):
+    //   - additionalPlugins: 사용자 ZntcPlugin 배열
+    //   - metroResolveRequest: 사용자 resolveRequest 함수(:414 에서 resolveId plugin 으로 래핑)
+    //   - babelTransformerPath: 사용자 transformer 모듈(:424 asset plugin onLoad 가 실행)
+    // 이들이 비결정이면 보존 경로가 unchanged 모듈을 재평가하지 않아 stale 번들이 될 수 있다.
+    // 단 사용자가 extra.preserveSafePlugins 를 명시하면(true/false) 그 값이 우선 — "내 resolver/
+    // transformer 는 결정적"이라는 책임 있는 opt-in(또는 명시 opt-out). `??` 라 false 도 존중.
+    preserveSafePlugins:
+      extra?.preserveSafePlugins ??
+      !(
+        (extra?.additionalPlugins && extra.additionalPlugins.length > 0) ||
+        extra?.metroResolveRequest ||
+        extra?.babelTransformerPath
+      ),
     resolveExtensions: buildResolveExtensions(rnPlatform, sourceExts),
     mainFields: ['react-native', 'browser', 'main'],
     loader: baseLoader,

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -378,6 +378,9 @@ pub const BundleOptions = struct {
     /// RN view config codegen — `*NativeComponent.{js,ts}` 의 codegenNativeComponent
     /// 호출을 inline view config 로 교체 (#2348). --platform=react-native 에서 자동 활성.
     codegen_transform: bool = false,
+    /// PR-3: HMR 위상 보존에서 plugin 게이트를 완화하는 opt-in 신호 — 이 빌드의 모든 user
+    /// plugin 이 결정적·모듈별 순수임을 호출자(RN preset)가 보장. graph.preserve_safe_plugins 로 mirror.
+    preserve_safe_plugins: bool = false,
     /// 증분 빌드용 모�� 파싱 캐시. null이면 매번 전체 파싱.
     /// IncrementalBundler가 소유하고 빌드 간 보존한다.
     module_store: ?*@import("module_store.zig").PersistentModuleStore = null,
@@ -953,6 +956,7 @@ pub const Bundler = struct {
         // #1961: worker 모듈도 transformer pre-pass 가 동일 옵션 사용 — drift 방지.
         worker_graph.worklet_transform = self.options.worklet_transform;
         worker_graph.codegen_transform = self.options.codegen_transform;
+        worker_graph.preserve_safe_plugins = self.options.preserve_safe_plugins;
         worker_graph.react_refresh = self.options.react_refresh;
         worker_graph.styled_components = self.options.styled_components;
         worker_graph.styled_components_ssr = self.options.styled_components_ssr;
@@ -1235,6 +1239,7 @@ pub const Bundler = struct {
         // react_refresh / code_splitting) 만 별도 mirror.
         graph.worklet_transform = self.options.worklet_transform;
         graph.codegen_transform = self.options.codegen_transform;
+        graph.preserve_safe_plugins = self.options.preserve_safe_plugins;
         graph.react_refresh = self.options.react_refresh;
         graph.styled_components = self.options.styled_components;
         graph.styled_components_ssr = self.options.styled_components_ssr;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -296,6 +296,16 @@ pub const ModuleGraph = struct {
     has_user_load_plugins: bool = false,
     /// transform 은 user plugin 또는 builtin RN codegen 이 활성이면 실행 — 둘을 합친 게이트.
     has_transform_plugins: bool = false,
+    /// PR-3: 빌드 호출자(RN preset 등)가 "이 빌드의 모든 user plugin 이 결정적·모듈별 순수
+    /// (전역 상태/lifecycle 출력 영향 없음)"를 보장하는 opt-in 신호. 기본 false(보수적).
+    /// HMR 위상 보존(canPreserveTopology)이 plugin 게이트를 이 신호로 완화한다.
+    preserve_safe_plugins: bool = false,
+    /// PR-3: preserve-safe 가 아닌(=보존 불가) user plugin hook 보유 여부. canPreserveTopology
+    /// 게이트가 has_user_* 대신 이걸 본다. `ensureBuiltinPlugins` 가 채움(codegen 은 native·
+    /// 결정적이라 unsafe transform 에 불포함).
+    has_unsafe_resolve_id_plugins: bool = false,
+    has_unsafe_load_plugins: bool = false,
+    has_unsafe_transform_plugins: bool = false,
 
     pub const PkgInfo = graph_state.PkgInfo;
     pub const WorkerEntry = graph_state.WorkerEntry;

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -1450,7 +1450,10 @@ fn fallbackFullRebuild(
 /// 변경-모듈 lazy-barrel 가드가 별도 차단.
 fn canPreserveTopology(self: *const ModuleGraph) bool {
     if (!self.dev_mode) return false;
-    if (self.has_user_resolve_id_plugins or self.has_user_load_plugins or self.has_transform_plugins) return false;
+    // PR-3: 비결정/전역 가능성이 있는 plugin 만 보존 거부. preserve_safe_plugins(빌드 호출자 보장,
+    //  RN preset)이면 결정적·모듈별 순수 plugin 으로 보고 has_unsafe_* 가 0 → 보존 통과. 변경 모듈만
+    //  plugin 재실행되고 unchanged 는 캐시 보존, topologyMatches 가 plugin 의 import/resolve 변화를 잡는다.
+    if (self.has_unsafe_resolve_id_plugins or self.has_unsafe_load_plugins or self.has_unsafe_transform_plugins) return false;
     if (self.code_splitting or self.preserve_modules) return false;
     if (self.lazy_compilation) return false;
     // (runtime_polyfills 게이트 제거 — PR-2: usage mode 는 buildIncrementalPreserved 의 변경-모듈
@@ -1478,8 +1481,8 @@ fn logPreserveFallbackGates(self: *const ModuleGraph) void {
     if (!debug_log.enabled(.topology_preserve)) return;
     if (!self.dev_mode)
         debug_log.print(.topology_preserve, "preserve-fallback gate: non-dev\n", .{});
-    if (self.has_user_resolve_id_plugins or self.has_user_load_plugins or self.has_transform_plugins)
-        debug_log.print(.topology_preserve, "preserve-fallback gate: plugin (resolveId={} load={} transform={})\n", .{ self.has_user_resolve_id_plugins, self.has_user_load_plugins, self.has_transform_plugins });
+    if (self.has_unsafe_resolve_id_plugins or self.has_unsafe_load_plugins or self.has_unsafe_transform_plugins)
+        debug_log.print(.topology_preserve, "preserve-fallback gate: unsafe-plugin (resolveId={} load={} transform={}; preserve_safe={})\n", .{ self.has_unsafe_resolve_id_plugins, self.has_unsafe_load_plugins, self.has_unsafe_transform_plugins, self.preserve_safe_plugins });
     if (self.code_splitting or self.preserve_modules)
         debug_log.print(.topology_preserve, "preserve-fallback gate: splitting={} preserve_modules={}\n", .{ self.code_splitting, self.preserve_modules });
     if (self.lazy_compilation)

--- a/src/bundler/graph/plugins.zig
+++ b/src/bundler/graph/plugins.zig
@@ -31,11 +31,28 @@ pub fn ensureBuiltinPlugins(self: anytype) void {
     self.has_user_resolve_id_plugins = false;
     self.has_user_load_plugins = false;
     self.has_transform_plugins = self.codegen_transform;
+    var user_transform = false;
     for (self.plugins) |p| {
         if (p.resolveId != null) self.has_user_resolve_id_plugins = true;
         if (p.load != null) self.has_user_load_plugins = true;
-        if (p.transform != null) self.has_transform_plugins = true;
+        if (p.transform != null) {
+            self.has_transform_plugins = true;
+            user_transform = true;
+        }
     }
+    // PR-3: preserve_safe_plugins(빌드 신호)면 user plugin 을 보존-안전으로 본다. codegen
+    // (native·결정적)은 has_transform_plugins 엔 포함되지만 unsafe transform 엔 불포함(user_transform
+    // 만 기준) — codegen-only RN 이 오분류되지 않게 한다.
+    //
+    // 주의(NAPI 현실): JS plugin 은 plugin_bridge 가 단일 dispatcher("js-plugin") 1개로 합쳐
+    // resolveId/load/transform 을 **전부 non-null** 로 채워 전달한다(per-plugin 분해 불가). 따라서
+    // 실제 RN/NAPI 빌드에선 JS plugin 이 하나라도 있으면 세 has_user_*/user_transform 이 항상 true
+    // → 안전성은 오직 preserve_safe_plugins 한 신호로 결정된다. 아래 hook 별 분리(user_transform 등)는
+    // 순수 Zig plugin 배열(유닛 테스트)에서만 fine-grained 하게 동작한다. 그러므로 preserve_safe_plugins
+    // 를 켜는 호출자(RN preset)는 "임의 사용자 코드 주입 경로가 없을 때만" 켜야 한다(preset.ts 게이트 참조).
+    self.has_unsafe_resolve_id_plugins = self.has_user_resolve_id_plugins and !self.preserve_safe_plugins;
+    self.has_unsafe_load_plugins = self.has_user_load_plugins and !self.preserve_safe_plugins;
+    self.has_unsafe_transform_plugins = user_transform and !self.preserve_safe_plugins;
 
     const u = self.transform_options_base.unsupported;
     self.helper_plugin_opts = .{

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -2904,3 +2904,145 @@ test "PR-2: polyfill 스텁 자체 변경 → 보존 reparse(is_context_dep 복�
     try std.testing.expectEqual(fb_before, graph.topology_fallback_count);
     try std.testing.expectEqualStrings(fresh.output, preserved.output);
 }
+
+// ── PR-3: plugin 게이트 결정적 plugin 한정 완화 ──────────────────────────────
+
+const plugin_mod_t = @import("plugin.zig");
+
+/// 결정적 identity transform — code 를 그대로(dupe) 반환. preserve_safe 보존 테스트용.
+fn pr3NoopTransform(ctx: ?*anyopaque, code: []const u8, id: []const u8, allocator: std.mem.Allocator, hook_ctx: *plugin_mod_t.HookContext) plugin_mod_t.PluginError!?[]const u8 {
+    _ = ctx;
+    _ = id;
+    _ = hook_ctx;
+    return try allocator.dupe(u8, code);
+}
+
+fn preservedBuildPlugin(
+    graph: *ModuleGraph_t,
+    store: *module_store.PersistentModuleStore,
+    rc: *@import("resolve_cache.zig").ResolveCache,
+    entry: []const u8,
+    plugins: []const plugin_mod_t.Plugin,
+    preserve_safe: bool,
+    is_first: bool,
+    changed: ?*const std.StringHashMapUnmanaged(void),
+) !BundleResult {
+    var opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .plugins = plugins,
+        .preserve_safe_plugins = preserve_safe,
+    });
+    if (!is_first) {
+        opts.module_store = store;
+        opts.changed_files = changed;
+        opts.preserve_topology = true;
+    }
+    var b = Bundler.initWithGraph(std.testing.allocator, opts, rc, graph);
+    defer b.deinit();
+    return try b.bundle(std.testing.io);
+}
+
+fn freshFullPlugin(entry: []const u8, plugins: []const plugin_mod_t.Plugin, preserve_safe: bool) !BundleResult {
+    var fresh = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .plugins = plugins,
+        .preserve_safe_plugins = preserve_safe,
+    });
+    defer fresh.deinit();
+    return try fresh.bundle(std.testing.io);
+}
+
+test "PR-3: preserve_safe transform plugin body-only edit → 보존 + byte-identical" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts",
+        \\export const x = 1;
+        \\console.log(x);
+    );
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const plugins = [_]plugin_mod_t.Plugin{.{ .name = "pr3-noop", .transform = pr3NoopTransform }};
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildPlugin(&graph, &store, &rc, entry, &plugins, true, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const hits_before = graph.topology_preserved_hits;
+    const fb_before = graph.topology_fallback_count;
+
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts",
+        \\export const x = 1;
+        \\console.log(x, 'edited');
+    );
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuildPlugin(&graph, &store, &rc, entry, &plugins, true, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh = try freshFullPlugin(entry, &plugins, true);
+    defer fresh.deinit(std.testing.allocator);
+    try std.testing.expect(!fresh.hasErrors());
+
+    // preserve_safe → plugin 있어도 보존 진입(hit++/fb 불변) + identity transform 이라 byte-identical.
+    try std.testing.expectEqual(hits_before + 1, graph.topology_preserved_hits);
+    try std.testing.expectEqual(fb_before, graph.topology_fallback_count);
+    try std.testing.expectEqualStrings(fresh.output, preserved.output);
+}
+
+test "PR-3: unsafe transform plugin(preserve_safe=false) → fallback" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts",
+        \\export const x = 1;
+        \\console.log(x);
+    );
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const plugins = [_]plugin_mod_t.Plugin{.{ .name = "pr3-noop", .transform = pr3NoopTransform }};
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var r1 = try preservedBuildPlugin(&graph, &store, &rc, entry, &plugins, false, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const fb_before = graph.topology_fallback_count;
+
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts",
+        \\export const x = 1;
+        \\console.log(x, 'edited');
+    );
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuildPlugin(&graph, &store, &rc, entry, &plugins, false, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    // preserve_safe=false → unsafe transform plugin → canPreserveTopology fallback.
+    // (fallback 경로의 byte 정확성은 기존 동작; 여기선 게이트의 fallback 전환만 단언 — 테스트
+    //  환경 mtime 해상도와 무관하게 결정적.)
+    try std.testing.expectEqual(fb_before + 1, graph.topology_fallback_count);
+}

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -249,6 +249,7 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "blockList", // RN resolver block list
     "collectModuleCodes", // NAPI 만 사용 (HMR module codes)
     "codegenTransform", // BuildOptions 전용 codegen transform hook
+    "preserveSafePlugins", // PR-3: HMR 위상 보존 plugin 게이트 완화 신호 (RN preset opt-in, NAPI 전용)
     "configurableExports", // RN configurable __toESM
     "devMode", // dev mode flag
     "emitDiskSourcemap", // sourcemap 디스크 emit


### PR DESCRIPTION
## 배경
HMR 위상 보존(`canPreserveTopology`)은 변경된 모듈만 reparse 하고 나머지 그래프(수천 모듈)를 그대로 재사용해 rebuild 를 가속한다. 그런데 plugin(resolveId/load/transform)이 하나라도 있으면 **무조건 fallback**(전체 그래프 재구성)했다.

mobile-seller(RN 8092 모듈) 실측 결과 **이 plugin 게이트가 유일한 fallback 원인**이었다. 그리고 fallback 의 병목은 plugin 실행이 아니라 8091개 cache-hit 모듈을 그래프에 다시 add 하는 **replay 152ms**다(plugin transform 자체는 0.45ms).

## 핵심 통찰
plugin 훅은 **모듈별 순수 함수**(ModuleGraph 무접근)이고, 보존 경로는 **이미 변경 모듈만 plugin 재실행**(unchanged 는 parse_arena 캐시 + store transfer 로 보존)한다. `topologyMatches` 가 plugin 의 import 추가/제거·resolveId redirect 를 fallback 으로 잡는다. 즉 plugin 이 **결정적**(같은 입력→같은 출력)이기만 하면 보존은 byte-identical 하게 안전하다.

## 변경
- **`preserve_safe_plugins`**(빌드 신호): "이 빌드의 user plugin 은 전부 결정적·모듈별 순수"를 호출자가 보장. `plugins.zig` 에서 `has_unsafe_{resolve_id,load,transform}_plugins = has_user_X and !preserve_safe_plugins` 계산. 게이트(`build_flow.zig`)를 `has_user_*` → `has_unsafe_*` 로 교체.
  - codegen(native·결정적)은 `user_transform` 과 분리해 unsafe 에 안 들어가게 함.
- **RN preset opt-in**: 내장 plugin(asset/metro-resolve-request/require-context/codegen)만이면 자동 `true`. 단 **사용자 코드가 주입되는 경로**(additionalPlugins / metroResolveRequest=사용자 resolver / babelTransformerPath=사용자 transformer)가 하나라도 있으면 `false` 강등(보수적). 사용자가 \"내 resolver/transformer 는 결정적\"임을 알면 `preserveSafePlugins: true` 명시로 override(책임은 사용자).

## Zig 초보 설명
- `has_unsafe_*` 는 graph 구조체의 새 `bool` 필드. `ensureBuiltinPlugins`(plugin 목록 lazy init)에서 plugin 배열을 한 번 훑어 채운다. **NAPI 현실**: JS plugin 은 단일 dispatcher 1개로 합쳐져 resolveId/load/transform 이 전부 non-null 이라, 실제로는 `preserve_safe_plugins` 단일 신호가 안전을 결정한다(주석 명시). hook 별 분리는 순수 Zig plugin 배열=유닛 테스트에서만 fine-grained 하다.
- `??`(JS): `extra?.preserveSafePlugins ?? 자동판정` — 명시값이 `undefined` 가 아니면(`true`/`false` 둘 다) 우선. `false` 도 존중되어 명시 opt-out 도 가능.

## 측정 (mobile-seller 8092 모듈)
| | 완화 전(fallback) | 완화 후(보존) |
|---|---|---|
| 게이트 | plugin → fallback | (없음) |
| grph | 188ms (replay 152) | **13ms** (replay 0) |
| HMR 총 | ~370ms | **~200ms** |

**byte-identical 검증**: 보존 graph 가 emit 한 전체 번들(72,190,230 B)과 `preserveSafePlugins=false` 강제 full-fallback 번들이 `cmp` 로 **완전 일치**.

## 안전성 (`/code-review max` 반영)
- 사용자 임의 코드 2경로(metroResolveRequest, babelTransformerPath)가 게이트를 우회하던 결함을 발견·차단(보수적 false 강등).
- mobile-seller 의 resolveRequest(redux-saga redirect)·svg-transformer 는 둘 다 결정적임을 코드로 확인 → 명시 opt-in 으로 보존 + byte-identical 실증.

## 테스트
- `incremental_test`: preserve_safe transform body-edit → 보존+byte-identical, unsafe(preserve_safe=false) → fallback.
- `preset.test`: 게이트 자동판정(내장 true / 사용자코드 false) + 명시 override(true/false) 6 케이스.
- `zig build test` / `zig build napi` / `bun test`(preset 81 pass) 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)