### PR TITLE
fix(regexp): literal non-ASCII atom 을 UTF-8 코드포인트 단위 노드로 — transform 재인쇄 mojibake

### DIFF
--- a/src/regexp/parser.zig
+++ b/src/regexp/parser.zig
@@ -688,11 +688,15 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                         return false;
                     }
                     self.advance();
-                    if (emit_ast) {
-                        self.last_node = self.addNode(.character, .{
-                            .start = self.pos - 1,
-                            .end = self.pos,
-                        }, .{ c, @intFromEnum(ast.CharacterKind.symbol), 0 });
+                    {
+                        const lit_start = self.pos - 1;
+                        const cp = self.consumeLiteralCp(c);
+                        if (emit_ast) {
+                            self.last_node = self.addNode(.character, .{
+                                .start = lit_start,
+                                .end = self.pos,
+                            }, .{ cp, @intFromEnum(ast.CharacterKind.symbol), 0 });
+                        }
                     }
                     return true;
                 },
@@ -702,26 +706,53 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                         return false;
                     }
                     self.advance();
-                    if (emit_ast) {
-                        self.last_node = self.addNode(.character, .{
-                            .start = self.pos - 1,
-                            .end = self.pos,
-                        }, .{ c, @intFromEnum(ast.CharacterKind.symbol), 0 });
+                    {
+                        const lit_start = self.pos - 1;
+                        const cp = self.consumeLiteralCp(c);
+                        if (emit_ast) {
+                            self.last_node = self.addNode(.character, .{
+                                .start = lit_start,
+                                .end = self.pos,
+                            }, .{ cp, @intFromEnum(ast.CharacterKind.symbol), 0 });
+                        }
                     }
                     return true;
                 },
                 ')' => return false, // alternative 종료
                 else => {
                     self.advance();
-                    if (emit_ast) {
-                        self.last_node = self.addNode(.character, .{
-                            .start = self.pos - 1,
-                            .end = self.pos,
-                        }, .{ c, @intFromEnum(ast.CharacterKind.symbol), 0 });
+                    {
+                        const lit_start = self.pos - 1;
+                        const cp = self.consumeLiteralCp(c);
+                        if (emit_ast) {
+                            self.last_node = self.addNode(.character, .{
+                                .start = lit_start,
+                                .end = self.pos,
+                            }, .{ cp, @intFromEnum(ast.CharacterKind.symbol), 0 });
+                        }
                     }
                     return true;
                 },
             }
+        }
+
+        /// literal 문자 atom 의 코드포인트 소비 (#4237). non-ASCII 첫 byte 면
+        /// UTF-8 시퀀스 tail 을 추가 소비해 단일 코드포인트 반환 — byte 단위
+        /// 노드는 printer 재인쇄 시 continuation byte 가 개별 cp 로 인코드돼
+        /// mojibake, transform 의 cp 기반 판정(fold 등)도 오류였다.
+        /// validate-only 경로도 동일하게 tail 을 소비해 파싱 진행이 일치한다.
+        /// invalid UTF-8 은 기존 byte 동작 폴백. 호출 규약: 첫 byte 는 이미
+        /// advance 된 상태.
+        fn consumeLiteralCp(self: *Self, first: u32) u32 {
+            if (first < 0x80) return first;
+            const start = self.pos - 1;
+            const fb: u8 = @intCast(first & 0xFF);
+            const len = std.unicode.utf8ByteSequenceLength(fb) catch return first;
+            if (len <= 1 or start + len > self.source.len) return first;
+            const cp = std.unicode.utf8Decode(self.source[start .. start + len]) catch return first;
+            var k: usize = 1;
+            while (k < len) : (k += 1) self.advance();
+            return cp;
         }
 
         // ================================================================
@@ -997,12 +1028,14 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                     }
                     // non-unicode: literal
                     self.advance();
-                    self.setClassValue(c);
+                    // #4237: identity escape 의 non-ASCII (\é 등) 도 cp 단위.
+                    const id_cp = self.consumeLiteralCp(c);
+                    self.setClassValue(id_cp);
                     if (emit_ast) {
                         self.last_node = self.addNode(.character, .{
                             .start = bs_pos,
                             .end = self.pos,
-                        }, .{ c, @intFromEnum(ast.CharacterKind.identifier), 0 });
+                        }, .{ id_cp, @intFromEnum(ast.CharacterKind.identifier), 0 });
                     }
                     return true;
                 },
