### PR TITLE
test(e2e): vue 설치를 3.5.35 로 고정 (2곳) — broken latest publish 회피

### DIFF
--- a/tests/e2e/tests/browser-smoke.test.ts
+++ b/tests/e2e/tests/browser-smoke.test.ts
@@ -121,7 +121,10 @@ const cases: BrowserSmokeCase[] = [
   },
   {
     name: 'vue',
-    pkg: 'vue',
+    // 버전 고정: vue@3.5.36(latest)는 published package.json 의 deps 가
+    // `workspace:*` 프로토콜로 잘못 배포돼 npm·bun 둘 다 해석 실패
+    // (EUNSUPPORTEDPROTOCOL). 미고정 시 broken latest 를 잡아 E2E flake.
+    pkg: 'vue@3.5.35',
     entry: `import { ref } from 'vue';\nconsole.log(ref(0).value);`,
     expected: '0',
   },

--- a/tests/e2e/tests/lib-scenario-e2e.test.ts
+++ b/tests/e2e/tests/lib-scenario-e2e.test.ts
@@ -501,7 +501,9 @@ mountComp();
   {
     name: 'H2_vue_h_render',
     category: 'H_jsx_ts',
-    packages: ['vue'],
+    // 버전 고정: vue@3.5.36(latest)는 deps 가 `workspace:*` 로 잘못 배포돼
+    // npm·bun 둘 다 설치 실패(EUNSUPPORTEDPROTOCOL). browser-smoke 와 동일.
+    packages: ['vue@3.5.35'],
     entry: `import { createApp, h } from 'vue';
 
 const mount = document.createElement('div');


### PR DESCRIPTION
## 문제

E2E 가 `vue`(버전 미고정)를 설치 → 현 npm `latest`인 **vue@3.5.36 이 published package.json 의 내부 deps(@vue/runtime-dom·@vue/compiler-sfc·@vue/server-renderer)를 `workspace:*` 프로토콜로 잘못 배포**해 npm·bun 둘 다 `EUNSUPPORTEDPROTOCOL`로 설치 실패. 모든 PR 의 E2E 가 변경과 무관하게 빨갛게 됨(retry 동일).

## 왜 bun 전환이 답이 아닌가

`bun add vue` 도 **동일하게 실패**(`@vue/runtime-dom@workspace:* failed to resolve`) — 패키지매니저 문제가 아니라 **upstream publish 버그**. 버전 고정이 정답.

## 수정

vue 설치처 **2곳** 모두 `vue@3.5.35`(직전 정상)로 핀:
- `tests/e2e/tests/browser-smoke.test.ts` (vue 케이스)
- `tests/e2e/tests/lib-scenario-e2e.test.ts` (H2_vue_h_render 시나리오)

검증(로컬): `npm install vue@3.5.35` 0 errors + zntc 번들 + 실행 `0`(expected). `vue@3.5.36` FAIL / `3.5.35` OK 확인.

이 PR 머지 후 진행 중인 다른 PR(#4252 등)의 E2E 가 풀립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)