### PR TITLE
test(renumber): identity 멱등 가드 — finalize/renumber skip 선행

### DIFF
--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -1460,6 +1460,37 @@ test "renumber: orphan modules sorted by path regardless of add order" {
     try std.testing.expectEqual(@as(u32, 2), graph.modules.at(2).index.toU32());
 }
 
+test "renumber identity: 위상 불변이면 재renumber 가 멱등 (orphan path-sort)" {
+    // 보존 경로 finalize/renumber skip 의 안전 근거: 같은 모듈 집합/순서를 다시 renumber 해도
+    // old_to_new[i]==i (배치 불변). 위상이 안 바뀌면 renumber 가 출력에 영향 없음을 보장.
+    const alloc = std.testing.allocator;
+    var cache = resolve_cache_mod.ResolveCache.init(alloc, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(alloc, &cache);
+    defer graph.deinit();
+
+    try graph.modules.append(alloc, Module.init(@enumFromInt(0), "c.ts"));
+    try graph.modules.append(alloc, Module.init(@enumFromInt(1), "b.ts"));
+    try graph.modules.append(alloc, Module.init(@enumFromInt(2), "a.ts"));
+    const arena_alloc = graph.path_arena.allocator();
+    try graph.path_to_module.put(alloc, try arena_alloc.dupe(u8, "c.ts"), @enumFromInt(0));
+    try graph.path_to_module.put(alloc, try arena_alloc.dupe(u8, "b.ts"), @enumFromInt(1));
+    try graph.path_to_module.put(alloc, try arena_alloc.dupe(u8, "a.ts"), @enumFromInt(2));
+
+    // 1회: a/b/c = 0/1/2 (path 정렬). 2·3회: 이미 정렬 → 멱등(불변).
+    try renumber_mod.renumberModulesDeterministically(&graph, &.{});
+    try renumber_mod.renumberModulesDeterministically(&graph, &.{});
+    try renumber_mod.renumberModulesDeterministically(&graph, &.{});
+
+    try std.testing.expectEqualStrings("a.ts", graph.modules.at(0).path);
+    try std.testing.expectEqualStrings("b.ts", graph.modules.at(1).path);
+    try std.testing.expectEqualStrings("c.ts", graph.modules.at(2).path);
+    try std.testing.expectEqual(@as(u32, 0), graph.path_to_module.get("a.ts").?.toU32());
+    try std.testing.expectEqual(@as(u32, 1), graph.path_to_module.get("b.ts").?.toU32());
+    try std.testing.expectEqual(@as(u32, 2), graph.path_to_module.get("c.ts").?.toU32());
+    for (0..3) |i| try std.testing.expectEqual(@as(u32, @intCast(i)), graph.modules.at(i).index.toU32());
+}
+
 // F4 (Issue #65, PR #3704) 회귀 가드 — `buildIncremental` 가 stale entry_dir 를
 // 강제 재계산해야 watch 모드에서 entry 추가/삭제 후 [dir] 토큰이 정확.
 // 옛 코드는 `entry_dir.len == 0` 가드로 첫 build 후 영구 보존 → stale.

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -3121,3 +3121,57 @@ test "PR-B: emit fast-path(compiled_cache+보존) unchanged 모듈 peek → byte
     try std.testing.expect(cache.hits >= 1); // util fast-path peek
     try std.testing.expectEqualStrings(fresh.output, preserved.output);
 }
