### PR TITLE
chore(hooks): repo-tracked .githooks (자동 포매팅 pre-commit) — CI fmt 깨짐 방지

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,45 @@
+#!/bin/sh
+# pre-commit: staged 파일만 자동 포매팅(빠름) → CI fmt:check 가 절대 깨지지 않게.
+#
+# 왜 pre-commit 인가: pre-push 는 느린 `zig build test` 를 돌려 `--no-verify` 로 우회하게
+# 되는데, 그러면 같은 훅의 fmt:check 도 같이 건너뛰어 포매팅 깨짐이 CI 까지 샌다(#4187).
+# 포매팅은 commit 시점에 staged 파일에만 적용하면 빠르고, push 플래그와 무관하게 항상 적용된다.
+#
+# 동작: staged .zig → `zig fmt`, staged TS/JS(fmt 범위) → `oxfmt format`, 변경분 재-stage.
+# 도구가 없으면 조용히 skip. SKIP_FMT=1 로 우회 가능.
+#
+# 설치: `git config core.hooksPath .githooks` (루트 package.json 의 `prepare` 가 자동 설정).
+
+[ -n "$SKIP_FMT" ] && exit 0
+
+# mise 로 설치된 zig 사용 (portable: PATH → $HOME/.local/bin → 무시)
+if command -v mise >/dev/null 2>&1; then
+    eval "$(mise env 2>/dev/null)" || true
+elif [ -x "$HOME/.local/bin/mise" ]; then
+    eval "$("$HOME/.local/bin/mise" env 2>/dev/null)" || true
+fi
+
+# 추가/수정된 staged 파일만 (삭제/rename 제외)
+staged=$(git diff --cached --name-only --diff-filter=ACM)
+[ -z "$staged" ] && exit 0
+
+# 1) Zig 포매팅
+zig_files=$(echo "$staged" | grep '\.zig$')
+if [ -n "$zig_files" ] && command -v zig >/dev/null 2>&1; then
+    echo "[pre-commit] zig fmt ($(echo "$zig_files" | wc -l | tr -d ' ') files)"
+    echo "$zig_files" | xargs zig fmt
+    echo "$zig_files" | xargs git add
+fi
+
+# 2) TS/JS 포매팅 (oxfmt 범위 = packages/ tests/integration tests/e2e tests/benchmark)
+js_files=$(echo "$staged" \
+    | grep -E '\.(ts|tsx|js|jsx|mjs|cjs)$' \
+    | grep -E '^(packages/|tests/integration/|tests/e2e/|tests/benchmark/)' \
+    | grep -vE '(/dist/|/test-results/|dev-overlay-client\.raw\.js)')
+if [ -n "$js_files" ] && [ -x node_modules/.bin/oxfmt ]; then
+    echo "[pre-commit] oxfmt format ($(echo "$js_files" | wc -l | tr -d ' ') files)"
+    echo "$js_files" | xargs node_modules/.bin/oxfmt format >/dev/null 2>&1
+    echo "$js_files" | xargs git add
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,50 @@
+#!/bin/sh
+# pre-push: lint + fmt + test before push.
+#
+# 포매팅은 pre-commit 이 commit 시점에 이미 적용한다(여기 fmt 체크는 안전망).
+# 느린 `zig build test` 는 `SKIP_TESTS=1 git push` 로 건너뛸 수 있다 — `--no-verify`(모든
+# 훅 skip → fmt 까지 누락, #4187 의 원인) 대신 이걸 쓰면 fmt/lint 안전망은 유지된다.
+#
+# 설치: `git config core.hooksPath .githooks` (루트 package.json 의 `prepare` 가 자동 설정).
+
+# mise 로 설치된 zig 사용 (portable)
+if command -v mise >/dev/null 2>&1; then
+    eval "$(mise env 2>/dev/null)" || true
+elif [ -x "$HOME/.local/bin/mise" ]; then
+    eval "$("$HOME/.local/bin/mise" env 2>/dev/null)" || true
+fi
+
+echo "[pre-push] Using zig $(zig version 2>/dev/null)"
+
+echo "[pre-push] zig fmt --check src/..."
+if ! zig fmt --check src/; then
+    echo "[pre-push] FAILED: zig formatting. Run 'zig fmt src/' (또는 commit 시 pre-commit 이 자동 처리)."
+    exit 1
+fi
+
+if [ -n "$SKIP_TESTS" ]; then
+    echo "[pre-push] SKIP_TESTS=1 → zig build test 건너뜀"
+else
+    echo "[pre-push] zig build test... (SKIP_TESTS=1 로 건너뛸 수 있음)"
+    if ! zig build test; then
+        echo "[pre-push] FAILED: tests. Fix test failures before pushing."
+        exit 1
+    fi
+fi
+
+# JS/TS 패키지: oxlint + oxfmt 체크
+if [ -x node_modules/.bin/oxlint ]; then
+    echo "[pre-push] oxlint..."
+    if ! bun run lint >/dev/null 2>&1; then
+        echo "[pre-push] FAILED: oxlint. Run 'bun run lint:fix' to fix."
+        exit 1
+    fi
+
+    echo "[pre-push] oxfmt --check..."
+    if ! bun run fmt:check >/dev/null 2>&1; then
+        echo "[pre-push] FAILED: oxfmt. Run 'bun run fmt' to fix."
+        exit 1
+    fi
+fi
+
+echo "[pre-push] All checks passed."

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "./tests/test-helpers"
   ],
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "test": "bun run test:integration",
     "test:integration": "bun run --cwd tests/integration test",
     "test:runtime-polyfills:coverage": "bun run scripts/check-runtime-polyfill-coverage.mjs",


