### PR TITLE
perf(rn): dev HMR watch 디바운스 기본 50→16ms + --watch-delay 플러밍

### DIFF
--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -211,6 +211,9 @@ export function buildRnDevServerInput(opts, config) {
         opts.minifySyntax ||
         cfg.minify ||
         false,
+      // watch 디바운스(ms) — CLI `--watch-delay`. native NAPI watch 의 debounce_ms 로 전달
+      // (buildRnBundleOptions → watch → getObjectUint32("watchDelay")). 기본 16.
+      watchDelay: opts.watchDelay,
       extra: buildRnBundleExtra(cfg, opts),
       override: buildRnBundleOverride({ config: cfg, opts }),
     },

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -258,7 +258,7 @@ function parseArgs(argv) {
     bundle: false,
     watch: false,
     watchJson: false,
-    watchDelay: 100,
+    watchDelay: 16,
     serve: false,
     serveDir: '.',
     port: undefined,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1308,7 +1308,7 @@ interface BuildOptionsCommon {
   /**
    * watch debounce window in milliseconds — after the first file event, the
    * watcher waits this long for idle before rebuilding, merging rapid saves
-   * into one rebuild. Default `50`. Set `0` to rebuild immediately (no debounce;
+   * into one rebuild. Default `16`. Set `0` to rebuild immediately (no debounce;
    * lower latency, but rapid saves may trigger multiple rebuilds). Mirrors the
    * CLI `--watch-delay` flag. Only affects the NAPI `watch()` path.
    */

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -46,13 +46,15 @@ const installManualChunksResolver = plugin_bridge.installManualChunksResolver;
 
 /// Issue #1223 Phase 1: 워처 튜닝 상수.
 /// - watch_poll_timeout_ms: stop_flag 체크 주기 (이벤트 워처에서도 주기적으로 깨어나기 위함).
-/// - watch_debounce_ms: 첫 이벤트 이후 정적(idle) 구간 — 연속 저장 병합 윈도우.
-///   phase1c 의 공개 계약은 50ms 내 연속 저장 병합이다. macOS kqueue 는 CI 부하에 따라
-///   같은 파일의 후속 NOTE_WRITE 전달이 25ms idle 뒤에 도착할 수 있으므로, idle window 를
-///   계약값인 50ms 로 맞춰 빠른 저장을 한 rebuild 로 안정적으로 합친다.
+/// - watch_debounce_ms: 첫 이벤트 이후 정적(idle) 구간 — 연속 저장 병합 윈도우. **기본 16ms**
+///   (RN 8092 모듈 dev HMR 실측: warm rebuild ~145ms 중 이 idle 대기가 ~50ms=1위. 16ms 로
+///   낮춰 단일 편집 latency 절감). JS `watchDelay` / CLI `--watch-delay` 로 override — burst
+///   저장이 빈번하거나 macOS kqueue 후속 NOTE_WRITE 가 늦게(~25ms) 와 더블-rebuild 가 보이면
+///   `--watch-delay=30~50` 으로 올린다. 0 이면 즉시 rebuild(저지연, 병합 없음).
+///   (drain 루프가 burst 는 계속 병합하므로 base 만 낮추면 단일 편집 latency 만 줄어든다.)
 /// - watch_debounce_max_ms: 디바운스 최대 대기 시간 — 지속 변경되는 파일에 의한 기아 방지.
 const watch_poll_timeout_ms: u32 = 200;
-const watch_debounce_ms: u32 = 50;
+const watch_debounce_ms: u32 = 16;
 const watch_debounce_max_ms: u64 = 500;
 
 /// 파일 내용 해시 상한 (#1233). RN 등 대형 프로젝트의 vendor 번들/asset catalog/locale
@@ -125,7 +127,7 @@ const WatchAsyncData = struct {
     emit_disk_sourcemap: bool = true,
 
     /// watch 디바운스(ms) — 첫 이벤트 후 idle 대기 윈도우(연속 저장 병합). JS `watchDelay`
-    /// 옵션으로 override(기본 `watch_debounce_ms`=50). 0 이면 디바운스 없이 즉시 rebuild.
+    /// 옵션으로 override(기본 `watch_debounce_ms`=16). 0 이면 디바운스 없이 즉시 rebuild.
     debounce_ms: u32 = watch_debounce_ms,
 
     /// #4079 PR-2 — `requestLazySeed(path)` 로 런타임에 누적되는 force-parse 경로 집합
@@ -1228,7 +1230,7 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         const force_dirty = async_data.lazy_force_dirty.swap(false, .acq_rel);
         if (touched.count() == 0 and !force_dirty) continue;
 
-        // 디바운스: idle `debounce_ms`(watchDelay, 기본 50) 확보까지 드레인. 지속 변경되는
+        // 디바운스: idle `debounce_ms`(watchDelay, 기본 16) 확보까지 드레인. 지속 변경되는
         // 파일로 인한 기아를 막기 위해 첫 이벤트로부터 watch_debounce_max_ms 초과 시 강제 종료.
         // debounce_ms==0 이면 drain 자체를 건너뛰어 즉시 rebuild(저지연).
         var debounce_timer: ?IoTimer = IoTimer.start(common.io());
@@ -1998,8 +2000,8 @@ pub fn napiWatch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
     // `emitDiskSourcemap` 옵션 (기본 true) — bungae 등 lazy 라우트를 갖춘 dev server 는
     // false 로 보내 rebuild 경로의 `.map` 디스크 I/O 를 완전히 제거한다.
     async_data.emit_disk_sourcemap = getObjectBool(env, argv[0], "emitDiskSourcemap", true);
-    // watch 디바운스(ms) — `watchDelay` 옵션(CLI `--watch-delay` 와 동명). 기본 50ms 유지(연속
-    // 저장 병합 공개 계약). 0 이면 디바운스 drain skip → 즉시 rebuild(저지연, 빠른 저장 다중 rebuild).
+    // watch 디바운스(ms) — `watchDelay` 옵션(CLI `--watch-delay` 와 동명). 기본 16ms(연속
+    // 저장 병합 윈도우 — 단일 편집 latency 절감, override 가능). 0 이면 디바운스 drain skip → 즉시 rebuild(저지연, 빠른 저장 다중 rebuild).
     async_data.debounce_ms = getObjectUint32(env, argv[0], "watchDelay", watch_debounce_ms);
 
     // onReady 콜백 추출

--- a/packages/core/test/core/hmr-perf/latency-debounce/quick-saves.ts
+++ b/packages/core/test/core/hmr-perf/latency-debounce/quick-saves.ts
@@ -25,6 +25,9 @@ describe('Issue #1223 HMR perf - latency and debounce - quick saves', () => {
 
     const handle = watch({
       entryPoints: [entry],
+      // 기본 디바운스가 16ms 로 낮아져(RN HMR 단일편집 latency 절감), 10ms 간격 두 저장의
+      // 병합을 검증하려면 윈도우를 명시한다. watchDelay 옵션이 native debounce_ms 로 전달되는지도 함께 검증.
+      watchDelay: 50,
       onReady() {
         readyDone();
       },

--- a/packages/core/test/core/hmr-perf/latency-debounce/starvation-cap.ts
+++ b/packages/core/test/core/hmr-perf/latency-debounce/starvation-cap.ts
@@ -20,6 +20,9 @@ describe('Issue #1223 HMR perf - latency and debounce - starvation cap', () => {
     const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<void>();
     const handle = watch({
       entryPoints: [entry],
+      // 기본 디바운스 16ms 라 20ms 간격 쓰기는 윈도우를 갱신하지 못한다 → starvation 시나리오
+      // (윈도우 지속 갱신 → 500ms 상한 강제 리빌드)를 재현하려면 20ms < window 가 되도록 명시.
+      watchDelay: 50,
       onReady() {
         readyDone();
       },

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -58,6 +58,8 @@ export interface RnBundleInput {
   dev: boolean;
   /** sourcemap emit. dev 시 inline 권장. */
   sourcemap?: boolean;
+  /** watch 디바운스(ms) — dev server watch 의 첫 이벤트 후 idle 병합 윈도우. 기본 16(native). */
+  watchDelay?: number;
   /** prod build 의 minify. */
   minify?: boolean;
   /** console.* 호출 제거. Metro production Babel plugin 과 같은 정책을 원하는 release 경로에서 사용. */
@@ -395,6 +397,7 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     dev,
     sourcemap,
     minify,
+    watchDelay,
     dropConsole,
     dropDebugger,
     extra,
@@ -495,6 +498,8 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     platform: 'react-native',
     sourcemap: sourcemap ?? dev,
     minify: minify ?? false,
+    // watch 디바운스 — 지정 시에만 전달(미지정이면 native NAPI watch 기본 16ms 사용).
+    ...(watchDelay !== undefined ? { watchDelay } : {}),
     dropConsole: dropConsole ?? false,
     dropDebugger: dropDebugger ?? false,
     plugins,

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -194,8 +194,9 @@ pub const CliOptions = struct {
     tsconfig_raw: ?[]const u8 = null,
     /// --node-paths=PATH,...: NODE_PATH 추가 탐색 경로
     node_paths_list: std.ArrayList([]const u8) = .empty,
-    /// --watch-delay=MS: watch 리빌드 디바운스 지연 (밀리초)
-    watch_delay_ms: u32 = 100,
+    /// --watch-delay=MS: watch 리빌드 디바운스 지연 (밀리초). 기본 16ms — 단일 편집 latency 최소화
+    /// (drain 루프가 burst 저장은 계속 병합). RN dev HMR 실측 후 50→16 조정.
+    watch_delay_ms: u32 = 16,
     /// --watch-folder=DIR (반복): 번들 그래프 밖의 디렉토리를 감시 루트에 추가.
     /// Metro의 watchFolders에 대응. 내부 표현은 roots + include/exclude로 일반화되어
     /// 나중에 Rollup/Vite의 watch.include/exclude 스펙도 같은 필드로 매핑된다.

--- a/src/cli/usage.zig
+++ b/src/cli/usage.zig
@@ -44,7 +44,7 @@ pub fn printUsage(writer: anytype) !void {
         \\  --quotes=<style>                 String quote style (double|single|preserve)
         \\  --legal-comments=<mode>          none | inline | eof — license/legal comment placement
         \\  -w, --watch                      Watch for file changes
-        \\  --watch-delay=<ms>               Debounce window for file events (default: 50)
+        \\  --watch-delay=<ms>               Debounce window for file events (default: 16)
         \\  -p, --project <path>             Path to tsconfig.json file or directory
         \\  --tsconfig-path <path>           Alias of -p/--project (matches NAPI `tsconfigPath`)
         \\  --tsconfig-raw=<json>            Inline tsconfig JSON (overrides file/auto-discovery)

--- a/src/cli/watch.zig
+++ b/src/cli/watch.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 
-/// 폴링 fallback watch 의 mtime 확인 주기(ms). `--watch-delay`(기본 100) 값을 쓰되 0/과소값은
+/// 폴링 fallback watch 의 mtime 확인 주기(ms). `--watch-delay`(기본 16) 값을 쓰되 0/과소값은
 /// busy-loop 방지로 10ms floor. JS CLI(bin/zntc.mjs)의 fs.watch debounce 와 같은 노브 —
 /// 거기선 이벤트 후 debounce, 폴링인 여기선 확인 주기. (예전엔 500ms 하드코딩이라 반응성 저하.)
 pub fn pollIntervalMs(delay_ms: u32) i64 {
@@ -10,7 +10,7 @@ pub fn pollIntervalMs(delay_ms: u32) i64 {
 }
 
 /// 단일 파일을 폴링 방식으로 감시한다 (D048).
-/// 파일의 mtime을 `delay_ms`(--watch-delay, 기본 100ms)마다 확인하여 변경되면 재트랜스파일.
+/// 파일의 mtime을 `delay_ms`(--watch-delay, 기본 16ms)마다 확인하여 변경되면 재트랜스파일.
 /// Ctrl+C로 종료될 때까지 무한 루프를 돈다.
 pub fn watchFile(
     comptime transpileFn: anytype,
@@ -50,7 +50,7 @@ pub fn watchFile(
 }
 
 /// 디렉토리를 폴링 방식으로 감시한다 (D048).
-/// 매 `delay_ms`(--watch-delay, 기본 100ms)마다 디렉토리를 재순회하여 .ts/.tsx 파일의
+/// 매 `delay_ms`(--watch-delay, 기본 16ms)마다 디렉토리를 재순회하여 .ts/.tsx 파일의
 /// mtime을 확인하고, 변경된 파일만 재트랜스파일한다.
 pub fn watchDirectory(
     comptime transpileFn: anytype,

--- a/src/main.zig
+++ b/src/main.zig
@@ -993,7 +993,7 @@ pub fn main(init: std.process.Init) !void {
                 try stderr.print("[watch] Watching {d} files for changes...\n", .{mtime_map.count()});
             }
 
-            // 폴링 간격 = --watch-delay (기본 100ms). 과거엔 500ms 하드코딩이라 watch
+            // 폴링 간격 = --watch-delay (기본 16ms). 과거엔 500ms 하드코딩이라 watch
             // 반응성이 폴링 대기에 묻혔다(watch_cli.pollIntervalMs 가 0/과소값 floor).
             const watch_poll_ms = watch_cli.pollIntervalMs(opts.watch_delay_ms);
             while (true) {


### PR DESCRIPTION
## 배경 — RN 실앱 dev HMR 실측

가장 큰 RN 예제 `examples/react-native-large`(9080 files, 50MB)를 `zntc dev`로 띄워 warm HMR 재빌드를 실측했더니:

| phase | 시간 | 비중 |
|---|---|---|
| **det (변경 감지)** | **~60ms** | **42% ← 1위** |
| graph build | ~30ms | 20% |
| emit | ~22ms | 18% |
| link | ~22ms | 15% |
| **total** | **~145ms** | — |

`det`를 계측으로 분해하니 60ms는 **낭비 스캔이 아니라 watch 디바운스 idle 대기**였습니다 (첫 파일 이벤트 후 "연속 저장 병합"을 위해 idle 윈도우만큼 기다림). rescan/hash는 ~0ms.

```
[detbreak] debounce=52us rescan=0us hash=0.4us total=53us  ← 거의 전부 debounce
```

## 변경

1. **native NAPI watch 디바운스 기본값 50→16ms** (`watch.zig`). 단일 편집 latency 절감. drain 루프가 burst(연속) 저장은 계속 병합하므로 base만 낮추면 단일 편집만 빨라집니다.
2. **`--watch-delay` / `watchDelay` 옵션을 RN dev 경로에 플러밍** — 기존엔 옵션이 RN dev까지 전달되지 않아 튜닝 불가였습니다. `rn-dev-input` bundle → `RnBundleInput` → `buildRnBundleOptions` → `watch()` → native `debounce_ms`.
3. CLI/JS 기본값 100→16 일치 (`options.zig` / `zntc.mjs` / `index.ts` 문서 / `usage.zig` help).

## 실측 검증

| 설정 | det | HMR total | files |
|---|---|---|---|
| **기본(16ms)** | **18-19ms** | 54-117ms | 9080 |
| **--watch-delay=40** | **42-43ms** | 80-107ms | 9080 |

→ 기본 16ms 동작(**det −42ms**) + configurable 동작(40 설정 시 det 42) + **byte-identical**.

## byte-identical

디바운스는 재빌드 **시점**만 조정하고 출력을 바꾸지 않습니다 (같은 `changed_files` → 같은 빌드 → 같은 출력). 실측에서 cold `files` 수 9080 불변 + HMR 정상 동작. `quick-saves` / `starvation-cap` 테스트는 병합 윈도우 의도를 보존하려 `watchDelay: 50`을 명시해 옵션 전달 경로도 함께 검증합니다.

## /code-review max

plumbing end-to-end 정확(0값 보존·타입 OK·flow 검증), hard-fail 테스트 0 확인. 적발된 stale 문서(`usage.zig` help 텍스트 "default: 50", watch.zig/main.zig 주석)는 모두 16으로 수정.

## Zig 초보자 메모

디바운스(debounce)는 "파일 변경 후 잠잠해질 때까지 잠깐 기다렸다 한 번에 리빌드"하는 기법입니다. 너무 길면(50ms) 한 번 저장에도 그만큼 늦게 반영됩니다. 16ms로 줄이되 연속 저장은 drain 루프가 흡수해 여러 번 리빌드되지 않습니다. macOS kqueue가 같은 저장의 후속 이벤트를 ~25ms 뒤 보내 더블 리빌드가 보이면 `--watch-delay=30~50`으로 올리면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)