### PR TITLE
fix(linker): ns_member_rewrites borrowed 값 deinit double-free 제거 (#4178)

### DIFF
--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -46,5 +46,6 @@ comptime {
     _ = @import("bundler_test/incremental_bench_v2.zig");
     _ = @import("bundler_test/incremental_bench_v4.zig");
     _ = @import("bundler_test/link_subphase_bench.zig");
+    _ = @import("bundler_test/ns_dblfree_repro.zig");
     _ = @import("namespace_access_test.zig");
 }

--- a/src/bundler/bundler_test/ns_dblfree_repro.zig
+++ b/src/bundler/bundler_test/ns_dblfree_repro.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+const Bundler = @import("../bundler.zig").Bundler;
+const test_helpers = @import("../test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+
+// #4178 회귀 가드: 다수 모듈이 동일 namespace 를 `import * as NS` + member-access(`NS.x`) 하면,
+// `LinkingMetadata.deinit` 의 ns_member_rewrites '{' free 휴리스틱이 borrowed(owned_rename_values
+// 등 다른 소유자) 값을 dangling read/double-free → 병렬 emit 에서 flaky segfault 였다(fix 전
+// 결정적 재현). 충분한 모듈 수(병렬 emit range 분할 + 공유 ns inline 트리거)가 필요.
+test "ns_dblfree #4178: dev 다수 모듈 동일 namespace member-access 가 crash 안 함" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "shared.ts", "export const a = 1;\nexport const b = 2;\nexport const c = 3;\nexport const d = 4;\n");
+    var idx: std.ArrayList(u8) = .empty;
+    defer idx.deinit(std.testing.allocator);
+    const N = 40;
+    var i: usize = 0;
+    while (i < N) : (i += 1) {
+        var pbuf: [32]u8 = undefined;
+        const p = try std.fmt.bufPrint(&pbuf, "m{d}.ts", .{i});
+        var sbuf: [128]u8 = undefined;
+        const s = try std.fmt.bufPrint(&sbuf, "import * as NS from './shared';\nexport const x{d} = NS.a + NS.b + NS.c + NS.d;\n", .{i});
+        try writeFile(tmp.dir, p, s);
+        try idx.print(std.testing.allocator, "import {{ x{d} }} from './m{d}';\nconsole.log(x{d});\n", .{ i, i, i });
+    }
+    try writeFile(tmp.dir, "index.ts", idx.items);
+
+    const entry = try test_helpers.absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .scope_hoist = true,
+        .dev_mode = true,
+        .collect_module_codes = true,
+    });
+    defer b.deinit();
+    const r = try b.bundle(std.testing.io);
+    defer r.deinit(std.testing.allocator);
+    try std.testing.expect(!r.hasErrors());
+}

--- a/src/bundler/linker/metadata_types.zig
+++ b/src/bundler/linker/metadata_types.zig
@@ -135,16 +135,14 @@ pub const LinkingMetadata = struct {
             while (vit.next()) |v| self.allocator.free(v.*);
             self.require_rewrites.deinit(self.allocator);
         }
-        // ns_member_rewrites의 inner map과 entries 배열 해제
+        // ns_member_rewrites의 inner map backing 만 해제. inner_map 의 *값* 은 전부 borrowed —
+        // owned_rename_values(위에서 먼저 free) / ns_inline_objects var_name / 전역 ns 캐시 /
+        // 모듈 export local 이 소유한다. 여기서 free 하면 (a) owned_rename_values 가 먼저 free 돼
+        // dangling read, (b) 진짜 소유자와 double-free → 병렬 emit 에서 flaky segfault (#4178).
+        // 키도 모듈 export 이름 borrow 라 map.deinit(backing만) 으로 충분.
         if (self.ns_member_rewrites.entries.len > 0) {
             for (self.ns_member_rewrites.entries) |*e| {
-                var m = @constCast(&e.map);
-                // 인라인 객체 문자열 (allocator에서 할당됨) 해제
-                var vit = m.valueIterator();
-                while (vit.next()) |v| {
-                    if (v.*.len > 0 and v.*[0] == '{') self.allocator.free(v.*);
-                }
-                m.deinit(self.allocator);
+                @constCast(&e.map).deinit(self.allocator);
             }
             self.allocator.free(self.ns_member_rewrites.entries);
         }


