### PR TITLE
fix(bundler): object rest 의 graph prepass 게이트에 object_spread 추가

### DIFF
--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -280,10 +280,19 @@ pub const TransformOptions = struct {
                 .for_of_statement => if (u.for_of) return true,
                 .for_await_of_statement => if (u.needsForAwaitOfDownlevel()) return true,
                 .spread_element => if (u.spread) return true,
-                .array_pattern,
                 .object_pattern,
-                .array_assignment_target,
                 .object_assignment_target,
+                => {
+                    if (u.destructuring) return true;
+                    // #4248: object rest (`{...r}`, ES2018) 는 object_spread 로
+                    // lowering(__rest 헬퍼). destructuring 지원 타겟(es2017 등)에서도
+                    // rest 가 있으면 prepass 필요 — 누락 시 bundle 에서 __rest 미등록
+                    // ReferenceError. rest 실재 시만 검사(plain `{a}` 과트리거 회피).
+                    if (u.object_spread and
+                        ast.nodeListSplitRest(node.data.list).rest_operand != null) return true;
+                },
+                .array_pattern,
+                .array_assignment_target,
                 .assignment_target_with_default,
                 .binding_rest_element,
                 .assignment_target_rest,

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -2110,6 +2110,48 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('object rest 헬퍼 주입 게이트 (#4248)', () => {
+    for (const target of ['es2015', 'es2016', 'es2017']) {
+      test(`object rest var-decl 이 ${target} bundle 에서 __rest 주입`, async () => {
+        // 회귀: object rest(ES2018)는 destructuring 지원 타겟에서도 lowering 되는데
+        // prepass 게이트가 u.destructuring(ES2015)만 검사 → bundle 에서 __rest
+        // 미등록 ReferenceError. es5 는 우연히 destructuring 게이트로 통과했었음.
+        const result = await bundleAndRun(
+          {
+            'index.ts': [
+              'const o = { a: 1, b: 2, c: 3 } as any;',
+              'const { a, ...r } = o;',
+              "console.log(a, Object.keys(r).join(','));",
+            ].join('\n'),
+          },
+          'index.ts',
+          [`--target=${target}`],
+        );
+        cleanup = result.cleanup;
+        expect(result.exitCode).toBe(0);
+        expect(result.runOutput).toBe('1 b,c');
+      });
+    }
+
+    test('rest 없는 plain object pattern 은 es2017 에서 __rest 미생성 (과트리거 회피)', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'const o = { a: 1, b: 2 } as any;',
+            'const { a, b } = o;',
+            'console.log(a + b);',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('3');
+      expect(result.bundleOutput).not.toContain('__rest');
+    });
+  });
+
   describe('destructuring 경계', () => {
     test('array hole (sparse) destructuring', async () => {
       const result = await bundleAndRun(


### PR DESCRIPTION
Closes #4248

## 문제

object rest(`{...r}`, ES2018)는 destructuring 지원 타겟(es2015~es2017)에서도 `__rest` 로 lowering 되는데(declarations.zig:77 `else if u.object_spread`), bundle 의 graph prepass 게이트(`requiresGraphPrePass`)의 `.object_pattern`/`.object_assignment_target` 분기가 **`u.destructuring`(ES2015)만** 검사 → es2015~es2017 bundle 에서 prepass 미통과 → `__rest` 헬퍼 모듈 미등록 → **런타임 ReferenceError**.

es5(destructuring 미지원)는 우연히 게이트 통과(정상), transpile 은 직접 lowering 이라 무사 — bundle 의 es2015~es2017 밴드만 깨짐(#4199 동류 gate 누락).

## 수정

두 분기에 `u.object_spread and nodeListSplitRest(node.data.list).rest_operand != null` 추가. **rest 실재 시만** 검사해 plain `{a}` destructure 의 불필요 prepass 과트리거 회피. array_pattern 등은 object rest 가 불가하므로 destructuring 게이트만 유지(분리).

## 검증 (`/code-review max` — 도입 결함 0)

- es2015/es2016/es2017/es5 bundle 전부 `__rest` 주입 + 실행 정확, plain `{a,b}` es2017 `__rest` 미생성(과트리거 회피 단언).
- computed key `{[k]:v,...r}` / nested rest `{inner:{...i},...o}` es2017 정상, es2018+ native(zero __rest) 무변경, es5 회귀 없음.
- `u.object_spread` 단락으로 nodeListSplitRest 는 es2015~17 밴드에서만 호출(perf 미미). zig green + integration 4.

리뷰가 명확화한 별개 pre-existing(이 PR 무관): **#4251**(함수 파라미터/assignment-target object rest 는 es2017 에서 lowering 자체 누락 — transform dispatch 가 `default_params`/`destructuring` 게이트라 미발동). 본 prepass 게이트는 그 컨텍스트의 rest 도 이미 커버하므로 #4251 transform fix 후 helper 주입 자동.

🤖 Generated with [Claude Code](https://claude.com/claude-code)