### PR TITLE
fix(runtime): __wrapRegExp constructor-side prototype 설정 — matchAll/split species 우회로 .groups 유실

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -681,6 +681,12 @@ pub const GENERATOR_RUNTIME_MIN = "var " ++ NAMES.GENERATOR_MIN ++ "=function(){
 /// 환경에서 strip 후에도 `re.exec(s).groups.NAME` / `s.replace(re, "$<NAME>")` 가 동작하도록
 /// RegExp 를 wrap 한다. Babel `_wrapRegExp` 와 동일 패턴 (RegExp 상속 + exec/Symbol.replace
 /// override + WeakMap 으로 groups map 보유).
+///
+/// constructor-side `setPrototypeOf(BabelRegExp, RegExp)` 는 `Symbol.species` 상속용 (#4200):
+/// 없으면 `matchAll`/`split` 의 SpeciesConstructor 가 %RegExp% 로 폴백해 strip 된 패턴의
+/// plain RegExp 를 새로 만들어 exec override 를 우회 → `.groups` 전부 유실. species 가
+/// BabelRegExp 를 반환해야 `new BabelRegExp(re, flags)` 가 `_groups.get(re)` 폴백으로
+/// 원본의 groups map 을 물려받는다 (babel `_inherits` 동형).
 pub const WRAP_REGEXP_RUNTIME =
     \\var __wrapRegExp = function() {
     \\  __wrapRegExp = function(re, groups) { return new BabelRegExp(re, undefined, groups); };
@@ -692,6 +698,7 @@ pub const WRAP_REGEXP_RUNTIME =
     \\    return Object.setPrototypeOf(_this, BabelRegExp.prototype);
     \\  }
     \\  Object.setPrototypeOf(BabelRegExp.prototype, RegExp.prototype);
+    \\  Object.setPrototypeOf(BabelRegExp, RegExp);
     \\  BabelRegExp.prototype.exec = function(str) {
     \\    var result = _super.exec.call(this, str);
     \\    if (result) {
@@ -739,7 +746,7 @@ pub const WRAP_REGEXP_RUNTIME =
     \\};
     \\
 ;
-pub const WRAP_REGEXP_RUNTIME_MIN = "var " ++ NAMES.WRAP_REGEXP_MIN ++ "=function(){" ++ NAMES.WRAP_REGEXP_MIN ++ "=function(re,groups){return new BabelRegExp(re,undefined,groups)};var _super=RegExp.prototype;var _groups=new WeakMap();function BabelRegExp(re,flags,groups){var _this=new RegExp(re,flags);_groups.set(_this,groups||_groups.get(re));return Object.setPrototypeOf(_this,BabelRegExp.prototype)}Object.setPrototypeOf(BabelRegExp.prototype,RegExp.prototype);BabelRegExp.prototype.exec=function(str){var result=_super.exec.call(this,str);if(result){result.groups=buildGroups(result,this);var indices=result.indices;if(indices)indices.groups=buildGroups(indices,this)}return result};BabelRegExp.prototype[Symbol.replace]=function(str,substitution){if(typeof substitution===\"string\"){var groups=_groups.get(this);return _super[Symbol.replace].call(this,str,substitution.replace(/\\$<([^>]+)(>|$)/g,function(match,name,end){if(end===\"\")return match;var group=groups[name];return Array.isArray(group)?\"$\"+group.join(\"$\"):typeof group===\"number\"?\"$\"+group:\"\"}))}else if(typeof substitution===\"function\"){var _this=this;return _super[Symbol.replace].call(this,str,function(){var args=arguments;if(typeof args[args.length-1]!==\"object\"){args=[].slice.call(args);args.push(buildGroups(args,_this))}return substitution.apply(this,args)})}return _super[Symbol.replace].call(this,str,substitution)};function buildGroups(result,re){var g=_groups.get(re);return Object.keys(g).reduce(function(groups,name){var i=g[name];if(typeof i===\"number\")groups[name]=result[i];else{var k=0;while(result[i[k]]===undefined&&k+1<i.length)k++;groups[name]=result[i[k]]}return groups},Object.create(null))}return " ++ NAMES.WRAP_REGEXP_MIN ++ ".apply(this,arguments)};";
+pub const WRAP_REGEXP_RUNTIME_MIN = "var " ++ NAMES.WRAP_REGEXP_MIN ++ "=function(){" ++ NAMES.WRAP_REGEXP_MIN ++ "=function(re,groups){return new BabelRegExp(re,undefined,groups)};var _super=RegExp.prototype;var _groups=new WeakMap();function BabelRegExp(re,flags,groups){var _this=new RegExp(re,flags);_groups.set(_this,groups||_groups.get(re));return Object.setPrototypeOf(_this,BabelRegExp.prototype)}Object.setPrototypeOf(BabelRegExp.prototype,RegExp.prototype);Object.setPrototypeOf(BabelRegExp,RegExp);BabelRegExp.prototype.exec=function(str){var result=_super.exec.call(this,str);if(result){result.groups=buildGroups(result,this);var indices=result.indices;if(indices)indices.groups=buildGroups(indices,this)}return result};BabelRegExp.prototype[Symbol.replace]=function(str,substitution){if(typeof substitution===\"string\"){var groups=_groups.get(this);return _super[Symbol.replace].call(this,str,substitution.replace(/\\$<([^>]+)(>|$)/g,function(match,name,end){if(end===\"\")return match;var group=groups[name];return Array.isArray(group)?\"$\"+group.join(\"$\"):typeof group===\"number\"?\"$\"+group:\"\"}))}else if(typeof substitution===\"function\"){var _this=this;return _super[Symbol.replace].call(this,str,function(){var args=arguments;if(typeof args[args.length-1]!==\"object\"){args=[].slice.call(args);args.push(buildGroups(args,_this))}return substitution.apply(this,args)})}return _super[Symbol.replace].call(this,str,substitution)};function buildGroups(result,re){var g=_groups.get(re);return Object.keys(g).reduce(function(groups,name){var i=g[name];if(typeof i===\"number\")groups[name]=result[i];else{var k=0;while(result[i[k]]===undefined&&k+1<i.length)k++;groups[name]=result[i[k]]}return groups},Object.create(null))}return " ++ NAMES.WRAP_REGEXP_MIN ++ ".apply(this,arguments)};";
 
 /// __await: async generator 안 await 표현의 wrapper. (#1911)
 /// `await x` 는 async generator body 안에서 `yield __await(x)` 로 변환되며,

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1400,6 +1400,25 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(result.runOutput).toBe('2024\n2025');
     });
 
