### PR TITLE
fix(runtime): __wrapRegExp buildGroups 의 groups map 부재 가드 — cloneRegExp 패턴 크래시

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -687,6 +687,15 @@ pub const GENERATOR_RUNTIME_MIN = "var " ++ NAMES.GENERATOR_MIN ++ "=function(){
 /// plain RegExp 를 새로 만들어 exec override 를 우회 → `.groups` 전부 유실. species 가
 /// BabelRegExp 를 반환해야 `new BabelRegExp(re, flags)` 가 `_groups.get(re)` 폴백으로
 /// 원본의 groups map 을 물려받는다 (babel `_inherits` 동형).
+///
+/// groups map 부재 가드 (#4207): `new re.constructor(re.source, re.flags)` (lodash
+/// cloneRegExp 패턴) 처럼 source 문자열로 재구성하면 WeakMap 폴백이 miss → map 이
+/// undefined. babel 은 여기서 throw 하지만 native 정합이 우선 (의도적 divergence):
+/// buildGroups 는 map 부재 시 `result.groups` 패스스루 — strip 된 source clone 은
+/// native 와 같이 undefined 가 되고, 모던 엔진에서 named-group 패턴을 직접 넣어
+/// 재구성한 경우엔 native exec 가 만든 groups 를 클로버하지 않는다. `$<n>` 문자열
+/// 치환은 super 위임(super 가 match 의 groups 를 그대로 사용), 콜백 groups 인자는
+/// native 가 안 줄 때 생략.
 pub const WRAP_REGEXP_RUNTIME =
     \\var __wrapRegExp = function() {
     \\  __wrapRegExp = function(re, groups) { return new BabelRegExp(re, undefined, groups); };
@@ -711,6 +720,7 @@ pub const WRAP_REGEXP_RUNTIME =
     \\  BabelRegExp.prototype[Symbol.replace] = function(str, substitution) {
     \\    if (typeof substitution === "string") {
     \\      var groups = _groups.get(this);
+    \\      if (!groups) return _super[Symbol.replace].call(this, str, substitution);
     \\      return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)(>|$)/g, function(match, name, end) {
     \\        if (end === "") return match;
     \\        var group = groups[name];
@@ -721,8 +731,11 @@ pub const WRAP_REGEXP_RUNTIME =
     \\      return _super[Symbol.replace].call(this, str, function() {
     \\        var args = arguments;
     \\        if (typeof args[args.length - 1] !== "object") {
-    \\          args = [].slice.call(args);
-    \\          args.push(buildGroups(args, _this));
+    \\          var g = buildGroups(args, _this);
+    \\          if (g !== undefined) {
+    \\            args = [].slice.call(args);
+    \\            args.push(g);
+    \\          }
     \\        }
     \\        return substitution.apply(this, args);
     \\      });
@@ -731,6 +744,7 @@ pub const WRAP_REGEXP_RUNTIME =
     \\  };
     \\  function buildGroups(result, re) {
     \\    var g = _groups.get(re);
+    \\    if (!g) return result.groups;
     \\    return Object.keys(g).reduce(function(groups, name) {
     \\      var i = g[name];
     \\      if (typeof i === "number") groups[name] = result[i];
@@ -746,7 +760,7 @@ pub const WRAP_REGEXP_RUNTIME =
     \\};
     \\
 ;
-pub const WRAP_REGEXP_RUNTIME_MIN = "var " ++ NAMES.WRAP_REGEXP_MIN ++ "=function(){" ++ NAMES.WRAP_REGEXP_MIN ++ "=function(re,groups){return new BabelRegExp(re,undefined,groups)};var _super=RegExp.prototype;var _groups=new WeakMap();function BabelRegExp(re,flags,groups){var _this=new RegExp(re,flags);_groups.set(_this,groups||_groups.get(re));return Object.setPrototypeOf(_this,BabelRegExp.prototype)}Object.setPrototypeOf(BabelRegExp.prototype,RegExp.prototype);Object.setPrototypeOf(BabelRegExp,RegExp);BabelRegExp.prototype.exec=function(str){var result=_super.exec.call(this,str);if(result){result.groups=buildGroups(result,this);var indices=result.indices;if(indices)indices.groups=buildGroups(indices,this)}return result};BabelRegExp.prototype[Symbol.replace]=function(str,substitution){if(typeof substitution===\"string\"){var groups=_groups.get(this);return _super[Symbol.replace].call(this,str,substitution.replace(/\\$<([^>]+)(>|$)/g,function(match,name,end){if(end===\"\")return match;var group=groups[name];return Array.isArray(group)?\"$\"+group.join(\"$\"):typeof group===\"number\"?\"$\"+group:\"\"}))}else if(typeof substitution===\"function\"){var _this=this;return _super[Symbol.replace].call(this,str,function(){var args=arguments;if(typeof args[args.length-1]!==\"object\"){args=[].slice.call(args);args.push(buildGroups(args,_this))}return substitution.apply(this,args)})}return _super[Symbol.replace].call(this,str,substitution)};function buildGroups(result,re){var g=_groups.get(re);return Object.keys(g).reduce(function(groups,name){var i=g[name];if(typeof i===\"number\")groups[name]=result[i];else{var k=0;while(result[i[k]]===undefined&&k+1<i.length)k++;groups[name]=result[i[k]]}return groups},Object.create(null))}return " ++ NAMES.WRAP_REGEXP_MIN ++ ".apply(this,arguments)};";
+pub const WRAP_REGEXP_RUNTIME_MIN = "var " ++ NAMES.WRAP_REGEXP_MIN ++ "=function(){" ++ NAMES.WRAP_REGEXP_MIN ++ "=function(re,groups){return new BabelRegExp(re,undefined,groups)};var _super=RegExp.prototype;var _groups=new WeakMap();function BabelRegExp(re,flags,groups){var _this=new RegExp(re,flags);_groups.set(_this,groups||_groups.get(re));return Object.setPrototypeOf(_this,BabelRegExp.prototype)}Object.setPrototypeOf(BabelRegExp.prototype,RegExp.prototype);Object.setPrototypeOf(BabelRegExp,RegExp);BabelRegExp.prototype.exec=function(str){var result=_super.exec.call(this,str);if(result){result.groups=buildGroups(result,this);var indices=result.indices;if(indices)indices.groups=buildGroups(indices,this)}return result};BabelRegExp.prototype[Symbol.replace]=function(str,substitution){if(typeof substitution===\"string\"){var groups=_groups.get(this);if(!groups)return _super[Symbol.replace].call(this,str,substitution);return _super[Symbol.replace].call(this,str,substitution.replace(/\\$<([^>]+)(>|$)/g,function(match,name,end){if(end===\"\")return match;var group=groups[name];return Array.isArray(group)?\"$\"+group.join(\"$\"):typeof group===\"number\"?\"$\"+group:\"\"}))}else if(typeof substitution===\"function\"){var _this=this;return _super[Symbol.replace].call(this,str,function(){var args=arguments;if(typeof args[args.length-1]!==\"object\"){var g=buildGroups(args,_this);if(g!==undefined){args=[].slice.call(args);args.push(g)}}return substitution.apply(this,args)})}return _super[Symbol.replace].call(this,str,substitution)};function buildGroups(result,re){var g=_groups.get(re);if(!g)return result.groups;return Object.keys(g).reduce(function(groups,name){var i=g[name];if(typeof i===\"number\")groups[name]=result[i];else{var k=0;while(result[i[k]]===undefined&&k+1<i.length)k++;groups[name]=result[i[k]]}return groups},Object.create(null))}return " ++ NAMES.WRAP_REGEXP_MIN ++ ".apply(this,arguments)};";
 
 /// __await: async generator 안 await 표현의 wrapper. (#1911)
 /// `await x` 는 async generator body 안에서 `yield __await(x)` 로 변환되며,

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1455,6 +1455,33 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(result.runOutput).toBe('axa\nbbbb\nundefined');
     });
 
+    test('named group wrapper 를 source 로 재구성(cloneRegExp 패턴) — 크래시 없이 plain regex 동작 (#4207)', async () => {
+      // 회귀: buildGroups 가 groups map 부재 시 Object.keys(undefined) TypeError.
+      // strip 된 source 로 만든 clone 의 native 동작 = named group 없는 plain regex
+      // (groups undefined, $<n> verbatim, 콜백 groups 인자 생략).
+      const result = await bundleAndRun(
+        {
+          'index.ts': `
+            const re = /(?<y>\\d{4})-x/g;
+            const clone = new (re.constructor as RegExpConstructor)(re.source, re.flags);
+            console.log(clone.test('2024-x'));
+            clone.lastIndex = 0;
+            console.log(String(clone.exec('2024-x')?.groups));
+            clone.lastIndex = 0;
+            console.log('2024-x'.replace(clone, '[$<y>]'));
+            clone.lastIndex = 0;
+            console.log('2024-x'.replace(clone, function () { return 'fn:' + arguments.length; }));
+            console.log([...'2024-x'.matchAll(re)][0]?.groups?.y);
+          `,
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('true\nundefined\n[$<y>]\nfn:4\n2024');
+    });
+
     test('named backreference \\k<name>', async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
Closes #4207

## 문제

named-group 다운레벨 wrapper 를 source 문자열로 재구성하면 (`new re.constructor(re.source, re.flags)` — lodash `cloneRegExp`/`cloneDeep` 의 정확한 패턴) `_groups.get(re)` WeakMap 폴백이 miss 해 map 이 undefined 로 저장되고, 복제본의 **첫 `.test()`/`.exec()` 에서 `Object.keys(undefined)` TypeError**. babel `_wrapRegExp` 도 동일한 구멍.

## 루트커즈와 수정

map 부재 = "이 인스턴스에 대해 우리가 아는 named-group 정보가 없다" 이므로, 그 경우 native 동작에 위임하는 것이 정답:

1. **`buildGroups`**: map 부재 시 `result.groups` **패스스루**. strip 된 source clone 은 native 와 같이 `undefined`, 모던 엔진에서 named-group 패턴을 직접 넣어 재구성한 경우(`new re.constructor('(?<z>\d+)')`)엔 native exec 가 만든 groups 를 **클로버하지 않음**. 후자는 `/code-review max` 가 적발 — 초안(`return undefined`)은 크래시는 막지만 native groups 를 지웠음. 패스스루로 exec/replace/matchAll 이 cascade 로 함께 고쳐짐.
2. **`Symbol.replace` string 경로**: map 부재 시 super 위임 — super 가 match 의 groups 를 그대로 사용 (strip clone → `$<n>` verbatim, named source → native 치환). 둘 다 native 와 일치.
3. **`Symbol.replace` function 경로**: groups 인자를 native 가 주지 않는 경우 push 생략 (콜백 인자 수 native 일치).

babel 은 throw — native 정합 우선의 의도적 divergence (doc comment 에 기록).

## 검증

- 3개 모집단 × 5개 소비 지점 전부 node 24 native 와 byte-동일 (plain + `--minify`):
  - strip clone: test `true` / exec groups `undefined` / `$<y>` verbatim / fn 인자 4개
  - hand-written named source 재구성: groups `77` / `$<z>` 치환 / matchAll `88` (수정 전엔 초안에서 undefined 클로버)
  - 원본 wrapper: matchAll groups 무손상 (회귀 0)
- `/code-review max` 4-앵글: 23-시나리오 실증 스위트 (정상 wrapper 21 출력 main/native 동일 = 회귀 0, MIN 카피 char-diff = 의도 삽입 3개뿐, 구식 엔진 Symbol.replace shim 시뮬레이션 포함). 잔여 finding 은 `$$` escape pre-existing babel-parity (#4205 기록) 뿐.
- `zig build test` green + integration 172 pass.

## Zig 초보자용 포인트

이 fix 는 Zig 로직이 아니라 Zig 문자열 상수에 박힌 런타임 JS 수정입니다. readable/`_MIN` 두 카피를 수동 lockstep 으로 유지하는 파일 관례를 따랐고, MIN 쪽은 char-diff 로 삽입 외 변경 없음을 검증했습니다. `if (!g) return result.groups` 한 줄이 세 갈래(클론=undefined, 모던엔진 named source=native groups, 정상 wrapper=도달 안 함)를 모두 native 와 일치시키는 지점입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)