### PR TITLE
fix(release): bun.lock 동기화 — v0.1.2 publish 복구

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -554,15 +554,15 @@
         "@zntc/test-helpers": "workspace:*",
       },
       "optionalDependencies": {
-        "@zntc/core-darwin-arm64": "0.1.1",
-        "@zntc/core-darwin-x64": "0.1.1",
-        "@zntc/core-linux-arm64-gnu": "0.1.1",
-        "@zntc/core-linux-arm64-musl": "0.1.1",
-        "@zntc/core-linux-x64-gnu": "0.1.1",
-        "@zntc/core-linux-x64-musl": "0.1.1",
-        "@zntc/core-win32-arm64-msvc": "0.1.1",
-        "@zntc/core-win32-ia32-msvc": "0.1.1",
-        "@zntc/core-win32-x64-msvc": "0.1.1",
+        "@zntc/core-darwin-arm64": "0.1.2",
+        "@zntc/core-darwin-x64": "0.1.2",
+        "@zntc/core-linux-arm64-gnu": "0.1.2",
+        "@zntc/core-linux-arm64-musl": "0.1.2",
+        "@zntc/core-linux-x64-gnu": "0.1.2",
+        "@zntc/core-linux-x64-musl": "0.1.2",
+        "@zntc/core-win32-arm64-msvc": "0.1.2",
+        "@zntc/core-win32-ia32-msvc": "0.1.2",
+        "@zntc/core-win32-x64-msvc": "0.1.2",
         "browserslist": "^4.24.0",
         "core-js": "^3.49.0",
         "core-js-compat": "^3.49.0",
@@ -3126,24 +3126,6 @@
     "@zntc/benchmark": ["@zntc/benchmark@workspace:tests/benchmark"],
 
     "@zntc/core": ["@zntc/core@workspace:packages/core"],
-
-    "@zntc/core-darwin-arm64": ["@zntc/core-darwin-arm64@0.1.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZhCUcErEm101VpfoIRQdAiNrhmEpP7FjlXVjBsJIwB6sDjInv4tt9ZLZwwU4HPDheKgHiNZp2wqWazdLzQN7Lw=="],
-
-    "@zntc/core-darwin-x64": ["@zntc/core-darwin-x64@0.1.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-go2WSnwSsFMiCy4roFrr0mc+rqDcmri9EBAqVw4TPcBYSrABY+z4vHHGikyzQGJY5tfzDBZpz4FecXooAfb6Bw=="],
-
-    "@zntc/core-linux-arm64-gnu": ["@zntc/core-linux-arm64-gnu@0.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-vFF08GrUvjvsuOKIgRmOjSwohhiRekNr4boozX/qV+xKfjBUTq27QkEDjL29W7lyB/TwlyJASTLZVydZwlBo7A=="],
-
-    "@zntc/core-linux-arm64-musl": ["@zntc/core-linux-arm64-musl@0.1.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-FgMrITlMp8vQRaZWyMCgmPeN/A04q28RBcsIeZNiZbU/t7Wm++dIrAyVcTeymCCBLo6YTGdRPBrx5wvlZdSUAA=="],
-
-    "@zntc/core-linux-x64-gnu": ["@zntc/core-linux-x64-gnu@0.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-akoA4ElGT9one9xalBzKDVY1SYHRyw6dwzW69ALf7UDRCPB/f+Awi6DOrrl2G8JYmo5Eh+eLdg/ba1gNIOa8QQ=="],
-
-    "@zntc/core-linux-x64-musl": ["@zntc/core-linux-x64-musl@0.1.1", "", { "os": "linux", "cpu": "x64" }, "sha512-73g3NqRufvvdeGvZedlpsym78rTYX2Uer3nw0CS1N24mBufMQwpr5wulPSwQFyEUoFDCkkurhi+5LrS1bJ4lyg=="],
-
-    "@zntc/core-win32-arm64-msvc": ["@zntc/core-win32-arm64-msvc@0.1.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-zeXry9pjoe2+eTJBEm6koklC8oZnmERWMlsYqxEoGB/kboiDMN2JsBof4VlyGsKQDy2hAlJ0aUwxkH0h60K6PA=="],
-
-    "@zntc/core-win32-ia32-msvc": ["@zntc/core-win32-ia32-msvc@0.1.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-4P5iw0vZdIFCvNetNY/63bS6CcTgv57ZdMqWebESZrKRuzxb2b8/bdy6BF39/VeStOLkSHef38U7qp7W1aRamg=="],
-
-    "@zntc/core-win32-x64-msvc": ["@zntc/core-win32-x64-msvc@0.1.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mLo2EectkhT49E3EKlvOuz0aFphSfkpxwiLveGbQOf2ej4+YuzmFs4Ili8hEerH0NhJLzwSXGDM18Ga69EXz6Q=="],
 
     "@zntc/e2e": ["@zntc/e2e@workspace:tests/e2e"],
 


### PR DESCRIPTION
## v0.1.2 publish 실패 복구

v0.1.2 release.yml 의 `Publish to npm` job 이 실패:
\`\`\`
bun install --frozen-lockfile
error: lockfile had changes, but lockfile is frozen
\`\`\`

**원인**: `changeset version` 의 `bun install` 이후 platform 바이너리 9개 / `@zntc/core` optionalDeps / root 를 **수동**으로 0.1.2 bump 했으나 `bun install` 을 재실행하지 않아 bun.lock 이 미반영. CI 의 `--frozen-lockfile` 이 검출.

**수정**: `bun install` 재실행으로 bun.lock 동기화. 로컬 `--frozen-lockfile` 통과 확인.

✅ **npm 에 0.1.2 아무것도 게시 안 됨** (부분 배포 없음 — 깨끗한 재시도 가능).

머지 후 `v0.1.2` 태그를 이 커밋으로 옮겨 release.yml 재실행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)