### PR TITLE
fix(transformer): 중첩 object rest assignment-target 을 es2017 에서 lowering — for ([b, {a,...r}] of)

### DIFF
--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -76,6 +76,34 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             return self.ast.nodeListSplitRest(pattern.data.list).rest_operand != null;
         }
 
+        /// assignment-target 트리(object/array_assignment_target)에 object rest 가
+        /// 중첩 포함되어 있는지 재귀 검사 (#4261). for-of/for-in LHS 게이트용 —
+        /// top-level `object_assignment_target` rest 뿐 아니라 `for ([b, {a,...r}] of)`
+        /// 처럼 array-target 안에 중첩된 object rest 도 검출. array rest(`[a,...r]`,
+        /// ES2015)는 제외(object rest=ES2018 만 lowering 필요).
+        pub fn destructuringTargetHasObjectRest(self: *const Transformer, node_idx: NodeIndex) bool {
+            if (node_idx.isNone()) return false;
+            const node = self.ast.getNode(node_idx);
+            return switch (node.tag) {
+                .object_assignment_target => blk: {
+                    if (self.ast.nodeListSplitRest(node.data.list).rest_operand != null) break :blk true;
+                    break :blk targetListHasObjectRest(self, node.data.list);
+                },
+                .array_assignment_target => targetListHasObjectRest(self, node.data.list),
+                .assignment_target_property_property => destructuringTargetHasObjectRest(self, node.data.binary.right),
+                .assignment_target_with_default => destructuringTargetHasObjectRest(self, node.data.binary.left),
+                else => false,
+            };
+        }
+
+        fn targetListHasObjectRest(self: *const Transformer, list: NodeList) bool {
+            const items = self.ast.extra_data.items[list.start .. list.start + list.len];
+            for (items) |raw| {
+                if (destructuringTargetHasObjectRest(self, @enumFromInt(raw))) return true;
+            }
+            return false;
+        }
+
         /// destructuring이 있는 variable_declaration을 분해한다.
         /// 각 destructuring declarator를 여러 개의 단순 declarator로 풀어서 반환.
         pub fn lowerDestructuringDeclaration(self: *Transformer, node: Node) Transformer.Error!NodeIndex {

--- a/src/transformer/transformer/control_flow.zig
+++ b/src/transformer/transformer/control_flow.zig
@@ -187,12 +187,14 @@ pub fn maybeLowerForInOfDestructuring(self: *Transformer, node: Node) Error!?Nod
         }
         return null;
     }
-    // #4254 후속: assignment-target object rest LHS (`for ({a,...r} of arr)`).
-    // es2015~17(for_of native, object_spread 미지원)에서 native 잔존 → es2017 엔진
-    // SyntaxError. rest 실재 시만(plain `for({a} of)` 과트리거 회피).
-    if (left_node.tag == .object_assignment_target and
+    // #4254 후속(+#4261): assignment-target object rest LHS (`for ({a,...r} of arr)`,
+    // `for ([b, {a,...r}] of arr)`). es2015~17(for_of native, object_spread 미지원)
+    // 에서 native 잔존 → es2017 엔진 SyntaxError. object/array_assignment_target
+    // 트리에 object rest 가 중첩 포함되면 lowering(plain `for({a} of)`/array rest
+    // `for([a,...x] of)` 과트리거 회피).
+    if ((left_node.tag == .object_assignment_target or left_node.tag == .array_assignment_target) and
         self.options.unsupported.object_spread and
-        self.ast.nodeListSplitRest(left_node.data.list).rest_operand != null)
+        D.destructuringTargetHasObjectRest(self, left))
     {
         return try D.lowerForInOfDestructuring(self, node);
     }

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -358,13 +358,13 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
                     if (left_node.tag == .object_assignment_target or left_node.tag == .array_assignment_target) {
                         const has_private = self.current_private_fields.len > 0 and
                             es2015_class.ES2015Class(Transformer).destructuringTargetHasPrivateField(self, left_idx);
-                        // #4251: object rest (`({a, ...r} = o)`, ES2018) 는 destructuring
-                        // 지원 타겟(es2017)에서도 lowering 필요 — 게이트가 destructuring
-                        // (ES2015)만 보면 native 잔존(진짜 es2017 엔진 SyntaxError).
-                        // rest 실재 시만(es2017 plain `({a}=o)` 과트리거 회피).
+                        // #4251(+#4261): object rest (`({a, ...r} = o)`, ES2018) 는
+                        // destructuring 지원 타겟(es2017)에서도 lowering 필요 — 게이트가
+                        // destructuring(ES2015)만 보면 native 잔존(es2017 엔진 SyntaxError).
+                        // object/array_assignment_target 트리에 object rest 가 중첩
+                        // (`([b, {a,...r}] = o)`)되어도 검출(top-level rest 만 보면 누락).
                         const has_object_rest = self.options.unsupported.object_spread and
-                            left_node.tag == .object_assignment_target and
-                            self.ast.nodeListSplitRest(left_node.data.list).rest_operand != null;
+                            es2015_destructuring.ES2015Destructuring(Transformer).destructuringTargetHasObjectRest(self, left_idx);
                         // #4244: destructuring 이 native(es2017+)라도 super lowering 이
                         // 활성(extracted private/static method 등)이면 super member
                         // target 이 READ-lowering 돼 `[__superGet(...)]=v` Invalid LHS.

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1803,6 +1803,45 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       expect(result.runOutput).toBe('1:b|3:c');
       expect(result.bundleOutput).toContain('__rest');
     });
