### PR TITLE
fix(transformer): for-of/for-in binding object rest LHS 의 es2015~17 코드깨짐 + per-iteration 보존

### DIFF
--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -942,13 +942,16 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             });
         }
 
-        /// for-in 루프의 destructuring을 분해한다.
+        /// for-in/for-of 루프의 binding destructuring을 분해한다 (node.tag 보존).
         /// for (var [i,j,k] in obj) { body }
         /// → for (var _ref in obj) { var i = _ref[0], j = _ref[1], k = _ref[2]; body }
+        /// for (const { a, ...r } of arr) { body }  (#4254: object rest at es2015~17)
+        /// → for (var _ref of arr) { var a = _ref.a, r = __rest(_ref, ["a"]); body }
         ///
-        /// for-in은 left에 단일 변수만 허용하므로, destructuring pattern이 있으면
-        /// 임시 변수로 교체하고 body 앞에 분해된 선언문을 삽입한다.
-        pub fn lowerForInDestructuring(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
+        /// for-in/for-of 는 left 에 단일 binding 만 허용하므로 destructuring pattern 을
+        /// 임시 변수로 교체하고 body 앞에 분해 선언문을 삽입한다. LHS 슬롯에 multi-
+        /// declarator 를 직접 넣으면(`for(var _a,a=_a.a,... of)`) invalid 문법이 된다.
+        pub fn lowerForInOfDestructuring(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
             const span = node.span;
             const left = node.data.ternary.a; // variable_declaration
             const right = node.data.ternary.b; // right-hand side expression
@@ -979,9 +982,17 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             const temp_span = try es_helpers.makeTempVarSpan(self);
 
             // 2) for-in의 left를 var _ref 로 교체
+            // #4254: per-iteration 바인딩 보존 — block_scoping native(es2015+)면
+            // 원본 let/const 유지. var 로 강등하면 loop temp/destructure 가 함수
+            // 스코프 단일 바인딩으로 붕괴해 closure capture 가 깨진다(마지막 iter
+            // 값만 캡처). block_scoping 미지원(es5)이면 var (for-of 는 es5 에서 이
+            // 경로 미도달=lowerForOfStatement; for-in 만, 기존 var 동작 유지).
+            const orig_kind = self.ast.variableDeclarationKind(left_node);
+            const out_kind: ast_mod.VariableDeclarationKind = if (self.options.unsupported.block_scoping) .@"var" else orig_kind;
+
             const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
             const temp_decl = try es_helpers.makeDeclarator(self, temp_binding, NodeIndex.none, span);
-            const new_left = try es_helpers.makeVarDeclaration(self, &.{temp_decl}, .@"var", span);
+            const new_left = try es_helpers.makeVarDeclaration(self, &.{temp_decl}, out_kind, span);
 
             // 3) right를 visit
             const new_right = try self.visitNode(right);
@@ -998,7 +1009,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
 
             // scratch에 쌓인 declarator들로 variable_declaration 생성
             const decl_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
-            const var_extra = try self.ast.addExtras(&.{ 0, decl_list.start, decl_list.len }); // 0 = var
+            const var_extra = try self.ast.addExtras(&.{ @intFromEnum(out_kind), decl_list.start, decl_list.len });
             const destr_decl = try self.ast.addNode(.{
                 .tag = .variable_declaration,
                 .span = span,
@@ -1011,9 +1022,9 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             else
                 new_body;
 
-            // 7) 새 for_in_statement 생성
+            // 7) 새 for_in/for_of_statement 생성 (입력 tag 보존)
             return self.ast.addNode(.{
-                .tag = .for_in_statement,
+                .tag = node.tag,
                 .span = span,
                 .data = .{ .ternary = .{ .a = new_left, .b = new_right, .c = final_body } },
             });

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -388,6 +388,7 @@ pub const Transformer = struct {
     pub const visitBinaryStatementBody = control_flow_mod.visitBinaryStatementBody;
     pub const visitForInOfTernary = control_flow_mod.visitForInOfTernary;
     pub const tryLowerForInOfPrivateTarget = control_flow_mod.tryLowerForInOfPrivateTarget;
+    pub const maybeLowerForInOfBindingDestructuring = control_flow_mod.maybeLowerForInOfBindingDestructuring;
     pub const visitForStatement = control_flow_mod.visitForStatement;
     pub const visitSwitchStatement = control_flow_mod.visitSwitchStatement;
     pub const visitSwitchCase = control_flow_mod.visitSwitchCase;

--- a/src/transformer/transformer/control_flow.zig
+++ b/src/transformer/transformer/control_flow.zig
@@ -8,6 +8,7 @@ const token_mod = @import("../../lexer/token.zig");
 const Span = token_mod.Span;
 const es2015_block_scoping = @import("../es2015_block_scoping.zig");
 const es2015_class = @import("../es2015_class.zig");
+const es2015_destructuring = @import("../es2015_destructuring.zig");
 const es_helpers = @import("../es_helpers.zig");
 const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
@@ -166,6 +167,27 @@ pub fn visitForInOfTernary(self: *Transformer, node: Node) Error!NodeIndex {
 /// - `for ({x: this.#x} of arr) BODY` → `for (var _t of arr) { ({x: this.#x} = _t); BODY }`
 /// body prefix의 assignment 는 이후 일반 assignment_expression lowering 경로를 거쳐
 /// __classPrivateFieldSet / destructuring helper 로 변환됨.
+/// #4254: for-in/for-of 의 LHS binding destructuring 을 lowering 해야 하면
+/// lowerForInOfDestructuring(body-destructure) 으로 라우팅. 두 경우:
+///   - es5(unsupported.destructuring): 모든 destructuring binding (기존 for-in).
+///   - es2015~17(unsupported.object_spread): object rest binding 만 (for_of 가
+///     native 라 LHS 슬롯 expand 불가 → body-destructure).
+/// LHS 가 binding(variable_declaration) 아니거나 lowering 불요면 null.
+pub fn maybeLowerForInOfBindingDestructuring(self: *Transformer, node: Node) Error!?NodeIndex {
+    const left = node.data.ternary.a;
+    if (left.isNone()) return null;
+    const left_node = self.ast.getNode(left);
+    if (left_node.tag != .variable_declaration) return null;
+    const D = es2015_destructuring.ES2015Destructuring(Transformer);
+    if (self.options.unsupported.destructuring and D.hasDestructuring(self, left_node)) {
+        return try D.lowerForInOfDestructuring(self, node);
+    }
+    if (self.options.unsupported.object_spread and D.hasObjectRest(self, left_node)) {
+        return try D.lowerForInOfDestructuring(self, node);
+    }
+    return null;
+}
+
 pub fn tryLowerForInOfPrivateTarget(self: *Transformer, node: Node) Error!?NodeIndex {
     const left_idx = node.data.ternary.a;
     if (left_idx.isNone()) return null;

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -470,18 +470,7 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
             if (node.tag == .for_in_statement and self.current_private_fields.len > 0) {
                 if (try self.tryLowerForInOfPrivateTarget(node)) |result| return result;
             }
-            if (self.options.unsupported.destructuring) {
-                // for (var [i,j,k] in obj) → for (var _ref in obj) { var i=_ref[0],...; body }
-                const left = node.data.ternary.a;
-                if (!left.isNone()) {
-                    const left_node = self.ast.getNode(left);
-                    if (left_node.tag == .variable_declaration and
-                        es2015_destructuring.ES2015Destructuring(Transformer).hasDestructuring(self, left_node))
-                    {
-                        return es2015_destructuring.ES2015Destructuring(Transformer).lowerForInDestructuring(self, node);
-                    }
-                }
-            }
+            if (try self.maybeLowerForInOfBindingDestructuring(node)) |result| return result;
             return self.visitForInOfTernary(node);
         },
         .try_statement,
@@ -499,6 +488,11 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
             // 임시 binding + body prefix assignment 패턴으로 변환 (#1491).
             if (self.current_private_fields.len > 0) {
                 if (try self.tryLowerForInOfPrivateTarget(node)) |result| return result;
+            }
+            // #4254: for_of 가 native(es2015~17)인데 LHS binding 이 object rest 면
+            // LHS 슬롯에 destructuring expand 불가 → body-destructure 로.
+            if (!self.options.unsupported.for_of) {
+                if (try self.maybeLowerForInOfBindingDestructuring(node)) |result| return result;
             }
             if (self.options.unsupported.for_of) {
                 return es2015_for_of.ES2015ForOf(Transformer).lowerForOfStatement(self, node);

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1724,6 +1724,66 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
     });
   });
 
+  describe('for-of/for-in binding object rest LHS (#4254)', () => {
+    for (const target of ['es2015', 'es2016', 'es2017', 'es5']) {
+      test(`for-of binding object rest 가 ${target} 에서 정상 lowering`, async () => {
+        // 회귀: for_of native(es2015~17)인데 LHS binding object rest 를
+        // lowerDestructuringDeclaration 이 LHS 슬롯에 multi-declarator 로 expand
+        // → `for(var _a,a=_a.a,... of)` invalid 문법. body-destructure 로.
+        const result = await bundleAndRun(
+          {
+            'index.ts': [
+              'const out: any[] = [];',
+              'for (const { a, ...r } of [{ a: 1, b: 2 }, { a: 3, c: 4 }] as any) out.push(a + ":" + Object.keys(r).join(""));',
+              'console.log(out.join("|"));',
+            ].join('\n'),
+          },
+          'index.ts',
+          [`--target=${target}`],
+        );
+        cleanup = result.cleanup;
+        expect(result.exitCode).toBe(0);
+        expect(result.runOutput).toBe('1:b|3:c');
+      });
+    }
+
+    test('for-of plain destructuring 은 es2017 에서 native 유지 (과트리거 회피)', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts': ['for (const { a, b } of [{ a: 1, b: 2 }] as any) console.log(a, b);'].join(
+            '\n',
+          ),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('1 2');
+      expect(result.bundleOutput).not.toContain('__rest');
+    });
+
+    test('for-of binding object rest + closure capture per-iteration (es2017)', async () => {
+      // 회귀(리뷰): lowerForInOfDestructuring var 강등 시 loop/destructure 가
+      // 함수스코프 단일 바인딩으로 붕괴 → 모든 closure 가 마지막 iter 값 캡처.
+      // block_scoping native(es2015+)면 const 보존해야 per-iteration.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'const fns: any[] = [];',
+            'for (const { a, ...r } of [{ a: 1, b: 2 }, { a: 3, c: 4 }] as any) fns.push(() => a + ":" + Object.keys(r).join(""));',
+            'console.log(fns.map((f: any) => f()).join("|"));',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('1:b|3:c');
+    });
+  });
+
   describe('for-of / iteration 경계', () => {
     test('for-of over string (코드포인트)', async () => {
       const result = await bundleAndRun(


### PR DESCRIPTION
Closes #4254

## 문제

for_of 가 native(es2015~es2017)인데 LHS binding 이 object rest(`for (const {a, ...r} of arr)`)면, `visitForInOfTernary` 가 LHS variable_declaration 을 `lowerDestructuringDeclaration` 으로 내려 multi-declarator var 를 for-of LHS 슬롯에 직접 넣어 **`for (var _a,a=_a.a,... of arr)` invalid 문법(SyntaxError)**. es5 는 for_of 자체가 `lowerForOfStatement`(iterator) 처리라 무사.

## 수정

- `lowerForInDestructuring` → `lowerForInOfDestructuring` 일반화(출력 tag=`node.tag`)로 for-in 의 body-destructure 패턴(`for (kind _ref of arr) { kind {a,...r-lowered}; body }`)을 for-of 에도 적용. node_dispatch 의 for_of/for_in dispatch 에 공유 게이트 `maybeLowerForInOfBindingDestructuring`(es5=destructuring 전체 / es2015~17=object rest binding 만, plain 과트리거 회피). helper 주입은 #4248 prepass 게이트가 커버.
- **per-iteration 보존**(`/code-review max` 적발 런타임 버그): loop temp/destructure 의 declaration kind 를 원본 `const`/`let` 로 보존(block_scoping native 시). `var` 강등은 함수스코프 단일 바인딩 붕괴로 **closure capture 가 마지막 iter 값만**(`3:c|3:c` vs native `1:b|3:c`). block_scoping 미지원(es5)만 var.

## 검증

for-of binding object rest es2015~es5 동작(1:b|3:c) + **closure capture per-iteration**, for-in object rest es2017, plain destructure es2017 native 유지(__rest 0), array/es2018/es5 for-in 회귀0 — node 24 일치. zig green + integration 7.

잔여(#4254 후속, 별개 LHS/메커니즘): **assignment-target for-of**(`for ({a,...r} of)` — LHS=object_assignment_target, es2017 native-stays) + **arrow object+array-rest 조합**(#4251 sweep). 본 PR 은 binding 형태(corruption)만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)