### PR TITLE
perf(graph): renumber identity fast-path — 위상 보존-hit 시 realloc/remap skip (#4175)

### DIFF
--- a/src/bundler/graph/renumber.zig
+++ b/src/bundler/graph/renumber.zig
@@ -18,6 +18,10 @@ const RequestedExports = @import("state.zig").RequestedExports;
 const bundler_symbol = @import("../symbol.zig");
 const profile = @import("../../profile.zig");
 
+/// kill-switch: renumber identity fast-path 를 끄고 항상 전체 renumber 수행(byte-identical
+/// 대조/진단용). fast-path 는 self-verifying 이라 정상 동작엔 영향 없음.
+const renumber_identity_fastpath_disabled = @import("../../env_flag.zig").Once("ZNTC_NO_RENUMBER_FASTPATH");
+
 pub const RenumberError = error{ RenumberIncomplete, OutOfMemory };
 
 pub fn renumberModulesDeterministically(
@@ -81,6 +85,23 @@ pub fn renumberModulesDeterministically(
         new_idx += 1;
     }
     if (new_idx != old_count) return error.RenumberIncomplete;
+
+    // identity fast-path (#4175): BFS 순서가 현재 배치와 동일(new_to_old[i]==i ∀i)이면 이후
+    // 단계가 전부 no-op 다 — old_to_new[x]==x 라 ModuleList 재할당/field remap/path_to_module·
+    // requested_exports·worker_entries remap 모두 자기 자신으로 매핑. 즉 self.modules 등 현 상태가
+    // 그대로 정답. 위상 보존-hit(HMR reuse-hit)에서 발생. **byte-identical 보장(가정 아님)**:
+    // 순서를 실제 BFS 로 계산해 identity 일 때만 건너뛴다(cold/worker-race 비-identity 는 전체 수행).
+    // 절감 = 재할당 + 2개 HashMap 재구축 + 전 모듈 field remap(renumber 비용의 대부분).
+    if (!renumber_identity_fastpath_disabled.enabled()) {
+        var identity = true;
+        for (new_to_old, 0..) |old_u32, new_i| {
+            if (old_u32 != @as(u32, @intCast(new_i))) {
+                identity = false;
+                break;
+            }
+        }
+        if (identity) return;
+    }
 
     var new_list: ModuleList = .{};
     errdefer new_list.deinit(allocator);


### PR DESCRIPTION
## 배경 (#4175 ①의 첫 단계)
dev HMR 위상 보존-hit 에서 `finalizeGraph` 의 `renumberModulesDeterministically` 가 매 rebuild 전 8092 모듈을 BFS 재배치한다 — **ModuleList 재할당 + `path_to_module`/`requested_exports` HashMap 재구축 + 전 모듈 field/SymbolRef remap**. RN cold 실측 renumber **~3.3ms**(finalize ~10ms 의 1/3). 위상이 안 바뀌면 BFS 순서가 현 배치와 같아(#4174 identity) 이 작업이 전부 no-op 다.

## 수정 (self-verifying — #4174 가정에 의존 안 함)
BFS 순서를 실제로 계산한 뒤 `new_to_old[i] == i ∀i`(identity)면 **early-return**. 이후 realloc/remap 을 전부 건너뛴다:
- `old_to_new[x] == x` 라 모든 remap(`remapList`/`remapSymbolRef`/`import_records[].resolved`/`path_to_module`/`requested_exports`/`worker_entries`)이 `idx→idx` no-op.
- `module.index` 는 직전 renumber 가 `position` 으로 설정 → identity 케이스에선 이미 `index==position` (skip 안전).
- 기존 `self.modules` 가 곧 새 `new_list` 와 동일(같은 모듈/순서/index) → 재할당 불요.

→ **byte-identical *보장*(가정 아님)**: 순서를 BFS 로 실제 계산해 identity 일 때만 skip. cold/worker-race 비-identity 는 전체 renumber 수행. kill-switch `ZNTC_NO_RENUMBER_FASTPATH`.

## 효과
- cold(non-identity): 발동 안 함 → renumber ~3.3ms 불변(**무회귀**).
- **warm reuse-hit**(모듈이 BFS 순서로 보존 → identity): realloc + 2 HashMap 재구축 + 전 모듈 remap **제거**.

## 검증
- **cold byte-identical 전수**: effect/date-fns/lodash-es/preact (cold 는 발동 안 하니 HEAD 동일).
- **기존 #4174 `renumber identity` 테스트가 fast-path 를 직접 발동**: renumber 3회 호출 → 2·3회차가 identity → fast-path → 결과 불변(a/b/c, path_to_module, `index==position`) 단언. (이 테스트가 본 skip 의 안전 근거로 작성됨.)
- 전체 스위트 green (testing.allocator: leak/UAF 0).
- `/code-review max` 5항목 **[]** (identity→remap no-op / `module.index` 이미 position / path_to_module 일관 / kill-switch / BFS 실제 계산).

## 범위
finalizeGraph ① 의 첫 단계(renumber). 나머지 ①(cycles DFS/collectRnAssetMetadata/markViaDynamic exec_index 보존) + ②(promote/propagate 부분 재계산)는 별도 후속 PR.

### Zig 초보자 노트
- `renumber` = discovery(병렬 워커)가 비결정 순서로 매긴 module index 를 BFS 순으로 다시 매겨 결정화. 보존-hit(HMR)에선 직전 빌드가 이미 BFS 순서라 다시 매겨도 그대로 → 재할당이 순수 낭비.
- `new_to_old[i]==i` = "새 i번째 자리에 올 모듈이 이미 i번째에 있다" = 순서 불변. 이때만 안전하게 건너뛴다(아니면 전체 수행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)