### PR TITLE
fix(transformer): ES2025 duplicate named capture group 다운레벨 silent miscompile

### DIFF
--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -125,13 +125,6 @@ const T = struct {
     /// 정확히 다운레벨 못한 astral 구문 발견 (lower() 가 u-strip 보류 판단).
     astral_u_incomplete: bool = false,
 
-    fn resolveIndex(self: *T, name: []const u8) ?u32 {
-        for (self.names) |g| {
-            if (std.mem.eql(u8, g.name, name)) return g.index;
-        }
-        return null;
-    }
-
     /// surrogate pair 2 노드를 list 에 push (cp>0xFFFF).
     fn pushSurrogate(self: *T, span: ast.Span, cp: u32, out: *std.ArrayList(u32)) TransformError!void {
         const sp = cps.splitSurrogatePair(cp);
@@ -342,8 +335,35 @@ const T = struct {
             },
             .named_reference => {
                 if (self.opts.strip_named and !self.in_class) {
-                    if (self.resolveIndex(self.in.source[n.data[0]..n.data[1]])) |gi| {
-                        return self.b.add(.{ .tag = .indexed_reference, .span = n.span, .data = .{ gi, 0, 0 } });
+                    const name = self.in.source[n.data[0]..n.data[1]];
+                    var count: u32 = 0;
+                    var first: u32 = 0;
+                    for (self.names) |g| {
+                        if (std.mem.eql(u8, g.name, name)) {
+                            if (count == 0) first = g.index;
+                            count += 1;
+                        }
+                    }
+                    if (count == 1) {
+                        return self.b.add(.{ .tag = .indexed_reference, .span = n.span, .data = .{ first, 0, 0 } });
+                    }
+                    if (count > 1) {
+                        // ES2025 duplicate named group: `\k<y>` 는 단일 `\N` 으로 표현
+                        // 불가 → 모든 인덱스의 backref 연접 `(?:\1\2)` 로 내린다.
+                        // 비참여 그룹 backref 는 빈 문자열 매치라 참여한 쪽 값만
+                        // 남는다 — `$<y>`→`$1$2` 와 동일 트릭, regexpu 동형 (#4198).
+                        // `(?:)` 래핑은 quantifier (`\k<y>+`) 안전용.
+                        var refs: std.ArrayList(u32) = .empty;
+                        defer refs.deinit(self.b.a);
+                        for (self.names) |g| {
+                            if (std.mem.eql(u8, g.name, name)) {
+                                const r = try self.b.add(.{ .tag = .indexed_reference, .span = n.span, .data = .{ g.index, 0, 0 } });
+                                try refs.append(self.b.a, @intFromEnum(r));
+                            }
+                        }
+                        const l = try self.b.addList(refs.items);
+                        const seq = try self.b.add(.{ .tag = .alternative, .span = n.span, .data = .{ l.start, l.len, 0 } });
+                        return self.b.add(.{ .tag = .ignore_group, .span = n.span, .data = .{ 0, 0, @intFromEnum(seq) } });
                     }
                 }
                 return self.b.add(n); // 못 찾으면 보존 (ad-hoc 동일)

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -450,6 +450,18 @@ test "#4198: replacement $<dup> → 모든 인덱스 이어붙임 ($1$2)" {
     try testing.expectEqualStrings("[$1$2]", out);
 }
 
+test "#4198: duplicate named group 의 \\k<name> → 모든 인덱스 backref 연접 (?:\\1\\2)" {
+    const out = (try runLower("/(?<y>a)\\k<y>|(?<y>b)\\k<y>/", .{ .regex_named_groups = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(a)(?:\\1\\2)|(b)(?:\\1\\2)/", out);
+}
+
+test "#4198: duplicate \\k<name> + quantifier — (?:) 래핑으로 안전" {
+    const out = (try runLower("/(?<y>a)\\k<y>+|(?<y>b)/", .{ .regex_named_groups = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(a)(?:\\1\\2)+|(b)/", out);
+}
+
 test "#4198: replacement 단일 이름은 기존과 동일 ($N)" {
     const mapping = [_]NamedGroupMapping{
         .{ .name = "y", .index = 1 },

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -190,17 +190,19 @@ pub fn rewriteReplacementNamedRefs(
         if (content[i] == '$' and i + 2 < content.len and content[i + 1] == '<') {
             if (std.mem.indexOfScalarPos(u8, content, i + 2, '>')) |gt| {
                 const name = content[i + 2 .. gt];
-                var found_idx: ?u32 = null;
+                // ES2025 duplicate named group: 같은 이름의 모든 인덱스를 이어붙인다
+                // (`$<y>` → `$1$2`). alternation 상 한쪽만 참여하므로 비참여 그룹은
+                // 빈 문자열 — babel __wrapRegExp 의 `group.join("$")` 동형 (#4198).
+                var found = false;
                 for (mapping) |m| {
                     if (std.mem.eql(u8, m.name, name)) {
-                        found_idx = m.index;
-                        break;
+                        var buf: [16]u8 = undefined;
+                        const s = std.fmt.bufPrint(&buf, "${d}", .{m.index}) catch unreachable;
+                        try out.appendSlice(allocator, s);
+                        found = true;
                     }
                 }
-                if (found_idx) |idx| {
-                    var buf: [16]u8 = undefined;
-                    const s = std.fmt.bufPrint(&buf, "${d}", .{idx}) catch unreachable;
-                    try out.appendSlice(allocator, s);
+                if (found) {
                     i = gt + 1;
                     changed = true;
                     continue;
@@ -421,6 +423,41 @@ test "regex: named backref — character class 안의 \\k는 그대로" {
     const out = (try runLower("/(?<n>a)[\\k<n>]/", .{ .regex_named_groups = true })).?;
     defer testing.allocator.free(out);
     try testing.expectEqualStrings("/(a)[\\k<n>]/", out);
+}
+
+// #4198: ES2025 duplicate named capture group — mapping 은 per-occurrence 로
+// 모든 (name, index) 쌍을 보존해야 호출자가 array 병합/`$1$2` 합성 가능.
+test "#4198: duplicate named group mapping 은 occurrence 별 전부 보존" {
+    const r = try lower(testing.allocator, "/(?<y>\\d{4})-a|(?<y>\\d{4})-b/", .{ .unsupported = .{ .regex_named_groups = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    defer if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expectEqualStrings("/(\\d{4})-a|(\\d{4})-b/", r.text.?);
+    const ng = r.named_groups.?;
+    try testing.expectEqual(@as(usize, 2), ng.len);
+    try testing.expectEqualStrings("y", ng[0].name);
+    try testing.expectEqual(@as(u32, 1), ng[0].index);
+    try testing.expectEqualStrings("y", ng[1].name);
+    try testing.expectEqual(@as(u32, 2), ng[1].index);
+}
+
+test "#4198: replacement $<dup> → 모든 인덱스 이어붙임 ($1$2)" {
+    const mapping = [_]NamedGroupMapping{
+        .{ .name = "y", .index = 1 },
+        .{ .name = "y", .index = 2 },
+    };
+    const out = (try rewriteReplacementNamedRefs(testing.allocator, "[$<y>]", &mapping)).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("[$1$2]", out);
+}
+
+test "#4198: replacement 단일 이름은 기존과 동일 ($N)" {
+    const mapping = [_]NamedGroupMapping{
+        .{ .name = "y", .index = 1 },
+        .{ .name = "m", .index = 2 },
+    };
+    const out = (try rewriteReplacementNamedRefs(testing.allocator, "$<m>/$<y>", &mapping)).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("$2/$1", out);
 }
 
 // #2472 회귀 가드: 32개 stack-cap 시 33번째부터 std.debug.assert 가 ReleaseFast 에서

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -742,7 +742,23 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
                 // identifier 는 실무상 짧으므로 256 byte 스택 버퍼로 heap alloc 회피.
                 const props_top = self.scratch.items.len;
                 defer self.scratch.shrinkRetainingCapacity(props_top);
-                for (ng) |entry| {
+                // ES2025 duplicate named group 의 value 노드 수집 버퍼.
+                var dup_vals: std.ArrayList(NodeIndex) = .empty;
+                defer dup_vals.deinit(self.allocator);
+                for (ng, 0..) |entry, ei| {
+                    // ES2025 duplicate named group: 같은 이름은 첫 등장에서 array 값
+                    // (`{"y": [1, 2]}`) 으로 합쳐 emit. 객체 리터럴 중복 키는 last-win
+                    // 이라 첫 분기 매치 시 groups.NAME 이 undefined 가 되는 silent
+                    // miscompile (#4198). 런타임 buildGroups/Symbol.replace 는 array
+                    // 값을 이미 지원 (babel 동형).
+                    var seen_before = false;
+                    for (ng[0..ei]) |prev| {
+                        if (std.mem.eql(u8, prev.name, entry.name)) {
+                            seen_before = true;
+                            break;
+                        }
+                    }
+                    if (seen_before) continue;
                     var stack_buf: [256]u8 = undefined;
                     const need_heap = entry.name.len + 2 > stack_buf.len;
                     const quoted = if (need_heap)
@@ -756,7 +772,20 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
                         .span = key_span,
                         .data = .{ .string_ref = key_span },
                     });
-                    const val_node = try es_helpers.makeNumericLiteral(self, entry.index);
+                    dup_vals.clearRetainingCapacity();
+                    for (ng[ei..]) |later| {
+                        if (std.mem.eql(u8, later.name, entry.name)) {
+                            try dup_vals.append(self.allocator, try es_helpers.makeNumericLiteral(self, later.index));
+                        }
+                    }
+                    const val_node = if (dup_vals.items.len == 1) dup_vals.items[0] else val_blk: {
+                        const vals_list = try self.ast.addNodeList(dup_vals.items);
+                        break :val_blk try self.ast.addNode(.{
+                            .tag = .array_expression,
+                            .span = node.span,
+                            .data = .{ .list = vals_list },
+                        });
+                    };
                     const prop_node = try self.ast.addNode(.{
                         .tag = .object_property,
                         .span = node.span,

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1381,6 +1381,41 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(result.runOutput).toBe('abc:123');
     });
 
+    test('ES2025 duplicate named capture group → groups map array 병합 (#4198)', async () => {
+      // 회귀: 그룹맵이 중복 키 객체({"y":1,"y":2}, last-win)로 emit 되어
+      // 첫 분기 매치 시 groups.y === undefined silent miscompile.
+      const result = await bundleAndRun(
+        {
+          'index.ts': `
+            const re = /(?<y>\\d{4})-a|(?<y>\\d{4})-b/;
+            console.log('2024-a'.match(re)?.groups?.y);
+            console.log('2025-b'.match(re)?.groups?.y);
+          `,
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('2024\n2025');
+    });
+
+    test('ES2025 duplicate named group + replace $<name> → $1$2 (#4198)', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts': `
+            console.log('2024-a'.replace(/(?<y>\\d{4})-a|(?<y>\\d{4})-b/, '<$<y>>'));
+            console.log('2025-b'.replace(/(?<y>\\d{4})-a|(?<y>\\d{4})-b/, '<$<y>>'));
+          `,
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('<2024>\n<2025>');
+    });
+
     test('named backreference \\k<name>', async () => {
       const result = await bundleAndRun(
         {

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1416,6 +1416,26 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(result.runOutput).toBe('<2024>\n<2025>');
     });
 
+    test('ES2025 duplicate named group + \\k<name> backref → (?:\\1\\2) 연접 (#4198)', async () => {
+      // 회귀: \k<dup> 가 첫 occurrence 인덱스로만 내려가 두 번째 분기에서
+      // 비참여 그룹 backref(빈 문자열 매치)가 되는 silent miscompile.
+      const result = await bundleAndRun(
+        {
+          'index.ts': `
+            const re = /(?<y>a)x\\k<y>|(?<y>bb)\\k<y>/;
+            console.log('axa'.match(re)?.[0]);
+            console.log('bbbb'.match(re)?.[0]);
+            console.log(String('bb'.match(re)?.[0]));
+          `,
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('axa\nbbbb\nundefined');
+    });
+
     test('named backreference \\k<name>', async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
Closes #4198

## 문제

ES2025 duplicate named capture group (`/(?<y>\d{4})-a|(?<y>\d{4})-b/`) 을 named-group 미지원 타겟(es2017 이하)으로 내릴 때, 이름→인덱스 매핑의 **3개 consumer 가 전부** 중복 이름을 잘못 붕괴시켜 에러 없이 값만 틀리는 silent miscompile 이 발생했다:

| consumer | 종전 출력 | 증상 |
|---|---|---|
| groups map (`__wrapRegExp`) | `{"y": 1, "y": 2}` 중복 키 | 객체 리터럴 last-win → 첫 분기 매치 시 `groups.y === undefined` |
| `$<name>` 정적 재작성 | 첫 인덱스만 `$1` | 두 번째 분기 매치 시 빈 문자열 치환 |
| `\k<name>` backref strip | 첫 인덱스만 `\1` | 두 번째 분기에서 비참여 그룹 backref = 빈 문자열 매치 → 매치 범위 자체가 달라짐 |

## 수정 (babel/regexpu 동형)

공통 트릭: **비참여 capture group 의 값/backref 는 빈 문자열** 이고, 중복 이름은 alternation 분기별로 최대 1개만 참여하므로 — 모든 인덱스를 "이어붙이면" 참여한 쪽 값만 남는다.

1. **groups map** (`node_dispatch.zig`): 중복 이름을 첫 등장에서 array 로 병합 → `{"y": [1, 2]}`. 런타임 헬퍼 `buildGroups`/`Symbol.replace` 는 이미 array 값을 지원(babel 동형)하므로 emit 쪽만 고치면 됨.
2. **`$<name>` 재작성** (`regex_lower.zig`): 모든 인덱스 이어붙임 → `$1$2`.
3. **`\k<name>` strip** (`src/regexp/transform.zig`): 모든 인덱스의 backref 연접 → `(?:\1\2)`. `(?:)` 래핑은 `\k<y>+` 같은 quantifier 안전용. regexpu-core 와 동형임을 리뷰 단계에서 실제 regexpu 출력으로 교차 확인.

단일 이름 경로는 3곳 모두 **byte-identical** (array 미생성, `$N`/`\N` 동일).

## Zig 초보자용 포인트

- `node_dispatch.zig` 의 `dup_vals: std.ArrayList(NodeIndex) = .empty` 는 Zig 0.16 unmanaged ArrayList 패턴 — allocator 를 각 호출에 넘기고 `defer dup_vals.deinit(self.allocator)` 로 블록 탈출 시 해제. transformer 의 `self.allocator` 는 프로덕션에선 arena 라 deinit 이 no-op 이지만 테스트(gpa, leak-check)에선 필수. 블록 안에서 즉시 해제되므로 CLAUDE.md 의 "#1287 arena 이후 deinit" 함정과는 무관.
- `ng[0..ei]` / `ng[ei..]` 슬라이스 스캔은 O(n²) 지만 n = 정규식 하나의 named group 수(보통 ≤5) 라 무시 가능 — 코드베이스의 tiny-n dedup 관례와 동일.
- `src/regexp/transform.zig` 는 입력 AST 를 새 Builder 로 복사하는 구조라, `\k` 1개를 노드 여러 개(`indexed_reference`×N → `alternative` → `ignore_group`)로 바꾸는 것이 자연스럽게 가능.

## 검증

- 유닛: `regex_lower.zig` 에 6개 추가 (mapping 보존, `$1$2`, 단일 이름 불변, `(?:\1\2)`, quantifier 래핑).
- integration: `downlevel-edge.test.ts` 에 3개 추가 (groups/replace/backref — 모두 fix 전 실패 확인됨). 전체 168 pass.
- e2e: es2017 다운레벨 출력 node 실행 = native(node 24) 와 전 케이스 일치 (`match`/`replace`/backref 4종/quantifier).
- `zig build test` green, 기존 regex 테스트 byte-identical.

## /code-review max 결과

9-앵글 finder + 검증 + sweep 수행. 이 PR 범위 finding 은 `\k<dup>` (커밋 2로 수정) 1건. 적발된 pre-existing 버그들은 별도 이슈로 분리:

- #4200 `__wrapRegExp` matchAll species 우회 (named group 전반, ctor proto 1줄)
- #4201 group 이름 `\u` escape 표기 raw-byte 비교 (dedup/`$<name>`/parser 검증)
- #4202 `extractNamedGroupMap` 의 `(?i:)` modifier 그룹 오집계 (인덱스 시프트)
- #4203 template replacement 재인용 escape 누락 (SyntaxError 출력)
- #4204 `__proto__` 그룹 이름 → groups map proto setter
- #4205 GetSubstitution 엣지 2건 (babel-parity, informational)
- #4199 es2018~es2024 타겟 feature gate 부재 (이 PR 선행 필요했던 건 — 다음 작업)

🤖 Generated with [Claude Code](https://claude.com/claude-code)