### PR TITLE
perf(emit): HMR 보존-hit unchanged 모듈 source 해시 skip — eMod 절감

### DIFF
--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -338,6 +338,9 @@ pub const CompiledOutputCache = struct {
     hits: u64 = 0,
     misses: u64 = 0,
     skipped_no_mtime: u64 = 0,
+    /// PR-B: emit fast-path 의 options 변동 가드. 직전 빌드 options_hash. emit 진입 시 현재와
+    /// 비교해 다르면(드묾) fast-path 전역 off → 전 모듈 full source-hash(stale 방지).
+    last_options_hash: u64 = 0,
 
     pub const Entry = struct {
         input_hash: u64,
@@ -389,6 +392,14 @@ pub const CompiledOutputCache = struct {
         }
         self.hits += 1;
         return &ptr.compiled;
+    }
+
+    /// PR-B: hash 검증 없이 path 로 직전 Entry borrow(카운터 불변). emit fast-path 가 이번 빌드
+    /// unchanged(reparse 안 됨)로 판정한 모듈에만 쓴다 — unchanged 면 input 물리 불변이라 저장
+    /// input_hash 가 자기 자신과 일치(tryHit 자기 hit 과 동치). caller 가 input_hashes[i] 에
+    /// ent.input_hash 를 그대로 재사용해 Phase 2.5 put 정합 유지.
+    pub fn peekEntry(self: *CompiledOutputCache, path: []const u8) ?*const Entry {
+        return self.entries.getPtr(path);
     }
 
     /// emit 결과를 cache 에 저장. `compiled` 의 slice 들은 cache allocator 로 dupe.

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -653,11 +653,31 @@ pub fn emitWithTreeShaking(
         0;
 
     if (options.compiled_cache) |cache| {
+        // PR-B: HMR 위상 보존-hit 의 unchanged 모듈은 input(source/import/mtime)이 물리 불변이라
+        // 직전 Entry 의 input_hash 가 자기 자신과 일치한다. graph.changed_emit_paths(보존-hit 에서만
+        // non-null)에 없는 모듈은 전체 source 해시(computeInputHash) 없이 peek 으로 직전 결과를
+        // 재사용해 eMod O(N) 해시를 제거한다. 가드: options_hash 가 직전과 같을 때만(options 변동 시
+        // 전 모듈 full hash). fast-path 비활성/peek-miss/dupe 실패면 종전 computeInputHash 로 fall-through.
+        const fast_path = graph.changed_emit_paths != null and options_hash == cache.last_options_hash;
         for (sorted.items, 0..) |m, i| {
             if (hit_mask[i]) continue;
             if (m.mtime == 0) {
                 cache.skipped_no_mtime += 1;
                 continue; // mtime unknown → cache 비활성
+            }
+            if (fast_path and !graph.changed_emit_paths.?.contains(m.path)) {
+                if (cache.peekEntry(m.path)) |ent| {
+                    if (ent.compiled.dupe(allocator)) |dup| {
+                        results[i] = dup;
+                        input_hashes[i] = ent.input_hash; // Phase 2.5 put 정합(어차피 hit_mask=true 라 skip)
+                        if (linker) |l| {
+                            l.restoreSharedNamespaceDecls(results[i].shared_ns_decls) catch {};
+                        }
+                        cache.hits += 1;
+                        hit_mask[i] = true;
+                        continue;
+                    } else |_| {} // dupe 실패 → 종전 경로 fall-through
+                }
             }
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
             const input_hash = cache_mod.computeInputHash(m, options_hash, used_names, graph);
@@ -669,6 +689,7 @@ pub fn emitWithTreeShaking(
             }
             hit_mask[i] = true;
         }
+        cache.last_options_hash = options_hash; // 다음 빌드 fast-path 가드용
     }
 
     if (linker) |l| {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -138,6 +138,11 @@ pub const ModuleGraph = struct {
     /// 실제 보존 경로를 탔는지(전량 fallback 이 아닌지)" 검증하는 데 사용. 빌드 정확성과 무관.
     topology_preserved_hits: usize = 0,
     topology_fallback_count: usize = 0,
+    /// PR-B: HMR 위상 보존-hit 시 변경(reparse)된 모듈 path set. emit 이 unchanged 모듈의
+    /// 전체 source 해시(computeInputHash)를 skip 하고 직전 compiled_cache 결과를 재사용하게 한다
+    /// (eMod 절감). 보존-hit 에서만 non-null(빈 set=변경 0), fallback/full/첫빌드=null →
+    /// emit fast-path 자동 비활성. key=path_arena 소유 path(borrow), graph 수명. lifecycle.deinit 해제.
+    changed_emit_paths: ?std.StringHashMapUnmanaged(void) = null,
     /// Phase B edge-reuse 내부 플래그 — 변경 모듈 *재resolve* 중에만 일시적으로 true.
     /// true 면 `linkDependency`/`linkDynamicImport` 가 no-op (보존된 edge 리스트를 그대로 두고
     /// import_records[].resolved + resolved_deps 만 재구성하기 위함). 보존 모드에서 변경 모듈의

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -1171,6 +1171,14 @@ pub fn buildIncrementalPreserved(
     store: *module_store.PersistentModuleStore,
     changed_files: ?*const std.StringHashMapUnmanaged(void),
 ) !IncrementalBuildResult {
+    // PR-B(F1): emit fast-path carrier 를 함수 최상단에서 clear(null) — 아래 어느 early-return
+    // (modules==0 / changed_files==null / !canPreserveTopology / 각종 fallback)을 타든 직전
+    // 보존-hit 의 stale set 이 남지 않게 한다. 보존-hit/early-return(변경0)만 이후 set 을 채운다.
+    // 이게 없으면 빌드 N(보존-hit, carrier={A}) 다음 빌드 N+1 이 fallback 으로 빠질 때 stale {A}
+    // 가 남아 emit 이 A 외 전 모듈을 unchanged 오판→peek stale.
+    if (self.changed_emit_paths) |*s| s.deinit(self.allocator);
+    self.changed_emit_paths = null;
+
     // cold / 첫 빌드 / 직전 fallback 으로 graph 가 비워진 경우 → full discovery.
     // (store 는 보존 모드에서 비어있어 전량 cache-miss = full parse → byte-identical full.)
     if (self.modules.count() == 0) {
@@ -1249,6 +1257,8 @@ pub fn buildIncrementalPreserved(
     if (changed_indices.items.len == 0) {
         resetPerBuildStateForPreserved(self);
         self.topology_preserved_hits += 1;
+        // PR-B: 변경 0 — carrier 빈 set(non-null) → emit 이 전 모듈을 peek 재사용(출력 불변).
+        self.changed_emit_paths = .empty;
         try finalizeGraph(self, entry_points);
         return .{ .graph_changed = false, .reparsed_indices = try self.allocator.alloc(types.ModuleIndex, 0) };
     }
@@ -1384,11 +1394,16 @@ pub fn buildIncrementalPreserved(
     // (path slice 는 path_arena 소유라 renumber 후에도 path_to_module 키로 유효).
     var reparsed: std.ArrayListUnmanaged(types.ModuleIndex) = .empty;
     errdefer reparsed.deinit(self.allocator);
+    // PR-B: emit fast-path carrier — 변경(reparse)된 모듈 path(path_arena 소유 borrow) set 구성.
+    // emit 이 이 set 에 없는 unchanged 모듈은 source 해시 없이 직전 compiled_cache 결과를 재사용.
+    self.changed_emit_paths = .empty;
     {
         var it = cf.iterator();
         while (it.next()) |e| {
             if (self.path_to_module.get(e.key_ptr.*)) |idx| {
                 try reparsed.append(self.allocator, idx);
+                // OOM 시 try 로 빌드 에러(부분 set 으로 stale peek 방지) — 다음 빌드 진입부가 clear.
+                try self.changed_emit_paths.?.put(self.allocator, self.modules.at(@intFromEnum(idx)).path, {});
             }
         }
     }

--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -180,6 +180,8 @@ pub fn deinit(self: *ModuleGraph) void {
     self.modules.deinit(self.allocator);
     // PR-Z4: path_to_module key 메모리는 path_arena 가 owned — 개별 free 불요, 일괄 해제.
     self.path_to_module.deinit(self.allocator);
+    // PR-B: changed_emit_paths key 는 path_arena borrow — set backing 만 해제(path_arena 보다 먼저).
+    if (self.changed_emit_paths) |*s| s.deinit(self.allocator);
     self.path_arena.deinit();
     var req_it = self.requested_exports.valueIterator();
     while (req_it.next()) |req| req.deinit(self.allocator);

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -3046,3 +3046,78 @@ test "PR-3: unsafe transform plugin(preserve_safe=false) → fallback" {
     //  환경 mtime 해상도와 무관하게 결정적.)
     try std.testing.expectEqual(fb_before + 1, graph.topology_fallback_count);
 }
+
+// ── PR-B: emit fast-path (compiled_cache + 보존-hit) byte-identical 가드 ──────
+
+fn preservedBuildTopoCache(
+    graph: *ModuleGraph_t,
+    store: *module_store.PersistentModuleStore,
+    rc: *@import("resolve_cache.zig").ResolveCache,
+    cache: *CompiledOutputCache,
+    entry: []const u8,
+    is_first: bool,
+    changed: ?*const std.StringHashMapUnmanaged(void),
+) !BundleResult {
+    var opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .collect_module_codes = true,
+        .compiled_cache = cache,
+    });
+    if (!is_first) {
+        opts.module_store = store;
+        opts.changed_files = changed;
+        opts.preserve_topology = true;
+    }
+    var b = Bundler.initWithGraph(std.testing.allocator, opts, rc, graph);
+    defer b.deinit();
+    return try b.bundle(std.testing.io);
+}
+
+test "PR-B: emit fast-path(compiled_cache+보존) unchanged 모듈 peek → byte-identical" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "util.ts", "export const x = 1;");
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x);");
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+    var cache = CompiledOutputCache.init(std.testing.allocator);
+    defer cache.deinit();
+
+    // 첫 빌드 — compiled_cache populate(util/index entry).
+    {
+        var r1 = try preservedBuildTopoCache(&graph, &store, &rc, &cache, entry, true, null);
+        defer r1.deinit(std.testing.allocator);
+        try std.testing.expect(!r1.hasErrors());
+    }
+    const hits_before = graph.topology_preserved_hits;
+    const fb_before = graph.topology_fallback_count;
+    _ = cache.takeStats(); // 첫 빌드 miss 카운터 리셋 — rebuild 의 fast-path hit 만 관측.
+
+    // index body-only edit (util unchanged → fast-path peek 대상).
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "index.ts", "import { x } from './util';\nconsole.log(x, 'edited');");
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, entry, {});
+
+    var preserved = try preservedBuildTopoCache(&graph, &store, &rc, &cache, entry, false, &touched);
+    defer preserved.deinit(std.testing.allocator);
+    try std.testing.expect(!preserved.hasErrors());
+
+    var fresh = try freshFull(entry);
+    defer fresh.deinit(std.testing.allocator);
+
+    // 보존 hit(fallback 아님) + unchanged util 이 fast-path peek 으로 cache hit + 출력 byte-identical.
+    try std.testing.expectEqual(hits_before + 1, graph.topology_preserved_hits);
+    try std.testing.expectEqual(fb_before, graph.topology_fallback_count);
+    try std.testing.expect(cache.hits >= 1); // util fast-path peek
+    try std.testing.expectEqualStrings(fresh.output, preserved.output);
+}


### PR DESCRIPTION
## 배경
HMR 위상 보존이 graph 를 188→13ms 로 줄였지만, **emit(~42ms)은 변경 모듈 집합을 알면서도 전체 8092 모듈마다 `computeInputHash`(전체 source Wyhash)를 돈다** — 이게 eMod ~25ms 의 지배항이다. 보존-hit 의 unchanged 모듈은 source 가 물리 불변이라 직전 결과를 그대로 재사용할 수 있다.

## 변경
**carrier** `ModuleGraph.changed_emit_paths`(보존-hit 의 변경 path set, fallback/full/첫빌드=null)를 도입. emit 이 set 에 없는 unchanged 모듈은 source 해시 없이 `compiled_cache.peekEntry` 로 직전 Entry 를 재사용한다.

- `graph.changed_emit_paths` + lifecycle deinit(path_arena 전).
- `build_flow.buildIncrementalPreserved`: 함수 최상단 clear(null), 보존-hit/변경0 에서만 set 구성.
- `compiled_cache.peekEntry`(hash 무검증 borrow) + `last_options_hash` 가드.
- `emitter` fast-path: set 에 없고 options_hash 불변이면 peek 재사용, 아니면 종전 경로.

## Zig 초보 설명
- `?StringHashMapUnmanaged(void)` = nullable string set. null 이면 "carrier 없음"(fallback) → fast-path 자동 off.
- `peekEntry` 는 hash 검증 없이 path 로 직전 결과를 빌려온다 — unchanged 면 input 이 물리 불변이라 저장 input_hash 가 자기 자신과 일치(tryHit self-hit 과 동치).

## ⚠️ 리뷰가 잡은 함정 (F1, HIGH)
처음엔 carrier clear 를 `ensureBuiltinPlugins` 뒤(canPreserveTopology 게이트 **후**)에 뒀는데, `modules==0`/`changed_files==null`/`!canPreserveTopology` 세 early-return 이 그 **전**에 있어, 보존-hit(carrier={A}) 다음 빌드가 그 경로로 fallback 되면 stale {A} 가 남아 emit 이 A 외 전 모듈을 unchanged 오판→stale peek 했다. clear 를 **함수 최상단**(모든 early-return 전)으로 옮겨 해결.

## ABA 회피
changed 판정은 `reparsed_indices`(ground truth)라 source.ptr 에 의존하지 않는다 — allocator 가 free 된 arena 주소를 재사용해도 오판 없음.

## 검증
- `zig build test`(F2 byte-identical 가드 포함) + `zig build napi` 통과.
- **단위(F2)**: compiled_cache 주입 보존 빌드 → unchanged 모듈 fast-path peek + cache hit + 출력==fresh full `expectEqualStrings`.
- **mobile-seller(8092)**: eMod 25→14-18ms, 총 ~200→~172-185ms. 보존 fast-path 번들 vs `preserveSafePlugins=false` 강제 full-fallback 번들 `cmp` byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)