### PR TITLE
fix(transformer): 합성 quoted key/super prop 의 identifier escape 처리

### DIFF
--- a/src/transformer/es2015_class/super_props.zig
+++ b/src/transformer/es2015_class/super_props.zig
@@ -136,7 +136,27 @@ pub fn SuperProps(comptime Transformer: type) type {
 
             // Parent.prototype.method 또는 static Parent.method
             const super_base = try buildSuperBaseRef(self, span);
-            const new_method_prop = try self.visitNode(method_prop_idx);
+            var new_method_prop = try self.visitNode(method_prop_idx);
+            // #4229: identifier escape (\u{6d} 등) 는 합성 member 에 verbatim
+            // 잔존하면 es5 산출물에 ES2015 문법 — canonical(디코드) identifier 로.
+            {
+                const mp = self.ast.getNode(new_method_prop);
+                if (mp.tag == .identifier_reference) {
+                    const raw = self.ast.getText(mp.data.string_ref);
+                    if (std.mem.indexOfScalar(u8, raw, '\\') != null) {
+                        const group_name = @import("../../regexp/group_name.zig");
+                        var decoded: std.ArrayList(u8) = .empty;
+                        defer decoded.deinit(self.allocator);
+                        try group_name.appendCanonical(self.allocator, &decoded, raw);
+                        const dec_span = try self.ast.addString(decoded.items);
+                        new_method_prop = try self.ast.addNode(.{
+                            .tag = .identifier_reference,
+                            .span = dec_span,
+                            .data = .{ .string_ref = dec_span },
+                        });
+                    }
+                }
+            }
             const method_member = try es_helpers.makeStaticMember(self, super_base, new_method_prop, span);
 
             // Parent.prototype.method.call
@@ -218,11 +238,22 @@ pub fn SuperProps(comptime Transformer: type) type {
 
         fn makeStaticSuperPropArg(self: *Transformer, prop_idx: NodeIndex) Transformer.Error!NodeIndex {
             const prop = self.ast.getNode(prop_idx);
-            const text = if (prop.tag == .identifier_reference or prop.tag == .binding_identifier)
-                self.ast.getText(prop.data.string_ref)
-            else
-                self.ast.getText(prop.span);
-            return makeStringLiteralFromText(self, text);
+            if (prop.tag == .identifier_reference or prop.tag == .binding_identifier) {
+                const raw = self.ast.getText(prop.data.string_ref);
+                // #4229: identifier 의 \u{...}/\uHHHH escape 는 이름 표기일 뿐 —
+                // 그대로 escape 루프에 넣으면 `\` 이중화로 멤버명이 리터럴
+                // 백슬래시 문자열이 된다 (모던 엔진 포함 오동작). canonical
+                // (디코드된 UTF-8) 이름으로 변환 후 인용.
+                if (std.mem.indexOfScalar(u8, raw, '\\') != null) {
+                    const group_name = @import("../../regexp/group_name.zig");
+                    var decoded: std.ArrayList(u8) = .empty;
+                    defer decoded.deinit(self.allocator);
+                    try group_name.appendCanonical(self.allocator, &decoded, raw);
+                    return makeStringLiteralFromText(self, decoded.items);
+                }
+                return makeStringLiteralFromText(self, raw);
+            }
+            return makeStringLiteralFromText(self, self.ast.getText(prop.span));
         }
 
         fn makeSuperPropRefForAssignment(self: *Transformer, prop_idx: NodeIndex, is_computed: bool, span: Span) Transformer.Error!SuperPropRef {

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -772,7 +772,16 @@ pub fn buildDefinePropertyKeyArg(self: anytype, key_idx: NodeIndex) !NodeIndex {
 /// 식별자/numeric/string literal key node 의 span 을 `"name"` 형태 string_literal 로 감쌈.
 /// heap alloc 경유로 긴 key name truncation 회피. (#1510 item4)
 pub fn buildQuotedKeyLiteral(self: anytype, key_span: Span) !NodeIndex {
-    const key_text = self.ast.getText(key_span);
+    const key_text_raw = self.ast.getText(key_span);
+    // #4229: 합성 노드는 visit 미경유라 identifier 의 \u{...} brace escape 가
+    // es5 산출물에 잔존(ES2015 문법 SyntaxError) — #4214 동형으로 직접 lowering.
+    const unicode_escape_lower = @import("unicode_escape_lower.zig");
+    const lowered: ?[]u8 = if (self.options.unsupported.unicode_brace_escape)
+        try unicode_escape_lower.lowerContent(self.allocator, key_text_raw)
+    else
+        null;
+    defer if (lowered) |l| self.allocator.free(l);
+    const key_text = lowered orelse key_text_raw;
     const quoted = try self.allocator.alloc(u8, key_text.len + 2);
     defer self.allocator.free(quoted);
     quoted[0] = '"';

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -3219,6 +3219,26 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('identifier \\u{} escape 합성 키 (#4229)', () => {
+    test('es5 class accessor 키 + super prop — brace lowering/canonical', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            String.raw`class C { get \u{61}b() { return 7; } }`,
+            String.raw`class D extends C { m() { return super.\u{61}b; } }`,
+            'console.log(new D().m());',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es5'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('7');
+      expect(result.bundleOutput).not.toContain('\\u{');
+    });
+  });
+
   describe('regex 추가 엣지', () => {
     test('ES2025 inline modifier 그룹 (?i:) 은 capture 인덱스 비차지 (#4202)', async () => {
       // 회귀: 텍스트 스캐너가 (?i:) 를 capturing 으로 오집계 → groups map 이


### PR DESCRIPTION
Closes #4229

## 문제 (둘 다 합성 노드 visit-우회 클래스 — 실증)

1. `buildQuotedKeyLiteral`: identifier raw 그대로 인용 — es5 defineProperty 키에 `\u{61}b`(ES2015 문법) 잔존 → 진짜 ES5 엔진 SyntaxError.
2. `super_props`: identifier 텍스트를 escape 루프에 넣어 `\`→`\\` 이중화 — `super.\u{6d}` 멤버명이 리터럴 백슬래시 문자열이 되는 **모던 엔진 포함** silent 오동작.

## 수정

buildQuotedKeyLiteral 에 `unicode_escape_lower`(#4214 동형) + super prop **3경로**(read/write + 리뷰가 적발한 method call) canonical 디코드(`group_name.appendCanonical`).

## 검증 (리뷰 실증)

read/write/compound/static/call/astral 키↔super 일관, es5 값 보존+`\u{` 0, esnext byte-clean, --minify. zig green + integration. 파생 pre-existing 4건 분리: #4241(고우선)/#4242/#4243/#4244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)