### PR TITLE
fix(transformer): const-enum string 인라인의 escape-aware 재인용 + brace lowering

### DIFF
--- a/src/transformer/transformer/enum.zig
+++ b/src/transformer/transformer/enum.zig
@@ -346,8 +346,35 @@ fn makeConstEnumLiteralNode(self: *Transformer, value: ConstEnumValue, _: Span) 
             defer buf.deinit(self.allocator);
             try buf.ensureTotalCapacity(self.allocator, raw.len + 2);
             try buf.append(self.allocator, '"');
-            try buf.appendSlice(self.allocator, raw);
+            // #4228: raw body 는 escape 보존 슬라이스 (출처 quote 는 '/" 혼합 가능
+            // — concat 포함). escape pair 는 원자 보존하고 unescaped `"` 만 추가
+            // escape — verbatim 재인용은 `'say "hi"'` 류에서 전 타겟 SyntaxError.
+            var i: usize = 0;
+            while (i < raw.len) : (i += 1) {
+                const ch = raw[i];
+                if (ch == '\\' and i + 1 < raw.len) {
+                    try buf.append(self.allocator, '\\');
+                    try buf.append(self.allocator, raw[i + 1]);
+                    i += 1;
+                } else if (ch == '"') {
+                    try buf.appendSlice(self.allocator, "\\\"");
+                } else {
+                    try buf.append(self.allocator, ch);
+                }
+            }
             try buf.append(self.allocator, '"');
+            // #4214 동형: 합성 노드는 visit 우회라 \u{...} brace escape 를 직접
+            // 다운레벨 (es5 등 unicode_brace 미지원 타겟).
+            if (self.options.unsupported.unicode_brace_escape) {
+                const unicode_escape_lower = @import("../unicode_escape_lower.zig");
+                if (try unicode_escape_lower.lowerContent(self.allocator, buf.items[1 .. buf.items.len - 1])) |lowered| {
+                    defer self.allocator.free(lowered);
+                    buf.clearRetainingCapacity();
+                    try buf.append(self.allocator, '"');
+                    try buf.appendSlice(self.allocator, lowered);
+                    try buf.append(self.allocator, '"');
+                }
+            }
             const str_span = try self.ast.addString(buf.items);
             return self.ast.addNode(.{
                 .tag = .string_literal,

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -3165,6 +3165,43 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('const enum string 인라인 escape (#4228)', () => {
+    test('quote/escape/brace — 전 타겟 유효 산출물', async () => {
+      // 회귀: raw body verbatim 재인용 → 내부 " 미escape 로 전 타겟 SyntaxError,
+      // \u{...} 잔존으로 es5 SyntaxError.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            String.raw`const enum E { A = '\u{1F600}', Q = 'say "hi"', S = "it's", C = 'a\'b' }`,
+            'console.log(E.A, E.Q, E.S, E.C);',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es5'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe(`😀 say "hi" it's a'b`);
+      expect(result.bundleOutput).not.toContain('\\u{');
+    });
+
+    test('quote escape 는 타겟 무관 (esnext — brace 보존)', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            String.raw`const enum E { A = '\u{1F600}', Q = 'say "hi"' }`,
+            'console.log(E.A, E.Q);',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=esnext'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('😀 say "hi"');
+    });
+  });
+
   describe('regex 추가 엣지', () => {
     test('ES2025 inline modifier 그룹 (?i:) 은 capture 인덱스 비차지 (#4202)', async () => {
       // 회귀: 텍스트 스캐너가 (?i:) 를 capturing 으로 오집계 → groups map 이


### PR DESCRIPTION
Closes #4228

## 문제 (전 타겟 빌드 산출물 파손 — 실증)

const enum 문자열 인라인(`makeConstEnumLiteralNode`)이 escape-보존 raw body(출처 quote `'`/`"` 혼합 가능 — concat 포함)를 `"` 재인용에 **verbatim** emit:

```ts
const enum E { A = '\u{1F600}', Q = 'say "hi"' }
```
→ `console.log("\u{1F600}", "say "hi"")` — 내부 `"` 미escape 로 **esnext 포함 모든 타겟에서 hard SyntaxError** (node 24 파싱 거부). 별개로 `\u{...}` 가 es5 잔존 (#4214 동류 visit-bypass).

## 루트커즈와 수정

1. **escape-pair 원자 소비** 재인용 (#4213 과 동일 원칙): pair 는 verbatim 보존, unescaped `"` 만 `\"` 로 escape — `'`/`"` 출처 혼합·concat 모두 안전.
2. unicode_brace 미지원 타겟에서 `lowerContent` 적용 (#4214 동형 — 합성 노드는 visit 미경유).

## 검증 (`/code-review max` 8-앵글 실증)

- 😀/`say "hi"`/`it's`/`a'b`/혼합-quote concat(`'x"' + "y\"z"`)/3-way concat/line continuation byte-보존/`\'` parity — es5+esnext 전부 값 보존 (이전: 파싱 거부).
- lowerContent 가 주입된 `\"` pair 를 원자 skip 함을 코드/실증 양면 확인, plain 문자열 byte-identical, numeric/boolean 불변, `--quotes`/`--ascii-only` 재인용 경로 정상.
- zig green + integration 184 pass (es5 + esnext 가드 변형).
- 리뷰 파생 pre-existing 이슈 분리: **#4231** (멤버 lookup raw 비교 — `E["A"]` 인라인 실패+선언 삭제 → ReferenceError, 다음 작업), #4232 (concat 중간 할당 GPA-contract).

## Zig 초보자용 포인트

body 는 "escape 보존 슬라이스"라 cooked 가 아닙니다 — 그래서 cooked 용 `string_escape.appendEscaped` 를 쓰면 기존 escape 가 이중화됩니다. pair-원자 walk + bare-`"` escape 가 이 표현형에 맞는 최소 변환입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)