### PR TITLE
fix(transformer): object rest exclusion 키의 quote/escape/numeric 처리

### DIFF
--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -838,16 +838,34 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
         }
 
         fn makeRestExcludeKey(self: *Transformer, key_node: Node) Transformer.Error!NodeIndex {
-            const raw = switch (key_node.tag) {
-                .identifier_reference, .binding_identifier => self.ast.getText(key_node.span),
-                .string_literal => blk: {
-                    const text = self.ast.getText(key_node.span);
-                    if (text.len >= 2 and (text[0] == '\'' or text[0] == '"')) break :blk text[1 .. text.len - 1];
-                    break :blk text;
+            // __rest 헬퍼는 `e[i] = String(e[i])` 로 exclusion 원소를 런타임 정규화
+            // (runtime_helpers.zig REST_RUNTIME). 따라서 #4242:
+            switch (key_node.tag) {
+                .identifier_reference, .binding_identifier => {
+                    // 이름 표기 — \u escape 는 디코드해야 es5 에서 잔존(SyntaxError)
+                    // /이중escape 안 됨. escape 없으면 byte-identical.
+                    const raw = self.ast.getText(key_node.span);
+                    if (std.mem.indexOfScalar(u8, raw, '\\') == null) {
+                        return self.wrapInStringLiteral(raw);
+                    }
+                    const group_name = @import("../regexp/group_name.zig");
+                    var decoded: std.ArrayList(u8) = .empty;
+                    defer decoded.deinit(self.allocator);
+                    try group_name.appendCanonical(self.allocator, &decoded, raw);
+                    return self.wrapInStringLiteral(decoded.items);
                 },
-                else => "",
-            };
-            return self.wrapInStringLiteral(raw);
+                // string/numeric/bigint key 는 노드 그대로 — 헬퍼 String() 이
+                // 정규화. 이전: string 은 strip+requote 로 `'q"z'`→`"q"z"`
+                // SyntaxError, numeric/bigint 는 `else=>""` 빈 exclusion(누락).
+                .string_literal, .numeric_literal, .bigint_literal => {
+                    return self.ast.addNode(.{
+                        .tag = key_node.tag,
+                        .span = key_node.span,
+                        .data = key_node.data,
+                    });
+                },
+                else => return self.wrapInStringLiteral(""),
+            }
         }
 
         /// `__rest(_ref, [exclude_keys...])` 호출과 visit 된 binding 을 한 쌍으로 빌드.

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -2071,6 +2071,45 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('object rest exclusion 키 (#4242)', () => {
+    test('quote/numeric/escaped-ident 키 — 정확 제외 (es5)', async () => {
+      // 회귀: string `'q"z'`→`"q"z"` SyntaxError, numeric `else=>""` 빈 exclusion
+      // (제외 안 됨), escaped ident `\u0061b` es5 잔존. __rest 헬퍼가 String()
+      // 정규화하므로 numeric/string 은 노드 패스스루, ident 는 canonical 디코드.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            String.raw`const o = { 'q"z': 1, 10: 2, ab: 3, keep: 4 } as any;`,
+            String.raw`const { 'q"z': a, 10: b, ab: c, ...r } = o;`,
+            "console.log(a, b, c, Object.keys(r).join(','));",
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es5'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('1 2 3 keep');
+    });
+
+    test('numeric 키 제외가 실제로 동작 (es5, #4241 후속)', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            "const o = { 10: 'x', 20: 'y', 30: 'z' } as any;",
+            'const { 10: m, ...rest } = o;',
+            "console.log(m, Object.keys(rest).join(','));",
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es5'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('x 20,30');
+    });
+  });
+
   describe('destructuring 경계', () => {
     test('array hole (sparse) destructuring', async () => {
       const result = await bundleAndRun(


### PR DESCRIPTION
Closes #4242

## 문제 (makeRestExcludeKey 가 키 종류별로 깨짐 — 전부 실증)

| 키 | 이전 | 결과 |
|---|---|---|
| `'q"z'` (string) | inner strip 후 재인용 `"q"z"` | 내부 `"` 미escape → **모든 엔진 SyntaxError** |
| `\u{61}b` (ident) | raw 그대로 인용 | es5 잔존 (ES2015 문법) |
| `10`/`10n` (numeric/bigint) | `else => ""` 빈 exclusion | rest 가 그 키 **제외 못 함** (silent, #4241 의 rest 부분) |

## 루트커즈와 수정

`__rest` 헬퍼(REST_RUNTIME)가 `e[i] = String(e[i])` 로 exclusion 원소를 **런타임 정규화**한 뒤 indexOf 한다는 게 핵심. 따라서:
- **string/numeric/bigint key → 노드 그대로 패스스루** — 헬퍼가 `String("q\"z")`/`String(10)`/`String(10n)` 로 정규화해 정확히 제외. 이전의 strip+requote/empty 제거.
- **identifier → `\u` escape 면 `group_name.appendCanonical` 로 canonical 디코드 후 인용**("ab"), escape 없으면 byte-identical.

## 검증 (`/code-review max` 실증)

`'q"z'`/numeric 10/escaped `ab`/astral `\u{1D456}b`/numeric-exclusion(20,30) es5 bundle → native(node 24) 일치 (이전 SyntaxError/제외누락). `--minify` 에서 exclusion array 문자열 미-mangle 확인, single-quote 키 출력 회귀 없음(ASCII byte-identical). zig green + integration 2.

리뷰가 격리한 별개 pre-existing(이 PR 무관): **#4248**(object rest 가 es2017 *bundle* 에서 __rest 미주입 — prepass 게이트 `u.destructuring` 만 체크, 그래서 테스트는 헬퍼 주입되는 es5 로 검증) · **#4249**(es5 computed object-literal 이 string key 를 `_a."q\"z"` dot 으로 emit). bigint/`\u{}` brace 의 es5 자체 미지원은 #4241/#4214 계열.

🤖 Generated with [Claude Code](https://claude.com/claude-code)