### PR TITLE
perf(linker): renameReuseGuard 변경-모듈 한정 — dev HMR lnk 절감

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -960,10 +960,24 @@ pub const Linker = struct {
         if (mc != snap.module_count) return false;
         if (snap.fingerprint.len != mc) return false;
 
+        // PR-C: HMR 보존-hit 의 unchanged 모듈(carrier changed_emit_paths 에 없음)은 semantic 이
+        // 물리 보존이라 full fingerprint(이름집합 G2/unresolved G4/nested G5/import-wrap G6)가 자명히
+        // snapshot 과 일치 → G1 경량(path_hash/exec_index)만 확인하고 scope_maps/binding 순회
+        // (moduleFingerprint)를 건너뛴다(lnk 절감). carrier=null(fallback/비보존)이면 전량 비교(종전).
+        // G1 만 renumber/DFS 재실행 영향 가능 → 경량 확인이 fail-safe(불일치→false→full computeRenames).
+        const changed = self.graph.changed_emit_paths;
         for (0..mc) |i| {
             const m = self.getModule(@intCast(i)) orelse return false;
-            const cur = self.moduleFingerprint(m.*) catch return false; // OOM → fail-safe
             const old = snap.fingerprint[i];
+            if (changed) |ch| {
+                if (!ch.contains(m.path)) {
+                    // unchanged: G1 경량만 (path_hash 는 moduleFingerprint 와 동일 seed 0x5a).
+                    if (std.hash.Wyhash.hash(0x5a, m.path) != old.path_hash) return false;
+                    if (m.exec_index != old.exec_index) return false;
+                    continue;
+                }
+            }
+            const cur = self.moduleFingerprint(m.*) catch return false; // OOM → fail-safe
             // G1 + G0(per-index path): 같은 인덱스에 같은 경로/실행순서.
             if (cur.path_hash != old.path_hash) return false;
             if (cur.exec_index != old.exec_index) return false;

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1794,6 +1794,45 @@ test "reuse: guard 통과 시 inject — single import 그래프" {
     try expectRenameTablesEqual(&r.linker, &fresh);
 }
 
+test "reuse PR-C: 변경-한정 가드(carrier set)가 전량 가드와 동일 verdict" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.ts", "import './b';\nimport './c';\nexport const count = 0;\nexport const name = 'a';");
+    try writeFile(tmp.dir, "b.ts", "export const count = 1;\nexport const name = 'b';");
+    try writeFile(tmp.dir, "c.ts", "export const count = 2;\nexport const name = 'c';");
+
+    var r = try buildLinkAndRename(std.testing.allocator, &tmp, "a.ts");
+    defer r.linker.deinit();
+    defer r.destroyGraph();
+    defer r.cache.deinit();
+
+    var snap = (try r.linker.buildRenameSnapshot(std.testing.allocator)).?;
+    defer snap.deinit();
+
+    var fresh = Linker.init(std.testing.allocator, r.graph, .esm);
+    defer fresh.deinit();
+    try fresh.link();
+
+    // 전량(carrier=null): 같은 그래프 → 통과(종전 경로).
+    try std.testing.expect(r.graph.changed_emit_paths == null);
+    try std.testing.expect(fresh.renameReuseGuard(&snap));
+
+    // 변경-한정(carrier={modules[0]}): carrier 에 있는 모듈은 full fingerprint, 나머지는 G1 경량
+    // (path_hash/exec_index). 같은 그래프라 전부 일치 → 동일하게 통과(carrier branch 진입 검증).
+    var carrier: std.StringHashMapUnmanaged(void) = .empty;
+    defer carrier.deinit(std.testing.allocator);
+    try carrier.put(std.testing.allocator, r.graph.modules.at(0).path, {});
+    r.graph.changed_emit_paths = carrier;
+    try std.testing.expect(fresh.renameReuseGuard(&snap));
+
+    // 빈 carrier(전부 unchanged=G1 경량)도 동일 통과.
+    r.graph.changed_emit_paths = .empty;
+    try std.testing.expect(fresh.renameReuseGuard(&snap));
+
+    // graph.deinit 가 테스트 소유 carrier 를 이중 해제하지 않게 복원(빈 set 은 backing 없음).
+    r.graph.changed_emit_paths = null;
+}
+
 test "reuse: G3 by-name 재유도 — 스냅샷의 inner idx 가 흔들려도 이름으로 복원" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## 배경
HMR 보존 link 단계(~70ms)의 마지막 안전 정리(3건 중 #3). dev HMR reuse-hit 가드 `renameReuseGuard` 가 매 rebuild **전체 8092 모듈에 full `moduleFingerprint`**(scope_maps/binding/unresolved 순회)를 돈다 — PR #4161 이 computeRenames(lRen)를 skip 한 절감의 일부를 이 guard 가 도로 먹고 있었다.

## 변경
PR-B 의 carrier `self.graph.changed_emit_paths`(보존-hit 변경 path set)를 재사용해 **unchanged 모듈은 G1 경량**(path_hash/exec_index)만 확인하고 full fingerprint 를 건너뛴다. carrier=null(fallback/비보존)이면 전량 비교(종전). 시그니처/호출부 무변경.

## Zig 초보 설명
- `moduleFingerprint` 의 6개 게이트: G1(path/순서) + G2(이름집합) + G4(전역참조) + G5(nested) + G6(import/wrap). unchanged 모듈은 G2/G4/G5/G6 가 자명 일치라 G1 만 본다.
- carrier 에 없는 모듈 = reparse 안 됨 = semantic 물리 동결.

## 정확성 (리뷰 확인)
보존-hit 의 unchanged 모듈은 `resolveModuleImports` 가 changed_indices 만(suppress_edge_link) 돌아 semantic 이 물리 동결된다 — G2/G4/G5/G6 가 읽는 필드는 전부 **모듈-로컬**(import_bindings.local_name, unresolved_references, wrap_kind)이라 다른 모듈 변경에 무관. G1 만 renumber/DFS 영향 가능 → 경량 확인이 **fail-safe**(불일치→false→full computeRenames, perf 회귀만, 출력은 항상 안전).

## 검증
- `zig build test`(carrier branch verdict 동치 단위 포함) + `zig build napi` 통과.
- **단위**: carrier set branch verdict 가 전량(carrier=null)과 동치(linker_test).
- **mobile-seller(8092)**: lnk 69→57-58ms, 총 ~172-185→~161-179ms. 보존 변경-한정 가드 번들 vs `preserveSafePlugins=false` full-fallback 번들 `cmp` byte-identical.

## 누적 성과 (안전 3건)
PR-A(ref_count skip) + PR-B(emit cache, eMod 25→14) + PR-C(guard 변경-한정, lnk 69→57): HMR ~200 → **~161-179ms**. 전부 byte-identical 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)