### PR TITLE
fix(hooks): pre-commit 안전성 — 공백 파일명/포매터 실패/부분 stage (#4188 후속)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,45 +1,74 @@
 #!/bin/sh
-# pre-commit: staged 파일만 자동 포매팅(빠름) → CI fmt:check 가 절대 깨지지 않게.
+# pre-commit: staged 파일만 안전하게 자동 포매팅 → CI fmt:check 가 깨지지 않게.
 #
-# 왜 pre-commit 인가: pre-push 는 느린 `zig build test` 를 돌려 `--no-verify` 로 우회하게
-# 되는데, 그러면 같은 훅의 fmt:check 도 같이 건너뛰어 포매팅 깨짐이 CI 까지 샌다(#4187).
-# 포매팅은 commit 시점에 staged 파일에만 적용하면 빠르고, push 플래그와 무관하게 항상 적용된다.
+# 왜 pre-commit 인가: pre-push 는 느린 `zig build test` 를 돌려 `SKIP_TESTS=1`/`--no-verify`
+# 로 우회하게 되는데, 포매팅을 commit 시점 staged 파일에만 적용하면 빠르고 push 플래그와
+# 무관하게 항상 적용된다.
 #
-# 동작: staged .zig → `zig fmt`, staged TS/JS(fmt 범위) → `oxfmt format`, 변경분 재-stage.
-# 도구가 없으면 조용히 skip. SKIP_FMT=1 로 우회 가능.
-#
-# 설치: `git config core.hooksPath .githooks` (루트 package.json 의 `prepare` 가 자동 설정).
+# 안전성(PR #4188 후속 fix):
+#   - 파일명을 `while IFS= read -r` 로 한 줄씩 읽어 **공백 포함 경로 안전**(xargs 미사용).
+#   - 포매터가 **실패하면 re-stage 하지 않고 commit 중단**(rc=1) — 깨진 포맷을 조용히 통과시키지 않음.
+#   - **부분 stage**(working-tree 에 unstaged 변경이 남은 파일)는 건너뜀 — re-stage 가 미검토
+#     변경을 commit 에 끌어오는 footgun 회피.
+#   - 파이프 subshell 회피(임시파일 경유)로 rc 가 부모 셸에 전파돼 실제 commit 이 중단된다.
+# SKIP_FMT=1 로 전체 우회. 설치: 루트 package.json `prepare` 가 `core.hooksPath=.githooks` 설정.
 
 [ -n "$SKIP_FMT" ] && exit 0
 
-# mise 로 설치된 zig 사용 (portable: PATH → $HOME/.local/bin → 무시)
+# mise 로 설치된 zig 사용 (portable)
 if command -v mise >/dev/null 2>&1; then
     eval "$(mise env 2>/dev/null)" || true
 elif [ -x "$HOME/.local/bin/mise" ]; then
     eval "$("$HOME/.local/bin/mise" env 2>/dev/null)" || true
 fi
 
-# 추가/수정된 staged 파일만 (삭제/rename 제외)
-staged=$(git diff --cached --name-only --diff-filter=ACM)
-[ -z "$staged" ] && exit 0
+rc=0
 
-# 1) Zig 포매팅
-zig_files=$(echo "$staged" | grep '\.zig$')
-if [ -n "$zig_files" ] && command -v zig >/dev/null 2>&1; then
-    echo "[pre-commit] zig fmt ($(echo "$zig_files" | wc -l | tr -d ' ') files)"
-    echo "$zig_files" | xargs zig fmt
-    echo "$zig_files" | xargs git add
-fi
+# 한 파일 포매팅 + 안전 re-stage.
+fmt_one() {
+    f="$1"
+    tool="$2"
+    # 부분 stage 회피: working-tree 에 unstaged 변경이 있으면 건너뜀(re-stage 가 미검토 변경 흡수 방지).
+    if ! git diff --quiet -- "$f"; then
+        echo "[pre-commit] skip(부분 stage — unstaged 변경 있음): $f" >&2
+        return 0
+    fi
+    case "$tool" in
+        zig) zig fmt "$f" ;;
+        oxfmt) node_modules/.bin/oxfmt format "$f" >/dev/null ;;
+    esac
+    if [ $? -ne 0 ]; then
+        echo "[pre-commit] FAILED: 포매팅 실패 — $f ($tool). 고친 뒤 다시 commit 하세요." >&2
+        rc=1
+        return 0
+    fi
+    git add -- "$f"
+}
 
