### PR TITLE
fix(transformer): 합성 temp 이름의 사용자 식별자 충돌 회피 + hoist shadow 일관성

### DIFF
--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -108,11 +108,40 @@ pub fn makeTempVarSpan(self: anytype) !Span {
         self.temp_var_counter += 1;
         const name = tempVarName(idx, &buf);
         if (collidesWithPrivateField(self, name)) continue;
+        // #4220: 사용자 식별자(_a 등)와 충돌하면 skip — 충돌 시 temp 대입이
+        // 사용자 const 를 덮거나(TypeError) mangler/tree-shake 가 선언·사용을
+        // 잘못 결합해 silent miscompile 이었다.
+        if (try collidesWithUserSymbol(self, name)) continue;
         return self.ast.addString(name);
     }
 }
 
-fn collidesWithPrivateField(self: anytype, name: []const u8) bool {
+/// 모듈 심볼 중 temp 패턴(`_`+letter[+digits]) 이름만 lazy 수집해 조회 (#4220).
+/// symbols 가 비어있는 경로(semantic-off 테스트)는 집합도 비어 기존 동작.
+pub fn collidesWithUserSymbol(self: anytype, name: []const u8) !bool {
+    if (self.temp_collision_set == null) {
+        var set: std.StringHashMapUnmanaged(void) = .empty;
+        errdefer set.deinit(self.allocator);
+        for (self.symbols) |sym| {
+            const sym_name = self.ast.getText(sym.name);
+            if (isTempLikeName(sym_name)) try set.put(self.allocator, sym_name, {});
+        }
+        self.temp_collision_set = set;
+    }
+    return self.temp_collision_set.?.contains(name);
+}
+
+fn isTempLikeName(name: []const u8) bool {
+    if (name.len < 2 or name.len > 6) return false;
+    if (name[0] != '_') return false;
+    if (name[1] < 'a' or name[1] > 'z') return false;
+    for (name[2..]) |c| {
+        if (c < '0' or c > '9') return false;
+    }
+    return true;
+}
+
+pub fn collidesWithPrivateField(self: anytype, name: []const u8) bool {
     for (self.current_private_fields) |pf| {
         if (std.mem.eql(u8, pf.var_name, name)) return true;
     }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -106,6 +106,10 @@ pub const Transformer = struct {
     /// 비어 있으면 unused import 제거 비활성.
     symbols: []const Symbol = &.{},
 
+    /// #4220: 합성 temp(_a, _b2 …)와 충돌하는 사용자 심볼 이름 집합 (lazy).
+    /// 키는 source 슬라이스 (ast/source 수명 — transform 동안 안정).
+    temp_collision_set: ?std.StringHashMapUnmanaged(void) = null,
+
     /// #1791 per-reference 기록 (`semantic/analyzer::SemanticAnalyzer.references`).
     /// import binding elision 판정은 `Symbol.reference_count` 대신 여기서 symbol 별
     /// Reference 를 돌며 **value-use 가 하나라도 있는지** 로 판단한다. 비어있으면

--- a/src/transformer/transformer/lifecycle.zig
+++ b/src/transformer/transformer/lifecycle.zig
@@ -120,6 +120,7 @@ pub fn deinit(self: *Transformer) void {
 /// `ast.deinit()` + `allocator.destroy(ast)` 둘 다 책임.
 pub fn deinitExceptAst(self: *Transformer) void {
     self.scratch.deinit(self.allocator);
+    if (self.temp_collision_set) |*set| set.deinit(self.allocator);
     self.pending_nodes.deinit(self.allocator);
     self.symbol_ids.deinit(self.allocator);
     self.helper_ref_nodes.deinit(self.allocator);

--- a/src/transformer/transformer/lists.zig
+++ b/src/transformer/transformer/lists.zig
@@ -354,6 +354,11 @@ pub fn hoistTempVarsSkippingSpans(self: *Transformer, body_idx: NodeIndex, saved
         const name = es_helpers.tempVarName(i, &buf);
         if (tempNameInSpans(self, name, skip_spans)) continue;
         if (has_block and bodyHasTopLevelVarBinding(self, body_node, name)) continue;
+        // #4220: makeTempVarSpan 이 skip 한 이름(사용자/private 충돌)을 여기서
+        // 재생성-선언하면 함수 스코프 `var _a` 가 outer 사용자 `_a` 를 shadow
+        // — make-시점과 동일 predicate 로 일관 skip (집합 불변이라 결정 일치).
+        if (es_helpers.collidesWithPrivateField(self, name)) continue;
+        if (try es_helpers.collidesWithUserSymbol(self, name)) continue;
         const name_span = try self.ast.addString(name);
         const binding = try self.ast.addNode(.{
             .tag = .binding_identifier,

--- a/tests/integration/tests/minify-temp-decl.test.ts
+++ b/tests/integration/tests/minify-temp-decl.test.ts
@@ -66,6 +66,65 @@ describe('#4218: bundle+minify 합성 temp 선언 보존', () => {
     expect(result.runOutput).toBe('1 2');
   });
 
+  test('사용자 _a/_b 식별자와 temp 충돌 회피 (#4220)', async () => {
+    // 회귀: makeTempVarSpan 이 private-field 만 회피 — 사용자 const _a 에
+    // temp 대입(TypeError) / minify 시 선언·사용 오결합.
+    const result = await bundleAndRun(
+      {
+        'index.ts': [
+          'const _a = 99;',
+          'const o = { a: { b: 1 } } as any;',
+          'console.log(o.a?.b, _a);',
+          'function f(x: any) { const _b = 5; return (x?.y ?? -1) + _b; }',
+          'console.log(f({ y: 2 }), f(null));',
+        ].join('\n'),
+      },
+      'index.ts',
+      ['--target=es2017', '--minify'],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe('1 99\n7 4');
+  });
+
+  for (const flags of [['--target=es2017'], ['--target=es2017', '--minify']] as string[][]) {
+    test(`함수가 outer _a 를 읽을 때 hoist shadow 금지 (#4220, ${flags.join(' ')})`, async () => {
+      // 회귀: hoist 가 skip 된 인덱스 이름(var _a)을 함수 본문에 선언해
+      // outer 사용자 _a 를 shadow → undefined 읽기 silent miscompile.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'let _a = 90; _a += 9;',
+            "function g(o: any) { return _a + ':' + (o.a?.b ?? 'd'); }",
+            'console.log(g({ a: { b: 1 } }), g({}));',
+          ].join('\n'),
+        },
+        'index.ts',
+        flags,
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('99:1 99:d');
+    });
+  }
+
+  test('private field WeakMap _a 와 hoist shadow 금지 (#1485 보완)', async () => {
+    const result = await bundleAndRun(
+      {
+        'index.ts': [
+          'class C { #a = 5; m(o: any) { return String(this.#a) + ":" + (o.a?.b ?? "d"); } }',
+          'const c = new C();',
+          'console.log(c.m({ a: { b: 1 } }), c.m({}));',
+        ].join('\n'),
+      },
+      'index.ts',
+      ['--target=es2017'],
+    );
+    cleanup = result.cleanup;
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe('5:1 5:d');
+  });
+
   test('함수 스코프 내부 temp + --minify (es2017)', async () => {
     const result = await bundleAndRun(
       {


### PR DESCRIPTION
Closes #4220

## 문제 (실증 — 두 결함이 한 쌍)

1. `makeTempVarSpan` 이 private-field 이름만 회피 — 사용자 `const _a` 가 있으면 temp 대입이 그 바인딩을 덮어 **TypeError(Assignment to constant)** / minify 에선 temp·사용자 심볼 오결합.
2. (리뷰가 적발한 동전의 뒷면) `hoistTempVars` 가 counter 범위에서 이름을 **재생성해 선언**하므로, make-시점에 skip 한 이름이라도 함수 본문에 `var _a` 가 선언돼 **outer 사용자 `_a` 를 shadow** — `const _a=99; function g(o){ return _a+':'+(o.a?.b??'d') }` 가 `undefined:1` 출력 (silent miscompile). pre-existing 동류: private-field skip(#1485)도 hoist 미반영이라 `class C { #a; m(){...} }` 가 메서드에서 WeakMap `_a` 를 shadow → TypeError — 같은 자리에서 함께 수리.

## 루트커즈와 수정

- `collidesWithUserSymbol`: semantic 심볼 테이블에서 temp 패턴 이름(`_`+letter[+digits])만 lazy 수집한 set 으로 make-시점 skip (collidesWithPrivateField 동일 패턴, semantic-off 경로는 빈 set = 기존 동작).
- **hoist 루프에 동일 predicate 2종 공유** — make/hoist 의 skip 결정이 항상 일치 (set 불변 + counter save/restore 와도 결정적).

## 검증 (`/code-review max` 실증 리뷰 반영)

- 모듈/함수 사용자 `_a`/`_b`, **outer-read shadow 케이스(minify 유/무)**, private-field `#a` 메서드 케이스 — 전부 값 보존 (이전: TypeError / `undefined:1` / WeakMap TypeError).
- counter save/restore 결정성, anytype 호출처 전수, set 키 수명(parse-time source span — 리뷰가 resync 경로 미도달 확인, 잠재 hardening 은 field 주석), lifecycle deinit #1287 패턴 — 전부 확인.
- zig green + integration 10/10 (신규 4 케이스).

## Zig 초보자용 포인트

skip 결정을 두 곳(make/hoist)에서 따로 계산해도 안전한 이유는 충돌 set 이 transform 동안 **불변**이고 이름이 counter 인덱스의 순수 함수이기 때문입니다 — 같은 인덱스는 언제나 같은 결정. 이 불변식이 깨지면(런타임 set 변경) 두 지점이 어긋나므로 주석으로 박아뒀습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)