### PR TITLE
fix(test): hmr-wait.ts oxfmt 포매팅 (CI fmt:check 복구)

### DIFF
--- a/packages/core/test/cli/app-builder/dev-hmr/hmr-wait.ts
+++ b/packages/core/test/cli/app-builder/dev-hmr/hmr-wait.ts
@@ -81,7 +81,9 @@ export function waitForHmrBroadcast(
       : () => {};
     let triggerCount = 0;
     const timeout = setTimeout(() => {
-      dbg(`TIMEOUT triggers=${triggerCount} received=${JSON.stringify(received.map((m) => m.type))}`);
+      dbg(
+        `TIMEOUT triggers=${triggerCount} received=${JSON.stringify(received.map((m) => m.type))}`,
+      );
       settle({ received });
     }, timeoutMs);
     // trigger() 가 throw 하면(예: 경로 문제) async onopen / setInterval 의 unhandled rejection


### PR DESCRIPTION
## 문제
`Integration & E2E` 워크플로의 **Lint & Format** job 이 `fmt:check`(oxfmt --check) exit 1 로 실패 — main 적색.

원인: #4185(dev HMR new-css-import flake fix)를 Zig 위주 변경이라 `--no-verify` 로 푸시하면서 pre-push oxfmt 훅을 건너뛰었는데, `hmr-wait.ts` 에 추가한 진단 로그의 긴 `dbg(...)` 호출 한 줄이 oxfmt 줄 길이 규칙에 걸렸다.

## 수정
`oxfmt format` 으로 해당 줄을 멀티라인 래핑. **동작 변경 0** (순수 포매팅). 로컬 `bun run fmt:check` green 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)