### PR TITLE
fix(test): dev HMR new-css-import flake — 재시도마다 fresh diff 강제 (#3813)

### DIFF
--- a/packages/core/test/cli/app-builder/dev-hmr/hmr-wait.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/hmr-wait.ts
@@ -41,12 +41,19 @@ export interface HmrWaitOptions {
 }
 
 /**
- * `/__hmr` WebSocket 에 연결해 `trigger()` 로 변경을 일으키고 `predicate` 를 충족하는
+ * `/__hmr` WebSocket 에 연결해 `trigger(attempt)` 로 변경을 일으키고 `predicate` 를 충족하는
  * broadcast 가 올 때까지 기다린다(watcher arm-race 에 견고). 파일 시스템 정리는 호출부가 담당.
+ *
+ * `trigger` 는 1-based `attempt` 를 받는다. **재시도(attempt≥2)는 *fresh* 한 내용을 써야
+ * 한다**: 첫 trigger 의 broadcast 가 (fsevents 의 event 분할/coalescing/타이밍으로) predicate
+ * 에 안 맞는 종류(예: css-update / noop)로 떨어지면, 똑같은 내용을 다시 써도 bundler 가 diff 0
+ * → noop → 영영 매칭 broadcast 가 안 온다(retry 가 arm-race 만 구제하고 이 경우는 못 구제).
+ * attempt 로 내용을 변주하면 매 재시도가 진짜 새 변경 → 새 broadcast 를 강제한다. attempt 를
+ * 안 쓰는(고정 내용) 기존 호출부는 arm-race(첫 write 영구 유실)만 대상이라 그대로 안전하다.
  */
 export function waitForHmrBroadcast(
   port: number,
-  trigger: () => void,
+  trigger: (attempt: number) => void,
   predicate: (msg: HmrMessage) => boolean,
   opts: HmrWaitOptions = {},
 ): Promise<HmrWaitResult> {
@@ -68,17 +75,28 @@ export function waitForHmrBroadcast(
       }
       resolve(out);
     };
-    const timeout = setTimeout(() => settle({ received }), timeoutMs);
+    const t0 = Date.now();
+    const dbg = process.env.ZNTC_HMR_DEBUG
+      ? (s: string) => console.error(`[hmr-wait +${Date.now() - t0}ms] ${s}`)
+      : () => {};
+    let triggerCount = 0;
+    const timeout = setTimeout(() => {
+      dbg(`TIMEOUT triggers=${triggerCount} received=${JSON.stringify(received.map((m) => m.type))}`);
+      settle({ received });
+    }, timeoutMs);
     // trigger() 가 throw 하면(예: 경로 문제) async onopen / setInterval 의 unhandled rejection
     // 대신 settle 로 라우팅 → 호출부 단언이 명확히 실패한다.
     const safeTrigger = () => {
       try {
-        trigger();
+        triggerCount += 1;
+        dbg(`trigger #${triggerCount}`);
+        trigger(triggerCount);
       } catch {
         settle({ received });
       }
     };
     ws.onopen = async () => {
+      dbg('ws open');
       await new Promise((r) => setTimeout(r, initialDelayMs));
       if (settled) return; // 대기 중 error/timeout 으로 종료됐으면 interval 안 건다
       safeTrigger();
@@ -88,8 +106,12 @@ export function waitForHmrBroadcast(
       const msg = JSON.parse(String(event.data)) as HmrMessage;
       if (msg.type === 'connected') return; // 핸드셰이크 무시
       received.push(msg);
+      dbg(`recv ${msg.type}`);
       if (predicate(msg)) settle({ result: msg, received });
     };
-    ws.onerror = () => settle({ received });
+    ws.onerror = () => {
+      dbg('ws error');
+      settle({ received });
+    };
   });
 }

