### PR TITLE
fix(fmt): preset.test.ts oxfmt drift 해소 — CI Lint & Format 복구

### DIFF
--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -523,9 +523,7 @@ describe('buildRnBundleOptions — plugins (asset/optional-babel/require-context
 
   test('preserveSafePlugins — additionalPlugins 있으면 false 강등', () => {
     const userPlugin: ZntcPlugin = { name: 'user:custom2', setup() {} };
-    const opts = buildRnBundleOptions(
-      baseInput({ extra: { additionalPlugins: [userPlugin] } }),
-    );
+    const opts = buildRnBundleOptions(baseInput({ extra: { additionalPlugins: [userPlugin] } }));
     expect(opts.preserveSafePlugins).toBe(false);
   });
 
@@ -542,9 +540,7 @@ describe('buildRnBundleOptions — plugins (asset/optional-babel/require-context
   });
 
   test('preserveSafePlugins — 명시 false override 가 내장-only(자동 true)보다 우선', () => {
-    const opts = buildRnBundleOptions(
-      baseInput({ extra: { preserveSafePlugins: false } }),
-    );
+    const opts = buildRnBundleOptions(baseInput({ extra: { preserveSafePlugins: false } }));
     expect(opts.preserveSafePlugins).toBe(false);
   });
 });


### PR DESCRIPTION
오늘 머지된 RN preset 커밋이 oxfmt 미적용으로 들어가 main 의 `Lint & Format` 체크가 결정적으로 fail → 모든 신규 PR(#4177/#4179 포함) 머지를 막고 있었습니다. `bun run fmt` 적용(포맷만, 동작 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)