### PR TITLE
fix(transformer): es5 computed object-literal 의 string/numeric 키를 computed member 로

### DIFF
--- a/src/transformer/es2015_computed.zig
+++ b/src/transformer/es2015_computed.zig
@@ -143,41 +143,20 @@ pub fn ES2015Computed(comptime Transformer: type) type {
                 const val_idx = member.data.binary.right;
                 if (key_idx.isNone()) continue;
 
-                const key = self.ast.getNode(key_idx);
                 const new_val = if (val_idx.isNone())
                     // shorthand → key 복제
                     try self.visitNode(key_idx)
                 else
                     try self.visitNode(val_idx);
 
-                // _a[computed_key] = val 또는 _a.key = val
-                const member_expr = if (key.tag == .computed_property_key) blk: {
-                    // computed: _a[expr]
-                    const inner_key = try self.visitNode(key.data.unary.operand);
-                    const me = try self.ast.addExtras(&.{
-                        @intFromEnum(try es_helpers.makeTempVarRef(self, temp_span, temp_span)),
-                        @intFromEnum(inner_key),
-                        0,
-                    });
-                    break :blk try self.ast.addNode(.{
-                        .tag = .computed_member_expression,
-                        .span = span,
-                        .data = .{ .extra = me },
-                    });
-                } else blk: {
-                    // static: _a.key
-                    const new_key = try self.visitNode(key_idx);
-                    const me = try self.ast.addExtras(&.{
-                        @intFromEnum(try es_helpers.makeTempVarRef(self, temp_span, temp_span)),
-                        @intFromEnum(new_key),
-                        0,
-                    });
-                    break :blk try self.ast.addNode(.{
-                        .tag = .static_member_expression,
-                        .span = span,
-                        .data = .{ .extra = me },
-                    });
-                };
+                // _a[key] = val. #4249: key 종류별 dot(identifier) vs computed
+                // (string/numeric/bigint/computed) 분기를 makeMemberFromKeyIdx 로
+                // 위임(#4241 동형). 이전엔 비-computed 키를 무조건 static_member
+                // (dot)로 emit → `_a."q\"z"`/`_a.10` 같은 비-identifier 키가
+                // SyntaxError. property 키는 rename 비대상이라 makeMemberFromKeyIdx
+                // 가 (computed inner 만 visit, 그 외 span 복사) 적절.
+                const obj_ref = try es_helpers.makeTempVarRef(self, temp_span, temp_span);
+                const member_expr = try es_helpers.makeMemberFromKeyIdx(self, obj_ref, key_idx, span);
 
                 const assign = try self.ast.addNode(.{
                     .tag = .assignment_expression,

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -2049,6 +2049,32 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('es5 computed object-literal 의 string/numeric 키 (#4249)', () => {
+    test('computed key + string/numeric 키 공존 → computed member (dot 아님)', async () => {
+      // 회귀: lowerComputedProperties 가 비-computed 키를 무조건 _a.key (dot)로
+      // emit → `_a."q\"z"`/`_a.10` SyntaxError. string/numeric 은 _a["q\"z"]/
+      // _a[10] (computed) 여야.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'const k = "x";',
+            'const o = { [k]: 1, "q\\"z": 2, 10: 4, "a b": 5, foo: 3 } as any;',
+            'console.log(o["q\\"z"], o[10], o["a b"], o.foo, o.x);',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es5'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('2 4 5 3 1');
+      // dot 뒤 비-identifier 키가 없어야 (SyntaxError 방지).
+      expect(result.bundleOutput).not.toContain('."q');
+      // temp 변수(_a/_b…) 의 dot-member 뒤 숫자(`_a.10`)= numeric dotted 회귀.
+      expect(result.bundleOutput).not.toMatch(/_[a-z]+\.\d/);
+    });
+  });
+
   describe('numeric 프로퍼티 키 (#4241)', () => {
     test('class field/accessor numeric key — defineProperty 정규화', async () => {
       // 회귀: makeMemberFromKeyIdx 가 numeric data 를 string_ref 로 오독 →


### PR DESCRIPTION
Closes #4249

## 문제

`lowerComputedProperties`(es2015_computed.zig)가 객체 리터럴을 `(_a={}, _a.key=v, …, _a)` 시퀀스로 내릴 때, **비-computed 키를 무조건 `static_member`(dot)** 로 emit → string/numeric/특수문자 키가 `_a."q\"z"`/`_a.10`/`_a."a b"` 같은 dot member 가 되어 **모든 엔진 SyntaxError** (computed key 와 공존해 시퀀스화될 때만 발동).

```js
// 이전(실증): var o = (_a = {}, _a[k] = 1, _a."q\"z" = 2, _a.10 = 4, ...);  ← SyntaxError
```

## 수정

member_expr 구성을 `es_helpers.makeMemberFromKeyIdx`(#4241 동형)로 위임 — 키 종류별 **dot(identifier) vs computed(string/numeric/bigint/computed)** 분기. property 키는 rename 비대상이라 makeMemberFromKeyIdx(computed inner 만 visit, 그 외 span 복사)가 적절. 기존의 static-member 직접 합성 + static key `visitNode`(키 rename 위험) 제거.

## 검증 (`/code-review max` — 프로덕션 결함 0)

`{ [k]:1, "q\"z":2, 10:4, "a b":5, foo:3 }` es5 → string/numeric/공백 키 computed(`_a["q\"z"]`/`_a[10]`), identifier 키 dot(`_a.foo`), 값 보존(`2 4 5 3 1`). 리뷰가 전수 확인: __proto__ 의미 보존, string escape/quote-style 보존, eval order 보존, identifier-visit 생략은 의도된 key-rename 보호. minify/identifier-only 회귀0 — native(node 24) 일치. zig green + integration(가드 어서션 실효화 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)