--- a/packages/core/test/cli/app-builder/dev-hmr/new-css-import.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/new-css-import.ts
@@ -42,9 +42,16 @@ describe('CLI: Vite-style app builder > dev HMR > new CSS import (#3813)', () =>
       // (arm-race 방어/재시도/teardown 은 waitForHmrBroadcast 가 담당 — hmr-wait.ts 참고.)
       const { result } = await waitForHmrBroadcast(
         port,
-        () => {
+        (attempt) => {
           writeFileSync(join(dir, 'src', 'styles.css'), 'body { background: lime; }');
-          writeFileSync(join(dir, 'src', 'main.ts'), 'import "./styles.css"; console.log("v2");');
+          // 새 CSS import 는 첫 write 가 추가(아래 import 줄). 재시도는 console.log 값을 매번
+          // 바꿔(`v${attempt+1}`) *fresh* JS diff 를 만든다 — 첫 broadcast 가 fsevents event
+          // 분할로 css-update/noop 으로 떨어져도(predicate 불일치) 다음 재시도가 새 update 를
+          // 강제해 영구 timeout(동일내용 재시도→diff 0→noop) 을 막는다.
+          writeFileSync(
+            join(dir, 'src', 'main.ts'),
+            `import "./styles.css"; console.log("v${attempt + 1}");`,
+          );
         },
         (m) => m.type === 'full-reload' || m.type === 'update-done',
       );


### PR DESCRIPTION
## 증상
`CLI: Vite-style app builder > dev HMR > new CSS import (#3813) > JS-only 변경이 새 CSS import 추가 → broadcast 수신` 이 full 병렬 test run 에서 **15s timeout** 으로 간헐 실패. 단독 실행은 항상 통과(~480ms).

## 근본 원인
dev 서버 `broadcastRebuildEvent`(packages/server/src/hmr-rebuild-broadcast.ts) 의 분기:
- `graphChanged=true` → `full-reload`
- `updates.length>0` → `update-done`
- **success + graphChanged=false + updates 빈 배열 → `noop`** (매칭 broadcast 없음)
- `success=false` → `error`

새 CSS import 추가 시 fsevents 가 `styles.css`(생성) / `main.ts`(수정) 이벤트를 분할·coalesce 하면, 어떤 rebuild 는 JS update 없이 **noop** 으로 떨어질 수 있다. 문제는 `waitForHmrBroadcast` 의 retry 가 **동일 내용을 다시 쓰던 것** — 한 번 적용된 뒤에는 diff=0 → 또 noop → predicate(`full-reload`|`update-done`)가 영영 안 맞아 15s timeout.

retry 는 *arm-race(첫 write 영구 유실)* 만 구제하지, **"첫 broadcast 가 매칭 안 되는 종류(noop/css-update)"** 는 동일내용 재시도로 못 구제한다.

## 수정
1. `waitForHmrBroadcast` 가 `trigger` 에 1-based `attempt` 를 전달.
2. `new-css-import` 가 매 재시도마다 `console.log("v${attempt+1}")` 로 **fresh JS diff** 생성 → 매 재시도가 진짜 새 update 를 강제 → `update-done` 도달.
3. predicate 는 **그대로**(의도 = JS update/full-reload 파이프라인 검증, css-update 로 약화 안 함).
4. 시그니처 변경은 **하위호환** — 나머지 7 호출부는 고정 내용 `() => {}` 라 그대로(`() => void` 는 `(attempt: number) => void` 에 assignable). 그들은 변경 종류상 arm-race 만 대상이라 안전.
5. `ZNTC_HMR_DEBUG` env-gated 진단 로그(ws open / trigger#/recv/timeout) 추가 — 미설정 시 비용 0, 향후 flake 진단용.

## 검증
- **14-spinner(16코어, ~1377% CPU) 부하 하 new-css 12/12 PASS** (수정본). 순수 CPU 부하로는 구버전도 통과 → flake 는 병렬-파일 fsevents 부하 패턴 특이라 on-demand 재현 불가하나, noop 메커니즘은 코드로 확정.
- 형제 helper 테스트(non-graph-reload / sourcemap-endpoint / postcss) 무회귀.
- `tsc --noEmit` clean (8 호출부 시그니처 호환).
- `/code-review max` 6항목 검증 **[]** (시그니처 호환 / fresh-diff 보장 / 진단 무영향 / settle teardown 불변 / predicate 유지 / 양 파일 write 무해).

### Zig 초보자 노트 (이번엔 TS 테스트지만)
- `fsevents` = macOS 파일 변경 알림 시스템. 두 파일을 잇따라 쓰면 이벤트가 합쳐지거나 쪼개져 순서/묶음이 비결정적 → 그래서 "어떤 broadcast 가 먼저 오나" 가 부하에 따라 흔들렸다.
- `noop` = 서버가 "바뀐 게 없다" 고 판단해 아무 메시지도 안 보내는 상태. 같은 내용을 또 쓰면 계속 noop → 테스트가 기다리는 메시지가 영영 안 옴. 그래서 **매번 다른 내용**을 써서 서버가 반드시 "바뀜" 으로 인식하게 만든 것.

🤖 Generated with [Claude Code](https://claude.com/claude-code)