### PR TITLE
perf(linker): injectPreservedRenames 스냅샷 문자열 borrow — dev HMR lInj −95% (#4176)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1086,8 +1086,10 @@ pub const Linker = struct {
             // by-name 재유도: 초기 idx 대신 fresh 그래프에서 이름으로 다시 찾는다.
             const fresh_idx = self.findSymbolIdx(module_index, entry.local_name) orelse continue;
             const id = bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(module_index)), fresh_idx);
-            const dup = try self.allocator.dupe(u8, entry.canonical);
-            try self.assignSymbolCanonical(id, dup);
+            // 스냅샷 문자열 borrow — 매 빌드 N dupe(alloc) 제거(lInj 절감, RFC_PERSISTENT_LINKER
+            // Phase 1). `entry.canonical` 은 snap(=PreservedRenames, IncrementalBundler 수명)
+            // 소유라 emit 까지 유효하고, linker.deinit 가 free 하지 않는다.
+            try self.assignSymbolCanonicalBorrowed(id, entry.canonical);
         }
     }
 
@@ -1692,6 +1694,21 @@ pub const Linker = struct {
             if (self.rename_table.get(id)) |prior| _ = self.canonical_names_used.fetchRemove(prior);
         }
         try self.canonical_strings.append(self.allocator, value);
