### PR TITLE
fix(transformer): const-enum 멤버 lookup 을 cooked(escape 디코드) 비교로

### DIFF
--- a/src/transformer/transformer/enum.zig
+++ b/src/transformer/transformer/enum.zig
@@ -225,7 +225,7 @@ fn evalConstEnumExpr(
             // 같은 enum 안의 다른 멤버 참조 (예: `B = A + 1`)
             const name = self.ast.getText(node.span);
             for (ctx.current_members) |m| {
-                if (std.mem.eql(u8, m.name, name)) return m.value;
+                if (cookedNameEql(m.name, name)) return m.value;
             }
             return null;
         },
@@ -257,14 +257,14 @@ fn tryEvalEnumMemberAccess(self: *const Transformer, node: Node, ctx: ConstEnumE
     // 현재 collecting 중인 enum self-reference (예: `Other.X` from inside Other 정의)
     if (matchesEnumName(ctx.current_name, ctx.current_symbol_id, obj_name, obj_sym)) {
         for (ctx.current_members) |m| {
-            if (std.mem.eql(u8, m.name, prop_name)) return m.value;
+            if (cookedNameEql(m.name, prop_name)) return m.value;
         }
     }
 
     for (self.const_enums.items) |decl| {
         if (!enumDeclMatches(decl, obj_name, obj_sym)) continue;
         for (decl.members) |m| {
-            if (std.mem.eql(u8, m.name, prop_name)) return m.value;
+            if (cookedNameEql(m.name, prop_name)) return m.value;
         }
     }
     return null;
@@ -296,11 +296,185 @@ pub fn tryInlineConstEnumMember(self: *Transformer, node: Node) Error!?NodeIndex
     for (self.const_enums.items) |decl| {
         if (!enumDeclMatches(decl, obj_name, obj_sym)) continue;
         for (decl.members) |m| {
-            if (!std.mem.eql(u8, m.name, prop_name)) continue;
+            if (!cookedNameEql(m.name, prop_name)) continue;
             return try makeConstEnumLiteralNode(self, m.value, node.span);
         }
     }
     return null;
+}
+
+/// escape-보존 표기에서 다음 cooked 코드포인트를 디코드 (#4231).
+/// string escape (\n \t \r \b \f \v \0 \xHH \uHHHH[pair] \u{...}
+/// NonEscape identity, LineContinuation=문자 없음) + raw UTF-8.
+/// 디코드 실패 시 null — 호출자는 raw eql 폴백.
+fn nextCookedCp(t: []const u8, i: *usize) ?u21 {
+    const c = t[i.*];
+    if (c != '\\') {
+        const len = std.unicode.utf8ByteSequenceLength(c) catch return null;
+        if (i.* + len > t.len) return null;
+        const cp = std.unicode.utf8Decode(t[i.* .. i.* + len]) catch return null;
+        i.* += len;
+        return cp;
+    }
+    if (i.* + 1 >= t.len) return null;
+    const e = t[i.* + 1];
+    i.* += 2;
+    switch (e) {
+        'n' => return '\n',
+        't' => return '\t',
+        'r' => return '\r',
+        'b' => return 0x08,
+        'f' => return 0x0C,
+        'v' => return 0x0B,
+        '0' => {
+            // \0 + digit 은 legacy octal — strict 금지, 보수적으로 실패 처리.
+            if (i.* < t.len and t[i.*] >= '0' and t[i.*] <= '9') return null;
+            return 0;
+        },
+        'x' => {
+            if (i.* + 2 > t.len) return null;
+            var cp: u21 = 0;
+            for (t[i.* .. i.* + 2]) |h| {
+                const d = std.fmt.charToDigit(h, 16) catch return null;
+                cp = cp * 16 + d;
+            }
+            i.* += 2;
+            return cp;
+        },
+        'u' => {
+            if (i.* < t.len and t[i.*] == '{') {
+                var j = i.* + 1;
+                const hs = j;
+                var cp: u32 = 0;
+                while (j < t.len and t[j] != '}') : (j += 1) {
+                    const d = std.fmt.charToDigit(t[j], 16) catch return null;
+                    cp = cp * 16 + d;
+                    if (cp > 0x10FFFF) return null;
+                }
+                if (j >= t.len or j == hs) return null;
+                i.* = j + 1;
+                return @intCast(cp);
+            }
+            if (i.* + 4 > t.len) return null;
+            var cp: u32 = 0;
+            for (t[i.* .. i.* + 4]) |h| {
+                const d = std.fmt.charToDigit(h, 16) catch return null;
+                cp = cp * 16 + d;
+            }
+            i.* += 4;
+            if (cp >= 0xD800 and cp <= 0xDBFF and i.* + 6 <= t.len and
+                t[i.*] == '\\' and t[i.* + 1] == 'u' and t[i.* + 2] != '{')
+            {
+                var lo: u32 = 0;
+                var ok = true;
+                for (t[i.* + 2 .. i.* + 6]) |h| {
+                    const d = std.fmt.charToDigit(h, 16) catch {
+                        ok = false;
+                        break;
+                    };
+                    lo = lo * 16 + d;
+                }
+                if (ok and lo >= 0xDC00 and lo <= 0xDFFF) {
+                    i.* += 6;
+                    return @intCast(0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00));
+                }
+            }
+            return @intCast(cp);
+        },
+        '1', '2', '3', '4', '5', '6', '7' => {
+            // legacy octal escape — TS 는 거부(TS1487)하나 우리 파서가 수용하는
+            // 입력에서 identity 오쿡 방지: 보수적으로 실패 → raw 폴백.
+            return null;
+        },
+        '\n', '\r' => {
+            // LineContinuation: cooked 기여 없음 — CRLF pair skip 후 다음 문자.
+            if (e == '\r' and i.* < t.len and t[i.*] == '\n') i.* += 1;
+            if (i.* >= t.len) return null;
+            return nextCookedCp(t, i);
+        },
+        else => {
+            // NonEscapeCharacter: identity (\' \" \\ \` 포함, 멀티바이트 lead 도 그대로)
+            const len = std.unicode.utf8ByteSequenceLength(e) catch return null;
+            if (i.* - 1 + len > t.len) return null;
+            const cp = std.unicode.utf8Decode(t[i.* - 1 .. i.* - 1 + len]) catch return null;
+            i.* += len - 1;
+            return cp;
+        },
+    }
+}
+
+/// LineContinuation (`\` + LF/CR[LF]/U+2028/9) 연쇄를 소거 — cooked 기여 0.
+/// end 검사 전에 호출해야 trailing continuation ('q\<LF>' vs 'q') 이 정확.
+fn skipLineContinuations(t: []const u8, i: *usize) void {
+    while (i.* + 1 < t.len and t[i.*] == '\\') {
+        const n1 = t[i.* + 1];
+        if (n1 == '\n') {
+            i.* += 2;
+        } else if (n1 == '\r') {
+            i.* += 2;
+            if (i.* < t.len and t[i.*] == '\n') i.* += 1;
+        } else if (n1 == 0xe2 and i.* + 4 <= t.len and
+            t[i.* + 2] == 0x80 and (t[i.* + 3] == 0xa8 or t[i.* + 3] == 0xa9))
+        {
+            i.* += 4;
+        } else break;
+    }
+}
+
+const CookedIter = struct {
+    t: []const u8,
+    i: usize = 0,
+    /// astral cp 의 low surrogate 보류분 — UTF-16 code unit 단위 비교용.
+    pending_lo: ?u21 = null,
+
+    /// u21 범위 밖은 불가하므로 surrogate-범위 위 값으로 디코드 실패 표시.
+    const error_marker: u21 = 0x1FFFFF;
+
+    /// 다음 UTF-16 code unit. 혼합 escape 표기(`\uD83D\u{DE00}` vs 😀)도
+    /// unit 시퀀스로는 동일해져 정확 비교 (#4231 리뷰).
+    fn next(self: *@This()) ?u21 {
+        if (self.pending_lo) |lo| {
+            self.pending_lo = null;
+            return lo;
+        }
+        skipLineContinuations(self.t, &self.i);
+        if (self.i >= self.t.len) return null;
+        const cp = nextCookedCp(self.t, &self.i) orelse return error_marker;
+        if (cp > 0xFFFF) {
+            self.pending_lo = @intCast(0xDC00 + ((cp - 0x10000) & 0x3FF));
+            return @intCast(0xD800 + ((cp - 0x10000) >> 10));
+        }
+        return cp;
+    }
+
+    fn atEnd(self: *@This()) bool {
+        if (self.pending_lo != null) return false;
+        skipLineContinuations(self.t, &self.i);
+        return self.i >= self.t.len;
+    }
+};
+
+/// 두 escape-보존 이름이 cooked(UTF-16 unit 시퀀스) 기준으로 같은가 (#4231).
+/// 디코드 실패 시 raw-byte 비교 폴백 (이전 동작 보존 방어선).
+/// NOTE: escape 디코더는 string_escape.decodeUnicodeHexEscape /
+/// regexp/group_name.zig nextCodepoint 와 의도적 별도 구현 — 여기는 string
+/// escape 전 문법(superset)이 필요하다. escape 처리 수정 시 셋을 교차 점검.
+fn cookedNameEql(a: []const u8, b: []const u8) bool {
+    // 공통 케이스 fast-path: byte-identical 이름 (escape 무관하게 동일 cooked).
+    if (std.mem.eql(u8, a, b)) return true;
+    var xa = CookedIter{ .t = a };
+    var xb = CookedIter{ .t = b };
+    while (true) {
+        const ae = xa.atEnd();
+        const be = xb.atEnd();
+        if (ae and be) return true;
+        if (ae != be) return false;
+        const ua = xa.next() orelse return false;
+        const ub = xb.next() orelse return false;
+        if (ua == CookedIter.error_marker or ub == CookedIter.error_marker)
+            return std.mem.eql(u8, a, b);
+        if (ua != ub) return false;
+    }
 }
 
 fn memberPropertyName(self: *const Transformer, member_tag: Tag, prop_idx: NodeIndex) ?[]const u8 {

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -3185,6 +3185,23 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(result.bundleOutput).not.toContain('\\u{');
     });
 
