### PR TITLE
fix(regexp): 그룹 이름 비교를 canonical (escape 디코드) 코드포인트 시퀀스로 통일

### DIFF
--- a/src/regexp/group_name.zig
+++ b/src/regexp/group_name.zig
@@ -1,0 +1,136 @@
+//! ES regex group name 의 canonical (escape-decoded) 비교/디코드 (#4201).
+//!
+//! 그룹 이름은 `\uHHHH`(surrogate pair 포함) / `\u{...}` escape 를 허용하고,
+//! 스펙상 이름의 정체성은 **디코드된 코드포인트 시퀀스**다 — `(?<y>)` 와
+//! `(?<y>)` 는 같은 이름. raw byte 비교는 escape 표기가 섞이면
+//! dedup(중복 키 객체)/`$<name>` 매칭/파서 중복 검증이 전부 어긋난다.
+//!
+//! 사용처: regexp/parser.zig (중복 검증) · regexp/transform.zig (\k 해석) ·
+//! transformer/regex_lower.zig ($<name> 재작성) · transformer/node_dispatch.zig
+//! (groups map dedup + canonical key emit).
+
+const std = @import("std");
+
+/// raw 표기에서 다음 코드포인트를 디코드. `\uHHHH`(상위 surrogate 면 후속
+/// `\uHHHH` 와 pair 결합) / `\u{...}` / raw UTF-8 모두 처리.
+/// 잘못된 시퀀스면 null — 호출자는 raw-byte 동작으로 폴백한다 (이름은 이미
+/// 파서 검증을 통과한 상태라 실전에선 도달하지 않는 방어선).
+fn nextCodepoint(s: []const u8, i: *usize) ?u21 {
+    if (s[i.*] == '\\' and i.* + 1 < s.len and s[i.* + 1] == 'u') {
+        var j = i.* + 2;
+        if (j < s.len and s[j] == '{') {
+            j += 1;
+            const hex_start = j;
+            var cp: u32 = 0;
+            while (j < s.len and s[j] != '}') : (j += 1) {
+                const d = std.fmt.charToDigit(s[j], 16) catch return null;
+                cp = cp * 16 + d;
+                if (cp > 0x10FFFF) return null;
+            }
+            if (j >= s.len or j == hex_start) return null;
+            i.* = j + 1;
+            return @intCast(cp);
+        }
+        if (j + 4 > s.len) return null;
+        var cp: u32 = 0;
+        for (s[j .. j + 4]) |c| {
+            const d = std.fmt.charToDigit(c, 16) catch return null;
+            cp = cp * 16 + d;
+        }
+        i.* = j + 4;
+        // 상위 surrogate + 후속 \uDC00..\uDFFF → astral 코드포인트로 결합.
+        if (cp >= 0xD800 and cp <= 0xDBFF and i.* + 6 <= s.len and
+            s[i.*] == '\\' and s[i.* + 1] == 'u' and s[i.* + 2] != '{')
+        {
+            var lo: u32 = 0;
+            var ok = true;
+            for (s[i.* + 2 .. i.* + 6]) |c| {
+                const d = std.fmt.charToDigit(c, 16) catch {
+                    ok = false;
+                    break;
+                };
+                lo = lo * 16 + d;
+            }
+            if (ok and lo >= 0xDC00 and lo <= 0xDFFF) {
+                i.* += 6;
+                return @intCast(0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00));
+            }
+        }
+        return @intCast(cp);
+    }
+    const len = std.unicode.utf8ByteSequenceLength(s[i.*]) catch return null;
+    if (i.* + len > s.len) return null;
+    const cp = std.unicode.utf8Decode(s[i.* .. i.* + len]) catch return null;
+    i.* += len;
+    return cp;
+}
+
+/// 두 raw 표기가 canonical 하게 같은 그룹 이름인가 (코드포인트 시퀀스 비교).
+/// 어느 쪽이든 디코드 실패 시 raw-byte 비교로 폴백.
+pub fn eqlCanonical(a: []const u8, b: []const u8) bool {
+    var ia: usize = 0;
+    var ib: usize = 0;
+    while (true) {
+        const a_end = ia >= a.len;
+        const b_end = ib >= b.len;
+        if (a_end and b_end) return true;
+        if (a_end != b_end) return false;
+        const ca = nextCodepoint(a, &ia) orelse return std.mem.eql(u8, a, b);
+        const cb = nextCodepoint(b, &ib) orelse return std.mem.eql(u8, a, b);
+        if (ca != cb) return false;
+    }
+}
+
+/// raw 표기를 canonical UTF-8 로 디코드해 out 에 append (groups map 키 emit 용).
+/// escape 없는 이름은 byte-identical. 디코드/인코드 실패 구간은 raw 그대로 복사
+/// (lone surrogate escape 등 — JS string 에선 여전히 유효한 표기).
+pub fn appendCanonical(allocator: std.mem.Allocator, out: *std.ArrayList(u8), raw: []const u8) !void {
+    var i: usize = 0;
+    while (i < raw.len) {
+        const start = i;
+        const cp = nextCodepoint(raw, &i) orelse {
+            try out.appendSlice(allocator, raw[start..]);
+            return;
+        };
+        var buf: [4]u8 = undefined;
+        const n = std.unicode.utf8Encode(cp, &buf) catch {
+            try out.appendSlice(allocator, raw[start..i]);
+            continue;
+        };
+        try out.appendSlice(allocator, buf[0..n]);
+    }
+}
+
+// ─── 테스트 ───
+
+const testing = std.testing;
+
+test "eqlCanonical: escape 표기 동치" {
+    try testing.expect(eqlCanonical("y", "\\u0079"));
+    try testing.expect(eqlCanonical("\\u0079", "\\u{79}"));
+    try testing.expect(eqlCanonical("year", "\\u0079ear"));
+    try testing.expect(!eqlCanonical("y", "\\u007A")); // z
+    try testing.expect(!eqlCanonical("y", "yy"));
+    try testing.expect(eqlCanonical("한", "\\uD55C"));
+    // astral: 𝑦 (U+1D466) = 𝑦 pair = \u{1D466}
+    try testing.expect(eqlCanonical("\\uD835\\uDC66", "\\u{1D466}"));
+    try testing.expect(eqlCanonical("𝑦", "\\uD835\\uDC66"));
+}
+
+test "eqlCanonical: 디코드 실패 시 raw 폴백" {
+    try testing.expect(eqlCanonical("\\uZZZZ", "\\uZZZZ"));
+    try testing.expect(!eqlCanonical("\\uZZZZ", "y"));
+}
+
+test "appendCanonical: escape → UTF-8, plain 은 byte-identical" {
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try appendCanonical(testing.allocator, &out, "\\u0079ear");
+    try testing.expectEqualStrings("year", out.items);
+    out.clearRetainingCapacity();
+    try appendCanonical(testing.allocator, &out, "plain한");
+    try testing.expectEqualStrings("plain한", out.items);
+    out.clearRetainingCapacity();
+    try appendCanonical(testing.allocator, &out, "\\u{1D466}");
+    try testing.expectEqualStrings("𝑦", out.items);
+}

