### PR TITLE
fix(codegen): identifier 위치 \u{...} brace escape 를 es5 에서 다운레벨

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -2031,6 +2031,8 @@ pub fn emitModule(
         .platform = options.platform,
         // --charset=utf8 → ascii_only=false (명시적 보장)
         .ascii_only = false,
+        // #4243: es5 타겟에서 identifier 의 `\u{...}` brace escape 다운레벨.
+        .lower_unicode_brace = options.unsupported.unicode_brace_escape,
         // 소스맵 옵션 전달
         .sourcemap = options.sourcemap.enable,
         .source_root = options.sourcemap.source_root orelse "",

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -303,6 +303,7 @@ pub const Codegen = struct {
     pub const writeSpan = writer_emit.writeSpan;
     pub const writeAsciiOnly = writer_emit.writeAsciiOnly;
     pub const writeNodeSpan = writer_emit.writeNodeSpan;
+    pub const writeIdentifierSpan = writer_emit.writeIdentifierSpan;
     pub const writeStringLiteral = writer_emit.writeStringLiteral;
 
     // ================================================================

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -443,7 +443,7 @@ pub fn emitObjectProperty(self: anytype, node: Node) !void {
     if (value.isNone()) {
         if (identifierHasRename(self, key) or identifierHasConstValue(self, key)) {
             const key_node = self.ast.getNode(key);
-            try self.writeSpan(key_node.data.string_ref);
+            try self.writeIdentifierSpan(key_node.data.string_ref);
             if (self.options.minify_whitespace) {
                 try self.writeByte(':');
             } else {
@@ -456,7 +456,7 @@ pub fn emitObjectProperty(self: anytype, node: Node) !void {
     } else {
         const key_node = self.ast.getNode(key);
         if (key_node.tag == .identifier_reference) {
-            try self.writeSpan(key_node.data.string_ref);
+            try self.writeIdentifierSpan(key_node.data.string_ref);
         } else if (key_node.tag == .string_literal and self.options.minify_syntax) {
             const raw = self.ast.getText(key_node.span);
             if (objectKeyUnquotable(raw)) {
@@ -650,7 +650,7 @@ pub fn emitStaticMember(self: anytype, node: Node, level: Level, flags: ExprFlag
     // 같이 빠지므로 명시 발행 후 raw span 출력.
     const prop_node = self.ast.getNode(property);
     try self.addSourceMapping(prop_node.span);
-    try self.writeNodeSpan(prop_node);
+    try self.writeIdentifierSpan(prop_node.span);
 }
 
 pub fn emitComputedMember(self: anytype, node: Node, level: Level, flags: ExprFlags) !void {

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -257,7 +257,7 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
                 }
             }
             try self.addSourceMapping(node.span);
-            try self.writeSpan(node.data.string_ref);
+            try self.writeIdentifierSpan(node.data.string_ref);
         },
 
         .this_expression => {

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -91,6 +91,11 @@ pub const CodegenOptions = struct {
     sourcemap: bool = false,
     /// non-ASCII 문자를 \uXXXX로 이스케이프 (D031)
     ascii_only: bool = false,
+    /// #4243: identifier 위치의 `\u{...}` brace escape(ES2015)를 es5 호환 `\uXXXX`
+    /// 로 다운레벨. unicode_brace_escape 미지원 타겟(es5)일 때 transform 이 set.
+    /// codegen 이 모든 identifier/property/key emit funnel 에서 일괄 적용(소스/
+    /// 합성/디스트럭처링/클래스필드 구분 없이 한 지점).
+    lower_unicode_brace: bool = false,
     /// 소스맵 sourceRoot 필드
     source_root: []const u8 = "",
     /// 소스맵에 sourcesContent 포함 여부 (기본: true)

--- a/src/codegen/writer.zig
+++ b/src/codegen/writer.zig
@@ -127,6 +127,60 @@ pub fn writeNodeSpan(self: anytype, node: ast_mod.Node) !void {
     try self.writeSpan(node.span);
 }
 
+/// identifier/property/key 이름 emit 전용 (#4243). lower_unicode_brace 시
+/// `\u{...}` brace escape(ES2015)를 es5 호환 `\uXXXX`(surrogate pair 포함)로
+/// 다운레벨. 그 외엔 writeSpan 과 동일(ascii_only 등 동작 보존). identifier
+/// 위치는 모두 이 함수로 funnel → 소스/합성/디스트럭처링/클래스필드 일괄 처리.
+pub fn writeIdentifierSpan(self: anytype, span: Span) !void {
+    if (self.options.lower_unicode_brace) {
+        const unicode_escape_lower = @import("../transformer/unicode_escape_lower.zig");
+        const text = self.ast.getText(span);
+        if (unicode_escape_lower.containsBraceEscape(text)) {
+            // `\u{...}` brace escape(ES2015) → raw UTF-8 codepoint. identifier 는
+            // string 과 달리 surrogate-pair escape(`𠀀`)가 es5 에서도
+            // invalid 이므로 raw 디코드가 정답(BMP/astral 모두 valid ES5 IdName).
+            // 비-brace 바이트는 그대로 — `\uHHHH` 4-digit 는 es5 valid 라 보존.
+            var out: std.ArrayList(u8) = .empty;
+            defer out.deinit(self.allocator);
+            var i: usize = 0;
+            while (i < text.len) {
+                // escaped backslash(`\\`)는 원자 복사 — 둘째 `\` 가 escape 시작으로
+                // 오인돼 `\\u{..}` 가 잘못 디코드되는 것 방지(containsBraceEscape 와
+                // 일관). identifier span 엔 현재 도달 불가하나 방어적.
+                if (text[i] == '\\' and i + 1 < text.len and text[i + 1] == '\\') {
+                    try out.appendSlice(self.allocator, text[i .. i + 2]);
+                    i += 2;
+                    continue;
+                }
+                if (text[i] == '\\' and i + 2 < text.len and text[i + 1] == 'u' and text[i + 2] == '{') {
+                    if (unicode_escape_lower.parseBraceHex(text, i + 2)) |r| {
+                        var buf: [4]u8 = undefined;
+                        if (std.unicode.utf8Encode(@intCast(r.cp), &buf)) |n| {
+                            try out.appendSlice(self.allocator, buf[0..n]);
+                            i = r.end;
+                            continue;
+                        } else |_| {}
+                    }
+                }
+                try out.append(self.allocator, text[i]);
+                i += 1;
+            }
+            // 한계(극단 edge): ascii_only + astral(>U+FFFF) identifier 는
+            // writeAsciiOnly 가 surrogate-pair escape(`𠀀`)로 재escape →
+            // identifier 로는 어떤 엔진도 invalid. 단 es5 에서 astral identifier 의
+            // 유효한 ASCII 표현 자체가 없으므로(brace=ES2015, surrogate escape 불가)
+            // 표현 불가 케이스. BMP+ascii_only 는 정상(`é`).
+            if (self.options.ascii_only) {
+                try self.writeAsciiOnly(out.items);
+            } else {
+                try self.write(out.items);
+            }
+            return;
+        }
+    }
+    try self.writeSpan(span);
+}
+
 pub fn writeStringLiteral(self: anytype, span: Span) !void {
     const text = self.ast.getText(span);
     if (text.len < 2) {

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1517,6 +1517,7 @@ fn transpileWithCallbackInternal(
         .minify_syntax = options.minify_syntax,
         .sourcemap = options.sourcemap,
         .ascii_only = if (options.charset_utf8) false else options.ascii_only,
+        .lower_unicode_brace = options.unsupported.unicode_brace_escape,
         .quote_style = options.quote_style,
         .linking_metadata = if (mangle_metadata) |*mm| mm else null,
         .platform = options.platform,

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1730,6 +1730,46 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('identifier \\u{} brace escape es5 다운레벨 (#4243)', () => {
+    test('binding/reference/member/destructuring/non-ASCII (es5)', async () => {
+      // 회귀: identifier 위치 \u{...}(ES2015 brace escape)가 es5 산출물에 raw
+      // 잔존 → 진짜 ES5 엔진 SyntaxError. codegen dot-member 는 span 기반 emit
+      // 이라 span+string_ref 둘 다 lowered 필요.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            String.raw`var \u{61}b = 5;`,
+            String.raw`const o = { cd: 7, caf\u{e9}: 3 } as any;`,
+            String.raw`const { \u{63}d } = o;`,
+            String.raw`class C { \u{61}b = 7; m() { return this.\u{61}b; } }`,
+            String.raw`console.log(\u{61}b, o.\u{63}d, \u{63}d, o.caf\u{e9}, new C().m());`,
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es5'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('5 7 7 3 7');
+      // es5 산출물에 brace escape 잔존 0 (진짜 ES5 엔진 SyntaxError 방지).
+      expect(result.bundleOutput).not.toContain('\\u{');
+    });
+
+    test('es2015 타겟은 \\u{} 보존 (supported, 미-lowering)', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts': [String.raw`var \u{61}b = 5;`, String.raw`console.log(\u{61}b);`].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2015'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('5');
+      expect(result.bundleOutput).toContain('\\u{61}');
+    });
+  });
+
   describe('신규 ES feature', () => {
     test('BigInt literal (ES2020) — es2019 target', async () => {
       const result = await bundleAndRun(


### PR DESCRIPTION
Closes #4243

## 문제

identifier(IdentifierName)의 `\u{...}` brace escape(ES2015)가 es5 산출물에 raw 잔존 → **진짜 ES5 엔진 SyntaxError**(모던 엔진 통과라 silent 계약 위반). 소스(`var \u{61}b`, `o.\u{63}d`)뿐 아니라 **합성 member**(디스트럭처링 `_a.\u{63}d`, 클래스필드 `this.\u{61}b`)·**object 리터럴 키**(`caf\u{e9}`)까지 — transformer-visit 으로는 합성/키 경로를 놓칩니다(#4214/#4228/#4229 의 per-site whack-a-mole).

## 수정 (정공 — codegen emit funnel 한 지점)

- `CodegenOptions.lower_unicode_brace` (transpile/emitter 가 `options.unsupported.unicode_brace_escape` 로 set).
- `writer.zig writeIdentifierSpan`: `\u{...}` → **raw UTF-8 codepoint** 디코드. identifier 는 string 과 달리 surrogate-pair escape(`𠀀`)가 **es5/모던 모두 invalid** 이므로 raw 디코드가 정답 (BMP `\u{61}`→`a`, astral `\u{20000}`→`𠀀` 전부 valid ES5 IdName). `\uHHHH` 4-digit 는 valid 라 보존, escaped-backslash 원자처리, ascii_only 존중.
- 4 emit 사이트 라우팅: identifier_reference/binding(node_dispatch), dot-member property + object key(value/shorthand)(expressions). rename/ns/cjs 치환은 clean name 이라 무관.

소스/합성/디스트럭처링/클래스필드/object키 구분 없이 한 funnel → 일괄 처리.

## 검증 (`/code-review max` — 도입 결함 0)

전 컨텍스트 es5 lowering+동작(node 24, `5 7 7 3 7`), astral raw 디코드(`𠀀`), minify, ascii_only(BMP), es2015+ 보존(미-lowering). zig 5874 green + integration 2. 한계(주석): astral+ascii_only 는 표현 불가 edge(es5 에 astral identifier 의 유효 ASCII 형 부재).

🤖 Generated with [Claude Code](https://claude.com/claude-code)