### PR TITLE
perf(linker): renameReuseGuard 변경-모듈 한정 O(N)→O(changed) — lGuard −60% (#4176)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -964,37 +964,45 @@ pub const Linker = struct {
         if (mc != snap.module_count) return false;
         if (snap.fingerprint.len != mc) return false;
 
-        // PR-C: HMR 보존-hit 의 unchanged 모듈(carrier changed_emit_paths 에 없음)은 semantic 이
-        // 물리 보존이라 full fingerprint(이름집합 G2/unresolved G4/nested G5/import-wrap G6)가 자명히
-        // snapshot 과 일치 → G1 경량(path_hash/exec_index)만 확인하고 scope_maps/binding 순회
-        // (moduleFingerprint)를 건너뛴다(lnk 절감). carrier=null(fallback/비보존)이면 전량 비교(종전).
-        // G1 만 renumber/DFS 재실행 영향 가능 → 경량 확인이 fail-safe(불일치→false→full computeRenames).
-        const changed = self.graph.changed_emit_paths;
+        // HMR 보존-hit(carrier changed_emit_paths non-null = 위상 보존)에서는 **변경 모듈만**
+        // full fingerprint 를 검사하고 unchanged 는 아예 순회하지 않는다(lGuard O(N)→O(changed),
+        // release link 의 ~32% 제거). unchanged 모듈은 #4174 renumber identity(위상 보존 시
+        // module_index 불변) + 물리 보존(path/exec_index/semantic 불변)으로 fingerprint 가 자명히
+        // snapshot 과 일치하기 때문. carrier 는 emit source-hash skip(#4172) / injectPreservedRenames
+        // 가 이미 정확성에 신뢰하는 동일 출처라, 가드가 carrier 를 신뢰하는 것은 새로운 trust 가
+        // 아니라 종전 #4173 의 per-unchanged G1 경량(redundant fail-safe)을 제거하는 것이다.
+        // (#4173 G1 이 막던 renumber non-identity 는 #4174 가 구조적으로 차단.)
+        // count(G0) 가 모듈 add/remove 를, carrier=null(위상 변경 시)이 fallback 전량 비교를 보장.
+        if (self.graph.changed_emit_paths) |ch| {
+            var it = ch.iterator();
+            while (it.next()) |e| {
+                const idx = self.graph.path_to_module.get(e.key_ptr.*) orelse return false;
+                const i = @intFromEnum(idx);
+                if (i >= mc) return false;
+                const m = self.getModule(@intCast(i)) orelse return false;
+                if (!self.fingerprintMatches(m.*, snap.fingerprint[i])) return false;
+            }
+            return true;
+        }
+
+        // carrier=null(fallback / 비보존): 전량 비교(종전).
         for (0..mc) |i| {
             const m = self.getModule(@intCast(i)) orelse return false;
-            const old = snap.fingerprint[i];
-            if (changed) |ch| {
-                if (!ch.contains(m.path)) {
-                    // unchanged: G1 경량만 (path_hash 는 moduleFingerprint 와 동일 seed 0x5a).
-                    if (std.hash.Wyhash.hash(0x5a, m.path) != old.path_hash) return false;
-                    if (m.exec_index != old.exec_index) return false;
-                    continue;
-                }
-            }
-            const cur = self.moduleFingerprint(m.*) catch return false; // OOM → fail-safe
-            // G1 + G0(per-index path): 같은 인덱스에 같은 경로/실행순서.
-            if (cur.path_hash != old.path_hash) return false;
-            if (cur.exec_index != old.exec_index) return false;
-            // G2: top-level owner 이름집합 불변 (body-only edit = 일치).
-            if (cur.toplevel_name_set_hash != old.toplevel_name_set_hash) return false;
-            // G4: unresolved_references (전역 참조) 불변.
-            if (cur.unresolved_refs_hash != old.unresolved_refs_hash) return false;
-            // G5: nested binding 이름집합 불변 (import shadow 결과 동일).
-            if (cur.nested_name_set_hash != old.nested_name_set_hash) return false;
-            // G6: import local_name 집합 + wrap_kind 불변.
-            if (cur.import_locals_wrap_hash != old.import_locals_wrap_hash) return false;
+            if (!self.fingerprintMatches(m.*, snap.fingerprint[i])) return false;
         }
         return true;
+    }
+
+    /// 모듈의 현재 fingerprint(G1 path/exec + G2 toplevel + G4 unresolved + G5 nested +
+    /// G6 import-locals/wrap)가 snapshot 의 `old` 와 전부 일치하는지. OOM 은 fail-safe(false).
+    fn fingerprintMatches(self: *Linker, m: Module, old: PreservedRenames.ModuleFingerprint) bool {
+        const cur = self.moduleFingerprint(m) catch return false;
+        return cur.path_hash == old.path_hash and
+            cur.exec_index == old.exec_index and
+            cur.toplevel_name_set_hash == old.toplevel_name_set_hash and
+            cur.unresolved_refs_hash == old.unresolved_refs_hash and
+            cur.nested_name_set_hash == old.nested_name_set_hash and
+            cur.import_locals_wrap_hash == old.import_locals_wrap_hash;
     }
 
     /// SymbolID 에 해당하는 module-local 이름 (scope_maps[0] reverse lookup → synthetic_name

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1821,17 +1821,30 @@ test "reuse PR-C: 변경-한정 가드(carrier set)가 전량 가드와 동일 v
     try std.testing.expect(r.graph.changed_emit_paths == null);
     try std.testing.expect(fresh.renameReuseGuard(&snap));
 
