### PR TITLE
fix(transformer): super prop 이 destructuring assignment target 일 때 __superSet write 로

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -553,6 +553,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
         pub const isSuperComputedMember = super_props_mod.isSuperComputedMember;
         pub const lowerSuperComputedMember = super_props_mod.lowerSuperComputedMember;
         pub const lowerSuperPropertyAssignment = super_props_mod.lowerSuperPropertyAssignment;
+        pub const trySuperAssignTarget = super_props_mod.trySuperAssignTarget;
+        pub const destructuringTargetHasSuper = super_props_mod.destructuringTargetHasSuper;
         pub const lowerSuperPropertyUpdate = super_props_mod.lowerSuperPropertyUpdate;
         pub const isSuperComputedMethodCall = super_props_mod.isSuperComputedMethodCall;
         pub const lowerSuperComputedMethodCall = super_props_mod.lowerSuperComputedMethodCall;

--- a/src/transformer/es2015_class/super_props.zig
+++ b/src/transformer/es2015_class/super_props.zig
@@ -412,6 +412,62 @@ pub fn SuperProps(comptime Transformer: type) type {
             return buildSuperPropGet(self, try self.visitNode(prop_idx), span);
         }
 
+        /// #4244: destructuring assignment target 이 super member (`[super.x] = …`,
+        /// `({a: super.x} = o)`) 일 때, generic `visitNode(target) = value` 는
+        /// super.x 를 READ(`__superGet`)로 내려 `__superGet(...) = v` (Invalid LHS)
+        /// 를 만든다. 대신 write helper(`__superSet(base, prop, value, receiver)`)로.
+        /// target 이 super member 가 아니면 null (호출자가 generic 경로).
+        pub fn trySuperAssignTarget(self: *Transformer, target_idx: NodeIndex, value: NodeIndex, span: Span) Transformer.Error!?NodeIndex {
+            if (!self.needsSuperLowering()) return null;
+            if (target_idx.isNone()) return null;
+            const target = self.ast.getNode(target_idx);
+            const is_computed = switch (target.tag) {
+                .static_member_expression => false,
+                .computed_member_expression => true,
+                else => return null,
+            };
+            const te = target.data.extra;
+            if (te >= self.ast.extra_data.items.len) return null;
+            const obj_idx: NodeIndex = self.readNodeIdx(te, 0);
+            if (!isSuperUnwrapped(self, obj_idx)) return null;
+            const prop_idx: NodeIndex = self.readNodeIdx(te, 1);
+            const prop_arg = if (is_computed)
+                try self.visitNode(prop_idx)
+            else
+                try makeStaticSuperPropArg(self, prop_idx);
+            return try buildSuperPropSet(self, prop_arg, value, span);
+        }
+
+        /// #4244: destructuring assignment target 트리에 super member 가 있는지
+        /// (force-gate). destructuring 이 native(es2017+)라도 needsSuperLowering
+        /// 활성이면 super member 가 READ-lowering 돼 Invalid LHS — lowering 을 강제해
+        /// trySuperAssignTarget 경로로 보낸다. destructuringTargetHasPrivateField 동형.
+        pub fn destructuringTargetHasSuper(self: *Transformer, node_idx: NodeIndex) bool {
+            if (node_idx.isNone()) return false;
+            const node = self.ast.getNode(node_idx);
+            return switch (node.tag) {
+                .static_member_expression, .computed_member_expression => blk: {
+                    const e = node.data.extra;
+                    if (e >= self.ast.extra_data.items.len) break :blk false;
+                    const obj_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+                    break :blk isSuperUnwrapped(self, obj_idx);
+                },
+                .object_assignment_target, .array_assignment_target => blk: {
+                    const start = node.data.list.start;
+                    const len = node.data.list.len;
+                    var i: u32 = 0;
+                    while (i < len) : (i += 1) {
+                        const child_raw = self.ast.extra_data.items[start + i];
+                        if (destructuringTargetHasSuper(self, @enumFromInt(child_raw))) break :blk true;
+                    }
+                    break :blk false;
+                },
+                .assignment_target_property_property => destructuringTargetHasSuper(self, node.data.binary.right),
+                .assignment_target_with_default => destructuringTargetHasSuper(self, node.data.binary.left),
+                else => false,
+            };
+        }
+
         /// super.x = v / super.x += v / super.x ||= v 를 receiver 보존 helper로 낮춘다.
         pub fn lowerSuperPropertyAssignment(self: *Transformer, node: Node) ?Transformer.Error!NodeIndex {
             const left_idx = node.data.binary.left;

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -466,6 +466,13 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 try self.scratch.append(self.allocator, call);
                 return;
             }
