### PR TITLE
fix(transformer): __proto__ 그룹명의 groups map 키를 computed key / JSON.parse 로 emit

### DIFF
--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -738,6 +738,78 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
             if (result.named_groups) |ng| {
                 self.runtime_helpers.wrap_regex = true;
 
+                // 그룹 이름이 문자 그대로 __proto__ 면 객체 리터럴 키는 (quoted 포함)
+                // B.3.1 proto setter 라 own property 가 안 생긴다 (#4204). es2015+ 는
+                // computed key 로 회피하지만 computed key 자체가 ES2015 문법이라
+                // es5 (object_extensions 미지원) 는 JSON.parse('{...}') 폴백 — B.3.1
+                // 은 JSON.parse 평가를 면제하므로 모든 키가 own property 로 생긴다.
+                // (canonical 이름은 quote/backslash/개행 불포함 → escape 불요)
+                var has_proto = false;
+                for (ng) |entry| {
+                    if (group_name.eqlCanonical(entry.name, "__proto__")) {
+                        has_proto = true;
+                        break;
+                    }
+                }
+                if (has_proto and self.options.unsupported.object_extensions) {
+                    var json: std.ArrayList(u8) = .empty;
+                    defer json.deinit(self.allocator);
+                    try json.appendSlice(self.allocator, "'{");
+                    var first = true;
+                    for (ng, 0..) |entry, ei| {
+                        var seen_before = false;
+                        for (ng[0..ei]) |prev| {
+                            if (group_name.eqlCanonical(prev.name, entry.name)) {
+                                seen_before = true;
+                                break;
+                            }
+                        }
+                        if (seen_before) continue;
+                        if (!first) try json.append(self.allocator, ',');
+                        first = false;
+                        try json.append(self.allocator, '"');
+                        try group_name.appendCanonical(self.allocator, &json, entry.name);
+                        try json.appendSlice(self.allocator, "\":");
+                        var count: u32 = 0;
+                        for (ng[ei..]) |later| {
+                            if (group_name.eqlCanonical(later.name, entry.name)) count += 1;
+                        }
+                        if (count > 1) try json.append(self.allocator, '[');
+                        var first_idx = true;
+                        for (ng[ei..]) |later| {
+                            if (group_name.eqlCanonical(later.name, entry.name)) {
+                                if (!first_idx) try json.append(self.allocator, ',');
+                                first_idx = false;
+                                try json.print(self.allocator, "{d}", .{later.index});
+                            }
+                        }
+                        if (count > 1) try json.append(self.allocator, ']');
+                    }
+                    try json.appendSlice(self.allocator, "}'");
+                    const json_span = try self.ast.addString(json.items);
+                    const json_node = try self.ast.addNode(.{
+                        .tag = .string_literal,
+                        .span = json_span,
+                        .data = .{ .string_ref = json_span },
+                    });
+                    const json_ident_span = try self.ast.addString("JSON");
+                    const json_ident = try self.ast.addNode(.{
+                        .tag = .identifier_reference,
+                        .span = json_ident_span,
+                        .data = .{ .string_ref = json_ident_span },
+                    });
+                    const parse_span = try self.ast.addString("parse");
+                    const parse_ident = try self.ast.addNode(.{
+                        .tag = .identifier_reference,
+                        .span = parse_span,
+                        .data = .{ .string_ref = parse_span },
+                    });
+                    const json_parse = try es_helpers.makeStaticMember(self, json_ident, parse_ident, node.span);
+                    const map_call = try es_helpers.makeCallExpr(self, json_parse, &.{json_node}, node.span);
+                    const wrap_ref_json = try es_helpers.makeRuntimeHelperRef(self, "__wrapRegExp");
+                    break :blk try es_helpers.makeCallExpr(self, wrap_ref_json, &.{ new_regex, map_call }, node.span);
+                }
+
                 // {name1: 1, name2: 2, ...} object literal 합성. property key 는 quoted
                 // string literal (`"name"`) — reserved word/하이픈 등 고려 않게 일관 처리.
                 // 키는 canonical UTF-8 디코드라 ArrayList 합성 (#4201).
@@ -772,11 +844,28 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
                     try group_name.appendCanonical(self.allocator, &quoted, entry.name);
                     try quoted.append(self.allocator, '"');
                     const key_span = try self.ast.addString(quoted.items);
-                    const key_node = try self.ast.addNode(.{
+                    const str_key = try self.ast.addNode(.{
                         .tag = .string_literal,
                         .span = key_span,
                         .data = .{ .string_ref = key_span },
                     });
+                    // 그룹 이름이 문자 그대로 __proto__ 면 (합법 ES 이름) 객체 리터럴
+                    // 키 `"__proto__"` 는 B.3.1 proto setter 로 동작 — own property 가
+                    // 안 생기고 (array 값이면 map 의 prototype 오염) groups 전체 무효.
+                    // computed key `["__proto__"]` 는 항상 own property 정의 (#4204).
+                    // minify 는 computed key 를 변형 대상에서 제외하므로 보존됨.
+                    // 단 computed key 자체가 ES2015 문법 — es5 등 object_extensions
+                    // 미지원 타겟에선 quoted key 폴백 (합성 노드는 visit 을 안 거쳐
+                    // es2015_computed lowering 미적용 — #4214 와 같은 클래스).
+                    const key_node = if (!self.options.unsupported.object_extensions and
+                        std.mem.eql(u8, quoted.items[1 .. quoted.items.len - 1], "__proto__"))
+                        try self.ast.addNode(.{
+                            .tag = .computed_property_key,
+                            .span = node.span,
+                            .data = .{ .unary = .{ .operand = str_key, .flags = 0 } },
+                        })
+                    else
+                        str_key;
                     dup_vals.clearRetainingCapacity();
                     for (ng[ei..]) |later| {
                         if (group_name.eqlCanonical(later.name, entry.name)) {

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1502,6 +1502,51 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(result.runOutput).toBe('2024\n<2025>\naba');
     });
 
+    test('group 이름 __proto__ — computed key 로 emit, proto setter 회피 (#4204)', async () => {
+      // 회귀: 객체 리터럴 키 "__proto__" 는 B.3.1 proto setter — own property 가
+      // 안 생기고 array 값이면 map prototype 오염 → groups 전체 무효.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            String.raw`const re = /(?<__proto__>\d+)-a|(?<__proto__>\d+)-b/;`,
+            String.raw`console.log('12-a'.match(re)?.groups?.__proto__);`,
+            String.raw`console.log('34-b'.match(re)?.groups?.__proto__);`,
+            String.raw`console.log(Object.keys('12-a'.match(re)?.groups ?? {}).length);`,
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('12\n34\n1');
+    });
+
+    test('__proto__ 그룹명 — es5(JSON.parse 폴백) + minify 보존 (#4204)', async () => {
+      // es5 는 computed key 가 ES2015 문법이라 JSON.parse('{...}') 폴백 (B.3.1 면제).
+      // minify 변형은 computed key 폴딩 회귀 가드.
+      for (const args of [['--target=es5'], ['--target=es2017', '--minify']]) {
+        const result = await bundleAndRun(
+          {
+            'index.ts': [
+              // NOTE: ?\./?? 미사용 — --bundle --minify 의 temp 선언 누락(#4218,
+              // 본 fix 와 무관한 pre-existing)에 안 걸리게 plain 접근으로 검증.
+              String.raw`const re = /(?<__proto__>\d+)-a|(?<__proto__>\d+)-b/;`,
+              String.raw`const m = '12-a'.match(re);`,
+              String.raw`const g = m && m.groups;`,
+              String.raw`console.log(g && g.__proto__);`,
+              String.raw`console.log(g ? Object.keys(g).length : -1);`,
+            ].join('\n'),
+          },
+          'index.ts',
+          args,
+        );
+        await result.cleanup();
+        expect(result.exitCode).toBe(0);
+        expect(result.runOutput).toBe('12\n1');
+      }
+    });
+
     test('named backreference \\k<name>', async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
Closes #4204

## 문제

그룹 이름이 문자 그대로 `__proto__` 면 (`/(?<__proto__>\d+)/` — 합법 ES 이름) groups map 객체 리터럴 키가 (quoted 포함) **B.3.1 proto setter** 로 동작:

- 단일: `{"__proto__": 1}` — own property 미생성 → `groups.__proto__` undefined
- duplicate(+#4198 array): `{"__proto__": [1, 2]}` — **map 의 prototype 이 array 로 오염** → `buildGroups` 의 `Object.keys` 가 빈 배열 → groups 전체 무효

## 루트커즈와 수정

emit 지점이 유일한 fix-point (런타임 헬퍼 도달 전에 own key 가 이미 소실). canonical 이름(#4201 — escape 표기도 포착) 기준:

1. **es2015+**: computed key `["__proto__"]` — 항상 own property 정의. minify 는 computed key 를 키 변형에서 제외(minify.zig:1141, 폴딩 패스 부재 확인)라 보존.
2. **es5** (object_extensions 미지원 — computed key 자체가 ES2015 문법): `JSON.parse('{"__proto__":[1,2]}')` 폴백 — **B.3.1 은 JSON.parse 평가를 명시 면제**하므로 own property 보장. JSON 은 ES5 빌트인, canonical 이름은 quote/backslash/개행 불포함이라 escape 불요. --quotes 변환도 writer 가 내부 quote 를 정확히 escape 함을 확인.

리뷰 초안은 es5 를 "문서화된 잔여 한계"로 남겼으나 `/code-review max` 가 JSON.parse 형태의 정당성을 검증해 채택 — 잔여 한계 0.

## 검증 (`/code-review max` 2-앵글 실증)

- B.3.1 동작 node 24 probe (ident/quoted = setter, computed/JSON.parse = own property).
- dup(array)/single × es2017/es5/minify/escape-spelled 이름 — 전부 native 일치 (이전: undefined + own key 0, es5 dup 은 prototype 오염).
- 다른 이름 경로 byte-identical / Hermes 는 object_extensions 지원이라 computed 경로 / 기존 `$<__proto__>` 테스트 영향 없음.
- zig green + integration 177 pass (es5·minify 가드 변형 포함).
- 테스트 중 적발한 무관 pre-existing: **#4218** (`--bundle --minify` 의 `?.`/`??` temp `var _a` 선언 누락 — 다음 작업으로 진행 중).

## Zig 초보자용 포인트

JSON 문자열 합성은 `std.ArrayList(u8)` + `json.print(alloc, "{d}", .{idx})` 로 쌓고, AST 에는 따옴표 포함 원문을 `addString` 으로 interning 합니다. `JSON.parse` 호출은 identifier 노드 2개 + `makeStaticMember` + `makeCallExpr` 조합 — 전역 빌트인이라 런타임 헬퍼 import(`makeRuntimeHelperRef`)가 필요 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)