### PR TITLE
fix(regex_lower): extractNamedGroupMap 이 ES2025 inline modifier 그룹 (?i:...) 을 capturing 으로 오집계

### DIFF
--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -151,7 +151,12 @@ pub fn extractNamedGroupMap(allocator: std.mem.Allocator, pattern: []const u8) !
         }
         if (i + 2 < pattern.len and pattern[i + 1] == '?') {
             const tag = pattern[i + 2];
-            if (tag == ':' or tag == '=' or tag == '!') {
+            // ES2025 inline modifier 그룹 `(?ims-ims:...)` 도 non-capturing (#4202).
+            // 빠뜨리면 AST 카운터 (regexp/transform.zig 의 ignore_group skip) 와
+            // 인덱스가 어긋나 groups map / `$<name>` 재작성이 +1 시프트된다.
+            if (tag == ':' or tag == '=' or tag == '!' or
+                tag == 'i' or tag == 'm' or tag == 's' or tag == '-')
+            {
                 i += 1;
                 continue;
             }
@@ -438,6 +443,30 @@ test "#4198: duplicate named group mapping 은 occurrence 별 전부 보존" {
     try testing.expectEqual(@as(u32, 1), ng[0].index);
     try testing.expectEqualStrings("y", ng[1].name);
     try testing.expectEqual(@as(u32, 2), ng[1].index);
+}
+
+// #4202: ES2025 inline modifier 그룹 (?i:...) 은 non-capturing — capture 인덱스를
+// 차지하면 안 된다 (AST 카운터와 어긋나 groups map 이 +1 시프트되던 버그).
+test "#4202: (?i:...) modifier 그룹은 capture 인덱스 비차지" {
+    const r = try lower(testing.allocator, "/(?i:id)(?<y>\\d+)/", .{ .unsupported = .{ .regex_named_groups = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    defer if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expectEqualStrings("/(?i:id)(\\d+)/", r.text.?);
+    const ng = r.named_groups.?;
+    try testing.expectEqual(@as(usize, 1), ng.len);
+    try testing.expectEqualStrings("y", ng[0].name);
+    try testing.expectEqual(@as(u32, 1), ng[0].index);
+}
+
+test "#4202: (?im-s:...) / (?-i:...) 변형도 비차지 + \\k 인덱스와 일치" {
+    const r = try lower(testing.allocator, "/(?im-s:a)(?-i:b)(?<y>c)\\k<y>/", .{ .unsupported = .{ .regex_named_groups = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    defer if (r.named_groups) |ng| testing.allocator.free(ng);
+    // \k<y> 의 AST 경로와 groups map 의 텍스트 스캐너가 같은 인덱스(1)를 내야 한다.
+    try testing.expectEqualStrings("/(?im-s:a)(?-i:b)(c)\\1/", r.text.?);
+    const ng = r.named_groups.?;
+    try testing.expectEqual(@as(usize, 1), ng.len);
+    try testing.expectEqual(@as(u32, 1), ng[0].index);
 }
 
 test "#4198: replacement $<dup> → 모든 인덱스 이어붙임 ($1$2)" {

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -2997,6 +2997,24 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
   });
 
   describe('regex 추가 엣지', () => {
+    test('ES2025 inline modifier 그룹 (?i:) 은 capture 인덱스 비차지 (#4202)', async () => {
+      // 회귀: 텍스트 스캐너가 (?i:) 를 capturing 으로 오집계 → groups map 이
+      // {"y": 2} 로 +1 시프트 → groups.y undefined / $<y> 빈 치환.
+      const result = await bundleAndRun(
+        {
+          'index.ts': `
+            console.log('ID42'.match(/(?i:id)(?<y>\\d+)/)?.groups?.y);
+            console.log('ID42'.replace(/(?i:id)(?<y>\\d+)/, '[$<y>]'));
+          `,
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('42\n[42]');
+    });
+
     test('named group + lookbehind 조합', async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
Closes #4202

## 문제

`extractNamedGroupMap` 텍스트 스캐너의 `(?` 분기가 `:`/`=`/`!`/`<` tag 만 non-capturing 으로 알고 있어, ES2025 inline modifier 그룹(`(?i:` `(?im-s:` `(?-i:`)의 tag `i`/`m`/`s`/`-` 가 capturing 으로 흘러 **capture 인덱스를 차지**했다.

`\k<name>` 재작성이 쓰는 AST 카운터(regexp/transform.zig 의 `.ignore_group` skip)와 파서의 `preParseGroups` 는 정확해서, **같은 출력 안에서 groups map 만 +1 시프트**:

```console
$ # /(?i:x)(?<y>a)\k<y>/ --target=es2017 (수정 전)
__wrapRegExp(/(?i:x)(a)\1/, { "y": 2 })   # \k → \1 정확 / map → 2 오류
```

→ `groups.NAME === undefined`, `$<name>` 빈 치환 silent miscompile (`"ID42".match(/(?i:id)(?<y>\d+)/)?.groups?.y` → native `42` / zntc `undefined`).

## 루트커즈와 수정

5개 그룹 카운팅 walk 중 이 스캐너만 modifier tag 를 몰랐다 (리뷰에서 5개 전부 교차 검증: preParseGroups / parseGroup / collectNamed / backref 상한 / 본 스캐너). fix = tag 집합에 `i`/`m`/`s`/`-` 추가 — modifier 그룹은 non-capturing. #3508(ad-hoc walk 의도적 유지) 결정과 충돌 없음.

## 검증 (`/code-review max` 3-앵글, 전부 실증)

- ES2025 `(?` 후속 문법 전수 열거 — 새 skip 집합이 잘못 스킵하는 합법 capturing 구문 없음, invalid 형(`(?-:` `(?i)` `(?P<` 등)은 lexer validate 가 모두 거부 (node 24 와 reject 동치 확인).
- 중첩 capture `/(?i:(a))(?<y>B)\k<y>/` → map `{y:2}` = AST `\2` = native, byte-동일.
- groups map 인덱스 2→1, match/replace 정적·런타임/regex_var_map 경로/Hermes 타겟 전부 native 일치.
- 기존 코퍼스에 modifier 패턴 의존 없음 확인 (test262 제외 grep).
- `zig build test` green + integration 173 pass (유닛 2 + integration 1 추가).
- 리뷰가 적발한 인접 pre-existing 버그는 이슈 분리: #4210 (modifier 문법 gate 부재), **#4211 (transform 이 modifier 비트 무시 — `(?-s:)` 안 dot 재작성 / `(?-i:)` 안 iu fold 확장 silent miscompile)**.

## Zig 초보자용 포인트

이 스캐너는 의도적으로 ad-hoc 텍스트 walk 입니다 (#3508 — AST 화하면 flags 없는 `regex_var_map` 경로에서 회귀). 그래서 수정도 walk 의 tag 집합 1분기로 한정했고, 두 번째 유닛 테스트가 "AST 경로(\k)와 텍스트 스캐너(map)가 같은 인덱스를 내는가" 를 cross-consistency 가드로 고정합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)