+
+    test('nested array-target object rest (for ([b, {a,...r}] of), es2017, #4261)', async () => {
+      // 회귀: array_assignment_target 안에 중첩된 object rest 가 게이트(top-level
+      // object-target rest 만 검사)를 못 통과해 native 잔존 → es2017 SyntaxError.
+      // destructuringTargetHasObjectRest 재귀 검출로 lowering.
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'let b: any, a: any, r: any; const out: any[] = [];',
+            'for ([b, { a, ...r }] of [[1, { a: 2, c: 3 }], [4, { a: 5, d: 6 }]] as any) out.push(b + ":" + a + ":" + Object.keys(r).join(""));',
+            'console.log(out.join("|"));',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('1:2:c|4:5:d');
+      expect(result.bundleOutput).toContain('__rest');
+    });
+
+    test('nested object rest standalone assignment (es2017, #4261 부수)', async () => {
+      const result = await bundleAndRun(
+        {
+          'index.ts': [
+            'let b: any, a: any, r: any;',
+            '([b, { a, ...r }] = [1, { a: 2, c: 3 }] as any);',
+            'console.log(b, a, Object.keys(r).join(""));',
+          ].join('\n'),
+        },
+        'index.ts',
+        ['--target=es2017'],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('1 2 c');
+      expect(result.bundleOutput).toContain('__rest');
+    });
   });
 
   describe('for-of / iteration 경계', () => {


### PR DESCRIPTION
Closes #4261

## 문제

assignment-target object rest 게이트(for-of/for-in dispatch + assignment_expression dispatch 둘 다)가 **top-level `object_assignment_target` rest 만** 검사 — `for ([b, {a, ...r}] of arr)` / `([b, {a, ...r}] = o)` 처럼 **array_assignment_target 안에 중첩된 object rest** 를 못 봐서 es2017 에서 native 잔존 → **진짜 es2017 엔진 SyntaxError**(object rest=ES2018). #4260 은 top-level 만 커버.

## 수정

`destructuringTargetHasObjectRest` 재귀 헬퍼 신설(object/array_assignment_target 트리 순회, `destructuringTargetHasPrivateField`/`Super` 와 동형; array rest=ES2015 는 제외). 두 게이트를 이걸로 교체:
- `control_flow.zig` `maybeLowerForInOfDestructuring` (for-of/for-in LHS)
- `node_dispatch.zig` assignment_expression #4251 게이트

`lowerForInOfAssignTargetDestructuring`(#4260)는 이미 array_assignment_target 도 처리하고, `lowerDestructuringAssignment` 가 중첩 object rest 를 `__rest` 로 내리므로 **게이트 확장만으로 충분**. 부수: standalone `([b,{a,...r}] = o)` es2017 도 lowering(이전 native 잔존=SyntaxError).

## 검증 (`/code-review max` — 도입 결함 0)

nested array-target for-of/standalone es2015~es5 동작(1:2:c|4:5:d), computed-key/private+rest/깊은 중첩/for-in nested 정상, plain `[a,b]`/array rest `[a,...r]`/es2018+ **byte-identical to main**(과트리거0/회귀0) — 전부 node 24 일치. zig green + integration 217.

**#4254 시리즈 잔여 nested 케이스 종결.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)