### PR TITLE
fix(semantic): unresolved_references 키를 stable 사본으로 — string_table slice dangling

### DIFF
--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -339,6 +339,8 @@ pub fn isRegisteredHelperBaseName(base_name: []const u8) bool {
 }
 
 /// map 에 들어있는 등록 helper base name 을 제거한다.
+/// NOTE(#4221): unresolved_references 의 키는 analyzer 소유 dupe — remove 는
+/// 키를 해제하지 않는다 (현 호출처는 parse_arena 라 arena 가 일괄 회수).
 pub fn removeRegisteredHelperBaseNames(map: *std.StringHashMapUnmanaged(void)) void {
     for (MODULES) |m| {
         for (m.helpers) |h| {

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -254,6 +254,9 @@ pub const SemanticAnalyzer = struct {
         for (self.scope_maps.items) |*m| m.deinit(self.allocator);
         self.scope_maps.deinit(self.allocator);
         self.exported_names.deinit(self.allocator);
+        // #4221: 키는 전부 dupe 사본 (소유) — 함께 해제.
+        var unres_it = self.unresolved_references.keyIterator();
+        while (unres_it.next()) |k| self.allocator.free(k.*);
         self.unresolved_references.deinit(self.allocator);
         self.labels.deinit(self.allocator);
         // resolvePrivateName에서 할당된 문자열 해제
@@ -961,7 +964,15 @@ pub const SemanticAnalyzer = struct {
 
         // 스코프 체인을 전부 올라갔는데 선언을 찾지 못함 → 미해결 참조 (글로벌).
         // 번들러 linker가 이 이름들을 예약하여 scope hoisting 시 shadowing을 방지.
-        self.unresolved_references.put(self.allocator, name, {}) catch {};
+        // #4221: 이름이 string_table 슬라이스(합성 노드)일 수 있다 — emitter 소비
+        // 시점까지 string_table 이 realloc 되면 dangling (#3100 클래스). declare
+        // 쪽(getTextStable)과 대칭으로 stable 사본 키 사용. 이미 등록된 키면
+        // 사본을 만들지 않는다.
+        if (self.unresolved_references.contains(name)) return;
+        const stable_name = self.allocator.dupe(u8, name) catch return;
+        self.unresolved_references.put(self.allocator, stable_name, {}) catch {
+            self.allocator.free(stable_name);
+        };
     }
 
     /// 노드가 식별자 참조이면 resolveIdentifier를 호출하고 true를 반환한다.


### PR DESCRIPTION
Closes #4221

## 문제

미해결 참조(unresolved_references) 키가 호출자 name slice **차용** — 합성 노드(#4218 이후 `identifierNameText` 가 반환하는 string_table 슬라이스 포함)면 이후 `addString` 의 realloc 로 dangling, emitter purity/globals·minify(unresolved_globals)·linker 예약 소비 시점에 가비지 이름 (#3100 클래스). declare 쪽은 `getTextStable` 로 방어돼 있던 비대칭.

## 수정

put 전 contains 선체크(중복 사본 방지) + **항상 dupe**(소스/string_table 혼재 키는 해제 시 구분 불가 → 일관 소유) + deinit 에서 키 전체 해제. `removeRegisteredHelperBaseNames` 의 키 비해제는 arena-한정임을 주석으로 명시.

## 검증 (`/code-review max` 6-앵글)

- put 사이트 단일(973), 외부 mutation 은 helper-name remove 1곳(parse_arena 한정 — 주석), 맵 핸들 value-copy 경로들은 전부 arena-backed·deinit 미호출(parse_module 주석) — double-free 경로 없음.
- resolved_names 와 키 aliasing 불가(항상 dupe), 결정성 무영향(content-hash), OOM 경로 동등성(informational).
- GPA 단위테스트(analyzer/checker, testing.allocator + defer deinit)가 새 free 루프를 leak-검증 — zig 5861 green.
- 성능: 모듈당 미해결 글로벌 수십 개 dupe — 미미. getOrPut 1-해시 대안은 OOM 시 비소유 키 잔존 위험으로 기각(리뷰 판단).

## Zig 초보자용 포인트

HashMap 키의 수명 규칙이 "차용 슬라이스 + 일부만 사본"이면 해제 시 출처를 구분할 수 없습니다 — 그래서 **전부 소유(dupe)** 로 일원화하고 deinit 에서 keyIterator 로 일괄 해제하는 게 안전한 형태입니다. 프로덕션은 arena 라 free 가 no-op, 테스트(GPA)에서 leak 검증이 작동합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)