+    test('named group + matchAll → species 가 wrapper 유지, .groups 보존 (#4200)', async () => {
+      // 회귀: ctor-side setPrototypeOf 부재 → Symbol.species 폴백으로 matchAll 이
+      // plain RegExp 를 재생성 → exec override 우회 → groups 전부 undefined.
+      const result = await bundleAndRun(
+        {
+          'index.ts': `
+            const out = [...'a-1 b-2'.matchAll(/(?<w>[a-z])-(?<n>\\d)/g)].map((m) => m.groups.w + m.groups.n);
+            console.log(out.join(','));
+            console.log('x1y2'.split(/(?<d>\\d)/).join('|'));
+          `,
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('a1,b2\nx|1|y|2|');
+    });
+
     test('ES2025 duplicate named group + replace $<name> → $1$2 (#4198)', async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
Closes #4200

## 문제

`__wrapRegExp` 헬퍼가 prototype-side `setPrototypeOf(BabelRegExp.prototype, RegExp.prototype)` 만 하고 babel `_inherits` 가 함께 하는 **constructor-side** `setPrototypeOf(BabelRegExp, RegExp)` 가 없었다. 그래서:

- `BabelRegExp[Symbol.species]` = undefined → `matchAll`/`split` 의 SpeciesConstructor 가 `%RegExp%` 로 폴백
- strip 된 패턴의 **plain RegExp** 를 재생성 → `exec` override 우회 → `.groups` 전부 undefined → `m.groups.NAME` 에서 TypeError

named-group 다운레벨 전반(중복 여부 무관)에 영향. `.match`/`.replace` 는 정상이라 `.matchAll` 로 바꾸는 순간 깨지는 함정이었다.

## 루트커즈

헬퍼에는 species 재생성 인스턴스가 원본의 groups map 을 물려받는 `_groups.get(re)` 폴백 경로가 **처음부터 설계돼 있었지만**, ctor proto 누락으로 species 가 wrapper 를 반환하지 않아 그 경로가 도달 불가였다. ctor-side proto 1줄(×2 카피)로 `RegExp[Symbol.species]` getter(`return this`)가 상속되어 `new BabelRegExp(wrapper, flags)` → groups map 상속 경로가 살아난다. babel `_inherits(BabelRegExp, RegExp)` 동형.

## 검증

- e2e: `matchAll` `.groups`(이전 TypeError → native 일치), `split` named-group, d-flag `indices.groups`, lastIndex 진행, sticky, limit — 전부 node 24 native 와 일치. plain + `--minify`(`$wR`) 양쪽.
- `/code-review max` (4 앵글 실증 리뷰): **회귀 0** — single-name 전 경로 main/native 대비 동일·개선, MIN 카피 byte-exact 삽입 프로그램 검증, 헬퍼 텍스트 스냅샷/해시 소비자 없음, ES5/Hermes 신규 요구 capability 없음 (setPrototypeOf/WeakMap 은 기존 요구). 유일한 관측 가능 delta = ctor 가 RegExp legacy statics 상속 (babel 동일, 개선 방향).
- 리뷰 sweep 이 적발한 인접 pre-existing 버그는 #4207 로 분리 (buildGroups undefined 가드 — lodash cloneRegExp 크래시).

## Zig 초보자용 포인트

런타임 헬퍼는 Zig 멀티라인 문자열(`\\` 접두)로 박힌 JS 소스이고, readable/`_MIN` 두 카피를 수동 lockstep 유지하는 것이 이 파일의 관례입니다 (빌드타임 minifier 없음 — 리뷰에서 ~25쌍 전수 확인). 두 카피 모두 같은 위치에 같은 문장을 삽입했고, MIN 쪽은 긴 단일 문자열이라 char-exact diff 로 삽입 외 변경 없음을 검증했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)