### PR TITLE
fix(transformer): rest param(ES2015)을 default_params 지원 타겟에서 native 유지 — arrow object+array-rest 조합

### DIFF
--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -137,6 +137,16 @@ pub fn ES2015Params(comptime Transformer: type) type {
                 const param = self.ast.getNode(@enumFromInt(raw_idx));
 
                 if (param.tag == .spread_element or param.tag == .rest_element) {
+                    // #4251: rest parameter(`...args`)는 ES2015 — default_params 지원
+                    // 타겟(es2016/es2017)에선 native 유지. arguments 기반 lowering 은
+                    // arrow 에 arguments 가 없어 ReferenceError(이 경로가 es2017 에서
+                    // 도는 건 object_spread 만 미지원이라 object rest 때문). es5(default_
+                    // params 미지원)만 `var args = [].slice.call(arguments, N)`.
+                    if (!self.options.unsupported.default_params) {
+                        const new_rest = try maybeVisit(self, @enumFromInt(raw_idx));
+                        try self.scratch.append(self.allocator, new_rest);
+                        continue;
+                    }
                     // rest parameter: ...args → var args = [].slice.call(arguments, N)
                     const rest_binding = try maybeVisit(self, param.data.unary.operand);
                     const rest_stmt = try buildRestSlice(self, rest_binding, param_index, span);

--- a/src/transformer/transformer/driver.zig
+++ b/src/transformer/transformer/driver.zig
@@ -122,17 +122,6 @@ pub fn transform(self: anytype) Error!NodeIndex {
 /// Pass 1에서 생성된 모든 function_declaration, function_expression, function,
 /// method_definition 노드를 순회하며, default/rest/destructuring params가 있으면
 /// lowerParams를 적용하고 extra_data를 in-place 수정한다.
-/// params 목록에 array-rest param (`...rest`, spread_element/rest_element) 이
-/// 있는지 (#4251). kept-arrow 의 array-rest 는 arguments 의존이라 lowering 불가.
-fn hasArrayRestParam(self: anytype, params: ast_mod.NodeList) bool {
-    const items = self.ast.extra_data.items[params.start .. params.start + params.len];
-    for (items) |raw| {
-        const t = self.ast.getNode(@as(NodeIndex, @enumFromInt(raw))).tag;
-        if (t == .spread_element or t == .rest_element) return true;
-    }
-    return false;
-}
-
 fn lowerAllFunctionParams(self: anytype) Error!void {
     const Self = @TypeOf(self.*);
     const node_count = self.ast.nodes.items.len;
@@ -196,13 +185,9 @@ fn lowerAllFunctionParams(self: anytype) Error!void {
                 const params_list = params_node.data.list;
                 if (params_list.len == 0) continue;
                 if (!es2015_params.ES2015Params(Self).hasObjectRestParam(self, params_list)) continue;
-                // #4251: array-rest param(`...rest`, ES2015)은 es2017 native 지원이나
-                // lowerParamsPass2 가 `[].slice.call(arguments, N)` 로 내림 — arrow 엔
-                // arguments 가 없어 ReferenceError. array-rest 가 섞인 arrow 는
-                // keep-arrow lowering 불가 → skip(native 유지, 진짜 es2017 엔진에선
-                // object rest SyntaxError 잔존이나 크래시는 회피). 드문 조합 #4254 추적.
-                if (hasArrayRestParam(self, params_list)) continue;
-
+                // (이전 #4251 array-rest skip 제거: lowerParamsImpl 이 default_params
+                //  지원 타겟에선 array-rest 를 native 유지하므로 arrow arguments 크래시
+                //  없음. object rest 만 temp+body 분해.)
                 var lr = try es2015_params.ES2015Params(Self).lowerParamsPass2(self, params_list, node.span);
                 defer lr.body_stmts.deinit(self.allocator);
 

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -2403,14 +2403,14 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(result.bundleOutput).toContain('__rest');
     });
 
-    test('arrow object-rest + array-rest 조합은 크래시 회피 (es2017, #4254)', async () => {
-      // 리뷰 적발: array-rest(...rest)는 ES2015 native 인데 lowerParamsPass2 가
-      // arguments 기반으로 내려 arrow 에서 ReferenceError → 그 조합은 skip(native
-      // 유지). 모던 엔진에선 동작(크래시 없음); 근본해결은 #4254.
+    test('arrow object-rest + array-rest 조합 — object 만 lower, array-rest native (es2017)', async () => {
+      // surgical 근본해결: array-rest(...rest, ES2015)는 native 유지, object rest
+      // (ES2018)만 __rest 로. arrow 엔 arguments 없으므로 arguments 기반 array-rest
+      // lowering 은 금지(이전엔 skip → 이제 정상 lowering).
       const result = await bundleAndRun(
         {
           'index.ts': [
-            'const f = ({ a, ...r }: any, ...rest: any[]) => a + rest.length;',
+            'const f = ({ a, ...r }: any, ...rest: any[]) => a + ":" + Object.keys(r).join("") + ":" + rest.length;',
             'console.log(f({ a: 1, b: 2 }, 7, 8, 9));',
           ].join('\n'),
         },
@@ -2419,8 +2419,9 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       );
       cleanup = result.cleanup;
       expect(result.exitCode).toBe(0);
-      expect(result.runOutput).toBe('4');
-      // arguments 기반 array-rest lowering 이 arrow 에 새지 않아야.
+      expect(result.runOutput).toBe('1:b:3');
+      expect(result.bundleOutput).toContain('__rest');
+      expect(result.bundleOutput).toContain('...rest');
       expect(result.bundleOutput).not.toContain('slice.call(arguments');
     });
   });


### PR DESCRIPTION
#4251/#4254 후속 (arrow object+array-rest 조합)

## 문제

`lowerParamsImpl` 이 rest param(`...args`)을 **무조건** `[].slice.call(arguments, N)` 로 내림. rest param 은 ES2015 라 default_params 지원 타겟(es2016/es2017)에선 native 유지해야 함 — 이 경로가 es2017 에서 도는 이유는 object_spread(ES2018) object rest 때문이고, **arrow 엔 `arguments` 가 없어** `({a, ...r}, ...rest) =>` 가 ReferenceError. #4251 은 그 조합을 skip(object rest 미lowering, native 잔존)으로 임시 회피했음.

## 수정 (surgical 근본)

array-rest 브랜치에 `!unsupported.default_params` 게이트: es2016/es2017 은 rest param 을 new_params 에 **native 로 push**(arguments 미사용), es5(default_params 미지원)만 `buildRestSlice`(arguments). object rest 는 그대로 `__rest`. driver 의 #4251 arrow array-rest skip 제거. **부수효과**: 함수도 es2017 에서 array-rest 를 native 유지(esbuild 동형, cleaner).

## 검증 (`/code-review max` — 도입 결함 0)

arrow `({a,...r}, ...rest)` es2017 → `__rest`(object) + `...rest`(native), 값 보존(`1:b:3`=native), 함수 동형, **es5 함수 rest 는 arguments 유지(byte-identical 회귀0)**, es2015 native rest, pure object-rest arrow 회귀0, arrow body 의 outer `arguments` 보존, TDZ default+rest, rest-with-array-pattern — 전부 node 24 일치. zig green + integration 215.

리뷰가 격리한 별개 pre-existing(회귀 아님): `for ([b, {a,...r}] of)` 중첩 array-target object rest = **#4261**(maybeLowerForInOfDestructuring 재귀 미적용, main 도 미처리).

🤖 Generated with [Claude Code](https://claude.com/claude-code)