@@ -1099,12 +1132,14 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                         return false;
                     }
                     self.advance();
-                    self.setClassValue(c);
+                    // #4237: identity escape 의 non-ASCII (\é 등) 도 cp 단위.
+                    const id_cp = self.consumeLiteralCp(c);
+                    self.setClassValue(id_cp);
                     if (emit_ast) {
                         self.last_node = self.addNode(.character, .{
                             .start = bs_pos,
                             .end = self.pos,
-                        }, .{ c, @intFromEnum(ast.CharacterKind.identifier), 0 });
+                        }, .{ id_cp, @intFromEnum(ast.CharacterKind.identifier), 0 });
                     }
                     return true;
                 },
@@ -1164,7 +1199,17 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                                 }
                             }
                             if (!first_is_escape and !self.last_class_is_class_escape) {
-                                if (first_value > self.last_class_value) {
+                                // #4237: non-u 모드의 range 의미는 UTF-16 unit —
+                                // astral 리터럴이 양끝이면 native 는 시작=low
+                                // surrogate / 끝=high surrogate 가 비교 대상.
+                                // cp 비교는 [😀-！] 류 valid 패턴 오거부.
+                                var lo_cmp = first_value;
+                                var hi_cmp = self.last_class_value;
+                                if (!self.flags.hasUnicodeMode()) {
+                                    if (lo_cmp > 0xFFFF) lo_cmp = 0xDC00 | ((lo_cmp - 0x10000) & 0x3FF);
+                                    if (hi_cmp > 0xFFFF) hi_cmp = 0xD800 | ((hi_cmp - 0x10000) >> 10);
+                                }
+                                if (lo_cmp > hi_cmp) {
                                     self.setError("character class range out of order");
                                     return false;
                                 }
@@ -1233,14 +1278,18 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                 return self.parseEscape();
             }
             const ch = self.peek();
-            self.last_class_value = ch;
             self.last_class_is_class_escape = false;
             self.advance();
+            const lit_start = self.pos - 1;
+            const cp = self.consumeLiteralCp(ch);
+            // #4237: range 비교(`a-z`)도 코드포인트 기준 — byte 비교는
+            // non-ASCII range 에서 부정확했다.
+            self.last_class_value = cp;
             if (emit_ast) {
                 self.last_node = self.addNode(.character, .{
-                    .start = self.pos - 1,
+                    .start = lit_start,
                     .end = self.pos,
-                }, .{ ch, @intFromEnum(ast.CharacterKind.symbol), 0 });
+                }, .{ cp, @intFromEnum(ast.CharacterKind.symbol), 0 });
             }
             return true;
         }
@@ -1997,12 +2046,14 @@ pub fn PatternParser(comptime emit_ast: bool) type {
             }
 
             self.advance();
-            self.setClassValue(ch);
+            const lit_start = self.pos - 1;
+            const cp = self.consumeLiteralCp(ch);
+            self.setClassValue(cp);
             if (emit_ast) {
                 self.last_node = self.addNode(.character, .{
-                    .start = self.pos - 1,
+                    .start = lit_start,
                     .end = self.pos,
-                }, .{ ch, @intFromEnum(ast.CharacterKind.symbol), 0 });
+                }, .{ cp, @intFromEnum(ast.CharacterKind.symbol), 0 });
             }
             return true;
         }

