### PR TITLE
fix(transformer): replace 재작성 합성 string literal 의 \u{...} brace escape 다운레벨

### DIFF
--- a/src/transformer/transformer/regex.zig
+++ b/src/transformer/transformer/regex.zig
@@ -6,6 +6,7 @@ const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
 const regex_lower = @import("../regex_lower.zig");
+const unicode_escape_lower = @import("../unicode_escape_lower.zig");
 const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
@@ -41,8 +42,18 @@ pub fn tryRewriteReplaceNamedRefs(self: *Transformer, callee_idx: NodeIndex, arg
     const new_content = (try regex_lower.rewriteReplacementNamedRefs(self.allocator, replacement.content, mapping)) orelse return null;
     defer self.allocator.free(new_content);
 
+    // #4214: 합성 string_literal 은 visit 을 다시 거치지 않아 리터럴 레벨
+    // lowering 이 누락된다 — node_dispatch 의 string_literal 분기와 동일하게
+    // \u{...} brace escape 를 직접 다운레벨 (es5 등 unicode_brace 미지원 타겟).
+    const lowered: ?[]u8 = if (self.options.unsupported.unicode_brace_escape)
+        try unicode_escape_lower.lowerContent(self.allocator, new_content)
+    else
+        null;
+    defer if (lowered) |l| self.allocator.free(l);
+    const final_content: []const u8 = lowered orelse new_content;
+
     const quote: u8 = if (replacement.is_template) '"' else replacement.quote;
-    const new_raw = try std.fmt.allocPrint(self.allocator, "{c}{s}{c}", .{ quote, new_content, quote });
+    const new_raw = try std.fmt.allocPrint(self.allocator, "{c}{s}{c}", .{ quote, final_content, quote });
     defer self.allocator.free(new_raw);
     const new_span = try self.ast.addString(new_raw);
     const new_str_node = try self.ast.addNode(.{

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -3144,6 +3144,27 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('replace 재작성 합성 리터럴 \\u{} 다운레벨 (#4214)', () => {
+    test('es5 — 합성 string literal 의 brace escape 가 lowering 됨', async () => {
+      // 회귀: 재작성 합성 노드가 visit 우회 → \u{...}(ES2015 문법)가 es5
+      // 산출물에 잔존해 진짜 ES5 엔진에서 SyntaxError.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            String.raw`console.log('xA'.replace(/(?<y>A)/, '<\u{41}> $<y>'));`,
+            'console.log("xB".replace(/(?<z>B)/, `[\\u{1F600}] $<z>`));',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es5'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('x<A> A\nx[😀] B');
+      expect(result.bundleOutput).not.toContain('\\u{');
+    });
+  });
+
   describe('regex 추가 엣지', () => {
     test('ES2025 inline modifier 그룹 (?i:) 은 capture 인덱스 비차지 (#4202)', async () => {
       // 회귀: 텍스트 스캐너가 (?i:) 를 capturing 으로 오집계 → groups map 이


### PR DESCRIPTION
Closes #4214

## 문제

`tryRewriteReplaceNamedRefs` 가 `$<name>` 재작성 후 합성한 string_literal 을 **visit 없이** 결과 AST 에 넣어 리터럴 레벨 lowering(`unicode_escape_lower`)이 우회됐다 — es5 타겟 산출물에 ES2015 전용 `\u{...}` 문법이 잔존해 **진짜 ES5 엔진에서 SyntaxError** (같은 번들의 일반 문자열은 정상 다운레벨되는 비일관).

## 수정

node_dispatch 의 string_literal 분기와 동일하게, emit 전 `unicode_escape_lower.lowerContent` 를 직접 적용 (string/template 양 분기 공통 1곳). `\u{41}`→`A`, `\u{1F600}`→surrogate pair.

## 검증 (`/code-review max` 7-앵글 실증)

- 순서 안전성: lowerContent 는 unescaped `\u{}` 만 재작성 — `$N`/`$<` 텍스트 불간섭, `\\u{41}`(escaped backslash) false-positive 없음 (escape-pair 원자 소비 확인).
- string/template 분기, `` \` `` escape, `\u{2028}` escape-text vs raw 구분(#4203 bail 과의 interplay), idempotency, es2015~2017(브레이스 합법) 무변경, 미지 이름 `$<\u{6e}ope>` 잔존 케이스 — 전부 native(node 24) parity.
- #4201 canonical 키/#4204 JSON.parse 폴백은 raw UTF-8 디코드라 무영향 확인.
- zig green + integration 182 pass.
- 리뷰 sweep 파생 pre-existing: **#4228** (const-enum string 인라인 quote 미escape — esnext 포함 전 타겟 SyntaxError, 고우선 다음 작업) / **#4229** (identifier `\u{}` es5 잔존, exotic).

## Zig 초보자용 포인트

`lowered: ?[]u8` + `defer if (lowered) |l| free(l)` + `final_content = lowered orelse new_content` 패턴으로 — 다운레벨이 불필요(null)하면 원본 슬라이스를 그대로 쓰고, 필요할 때만 새 버퍼가 생겨 LIFO defer 로 정리됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)