### PR TITLE
perf(linker): lNs(populateNamespaceAccesses) 변경∪importer 한정 partial-skip (#4176)

### DIFF
--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -3175,3 +3175,61 @@ test "renumber identity: 실제 reachable graph 재renumber 시 path→index 멱
         try std.testing.expectEqual(@as(u32, @intCast(i)), graph.modules.at(i).index.toU32());
     }
 }
+
+// lNs 변경∪importer 한정 partial-skip(보존-hit) 회귀 가드: 다수 모듈이 namespace member-access
+// 하는 fixture 를 reuse-hit rebuild 하면 carrier 기반 lNs 재계산 경로가 crash 없이 정상 동작하고
+// 변경 모듈이 올바르게 재방출돼야 한다. (skip 자체의 byte-identical 은 AST 보존 by-construction
+// + /code-review max 검증. 여기선 carrier recompute 경로가 깨지지 않음을 가드.)
+test "lNs partial-skip: reuse-hit namespace member-access rebuild 정상" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "shared.ts", "export const a = 1;\nexport const b = 2;\nexport const c = 3;\nexport const d = 4;\n");
+    const N = 12;
+    inline for (0..N) |n| {
+        const ns = std.fmt.comptimePrint("{d}", .{n});
+        try writeFile(tmp.dir, "m" ++ ns ++ ".ts", "import * as NS from './shared';\nexport const x" ++ ns ++ " = NS.a + NS.b + 0;\n");
+    }
+    var idx: std.ArrayList(u8) = .empty;
+    defer idx.deinit(std.testing.allocator);
+    inline for (0..N) |n| {
+        try idx.print(std.testing.allocator, "import {{ x{d} }} from './m{d}';\nconsole.log(x{d});\n", .{ n, n, n });
+    }
+    try writeFile(tmp.dir, "index.ts", idx.items);
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const m0 = try absPath(&tmp, "m0.ts");
+    defer std.testing.allocator.free(m0);
+
+    var ib = IncrementalBundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .collect_module_codes = true,
+    });
+    ib.enable_persistence = true;
+    defer ib.deinit();
+
+    // cold
+    {
+        const r = try ib.rebuild(std.testing.io);
+        switch (r) {
+            .success => |s| BundleResult.ModuleDevCode.freeAll(s.changed_modules, std.testing.allocator),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    // warm reuse-hit: m0 body-only edit(member-access 변경 NS.c 추가, 이름집합 불변).
+    var changed: std.StringHashMapUnmanaged(void) = .empty;
+    defer changed.deinit(std.testing.allocator);
+    try changed.put(std.testing.allocator, m0, {});
+    try writeFile(tmp.dir, "m0.ts", "import * as NS from './shared';\nexport const x0 = NS.a + NS.b + NS.c + 1;\n");
+
+    const r = try ib.rebuildWithChanges(std.testing.io, &changed);
+    switch (r) {
+        .success => |s| {
+            defer BundleResult.ModuleDevCode.freeAll(s.changed_modules, std.testing.allocator);
+            try std.testing.expectEqual(false, s.graph_changed); // 보존-hit
+            try std.testing.expect(s.changed_modules.len > 0); // m0 재방출
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -13,6 +13,9 @@
 
 const std = @import("std");
 const spin = @import("../util/spin_lock.zig");
+/// kill-switch: 보존-hit lNs 변경∪importer 한정 skip 을 끄고 전량 재계산(byte-identical 회귀
+/// 진단/대조용). 설정 시 populateNamespaceAccesses 가 carrier 와 무관하게 모든 모듈 재계산.
+const ns_access_skip_disabled = @import("../env_flag.zig").Once("ZNTC_NO_NS_ACCESS_SKIP");
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 const BundlerDiagnostic = types.BundlerDiagnostic;
@@ -2546,8 +2549,38 @@ pub const Linker = struct {
         var scope = profile.begin(.link_populate_namespace_accesses);
         defer scope.end();
 
+        // 보존-hit(carrier non-null = 위상 보존): lNs 출력(ib.namespace_used_properties)은 모듈
+        // parse_arena 소유(AST-resident)라 unchanged 모듈은 직전 빌드 값이 보존된다 → **변경 ∪
+        // 직접 importer** 만 재계산하고 나머지는 skip(byte-identical). 변경 모듈=재파싱(fresh AST →
+        // 값 null)이라 재계산 필수, 변경 모듈을 import 하는 모듈=직접 source 의 게이팅(wrap_kind /
+        // default_export_named_local / re_export_namespace)이 바뀔 수 있어 재계산. per-importer
+        // 분석은 importer 자신의 AST + *직접* source 게이팅만 읽고 re-export 체인 끝은 안 보므로
+        // 직접 importer 로 충분(이슈 #4176 위험#4). carrier=null(fallback)/키 미스/OOM → 전량
+        // (recompute=null, fail-safe). RN 같은 namespace-heavy 앱의 warm lNs 절감(web 은 ~0%).
+        var recompute: ?std.AutoHashMapUnmanaged(u32, void) = null;
+        defer if (recompute) |*r| r.deinit(self.allocator);
+        if (self.graph.changed_emit_paths != null and !ns_access_skip_disabled.enabled()) {
+            const ch = self.graph.changed_emit_paths.?;
+            var set: std.AutoHashMapUnmanaged(u32, void) = .empty;
+            const ok = blk: {
+                var it = ch.iterator();
+                while (it.next()) |e| {
+                    const idx = self.graph.path_to_module.get(e.key_ptr.*) orelse break :blk false;
+                    set.put(self.allocator, @intFromEnum(idx), {}) catch break :blk false;
+                    // path 는 resolve 됐는데 module 미존재 = graph 불일치 → importer 누락 위험,
+                    // 전량 재계산으로 fail-safe(false-skip 차단).
+                    const m = self.getModule(@intFromEnum(idx)) orelse break :blk false;
+                    for (m.importers.items) |imp| set.put(self.allocator, @intFromEnum(imp), {}) catch break :blk false;
+                    for (m.dynamic_importers.items) |imp| set.put(self.allocator, @intFromEnum(imp), {}) catch break :blk false;
+                }
+                break :blk true;
+            };
+            if (ok) recompute = set else set.deinit(self.allocator);
+        }
+
         const mod_count = self.graph.moduleCount();
         for (0..mod_count) |i| {
+            if (recompute) |r| if (!r.contains(@intCast(i))) continue;
             const importer = self.moduleAtMut(@intCast(i)) orelse continue;
             const sem = importer.semantic orelse continue;
             const ast = if (importer.ast) |*a| a else continue;


### PR DESCRIPTION
## 배경 (#4176)

dev HMR **보존-hit**(carrier non-null = 위상 보존) rebuild 에서 `populateNamespaceAccesses`(lNs) 가 매 빌드 **모든 모듈**을 재분석한다. 변경 1개여도 8092 전량.

RN(`react-native-large`, 8092모듈) cold link 분해 실측:

| sub-phase | self | % of link |
|---|---|---|
| lRen (computeRenames) | 32.19ms | 72.5% |
| **lNs (populateNamespaceAccesses)** | **8.42ms** | **19.0%** |
| lRes (resolveImports) | 3.99ms | 9.0% |
| lImp (populateImportSymbols) | 3.99ms | 9.0% |
| lReExp (populateReExportAliases) | 2.65ms | 6.0% |
| lExp (buildExportMap) | 1.59ms | 3.6% |

lNs 는 RN 에서 2위 레버다(barrel `re_export_namespace` 순회 + 다수 `import * as NS` 모듈). **web 코퍼스는 ~0%** 라 이전 세션에서 "ROI 0" 로 닫았으나 RN-specific 레버였다.

## 왜 warm 에 효과 (전체 체인 검증)

1. RN HMR(`dev_mode` + RN preset `preserve_safe_plugins` + no-split) → `canPreserveTopology`(build_flow.zig:1466, **platform/RN 배제 게이트 없음** — 주석이 InitializeCore/rn_asset(PR-1)/runtime_polyfill_roots(PR-2) 로 RN 명시 활성) = true → `buildIncrementalPreserved` → **carrier(`changed_emit_paths`) set**.
2. `populateNamespaceAccesses`(linker.zig:3058, `populate_namespace_accesses:bool=true` 기본)는 **매 빌드 전량** 호출. reuse-hit 도 동일 함수(`skip_ref_counts` 만 다름) → warm lNs = full = 8.42ms (보존본이 있어도 중복 재계산).
3. 본 PR: carrier non-null → **변경 ∪ 직접 importer(+dynamic)** 만 재계산 → 1-모듈 HMR edit 시 sub-ms.

→ **RN warm rebuild lNs ~8.42ms → sub-ms (RN-specific; web 무영향).**

## byte-identical 근거

lNs 출력(`ib.namespace_used_properties`)은 모듈 `parse_arena` 소유(AST-resident)라 unchanged 모듈은 직전 빌드 값이 그대로 보존된다.

- **변경 모듈**: 재파싱 → fresh AST(값 null) → carrier 에 포함 → 재계산.
- **변경 모듈의 직접 importer**: 직접 source 게이팅(`wrap_kind` / `default_export_named_local` / `re_export_namespace`)이 바뀔 수 있어 재계산. importers set 에 포함.
- per-importer 분석은 importer 자신의 AST + **직접** source 만 읽고 re-export 체인 끝은 안 본다 → barrel 체인(`export * as NS from './src'`)에서 src 변경 시 barrel(∈ src.importers)만 재계산하면 충분, barrel 의 importer 는 barrel 보존본에 의존하므로 skip 가능(#4176 위험#4 해소).

## 안전장치

- **fail-safe**: carrier=null / path miss / getModule miss / OOM → `recompute=null` → 전량 재계산(false-skip 차단).
- **kill-switch** `ZNTC_NO_NS_ACCESS_SKIP`: skip 끄고 전량 재계산(production A/B / 회귀 진단).
- **회귀가드**: `incremental_test.zig` reuse-hit namespace member-access 테스트(carrier recompute 경로 crash-free + 보존-hit 확인).

## 검증

- `/code-review max` 1 finder **7항목 엄밀검증 []** (AST보존 / changed재계산 / direct-source / importers충분 / chain차단 / field타입 / OOM fallback).
- 전체 테스트 스위트 green.

### Zig 초보자 노트
- `parse_arena` 소유 = 모듈 AST 메모리가 빌드 사이 보존되는 arena. 여기 들어간 lNs 결과는 다음 빌드까지 살아있어, 안 바뀐 모듈은 재계산 없이 직전 값을 그대로 쓴다.
- `AutoHashMapUnmanaged(u32, void)` = "이 모듈 인덱스 집합에 들어있나"만 보는 set. `recompute` 에 없으면 `continue` 로 분석 skip.
- carrier(`changed_emit_paths`) 가 `null` 이면 보존-hit 가 아니므로(cold/위상변경) 종전대로 전량 — 그래서 web/일반 빌드는 동작 불변.

🤖 Generated with [Claude Code](https://claude.com/claude-code)