+            // #4244: super member target (`[super.x] = …`, `({a: super.x} = o)`) →
+            // __superSet write helper. generic `visitNode(target)=value` 는 super.x 를
+            // READ(`__superGet`)로 내려 `__superGet(...)=v` (Invalid LHS) 를 만든다.
+            if (try es2015_class.ES2015Class(Transformer).trySuperAssignTarget(self, target_old_idx, value, span)) |super_set| {
+                try self.scratch.append(self.allocator, super_set);
+                return;
+            }
             const target_node = self.ast.getNode(target_old_idx);
             if (target_node.tag == .object_assignment_target or target_node.tag == .array_assignment_target or target_node.tag == .object_pattern or target_node.tag == .array_pattern) {
                 // nested: _inner = value; 각 element 재귀 emit.

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -365,7 +365,13 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
                         const has_object_rest = self.options.unsupported.object_spread and
                             left_node.tag == .object_assignment_target and
                             self.ast.nodeListSplitRest(left_node.data.list).rest_operand != null;
-                        if (self.options.unsupported.destructuring or has_private or has_object_rest) {
+                        // #4244: destructuring 이 native(es2017+)라도 super lowering 이
+                        // 활성(extracted private/static method 등)이면 super member
+                        // target 이 READ-lowering 돼 `[__superGet(...)]=v` Invalid LHS.
+                        // super target 실재 시 lowering 강제(trySuperAssignTarget 경로).
+                        const has_super = self.needsSuperLowering() and
+                            es2015_class.ES2015Class(Transformer).destructuringTargetHasSuper(self, left_idx);
+                        if (self.options.unsupported.destructuring or has_private or has_object_rest or has_super) {
                             return es2015_destructuring.ES2015Destructuring(Transformer).lowerDestructuringAssignment(self, node);
                         }
                     }

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -393,6 +393,58 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('super prop destructuring assignment target (#4244)', () => {
+    for (const [name, body, expected] of [
+      ['array [super.ab]', '[super.ab] = [7]; return this.ab;', '7'],
+      ['object {x:super.ab}', '({ x: super.ab } = { x: 9 } as any); return this.ab;', '9'],
+      ['computed [super[k]]', 'const k = "ab"; [super[k]] = [5]; return this.ab;', '5'],
+      ['default [super.ab=3]', '[super.ab = 3] = [] as any; return this.ab;', '3'],
+      ['nested [[super.ab]]', '[[super.ab]] = [[8]] as any; return this.ab;', '8'],
+    ] as [string, string, string][]) {
+      test(`${name} es5 → __superSet (Invalid LHS 회피)`, async () => {
+        // 회귀: super member 가 destructuring assignment target 이면 READ
+        // lowering(`__superGet(...)=v`)으로 빠져 Invalid LHS. __superSet write
+        // 로 분기해야.
+        const result = await bundleAndRun(
+          {
+            'index.ts': [
+              'class A { ab: any = 0; }',
+              `class B extends A { m() { ${body} } }`,
+              'console.log(new B().m());',
+            ].join('\n'),
+          },
+          'index.ts',
+          ['--target=es5'],
+        );
+        cleanup = result.cleanup;
+        expect(result.exitCode).toBe(0);
+        expect(result.runOutput).toBe(expected);
+        expect(result.bundleOutput).not.toMatch(/__superGet\([^;]*\) =/);
+      });
+    }
+
+    test('es2017 + private method 안 super target (force-gate) — Invalid LHS 회피', async () => {
+      // 회귀: destructuring 이 native(es2017)라도 extracted private method 의
+      // super lowering 활성 → [super.ab] 가 [__superGet(...)]=v Invalid LHS.
+      // destructuringTargetHasSuper force-gate 로 lowering 강제.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'class A { ab: any = 0; }',
+            'class B extends A { #h() { [super.ab] = [5]; return this.ab; } run() { return this.#h(); } }',
+            'console.log(new B().run());',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('5');
+      expect(result.bundleOutput).not.toMatch(/__superGet\([^;]*\) =/);
+    });
+  });
+
   describe('class private + static + decorator 조합', () => {
     test('private field + static + getter', async () => {
       const result = await bundleAndRun(


### PR DESCRIPTION
Closes #4244

## 문제

derived method 의 `[super.ab] = [7]` / `({x: super.ab} = o)` 에서, destructuring assignment 의 per-target 처리(`emitTargetAssignOrRecurse`)가 super member 를 generic `visitNode(target) = value` 로 내림 → super.ab 가 READ(`__superGet(...)`)로 lowering 되어 **`__superGet(...) = v` (런타임 Invalid left-hand side)**. `lowerSuperPropertyAssignment` 은 직접 대입(`super.x = v`)만 인터셉트, destructuring target 경로엔 미적용.

## 수정 (2단)

- `emitTargetAssignOrRecurse` 에 private-field(`tryLowerPrivateFieldAssign`, #1485) 선례와 동형으로 super 분기: `trySuperAssignTarget` → `__superSet(base, prop, value, receiver)` write.
- **force-gate**: destructuring 이 native(es2017+)라도 super lowering 이 활성(extracted private/static method, `needsSuperLowering()`)이면 super target 이 READ-lowering 돼 Invalid LHS → `destructuringTargetHasSuper` 로 lowering 강제(`has_private` force-gate 동형). `/code-review max` 가 적발한 es2017+private 갭 봉합.

`super_props` 에 `trySuperAssignTarget`/`destructuringTargetHasSuper` pub helper 신설(`buildSuperPropSet`/`isSuperUnwrapped` 재사용, non-super=null/false 게이트).

## 검증 (`/code-review max` 2회)

array/object/computed-key/default/nested super target es5 + **es2017 private-method 안 super target** → `__superSet`, 값 보존(5/6/7/8/9), 일반 member target 회귀0, es2017 외부 native — 전부 node 24 일치(이전 Invalid LHS). zig green + integration 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)