-    // 변경-한정(carrier={modules[0]}): carrier 에 있는 모듈은 full fingerprint, 나머지는 G1 경량
-    // (path_hash/exec_index). 같은 그래프라 전부 일치 → 동일하게 통과(carrier branch 진입 검증).
+    // 변경-한정(carrier={modules[0]}): carrier 에 있는 모듈만 full fingerprint 검사, 나머지는
+    // 아예 순회 안 함(O(changed)). 같은 그래프라 carrier 모듈도 일치 → 동일하게 통과.
     var carrier: std.StringHashMapUnmanaged(void) = .empty;
     defer carrier.deinit(std.testing.allocator);
     try carrier.put(std.testing.allocator, r.graph.modules.at(0).path, {});
     r.graph.changed_emit_paths = carrier;
     try std.testing.expect(fresh.renameReuseGuard(&snap));
 
-    // 빈 carrier(전부 unchanged=G1 경량)도 동일 통과.
+    // 빈 carrier(변경 0 = 검사할 모듈 없음)도 통과.
     r.graph.changed_emit_paths = .empty;
     try std.testing.expect(fresh.renameReuseGuard(&snap));
+
+    // 정확성: carrier 모듈의 fingerprint 가 snapshot 과 다르면 reject(=full computeRenames).
+    // snapshot 의 modules[0] toplevel 이름집합 해시를 손상시키고 그 모듈을 carrier 에 넣으면
+    // O(changed) 가드가 그 모듈을 검사해 불일치 감지 → false 여야 한다(이름 추가 edit 모사).
+    const fp0 = @constCast(&snap.fingerprint[0]); // arena-backed, 테스트 목적 변형
+    const orig_hash = fp0.toplevel_name_set_hash;
+    fp0.toplevel_name_set_hash = orig_hash ^ 0xdead_beef;
+    r.graph.changed_emit_paths = carrier; // {modules[0]}
+    try std.testing.expect(!fresh.renameReuseGuard(&snap));
+    // 전량 가드(carrier=null)도 동일하게 false — verdict 일치.
+    r.graph.changed_emit_paths = null;
+    try std.testing.expect(!fresh.renameReuseGuard(&snap));
+    fp0.toplevel_name_set_hash = orig_hash; // 복원
 
     // graph.deinit 가 테스트 소유 carrier 를 이중 해제하지 않게 복원(빈 set 은 backing 없음).
     r.graph.changed_emit_paths = null;


### PR DESCRIPTION
## 배경
릴리스 실측(`zntc dev` + ZNTC_PROFILE, 실제 패키지 date-fns+lodash-es+rxjs ~600모듈, reuse-hit HMR)에서 dev HMR 보존-hit link 의 **최대 sub-phase 가 `renameReuseGuard`(lGuard, ~32%)** 였다. (debug 측정의 "lExp 60%"는 해시맵 alloc 느림 아티팩트 — 릴리스에선 lExp 8%.)

#4173 이 변경 모듈만 full fingerprint 하고 unchanged 는 G1 경량(path_hash/exec_index)으로 줄였으나 **여전히 전 모듈(O(N))을 순회**한다.

## 변경
**#4174(renumber identity)** 머지로 carrier(`changed_emit_paths`) non-null = 위상 보존 ⟹ unchanged 모듈의 module_index/path/exec_index/semantic 이 자명히 불변 → fingerprint 가 snapshot 과 guaranteed match. 따라서 **변경 모듈만 순회(O(changed))**, unchanged 는 검사하지 않는다.

- `renameReuseGuard`: carrier non-null 이면 carrier(변경 path) → index → full fingerprint 만 검사. carrier=null(fallback/비보존)은 종전 full O(N).
- fingerprint 6필드 비교를 `fingerprintMatches` 헬퍼로 추출(양 경로 공유, 동작 불변).

## 측정 (release, reuse-hit, ~600 모듈)
| | before | after |
|---|---|---|
| **lGuard** | ~32% (1.45ms) | **27%→ 0.57ms (−60%)** |

O(changed) 라 잔여(0.57ms)는 **변경 모듈 1개의 fingerprint** — 총 모듈 수와 무관. → 8092 에서 O(N) ~18ms 가 **~sub-ms(O(changed))** 로 떨어진다(가장 큰 release link 레버 제거).

## 정확성 (byte-identical — 최상 민감 영역)
- **carrier-trust 일관**: emit source-hash skip(#4172) / `injectPreservedRenames` 가 이미 동일 carrier 를 정확성에 신뢰. 가드가 carrier 를 신뢰하는 것은 새 trust 가 아니라 #4173 의 redundant per-unchanged G1(=#4174 가 막는 renumber non-identity 대비 fail-safe)을 제거하는 것.
- 안전망: `module_count`(G0)=add/remove 감지, `carrier=null`(위상 변경 시)=full fallback.
- 테스트: O(changed) verdict == full verdict — carrier 모듈 fingerprint 손상 시 양 경로 모두 reject 검증("reuse PR-C" 확장).
- 전체 `zig build test` green. **`/code-review max` 2 finder 모두 `[]`** (carrier 완전성/위상-보존 불변/renumber identity/emit-skip 일관 전부 검증).

## Zig 초보자용
- `renameReuseGuard` = HMR rebuild 시 "이전 빌드의 rename(이름 충돌 해소 결과)을 그대로 재사용해도 되는가"를 판정. 모든 모듈의 *지문(fingerprint)*이 이전과 같으면 재사용(빠름), 하나라도 다르면 전체 재계산(느림).
- 기존엔 안 변한 모듈까지 매번 지문을 다시 떠서 비교(O(N)). 위상이 보존되면 안 변한 모듈은 당연히 같으므로, **변한 모듈만** 비교하면 된다(O(changed)). 안전성은 #4174(위상 보존 시 모듈 번호 불변)가 보장.

## 관련
- 이슈 #4176. [[lInj P1-2]]는 후속 PR. release link 레버 분석은 #4176 코멘트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