--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -155,7 +155,8 @@ const T = struct {
     fn isAstralUnicodeEscape(n: Node) bool {
         if (n.tag != .character) return false;
         const kind: ast.CharacterKind = @enumFromInt(n.data[1]);
-        return kind == .unicode_escape and n.data[0] > 0xFFFF;
+        // #4237: literal astral (.symbol) 도 cp 단위 노드 — 동일 분할 대상.
+        return (kind == .unicode_escape or kind == .symbol) and n.data[0] > 0xFFFF;
     }
 
     // ── #3509: positive character class 의 astral → surrogate-alternation ──
@@ -346,6 +347,12 @@ const T = struct {
             .indexed_reference,
             => return self.b.add(n),
             .character => {
+                // #4237: 단일 노드 컨텍스트(quantifier body 등 — expandList 의
+                // 1→2 surrogate 분할 불가 위치)의 astral 은 u-strip 시 의미가
+                // 변함(`/😀+/u` 의 + 가 low surrogate 로 격하) → u 보존 게이트.
+                if (self.opts.unicode_brace and n.data[0] > 0xFFFF) {
+                    self.astral_u_incomplete = true;
+                }
                 // #4225: u-전용 fold 등가(Kelvin U+212A 등)를 가진 atom 은
                 // u-strip 시 /i 의 non-unicode fold 로 등가가 소실 → u 보존 게이트
                 // (#3509 "틀린 출력 0"). lower() 의 #4211 재변환이 전체 일관 보존.

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -620,6 +620,21 @@ test "#4225: fold 무관 atom 은 기존 u-strip 유지" {
     try testing.expectEqualStrings("/x\\uD83D\\uDE00/i", out);
 }
 
+// #4237: literal non-ASCII cp 단위 노드 + astral 단일컨텍스트 u-보존 게이트.
+test "#4237: literal sharp-s dotall 재인쇄 mojibake 없음" {
+    const out = (try runLower("/\xC5\xBF.b/s", .{ .regex_dotall = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/\xC5\xBF[\\s\\S]b/", out);
+}
+
+test "#4237: astral literal + quantifier /u — u 보존 게이트" {
+    const r = try lower(testing.allocator, "/\xF0\x9F\x98\x80+x/u", .{ .unsupported = .{ .unicode_brace_escape = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    defer if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(r.text != null);
+    try testing.expect(std.mem.endsWith(u8, r.text.?, "/u"));
+}
+
 // #2472 회귀 가드: 32개 stack-cap 시 33번째부터 std.debug.assert 가 ReleaseFast 에서
 // 비활성화되어 OOB 쓰기 (UB) 가 발생했음. dynamic ArrayList 로 전환 후 50개도 정상 동작.
 test "#2472 regression: 50 named groups + last backref — no truncation" {


### PR DESCRIPTION
Closes #4237

## 문제 (u 무관 corruption — 실증)

regexp 파서가 literal 비-ASCII 를 **UTF-8 byte 당 `.character` 노드 1개**로 emit — printer 의 `wCp` 가 continuation byte 를 개별 코드포인트로 재인코딩해, transform 을 거치는 모든 패턴이 mojibake:

```
/ſ.b/s → /Ã…Â¿[\s\S]b/ 류  (매치 대상이 바뀌는 silent miscompile)
```

transform 의 cp 기반 판정(#4225 fold, class range)도 byte 값을 오인.

## 루트커즈와 수정

`consumeLiteralCp` — non-ASCII 첫 byte 면 UTF-8 시퀀스를 디코드해 단일 cp 노드 (atom 3 + class 2 + identity-escape 2 = 7개 emit 사이트). validate-only 경로도 동일 tail 소비로 진행 일치, invalid UTF-8 은 byte 폴백.

`/code-review max` 가 적발한 3건 추가 반영:
- **non-u class range 는 UTF-16 unit 의미** — cp 비교는 `[😀-！]` 류 valid JS 를 오거부(회귀였음). astral 양끝을 low/high surrogate unit 으로 매핑해 native 와 수용/거부 동치.
- **identity-escape**(`\é`) 6·7번째 사이트 — 동일 cp 화.
- **astral literal + quantifier `/u`**: `.symbol` astral 을 expandList surrogate 분할 대상에 포함 + 단일 노드 컨텍스트(quantifier body — 분할 불가)는 `astral_u_incomplete` u-보존 게이트 (`/😀+/u` u-strip 시 `+` 가 low surrogate 로 격하되는 silent 의미 변경 차단).

## 검증

/ſ.b/s 보존·동작, `/é+/s`, `/😀.b/s`, `[😀-！]` 수용(native 동치)/역방향 거부, `\é` 보존, `/^😀+x$/u` **u 보존** + anchored native 일치, `[😀]`/`[😀-😁]` /u es5 surrogate-alternation 기존 동작 byte-identical, 한글 named group 무영향 — 전부 node 24 대조. zig 5869 green (유닛 2종 — raw 바이트는 zig escape 로).

## Zig 초보자용 포인트

테스트에 raw UTF-8 바이트를 넣을 때 python 스크립트 경유는 함정입니다 — 텍스트 모드 write 가 `'\xF0'` 을 U+00F0 의 UTF-8(C3 B0)로 재인코딩합니다. zig 문자열 escape(`"\xF0\x9F\x98\x80"`)를 소스에 직접 쓰는 것이 안전합니다 (이번 디버깅의 교훈).

🤖 Generated with [Claude Code](https://claude.com/claude-code)