### PR TITLE
fix(transformer): numeric/bigint 프로퍼티 키 합성을 노드 패스스루로

### DIFF
--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -539,13 +539,24 @@ pub fn makeMemberFromKeyIdx(self: anytype, obj: NodeIndex, key_idx: NodeIndex, s
     if (key_node.tag == .computed_property_key) {
         const inner = try self.visitNode(key_node.data.unary.operand);
         return makeComputedMember(self, obj, inner, span);
-    } else {
-        // 프로퍼티 키는 문자열 이름이므로 visitNode(symbol 전파) 대신 span만 복사.
-        // destructuring { polyfillGlobal: renamed } → _ref.polyfillGlobal 에서
-        // linker가 polyfillGlobal → polyfillGlobal$4 로 잘못 리네이밍하는 것을 방지.
-        const new_key = try makeIdentifierRefFromSpan(self, key_node.data.string_ref);
-        return makeMemberFromKey(self, obj, new_key, key_node.tag, span);
     }
+    if (key_node.tag == .numeric_literal or key_node.tag == .bigint_literal) {
+        // #4241: numeric/bigint key 는 data 가 `.none` variant — string_ref 로
+        // 읽으면 빈/garbage span → `this[]` SyntaxError. 노드를 그대로 computed
+        // key 로: `obj[1e3]`/`obj[10n]` 은 ToPropertyKey 가 "1000"/"10" 으로
+        // 정규화 → 런타임 정확 (exp/hex/bigint 모두). span 으로 원본 텍스트 보존.
+        const num = try self.ast.addNode(.{
+            .tag = key_node.tag,
+            .span = key_node.span,
+            .data = key_node.data,
+        });
+        return makeComputedMember(self, obj, num, span);
+    }
+    // 프로퍼티 키는 문자열 이름이므로 visitNode(symbol 전파) 대신 span만 복사.
+    // destructuring { polyfillGlobal: renamed } → _ref.polyfillGlobal 에서
+    // linker가 polyfillGlobal → polyfillGlobal$4 로 잘못 리네이밍하는 것을 방지.
+    const new_key = try makeIdentifierRefFromSpan(self, key_node.data.string_ref);
+    return makeMemberFromKey(self, obj, new_key, key_node.tag, span);
 }
 
 /// callee(args...) call expression 생성.
@@ -765,6 +776,16 @@ pub fn buildDefinePropertyKeyArg(self: anytype, key_idx: NodeIndex) !NodeIndex {
         // string literal key 는 이미 quote 포함이라 buildQuotedKeyLiteral 로 감싸면 이중 quote.
         // visitNode 경로가 quote 보존 + unicode_brace_escape 같은 ES5 lower 까지 동시 처리.
         return self.visitNode(key_idx);
+    }
+    if (key_node.tag == .numeric_literal or key_node.tag == .bigint_literal) {
+        // #4241: numeric/bigint key 는 노드 그대로 — defineProperty(proto, 1e3, …)
+        // 가 ToPropertyKey 로 "1000"/"10" 정규화. 따옴표로 감싸면 "1e3"/"10n" ≠
+        // "1000"/"10" (silent 오동작) 이고, data 가 `.none` variant 라 위험.
+        return self.ast.addNode(.{
+            .tag = key_node.tag,
+            .span = key_node.span,
+            .data = key_node.data,
+        });
     }
     return buildQuotedKeyLiteral(self, key_node.span);
 }

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -2009,6 +2009,68 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('numeric 프로퍼티 키 (#4241)', () => {
+    test('class field/accessor numeric key — defineProperty 정규화', async () => {
+      // 회귀: makeMemberFromKeyIdx 가 numeric data 를 string_ref 로 오독 →
+      // this[] SyntaxError. buildDefinePropertyKeyArg 는 "1e3" 박제 →
+      // 런타임 "1000" 과 불일치.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            "class C { 10 = 'ten'; 0x10 = 'hex'; get 1e3() { return 'K'; } }",
+            'const c = new C() as any;',
+            'console.log(c[10], c[16], c[1000]);',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es5'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('ten hex K');
+    });
+
+    test('numeric key destructuring 값 읽기', async () => {
+      // 회귀: `{ 10: x } = o` 의 값 읽기가 _a[] (빈 span).
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'const o = { 10: 99, 20: 7 } as any;',
+            'const { 10: x, 20: y } = o;',
+            'console.log(x + y);',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('106');
+    });
+
+    test('bigint key — numeric 과 동일 .none variant (리뷰 적발)', async () => {
+      // 회귀: bigint_literal 도 data=.none — else 경로 string_ref 오독 →
+      // class field `this.`(SyntaxError)/destructuring `_a.`. (bigint getter
+      // 의 defineProperty 키는 es5 에서만 도달인데 bigint=es2020 이라 비현실,
+      // 게다가 bun 파서가 `get 10n()` 미지원이라 field/destructuring 만 검증.)
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            "class C { 10n = 'ten' }",
+            'const c = new C() as any;',
+            'const { 10n: x } = { 10n: 9 } as any;',
+            'console.log(c[10], x);',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2021'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('ten 9');
+    });
+  });
+
   describe('destructuring 경계', () => {
     test('array hole (sparse) destructuring', async () => {
       const result = await bundleAndRun(


### PR DESCRIPTION
Closes #4241

## 문제 (numeric_literal·bigint_literal 의 data 는 `.none` variant — 전부 실증)

1. `makeMemberFromKeyIdx` 가 numeric/bigint key 에서 `data.string_ref` 를 오독 → 빈/garbage span → `class C { 10 = 'x' }` es5 가 `this[]`, bigint `10n` 은 `this.`, `{ 10: x } = o` 가 `_a[]` (**모든 엔진 SyntaxError**).
2. `buildDefinePropertyKeyArg` 가 numeric span 을 따옴표로 박제 → `get 1e3()` 가 `defineProperty(proto, "1e3", …)` (런타임 키 `"1000"` 불일치 → **silent undefined**). `1_000`/`0x10` 동일.

## 루트커즈와 수정

두 함수에 `numeric_literal`/`bigint_literal` 분기 — 노드를 그대로 computed key / defineProperty arg 로 **패스스루**. `obj[1e3]`·`obj[10n]`·`defineProperty(proto, 1e3, …)` 는 런타임 `ToPropertyKey` 가 `"1000"`/`"10"` 으로 정규화하므로 전 형태(exp/hex/bigint) 정확. 원본 span 보존이라 별도 Number→String 불요.

bigint 분기는 `/code-review max` 가 동일 `.none` variant 의 3경로(class field/getter/destructuring) 깨짐을 적발해 추가했습니다.

## 검증

class field(10/0x10/10n) + getter(1e3) + numeric/bigint destructuring → es5~esnext native(node 24) 일치 (이전 SyntaxError/undefined). zig green + integration 3.

비고: ① es5 object-rest 의 numeric 키 exclusion 누락은 별개 #4242. ② numeric-separator/bigint 의 es5 자체 미지원은 orthogonal pre-existing. ③ bigint getter 의 defineProperty 키는 es5(bigint 부재)에서만 도달이라 비현실적 + bun 파서가 `get 10n()` 미지원이라 통합테스트는 field/destructuring 만(node 는 수용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)