### PR DESCRIPTION
## 증상
다수 모듈이 동일 namespace 를 `import * as NS` + member-access(`NS.x`) 하면 병렬 emit 에서 **flaky segfault**(`metadata_types.zig:145`, ~1/6 빈도). 실제 패키지 **effect** 도 dev server cold emit 에서 즉시 crash(별도 트랙으로 발견됨).

```
Segmentation fault
src/bundler/linker/metadata_types.zig:145: in deinit
    if (v.*.len > 0 and v.*[0] == '{') self.allocator.free(v.*);
src/bundler/emitter.zig: in emitModule (defer metadata.deinit())  ← 병렬 emitRangeThread
```

## Root cause
`LinkingMetadata.deinit` 의 `ns_member_rewrites` inner_map free 휴리스틱이 잘못됐다:
- inner_map 의 *값* 은 **전부 borrowed** — `owned_rename_values` / `ns_inline_objects` var_name / 전역 ns 캐시 / 모듈 export local 이 소유한다(`registerNamespaceRewrites` 가 owned_* 리스트로 이전).
- 그런데 `deinit` 이 `owned_rename_values` 를 **먼저** free 한 뒤 inner_map 을 순회하므로, borrowed 값이 이미 **dangling**.
- 그 freed 메모리가 다른 inline-object(`{...}`) 할당으로 재사용되면 `v.*[0]` 이 `'{'` 로 읽혀(빌드 시점엔 inner_map 에 '{' 값 0개 — 계측 확인) 휴리스틱이 그걸 **또 free** → 진짜 소유자와 double-free + 병렬 read-while-free → segfault.

즉 `'{'` 는 "owned 인라인 객체" 표식이 아니라 **재사용된 dangling 메모리의 우연한 첫 바이트**였다.

## Fix
inner_map 값을 free 하지 않는다(전부 borrowed). map backing 만 `deinit`. 키도 모듈 export 이름 borrow 라 안전.
```zig
for (self.ns_member_rewrites.entries) |*e| {
    @constCast(&e.map).deinit(self.allocator); // backing 만 — 값/키는 borrowed
}
```

## 검증
- **회귀 가드**: dev 40-module 동일 namespace member-access bundle 이 crash 안 함(fix 전 결정적 재현, 8/8 clean).
- **leak 0**: 전체 `zig build test` green — testing allocator 가 *진짜 inner_map-소유* 값이 있었다면 leak 검출. green = 전부 borrowed 확정.
- **byte-identical**: `deinit` 은 emit 후 cleanup, 출력 무관.
- **`/code-review max` finder `[]`**: 5개 inner_map.put 값 전부 borrowed 추적(void0 literal / `__toESM`·`(...)`→owned_rename_values / ns_var→ns_inline_list / global·exp.local→caches·module), 키도 borrowed.

## Zig 초보자용
- `deinit` = 빌드 끝나고 메모리 정리. inner_map 은 "어떤 namespace 멤버를 무엇으로 바꿀지" 매핑인데, 그 값(문자열)들은 *다른 곳이 소유*하고 inner_map 은 *가리키기만* 한다(borrow).
- 기존 코드는 값이 `{` 로 시작하면 "내가 만든 인라인 객체"라 보고 free 했는데, 실제론 그 시점에 값이 이미 해제된 메모리를 가리켜서(dangling) `{` 는 재사용된 남의 데이터였다. 그걸 free → 같은 메모리 두 번 해제 → 크래시.
- fix: 남이 소유한 값은 안 건드리고, 매핑 테이블 자체(backing)만 해제.

Closes #4178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
