### PR TITLE
feat(compat): ES2025 regex inline modifier (?i:...) 미지원 타겟 진단 게이트 (#4210)

### DIFF
--- a/packages/shared/compat-engines.ts
+++ b/packages/shared/compat-engines.ts
@@ -63,6 +63,7 @@ export const FEATURES = [
   'regex_named_groups', // ES2018
   'unicode_brace_escape', // ES2015
   'regex_duplicate_named_groups', // ES2025
+  'regex_modifiers', // ES2025
 ] as const;
 
 export type Feature = (typeof FEATURES)[number];
@@ -295,6 +296,17 @@ export const SUPPORT: Partial<Record<Feature, Partial<Record<Engine, [number, nu
     firefox: [129, 0],
     safari: [17, 4],
     ios: [17, 4],
+    node: [23, 0],
+    deno: [1, 44],
+  },
+  regex_modifiers: {
+    // ES2025 inline modifier group `(?ims-ims:...)` (#4210). compat.zig 거울.
+    // safari 가 26 으로 늦음(dup-named 의 17.4 와 다름). hermes 미지원.
+    chrome: [125, 0],
+    edge: [125, 0],
+    firefox: [132, 0],
+    safari: [26, 0],
+    ios: [26, 0],
     node: [23, 0],
     deno: [1, 44],
   },

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -176,21 +176,22 @@ export interface TranspileResult {
 //   25-26 ES2018 (regex_dotall, regex_named_groups)
 //   27    ES2015 (unicode_brace_escape)
 //   28    ES2025 (regex_duplicate_named_groups)
+//   29    ES2025 (regex_modifiers)
 //
 // 타겟 T 에 대해 "T 이후 도입된" 모든 feature 비트를 set 한다.
 // Feature 추가 시 compat.zig 와 함께 갱신.
 export const ES_TARGET_BITS: Record<string, number> = {
-  es5: 0x1fffffff, // bits 0-28 (모든 feature)
-  es2015: 0x16fff800, // bits 11-23, 25, 26, 28 (ES2015/regex_sticky/unicode_brace_escape 제외)
-  es2016: 0x16fff000, // bits 12-23, 25, 26, 28
-  es2017: 0x16ffe000, // bits 13-23, 25, 26, 28
-  es2018: 0x10ffc000, // bits 14-23, 28 (ES2018 features 도 제외)
-  es2019: 0x10ff8000, // bits 15-23, 28
-  es2020: 0x10fe0000, // bits 17-23, 28
-  es2021: 0x10fc0000, // bits 18-23, 28
-  es2022: 0x10c00000, // bits 22-23, 28 (hashbang + using + regex dup-named)
-  es2023: 0x10800000, // bits 23, 28
-  es2024: 0x10800000, // bits 23, 28 (ES2024 자체 구문 변환 기능 없음)
+  es5: 0x3fffffff, // bits 0-29 (모든 feature)
+  es2015: 0x36fff800, // bits 11-23, 25, 26, 28, 29 (ES2015/regex_sticky/unicode_brace_escape 제외)
+  es2016: 0x36fff000, // bits 12-23, 25, 26, 28, 29
+  es2017: 0x36ffe000, // bits 13-23, 25, 26, 28, 29
+  es2018: 0x30ffc000, // bits 14-23, 28, 29 (ES2018 features 도 제외)
+  es2019: 0x30ff8000, // bits 15-23, 28, 29
+  es2020: 0x30fe0000, // bits 17-23, 28, 29
+  es2021: 0x30fc0000, // bits 18-23, 28, 29
+  es2022: 0x30c00000, // bits 22-23, 28, 29 (hashbang + using + regex dup-named + modifiers)
+  es2023: 0x30800000, // bits 23, 28, 29
+  es2024: 0x30800000, // bits 23, 28, 29 (ES2024 자체 구문 변환 기능 없음)
   es2025: 0x0,
   esnext: 0x0,
 };

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -121,6 +121,10 @@ pub fn run(self: anytype, module: *Module, arena_alloc: std.mem.Allocator) void 
     if (opts.jsxClassicPragmaIgnoredUnderAutomatic(ast_ptr)) {
         self.addDiag(.jsx_pragma_ignored, .warning, module.path, Span.EMPTY, .parse, TransformOptions.jsx_pragma_ignored_msg, null);
     }
+    // #4210: ES2025 regex inline modifier 미지원 타겟 사용 → verbatim 패스스루. loud 진단.
+    if (opts.usesUnsupportedRegexModifier(ast_ptr)) {
+        self.addDiag(.regex_modifier_unsupported, .warning, module.path, Span.EMPTY, .parse, TransformOptions.regex_modifier_unsupported_msg, null);
+    }
     // #1961 PR 1h 후 splitting / single-bundle 양쪽에서 helper module virtual import
     // 모델 활성. mangler 가 helper module top-level 식별자를 reserved 처리
     // (linker.zig 의 candidates collect 에서 isVirtualId 분기) — cross-module binding

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -810,6 +810,9 @@ pub const BundlerDiagnostic = struct {
         /// `@jsx` / `@jsxFrag` pragma 가 있는데 effective JSX runtime 이 automatic — classic
         /// factory 가 무시됨 (D026). warning severity.
         jsx_pragma_ignored,
+        /// ES2025 regex inline modifier `(?ims-ims:...)` 를 미지원 타겟에서 사용 — lowering
+        /// 부재로 verbatim 패스스루, 구형 엔진 SyntaxError (#4210). warning severity.
+        regex_modifier_unsupported,
     };
 
     pub const Severity = enum {

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -102,6 +102,9 @@ pub const Feature = enum(u5) {
     /// regex_named_groups 와 같은 strip+__wrapRegExp 경로로 다운레벨 (#4199).
     /// NOTE: Feature enum 과 UnsupportedFeatures 필드는 비트 위치가 1:1 — 끝에만 추가.
     regex_duplicate_named_groups,
+    /// ES2025 inline modifier group `(?ims-ims:...)` (#4210). 미지원 타겟에선
+    /// 다운레벨 부재 — verbatim 패스스루 + loud 진단으로 silent SyntaxError 방지.
+    regex_modifiers,
 
     /// 이 feature가 도입된 ES 버전.
     pub fn esVersion(self: Feature) ESTarget {
@@ -115,7 +118,7 @@ pub const Feature = enum(u5) {
             .logical_assignment => .es2021,
             .class_static_block, .class_private_method, .class_private_field, .top_level_await => .es2022,
             .hashbang => .es2023,
-            .using, .regex_duplicate_named_groups => .es2025,
+            .using, .regex_duplicate_named_groups, .regex_modifiers => .es2025,
         };
     }
 };
@@ -166,8 +169,11 @@ pub const UnsupportedFeatures = packed struct(u32) {
     regex_named_groups: bool = false,
     unicode_brace_escape: bool = false,
     regex_duplicate_named_groups: bool = false,
+    /// ES2025 inline modifier group `(?ims-ims:...)` (#4210). lowering 미구현 단계 —
+    /// 비트는 진단 게이트 전용(needsRegexLowering 에는 아직 미포함, passthrough 유지).
+    regex_modifiers: bool = false,
 
-    _: u3 = 0,
+    _: u2 = 0,
 
     /// regex literal lowering 이 필요한 비트가 하나라도 set 인지.
     /// node_dispatch 조기탈출/graph prepass 게이트가 공유 — 새 regex 비트는
@@ -613,6 +619,16 @@ const compat_table = [_]CompatEntry{
     .{ .feature = .regex_duplicate_named_groups, .engine = .deno, .major = 1, .minor = 44 },
     // edge, ios, hermes: 미지원 → compat_table에 없음 → 항상 다운레벨링
 
+    // ── ES2025: regex inline modifiers `(?ims-ims:...)` (#4210) ──
+    // BCD: safari 가 26 으로 늦음(dup-named 의 17.4 와 다름). hermes 미지원.
+    .{ .feature = .regex_modifiers, .engine = .chrome, .major = 125 },
+    .{ .feature = .regex_modifiers, .engine = .edge, .major = 125 },
+    .{ .feature = .regex_modifiers, .engine = .firefox, .major = 132 },
+    .{ .feature = .regex_modifiers, .engine = .safari, .major = 26 },
+    .{ .feature = .regex_modifiers, .engine = .ios, .major = 26 },
+    .{ .feature = .regex_modifiers, .engine = .node, .major = 23 },
+    .{ .feature = .regex_modifiers, .engine = .deno, .major = 1, .minor = 44 },
+
     // ── ES2015: regex_sticky (/y) ──
     .{ .feature = .regex_sticky, .engine = .chrome, .major = 49 },
     .{ .feature = .regex_sticky, .engine = .firefox, .major = 3 },
@@ -965,7 +981,9 @@ test "unsupportedFeatures — 최신 엔진은 모두 지원" {
     const f = unsupportedFeatures(&.{
         .{ .engine = .chrome, .major = 134 },
         .{ .engine = .firefox, .major = 132 },
-        .{ .engine = .safari, .major = 18, .minor = 2 },
+        // safari 26: regex_modifiers (#4210) 가 safari 26 부터라 이전 버전은
+        // 모든 feature 지원이 아니다 (dup-named 의 17.4 와 다른 경계).
+        .{ .engine = .safari, .major = 26 },
     });
     try std.testing.expectEqual(@as(u32, 0), @as(u32, @bitCast(f)));
 }
@@ -1125,4 +1143,27 @@ test "browserslistToUnsupported — 다중 엔진 union" {
 test "browserslistToUnsupported — stat 쿼리는 null" {
     try std.testing.expectEqual(@as(?UnsupportedFeatures, null), browserslistToUnsupported("defaults"));
     try std.testing.expectEqual(@as(?UnsupportedFeatures, null), browserslistToUnsupported("last 2 versions"));
+}
+
+test "regex_modifiers — es2024는 미지원, es2025는 지원 (#4210)" {
+    try std.testing.expect(fromESTarget(.es2024).regex_modifiers);
+    try std.testing.expect(!fromESTarget(.es2025).regex_modifiers);
+    try std.testing.expect(!fromESTarget(.esnext).regex_modifiers);
+    // es5 = 모든 feature 미지원에 포함
+    try std.testing.expect(fromESTarget(.es5).regex_modifiers);
+}
+
+test "regex_modifiers — safari 26 경계 (dup-named 의 17.4 와 다름, #4210)" {
+    // Safari 25 < 26 → modifiers 미지원이지만 dup-named(17.4)는 지원
+    const s25 = unsupportedFeatures(&.{.{ .engine = .safari, .major = 25 }});
+    try std.testing.expect(s25.regex_modifiers);
+    try std.testing.expect(!s25.regex_duplicate_named_groups);
+    // Safari 26 → 둘 다 지원
+    const s26 = unsupportedFeatures(&.{.{ .engine = .safari, .major = 26 }});
+    try std.testing.expect(!s26.regex_modifiers);
+    // node 22 < 23 → 미지원, node 23 → 지원
+    try std.testing.expect(unsupportedFeatures(&.{.{ .engine = .node, .major = 22 }}).regex_modifiers);
+    try std.testing.expect(!unsupportedFeatures(&.{.{ .engine = .node, .major = 23 }}).regex_modifiers);
+    // hermes: compat table 미등록 → 항상 미지원
+    try std.testing.expect(unsupportedFeatures(&.{.{ .engine = .hermes, .major = 0, .minor = 12 }}).regex_modifiers);
 }

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -7,6 +7,7 @@ const Node = ast_mod.Node;
 const profile = @import("../profile.zig");
 const define_mod = @import("transformer/define.zig");
 const codegen_options = @import("../codegen/options.zig");
+const regex_lower = @import("regex_lower.zig");
 
 /// define 치환 엔트리. key=식별자 텍스트, value=치환 문자열.
 /// `parser.scan_results.DefineEntry` 와 동일 정의 — parser 의 inline scan 도 같은 entries 사용.
@@ -316,6 +317,11 @@ pub const TransformOptions = struct {
                     // 때만 prepass — 일반 regex 모듈에 graph prepass 비용 미부과 (#4199).
                     if (u.regex_duplicate_named_groups and
                         std.mem.indexOf(u8, ast.getText(node.span), "(?<") != null) return true;
+                    // #4210: modifier-gate 만 set 인 es2024↓ 에서도 modifier 그룹이 실재할
+                    // 때만 prepass — run() 이 loud 진단을 띄운다 (lowering 은 미구현이라
+                    // regexp 는 passthrough, 출력 무변경). hasModifierGroup 으로 후보 게이트.
+                    if (u.regex_modifiers and
+                        regex_lower.hasModifierGroup(ast.getText(node.span))) return true;
                 },
                 else => {},
             }
@@ -376,6 +382,27 @@ pub const TransformOptions = struct {
     pub const jsx_pragma_ignored_msg =
         "@jsx / @jsxFrag pragma ignored — the effective JSX runtime is automatic; " ++
         "add /** @jsxRuntime classic */ to use a custom factory, or remove the pragma";
+
+    /// ES2025 inline modifier group `(?ims-ims:...)` 를 미지원 타겟에서 쓰고 있는지 (#4210).
+    /// lowering 미구현이라 verbatim 패스스루 → 구형 엔진에서 regex 컴파일 SyntaxError.
+    /// caller 가 loud 진단을 띄운다. `regex_modifiers` 비트가 set 인 (es2024↓) 타겟에서만
+    /// 노드를 스캔 — 모던 타겟(es2025+)은 비트가 false 라 스캔조차 안 한다.
+    pub fn usesUnsupportedRegexModifier(self: @This(), ast: *const Ast) bool {
+        if (!self.unsupported.regex_modifiers) return false;
+        for (ast.nodes.items) |node| {
+            if (node.tag == .regexp_literal and
+                regex_lower.hasModifierGroup(ast.getText(node.span))) return true;
+        }
+        return false;
+    }
+
+    /// `usesUnsupportedRegexModifier` 가 true 일 때 caller 가 띄우는 메시지.
+    /// graph pre-pass(structured diagnostic) 와 transpile(`std.log.warn`) 양쪽이 공유.
+    pub const regex_modifier_unsupported_msg =
+        "regular expression inline modifier group ((?i:...) / (?ims-ims:...)) is an " ++
+        "ES2025 feature not supported by the configured target — it is emitted unchanged " ++
+        "and will throw a SyntaxError on older engines. Raise the target to es2025+, or " ++
+        "rewrite the pattern without inline modifiers.";
 };
 
 /// 점-구분 pragma 의 head segment. `jsx_lowering.makeFactoryCallee` 가 동일하게

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -17,6 +17,7 @@ const std = @import("std");
 const compat = @import("compat.zig");
 const regexp = @import("../regexp/mod.zig");
 const group_name = @import("../regexp/group_name.zig");
+const char_helpers = @import("../regexp/char_helpers.zig");
 const cooked_name = @import("cooked_name.zig");
 
 pub const Options = struct {
@@ -285,6 +286,42 @@ fn hasNamedGroup(pattern: []const u8) bool {
         if (c == '(' and i + 2 < pattern.len and pattern[i + 1] == '?' and pattern[i + 2] == '<') {
             if (i + 3 < pattern.len and (pattern[i + 3] == '=' or pattern[i + 3] == '!')) continue;
             return true;
+        }
+    }
+    return false;
+}
+
+/// `(?ims-ims:...)` inline modifier 그룹(ES2025)이 패턴에 있는지. char class 안과
+/// escape 는 제외하고, `(?:`(non-capturing)·`(?<name>`·lookaround 와 구분한다 —
+/// `(?` 뒤가 modifier 문자(i/m/s) ≥1 개 (선택적 `-[ims]+`) + `:` 로 끝나야 한다.
+pub fn hasModifierGroup(pattern: []const u8) bool {
+    var i: usize = 0;
+    var in_class: bool = false;
+    while (i < pattern.len) : (i += 1) {
+        const c = pattern[i];
+        if (c == '\\') {
+            i += 1;
+            continue;
+        }
+        if (in_class) {
+            if (c == ']') in_class = false;
+            continue;
+        }
+        if (c == '[') {
+            in_class = true;
+            continue;
+        }
+        if (c == '(' and i + 1 < pattern.len and pattern[i + 1] == '?') {
+            var j = i + 2;
+            var mods: u32 = 0;
+            // modifier 문자 정의는 파서(char_helpers.isModifierChar)와 공유 — 둘이
+            // 어긋나면 검출/파싱 불일치. ES2025 는 i/m/s 만 inline modifier.
+            while (j < pattern.len and char_helpers.isModifierChar(pattern[j])) : (j += 1) mods += 1;
+            if (j < pattern.len and pattern[j] == '-') {
+                j += 1;
+                while (j < pattern.len and char_helpers.isModifierChar(pattern[j])) : (j += 1) mods += 1;
+            }
+            if (mods > 0 and j < pattern.len and pattern[j] == ':') return true;
         }
     }
     return false;
@@ -664,4 +701,35 @@ test "#2472 regression: 50 named groups + last backref — no truncation" {
     try testing.expect(std.mem.indexOf(u8, out, "\\50") != null);
     // 32-stack 회귀 시 named[32..] 가 누락되어 backref 변환 실패 → "\\k<n49>" 잔존했음.
     try testing.expect(std.mem.indexOf(u8, out, "\\k<n") == null);
+}
+
+test "hasModifierGroup — inline modifier 그룹 검출 (#4210)" {
+    // enabling / disabling / 혼합 / 패턴 중간
+    try testing.expect(hasModifierGroup("(?i:a)"));
+    try testing.expect(hasModifierGroup("(?s:.)x"));
+    try testing.expect(hasModifierGroup("(?-i:b)"));
+    try testing.expect(hasModifierGroup("(?im-s:a)"));
+    try testing.expect(hasModifierGroup("foo(?i:bar)baz"));
+    try testing.expect(hasModifierGroup("(?m:^a$)"));
+}
+
+test "hasModifierGroup — non-modifier 그룹과 구분 (#4210)" {
+    // non-capturing / named / lookaround 은 modifier 아님
+    try testing.expect(!hasModifierGroup("(?:a)"));
+    try testing.expect(!hasModifierGroup("(?<n>a)"));
+    try testing.expect(!hasModifierGroup("(?=a)"));
+    try testing.expect(!hasModifierGroup("(?<=a)"));
+    try testing.expect(!hasModifierGroup("(?!a)"));
+    try testing.expect(!hasModifierGroup("plain"));
+    // modifier 문자 없이 `:` 만 → 아님
+    try testing.expect(!hasModifierGroup("(?:-)"));
+}
+
+test "hasModifierGroup — char class 안 / escape 는 제외 (#4210)" {
+    // `[(?i:]` 는 char class 멤버라 modifier 아님
+    try testing.expect(!hasModifierGroup("[(?i:]"));
+    // escape 된 `\(` 는 group 시작 아님
+    try testing.expect(!hasModifierGroup("\\(?i:"));
+    // class 밖의 진짜 modifier 는 여전히 검출
+    try testing.expect(hasModifierGroup("[abc](?i:x)"));
 }

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1444,6 +1444,11 @@ fn transpileWithCallbackInternal(
     if (effective_opts.jsxClassicPragmaIgnoredUnderAutomatic(&parser.ast)) {
         std.log.warn("zntc: {s}: {s}", .{ file_path, TransformOptions.jsx_pragma_ignored_msg });
     }
+    // #4210: ES2025 regex inline modifier 를 미지원 타겟에서 사용 → verbatim 패스스루.
+    // silent SyntaxError 대신 loud 진단 (graph pre-pass 와 동일 메시지/경로).
+    if (effective_opts.usesUnsupportedRegexModifier(&parser.ast)) {
+        std.log.warn("zntc: {s}: {s}", .{ file_path, TransformOptions.regex_modifier_unsupported_msg });
+    }
     // RFC_TRANSFORMER_OWN_AST PR-2: clone 회피 — transformer 가 parser.ast 의 ownership 을
     // 양도받아 *동일 instance* 를 직접 mutate. cloneForTransformer 의 deep copy 회피로
     // 87MB synthetic 기준 peak RSS -84 MB (-2.6%, n=30 p<0.0001) 절감 (clone 배열이


### PR DESCRIPTION
## 무엇을 / 왜

ES2025 inline modifier 그룹 `(?i:...)` / `(?ims-ims:...)` (정규식 일부에만 `i`/`m`/`s` 플래그를 켜고 끄는 문법)은 zntc 파서/프린터가 이미 지원하지만, **compat 게이트가 없어 모든 타겟에서 그대로(verbatim) 패스스루**됐습니다. 그래서 es2024 이하 엔진에서는 정규식 컴파일 시점에 **silent SyntaxError**가 납니다.

다른 트랜스파일러 실측 비교 (es2016 타겟):

| 도구 | modifier 다운레벨? | 동작 |
|---|---|---|
| Babel (`@babel/plugin-transform-regexp-modifiers`) | ✅ 완전 | `(?i:foo)`→`(?:[Ff][Oo][Oo])` 등 |
| swc / oxc(→rolldown) / esbuild | ❌ | verbatim 패스스루, **경고 없음** |
| zntc (이전) | ❌ | verbatim 패스스루, **경고 없음** |

oxc 는 미구현 트래킹 중([oxc#11826](https://github.com/oxc-project/oxc/issues/11826)). 즉 번들러 생태계 중 누구도 다운레벨하지 않고, **모두 silent**합니다.

## 이 PR의 범위 (게이트 + loud 진단)

실제 다운레벨(regexpu 식 `i`=fold 확장 / `s`=dot 재작성 / `m`=lookbehind anchor 재작성)은 XL 이라 **후속 PR로 분리**하고, 본 PR은 **게이트 + loud 진단**만 추가합니다. 이것만으로 zntc 는 *silent SyntaxError 를 안 내보내는 유일한 번들러*가 됩니다. (후속 PR에서 lowering 이 붙으면 진단 범위는 "es2017 이하의 m-modifier 처럼 못 내리는 잔여"로 줄어듭니다.)

```
$ zntc app.js --target=es2024
warning: zntc: app.js: regular expression inline modifier group ((?i:...) / (?ims-ims:...))
is an ES2025 feature not supported by the configured target — it is emitted unchanged and
will throw a SyntaxError on older engines. Raise the target to es2025+, or rewrite the
pattern without inline modifiers.
```

## 변경 내용

- **`compat.zig`**: `regex_modifiers` feature 비트(es2025) + 엔진 호환 테이블. 버전은 MDN BCD 실측 — chrome 125 / edge 125 / firefox 132 / **safari 26** / ios 26 / node 23 / deno 1.44. (safari 가 26 으로, 같은 ES2025 인 duplicate named group 의 17.4 와 경계가 다릅니다.)
- **`regex_lower.zig`**: `hasModifierGroup()` 검출기 — `(?:`(non-capturing) · `(?<name>` · lookaround · char-class 내부 · escape 와 정확히 구분. modifier 문자 정의는 파서가 쓰는 `char_helpers.isModifierChar` 를 공유(검출/파싱 불일치 방지).
- **`options.zig`**: `usesUnsupportedRegexModifier()` + graph prepass 트리거. modifier 가 *실재할 때만* prepass 를 켭니다(중복 named-group 게이트 #4199 와 동형) — 일반 정규식 모듈엔 비용을 안 물립니다.
- **진단 2 경로**: 단일파일 transpile(`std.log.warn`) + 번들러(structured diagnostic, `jsx_pragma_ignored` 선례와 동일).
- **JS 미러 2곳**: `compat-engines.ts`(FEATURES/SUPPORT) + `index.ts`(ES_TARGET_BITS bit 29).

## 성능 / 안전

- lowering 미구현이라 정규식은 **passthrough(출력 바이트 무변경)** — `regex_modifiers` 비트는 `needsRegexLowering()` 에 넣지 않고 진단 게이트 전용으로만 씁니다.
- **모던 타겟(es2025+)은 비트가 false 라 AST 스캔조차 안 합니다 → perf 회귀 0.** es2024 이하 + modifier 보유 모듈만(희소 교집합) 값싼 선형 스캔 1회.

> 🧑‍🏫 Zig 초보자 메모
> - `UnsupportedFeatures` 는 `packed struct(u32)` — 각 feature 가 비트 하나입니다. feature 를 추가하면 끝에 `bool` 필드를 더하고 패딩 `_: u3` → `_: u2` 로 줄여 총 32비트를 유지합니다. `comptime` 블록이 `Feature` enum 과 이 구조체 필드 순서가 1:1 인지 컴파일 타임에 검증합니다(어긋나면 빌드 실패).
> - Zig 의 `and` 는 **단락 평가(short-circuit)** 라, `if (!self.unsupported.regex_modifiers) return false;` 로 먼저 막으면 모던 타겟에선 뒤의 스캔 함수가 아예 호출되지 않습니다 — 이게 "회귀 0" 의 핵심입니다.

## 테스트

- 단위: `hasModifierGroup` 검출/구분/escape 3건, compat 비트 경계(es2024/es2025, safari 25↔26, node 22↔23, hermes) 2건. 전체 스위트 **5880/5880 통과**.
- E2E: 단일파일·번들러 양 경로에서 es2024/safari25 경고, es2025/safari26 무경고, 비-modifier 정규식 false-positive 0 확인.
- `/code-review max`: 정확성 결함 0, cleanup 1건(char_helpers reuse) 반영.

관련 #4210
