### PR TITLE
fix(semantic): 식별자 이름 해석을 string_ref 정본으로 — bundle+minify 합성 temp 선언 오삭제/반쪽 rename

### DIFF
--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -179,7 +179,7 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
             // (`void 0.x` 가 `void (0.x)` 로 오파싱 되는 위험 회피) — 그 외는 paren 불필요.
             // global binding 일 때만 치환 (shadow rebind 드물지만 보호).
             if (self.options.minify_syntax and node.tag == .identifier_reference and sym_id == null) {
-                const text = self.ast.getText(node.span);
+                const text = self.ast.identifierNameText(node);
                 if (std.mem.eql(u8, text, "undefined")) {
                     try self.addSourceMapping(node.span);
                     try self.write("void 0");

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1542,6 +1542,22 @@ pub const Ast = struct {
         return self.getText(span);
     }
 
+    /// identifier 류 노드의 "이름" 텍스트 (#4218).
+    ///
+    /// transformer 가 합성한 식별자(es_helpers.makeTempVarRef 등)는 sourcemap
+    /// 용으로 node.span 을 원본 소스 위치로 유지하고 실제 이름은
+    /// data.string_ref(string_table) 에만 둘 수 있다. codegen 은 string_ref 를
+    /// 정본으로 출력하므로 이름 해석(semantic)도 string_ref 가 string_table
+    /// 참조면 그쪽을 읽어야 한다 — span 으로 읽으면 원본 텍스트(`o.a?.b` 등)가
+    /// 이름이 되어 미해결 참조가 되고, bundle 의 post-transform 재분석에서
+    /// temp 선언만 심볼을 얻어 tree-shake 오삭제/반쪽 rename 이 발생했다.
+    /// 파서 생성 노드는 string_ref == span 이라 동작 불변.
+    pub fn identifierNameText(self: *const Ast, node: Node) []const u8 {
+        const ref = node.data.string_ref;
+        if (ref.start & STRING_TABLE_BIT != 0) return self.getText(ref);
+        return self.getText(node.span);
+    }
+
     /// 합성 문자열을 string_table에 추가하고, 이를 가리키는 Span을 반환한다.
     /// 반환된 Span의 start에는 bit 31이 설정되어 getText()가 string_table에서 읽도록 한다.
     ///

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -661,7 +661,9 @@ fn parsePredicateSubject(self: *Parser) ParseError2!NodeIndex {
     return try self.ast.addNode(.{
         .tag = .identifier_reference,
         .span = id_span,
-        .data = .{ .none = 0 },
+        // #4218: identifier_reference 는 data.string_ref 가 이름 정본
+        // (ast.identifierNameText) — .none 저장은 invariant 위반.
+        .data = .{ .string_ref = id_span },
     });
 }
 
@@ -1660,7 +1662,7 @@ fn parseImportType(self: *Parser, start: u32) ParseError2!NodeIndex {
             .data = .{ .binary = .{ .left = result, .right = try self.ast.addNode(.{
                 .tag = .identifier_reference,
                 .span = member_span,
-                .data = .{ .none = 0 },
+                .data = .{ .string_ref = member_span },
             }), .flags = 0 } },
         });
     }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1100,7 +1100,7 @@ pub const SemanticAnalyzer = struct {
             .null_literal => .{ .kind = .null_ },
             .numeric_literal => .{ .kind = .number, .number_text = self.ast.getText(node.span) },
             .identifier_reference => blk: {
-                const text = self.ast.getText(node.span);
+                const text = self.ast.identifierNameText(node);
                 if (std.mem.eql(u8, text, "undefined")) break :blk ConstValue{ .kind = .undefined_ };
                 break :blk ConstValue{};
             },
@@ -1141,7 +1141,8 @@ pub const SemanticAnalyzer = struct {
         const node = self.ast.getNode(idx);
         switch (node.tag) {
             .identifier_reference, .assignment_target_identifier => {
-                const name = self.ast.getSourceText(node.span);
+                // #4218: 합성 식별자는 이름이 string_ref 에만 있다 (span = sourcemap 용)
+                const name = self.ast.identifierNameText(node);
                 self.resolveIdentifier(name, idx, .{ .write = true });
             },
             .array_assignment_target, .object_assignment_target => {
@@ -1184,7 +1185,7 @@ pub const SemanticAnalyzer = struct {
         if (node_idx.isNone() or @intFromEnum(node_idx) >= self.ast.nodes.items.len) return false;
         const node = self.ast.getNode(node_idx);
         if (node.tag == .identifier_reference or node.tag == .assignment_target_identifier) {
-            const name = self.ast.getSourceText(node.span);
+            const name = self.ast.identifierNameText(node);
             self.resolveIdentifier(name, node_idx, flags);
             return true;
         }
@@ -1231,7 +1232,7 @@ pub const SemanticAnalyzer = struct {
         const t = self.ast.getNode(ti);
         switch (t.tag) {
             .identifier_reference, .assignment_target_identifier => {
-                const flags = self.lookupBindingFlags(self.ast.getSourceText(t.span)) orelse return;
+                const flags = self.lookupBindingFlags(self.ast.identifierNameText(t)) orelse return;
                 if (flags.is_import) try self.addImportMutationError(t.span, is_delete);
             },
             .static_member_expression, .computed_member_expression, .private_field_expression => {
@@ -1239,7 +1240,7 @@ pub const SemanticAnalyzer = struct {
                 // named import 멤버(`obj.x`)는 object 가 namespace import 가 아니라 제외.
                 const obj = self.ast.getNode(self.unwrapTarget(self.ast.readExtraNode(t.data.extra, 0)));
                 if (obj.tag != .identifier_reference) return;
-                const flags = self.lookupBindingFlags(self.ast.getSourceText(obj.span)) orelse return;
+                const flags = self.lookupBindingFlags(self.ast.identifierNameText(obj)) orelse return;
                 if (flags.is_namespace_import) try self.addImportMutationError(t.span, is_delete);
             },
             // destructuring target — leaf 까지 재귀(visitAsWriteTarget 구조 대응). default 값
@@ -1504,7 +1505,7 @@ pub const SemanticAnalyzer = struct {
 
             // ---- 식별자 참조 추적 ----
             .identifier_reference, .assignment_target_identifier => {
-                const name = self.ast.getSourceText(node.span);
+                const name = self.ast.identifierNameText(node);
                 // assignment_target_identifier 는 parser 가 LHS 로 확정한 pure write 위치
                 // (for-in/of LHS 등 assignment_expression 상위 분기를 거치지 않는 target).
                 // compound/update 는 각각의 분기에서 tryResolveNodeAsRef 로 flags 를 직접 지정.
@@ -1660,7 +1661,7 @@ pub const SemanticAnalyzer = struct {
                         if (callee_ni < self.ast.nodes.items.len) {
                             const callee_node = self.ast.nodes.items[callee_ni];
                             if (callee_node.tag == .identifier_reference) {
-                                const callee_name = self.ast.getSourceText(callee_node.span);
+                                const callee_name = self.ast.identifierNameText(callee_node);
                                 if (std.mem.eql(u8, callee_name, "eval")) {
                                     self.markScopeFieldToRoot("subtree_has_direct_eval");
                                 }

--- a/src/transformer/es2015_for_of.zig
+++ b/src/transformer/es2015_for_of.zig
@@ -417,9 +417,10 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
         // ================================================================
 
         /// reference 의 `node.span` 은 `name_span` 사용 (binding 과 동일한 정책).
-        /// 다른 정책 (e.g. for-of 자체의 source span) 을 쓰면 post-transform
-        /// `SemanticAnalyzer.getSourceText(node.span)` 이 원본 source 영역의 다른
-        /// 텍스트를 읽어 binding 매칭 실패 → symbol_id 가 None → mangler 의
+        /// #4218 이후 analyzer 는 `ast.identifierNameText`(string_ref 정본)로
+        /// 이름을 읽으므로 span 분리도 동작은 하지만, 여기는 합성 전용 이름이라
+        /// 원본 위치 매핑 가치가 없어 단순한 동일-span 정책을 유지한다. (구 사유:
+        /// `getSourceText(node.span)` 이 원본 텍스트를 읽어 매칭 실패 → mangler 의
         /// cross-module rename 이 declaration 에만 적용되는 비대칭이 발생한다.
         fn makeRefFromSpan(self: *Transformer, name_span: Span) Transformer.Error!NodeIndex {
             return self.ast.addNode(.{

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -124,6 +124,8 @@ fn collidesWithPrivateField(self: anytype, name: []const u8) bool {
 }
 
 /// 임시 변수 identifier_reference 노드 생성.
+/// node_span(원본 위치, sourcemap 용)과 span(string_table 이름)이 다를 수 있다 —
+/// semantic 의 이름 해석은 ast.identifierNameText 가 string_ref 를 정본으로 읽는다 (#4218).
 pub fn makeTempVarRef(self: anytype, span: Span, node_span: Span) !NodeIndex {
     return self.ast.addNode(.{
         .tag = .identifier_reference,

--- a/tests/integration/tests/minify-temp-decl.test.ts
+++ b/tests/integration/tests/minify-temp-decl.test.ts
@@ -1,0 +1,84 @@
+// #4218: bundle + minify 에서 ?\./??/논리할당 lowering 의 합성 temp (`var _a`)
+// 선언이 tree-shake 로 오삭제되거나(--minify-syntax) 선언만 rename 되던
+// (--minify-identifiers) 회귀 가드. bun 은 출력을 ESM(strict)으로 실행하므로
+// 미선언 `_a` 할당이 즉시 ReferenceError 로 드러난다 (node CJS sloppy 는 은폐).
+import { describe, test, expect, afterEach } from 'bun:test';
+import { bundleAndRun } from './helpers';
+
+describe('#4218: bundle+minify 합성 temp 선언 보존', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  const SRC = [
+    'const o = { a: { b: 1 } } as any;',
+    'console.log(o.a?.b);',
+    "console.log(o.x ?? 'd');",
+  ].join('\n');
+
+  for (const flag of ['--minify', '--minify-syntax', '--minify-identifiers']) {
+    test(`optional chain + nullish (es2017, ${flag})`, async () => {
+      const result = await bundleAndRun({ 'index.ts': SRC }, 'index.ts', ['--target=es2017', flag]);
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('1\nd');
+    });
+  }
+
+  test('논리할당 ??= (es2020, --minify)', async () => {
+    const result = await bundleAndRun(
+      {
+        'index.ts': [
+          'const g = () => ({} as any);',
+          'g().x ??= 5;',
+          'const h: any = {};',
+          'h.y ||= 7;',
+          'console.log(h.y);',
+        ].join('\n'),
+      },
+      'index.ts',
+      ['--target=es2020', '--minify'],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe('7');
+  });
+
+  test('es5 destructuring temp 관례 가드 (--minify)', async () => {
+    const result = await bundleAndRun(
+      {
+        'index.ts': [
+          'const o = { a: 1, b: 2, c: 3 } as any;',
+          'const { a, ...rest } = o;',
+          'console.log(a, Object.keys(rest).length);',
+        ].join('\n'),
+      },
+      'index.ts',
+      ['--target=es5', '--minify'],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe('1 2');
+  });
+
+  test('함수 스코프 내부 temp + --minify (es2017)', async () => {
+    const result = await bundleAndRun(
+      {
+        'index.ts': [
+          'function f(o: any) { return o.a?.b ?? -1; }',
+          'console.log(f({ a: { b: 2 } }), f({}));',
+        ].join('\n'),
+      },
+      'index.ts',
+      ['--target=es2017', '--minify'],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe('2 -1');
+  });
+});


### PR DESCRIPTION
Closes #4218

## 문제

`--bundle` + `--minify`(또는 `--minify-syntax`/`--minify-identifiers`) + ES2020 이하 타겟에서 `?.`/`??`/논리할당 lowering 의 합성 temp 가 깨졌다:

- `--minify-syntax`: `var _a;` 선언이 tree-shake 로 **오삭제** → ESM/strict 실행(bun, `--format=esm`) 즉시 `ReferenceError: _a is not defined` (node CJS sloppy 는 암묵 전역으로 은폐)
- `--minify-identifiers`: 선언만 `var t;` 로 rename, 사용처 `_a` 는 그대로 — dangling

`?.`/`??` + bundle + minify 조합 빈도가 높아 고우선으로 처리.

## 루트커즈

합성 temp 의 `identifier_reference` 는 sourcemap 충실도를 위해 `node.span` 을 **원본 소스 위치**로 유지하고 실제 이름은 `data.string_ref`(string_table) 에만 둔다 (`makeTempVarRef`). codegen 은 string_ref 를 정본으로 출력하는데, **semantic analyzer 만 `getSourceText(node.span)` 으로 이름을 읽어** 사용처 이름이 원본 텍스트(`o.a?.b`)가 됨 → 미해결 참조. bundle 의 post-transform 재분석(resyncAfterAstMutation)에서 hoist 된 선언(span=string_table)만 심볼을 얻고 사용처 refcount=0 → tree-shaker 삭제/반쪽 rename.

증거 대조군: es5 destructuring temp 는 `makeTempVarRef(span, span)` 동일 전달이라 무사. transpile(비번들) 경로는 재분석이 없어 양쪽 다 안 보여 무사.

## 수정

`ast.identifierNameText` 신설 — string_ref 가 string_table 참조면 그쪽(codegen 과 동일 규칙), 아니면 기존 span 읽기 — analyzer 의 식별자 해석 3지점 적용. 파서 노드는 string_ref==span 이라 동작 불변.

리뷰 반영 추가: ts.zig 의 `.data=.{.none=0}` identifier 프로듀서 2곳 invariant 하드닝, 같은 클래스 잠재 사이트 5곳(extractConstValue/checkImportMutation×2/direct-eval/codegen `undefined`→`void 0` 피홀) 헬퍼 통일, for-of doc 갱신.

## 검증 (`/code-review max` 2-앵글, main 바이너리 worktree A/B 포함)

- 최소 재현 3종 + `??=`/`||=` + 함수 스코프 + es5 destructuring 가드 — 신규 테스트 파일 6케이스 전부 통과 (이전: 5/6 ReferenceError).
- **round11 50-fixture bundle+minify A/B**: diff 5/50 전부 의도된 수정(`var t,n` 선언+rename), **실행 branch 50/50 vs main 45/50**. transpile 12-fixture **byte-identical**. 결정성 2-run 동일.
- `identifier_reference` 프로듀서 117곳 전수 — union-read 안전성 확인 (ts.zig 2곳은 하드닝). `__wrapRegExp` 등 helper ref 는 node-index sidecar 로 별도 해석이라 무영향 (user 변수 `__wrapRegExp` 케이스 byte-identical 실증).
- zig green + integration 4054 중 신규 실패 0 (hermes-runtime/watch-stress 2건은 main 동일 = pre-existing).
- 파생 이슈: #4220 (makeTempVarSpan 이 user `_a` 와 충돌 회피 안 함 — main 동일 pre-existing), #4221 (unresolved_references raw slice — #3100 클래스).

## Zig 초보자용 포인트

`Node.data` 는 untagged union 이라 `string_ref` 읽기는 해당 tag 의 모든 프로듀서가 그 variant 를 쓴다는 invariant 에 기댑니다 — 그래서 ts.zig 의 `.none` 프로듀서 2곳을 함께 하드닝했고, 헬퍼는 bit31 체크 후 span 폴백을 남겨 미래의 invariant 위반이 garbage 이름 대신 기존 동작으로 떨어지게 했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)