### PR TITLE
perf(linker): reuse-hit 에서 populateSymbolRefCounts skip — dev HMR lnk 절감

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1480,6 +1480,9 @@ pub const Bundler = struct {
             try l.finalize(.{
                 .compute_renames = did_compute_renames,
                 .compute_mangling = self.options.minify_identifiers and !will_tree_shake,
+                // reuse-hit 만 ref_count populate skip. splitting(can_reuse=false)은 per-chunk
+                // mangling 이 ref_count 를 소비하므로 반드시 populate(byte-identical 보존).
+                .skip_ref_counts = can_reuse,
             });
 
             // computeRenames 가 실제 실행됐을 때만 스냅샷 박제(초기/fallback). 재사용-hit 는

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2965,6 +2965,10 @@ pub const Linker = struct {
         compute_mangling: bool,
         clear_first: bool = false,
         populate_namespace_accesses: bool = true,
+        /// dev HMR reuse-hit 전용 — ref_count(populateSymbolRefCounts) populate 를 skip.
+        /// reuse-hit 는 computeRenames 도 skip 하고 capture_eligible 이 minify/splitting 을
+        /// 제외하므로 ref_count 가 어디서도 소비되지 않는다(아래 populate 가드 주석 참조).
+        skip_ref_counts: bool = false,
     }) !void {
         if (opts.clear_first) {
             self.clearCanonicalNames();
@@ -2977,7 +2981,15 @@ pub const Linker = struct {
         self.populateReExportAliases();
         self.populateImportSymbols();
         if (opts.populate_namespace_accesses) self.populateNamespaceAccesses();
-        self.populateSymbolRefCounts();
+        // ref_count(populateSymbolRefCounts)는 mangle candidate 우선순위(collectUnifiedInput)에서
+        // 소비된다 — 전역 computeMangling 뿐 아니라 code-splitting 의 per-chunk computeChunkMangling
+        // (computeRenamesForModules)도 소비하므로 `compute_renames=false` 라고 무조건 skip 하면
+        // splitting minified 출력의 짧은-이름 배정이 갈린다. 따라서 dev HMR reuse-hit
+        // (skip_ref_counts=true)만 안전하게 skip한다: reuse-hit 는 computeRenames 를 skip 하고
+        // capture_eligible 이 minify_identifiers/code_splitting 을 제외하므로 ref_count 가 어디서도
+        // 소비되지 않는다. 전체 모듈 import_bindings O(N) 순회 절약(lnk). 첫빌드/fallback/splitting
+        // (skip_ref_counts=false)은 종전대로 populate.
+        if (!opts.skip_ref_counts) self.populateSymbolRefCounts();
     }
 
     /// pre-shake AST mutation (cross-module const materialize) 직후, 후속 BFS 가


### PR DESCRIPTION
## 배경
HMR 위상 보존이 graph 단계를 188→13ms로 줄인 뒤 남은 **lnk(~70ms)·emt(~42ms)는 변경 모듈 집합을 알면서도 전체 8092 모듈을 다시 돈다**. 이 PR은 그 중 link 단계의 불필요한 O(N) 순회 1개를 제거하는 안전 정리다(안전 3건 중 첫 번째).

## 변경
`populateSymbolRefCounts`(linker.zig:2392, 전체 모듈 import_bindings 순회하며 `reference_count += 1`)는 `finalize`에서 무조건 호출됐다. 이 ref_count 는 **mangle candidate 우선순위**(짧은 이름 배정, `collectUnifiedInput`)에서만 소비된다. dev HMR reuse-hit 는 computeRenames 를 skip(PR #4161, rename_table 재사용)하므로 ref_count 도 불필요.

`finalize` 에 `skip_ref_counts` 플래그를 추가하고 **reuse-hit(`can_reuse`)일 때만** skip 한다.

## Zig 초보 설명
- `finalize` 의 opts 는 익명 struct. 필드에 `skip_ref_counts: bool = false`(기본 false=종전 동작) 추가.
- `can_reuse`(bundler.zig:1469)는 rename 스냅샷 재사용이 성립한 dev HMR rebuild 에서만 true.

## ⚠️ 리뷰가 잡은 함정 (CRITICAL 수정)
처음엔 `if (opts.compute_renames)` 로 게이트했으나, `compute_renames=false` 는 **code-splitting 빌드**에서도 발생한다(`did_compute_renames = !code_splitting and !can_reuse`). splitting 은 per-chunk `computeChunkMangling`(computeRenamesForModules)이 ref_count 를 소비하므로, 그대로 두면 **minified code-split 출력의 짧은-이름 배정이 뒤섞여 byte-different** 해진다. 그래서 `compute_renames` 가 아니라 `can_reuse` 한정으로 좁혔다 — splitting/첫빌드/fallback 은 populate 유지.

## 검증
- `zig build test`(splitting/minify 회귀 포함) + `zig build napi` 통과.
- mobile-seller(8092): 보존 graph emit 번들 vs `preserveSafePlugins=false` 강제 full-fallback 번들 `cmp` **byte-identical**.
- 절감: populateSymbolRefCounts 비중이 작아 lnk 측정 노이즈(±20ms)에 묻히나, dev hot path 의 불필요한 O(N) 순회 제거. 측정 가능한 절감은 후속 PR-B(emit cache ~25ms)·PR-C(guard 변경-한정)와 누적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)