+        try self.canonical_names_used.put(self.allocator, value, {});
+        if (id.isValid()) try self.rename_table.put(self.allocator, id, value);
+    }
+
+    /// `assignSymbolCanonical` 의 borrow 변형 — `value` 소유권을 `canonical_strings` 로
+    /// 이전하지 *않는다*. `value` 가 build 보다 오래 사는 외부 store 소유일 때만 쓴다
+    /// (현 유일 호출처 = `injectPreservedRenames` 의 `PreservedRenames` 스냅샷,
+    /// `IncrementalBundler.preserved_renames` 수명). `canonical_strings.append` 를 생략해
+    /// `linker.deinit`(canonical_strings 일괄 free)가 외부 소유 문자열을 free 하지 않게 한다
+    /// — 스냅샷 dangling/다음-빌드 재주입 시 use-after-free 방지. `canonical_names_used`/
+    /// `rename_table` 는 값 string 을 borrow 만 하므로(키/값 미소유) 그대로 put 안전.
+    fn assignSymbolCanonicalBorrowed(self: *Linker, id: bundler_symbol.SymbolID, value: []const u8) !void {
+        if (id.isValid()) {
+            if (self.rename_table.get(id)) |prior| _ = self.canonical_names_used.fetchRemove(prior);
+        }
         try self.canonical_names_used.put(self.allocator, value, {});
         if (id.isValid()) try self.rename_table.put(self.allocator, id, value);
     }

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1792,6 +1792,10 @@ test "reuse: guard 통과 시 inject — single import 그래프" {
     try std.testing.expect(fresh.renameReuseGuard(&snap));
     try fresh.injectPreservedRenames(&snap);
     try expectRenameTablesEqual(&r.linker, &fresh);
+    // RFC_PERSISTENT_LINKER Phase 1: 주입은 스냅샷 문자열을 borrow 하므로 per-entry
+    // dupe(alloc)가 없다 → canonical_strings(linker 소유분)는 비어 있어야 한다.
+    // dupe 로 회귀하면 이 단언이 깨진다(lInj 비용 재증가 가드).
+    try std.testing.expectEqual(@as(usize, 0), fresh.canonical_strings.items.len);
 }
 
 test "reuse PR-C: 변경-한정 가드(carrier set)가 전량 가드와 동일 verdict" {


### PR DESCRIPTION
## 배경
dev HMR 보존-hit rebuild 의 link 단계를 분해 측정([PR #4177](https://github.com/ohah/zntc/pull/4177) bench)한 결과, **warm link 의 ~37%가 `injectPreservedRenames`(lInj)** 였다. reuse-hit 이 `computeRenames` 를 skip 하는 대신, 보존 rename 스냅샷(`snap.entries`)의 모든 entry 를 **매 빌드 `dupe`(alloc) 후 재주입**하는 비용이다. 변경이 1개여도 전 모듈 rename 을 전량 재주입한다. (RFC: `docs/RFC_PERSISTENT_LINKER.md` Phase 1)

## 변경
`entry.canonical` 은 `PreservedRenames` 스냅샷 소유이고, 그 스냅샷은 `IncrementalBundler.preserved_renames` 에 얹혀 **build(=per-build Linker) 보다 오래 산다**. 따라서 linker 가 자기 사본을 또 만들 이유가 없다.

- `assignSymbolCanonicalBorrowed(id, value)` 추가 — `assignSymbolCanonical` 과 동일하되 `canonical_strings.append`(linker 소유분, `deinit` 에서 일괄 free)를 **생략**. `rename_table`/`canonical_names_used` 는 값 string 을 borrow 만 하므로(키/값 미소유) 그대로 put.
- `injectPreservedRenames` 가 `dupe` 없이 `entry.canonical` 직접 borrow.

## 측정 (link_subphase_bench, debug — 상대치가 신호)
| | before | after |
|---|---|---|
| **lInj** | ~37ms (37%) | **~1.6ms (2%)** (−95%) |
| **warm link 총합** | ~92ms | **~57ms** (−38%) |

dupe(N alloc)가 lInj 비용의 ~96%였다. 제거 후 warm link 은 lExp/lRes(persistent-linker Phase 2 영역)가 지배.

## 정확성 / 안전
- **byte-identical**: rename_table 내용은 dupe 와 동일(같은 content). 기존 가드 `expectRenameTablesEqual`(주입 결과 == `computeRenames` 결과)가 통과. canonical_names_used 는 content-keyed(StringHashMap)라 어느 string 객체가 키든 등가.
- **메모리 안전** (`/code-review max` 2 finder 모두 `[]`):
  1. 스냅샷이 borrowing linker + emit 보다 오래 산다(빌드 내·빌드 간 모두). reuse-hit 은 스냅샷 유지, fallback/initial 은 injectPreservedRenames 미사용(computeRenames) + 스냅샷 교체는 linker deinit 후.
  2. rename 값이 BundleResult/compiled_cache/module_dev_codes 로 escape 안 함(emit 은 output 버퍼에 content 복사).
  3. `canonical_names_used`/`rename_table` 는 키/값 미소유 → double-free 없음.
- **테스트**: reuse/rename/incremental(GPA UAF 검출) + 전체 `zig build test` green. 회귀 가드로 "reuse: guard 통과 시 inject" 에 `canonical_strings.items.len == 0` 단언 추가(dupe 회귀 시 깨짐).

## Zig 초보자용 설명
- `canonical_strings` = linker 가 *소유* 하는 rename 문자열 리스트. linker 가 죽을 때(`deinit`) 여기 든 문자열을 전부 `free` 한다.
- `rename_table`(SymbolID→이름)/`canonical_names_used` 은 그 문자열을 *빌려서* 가리키기만 한다(미소유).
- 기존엔 스냅샷 문자열을 `dupe`(복사)해서 canonical_strings 에 넣어 linker 소유로 만들었다. 이번엔 스냅샷이 어차피 더 오래 사니 복사 없이 직접 가리킨다 → 매 빌드 N번의 복사 alloc 제거. 단, 복사 안 한 문자열을 canonical_strings 에 넣으면 linker.deinit 가 *남의 메모리*를 free 해버리므로, borrow 변형은 canonical_strings 에 *안 넣는다*.

## 관련
- 측정 인프라/RFC: PR #4177 (bench + `link_inject_renames` profile 카테고리 + `docs/RFC_PERSISTENT_LINKER.md`)
- 이슈 #4176. 8092 release 실측은 dev server snapshot 의 `link_inject_renames_ms` 로 확인 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
