### PR TITLE
fix(transformer): replace template replacement 의 unsafe 문자 시 정적 재작성 bail

### DIFF
--- a/src/transformer/transformer/regex.zig
+++ b/src/transformer/transformer/regex.zig
@@ -136,6 +136,14 @@ fn extractReplacementContent(self: *Transformer, arg_idx: NodeIndex) Error!?Repl
             const body = raw[1 .. raw.len - 1];
             // 본문 안에 ${ 가 있으면 보간 있는 케이스 — 안전하게 fallback.
             if (std.mem.indexOf(u8, body, "${") != null) return null;
+            // #4203: template 본문은 `"` 재인용 시 escape 없이 verbatim emit 되므로,
+            // `"`/개행이 있으면 깨진 string literal 이 되고, `\r`(cooked CRLF→LF 정규화)
+            // / U+2028/9(pre-ES2019 string 에서 SyntaxError) 는 의미가 달라진다.
+            // 해당 문자는 정적 재작성 포기 — 런타임 __wrapRegExp Symbol.replace 가
+            // 동일 의미로 처리 (틀린 출력 0 원칙, #3509 게이트 선례).
+            if (std.mem.indexOfAny(u8, body, "\"\r\n") != null or
+                std.mem.indexOf(u8, body, "\u{2028}") != null or
+                std.mem.indexOf(u8, body, "\u{2029}") != null) return null;
             const owned = try self.allocator.dupe(u8, body);
             return .{ .content = owned, .quote = '"', .is_template = true };
         },

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -3130,6 +3130,26 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(result.runOutput).toBe('[42:foo]');
     });
 
+    test('template replacement 에 " / 개행 — 정적 재작성 bail, 런타임 경로로 정상 (#4203)', async () => {
+      // 회귀: template 본문을 " 재인용 시 escape 없이 verbatim emit → 본문에
+      // " 또는 raw 개행이 있으면 SyntaxError 산출물. bail 후엔 template 그대로
+      // 유지되어 __wrapRegExp Symbol.replace 가 런타임에 동일 의미로 처리.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'console.log("x9".replace(/(?<y>\\d+)/, `a"b $<y>`));',
+            'console.log("x9".replace(/(?<y>\\d+)/, `l1',
+            'l2 $<y>`));',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('xa"b 9\nxl1\nl2 9');
+    });
+
     test('let 변수 regex는 추적 안 됨 (재할당 가능)', async () => {
       // let 은 재할당 가능 → 추적 비활성. ES2018+ 타겟이라 named group 그대로 유지.
       const result = await bundleAndRun(


### PR DESCRIPTION
Closes #4203

## 문제

`tryRewriteReplaceNamedRefs` 가 `.replace(re, \`...\$<name>...\`)` 의 template 본문을 `"` 재인용에 **escape 없이 verbatim** emit 했다. template 에서 합법인 문자들이 산출물을 깨뜨림:

- `"` / raw 개행 → 깨진 string literal = **SyntaxError 빌드 산출물** (실증: `missing ) after argument list` / `Invalid or unexpected token`)
- `\r` → cooked 정규화(CRLF→LF) 미적용으로 의미 변경
- U+2028/9 → pre-ES2019 string 에서 SyntaxError

## 루트커즈와 수정

근본 문제는 "template cooked 의미를 string literal 로 재현"이 자명하지 않다는 것 (escape 만으론 CRLF 정규화 미해결). cooked 재구현 대신 **해당 문자 감지 시 정적 재작성을 bail** — template 이 원형 유지되고 `__wrapRegExp` 의 `Symbol.replace` 런타임 경로(#4207 까지 검증, 의미 정확)가 처리한다. "틀린 출력 0" 게이트 원칙 (#3509 `astral_u_incomplete` 선례). 안전한 template 은 기존대로 정적 재작성 유지 (`plain $<y>` → `"plain $1"` 확인).

## 검증 (`/code-review max` 3-앵글 실증)

- bail 문자 집합 완전성: template→string verbatim 복사가 깨지거나 의미가 변하는 문자 전수 열거 — LineTerminator 4종 + `"` 로 완전 (escape sequence 는 template ⊂ string 문법이라 cooked 동일, invalid escape 는 렉서가 선거부 실증). UTF-8 부분매치 오탐 불가(E2 lead byte 자기동기성), escape 텍스트 `\u{2028}` 오-bail 없음 실증.
- 9-케이스 매트릭스 (`"`/CRLF/lone CR/U+2028/line continuation/부분 재작성/`\$<y>` 등) native(node 24) byte-동일. es5(template 자체 lowering 경유)/minify/replaceAll/const 변수 경로 동일.
- 기존에 template 정적 재작성을 전제한 테스트/스냅샷 없음 확인. zig green + integration 174 pass.
- 리뷰 파생 pre-existing 이슈 분리: **#4213** (es5 template 다운레벨 cooked CR/CRLF→LF 정규화 누락 — bail 경로의 es5 하단), **#4214** (재작성 합성 string literal 의 visit 우회 → `\u{...}` es5 미다운레벨).

## Zig 초보자용 포인트

`"\u{2028}"` Zig 문자열 리터럴은 UTF-8 바이트(E2 80 A8)로 인코딩되므로 `std.mem.indexOf` 바이트 검색이 정확히 그 코드포인트만 매치합니다 (UTF-8 자기동기성 — lead byte 가 continuation 위치에 못 옴). `indexOfAny` 는 단일 바이트 집합용이라 ASCII 3종만 거기서 처리합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)