### PR TITLE
perf(linker): reuse-hit injection canonical_names_used dead-write 제거 — lInj −48% (#4176)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1710,18 +1710,19 @@ pub const Linker = struct {
         if (id.isValid()) try self.rename_table.put(self.allocator, id, value);
     }
 
-    /// `assignSymbolCanonical` 의 borrow 변형 — `value` 소유권을 `canonical_strings` 로
-    /// 이전하지 *않는다*. `value` 가 build 보다 오래 사는 외부 store 소유일 때만 쓴다
-    /// (현 유일 호출처 = `injectPreservedRenames` 의 `PreservedRenames` 스냅샷,
-    /// `IncrementalBundler.preserved_renames` 수명). `canonical_strings.append` 를 생략해
-    /// `linker.deinit`(canonical_strings 일괄 free)가 외부 소유 문자열을 free 하지 않게 한다
-    /// — 스냅샷 dangling/다음-빌드 재주입 시 use-after-free 방지. `canonical_names_used`/
-    /// `rename_table` 는 값 string 을 borrow 만 하므로(키/값 미소유) 그대로 put 안전.
+    /// `assignSymbolCanonical` 의 reuse-hit 전용 변형 — emit 이 소비하는 `rename_table` 만
+    /// 채운다. 단일 호출처 = `injectPreservedRenames`(reuse-hit, `PreservedRenames` 스냅샷,
+    /// `IncrementalBundler.preserved_renames` 수명).
+    ///
+    /// 두 가지를 생략한다(reuse-hit 정밀화):
+    ///  1. `canonical_strings.append` — `value` 는 스냅샷 소유라 linker.deinit 가 free 하면
+    ///     안 됨(double-free/dangling 방지). rename_table/canonical_names_used 는 값 미소유라 put 안전.
+    ///  2. `canonical_names_used.put`/`fetchRemove` — `canonical_names_used` 는 deconflict 의
+    ///     `isCanonicalNameTaken`(=`findAvailableCandidate`) 만 읽는데, reuse-hit 은 computeRenames/
+    ///     deconflict 를 통째로 skip 한다 → 이 맵은 reuse-hit 에서 *write-only(dead)*. 매 entry 의
+    ///     put 은 낭비라 생략(lInj 절감). canonical_names_used 는 per-build(deinit) 라 다음 빌드에도
+    ///     영향 없음. (fresh rename_table 이라 prior 도 없어 fetchRemove 도 dead.)
     fn assignSymbolCanonicalBorrowed(self: *Linker, id: bundler_symbol.SymbolID, value: []const u8) !void {
-        if (id.isValid()) {
-            if (self.rename_table.get(id)) |prior| _ = self.canonical_names_used.fetchRemove(prior);
-        }
-        try self.canonical_names_used.put(self.allocator, value, {});
         if (id.isValid()) try self.rename_table.put(self.allocator, id, value);
     }
 

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1796,6 +1796,9 @@ test "reuse: guard 통과 시 inject — single import 그래프" {
     // dupe(alloc)가 없다 → canonical_strings(linker 소유분)는 비어 있어야 한다.
     // dupe 로 회귀하면 이 단언이 깨진다(lInj 비용 재증가 가드).
     try std.testing.expectEqual(@as(usize, 0), fresh.canonical_strings.items.len);
+    // reuse-hit 정밀화: injectPreservedRenames 는 canonical_names_used 에 쓰지 않는다
+    // (deconflict 가 skip 돼 write-only=dead). 다시 put 하면 이 단언이 깨진다(lInj 가드).
+    try std.testing.expectEqual(@as(u32, 0), fresh.canonical_names_used.count());
 }
 
 test "reuse PR-C: 변경-한정 가드(carrier set)가 전량 가드와 동일 verdict" {


### PR DESCRIPTION
## 배경
릴리스 실측에서 dev HMR 보존-hit `injectPreservedRenames`(lInj)의 잔여 비용(P1-1 borrow [#4179] 후)을 분해했다.

먼저 시도한 **P1-2(unchanged 모듈의 fresh_idx 캐시로 findSymbolIdx 생략)는 measure-first NO-GO** — findSymbolIdx 는 대부분 scope_maps O(1) hit 라 lInj 가 0.44ms 로 불변이었다. lInj 잔여의 진짜 비용은 `assignSymbolCanonicalBorrowed` 의 **per-entry hashmap put 2회**였다.

## 변경
그 2회 중 `canonical_names_used.put`/`fetchRemove` 는 **reuse-hit 에서 dead** 임을 확인:
- `canonical_names_used` 는 deconflict 의 `isCanonicalNameTaken`(←`isCandidateAvailable`←`findAvailableCandidate`←`calculateRenames`←`computeRenames`)만 읽는다.
- reuse-hit 은 `computeRenames`/deconflict 를 통째로 skip(`compute_renames=false`). + `code_splitting`/`minify_identifiers` 도 `capture_eligible` 에서 제외라 per-chunk 경로(`computeRenamesForModules`)도 없다.
- → `canonical_names_used` 는 reuse-hit 에서 **write-only(dead)**. per-build(deinit)라 다음 빌드 영향도 0. fresh `rename_table` 이라 prior 도 없어 `fetchRemove` 도 dead.

emit 이 소비하는 건 `rename_table` 뿐 → 그것만 put. `assignSymbolCanonicalBorrowed` 5줄→1줄 단순화, per-entry put **2→1**.

## 측정 (release, reuse-hit, ~600 모듈)
| | before | after |
|---|---|---|
| **lInj** | 21% (0.44ms) | **12% (0.23ms) — −48%** |

8092 외삽 ~5ms→~2.5ms.

## 정확성 (byte-identical)
- `rename_table` 불변 → emit 출력 동일.
- **`/code-review max` 6-gate finder `[]`**: ① sole caller=injectPreservedRenames(reuse-hit) ② canonical_names_used 유일 reader=deconflict(skip) ③ code-split·mangle 제외 ④ per-build fresh(cross-build 영향 0) ⑤ fetchRemove no-op(fresh rename_table) ⑥ rename_table.put 불변.
- 전체 `zig build test` green. 회귀 가드: inject 후 `canonical_names_used.count()==0` 단언 추가.

## Zig 초보자용
- `injectPreservedRenames` = HMR rebuild 시 보존한 rename(이름 충돌 해소 결과)을 다시 적용. entry 마다 hashmap 에 기록.
- 기존엔 두 맵(`rename_table` + `canonical_names_used`)에 다 기록했는데, `canonical_names_used` 는 "이름 충돌 해소(deconflict)" 단계만 읽는다. HMR reuse-hit 은 그 단계를 건너뛰므로, 거기 기록하는 건 *아무도 안 읽는 죽은 작업*. 빼면 entry 당 작업이 절반.

## 관련
- 이슈 #4176. lGuard 레버는 #4181(머지). release link 레버 분석은 #4176 코멘트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
