### PR TITLE
feat(compat): ES2025 regex_duplicate_named_groups feature gate

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -299,7 +299,7 @@ Options:
 - `--target=es5` ~ `es2025` / `esnext` 지원
 - 엔진 타겟(`--target=chrome80,safari14,node16` 등)은 compat-table 기반 feature-level 다운레벨링
 - ES2023: hashbang(`#!`) strip
-- ES2025: `using` / `await using` 다운레벨
+- ES2025: `using` / `await using` 다운레벨, duplicate named capture group (`/(?<y>..)|(?<y>..)/`) — es2018~es2024 타겟에서도 strip+`__wrapRegExp` 로 다운레벨 (#4199)
 
 ### 런타임 API 폴리필
 

--- a/packages/shared/compat-engines.ts
+++ b/packages/shared/compat-engines.ts
@@ -62,6 +62,7 @@ export const FEATURES = [
   'regex_dotall', // ES2018
   'regex_named_groups', // ES2018
   'unicode_brace_escape', // ES2015
+  'regex_duplicate_named_groups', // ES2025
 ] as const;
 
 export type Feature = (typeof FEATURES)[number];
@@ -286,6 +287,16 @@ export const SUPPORT: Partial<Record<Feature, Partial<Record<Engine, [number, nu
     // ES2025 `using` / `await using` 선언. 2026-04 기준 어떤 엔진도 미지원이라
     // SUPPORT 테이블은 비어있고, computeUnsupported는 모든 엔진에서 비트를 set.
     // 엔진 지원이 시작되면 여기에 추가.
+  },
+  regex_duplicate_named_groups: {
+    // ES2025 duplicate named capture group (#4199). compat.zig 거울.
+    chrome: [125, 0],
+    edge: [125, 0],
+    firefox: [129, 0],
+    safari: [17, 4],
+    ios: [17, 4],
+    node: [23, 0],
+    deno: [1, 44],
   },
 };
 

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -160,7 +160,7 @@ export interface TranspileResult {
 
 // ─── ES Target → UnsupportedFeatures bitmask ───
 
-// compat.zig Feature enum 순서와 1:1 대응 (총 28 bits, src/transformer/compat.zig 참조):
+// compat.zig Feature enum 순서와 1:1 대응 (총 29 bits, src/transformer/compat.zig 참조):
 //   0-10  ES2015 (arrow, class, template_literal, destructuring, for_of, spread,
 //                  object_extensions, default_params, block_scoping, generator, new_target)
 //   11    ES2016 (exponentiation)
@@ -175,21 +175,22 @@ export interface TranspileResult {
 //   24    ES2015 (regex_sticky)
 //   25-26 ES2018 (regex_dotall, regex_named_groups)
 //   27    ES2015 (unicode_brace_escape)
+//   28    ES2025 (regex_duplicate_named_groups)
 //
 // 타겟 T 에 대해 "T 이후 도입된" 모든 feature 비트를 set 한다.
 // Feature 추가 시 compat.zig 와 함께 갱신.
 export const ES_TARGET_BITS: Record<string, number> = {
-  es5: 0x0fffffff, // bits 0-27 (모든 feature)
-  es2015: 0x06fff800, // bits 11-23, 25, 26 (ES2015/regex_sticky/unicode_brace_escape 제외)
-  es2016: 0x06fff000, // bits 12-23, 25, 26
-  es2017: 0x06ffe000, // bits 13-23, 25, 26
-  es2018: 0x00ffc000, // bits 14-23 (ES2018 features 도 제외)
-  es2019: 0x00ff8000, // bits 15-23
-  es2020: 0x00fe0000, // bits 17-23
-  es2021: 0x00fc0000, // bits 18-23
-  es2022: 0x00c00000, // bits 22-23 (hashbang + using)
-  es2023: 0x00800000, // bit 23 (using only)
-  es2024: 0x00800000, // ES2024 에 구문 변환 기능 없음
+  es5: 0x1fffffff, // bits 0-28 (모든 feature)
+  es2015: 0x16fff800, // bits 11-23, 25, 26, 28 (ES2015/regex_sticky/unicode_brace_escape 제외)
+  es2016: 0x16fff000, // bits 12-23, 25, 26, 28
+  es2017: 0x16ffe000, // bits 13-23, 25, 26, 28
+  es2018: 0x10ffc000, // bits 14-23, 28 (ES2018 features 도 제외)
+  es2019: 0x10ff8000, // bits 15-23, 28
+  es2020: 0x10fe0000, // bits 17-23, 28
+  es2021: 0x10fc0000, // bits 18-23, 28
+  es2022: 0x10c00000, // bits 22-23, 28 (hashbang + using + regex dup-named)
+  es2023: 0x10800000, // bits 23, 28
+  es2024: 0x10800000, // bits 23, 28 (ES2024 자체 구문 변환 기능 없음)
   es2025: 0x0,
   esnext: 0x0,
 };

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -98,6 +98,10 @@ pub const Feature = enum(u5) {
     /// `\u{X}` brace unicode escape (ES2015). 문자열/template 내부는 surrogate pair로,
     /// regex 의 `u` flag + `\u{X}` 도 surrogate pair + flag strip (#1388).
     unicode_brace_escape,
+    /// ES2025 duplicate named capture group (`(?<y>..)|(?<y>..)`). 미지원 타겟에선
+    /// regex_named_groups 와 같은 strip+__wrapRegExp 경로로 다운레벨 (#4199).
+    /// NOTE: Feature enum 과 UnsupportedFeatures 필드는 비트 위치가 1:1 — 끝에만 추가.
+    regex_duplicate_named_groups,
 
     /// 이 feature가 도입된 ES 버전.
     pub fn esVersion(self: Feature) ESTarget {
@@ -111,7 +115,7 @@ pub const Feature = enum(u5) {
             .logical_assignment => .es2021,
             .class_static_block, .class_private_method, .class_private_field, .top_level_await => .es2022,
             .hashbang => .es2023,
-            .using => .es2025,
+            .using, .regex_duplicate_named_groups => .es2025,
         };
     }
 };
@@ -161,8 +165,17 @@ pub const UnsupportedFeatures = packed struct(u32) {
     regex_dotall: bool = false,
     regex_named_groups: bool = false,
     unicode_brace_escape: bool = false,
+    regex_duplicate_named_groups: bool = false,
 
-    _: u4 = 0,
+    _: u3 = 0,
+
+    /// regex literal lowering 이 필요한 비트가 하나라도 set 인지.
+    /// node_dispatch 조기탈출/graph prepass 게이트가 공유 — 새 regex 비트는
+    /// 여기 한 곳만 추가하면 된다 (#4199 에서 게이트 2곳 누락이 실제 발생).
+    pub fn needsRegexLowering(self: @This()) bool {
+        return self.regex_dotall or self.regex_named_groups or self.regex_sticky or
+            self.unicode_brace_escape or self.regex_duplicate_named_groups;
+    }
 
     /// 어떤 feature flag 라도 set 됐는지 (= packed struct 가 zero 가 아닌지).
     /// `.{}` (기본값, 모든 비트 false) 와 명시적으로 어느 비트라도 set 된 상태를 구분할 때 사용.
@@ -589,6 +602,15 @@ const compat_table = [_]CompatEntry{
     .{ .feature = .using, .engine = .safari, .major = 18, .minor = 2 },
     .{ .feature = .using, .engine = .node, .major = 22 },
     .{ .feature = .using, .engine = .deno, .major = 1, .minor = 38 },
+
+    // ── ES2025: duplicate named capture groups (#4199) ── (hermes row 없음 = 미지원)
+    .{ .feature = .regex_duplicate_named_groups, .engine = .chrome, .major = 125 },
+    .{ .feature = .regex_duplicate_named_groups, .engine = .edge, .major = 125 },
+    .{ .feature = .regex_duplicate_named_groups, .engine = .firefox, .major = 129 },
+    .{ .feature = .regex_duplicate_named_groups, .engine = .safari, .major = 17, .minor = 4 },
+    .{ .feature = .regex_duplicate_named_groups, .engine = .ios, .major = 17, .minor = 4 },
+    .{ .feature = .regex_duplicate_named_groups, .engine = .node, .major = 23 },
+    .{ .feature = .regex_duplicate_named_groups, .engine = .deno, .major = 1, .minor = 44 },
     // edge, ios, hermes: 미지원 → compat_table에 없음 → 항상 다운레벨링
 
     // ── ES2015: regex_sticky (/y) ──
@@ -649,6 +671,8 @@ fn getMinVersion(engine: Engine, feature: Feature) ?struct { major: u16, minor: 
 /// React Native (Hermes) preset.
 /// 명시되지 않은 features 는 native keep (default false).
 pub fn fromHermesPreset() UnsupportedFeatures {
+    // NOTE: regex_duplicate_named_groups 비트는 별도 set 안 함 — 아래
+    // regex_named_groups=true 가 strip 경로를 superset 으로 커버 (#4199).
     return .{
         // 호환 마진 다운레벨링 (closure 의미 / state machine 종속 / Hermes runtime 버그 회피)
         .arrow = true, // #1299: object property arrow ternary 뒤 prop 누락

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -301,7 +301,12 @@ pub const TransformOptions = struct {
                 // named capture 는 wrap 변환에 helper module import 필요 — prepass 거쳐야
                 // graph 가 helper module 을 등록.
                 .regexp_literal => {
-                    if (u.regex_dotall or u.regex_named_groups or u.regex_sticky or u.unicode_brace_escape) return true;
+                    if (u.regex_dotall or u.regex_named_groups or u.regex_sticky or
+                        u.unicode_brace_escape) return true;
+                    // dup-gate 만 set 인 es2018~es2024 에선 named group 후보가 있을
+                    // 때만 prepass — 일반 regex 모듈에 graph prepass 비용 미부과 (#4199).
+                    if (u.regex_duplicate_named_groups and
+                        std.mem.indexOf(u8, ast.getText(node.span), "(?<") != null) return true;
                 },
                 else => {},
             }

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -52,7 +52,12 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
     const has_i = std.mem.indexOfScalar(u8, flags, 'i') != null;
 
     const need_dotall = has_s and opts.unsupported.regex_dotall;
-    const need_named = opts.unsupported.regex_named_groups and hasNamedGroup(pattern);
+    // #4199: duplicate named group (ES2025) 은 named group 자체를 지원하는
+    // es2018~es2024 타겟에서도 SyntaxError — 중복이 실재하면 strip 경로 전체를
+    // 활성화한다 (#4198 의 array 병합/$1$2/\k 연접이 정확성을 보장).
+    const need_named = (opts.unsupported.regex_named_groups and hasNamedGroup(pattern)) or
+        (opts.unsupported.regex_duplicate_named_groups and
+            try hasDuplicateNamedGroup(allocator, pattern));
     const need_sticky = has_y and opts.unsupported.regex_sticky;
     // `u` flag 자체는 runtime 지원 대상이 아니지만, `\u{X}` brace escape 는 `u` flag 하에서만
     // 허용된다. brace escape 를 surrogate pair 로 내리면서 flag 도 함께 strip 한다.
@@ -223,6 +228,23 @@ pub fn rewriteReplacementNamedRefs(
         return null;
     }
     return try out.toOwnedSlice(allocator);
+}
+
+/// pattern 에 canonical 동일 이름의 named group 이 2개 이상 있는지 (#4199).
+/// extractNamedGroupMap 재사용 — 호출 빈도는 "dup gate 만 미지원인 타겟 ×
+/// named group 패턴" 으로 좁다.
+fn hasDuplicateNamedGroup(allocator: std.mem.Allocator, pattern: []const u8) !bool {
+    // named group 이 2개 미만이면 dup 불가 — alloc 전 비할당 프리스캔.
+    if (std.mem.count(u8, pattern, "(?<") < 2) return false;
+    if (!hasNamedGroup(pattern)) return false;
+    const map = try extractNamedGroupMap(allocator, pattern);
+    defer allocator.free(map);
+    for (map, 0..) |entry, i| {
+        for (map[0..i]) |prev| {
+            if (group_name.eqlCanonical(prev.name, entry.name)) return true;
+        }
+    }
+    return false;
 }
 
 /// pattern에 `(?<name>...)` (lookbehind 제외) 가 있는지 스캔.
@@ -517,6 +539,28 @@ test "#4198: replacement 단일 이름은 기존과 동일 ($N)" {
     const out = (try rewriteReplacementNamedRefs(testing.allocator, "$<m>/$<y>", &mapping)).?;
     defer testing.allocator.free(out);
     try testing.expectEqualStrings("$2/$1", out);
+}
+
+// #4199: es2018~es2024 (named group 지원, dup 미지원) gate.
+test "#4199: dup gate — es2022 류 타겟에서 duplicate 만 strip" {
+    // dup 있음 → strip + mapping
+    const r = try lower(testing.allocator, "/(?<y>a)|(?<y>b)/", .{ .unsupported = .{ .regex_duplicate_named_groups = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    defer if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expectEqualStrings("/(a)|(b)/", r.text.?);
+    try testing.expectEqual(@as(usize, 2), r.named_groups.?.len);
+}
+
+test "#4199: dup gate — 단일 이름은 no-op (named group 유지)" {
+    const out = try runLower("/(?<y>a)-(?<m>b)/", .{ .regex_duplicate_named_groups = true });
+    try testing.expect(out == null);
+}
+
+test "#4199: dup gate — escape-aliased dup 도 감지 (canonical)" {
+    const r = try lower(testing.allocator, "/(?<y>a)|(?<\\u0079>b)/", .{ .unsupported = .{ .regex_duplicate_named_groups = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    defer if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expectEqualStrings("/(a)|(b)/", r.text.?);
 }
 
 // #2472 회귀 가드: 32개 stack-cap 시 33번째부터 std.debug.assert 가 ReleaseFast 에서

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -715,7 +715,7 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
         },
         .regexp_literal => blk: {
             const u = self.options.unsupported;
-            if (!(u.regex_dotall or u.regex_named_groups or u.regex_sticky or u.unicode_brace_escape)) {
+            if (!u.needsRegexLowering()) {
                 break :blk self.copyNodeDirect(idx);
             }
             const raw = self.ast.getText(node.span);

--- a/tests/integration/tests/compat-table.test.ts
+++ b/tests/integration/tests/compat-table.test.ts
@@ -139,6 +139,7 @@ const RUNTIME_FEATURES = new Set([
 
 // --- 구문 변환 대상 feature + 도입 연도 ---
 const SYNTAX_FEATURES: Record<string, number> = {
+  'Duplicate named capturing groups': 2025,
   // ES2015 (ES6)
   'default function parameters': 2015,
   'rest parameters': 2015,

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1547,6 +1547,29 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       }
     });
 
+    test('ES2025 dup named group gate — es2022 에서 dup 만 strip (#4199)', async () => {
+      // named group 자체는 es2018+ 지원이라 기존엔 dup 이 verbatim 패스스루
+      // (es2018~es2024 엔진에서 SyntaxError). gate 가 strip 경로를 활성화.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            String.raw`const re = /(?<y>\d{4})-a|(?<y>\d{4})-b/;`,
+            String.raw`console.log('2024-a'.match(re)?.groups?.y, '2025-b'.match(re)?.groups?.y);`,
+            String.raw`console.log('x1'.match(/(?<s>\d)/)?.groups?.s);`,
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2022'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('2024 2025\n1');
+      // dup regex 만 wrap, 단일 이름은 native named group 유지
+      expect(result.bundleOutput).toContain('__wrapRegExp');
+      expect(result.bundleOutput).toContain('(?<s>');
+      expect(result.bundleOutput).not.toContain('(?<y>');
+    });
+
     test('named backreference \\k<name>', async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
Closes #4199

## 문제

es2018~es2024 타겟은 named group 자체를 지원해 regex lowering 이 비활성 — **ES2025 전용**인 duplicate named capture group 이 verbatim 패스스루되어 해당 엔진(Chrome <125 / Firefox <129 / Safari <17.4 / Node <23)에서 regex 컴파일 시점 SyntaxError.

## 수정

- **compat.zig**: Feature `regex_duplicate_named_groups` (es2025) + 엔진 rows (chrome/edge 125, firefox 129, safari/ios 17.4, node 23, deno 1.44; hermes row 없음=미지원). enum↔packed struct 비트 1:1 invariant 는 기존 comptime assert 가 보장 — 끝에 추가 + 주석 명시.
- **regex_lower**: dup 실재 시(canonical 비교 — escape-aliased `(?<y>)|(?<y>)` 포함) named strip 경로 전체 활성화. #4198/#4201 의 array 병합/`$1$2`/`\k` 연접이 정확성 보장. 단일 이름 패턴은 no-op (native named group 유지). alloc 전 `(?<` 2회 프리스캔.
- **게이트 전파**: `needsRegexLowering()` 접근자 신설(compat.zig) — node_dispatch 조기탈출이 사용. options.zig prepass 는 dup-only 케이스에 `(?<` 포함 검사 2-tier (일반 regex 모듈에 graph prepass 비용 미부과). *(이 두 게이트는 구현 중 각각 누락→e2e 적발→수정 — 접근자가 그 함정을 제거)*
- **JS API 미러 2곳** (리뷰 적발 — 누락 시 CLI/JS API 동작 분기): `packages/shared/index.ts` ES_TARGET_BITS bit 28 + `compat-engines.ts` FEATURES/SUPPORT.
- compat-table CI 활성화('Duplicate named capturing groups': 2025 — fixture 에 이미 있었으나 silently skip 중이었음), docs/USAGE.md, fromHermesPreset 주석(named_groups=true 가 superset 커버).

## 검증 (`/code-review max` 2-앵글 실증)

- 타겟 매트릭스: es2018/es2022/es2024 dup→`__wrapRegExp` wrap·single→native 유지 / es2025·esnext 패스스루 / 엔진 경계 chrome124↔125, node22↔23(V8 12.4/12.5 — MDN 대조), chrome125+firefox128 교집합 / bundle helper 주입 / es2022 에서 replace(`$<y>` 3형태)·dotall `/s` 보존·u-flag `\u{}` 보존·`\k` 연접·mixed single+dup 패턴 — 전부 native(node 24) byte-동일.
- 비트 정렬은 comptime assert 확인, JS 미러 hex 전수 갱신 (헤더 "총 29 bits").
- zig green + integration 194 pass (compat-table 신규 활성 행 포함).
- 무관 pre-existing 발견: #4223 (react-refresh CLI flag schema drift — packages/core 테스트 4건, 타 작업 유래).

## Zig 초보자용 포인트

`UnsupportedFeatures` 는 `packed struct(u32)` 라 필드 순서가 곧 비트 위치입니다 — Feature enum 과의 1:1 은 comptime `std.mem.eql(u8, ff.name, struct_fields[ff.value].name)` assert 가 컴파일 타임에 깨뜨려 줍니다. 새 비트는 패딩(`_: u4`→`u3`)을 줄이며 끝에만 추가해야 기존 비트마스크(JS 미러 hex 포함)가 유지됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)