### PR DESCRIPTION
## 배경
기존 git 훅은 로컬 `.git/hooks/`(버전관리 X)라 공유·영속되지 않았고, `pre-push` 가 느린 `zig build test` 를 매번 돌려 `--no-verify` 로 우회하면 **같은 훅의 `fmt:check` 까지 건너뛰어 포매팅 깨짐이 CI 로 샜다**(#4187 의 직접 원인).

## 변경 (repo 트래킹 + 공유)
- **`.githooks/pre-commit`** (신규): commit 시점에 **staged 파일만 자동 포매팅**.
  - staged `.zig` → `zig fmt`, staged TS/JS(oxfmt 범위) → `oxfmt format`, 변경분 재-stage.
  - 빠름(staged만) + commit 시점이라 **push 플래그와 무관하게 항상 적용** → CI fmt 가 안 깨짐.
  - `SKIP_FMT=1` 우회, 도구 없으면 조용히 skip.
- **`.githooks/pre-push`**: 기존 검사(zig fmt/test/oxlint/fmt:check) 이식 + portable mise 경로 + 느린 `zig build test` 를 **`SKIP_TESTS=1`** 로만 건너뛰게.
  - → `--no-verify`(모든 훅 skip) 대신 `SKIP_TESTS=1 git push` 를 쓰면 fmt/lint 안전망은 유지.
- **루트 `prepare`**: `bun install` 시 `git config core.hooksPath .githooks` 자동 설정(멱등, 비-git/CI 는 `|| true`).
- mise 하드코딩 경로 제거(PATH → `\$HOME/.local/bin` fallback)로 **다른 기여자도 동작**.

## 검증
- pre-commit: 잘못 포맷된 staged `.zig`/`.ts` 모두 자동 포매팅 + 재-stage 확인.
- pre-push: 본 PR 을 `SKIP_TESTS=1 git push` 로 푸시 → fmt/lint 통과, 느린 test 만 skip("All checks passed").
- `prepare` 멱등 + `core.hooksPath=.githooks` 설정 확인. 훅 파일 실행권한(100755) git 트래킹.

## 사용법
- `bun install` 한 번이면 자동 적용(`prepare`).
- 빠른 푸시: `SKIP_TESTS=1 git push` (fmt/lint 유지, 느린 test skip).
- 포매팅 우회(드묾): `SKIP_FMT=1 git commit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)