### PR TITLE
fix(transformer): $<name> 재작성의 replacement-side 이름을 string-escape cook 으로 비교

### DIFF
--- a/src/regexp/group_name.zig
+++ b/src/regexp/group_name.zig
@@ -6,7 +6,9 @@
 //! dedup(중복 키 객체)/`$<name>` 매칭/파서 중복 검증이 전부 어긋난다.
 //!
 //! 사용처: regexp/parser.zig (중복 검증) · regexp/transform.zig (\k 해석) ·
-//! transformer/regex_lower.zig ($<name> 재작성) · transformer/node_dispatch.zig
+//! transformer/regex_lower.zig (pattern-side dup 감지 — replacement-side $<name>
+//! 비교는 string-escape superset 인 transformer/cooked_name.zig #4216) ·
+//! transformer/node_dispatch.zig
 //! (groups map dedup + canonical key emit).
 
 const std = @import("std");

--- a/src/root.zig
+++ b/src/root.zig
@@ -46,6 +46,7 @@ test {
     _ = runtime_helper_modules;
     _ = server;
     _ = app;
+    _ = @import("transformer/cooked_name.zig");
     _ = @import("test_arena.zig");
     _ = @import("env_flag.zig");
     _ = util.wyhash;

--- a/src/transformer/cooked_name.zig
+++ b/src/transformer/cooked_name.zig
@@ -1,0 +1,207 @@
+//! escape-보존 JS string 표기의 cooked 비교 (#4231/#4216 공용).
+//!
+//! string escape 전 문법(\n \t … \xHH \uHHHH[pair] \u{...} NonEscape identity,
+//! LineContinuation 소거)을 디코드해 UTF-16 code unit 시퀀스로 비교한다.
+//! 사용처: const-enum 멤버 lookup(enum.zig), replace $<name> 재작성의
+//! replacement-side 이름(regex_lower — string escape 표기 \x79 등도 그룹
+//! 이름과 동일 cook).
+
+const std = @import("std");
+
+/// escape-보존 표기에서 다음 cooked 코드포인트를 디코드 (#4231).
+/// string escape (\n \t \r \b \f \v \0 \xHH \uHHHH[pair] \u{...}
+/// NonEscape identity, LineContinuation=문자 없음) + raw UTF-8.
+/// 디코드 실패 시 null — 호출자는 raw eql 폴백.
+pub fn nextCookedCp(t: []const u8, i: *usize) ?u21 {
+    const c = t[i.*];
+    if (c != '\\') {
+        const len = std.unicode.utf8ByteSequenceLength(c) catch return null;
+        if (i.* + len > t.len) return null;
+        const cp = std.unicode.utf8Decode(t[i.* .. i.* + len]) catch return null;
+        i.* += len;
+        return cp;
+    }
+    if (i.* + 1 >= t.len) return null;
+    const e = t[i.* + 1];
+    i.* += 2;
+    switch (e) {
+        'n' => return '\n',
+        't' => return '\t',
+        'r' => return '\r',
+        'b' => return 0x08,
+        'f' => return 0x0C,
+        'v' => return 0x0B,
+        '0' => {
+            // \0 + digit 은 legacy octal — strict 금지, 보수적으로 실패 처리.
+            if (i.* < t.len and t[i.*] >= '0' and t[i.*] <= '9') return null;
+            return 0;
+        },
+        'x' => {
+            if (i.* + 2 > t.len) return null;
+            var cp: u21 = 0;
+            for (t[i.* .. i.* + 2]) |h| {
+                const d = std.fmt.charToDigit(h, 16) catch return null;
+                cp = cp * 16 + d;
+            }
+            i.* += 2;
+            return cp;
+        },
+        'u' => {
+            if (i.* < t.len and t[i.*] == '{') {
+                var j = i.* + 1;
+                const hs = j;
+                var cp: u32 = 0;
+                while (j < t.len and t[j] != '}') : (j += 1) {
+                    const d = std.fmt.charToDigit(t[j], 16) catch return null;
+                    cp = cp * 16 + d;
+                    if (cp > 0x10FFFF) return null;
+                }
+                if (j >= t.len or j == hs) return null;
+                i.* = j + 1;
+                return @intCast(cp);
+            }
+            if (i.* + 4 > t.len) return null;
+            var cp: u32 = 0;
+            for (t[i.* .. i.* + 4]) |h| {
+                const d = std.fmt.charToDigit(h, 16) catch return null;
+                cp = cp * 16 + d;
+            }
+            i.* += 4;
+            if (cp >= 0xD800 and cp <= 0xDBFF and i.* + 6 <= t.len and
+                t[i.*] == '\\' and t[i.* + 1] == 'u' and t[i.* + 2] != '{')
+            {
+                var lo: u32 = 0;
+                var ok = true;
+                for (t[i.* + 2 .. i.* + 6]) |h| {
+                    const d = std.fmt.charToDigit(h, 16) catch {
+                        ok = false;
+                        break;
+                    };
+                    lo = lo * 16 + d;
+                }
+                if (ok and lo >= 0xDC00 and lo <= 0xDFFF) {
+                    i.* += 6;
+                    return @intCast(0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00));
+                }
+            }
+            return @intCast(cp);
+        },
+        '1', '2', '3', '4', '5', '6', '7' => {
+            // legacy octal escape — TS 는 거부(TS1487)하나 우리 파서가 수용하는
+            // 입력에서 identity 오쿡 방지: 보수적으로 실패 → raw 폴백.
+            return null;
+        },
+        '\n', '\r' => {
+            // LineContinuation: cooked 기여 없음 — CRLF pair skip 후 다음 문자.
+            if (e == '\r' and i.* < t.len and t[i.*] == '\n') i.* += 1;
+            if (i.* >= t.len) return null;
+            return nextCookedCp(t, i);
+        },
+        else => {
+            // NonEscapeCharacter: identity (\' \" \\ \` 포함, 멀티바이트 lead 도 그대로)
+            const len = std.unicode.utf8ByteSequenceLength(e) catch return null;
+            if (i.* - 1 + len > t.len) return null;
+            const cp = std.unicode.utf8Decode(t[i.* - 1 .. i.* - 1 + len]) catch return null;
+            i.* += len - 1;
+            return cp;
+        },
+    }
+}
+
+/// LineContinuation (`\` + LF/CR[LF]/U+2028/9) 연쇄를 소거 — cooked 기여 0.
+/// end 검사 전에 호출해야 trailing continuation ('q\<LF>' vs 'q') 이 정확.
+pub fn skipLineContinuations(t: []const u8, i: *usize) void {
+    while (i.* + 1 < t.len and t[i.*] == '\\') {
+        const n1 = t[i.* + 1];
+        if (n1 == '\n') {
+            i.* += 2;
+        } else if (n1 == '\r') {
+            i.* += 2;
+            if (i.* < t.len and t[i.*] == '\n') i.* += 1;
+        } else if (n1 == 0xe2 and i.* + 4 <= t.len and
+            t[i.* + 2] == 0x80 and (t[i.* + 3] == 0xa8 or t[i.* + 3] == 0xa9))
+        {
+            i.* += 4;
+        } else break;
+    }
+}
+
+pub const CookedIter = struct {
+    t: []const u8,
+    i: usize = 0,
+    /// astral cp 의 low surrogate 보류분 — UTF-16 code unit 단위 비교용.
+    pending_lo: ?u21 = null,
+
+    /// u21 범위 밖은 불가하므로 surrogate-범위 위 값으로 디코드 실패 표시.
+    const error_marker: u21 = 0x1FFFFF;
+
+    /// 다음 UTF-16 code unit. 혼합 escape 표기(`\uD83D\u{DE00}` vs 😀)도
+    /// unit 시퀀스로는 동일해져 정확 비교 (#4231 리뷰).
+    fn next(self: *@This()) ?u21 {
+        if (self.pending_lo) |lo| {
+            self.pending_lo = null;
+            return lo;
+        }
+        skipLineContinuations(self.t, &self.i);
+        if (self.i >= self.t.len) return null;
+        const cp = nextCookedCp(self.t, &self.i) orelse return error_marker;
+        if (cp > 0xFFFF) {
+            self.pending_lo = @intCast(0xDC00 + ((cp - 0x10000) & 0x3FF));
+            return @intCast(0xD800 + ((cp - 0x10000) >> 10));
+        }
+        return cp;
+    }
+
+    fn atEnd(self: *@This()) bool {
+        if (self.pending_lo != null) return false;
+        skipLineContinuations(self.t, &self.i);
+        return self.i >= self.t.len;
+    }
+};
+
+/// 두 escape-보존 이름이 cooked(UTF-16 unit 시퀀스) 기준으로 같은가 (#4231).
+/// 디코드 실패 시 raw-byte 비교 폴백 (이전 동작 보존 방어선).
+/// NOTE: escape 디코더는 string_escape.decodeUnicodeHexEscape /
+/// regexp/group_name.zig nextCodepoint 와 의도적 별도 구현 — 여기는 string
+/// escape 전 문법(superset)이 필요하다. escape 처리 수정 시 셋을 교차 점검.
+pub fn eql(a: []const u8, b: []const u8) bool {
+    // 공통 케이스 fast-path: byte-identical 이름 (escape 무관하게 동일 cooked).
+    if (std.mem.eql(u8, a, b)) return true;
+    var xa = CookedIter{ .t = a };
+    var xb = CookedIter{ .t = b };
+    while (true) {
+        const ae = xa.atEnd();
+        const be = xb.atEnd();
+        if (ae and be) return true;
+        if (ae != be) return false;
+        const ua = xa.next() orelse return false;
+        const ub = xb.next() orelse return false;
+        if (ua == CookedIter.error_marker or ub == CookedIter.error_marker)
+            return std.mem.eql(u8, a, b);
+        if (ua != ub) return false;
+    }
+}
+
+// ─── 테스트 ───
+
+const testing = std.testing;
+
+test "eql: string-escape 표기 동치 (\\x79/\\u0079/y)" {
+    try testing.expect(eql("y", "\\x79"));
+    try testing.expect(eql("\\x79", "\\u0079"));
+    try testing.expect(!eql("\\x7A", "y"));
+}
+
+test "eql: 혼합 surrogate 표기 — UTF-16 unit 시퀀스" {
+    try testing.expect(eql("\\uD835\\uDC66", "\\u{1D466}"));
+    try testing.expect(eql("\\uD835\\u{DC66}", "\\u{1D466}"));
+}
+
+test "eql: trailing line continuation 소거" {
+    try testing.expect(eql("q\\\n", "q"));
+}
+
+test "eql: legacy octal 은 raw 폴백 (오쿡 금지)" {
+    try testing.expect(!eql("\\1", "\\x01"));
+    try testing.expect(eql("\\1", "\\1"));
+}

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -17,6 +17,7 @@ const std = @import("std");
 const compat = @import("compat.zig");
 const regexp = @import("../regexp/mod.zig");
 const group_name = @import("../regexp/group_name.zig");
