### PR TITLE
fix(transformer): es5 template lowering 의 TV/TRV CR·CRLF→LF 정규화 + LineContinuation

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2665,9 +2665,11 @@ test "ES2015: template with newline and substitution" {
 }
 
 test "ES2015: template with carriage return" {
+    // ECMA-262 TV: <CR><LF>/<CR> 은 <LF> 로 정규화 (#4213) — 이전 기대값
+    // "a\r\nb" 는 스펙 위반(native cooked 와 divergence) 박제였다.
     var r = try e2eTarget(std.testing.allocator, "var s=`a\r\nb`;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var s=\"a\\r\\nb\";", r.output);
+    try std.testing.expectEqualStrings("var s=\"a\\nb\";", r.output);
 }
 
 test "ES2015: template with U+2028 line separator" {

--- a/src/transformer/es2015_template.zig
+++ b/src/transformer/es2015_template.zig
@@ -151,8 +151,10 @@ pub fn buildRawStringLiteral(self: anytype, text: []const u8) !NodeIndex {
             buf.appendAssumeCapacity('\\');
             buf.appendAssumeCapacity('n');
         } else if (c == '\r') {
+            // ECMA-262 TRV: <CR><LF> / 단독 <CR> 은 <LF> 로 정규화 (#4213).
             buf.appendAssumeCapacity('\\');
-            buf.appendAssumeCapacity('r');
+            buf.appendAssumeCapacity('n');
+            if (j + 1 < text.len and text[j + 1] == '\n') j += 1;
         } else {
             buf.appendAssumeCapacity(c);
         }
@@ -276,15 +278,39 @@ pub fn buildStringLiteral(self: anytype, text: []const u8) !NodeIndex {
         if (c == '"') {
             buf.appendAssumeCapacity('\\');
             buf.appendAssumeCapacity('"');
-        } else if (c == '\\' and j + 1 < text.len and text[j + 1] == '`') {
-            buf.appendAssumeCapacity('`');
-            j += 1;
+        } else if (c == '\\' and j + 1 < text.len) {
+            // escape pair 는 원자 소비 (#4213 리뷰): 짝을 안 맞추면 `\\`+CR 의
+            // 두 번째 백슬래시가 LineContinuation 으로 오인돼 "\b"(backspace)
+            // 류 오염이 생긴다.
+            const n1 = text[j + 1];
+            if (n1 == '`') {
+                buf.appendAssumeCapacity('`');
+                j += 1;
+            } else if (n1 == '\n') {
+                // LineContinuation: TV 기여 없음 — 통째로 소거.
+                j += 1;
+            } else if (n1 == '\r') {
+                j += 1;
+                if (j + 1 < text.len and text[j + 1] == '\n') j += 1;
+            } else if (n1 == 0xe2 and j + 3 < text.len and
+                text[j + 2] == 0x80 and (text[j + 3] == 0xa8 or text[j + 3] == 0xa9))
+            {
+                // `\` + U+2028/9 도 LineTerminatorSequence — continuation 소거.
+                j += 3;
+            } else {
+                // 그 외 escape 는 verbatim pair 보존 ("..." 에서도 동일 cooked).
+                buf.appendAssumeCapacity('\\');
+                buf.appendAssumeCapacity(n1);
+                j += 1;
+            }
         } else if (c == '\n') {
             buf.appendAssumeCapacity('\\');
             buf.appendAssumeCapacity('n');
         } else if (c == '\r') {
+            // ECMA-262 TV: <CR><LF> / 단독 <CR> 은 <LF> 로 정규화 (#4213).
             buf.appendAssumeCapacity('\\');
-            buf.appendAssumeCapacity('r');
+            buf.appendAssumeCapacity('n');
+            if (j + 1 < text.len and text[j + 1] == '\n') j += 1;
         } else if (c == 0xe2 and j + 2 < text.len and text[j + 1] == 0x80 and (text[j + 2] == 0xa8 or text[j + 2] == 0xa9)) {
             // U+2028 (Line Separator) / U+2029 (Paragraph Separator)
             // 템플릿 리터럴에서는 유효하지만 ES5 문자열 리터럴에서는 줄바꿈으로 취급

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -3102,6 +3102,48 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('template CRLF cooked 정규화 (#4213)', () => {
+    test('es5 template lowering — TV/TRV CR·CRLF→LF + line continuation', async () => {
+      // 회귀: buildStringLiteral/buildRawStringLiteral 이 raw CR 를 \r 로
+      // 보존 → CRLF(Windows) 소스에서 native cooked(LF 정규화)와 divergence.
+      const result = await bundleAndRun(
+        {
+          'index.ts':
+            'const s = `l1\r\nl2`;\n' +
+            'console.log(JSON.stringify(s), s.length);\n' +
+            'const r = String.raw`r1\r\nr2`;\n' +
+            'console.log(JSON.stringify(r));\n',
+        },
+        'index.ts',
+        ['--target=es5'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('"l1\\nl2" 5\n"r1\\nr2"');
+    });
+
+    test('escape pair 원자성 — \\\\+CRLF backspace 오염 가드 + continuation (#4213)', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts':
+            'const a = `x\\\\\r\ny`;\n' + // \\ + CRLF: escaped backslash 뒤 줄바꿈
+            'console.log(JSON.stringify(a));\n' +
+            'const c = `m\rn`;\n' + // lone CR
+            'console.log(JSON.stringify(c));\n' +
+            'const lc = `a\\\r\nb`;\n' + // line continuation
+            'console.log(JSON.stringify(lc));\n' +
+            'function tag(s: TemplateStringsArray){return JSON.stringify(s[0])+JSON.stringify(s.raw[0]);}\n' +
+            'console.log(tag`t1\r\nt2`);\n',
+        },
+        'index.ts',
+        ['--target=es5'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('"x\\\\\\ny"\n"m\\nn"\n"ab"\n"t1\\nt2""t1\\nt2"');
+    });
+  });
+
   describe('regex 추가 엣지', () => {
     test('ES2025 inline modifier 그룹 (?i:) 은 capture 인덱스 비차지 (#4202)', async () => {
       // 회귀: 텍스트 스캐너가 (?i:) 를 capturing 으로 오집계 → groups map 이


### PR DESCRIPTION
Closes #4213

## 문제

ECMA-262 는 템플릿 cooked(TV)/raw(TRV) 값에서 `<CR><LF>`/단독 `<CR>` 을 `<LF>` 로 정규화하는데, es5 template lowering(`buildStringLiteral`/`buildRawStringLiteral`)이 raw CR 를 `\r` escape 로 보존 — **CRLF(Windows) 소스의 멀티라인 템플릿이 native 와 다른 문자열** (`length`/`split('\n')` silent divergence). 같은 루프에서 LineContinuation(`\`+줄바꿈, TV 기여 없음)도 `\` + `\n` 으로 오출력.

## 루트커즈와 수정

1. 양 함수의 CR 분기를 **LF 정규화**(+후속 LF skip)로 — TV/TRV 동일 규칙.
2. `buildStringLiteral` 의 backslash 처리를 **escape-pair 원자 소비**로 재구성: LineContinuation(`\`+LF/CR[LF]/U+2028/9) 소거, 백틱 unescape, 그 외 pair verbatim. 초안의 비원자 분기는 `/code-review max` 가 **`\\`+CRLF 에서 두 번째 백슬래시를 continuation 으로 오인 → `"a\b"`(backspace) 오염 회귀**를 실증 적발 — 원자 소비가 근본 형태.
3. 기존 codegen 유닛 "template with carriage return" 은 구(스펙 위반) 동작 박제 — native 대조 후 기대값 갱신.

raw 빌더는 모든 `\` 를 독립적으로 이중화하므로 pair 로직 불요 (리뷰 확인 — `String.raw` `\`+CRLF native byte-동일).

## 검증 (`/code-review max` 실증 리뷰 반영)

- cooked CRLF/lone CR, raw TRV, line continuation(`\`+CRLF), **`\\`+CRLF/`\\`+LF (escape-pair 가드)**, `\`+U+2028 continuation, tagged template cooked+raw 배열 — 전부 native(node 24) JSON 동일.
- escape 텍스트(`\r` 2-char, `\\n`) false-positive 없음, `\u{}` lowering 경로 무변경.
- zig 5861 green + integration 전체 pass (신규 integration 2 + 갱신 유닛 1).

## Zig 초보자용 포인트

TV 루프는 이제 `\` 를 만나면 다음 1글자(또는 U+2028/9 의 3바이트)를 같은 분기에서 소비합니다 — 바이트 단위 독립 처리로는 backslash run 의 짝수/홀수 경계를 구분할 수 없어서 생긴 회귀였습니다. raw(TRV) 빌더는 `\`→`\\` 이중화가 그 자체로 짝을 보존하므로 그대로 둡니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)