### PR TITLE
fix(transformer): 함수/arrow 파라미터·assignment-target object rest 를 es2017 에서 lowering

### DIFF
--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -30,6 +30,28 @@ const es_helpers = @import("es_helpers.zig");
 
 pub fn ES2015Params(comptime Transformer: type) type {
     return struct {
+        /// 파라미터 패턴 안에 object rest (`{a, ...r}`, ES2018) 가 있는지 검사 (#4251).
+        /// default_params(ES2015) 는 지원하나 object_spread(ES2018) 만 미지원인
+        /// 타겟(es2016/es2017)에서, object rest 가 든 param 만 lowering 하기 위한
+        /// target-aware 게이트. (default-param-only 함수의 불필요 lowering 회피.)
+        pub fn hasObjectRestParam(self: *const Transformer, params: ast_mod.NodeList) bool {
+            const old_params = self.ast.extra_data.items[params.start .. params.start + params.len];
+            for (old_params) |raw_idx| {
+                const param = self.ast.getNode(@enumFromInt(raw_idx));
+                const pattern_idx: NodeIndex = switch (param.tag) {
+                    .object_pattern => @enumFromInt(raw_idx),
+                    .formal_parameter => @enumFromInt(self.ast.extra_data.items[param.data.extra + ast_mod.FormalParameterExtra.pattern]),
+                    .assignment_pattern => param.data.binary.left,
+                    else => continue,
+                };
+                if (pattern_idx.isNone()) continue;
+                const pattern = self.ast.getNode(pattern_idx);
+                if (pattern.tag == .object_pattern and
+                    self.ast.nodeListSplitRest(pattern.data.list).rest_operand != null) return true;
+            }
+            return false;
+        }
+
         /// 파라미터 목록에서 default/rest 파라미터가 있는지 검사한다.
         pub fn hasDefaultOrRest(self: *const Transformer, params: ast_mod.NodeList) bool {
             const old_params = self.ast.extra_data.items[params.start .. params.start + params.len];

--- a/src/transformer/transformer/driver.zig
+++ b/src/transformer/transformer/driver.zig
@@ -42,7 +42,11 @@ pub fn transform(self: anytype) Error!NodeIndex {
     }
 
     // Pass 2: ES2015 params lowering 일괄 적용
-    if (self.options.unsupported.default_params) {
+    // #4251: object rest 가 든 param (`{a, ...r}`, ES2018) 은 default_params 지원
+    // 타겟(es2017)에서도 lowering 필요 → object_spread 도 게이트. per-function 은
+    // lowerAllFunctionParams 가 target-aware 로 object-rest param 만 선별(default-
+    // param-only 함수 과트리거 방지).
+    if (self.options.unsupported.default_params or self.options.unsupported.object_spread) {
         var pass2_scope = profile.begin(.transform_pass2);
         defer pass2_scope.end();
         try lowerAllFunctionParams(self);
@@ -118,6 +122,17 @@ pub fn transform(self: anytype) Error!NodeIndex {
 /// Pass 1에서 생성된 모든 function_declaration, function_expression, function,
 /// method_definition 노드를 순회하며, default/rest/destructuring params가 있으면
 /// lowerParams를 적용하고 extra_data를 in-place 수정한다.
+/// params 목록에 array-rest param (`...rest`, spread_element/rest_element) 이
+/// 있는지 (#4251). kept-arrow 의 array-rest 는 arguments 의존이라 lowering 불가.
+fn hasArrayRestParam(self: anytype, params: ast_mod.NodeList) bool {
+    const items = self.ast.extra_data.items[params.start .. params.start + params.len];
+    for (items) |raw| {
+        const t = self.ast.getNode(@as(NodeIndex, @enumFromInt(raw))).tag;
+        if (t == .spread_element or t == .rest_element) return true;
+    }
+    return false;
+}
+
 fn lowerAllFunctionParams(self: anytype) Error!void {
     const Self = @TypeOf(self.*);
     const node_count = self.ast.nodes.items.len;
@@ -135,7 +150,14 @@ fn lowerAllFunctionParams(self: anytype) Error!void {
                 if (params_node.tag != .formal_parameters) continue;
                 const params_list = params_node.data.list;
                 if (params_list.len == 0) continue;
-                if (!es2015_params.ES2015Params(Self).hasDefaultOrRest(self, params_list)) continue;
+                // #4251: default_params 미지원(es5..es2015)이면 전체(default/rest/
+                // destructuring) lowering. object_spread 만 미지원(es2016/es2017)이면
+                // object rest 든 param 만 — default-param-only 함수 불필요 lowering 회피.
+                const needs_lowering = if (self.options.unsupported.default_params)
+                    es2015_params.ES2015Params(Self).hasDefaultOrRest(self, params_list)
+                else
+                    es2015_params.ES2015Params(Self).hasObjectRestParam(self, params_list);
+                if (!needs_lowering) continue;
 
                 var lr = try es2015_params.ES2015Params(Self).lowerParamsPass2(self, params_list, node.span);
                 defer lr.body_stmts.deinit(self.allocator);
@@ -151,6 +173,63 @@ fn lowerAllFunctionParams(self: anytype) Error!void {
                     if (!body_idx.isNone()) {
                         const new_body = try self.prependStatementsToBody(body_idx, lr.body_stmts.items);
                         self.ast.extra_data.items[e + 2] = @intFromEnum(new_body);
+                    }
+                }
+            },
+            // #4251: arrow 의 object rest param 은 es2017(arrow 지원, object_spread
+            // 미지원)에서 arrow→function 변환 없이(this 보존) param 만 lowering.
+            // es5 에선 arrow 가 Pass 1 에서 function 으로 변환돼 위 arm 이 처리 →
+            // 여기 도달하는 건 orphan(무해). default/array-rest arrow param 도 그
+            // 경로라, 여기선 object rest 만 대상(hasObjectRestParam).
+            .arrow_function_expression => {
+                // arrow 가 미지원(es5..es2015)이면 Pass 1 에서 function 으로 변환됨 →
+                // 여기 남은 arrow 노드는 orphan(변환 전 원본). 처리하면 temp 카운터를
+                // 소비해 live function 의 temp 이름이 밀리고 dead `var _a` 가 샌다.
+                // arrow 가 지원되는 타겟(es2016/es2017)에서만 keep-arrow lowering.
+                if (self.options.unsupported.arrow) continue;
+                const e = node.data.extra;
+                if (e + 1 >= self.ast.extra_data.items.len) continue;
+                const params_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 0]);
+                if (params_idx.isNone() or @intFromEnum(params_idx) >= self.ast.nodes.items.len) continue;
+                const params_node = self.ast.getNode(params_idx);
+                if (params_node.tag != .formal_parameters) continue;
+                const params_list = params_node.data.list;
+                if (params_list.len == 0) continue;
+                if (!es2015_params.ES2015Params(Self).hasObjectRestParam(self, params_list)) continue;
+                // #4251: array-rest param(`...rest`, ES2015)은 es2017 native 지원이나
+                // lowerParamsPass2 가 `[].slice.call(arguments, N)` 로 내림 — arrow 엔
+                // arguments 가 없어 ReferenceError. array-rest 가 섞인 arrow 는
+                // keep-arrow lowering 불가 → skip(native 유지, 진짜 es2017 엔진에선
+                // object rest SyntaxError 잔존이나 크래시는 회피). 드문 조합 #4254 추적.
+                if (hasArrayRestParam(self, params_list)) continue;
+
+                var lr = try es2015_params.ES2015Params(Self).lowerParamsPass2(self, params_list, node.span);
+                defer lr.body_stmts.deinit(self.allocator);
+
+                const new_params_node = try self.ast.addFormalParameters(lr.new_params, params_node.span);
+                self.ast.extra_data.items[e + 0] = @intFromEnum(new_params_node);
+
+                if (lr.body_stmts.items.len > 0) {
+                    const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
+                    if (!body_idx.isNone()) {
+                        // arrow expression body → `{ return expr; }` 먼저 (implicit
+                        // return 보존), 그 후 rest 추출문 prepend. (es2015_arrow 동형.)
+                        const body_node = self.ast.getNode(body_idx);
+                        const block_body = if (body_node.tag != .block_statement and body_node.tag != .function_body) blk: {
+                            const ret = try self.ast.addNode(.{
+                                .tag = .return_statement,
+                                .span = node.span,
+                                .data = .{ .unary = .{ .operand = body_idx, .flags = 0 } },
+                            });
+                            const list = try self.ast.addNodeList(&.{ret});
+                            break :blk try self.ast.addNode(.{
+                                .tag = .block_statement,
+                                .span = node.span,
+                                .data = .{ .list = list },
+                            });
+                        } else body_idx;
+                        const new_body = try self.prependStatementsToBody(block_body, lr.body_stmts.items);
+                        self.ast.extra_data.items[e + 1] = @intFromEnum(new_body);
                     }
                 }
             },

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -358,7 +358,14 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
                     if (left_node.tag == .object_assignment_target or left_node.tag == .array_assignment_target) {
                         const has_private = self.current_private_fields.len > 0 and
                             es2015_class.ES2015Class(Transformer).destructuringTargetHasPrivateField(self, left_idx);
-                        if (self.options.unsupported.destructuring or has_private) {
+                        // #4251: object rest (`({a, ...r} = o)`, ES2018) 는 destructuring
+                        // 지원 타겟(es2017)에서도 lowering 필요 — 게이트가 destructuring
+                        // (ES2015)만 보면 native 잔존(진짜 es2017 엔진 SyntaxError).
+                        // rest 실재 시만(es2017 plain `({a}=o)` 과트리거 회피).
+                        const has_object_rest = self.options.unsupported.object_spread and
+                            left_node.tag == .object_assignment_target and
+                            self.ast.nodeListSplitRest(left_node.data.list).rest_operand != null;
+                        if (self.options.unsupported.destructuring or has_private or has_object_rest) {
                             return es2015_destructuring.ES2015Destructuring(Transformer).lowerDestructuringAssignment(self, node);
                         }
                     }

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -2110,6 +2110,122 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('함수 파라미터/assignment-target object rest lowering (#4251)', () => {
+    test('함수 파라미터 object rest 가 es2017 에서 lowering+동작', async () => {
+      // 회귀: param object rest(ES2018)가 es2017 에서 lowering 안 됨(transform
+      // dispatch 가 default_params/destructuring=ES2015 만 게이트) → native 잔존,
+      // 진짜 es2017 엔진 SyntaxError.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'function f({ a, ...r }: any) { return a + ":" + Object.keys(r).join(","); }',
+            'console.log(f({ a: 1, b: 2, c: 3 }));',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('1:b,c');
+      expect(result.bundleOutput).toContain('__rest');
+    });
+
+    test('assignment-target object rest 가 es2017 에서 lowering+동작', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'let a: any, r: any;',
+            '({ a, ...r } = { a: 1, b: 2, c: 3 } as any);',
+            'console.log(a, Object.keys(r).join(","));',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('1 b,c');
+      expect(result.bundleOutput).toContain('__rest');
+    });
+
+    test('default-param-only 함수는 es2017 에서 미-lowering (과트리거 회피)', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts': ['function g(a = 5) { return a; }', 'console.log(g(), g(9));'].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('5 9');
+      // default 가 body 로 안 내려가야 (es2017 native).
+      expect(result.bundleOutput).not.toContain('void 0');
+    });
+
+    test('mixed default + object rest (es2017) native 일치', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'function m(a = 1, { b, ...r }: any) { return a + b + ":" + Object.keys(r).join(","); }',
+            'console.log(m(undefined, { b: 2, c: 3, d: 4 }));',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('3:c,d');
+    });
+
+    test('arrow object rest 가 es2017 에서 keep-arrow lowering (this 보존)', async () => {
+      // 회귀: arrow object rest 가 es2017 에서 미lowering(arrow 는 변환 안 되고
+      // param lowering 경로 부재) → native 잔존. arrow→function 변환은 this 를
+      // 깨므로 arrow 유지한 채 param 만 lowering.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'const obj = {',
+            '  v: 10,',
+            '  m() { return [{ a: 1, b: 2, c: 3 }].map(({ a, ...r }: any) => this.v + a + Object.keys(r).length); },',
+            '};',
+            'const f = ({ a, ...r }: any) => a + ":" + Object.keys(r).join(",");',
+            'console.log(obj.m()[0], f({ a: 1, b: 2, c: 3 }));',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('13 1:b,c');
+      expect(result.bundleOutput).toContain('__rest');
+    });
+
+    test('arrow object-rest + array-rest 조합은 크래시 회피 (es2017, #4254)', async () => {
+      // 리뷰 적발: array-rest(...rest)는 ES2015 native 인데 lowerParamsPass2 가
+      // arguments 기반으로 내려 arrow 에서 ReferenceError → 그 조합은 skip(native
+      // 유지). 모던 엔진에선 동작(크래시 없음); 근본해결은 #4254.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'const f = ({ a, ...r }: any, ...rest: any[]) => a + rest.length;',
+            'console.log(f({ a: 1, b: 2 }, 7, 8, 9));',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('4');
+      // arguments 기반 array-rest lowering 이 arrow 에 새지 않아야.
+      expect(result.bundleOutput).not.toContain('slice.call(arguments');
+    });
+  });
+
   describe('object rest 헬퍼 주입 게이트 (#4248)', () => {
     for (const target of ['es2015', 'es2016', 'es2017']) {
       test(`object rest var-decl 이 ${target} bundle 에서 __rest 주입`, async () => {


### PR DESCRIPTION
Closes #4251

## 문제

object rest(`{...r}`, ES2018)가 **함수 파라미터·arrow 파라미터·assignment-target** 에서 es2017(destructuring/default_params/arrow=ES2015 지원, object_spread 미지원)에 lowering 안 됨 — dispatch 게이트가 ES2015 feature 만 검사. var-decl 경로(declarations.zig:77)만 `else if object_spread` 가 있었음. native 잔존 → **진짜 es2017 엔진 SyntaxError**.

## 수정 (lowering 함수는 이미 object rest→`__rest` 처리, 게이트만 누락)

- **함수(decl/expr/method) 파라미터**: Pass 2 외부 게이트 `default_params or object_spread` 확장 + per-function **target-aware**(`default_params` 미지원=`hasDefaultOrRest` 전체 / `object_spread` 만 미지원=`hasObjectRestParam` — default-param-only 과트리거 회피).
- **arrow 파라미터**: arrow→function 변환은 `this` 를 깨므로 **arrow 유지**한 채 param lowering(expr body→`{return expr}` 변환 후 rest 추출 prepend). 가드 2종: arrow 미지원(es5)은 Pass 1 변환이 처리하므로 skip(orphan temp 카운터 소비→이름 밀림 회귀 방지), array-rest(`...rest`) 든 arrow 도 skip(arguments 부재 크래시 회피).
- **assignment-target**: 게이트에 `object_spread and object_assignment_target rest 실재` 추가(per-node surgical).

helper 주입은 **#4248** prepass 게이트가 이 컨텍스트들을 이미 커버 → bundle 자동.

## 검증 (`/code-review max` 2회 — arrow 크래시 1건 적발·수정)

함수/arrow(expr·block body·**this 보존**·async)·assignment object rest es2017 lowering+동작, default-param-only 과트리거 회피, mixed default+rest, **arrow+array-rest 크래시 회피**, es5 회귀0(기존 arrow→function 테스트 포함), es2018 native — 전부 node 24 일치. zig 5874 green + integration 6.

리뷰가 격리한 잔여(별개 **#4254**): for-of/for-in object rest LHS(es2017 미lowering + binding 형태 es2015 부터 코드깨짐) + arrow object-rest+array-rest 조합(surgical lowering 필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)