+const cooked_name = @import("cooked_name.zig");
 
 pub const Options = struct {
     unsupported: compat.UnsupportedFeatures,
@@ -219,7 +220,10 @@ pub fn rewriteReplacementNamedRefs(
                 // 빈 문자열 — babel __wrapRegExp 의 `group.join("$")` 동형 (#4198).
                 var found = false;
                 for (mapping) |m| {
-                    if (group_name.eqlCanonical(m.name, name)) {
+                    // #4216: replacement 쪽 이름은 JS string 표기 — \x79 등
+                    // string-escape 도 cook 하면 그룹 이름과 동치. cooked_name 은
+                    // \u 계열을 포함한 superset 디코더라 그룹이름 측에도 안전.
+                    if (cooked_name.eql(m.name, name)) {
                         var buf: [16]u8 = undefined;
                         const s = std.fmt.bufPrint(&buf, "${d}", .{m.index}) catch unreachable;
                         try out.appendSlice(allocator, s);
@@ -520,6 +524,13 @@ test "#4202: (?im-s:...) / (?-i:...) 변형도 비차지 + \\k 인덱스와 일�
     const ng = r.named_groups.?;
     try testing.expectEqual(@as(usize, 1), ng.len);
     try testing.expectEqual(@as(u32, 1), ng[0].index);
+}
+
+test "#4216: replacement $<\\x79> — string-escape 표기도 그룹 이름과 cook 동치" {
+    const mapping = [_]NamedGroupMapping{.{ .name = "y", .index = 1 }};
+    const out = (try rewriteReplacementNamedRefs(testing.allocator, "[$<\\x79>]", &mapping)).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("[$1]", out);
 }
 
 test "#4198: replacement $<dup> → 모든 인덱스 이어붙임 ($1$2)" {

--- a/src/transformer/transformer/enum.zig
+++ b/src/transformer/transformer/enum.zig
@@ -5,6 +5,7 @@ const ast_mod = @import("../../parser/ast.zig");
 const Node = ast_mod.Node;
 const Tag = Node.Tag;
 const NodeIndex = ast_mod.NodeIndex;
+const cooked_name = @import("../cooked_name.zig");
 const token_mod = @import("../../lexer/token.zig");
 const Span = token_mod.Span;
 const transformer_mod = @import("../transformer.zig");
@@ -225,7 +226,7 @@ fn evalConstEnumExpr(
             // 같은 enum 안의 다른 멤버 참조 (예: `B = A + 1`)
             const name = self.ast.getText(node.span);
             for (ctx.current_members) |m| {
-                if (cookedNameEql(m.name, name)) return m.value;
+                if (cooked_name.eql(m.name, name)) return m.value;
             }
             return null;
         },
@@ -257,14 +258,14 @@ fn tryEvalEnumMemberAccess(self: *const Transformer, node: Node, ctx: ConstEnumE
     // 현재 collecting 중인 enum self-reference (예: `Other.X` from inside Other 정의)
     if (matchesEnumName(ctx.current_name, ctx.current_symbol_id, obj_name, obj_sym)) {
         for (ctx.current_members) |m| {
-            if (cookedNameEql(m.name, prop_name)) return m.value;
+            if (cooked_name.eql(m.name, prop_name)) return m.value;
         }
     }
 
     for (self.const_enums.items) |decl| {
         if (!enumDeclMatches(decl, obj_name, obj_sym)) continue;
         for (decl.members) |m| {
-            if (cookedNameEql(m.name, prop_name)) return m.value;
+            if (cooked_name.eql(m.name, prop_name)) return m.value;
         }
     }
     return null;
@@ -296,185 +297,11 @@ pub fn tryInlineConstEnumMember(self: *Transformer, node: Node) Error!?NodeIndex
     for (self.const_enums.items) |decl| {
         if (!enumDeclMatches(decl, obj_name, obj_sym)) continue;
         for (decl.members) |m| {
-            if (!cookedNameEql(m.name, prop_name)) continue;
+            if (!cooked_name.eql(m.name, prop_name)) continue;
             return try makeConstEnumLiteralNode(self, m.value, node.span);
         }
     }
     return null;
-}
-
-/// escape-보존 표기에서 다음 cooked 코드포인트를 디코드 (#4231).
-/// string escape (\n \t \r \b \f \v \0 \xHH \uHHHH[pair] \u{...}
-/// NonEscape identity, LineContinuation=문자 없음) + raw UTF-8.
-/// 디코드 실패 시 null — 호출자는 raw eql 폴백.
-fn nextCookedCp(t: []const u8, i: *usize) ?u21 {
-    const c = t[i.*];
-    if (c != '\\') {
-        const len = std.unicode.utf8ByteSequenceLength(c) catch return null;
-        if (i.* + len > t.len) return null;
-        const cp = std.unicode.utf8Decode(t[i.* .. i.* + len]) catch return null;
-        i.* += len;
-        return cp;
-    }
-    if (i.* + 1 >= t.len) return null;
-    const e = t[i.* + 1];
-    i.* += 2;
-    switch (e) {
-        'n' => return '\n',
-        't' => return '\t',
-        'r' => return '\r',
-        'b' => return 0x08,
-        'f' => return 0x0C,
-        'v' => return 0x0B,
-        '0' => {
-            // \0 + digit 은 legacy octal — strict 금지, 보수적으로 실패 처리.
-            if (i.* < t.len and t[i.*] >= '0' and t[i.*] <= '9') return null;
-            return 0;
-        },
-        'x' => {
-            if (i.* + 2 > t.len) return null;
-            var cp: u21 = 0;
-            for (t[i.* .. i.* + 2]) |h| {
-                const d = std.fmt.charToDigit(h, 16) catch return null;
-                cp = cp * 16 + d;
-            }
-            i.* += 2;
-            return cp;
-        },
-        'u' => {
-            if (i.* < t.len and t[i.*] == '{') {
-                var j = i.* + 1;
-                const hs = j;
-                var cp: u32 = 0;
-                while (j < t.len and t[j] != '}') : (j += 1) {
-                    const d = std.fmt.charToDigit(t[j], 16) catch return null;
-                    cp = cp * 16 + d;
-                    if (cp > 0x10FFFF) return null;
-                }
-                if (j >= t.len or j == hs) return null;
-                i.* = j + 1;
-                return @intCast(cp);
-            }
-            if (i.* + 4 > t.len) return null;
-            var cp: u32 = 0;
-            for (t[i.* .. i.* + 4]) |h| {
-                const d = std.fmt.charToDigit(h, 16) catch return null;
-                cp = cp * 16 + d;
-            }
-            i.* += 4;
-            if (cp >= 0xD800 and cp <= 0xDBFF and i.* + 6 <= t.len and
-                t[i.*] == '\\' and t[i.* + 1] == 'u' and t[i.* + 2] != '{')
-            {
-                var lo: u32 = 0;
-                var ok = true;
-                for (t[i.* + 2 .. i.* + 6]) |h| {
-                    const d = std.fmt.charToDigit(h, 16) catch {
-                        ok = false;
-                        break;
-                    };
-                    lo = lo * 16 + d;
-                }
-                if (ok and lo >= 0xDC00 and lo <= 0xDFFF) {
-                    i.* += 6;
-                    return @intCast(0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00));
-                }
-            }
-            return @intCast(cp);
-        },
-        '1', '2', '3', '4', '5', '6', '7' => {
-            // legacy octal escape — TS 는 거부(TS1487)하나 우리 파서가 수용하는
-            // 입력에서 identity 오쿡 방지: 보수적으로 실패 → raw 폴백.
-            return null;
-        },
-        '\n', '\r' => {
-            // LineContinuation: cooked 기여 없음 — CRLF pair skip 후 다음 문자.
-            if (e == '\r' and i.* < t.len and t[i.*] == '\n') i.* += 1;
-            if (i.* >= t.len) return null;
-            return nextCookedCp(t, i);
-        },
-        else => {
-            // NonEscapeCharacter: identity (\' \" \\ \` 포함, 멀티바이트 lead 도 그대로)
-            const len = std.unicode.utf8ByteSequenceLength(e) catch return null;
-            if (i.* - 1 + len > t.len) return null;
-            const cp = std.unicode.utf8Decode(t[i.* - 1 .. i.* - 1 + len]) catch return null;
-            i.* += len - 1;
-            return cp;
-        },
-    }
-}
-
-/// LineContinuation (`\` + LF/CR[LF]/U+2028/9) 연쇄를 소거 — cooked 기여 0.
-/// end 검사 전에 호출해야 trailing continuation ('q\<LF>' vs 'q') 이 정확.
-fn skipLineContinuations(t: []const u8, i: *usize) void {
-    while (i.* + 1 < t.len and t[i.*] == '\\') {
-        const n1 = t[i.* + 1];
-        if (n1 == '\n') {
-            i.* += 2;
-        } else if (n1 == '\r') {
-            i.* += 2;
-            if (i.* < t.len and t[i.*] == '\n') i.* += 1;
-        } else if (n1 == 0xe2 and i.* + 4 <= t.len and
-            t[i.* + 2] == 0x80 and (t[i.* + 3] == 0xa8 or t[i.* + 3] == 0xa9))
-        {
-            i.* += 4;
-        } else break;
-    }
-}
-
-const CookedIter = struct {
-    t: []const u8,
-    i: usize = 0,
-    /// astral cp 의 low surrogate 보류분 — UTF-16 code unit 단위 비교용.
-    pending_lo: ?u21 = null,
-
-    /// u21 범위 밖은 불가하므로 surrogate-범위 위 값으로 디코드 실패 표시.
-    const error_marker: u21 = 0x1FFFFF;
-
-    /// 다음 UTF-16 code unit. 혼합 escape 표기(`\uD83D\u{DE00}` vs 😀)도
-    /// unit 시퀀스로는 동일해져 정확 비교 (#4231 리뷰).
-    fn next(self: *@This()) ?u21 {
-        if (self.pending_lo) |lo| {
-            self.pending_lo = null;
-            return lo;
-        }
-        skipLineContinuations(self.t, &self.i);
-        if (self.i >= self.t.len) return null;
-        const cp = nextCookedCp(self.t, &self.i) orelse return error_marker;
-        if (cp > 0xFFFF) {
-            self.pending_lo = @intCast(0xDC00 + ((cp - 0x10000) & 0x3FF));
-            return @intCast(0xD800 + ((cp - 0x10000) >> 10));
-        }
-        return cp;
-    }
-
-    fn atEnd(self: *@This()) bool {
-        if (self.pending_lo != null) return false;
-        skipLineContinuations(self.t, &self.i);
-        return self.i >= self.t.len;
-    }
-};
-
-/// 두 escape-보존 이름이 cooked(UTF-16 unit 시퀀스) 기준으로 같은가 (#4231).
-/// 디코드 실패 시 raw-byte 비교 폴백 (이전 동작 보존 방어선).
-/// NOTE: escape 디코더는 string_escape.decodeUnicodeHexEscape /
-/// regexp/group_name.zig nextCodepoint 와 의도적 별도 구현 — 여기는 string
-/// escape 전 문법(superset)이 필요하다. escape 처리 수정 시 셋을 교차 점검.
-fn cookedNameEql(a: []const u8, b: []const u8) bool {
-    // 공통 케이스 fast-path: byte-identical 이름 (escape 무관하게 동일 cooked).
-    if (std.mem.eql(u8, a, b)) return true;
-    var xa = CookedIter{ .t = a };
-    var xb = CookedIter{ .t = b };
-    while (true) {
-        const ae = xa.atEnd();
-        const be = xb.atEnd();
-        if (ae and be) return true;
-        if (ae != be) return false;
-        const ua = xa.next() orelse return false;
-        const ub = xb.next() orelse return false;
-        if (ua == CookedIter.error_marker or ub == CookedIter.error_marker)
-            return std.mem.eql(u8, a, b);
-        if (ua != ub) return false;
-    }
 }
 
 fn memberPropertyName(self: *const Transformer, member_tag: Tag, prop_idx: NodeIndex) ?[]const u8 {


### PR DESCRIPTION
Closes #4216

## 문제

replacement 는 JS *string* 표기라 `\x79`/`y`/`y` 가 런타임에 같은 이름으로 cook 되는데, `$<name>` 정적 재작성의 비교는 group-name escape 문법(`\u` 계열만)이라 **`\x` 류 표기는 누락** — ES2015+ 런타임은 `__wrapRegExp` 가 cooked 문자열로 회복하지만 true-ES5(Symbol dispatch 부재)에선 `$<y>` 잔존. 부수 효과로 모든 타겟에서 정적 재작성 적중률 자체가 향상.

## 루트커즈와 수정

enum.zig(#4231)의 string-escape cook 디코더를 **`src/transformer/cooked_name.zig` 공용 모듈로 승격**(3중 카피 방지 — UTF-16 unit 비교/LineContinuation/혼합 surrogate 표기 포함) 후 replacement-side 비교 1지점에 적용. `\u` 계열 superset 이라 그룹이름 측에도 안전 — pattern-side 비교들(dedup/`\k`/groups-map)은 group_name.eqlCanonical 유지 (의미적으로 정합한 분리, 양 모듈 doc 에 교차참조).

## 검증 (`/code-review max` 실증)

- 3-표기(`\x79`/`y`/`y`) × literal/variable/template × es2017/es5, dup `$1$2`, `$<\x3E>` 슬라이싱 native 동치, `$<\\x79>`(escaped backslash) 비매치, #4214 lowerContent 순서 무간섭, const-enum 경유 동작 무변경 — 전부 node 24 byte-동치.
- 모듈 추출 byte-identical (전체 suite 로 증명 + 의도적 테스트 파손 실험으로 aggregate 포함 확인), `cooked_name` 자체 유닛 4종 + **root.zig test aggregate 등록** (#4111 미실행 트랩 방지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)