--- a/src/regexp/group_name.zig
+++ b/src/regexp/group_name.zig
@@ -13,6 +13,11 @@ const std = @import("std");
 
 /// raw 표기에서 다음 코드포인트를 디코드. `\uHHHH`(상위 surrogate 면 후속
 /// `\uHHHH` 와 pair 결합) / `\u{...}` / raw UTF-8 모두 처리.
+///
+/// NOTE: escape 디코드는 string_escape.decodeUnicodeHexEscape / parser.zig
+/// parseGroupNameChar 와 의도적 별도 구현 — RegExp HexTrailSurrogate 는
+/// Hex4Digits 전용이라 brace-trail 결합을 막는 가드(`s[i+2] != '{'`)가 필요하고,
+/// 셋의 overflow/empty 처리 정합은 각자의 in-loop cap 으로 유지한다.
 /// 잘못된 시퀀스면 null — 호출자는 raw-byte 동작으로 폴백한다 (이름은 이미
 /// 파서 검증을 통과한 상태라 실전에선 도달하지 않는 방어선).
 fn nextCodepoint(s: []const u8, i: *usize) ?u21 {
@@ -104,6 +109,19 @@ pub fn appendCanonical(allocator: std.mem.Allocator, out: *std.ArrayList(u8), ra
 // ─── 테스트 ───
 
 const testing = std.testing;
+
+test "eqlCanonical: 인자 순서 대칭 + prefix 불일치" {
+    try testing.expect(eqlCanonical("\\u0079", "y")); // 역순
+    try testing.expect(!eqlCanonical("ye", "\\u0079"));
+    try testing.expect(!eqlCanonical("\\u0079e", "y"));
+}
+
+test "appendCanonical: surrogate-pair escape → astral UTF-8" {
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try appendCanonical(testing.allocator, &out, "\\uD835\\uDC66");
+    try testing.expectEqualStrings("\xF0\x9D\x91\xA6", out.items); // 𝑦 U+1D466
+}
 
 test "eqlCanonical: escape 표기 동치" {
     try testing.expect(eqlCanonical("y", "\\u0079"));

--- a/src/regexp/mod.zig
+++ b/src/regexp/mod.zig
@@ -27,6 +27,7 @@ pub const transform = @import("transform.zig");
 pub const codepoint_set = @import("codepoint_set.zig");
 pub const iu_case_fold = @import("iu_case_fold.zig");
 pub const unicode_property = @import("unicode_property.zig");
+pub const group_name = @import("group_name.zig");
 
 /// 정규식 리터럴을 검증한다.
 /// pattern: `/` 사이의 패턴 텍스트 (예: "\\d{4}")
@@ -98,6 +99,7 @@ test {
     _ = unicode_property;
 
     // test files
+    _ = @import("group_name.zig");
     _ = @import("parser_test.zig");
     _ = @import("unicode_property_test.zig");
     _ = @import("flags_test.zig");

--- a/src/regexp/parser.zig
+++ b/src/regexp/parser.zig
@@ -1484,6 +1484,13 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                                 return false;
                             };
                             codepoint = codepoint * 16 + d;
+                            // #4201: in-loop cap — 9+ hex digit 에서 u32 오버플로우
+                            // (Debug 패닉 / ReleaseFast accept-invalid). group_name.zig
+                            // nextCodepoint 와 동일 가드.
+                            if (codepoint > 0x10FFFF) {
+                                self.setError("invalid unicode escape in group name");
+                                return false;
+                            }
                             self.advance();
                         }
                         if (!self.eat('}') or self.pos == hex_start + 1) {

--- a/src/regexp/parser.zig
+++ b/src/regexp/parser.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const char_helpers = @import("char_helpers.zig");
+const group_name = @import("group_name.zig");
 const flags_mod = @import("flags.zig");
 const Flags = flags_mod.Flags;
 
@@ -342,7 +343,8 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                 for (self.named_refs.items()) |ref_name| {
                     var found = false;
                     for (self.named_groups.items()) |entry| {
-                        if (std.mem.eql(u8, ref_name, entry.name)) {
+                        // #4201: 이름 정체성은 escape 디코드된 코드포인트 시퀀스
+                        if (group_name.eqlCanonical(ref_name, entry.name)) {
                             found = true;
                             break;
                         }
@@ -1297,7 +1299,8 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                         const cur_depth = @min(self.alt_depth, 7);
                         const cur_path = self.alt_indices[0 .. cur_depth + 1];
                         for (self.named_groups.items()) |existing| {
-                            if (std.mem.eql(u8, existing.name, name)) {
+                            // #4201: 이름 정체성은 escape 디코드된 코드포인트 시퀀스
+                            if (group_name.eqlCanonical(existing.name, name)) {
                                 const ex_path = existing.alt_path[0 .. existing.alt_depth + 1];
                                 if (!canParticipate(ex_path, cur_path)) {
                                     self.setError("duplicate named capturing group in same alternative");

--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -12,6 +12,7 @@ const std = @import("std");
 const ast = @import("ast.zig");
 const cps = @import("codepoint_set.zig");
 const iu_fold = @import("iu_case_fold.zig");
+const group_name = @import("group_name.zig");
 
 const NodeIndex = ast.NodeIndex;
 const Node = ast.Node;
@@ -339,7 +340,7 @@ const T = struct {
                     var count: u32 = 0;
                     var first: u32 = 0;
                     for (self.names) |g| {
-                        if (std.mem.eql(u8, g.name, name)) {
+                        if (group_name.eqlCanonical(g.name, name)) {
                             if (count == 0) first = g.index;
                             count += 1;
                         }
@@ -356,7 +357,7 @@ const T = struct {
                         var refs: std.ArrayList(u32) = .empty;
                         defer refs.deinit(self.b.a);
                         for (self.names) |g| {
-                            if (std.mem.eql(u8, g.name, name)) {
+                            if (group_name.eqlCanonical(g.name, name)) {
                                 const r = try self.b.add(.{ .tag = .indexed_reference, .span = n.span, .data = .{ g.index, 0, 0 } });
                                 try refs.append(self.b.a, @intFromEnum(r));
                             }

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -16,6 +16,7 @@
 const std = @import("std");
 const compat = @import("compat.zig");
 const regexp = @import("../regexp/mod.zig");
+const group_name = @import("../regexp/group_name.zig");
 
 pub const Options = struct {
     unsupported: compat.UnsupportedFeatures,
@@ -200,7 +201,7 @@ pub fn rewriteReplacementNamedRefs(
                 // 빈 문자열 — babel __wrapRegExp 의 `group.join("$")` 동형 (#4198).
                 var found = false;
                 for (mapping) |m| {
-                    if (std.mem.eql(u8, m.name, name)) {
+                    if (group_name.eqlCanonical(m.name, name)) {
                         var buf: [16]u8 = undefined;
                         const s = std.fmt.bufPrint(&buf, "${d}", .{m.index}) catch unreachable;
                         try out.appendSlice(allocator, s);
@@ -443,6 +444,23 @@ test "#4198: duplicate named group mapping 은 occurrence 별 전부 보존" {
     try testing.expectEqual(@as(u32, 1), ng[0].index);
     try testing.expectEqualStrings("y", ng[1].name);
     try testing.expectEqual(@as(u32, 2), ng[1].index);
+}
+
+// #4201: 그룹 이름 정체성 = escape 디코드된 코드포인트 시퀀스.
+test "#4201: \\k<\\u0079> 가 (?<y>) 를 canonical 매칭" {
+    const out = (try runLower("/(?<y>a)b\\k<\\u0079>/", .{ .regex_named_groups = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(a)b\\1/", out);
+}
+
+test "#4201: escape-aliased duplicate — $<y> 가 양쪽 occurrence 모두 매칭" {
+    const mapping = [_]NamedGroupMapping{
+        .{ .name = "y", .index = 1 },
+        .{ .name = "\\u0079", .index = 2 },
+    };
+    const out = (try rewriteReplacementNamedRefs(testing.allocator, "[$<y>]", &mapping)).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("[$1$2]", out);
 }
 
 // #4202: ES2025 inline modifier 그룹 (?i:...) 은 non-capturing — capture 인덱스를

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -27,6 +27,7 @@ const es2015_destructuring = @import("../es2015_destructuring.zig");
 const es2015_class = @import("../es2015_class.zig");
 const es2015_generator = @import("../es2015_generator.zig");
 const regex_lower = @import("../regex_lower.zig");
+const group_name = @import("../../regexp/group_name.zig");
 const unicode_escape_lower = @import("../unicode_escape_lower.zig");
 const es2022_tla = @import("../es2022_tla.zig");
 const jsx_lowering_mod = @import("../jsx_lowering.zig");
@@ -753,20 +754,24 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
                     // 값을 이미 지원 (babel 동형).
                     var seen_before = false;
                     for (ng[0..ei]) |prev| {
-                        if (std.mem.eql(u8, prev.name, entry.name)) {
+                        // #4201: 이름 정체성 = escape 디코드된 코드포인트 시퀀스
+                        // ((?<y>) ≡ (?<y>)). raw byte 비교는 escape 표기 혼용 시
+                        // dedup 을 놓쳐 중복 JS 키(last-win) miscompile 재발.
+                        if (group_name.eqlCanonical(prev.name, entry.name)) {
                             seen_before = true;
                             break;
                         }
                     }
                     if (seen_before) continue;
-                    var stack_buf: [256]u8 = undefined;
-                    const need_heap = entry.name.len + 2 > stack_buf.len;
-                    const quoted = if (need_heap)
-                        try std.fmt.allocPrint(self.allocator, "\"{s}\"", .{entry.name})
-                    else
-                        std.fmt.bufPrint(&stack_buf, "\"{s}\"", .{entry.name}) catch unreachable;
-                    defer if (need_heap) self.allocator.free(quoted);
-                    const key_span = try self.ast.addString(quoted);
+                    // 키는 canonical UTF-8 로 emit — escape 표기가 키에 남으면 JS 쪽
+                    // 디코드 결과가 같은 키로 충돌할 수 있다. escape 없는 이름은
+                    // byte-identical (#4201).
+                    var quoted: std.ArrayList(u8) = .empty;
+                    defer quoted.deinit(self.allocator);
+                    try quoted.append(self.allocator, '"');
+                    try group_name.appendCanonical(self.allocator, &quoted, entry.name);
+                    try quoted.append(self.allocator, '"');
+                    const key_span = try self.ast.addString(quoted.items);
                     const key_node = try self.ast.addNode(.{
                         .tag = .string_literal,
                         .span = key_span,
@@ -774,7 +779,7 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
                     });
                     dup_vals.clearRetainingCapacity();
                     for (ng[ei..]) |later| {
-                        if (std.mem.eql(u8, later.name, entry.name)) {
+                        if (group_name.eqlCanonical(later.name, entry.name)) {
                             try dup_vals.append(self.allocator, try es_helpers.makeNumericLiteral(self, later.index));
                         }
                     }

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -740,7 +740,7 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
 
                 // {name1: 1, name2: 2, ...} object literal 합성. property key 는 quoted
                 // string literal (`"name"`) — reserved word/하이픈 등 고려 않게 일관 처리.
-                // identifier 는 실무상 짧으므로 256 byte 스택 버퍼로 heap alloc 회피.
+                // 키는 canonical UTF-8 디코드라 ArrayList 합성 (#4201).
                 const props_top = self.scratch.items.len;
                 defer self.scratch.shrinkRetainingCapacity(props_top);
                 // ES2025 duplicate named group 의 value 노드 수집 버퍼.

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1482,6 +1482,26 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(result.runOutput).toBe('true\nundefined\n[$<y>]\nfn:4\n2024');
     });
 
+    test('escape 표기 그룹 이름 — canonical 동치 (dedup/replace/\\k) (#4201)', async () => {
+      // 회귀: 이름 비교가 raw byte 라 (?<y>) 와 (?<\u0079>) 가 다른 이름 취급
+      // → 중복 JS 키(last-win) miscompile 재발 + $<y> 재작성 누락 + \k 매칭 실패.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            String.raw`const re = /(?<y>\d{4})-a|(?<\u0079>\d{4})-b/;`,
+            String.raw`console.log('2024-a'.match(re)?.groups?.y);`,
+            String.raw`console.log('2025-b'.replace(re, '<$<y>>'));`,
+            String.raw`console.log('aba'.match(/(?<y>a)b\k<\u0079>/)?.[0]);`,
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('2024\n<2025>\naba');
+    });
+
     test('named backreference \\k<name>', async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
Closes #4201

## 문제

그룹 이름은 `\uHHHH`(surrogate pair)/`\u{...}` escape 를 허용하고 스펙상 정체성은 **디코드된 코드포인트 시퀀스**인데 (`(?<y>)` ≡ `(?<y>)`), 이름을 다루는 **5개 지점이 전부 raw byte 비교**였다:

| 지점 | 증상 (전부 실증) |
|---|---|
| parser 중복 검증 | 같은 alternative escape-aliased dup 수용 — native SyntaxError 와 불일치 |
| parser `\k` 존재 검증 | `\k<y>` 가 "group not defined" **오거부** (유효 JS 를 모든 타겟에서 거부 — 리뷰 parity matrix 가 main 에서 확인) |
| transform `\k` 해석 | canonical 매칭 실패 |
| `$<name>` 정적 재작성 | escape 표기 occurrence 누락 → `$1` 만 emit |
| node_dispatch dedup/키 | 병합 누락 → `{"y":1,"y":2}` 중복 JS 키 last-win (#4198 miscompile 재발) + es5 에서 `"\u{79}"` 키는 SyntaxError |

## 루트커즈와 수정

`src/regexp/group_name.zig` 신설 — `eqlCanonical`(allocation-free 스트리밍 코드포인트 비교, 디코드 실패 시 raw 폴백) + `appendCanonical`(키 emit 용 canonical UTF-8 디코드) — 후 5개 지점 일괄 적용. groups map 키는 canonical UTF-8 로 emit (`{"year": 1}`). surrogate pair 결합은 스펙대로 Hex4Digits trail 전용 (`\uD835\u{DC66}` 비결합 — native SyntaxError 동치).

**+ 리뷰가 재현한 인접 크래시 fix (2번째 커밋)**: `parseGroupNameChar` 의 `\u{...}` hex 누적이 in-loop cap 없이 u32 오버플로우 — `/(?<\u{100000000}>x)/` 입력에 Debug 패닉(프로세스 다운)/ReleaseFast accept-invalid. group_name 과 동일 가드로 graceful SyntaxError 화 (native 동치).

## 검증 (`/code-review max` 3-앵글, main 바이너리 대비 parity matrix 포함)

- (a) plain dup **byte-identical to main** (회귀 0) (b) escape-aliased dup match/replace/matchAll (c) `\k<y>` (d) `$<y>` (e) canonical 키 (f) astral(`𝑦` 3-표기)/한글 (g) `--ascii-only` 재escape (h) `--minify` — 전부 native(node 24) 일치.
- 디코더 14-케이스 corner probe (overflow/empty/unterminated/lone surrogate/brace-trail) + 파서와의 정합 교차 검증. lexer validate 경로 allocation-free 유지, 2000-리터럴 합성 벤치 +0.9ms (실코퍼스 ≈0).
- zig green + integration 175 pass (유닛 7 + integration 1 추가).
- 파생: #4216 (`\x79` string-escape 표기 — true-ES5 한정 잔존, 협소) 분리.

## Zig 초보자용 포인트

`eqlCanonical` 은 두 슬라이스를 각자 인덱스로 전진시키며 코드포인트 단위로 비교해 **할당이 전혀 없습니다** — 렉서 validate 핫패스에 들어가도 안전한 이유입니다. `appendCanonical` 만 출력 버퍼가 필요해 호출자(ArrayList) 가 메모리를 댑니다. 디코더를 string_escape/parser 와 의도적으로 분리한 사유(RegExp HexTrailSurrogate 는 4-digit 전용)는 모듈 주석에 박아 두었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)