-# 2) TS/JS 포매팅 (oxfmt 범위 = packages/ tests/integration tests/e2e tests/benchmark)
-js_files=$(echo "$staged" \
-    | grep -E '\.(ts|tsx|js|jsx|mjs|cjs)$' \
-    | grep -E '^(packages/|tests/integration/|tests/e2e/|tests/benchmark/)' \
-    | grep -vE '(/dist/|/test-results/|dev-overlay-client\.raw\.js)')
-if [ -n "$js_files" ] && [ -x node_modules/.bin/oxfmt ]; then
-    echo "[pre-commit] oxfmt format ($(echo "$js_files" | wc -l | tr -d ' ') files)"
-    echo "$js_files" | xargs node_modules/.bin/oxfmt format >/dev/null 2>&1
-    echo "$js_files" | xargs git add
-fi
+have_zig=$(command -v zig >/dev/null 2>&1 && echo 1 || echo "")
+have_oxfmt=$([ -x node_modules/.bin/oxfmt ] && echo 1 || echo "")
 
-exit 0
+# 추가/수정된 staged 파일만(삭제/rename 제외). 임시파일 경유로 while 이 subshell 이 아님(rc 전파).
+tmp=$(mktemp 2>/dev/null) || tmp=".git/pre-commit-staged.$$"
+git diff --cached --name-only --diff-filter=ACM >"$tmp"
+
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    case "$f" in
+        *.zig)
+            [ -n "$have_zig" ] && fmt_one "$f" zig
+            ;;
+        packages/* | tests/integration/* | tests/e2e/* | tests/benchmark/*)
+            # oxfmt 범위 + 제외 패턴(dist/test-results/dev-overlay-client.raw.js).
+            case "$f" in
+                */dist/* | */test-results/* | *dev-overlay-client.raw.js) ;;
+                *.ts | *.tsx | *.js | *.jsx | *.mjs | *.cjs)
+                    [ -n "$have_oxfmt" ] && fmt_one "$f" oxfmt
+                    ;;
+            esac
+            ;;
+    esac
+done <"$tmp"
+
+rm -f "$tmp"
+exit $rc


### PR DESCRIPTION
## 배경
#4188 의 `.githooks/pre-commit` 을 (뒤늦게) `/code-review max` 로 소급 검토하다 **실제 결함 3건**을 발견했다. 리뷰를 건너뛰고 머지한 게 원인.

## 수정한 결함
1. **공백 파일명 → `xargs` 분리**: `echo "$files" | xargs zig fmt` 는 `my file.zig` 를 `my`+`file.zig` 2개 인자로 → 포맷 실패/오동작. **`while IFS= read -r f`** 루프로 교체(공백 안전).
2. **포매터 실패 silent → bad 파일 re-stage**: `oxfmt format … >/dev/null 2>&1` 후 무조건 `git add` → oxfmt 가 실패(syntax error 등)해도 unformatted 파일을 그대로 stage → **CI fmt:check 가 또 깨짐**(#4188 이 막으려던 그 문제). 실패 시 re-stage 안 하고 **`rc=1` 로 commit 중단**. 임시파일 경유로 `while` 가 subshell 이 아니게 해 rc 가 부모 셸에 전파.
3. **부분 stage footgun**: staged 후 working-tree 수정된 파일을 `git add` 하면 미검토 변경까지 commit. `git diff --quiet -- "$f"` 로 unstaged 변경 있는 파일 **skip(경고)**.

## 검증
- 3케이스 수동: ① `my file.ts` 정상 포맷 ② syntax-error 파일 → commit 중단(exit 1, 미-stage) ③ 부분 stage → skip.
- `/code-review max` 7항목 **[]** (rc 전파/POSIX dash 호환/temp 누수/부분stage/실패-중단/**oxfmt scope = package.json fmt 100% 일치**/edge).
- POSIX `#!/bin/sh`(no bashism), oxfmt 범위는 `bun run fmt` 와 동일.

## 메타
이 PR 자체가 "PR 전 `/code-review max` 필수" 규칙을 #4188 에서 어긴 결과의 시정입니다 — 리뷰를 돌렸으면 머지 전 잡혔을 결함들.

🤖 Generated with [Claude Code](https://claude.com/claude-code)