### PR TITLE
perf(graph): dev cold build 병렬 scan — preserve 경로 cold 를 build() 로 라우팅

### DIFF
--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -1180,9 +1180,22 @@ pub fn buildIncrementalPreserved(
     self.changed_emit_paths = null;
 
     // cold / 첫 빌드 / 직전 fallback 으로 graph 가 비워진 경우 → full discovery.
-    // (store 는 보존 모드에서 비어있어 전량 cache-miss = full parse → byte-identical full.)
+    // 보존 모드는 store 를 안 채워(transferModulesToStore 비활성) cold 빌드가 전량 cache-miss 다.
+    // buildIncremental 의 discovery 는 *순차*(증분=cache-hit-heavy 가정, scan_worker 미사용) 라
+    // cold(전량 miss)엔 정반대로 비효율 — RN 9080 모듈 dev cold graph 의 81%(scan_worker=0 실측).
+    // 보존할 것이 없으므로 build() 의 *병렬* scan_worker 경로로 라우팅한다. build() 는 store 를
+    // 쓰지 않아 modules 가 graph parse_arena 단독 owner 로 남고(보존 모드 불변식 유지), finalizeGraph
+    // 까지 동일 수행. 출력은 renumber/path-sort(#3564)로 discovery 순서·worker 수와 무관하게
+    // byte-identical. cold = 전량 fresh 이므로 graph_changed=true + reparsed=전 모듈(0..n).
+    // (buildIncremental 의 cold reparsed 는 disabled(.ready) 모듈을 제외하나, cold 는 disabled 포함
+    //  전 모듈이 first-emit 이라 전량 reparsed 가 더 정확 — 게다가 cold 는 consumer 가 graph_changed=true
+    //  로 reparsed 필터를 우회. index==position 은 finalizeGraph→renumber 가 보장. caller 가 free.)
     if (self.modules.count() == 0) {
-        return buildIncremental(self, io, entry_points, store, changed_files);
+        try build(self, io, entry_points);
+        const n = self.modules.count();
+        const reparsed = try self.allocator.alloc(types.ModuleIndex, n);
+        for (0..n) |i| reparsed[i] = @enumFromInt(@as(u32, @intCast(i)));
+        return .{ .graph_changed = true, .reparsed_indices = reparsed };
     }
 
     // 변경 정보가 없으면(initial-after-warm / CLI) 보존 판정 불가 → full fallback.


### PR DESCRIPTION
## 배경 — RN 실앱 dev cold 5.4s 병목 추적

`react-native-large`(9080 files) dev cold 빌드를 단계별로 실측했더니 가설을 차례로 걸러냈습니다:

| 후보 | 측정 | 판정 |
|---|---|---|
| sourcemap | +568ms | 일부 |
| collectModuleCodes(emit) | 557ms | ❌ |
| pkg.json | 8ms (RF) | ❌ 노이즈 |
| **graph discovery** | **3923ms = cold의 81%** | ✅ 병목 |

graph 분해의 결정타: **`graph_discover_scan_worker = 0`** — 병렬 scan worker가 **전혀 안 돕니다**. dev cold discovery 3911ms가 완전 직렬.

## 루트커즈

```
dev RN → Bundler.initWithGraph(preserve_topology) → buildIncrementalPreserved
       → graph 비어있음(cold) → buildIncremental  ← 직렬 incremental discovery
native CLI → build() → 병렬 scan_worker
```

`buildIncremental`의 discovery는 *"증분=cache-hit이 대부분이라 스레드풀 오버헤드보다 순차가 효율적"*이라는 주석대로 **직렬**입니다. 하지만 **cold(첫 빌드)는 전량 cache-miss**라 이 논리가 정반대 — 9080개를 한 코어로 순차 파싱하느라 CPU를 놀립니다.

## 수정

cold(`modules.count()==0`) 분기를 `buildIncremental`(직렬) → **`build()`(병렬 scan_worker)**로 라우팅. `build()`는 store를 쓰지 않아 modules가 graph parse_arena 단독 owner로 남고(보존 불변식 유지) `finalizeGraph`까지 동일 수행. (13줄, build_flow.zig 단일.)

## 실측 검증

| | 결과 |
|---|---|
| **dev cold** | **4847 → 1815ms (2.7x, −3s)** — native parallel 1778ms과 동일 |
| warm HMR | 102ms 정상 + app-builder dev-hmr e2e **13/13 pass** |
| **byte-identical** | OLD(직렬) vs NEW(병렬) dev 번들 **sha 일치 + cmp 완전 동일** |

byte-identical은 renumber/path-sort(#3564)가 discovery 순서·worker 수와 무관하게 출력을 결정화하기 때문입니다. (⚠️ 비교 시 sourceURL 포트/sourceMappingURL strip 필수 — 안 하면 false 차이.)

## /code-review max

correctness 버그 **0**. 두 검토 축 모두 통과:
- `reparsed=0..n`은 disabled(.ready) 모듈 포함 superset이나 **cold엔 더 정확**(전 모듈 first-emit) + consumer가 cold에서 `graph_changed=true`로 reparsed 필터 우회. `index==position`은 renumber가 보장.
- store(preserve 모드 미기록)·mtime(build()가 incremental_mode로 채워 compiled_cache 워밍)·changed_files(cold=null)·double-finalize·second-cold 전부 동등 검증.

## Zig 초보자 메모

cold 빌드는 9080개 모듈을 캐시 없이 처음부터 전부 파싱해야 합니다. 이 일을 여러 CPU 코어로 나누는 게 `build()`(병렬), 한 코어로 순서대로 하는 게 `buildIncremental`(직렬)입니다. 직렬은 "이미 캐시된 모듈이 대부분인 warm 재빌드"엔 스레드 오버헤드가 없어 유리하지만, cold(전부 새로 파싱)엔 코어를 놀려 2.7배 느렸습니다. **cold만 병렬로 돌리도록 분기**한 게 이 PR입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)