+
+// ── renumber identity: 위상 불변 graph 재renumber 멱등 (finalize/renumber skip 안전 근거) ──
+
+test "renumber identity: 실제 reachable graph 재renumber 시 path→index 멱등 (BFS)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "d.ts", "export const d = 4;");
+    try writeFile(tmp.dir, "b.ts", "import { d } from './d';\nexport const b = d;");
+    try writeFile(tmp.dir, "c.ts", "export const c = 3;");
+    try writeFile(tmp.dir, "index.ts",
+        \\import { b } from './b';
+        \\import { c } from './c';
+        \\console.log(b, c);
+    );
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var rc = Bundler.initResolveCacheFromOptions(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true });
+    defer rc.deinit();
+    var graph = ModuleGraph_t.init(std.testing.allocator, &rc);
+    defer graph.deinit();
+
+    {
+        var b = Bundler.initWithGraph(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = true }, &rc, &graph);
+        defer b.deinit();
+        var r = try b.bundle(std.testing.io);
+        defer r.deinit(std.testing.allocator);
+        try std.testing.expect(!r.hasErrors());
+    }
+
+    // 빌드 후 graph 는 이미 renumber 됨(finalizeGraph). path → index snapshot.
+    var snap: std.StringHashMapUnmanaged(u32) = .empty;
+    defer snap.deinit(std.testing.allocator);
+    {
+        var it = graph.path_to_module.iterator();
+        while (it.next()) |e| try snap.put(std.testing.allocator, e.key_ptr.*, e.value_ptr.toU32());
+    }
+    try std.testing.expect(snap.count() >= 4); // index/b/c/d (+ helper 가능)
+
+    // 위상 불변(같은 graph) 재renumber → 모든 path 의 index 불변(멱등=identity).
+    // 보존 경로가 finalize/renumber 를 매 rebuild 재실행해도 배치가 안 바뀜을 보장 → skip 안전 근거.
+    const renumber_id = @import("graph/renumber.zig");
+    try renumber_id.renumberModulesDeterministically(&graph, &.{entry});
+
+    var it2 = graph.path_to_module.iterator();
+    while (it2.next()) |e| {
+        const before = snap.get(e.key_ptr.*) orelse return error.TestUnexpectedResult;
+        try std.testing.expectEqual(before, e.value_ptr.toU32());
+    }
+    // Module.index == position (renumber 후 일관).
+    for (0..graph.modules.count()) |i| {
+        try std.testing.expectEqual(@as(u32, @intCast(i)), graph.modules.at(i).index.toU32());
+    }
+}


### PR DESCRIPTION
## 배경
HMR 100ms 도전(보존 경로 안에서 `finalizeGraph`의 renumber+DFS를 위상 불변 시 skip)의 **선행 가드**다. 그 최적화는 "위상이 안 바뀌면 renumber 결과가 직전 빌드와 동일(=identity)"를 전제로 하는데, 지금까지 코드로 검증된 적이 없었다(리뷰 지적). 이 PR은 그 전제만 테스트로 박제한다 — **구현 변경은 없다.**

## 변경
테스트 2개 추가:
- **graph_test**: orphan path-sort 멱등 — 같은 모듈 집합을 2·3회 재renumber 해도 `old_to_new[i]==i`(배치 불변).
- **incremental_test**: 실제 reachable graph(entry→b→d, entry→c) 빌드 후 재renumber → 모든 path 의 index 불변 + `Module.index == position`. seed(inject→rbm→entry) BFS 경로까지 멱등임을 실그래프로 검증.

## Zig 초보 설명
- `renumberModulesDeterministically`(renumber.zig:23)는 seed 기반 BFS 로 `old_to_new` 매핑을 만든다. **결정적**이라 같은 입력(모듈 집합+import 순서)이면 같은 출력 → 이미 정렬된 graph 를 다시 renumber 하면 identity.
- 멱등(idempotent) = `f(f(x)) == f(x)`. 위상 불변이면 renumber 가 멱등이므로, 보존 경로가 매 rebuild renumber 를 재실행해도 module_index 가 안 바뀐다.

## 부수 확인 (fallback 조사에서)
dev_id·module_id·cross-module 변수명(require/init/exports)은 전부 **path 기반**(emitter/dev.zig:266)이라 renumber 가 이들을 바꾸지 않는다. 즉 renumber 가 emit 출력에 영향 주는 유일한 축은 module_index 배치뿐이고, 그게 멱등이면 위상 불변 시 출력도 불변 — 이게 finalize/renumber skip 의 안전 근거다.

## 검증
- `zig build test`(신규 2 테스트 + 전체 회귀, leak 없음) 통과.
- 다음 단계: 이 가드 위에서 `finalizeGraph` 를 위상 불변(보존-hit) 시 skip — 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)