### PR TITLE
fix(regexp): transform 이 inline modifier 영역의 유효 플래그 존중 — (?-s:) dot 오재작성 / (?-i:) iu fold 오확장

### DIFF
--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -125,6 +125,13 @@ const T = struct {
     in_class: bool = false,
     /// 정확히 다운레벨 못한 astral 구문 발견 (lower() 가 u-strip 보류 판단).
     astral_u_incomplete: bool = false,
+    /// `(?-s:)` 영역 깊이 (#4211). 내부 `.` 는 global /s dotall 의 적용 대상이
+    /// 아니므로 재작성하면 안 된다 — modifier 그룹은 출력에 보존되어 모던 엔진이
+    /// 영역 의미를 직접 제공한다 (`(?s:)` 내부 재작성은 의미 동치라 추적 불요).
+    mod_s_off_depth: u32 = 0,
+    /// i 를 건드리는 modifier 영역 깊이 (#4211). 내부 class 의 iu fold 확장은
+    /// 영역별 유효 i 를 정확히 반영할 수 없어 u-보존 게이트로 폴백.
+    mod_i_depth: u32 = 0,
 
     /// surrogate pair 2 노드를 list 에 push (cp>0xFFFF).
     fn pushSurrogate(self: *T, span: ast.Span, cp: u32, out: *std.ArrayList(u32)) TransformError!void {
@@ -331,7 +338,8 @@ const T = struct {
             .indexed_reference,
             => return self.b.add(n),
             .dot => {
-                if (self.opts.dotall) return self.makeDotAllClass(n.span);
+                // #4211: (?-s:) 안의 `.` 는 global /s 비적용 — 재작성 금지.
+                if (self.opts.dotall and self.mod_s_off_depth == 0) return self.makeDotAllClass(n.span);
                 return self.b.add(n);
             },
             .named_reference => {
@@ -383,7 +391,11 @@ const T = struct {
                 // 미지원(\p{}/class_string/\D\W\S) → incomplete → u 보존(오변환 0).
                 if (self.opts.unicode_brace) {
                     const negative = (n.data[0] & 1) != 0;
-                    if (negative or self.opts.ignore_case or self.classHasAstral(n)) {
+                    // #4211: i-modifier 영역 안 class 는 영역별 유효 i 를 fold 확장에
+                    // 반영할 수 없다 — u 보존(부분 커버리지, 틀린 출력 0, #3509 동형).
+                    if (self.mod_i_depth > 0) {
+                        self.astral_u_incomplete = true;
+                    } else if (negative or self.opts.ignore_case or self.classHasAstral(n)) {
                         var set = cps.CodePointSet{};
                         defer set.deinit(self.b.a);
                         if (try self.collectClassSet(n, &set)) {
@@ -429,6 +441,18 @@ const T = struct {
                 return self.b.add(.{ .tag = .capturing_group, .span = n.span, .data = .{ name0, name1, @intFromEnum(body) } });
             },
             .ignore_group => {
+                // modifier 비트: bit0=i, bit1=m, bit2=s (ast.zig ignore_group).
+                const s_off = (n.data[1] & 0b100) != 0;
+                const i_mod = ((n.data[0] | n.data[1]) & 0b001) != 0;
+                // in_class 와 동일한 save/restore 관용구 — 에러 경로에서도 오염 없음.
+                const saved_s = self.mod_s_off_depth;
+                const saved_i = self.mod_i_depth;
+                if (s_off) self.mod_s_off_depth += 1;
+                if (i_mod) self.mod_i_depth += 1;
+                defer {
+                    self.mod_s_off_depth = saved_s;
+                    self.mod_i_depth = saved_i;
+                }
                 const body = try self.node(@enumFromInt(n.data[2]));
                 return self.b.add(.{ .tag = .ignore_group, .span = n.span, .data = .{ n.data[0], n.data[1], @intFromEnum(body) } });
             },

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -87,8 +87,21 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
             .unicode_brace = need_unicode,
             .ignore_case = has_i,
         }, allocator);
-        defer tr.deinit();
         astral_u_incomplete = tr.astral_u_incomplete;
+        // #4211: u 를 보존하기로 결정되면(incomplete) 패턴 *전체*가 u-유효해야
+        // 한다 — 이미 적용된 surrogate-alternation/complement 재작성은 u-strip
+        // 전제라 부분 적용 시 비일관 miscompile (kept-u 아래서 lone surrogate
+        // 매치 불가). unicode_brace 끄고 재변환해 astral 구문을 verbatim 유지.
+        if (astral_u_incomplete and need_unicode) {
+            tr.deinit();
+            tr = try regexp.transform.transform(in_ast, .{
+                .dotall = need_dotall,
+                .strip_named = need_named,
+                .unicode_brace = false,
+                .ignore_case = has_i,
+            }, allocator);
+        }
+        defer tr.deinit();
         owned_pattern = regexp.printer.print(tr.ast, allocator) catch return .{ .text = null };
         break :blk owned_pattern.?;
     } else pattern;
@@ -561,6 +574,31 @@ test "#4199: dup gate — escape-aliased dup 도 감지 (canonical)" {
     defer if (r.text) |t| testing.allocator.free(t);
     defer if (r.named_groups) |ng| testing.allocator.free(ng);
     try testing.expectEqualStrings("/(a)|(b)/", r.text.?);
+}
+
+// #4211: transform 이 modifier 영역의 유효 플래그를 존중.
+test "#4211: (?-s:) 안 dot 은 dotall 재작성 제외" {
+    const out = (try runLower("/(?-s:a.b)x./s", .{ .regex_dotall = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?-s:a.b)x[\\s\\S]/", out);
+}
+
+test "#4211: (?-i:[k])/iu — fold 확장 대신 u 보존 (byte-exact)" {
+    const r = try lower(testing.allocator, "/(?-i:[k])y/iu", .{ .unsupported = .{ .unicode_brace_escape = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    defer if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(r.text != null);
+    try testing.expectEqualStrings("/(?-i:[k])y/iu", r.text.?);
+}
+
+test "#4211: i-영역 class + 바깥 astral class — u 보존 시 전체 verbatim (일관성)" {
+    // 부분 재작성(surrogate-alternation)은 kept-u 아래서 lone surrogate 가
+    // pair 안을 매치 못해 miscompile — 재변환으로 전체 보존되어야 한다.
+    const r = try lower(testing.allocator, "/(?i:[a-z])[\\u{1F600}-\\u{1F601}]/u", .{ .unsupported = .{ .unicode_brace_escape = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    defer if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(r.text != null);
+    try testing.expectEqualStrings("/(?i:[a-z])[\\u{1F600}-\\u{1F601}]/u", r.text.?);
 }
 
 // #2472 회귀 가드: 32개 stack-cap 시 33번째부터 std.debug.assert 가 ReleaseFast 에서

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1570,6 +1570,24 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(result.bundleOutput).not.toContain('(?<y>');
     });
 
+    test('(?-s:) 영역 dot 은 dotall 재작성 제외 (#4211)', async () => {
+      // 회귀: transform 이 modifier 비트를 무시하고 (?-s:) 안 `.` 도 [\s\S] 로
+      // 재작성 → 개행을 오매치하는 silent miscompile.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            String.raw`const re = /(?-s:a.b)x./s;`,
+            String.raw`console.log(re.test('a\nbxq'), re.test('axbxq'), re.test('axbx\n'));`,
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('false true true');
+    });
+
     test('named backreference \\k<name>', async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
Closes #4211

## 문제 (둘 다 실증된 silent miscompile)

파서는 modifier 그룹의 enabling/disabling 비트를 `ignore_group` data 에 기록하지만 transform 의 두 semantics walk 가 무시했다:

1. **dotall**: `/(?-s:a.b)x./s` 에서 `(?-s:)` 안의 `.` 까지 `[\s\S]` 재작성 → 개행 오매치 (native `false` vs zntc `true`)
2. **iu fold (#3511 경로)**: `/(?-i:[k])/iu` 의 class 를 글로벌 i 만 보고 fold 확장 → Kelvin 오매치. (역방향 `(?i:[k])/u` 의 fold 누락도 기존 버그였음을 리뷰가 확인)

## 루트커즈와 수정

`T` 에 modifier 컨텍스트 추가 (`ignore_group` 방문 시 save/restore — `in_class` 관용구 동일, 에러 경로 오염 없음):

- `mod_s_off_depth`: `(?-s:)` 영역 안 dot 재작성 금지. modifier 그룹은 출력에 보존되므로 모던 엔진이 영역 의미를 직접 제공 (`(?s:)` 안 재작성은 의미 동치라 추적 불요).
- `mod_i_depth`: i 를 건드리는 영역 안 class 는 영역별 유효 i 를 fold 에 반영 불가 → `astral_u_incomplete` 게이트 (#3509 "틀린 출력 0" 동형).

**+ 리뷰가 적발한 일관성 결함 수정**: u 를 보존하기로 결정된 패턴에서 *다른 위치의* astral 재작성(surrogate-alternation, u-strip 전제)이 이미 적용돼 있으면 kept-u 아래서 lone surrogate 매치 불가 — 신규 게이트가 트리거를 넓혔고 동류 pre-existing(collectClassSet 실패 경로)도 있었다. fix = `lower()` 에서 incomplete 판정 시 **unicode_brace=off 로 재변환**해 패턴 전체를 u-유효 verbatim 으로 통일 (rare 경로에서만 2-pass).

## 검증 (`/code-review max` — 16-케이스 transpile-vs-native parity)

- 중첩 `(?-s:(?s:a.b))`, lookaround 내부, quantifier/disjunction/capture 내부, `(?i-s:)`, s+u 복합 — 전부 native(node 24) byte-동일.
- 일관성 케이스: `(?i:[a-z])[\u{1F600}-\u{1F601}]/u`, `(?i:[a-z])[^x]y/u` — 재변환으로 전체 verbatim, native 일치 (수정 전 초안은 미스컴파일).
- Kelvin probe: 신규 게이트가 기존 `(?i:[k])/u` u-strip 버그도 함께 수리함을 확인.
- 기존 regex 테스트 byte-identical (modifier 무관 패턴 무변경). zig green + integration 179 pass.
- 구형 엔진에서 modifier 문법 자체가 SyntaxError 인 갭은 별개 (#4210). 파생: #4225 (`/k/iu` 리터럴 atom fold — pre-existing, #4211 의 재변환 메커니즘 재사용 가능).

## Zig 초보자용 포인트

depth 카운터는 `defer` 로 save/restore 해 `try` 실패 경로에서도 오염되지 않습니다. 재변환 2-pass 는 `tr.deinit()` 후 같은 `in_ast` 로 다시 `transform()` — `in_ast` 는 그 시점까지 불변이라 안전하고, `defer tr.deinit()` 는 최종 tr 에만 걸립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)