+    test('멤버 lookup cooked 비교 — E["\\u0041"] 인라인 (#4231)', async () => {
+      // 회귀: raw escape 표기 비교라 인라인 실패 + 선언 삭제 → ReferenceError.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            String.raw`const enum E { A = 1, 'a b' = 2 }`,
+            String.raw`console.log(E['\u0041'], E.A, E['a b'], E['a\u0020b']);`,
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=esnext'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('1 1 2 2');
+    });
+
     test('quote escape 는 타겟 무관 (esnext — brace 보존)', async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
Closes #4231

## 문제 (실증 — silent ReferenceError)

```ts
const enum E { A = 1 }
console.log(E["A"]);   // tsc: 1 인라인
```
zntc 는 선언키/접근키가 **escape-보존 raw 슬라이스**인 채 4개 지점에서 raw byte 비교 — `"A"` ≠ `A` 로 인라인 실패, 선언은 삭제돼 **런타임 ReferenceError**.

## 루트커즈와 수정

이름 정체성은 cooked 문자열. `nextCookedCp`(string escape 전 문법: `\n\t\r\b\f\v\0 \xHH \uHHHH[pair] \u{...}` NonEscape identity, LineContinuation 소거) + `cookedNameEql` 로 4개 비교 지점 교체.

`/code-review max` 가 적발한 정밀 케이스까지 반영:
- **UTF-16 code unit 시퀀스 비교** (`CookedIter` + pending low surrogate) — 혼합 표기 `\uD83D\u{DE00}` ≡ `😀` ≡ `\u{1F600}` 정확 매치 (cp 비교로는 불가능한 케이스, tsc 동치 실증).
- **trailing LineContinuation** (`'q\<LF>'` ≡ `'q'`) — end 검사 전 continuation 소거 (`skipLineContinuations`, LS/PS 포함).
- legacy octal `\1-\7` 은 보수 폴백 (TS 가 거부하는 입력의 identity 오쿡 방지).
- fast-path `mem.eql` (plain 이름 = 기존 memcmp 비용), 디코더 3종(string_escape/group_name/본 함수) cross-link 주석.
- 디코드 실패 시 raw 비교 폴백 = 이전 동작 보존 방어선.

## 검증

`E['A']/E.A/E['a b']/E['a b']` → `1 1 2 2`, 혼합 surrogate `3 3`, trailing continuation `9`, `\x41`/`\u{41}`/self-ref/cross-enum/`E.A` — 전부 tsc 동치 (이전: ReferenceError). plain 이름 corpora byte-identical. zig green + integration pass. 잔여 note: enum *이름* 자체의 escape 표기는 symbol_id 매칭이 커버 (analyzer-off 테스트 환경 한정 한계 — 리뷰 note-only).

## Zig 초보자용 포인트

`CookedIter` 는 astral 코드포인트를 high/low surrogate 두 unit 으로 쪼개 반환하는 작은 상태기계입니다 — JS 문자열의 정체성이 UTF-16 unit 시퀀스라서, lone surrogate escape 와 pair 혼합 표기까지 같은 잣대로 비교하려면 cp 가 아니라 unit 스트림이 정답입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)