### PR TITLE
perf(linker): lImp/lReExp 를 변경∪importer 한정 partial-skip (#4189)

### DIFF
--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -3233,3 +3233,64 @@ test "lNs partial-skip: reuse-hit namespace member-access rebuild 정상" {
         else => return error.TestUnexpectedResult,
     }
 }
+
+// lImp(populateImportSymbols)/lReExp(populateReExportAliases) 변경∪importer partial-skip
+// 회귀 가드(#4189): named import 가 re-export barrel 체인을 경유하는 fixture 를 reuse-hit
+// rebuild 하면 carrier 기반 recompute 경로(헬퍼 carrierRecomputeSet)가 crash 없이 정상
+// 동작하고 변경 모듈이 재방출돼야 한다. (skip 자체 byte-identical 은 AST-resident 보존 +
+// reuse-hit 가드 G2 이름 안정 by-construction + /code-review max 검증.)
+test "lImp/lReExp partial-skip: reuse-hit named-import via re-export barrel 정상" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "src.ts", "export const a = 1;\nexport const b = 2;\nexport const c = 3;\n");
+    // barrel 이 src 를 named re-export (lReExp) — 소비자는 barrel 에서 named import (lImp).
+    try writeFile(tmp.dir, "barrel.ts", "export { a, b, c } from './src';\n");
+    const N = 12;
+    inline for (0..N) |n| {
+        const ns = std.fmt.comptimePrint("{d}", .{n});
+        try writeFile(tmp.dir, "m" ++ ns ++ ".ts", "import { a, b } from './barrel';\nexport const x" ++ ns ++ " = a + b + 0;\n");
+    }
+    var idx: std.ArrayList(u8) = .empty;
+    defer idx.deinit(std.testing.allocator);
+    inline for (0..N) |n| {
+        try idx.print(std.testing.allocator, "import {{ x{d} }} from './m{d}';\nconsole.log(x{d});\n", .{ n, n, n });
+    }
+    try writeFile(tmp.dir, "index.ts", idx.items);
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+    const m0 = try absPath(&tmp, "m0.ts");
+    defer std.testing.allocator.free(m0);
+
+    var ib = IncrementalBundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .collect_module_codes = true,
+    });
+    ib.enable_persistence = true;
+    defer ib.deinit();
+
+    {
+        const r = try ib.rebuild(std.testing.io);
+        switch (r) {
+            .success => |s| BundleResult.ModuleDevCode.freeAll(s.changed_modules, std.testing.allocator),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+    // warm reuse-hit: m0 body-only edit(named import c 추가 — barrel 경유 lImp/lReExp 재해석,
+    // top-level 이름집합 x0 불변이라 G2 통과 → 보존-hit).
+    var changed: std.StringHashMapUnmanaged(void) = .empty;
+    defer changed.deinit(std.testing.allocator);
+    try changed.put(std.testing.allocator, m0, {});
+    try writeFile(tmp.dir, "m0.ts", "import { a, b, c } from './barrel';\nexport const x0 = a + b + c + 1;\n");
+
+    const r = try ib.rebuildWithChanges(std.testing.io, &changed);
+    switch (r) {
+        .success => |s| {
+            defer BundleResult.ModuleDevCode.freeAll(s.changed_modules, std.testing.allocator);
+            try std.testing.expectEqual(false, s.graph_changed); // 보존-hit
+            try std.testing.expect(s.changed_modules.len > 0); // m0 재방출
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -16,6 +16,10 @@ const spin = @import("../util/spin_lock.zig");
 /// kill-switch: 보존-hit lNs 변경∪importer 한정 skip 을 끄고 전량 재계산(byte-identical 회귀
 /// 진단/대조용). 설정 시 populateNamespaceAccesses 가 carrier 와 무관하게 모든 모듈 재계산.
 const ns_access_skip_disabled = @import("../env_flag.zig").Once("ZNTC_NO_NS_ACCESS_SKIP");
+/// kill-switch: 보존-hit lImp(populateImportSymbols) 변경∪importer 한정 skip 끄고 전량 재계산.
+const import_sym_skip_disabled = @import("../env_flag.zig").Once("ZNTC_NO_IMPORT_SYM_SKIP");
+/// kill-switch: 보존-hit lReExp(populateReExportAliases) 변경∪importer 한정 skip 끄고 전량 재계산.
+const reexport_alias_skip_disabled = @import("../env_flag.zig").Once("ZNTC_NO_REEXPORT_ALIAS_SKIP");
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 const BundlerDiagnostic = types.BundlerDiagnostic;
@@ -2452,12 +2456,44 @@ pub const Linker = struct {
     /// 직접 읽어 문자열 기반 `resolveExportChain` 호출을 제거한다.
     ///
     /// link() 이후에 호출되어야 한다 — export_map과 canonical_names가 준비된 상태를 전제.
+    /// 보존-hit(carrier non-null = 위상 보존) 부분-skip 공용 recompute set =
+    /// **변경 모듈 ∪ 그 직접/dynamic importer**. AST-resident sink(lNs/lImp/lReExp)는 unchanged
+    /// 모듈의 직전 빌드 값이 보존되므로, 이 집합 밖 모듈은 재계산 skip 해도 byte-identical.
+    /// carrier=null(보존-hit 아님) / path 키 미스 / module 미존재(graph 불일치) / OOM → null
+    /// = 전량 재계산(fail-safe, false-skip 차단). 반환 set 은 caller 가 deinit.
+    fn carrierRecomputeSet(self: *const Linker) ?std.AutoHashMapUnmanaged(u32, void) {
+        const ch = self.graph.changed_emit_paths orelse return null;
+        var set: std.AutoHashMapUnmanaged(u32, void) = .empty;
+        const ok = blk: {
+            var it = ch.iterator();
+            while (it.next()) |e| {
+                const idx = self.graph.path_to_module.get(e.key_ptr.*) orelse break :blk false;
+                set.put(self.allocator, @intFromEnum(idx), {}) catch break :blk false;
+                const m = self.getModule(@intFromEnum(idx)) orelse break :blk false;
+                for (m.importers.items) |imp| set.put(self.allocator, @intFromEnum(imp), {}) catch break :blk false;
+                for (m.dynamic_importers.items) |imp| set.put(self.allocator, @intFromEnum(imp), {}) catch break :blk false;
+            }
+            break :blk true;
+        };
+        if (ok) return set;
+        set.deinit(self.allocator);
+        return null;
+    }
+
     pub fn populateReExportAliases(self: *const Linker) void {
         var scope = profile.begin(.link_populate_re_export_aliases);
         defer scope.end();
 
+        // 보존-hit: lReExp 출력(m.alias_table canonical name)은 AST-resident 보존본. reuse-hit
+        // 가드 G2(변경 모듈 top-level 이름 안정)가 resolveExportChain 의 체인-끝 이름을 안정화
+        // → unchanged 모듈의 alias 는 직전 값 유효 → 변경 ∪ importer 만 재계산(byte-identical).
+        var recompute: ?std.AutoHashMapUnmanaged(u32, void) =
+            if (!reexport_alias_skip_disabled.enabled()) self.carrierRecomputeSet() else null;
+        defer if (recompute) |*r| r.deinit(self.allocator);
+
         const count = self.graph.moduleCount();
         for (0..count) |idx| {
+            if (recompute) |r| if (!r.contains(@intCast(idx))) continue;
             const m = self.moduleAtMut(@intCast(idx)) orelse continue;
             const mod_idx: ModuleIndex = ModuleIndex.fromUsize(idx);
             const table_ptr = if (m.alias_table) |*t| t else continue;
@@ -2526,8 +2562,17 @@ pub const Linker = struct {
         var scope = profile.begin(.link_populate_import_symbols);
         defer scope.end();
 
+        // 보존-hit: lImp 출력(ib.symbol/ib.local_symbol)은 importer.import_bindings(AST-resident)
+        // 보존본. ib.symbol = *직접* source(import_record.resolved)의 export SymbolRef 복사라,
+        // source 재파싱(symbol id 변동) 시 importer 의 ib.symbol 이 stale → 변경 ∪ 직접 importer
+        // 만 재계산(이슈 #4176 위험#2). chain end 아닌 직접 source 만 읽어 직접 importer 로 충분.
+        var recompute: ?std.AutoHashMapUnmanaged(u32, void) =
+            if (!import_sym_skip_disabled.enabled()) self.carrierRecomputeSet() else null;
+        defer if (recompute) |*r| r.deinit(self.allocator);
+
         const count = self.graph.moduleCount();
         for (0..count) |i| {
+            if (recompute) |r| if (!r.contains(@intCast(i))) continue;
             const importer = self.moduleAtMut(@intCast(i)) orelse continue;
             const sem_opt = importer.semantic;
             const module_scope_opt = if (sem_opt) |sem|
@@ -2610,26 +2655,9 @@ pub const Linker = struct {
         // 분석은 importer 자신의 AST + *직접* source 게이팅만 읽고 re-export 체인 끝은 안 보므로
         // 직접 importer 로 충분(이슈 #4176 위험#4). carrier=null(fallback)/키 미스/OOM → 전량
         // (recompute=null, fail-safe). RN 같은 namespace-heavy 앱의 warm lNs 절감(web 은 ~0%).
-        var recompute: ?std.AutoHashMapUnmanaged(u32, void) = null;
+        var recompute: ?std.AutoHashMapUnmanaged(u32, void) =
+            if (!ns_access_skip_disabled.enabled()) self.carrierRecomputeSet() else null;
         defer if (recompute) |*r| r.deinit(self.allocator);
-        if (self.graph.changed_emit_paths != null and !ns_access_skip_disabled.enabled()) {
-            const ch = self.graph.changed_emit_paths.?;
-            var set: std.AutoHashMapUnmanaged(u32, void) = .empty;
-            const ok = blk: {
-                var it = ch.iterator();
-                while (it.next()) |e| {
-                    const idx = self.graph.path_to_module.get(e.key_ptr.*) orelse break :blk false;
-                    set.put(self.allocator, @intFromEnum(idx), {}) catch break :blk false;
-                    // path 는 resolve 됐는데 module 미존재 = graph 불일치 → importer 누락 위험,
-                    // 전량 재계산으로 fail-safe(false-skip 차단).
-                    const m = self.getModule(@intFromEnum(idx)) orelse break :blk false;
-                    for (m.importers.items) |imp| set.put(self.allocator, @intFromEnum(imp), {}) catch break :blk false;
-                    for (m.dynamic_importers.items) |imp| set.put(self.allocator, @intFromEnum(imp), {}) catch break :blk false;
-                }
-                break :blk true;
-            };
-            if (ok) recompute = set else set.deinit(self.allocator);
-        }
 
         const mod_count = self.graph.moduleCount();
         for (0..mod_count) |i| {


### PR DESCRIPTION
## 배경 (#4176 → #4189)
#4184 가 lNs 를 carrier(`changed_emit_paths`) ∪ 직접 importer 한정 partial-skip 으로 줄였다. **lImp/lReExp 는 같은 AST-resident 성질인데 아직 매 빌드 전량 순회**. RN cold link 실측 **lImp 3.81ms(10.5%) + lReExp 2.41ms(6.6%)** 가 warm reuse-hit 에서도 중복 재계산된다.

## 수정
공용 헬퍼 `carrierRecomputeSet`(carrier ∪ importers ∪ dynamic_importers)을 추출해 **lNs/lImp/lReExp 3곳이 공유**(lNs 인라인 중복 제거, 동작 무변경) → 각 함수가 set 밖 모듈 skip.

## byte-identical 근거 (per-function)
- **lImp** (`populateImportSymbols`): `ib.symbol` = *직접* source(`import_records[..].resolved`)의 export SymbolRef 복사 = **구조적 ref**. source 재파싱 시 symbol id 변동 → importer `ib.symbol` stale → 변경+직접 importer 재계산(이슈 #4176 위험#2). **chain end 아닌 직접 source 만** 읽어 직접 importer 로 충분. 보존 sink = `importer.import_bindings`(AST-resident).
- **lReExp** (`populateReExportAliases`): `m.alias_table` canonical name = `resolveExportChain`(체인 끝) 이름. **highest-risk(체인-끝 의존)** 이나, reuse-hit 가드 **G2(변경 모듈 top-level 이름집합 안정, renameReuseGuard `toplevel_name_set_hash`)** + reuse-hit 의 **computeRenames skip(rename 재사용)** 이 체인-끝 이름을 안정화 → export-rename edit 은 G2 불일치로 fallback(=skip 비활성), body-only edit 은 이름 안정 → unchanged 모듈(deep re-exporter 포함)의 보존 alias 유효 → 변경∪importer 만 재계산해도 동일. 보존 sink = `m.alias_table`(AST-resident).

## 안전장치
- fail-safe: carrier=null / path miss / getModule miss / OOM → 헬퍼 null 반환 → 전량 재계산.
- kill-switch `ZNTC_NO_IMPORT_SYM_SKIP` / `ZNTC_NO_REEXPORT_ALIAS_SKIP`.
- 회귀가드: `incremental_test.zig` reuse-hit named-import via re-export barrel(carrier recompute 경로 crash-free + 보존-hit).

## 검증
- **cold byte-identical 전수**: effect/date-fns/lodash-es/preact (carrier=null 라 skip 비활성 → HEAD 동일). 헬퍼 추출(lNs refactor) 무회귀 포함.
- 전체 테스트 스위트 green (testing.allocator: leak/UAF 0).
- `/code-review max` 6항목 검증 **[]** (helper / lNs refactor / lImp 구조적-ref / **lReExp G2 가드(체인-끝 안정성 확정)** / sink 보존 / index space).

## 성격
cold-only 아님 — lImp/lReExp 는 `finalize` 에서 매 빌드(warm reuse-hit 포함) 호출되므로 **warm 에도 작동**(warm reduction). lExp/lRes 는 linker-resident → persistent-linker(Phase 2) NO-GO 로 본 PR 범위 밖.

### Zig 초보자 노트
- `carrier`(`changed_emit_paths`) = 보존-hit 빌드에서 "이번에 바뀐 모듈 경로" 집합. 위상(모듈 그래프 구조)이 그대로면 안 바뀐 모듈의 link 결과는 직전 값과 같으니 다시 계산할 필요가 없다.
- `AST-resident` = 결과가 모듈 자신(parse_arena/import_bindings/alias_table)에 저장돼 빌드 사이 보존됨 → skip 해도 직전 값이 남아 있어 안전.
- lReExp 가 까다로운 건 "재-export 체인 끝"의 이름에 의존하기 때문인데, reuse-hit 가드가 "바뀐 모듈의 top-level 이름은 그대로"를 보장해서 체인 결과가 안 흔들린다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)