### PR TITLE
feat(transformer): ES2025 regex (?s:…) modifier 다운레벨 + effective-flag 컨텍스트 (#4210)

### DIFF
--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -36,6 +36,11 @@ pub const Options = struct {
     /// `i` flag 활성 여부. negated class 의 정확 다운레벨은 case-fold 와
     /// 얽히므로(#3511), `i`+`u` negated 는 보수적으로 게이트(미변환).
     ignore_case: bool = false,
+    /// ES2025 inline modifier 그룹 `(?i:…)`/`(?s:…)` 다운레벨 (#4210). 켜지면
+    /// enabling i/s 영역을 fold/dot 재작성으로 baked-in 한 뒤 modifier 비트를
+    /// strip 한다. disabling(`-i`/`-s`)·`m`·전역 /i on·u/astral 은 보수적 bail
+    /// (그룹 보존 → lower() 가 진단). global /s 플래그(=`s` flag 존재) 여부.
+    lower_modifiers: bool = false,
 };
 
 pub const NamedGroup = struct {
@@ -125,13 +130,14 @@ const T = struct {
     in_class: bool = false,
     /// 정확히 다운레벨 못한 astral 구문 발견 (lower() 가 u-strip 보류 판단).
     astral_u_incomplete: bool = false,
-    /// `(?-s:)` 영역 깊이 (#4211). 내부 `.` 는 global /s dotall 의 적용 대상이
-    /// 아니므로 재작성하면 안 된다 — modifier 그룹은 출력에 보존되어 모던 엔진이
-    /// 영역 의미를 직접 제공한다 (`(?s:)` 내부 재작성은 의미 동치라 추적 불요).
-    mod_s_off_depth: u32 = 0,
-    /// i 를 건드리는 modifier 영역 깊이 (#4211). 내부 class 의 iu fold 확장은
-    /// 영역별 유효 i 를 정확히 반영할 수 없어 u-보존 게이트로 폴백.
-    mod_i_depth: u32 = 0,
+    /// 영역별 effective s/i (#4211/#4225 → #4210). null=상속(global flag),
+    /// true=(?s:)/(?i:) 으로 켜짐, false=(?-s:)/(?-i:) 으로 꺼짐. enclosing
+    /// modifier group 진입 시 save/restore (regexpu `modifiersData` 동형).
+    ///   - 비-lowering 경로: `mod_s != false` ⟺ 옛 `mod_s_off_depth==0`,
+    ///     `mod_i != null` ⟺ 옛 `mod_i_depth>0` (동작 보존).
+    ///   - lowering 경로(#4210): effective 값으로 dot 재작성 / fold 확장.
+    mod_s: ?bool = null,
+    mod_i: ?bool = null,
 
     /// surrogate pair 2 노드를 list 에 push (cp>0xFFFF).
     fn pushSurrogate(self: *T, span: ast.Span, cp: u32, out: *std.ArrayList(u32)) TransformError!void {
@@ -305,7 +311,7 @@ const T = struct {
             if (self.opts.unicode_brace and isAstralUnicodeEscape(cn)) {
                 // #4225: astral fast-path 도 fold 게이트 적용 (Deseret/Adlam 등
                 // astral u-전용 등가) — 게이트 시 surrogate 분해 없이 보존 경로로.
-                if ((self.opts.ignore_case or self.mod_i_depth > 0) and
+                if ((self.opts.ignore_case or self.mod_i != null) and
                     iu_fold.hasEntry(cn.data[0]))
                 {
                     self.astral_u_incomplete = true;
@@ -358,7 +364,7 @@ const T = struct {
                 // (#3509 "틀린 출력 0"). lower() 의 #4211 재변환이 전체 일관 보존.
                 // i-유효성은 글로벌 /i 또는 (?i:) 영역(#4211 mod_i_depth) 둘 다.
                 if (self.opts.unicode_brace and
-                    (self.opts.ignore_case or self.mod_i_depth > 0))
+                    (self.opts.ignore_case or self.mod_i != null))
                 {
                     const kind: ast.CharacterKind = @enumFromInt(n.data[1]);
                     // literal(symbol) non-ASCII 는 파서가 UTF-8 byte 단위 노드라
@@ -372,8 +378,12 @@ const T = struct {
                 return self.b.add(n);
             },
             .dot => {
-                // #4211: (?-s:) 안의 `.` 는 global /s 비적용 — 재작성 금지.
-                if (self.opts.dotall and self.mod_s_off_depth == 0) return self.makeDotAllClass(n.span);
+                // #4211: (?-s:) 안의 `.` 는 global /s 비적용 — 재작성 금지
+                // (mod_s != false ⟺ 옛 mod_s_off_depth==0). #4210: (?s:) 영역
+                // (mod_s==true) 은 lowering 시 dot 을 직접 dotall 화.
+                if ((self.opts.dotall and self.mod_s != false) or
+                    (self.opts.lower_modifiers and self.mod_s == true))
+                    return self.makeDotAllClass(n.span);
                 return self.b.add(n);
             },
             .named_reference => {
@@ -427,7 +437,7 @@ const T = struct {
                     const negative = (n.data[0] & 1) != 0;
                     // #4211: i-modifier 영역 안 class 는 영역별 유효 i 를 fold 확장에
                     // 반영할 수 없다 — u 보존(부분 커버리지, 틀린 출력 0, #3509 동형).
-                    if (self.mod_i_depth > 0) {
+                    if (self.mod_i != null) {
                         self.astral_u_incomplete = true;
                     } else if (negative or self.opts.ignore_case or self.classHasAstral(n)) {
                         var set = cps.CodePointSet{};
@@ -476,19 +486,30 @@ const T = struct {
             },
             .ignore_group => {
                 // modifier 비트: bit0=i, bit1=m, bit2=s (ast.zig ignore_group).
-                const s_off = (n.data[1] & 0b100) != 0;
-                const i_mod = ((n.data[0] | n.data[1]) & 0b001) != 0;
+                const en = n.data[0]; // enabling
+                const dis = n.data[1]; // disabling
                 // in_class 와 동일한 save/restore 관용구 — 에러 경로에서도 오염 없음.
-                const saved_s = self.mod_s_off_depth;
-                const saved_i = self.mod_i_depth;
-                if (s_off) self.mod_s_off_depth += 1;
-                if (i_mod) self.mod_i_depth += 1;
+                // effective: enabling→true, disabling→false, 무관→상속(불변).
+                const saved_s = self.mod_s;
+                const saved_i = self.mod_i;
+                if (en & 0b100 != 0) self.mod_s = true;
+                if (dis & 0b100 != 0) self.mod_s = false;
+                if (en & 0b001 != 0) self.mod_i = true;
+                if (dis & 0b001 != 0) self.mod_i = false;
                 defer {
-                    self.mod_s_off_depth = saved_s;
-                    self.mod_i_depth = saved_i;
+                    self.mod_s = saved_s;
+                    self.mod_i = saved_i;
                 }
                 const body = try self.node(@enumFromInt(n.data[2]));
-                return self.b.add(.{ .tag = .ignore_group, .span = n.span, .data = .{ n.data[0], n.data[1], @intFromEnum(body) } });
+                // #4210 lowering: s-enabling 영역의 `.` 는 body 에서 [\s\S] 로
+                // baked-in(dot 핸들러) → s-enabling 비트만 strip. i/m/모든
+                // disabling 은 보수적으로 보존(lower() 진단이 잔여 경고). 모든
+                // 비트가 빠지면 평범한 `(?:…)`.
+                if (self.opts.lower_modifiers) {
+                    const kept_en = en & ~@as(u32, 0b100); // s-enabling(4) 제거
+                    return self.b.add(.{ .tag = .ignore_group, .span = n.span, .data = .{ kept_en, dis, @intFromEnum(body) } });
+                }
+                return self.b.add(.{ .tag = .ignore_group, .span = n.span, .data = .{ en, dis, @intFromEnum(body) } });
             },
             .quantifier => {
                 const body = try self.node(n.getQuantifierBody());

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -169,8 +169,8 @@ pub const UnsupportedFeatures = packed struct(u32) {
     regex_named_groups: bool = false,
     unicode_brace_escape: bool = false,
     regex_duplicate_named_groups: bool = false,
-    /// ES2025 inline modifier group `(?ims-ims:...)` (#4210). lowering 미구현 단계 —
-    /// 비트는 진단 게이트 전용(needsRegexLowering 에는 아직 미포함, passthrough 유지).
+    /// ES2025 inline modifier group `(?ims-ims:...)` (#4210). s-enabling `(?s:)` 는
+    /// 다운레벨(needsRegexLowering 포함), i/m/disabling 잔여는 보존 + 진단.
     regex_modifiers: bool = false,
 
     _: u2 = 0,
@@ -180,7 +180,7 @@ pub const UnsupportedFeatures = packed struct(u32) {
     /// 여기 한 곳만 추가하면 된다 (#4199 에서 게이트 2곳 누락이 실제 발생).
     pub fn needsRegexLowering(self: @This()) bool {
         return self.regex_dotall or self.regex_named_groups or self.regex_sticky or
-            self.unicode_brace_escape or self.regex_duplicate_named_groups;
+            self.unicode_brace_escape or self.regex_duplicate_named_groups or self.regex_modifiers;
     }
 
     /// 어떤 feature flag 라도 set 됐는지 (= packed struct 가 zero 가 아닌지).

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -383,15 +383,16 @@ pub const TransformOptions = struct {
         "@jsx / @jsxFrag pragma ignored — the effective JSX runtime is automatic; " ++
         "add /** @jsxRuntime classic */ to use a custom factory, or remove the pragma";
 
-    /// ES2025 inline modifier group `(?ims-ims:...)` 를 미지원 타겟에서 쓰고 있는지 (#4210).
-    /// lowering 미구현이라 verbatim 패스스루 → 구형 엔진에서 regex 컴파일 SyntaxError.
-    /// caller 가 loud 진단을 띄운다. `regex_modifiers` 비트가 set 인 (es2024↓) 타겟에서만
-    /// 노드를 스캔 — 모던 타겟(es2025+)은 비트가 false 라 스캔조차 안 한다.
+    /// ES2025 inline modifier group `(?ims-ims:...)` 중 *다운레벨 안 되는* 그룹을 미지원
+    /// 타겟에서 쓰고 있는지 (#4210). PR2 가 s-enabling `(?s:)` 는 내리므로, 잔여
+    /// (i/m/disabling = `scanModifiers().unlowered`)만 verbatim 패스스루 → 구형 엔진
+    /// SyntaxError → caller 가 loud 진단. `regex_modifiers` 비트가 set 인 (es2024↓)
+    /// 타겟에서만 스캔 — 모던 타겟(es2025+)은 비트 false 라 스캔조차 안 한다.
     pub fn usesUnsupportedRegexModifier(self: @This(), ast: *const Ast) bool {
         if (!self.unsupported.regex_modifiers) return false;
         for (ast.nodes.items) |node| {
             if (node.tag == .regexp_literal and
-                regex_lower.hasModifierGroup(ast.getText(node.span))) return true;
+                regex_lower.scanModifiers(ast.getText(node.span)).unlowered) return true;
         }
         return false;
     }

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -64,13 +64,17 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
     // `u` flag 자체는 runtime 지원 대상이 아니지만, `\u{X}` brace escape 는 `u` flag 하에서만
     // 허용된다. brace escape 를 surrogate pair 로 내리면서 flag 도 함께 strip 한다.
     const need_unicode = has_u and opts.unsupported.unicode_brace_escape;
+    // #4210: ES2025 inline modifier 다운레벨. PR2 는 s-enabling `(?s…:…)` 만
+    // 내린다(dot→[\s\S] 후 s 비트 strip). i/m/disabling 잔여는 그룹 보존 +
+    // 진단(usesUnsupportedRegexModifier). lowerable 일 때만 transform 실행.
+    const need_modifier = opts.unsupported.regex_modifiers and scanModifiers(pattern).lowerable;
 
-    if (!need_dotall and !need_named and !need_sticky and !need_unicode) return .{ .text = null };
+    if (!need_dotall and !need_named and !need_sticky and !need_unicode and !need_modifier) return .{ .text = null };
 
-    // sticky 는 flag strip 만 → 패턴 무변경. dotall/named/unicode 만 패턴 변환.
+    // sticky 는 flag strip 만 → 패턴 무변경. dotall/named/unicode/modifier 만 패턴 변환.
     // sticky-only 면 parse/transform/print 를 건너뛰고 원본 패턴 verbatim
     // (불필요 작업 제거 + canonical 정규화 미적용 — ad-hoc 과 동일 바이트).
-    const need_pattern_xform = need_dotall or need_named or need_unicode;
+    const need_pattern_xform = need_dotall or need_named or need_unicode or need_modifier;
 
     // parse → AST transform → dumb printer (#1475 PR2 정공법; ad-hoc byte-walk
     // 제거). 파서는 렉서 validate 와 동일하므로(이미 통과한 리터럴) parse 실패는
@@ -88,6 +92,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
             .strip_named = need_named,
             .unicode_brace = need_unicode,
             .ignore_case = has_i,
+            .lower_modifiers = need_modifier,
         }, allocator);
         astral_u_incomplete = tr.astral_u_incomplete;
         // #4211: u 를 보존하기로 결정되면(incomplete) 패턴 *전체*가 u-유효해야
@@ -291,10 +296,23 @@ fn hasNamedGroup(pattern: []const u8) bool {
     return false;
 }
 
-/// `(?ims-ims:...)` inline modifier 그룹(ES2025)이 패턴에 있는지. char class 안과
-/// escape 는 제외하고, `(?:`(non-capturing)·`(?<name>`·lookaround 와 구분한다 —
-/// `(?` 뒤가 modifier 문자(i/m/s) ≥1 개 (선택적 `-[ims]+`) + `:` 로 끝나야 한다.
-pub fn hasModifierGroup(pattern: []const u8) bool {
+/// 패턴의 inline modifier 그룹(ES2025) 스캔 결과.
+pub const ModifierScan = struct {
+    /// modifier 그룹이 하나라도 있는가 (`(?:`·`(?<name>`·lookaround 와 구분).
+    any: bool = false,
+    /// PR2 가 다운레벨 가능한 s-enabling 그룹(`(?s…:…)`)이 있는가 → transform 실행.
+    lowerable: bool = false,
+    /// 완전 다운레벨 안 되는 그룹(순수 s-enabling 외 — i/m/disabling 포함)이
+    /// 있는가 → 미지원 타겟에서 진단 대상.
+    unlowered: bool = false,
+};
+
+/// `(?ims-ims:...)` inline modifier 그룹을 스캔. char class 안과 escape 는 제외하고,
+/// `(?:`·`(?<name>`·lookaround 와 구분한다 — `(?` 뒤가 modifier 문자(i/m/s) ≥1 개
+/// (선택적 `-[ims]+`) + `:` 로 끝나야 한다. 비트 정의(i=1,m=2,s=4)는 파서
+/// char_helpers 와 공유 — 어긋나면 검출/파싱 불일치.
+pub fn scanModifiers(pattern: []const u8) ModifierScan {
+    var r = ModifierScan{};
     var i: usize = 0;
     var in_class: bool = false;
     while (i < pattern.len) : (i += 1) {
@@ -313,18 +331,28 @@ pub fn hasModifierGroup(pattern: []const u8) bool {
         }
         if (c == '(' and i + 1 < pattern.len and pattern[i + 1] == '?') {
             var j = i + 2;
-            var mods: u32 = 0;
-            // modifier 문자 정의는 파서(char_helpers.isModifierChar)와 공유 — 둘이
-            // 어긋나면 검출/파싱 불일치. ES2025 는 i/m/s 만 inline modifier.
-            while (j < pattern.len and char_helpers.isModifierChar(pattern[j])) : (j += 1) mods += 1;
+            var en: u8 = 0;
+            var dis: u8 = 0;
+            while (j < pattern.len and char_helpers.isModifierChar(pattern[j])) : (j += 1)
+                en |= char_helpers.modifierBit(pattern[j]);
             if (j < pattern.len and pattern[j] == '-') {
                 j += 1;
-                while (j < pattern.len and char_helpers.isModifierChar(pattern[j])) : (j += 1) mods += 1;
+                while (j < pattern.len and char_helpers.isModifierChar(pattern[j])) : (j += 1)
+                    dis |= char_helpers.modifierBit(pattern[j]);
             }
-            if (mods > 0 and j < pattern.len and pattern[j] == ':') return true;
+            if ((en != 0 or dis != 0) and j < pattern.len and pattern[j] == ':') {
+                r.any = true;
+                if (en & 0b100 != 0) r.lowerable = true; // s-enabling (s=4)
+                if (!(en == 0b100 and dis == 0)) r.unlowered = true; // 순수 s-enabling 외
+            }
         }
     }
-    return false;
+    return r;
+}
+
+/// modifier 그룹이 하나라도 있는가 (graph prepass 게이트 / 진단 후보).
+pub fn hasModifierGroup(pattern: []const u8) bool {
+    return scanModifiers(pattern).any;
 }
 
 // ─── 테스트 ───
@@ -732,4 +760,65 @@ test "hasModifierGroup — char class 안 / escape 는 제외 (#4210)" {
     try testing.expect(!hasModifierGroup("\\(?i:"));
     // class 밖의 진짜 modifier 는 여전히 검출
     try testing.expect(hasModifierGroup("[abc](?i:x)"));
+}
+
+test "scanModifiers — lowerable(s-enabling) / unlowered 분류 (#4210)" {
+    // 순수 s-enabling → lowerable, NOT unlowered
+    const s = scanModifiers("(?s:.)x");
+    try testing.expect(s.any and s.lowerable and !s.unlowered);
+    // i-enabling → unlowered, NOT lowerable
+    const i = scanModifiers("(?i:a)");
+    try testing.expect(i.any and !i.lowerable and i.unlowered);
+    // 혼합 (?is:) → lowerable(s strip) + unlowered(i 잔여)
+    const is = scanModifiers("(?is:a)");
+    try testing.expect(is.any and is.lowerable and is.unlowered);
+    // disabling (?-s:) → NOT lowerable(enabling 아님), unlowered
+    const ds = scanModifiers("(?-s:a)");
+    try testing.expect(ds.any and !ds.lowerable and ds.unlowered);
+    // (?s-i:) → s-enabling lowerable + disabling 으로 unlowered
+    const sdi = scanModifiers("(?s-i:a)");
+    try testing.expect(sdi.any and sdi.lowerable and sdi.unlowered);
+    // modifier 없음
+    const none = scanModifiers("(?:a)(?<n>b)");
+    try testing.expect(!none.any and !none.lowerable and !none.unlowered);
+}
+
+test "#4210: (?s:.) → (?:[\\s\\S]) 다운레벨 + s-enabling strip" {
+    const out = (try runLower("/(?s:.)x/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?:[\\s\\S])x/", out);
+}
+
+test "#4210: 중첩 dot — a(?s:b.c)d 내부 dot 만 dotall" {
+    const out = (try runLower("/a(?s:b.c)d/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/a(?:b[\\s\\S]c)d/", out);
+}
+
+test "#4210: 혼합 (?s:.)(?i:x) — s 다운레벨, i 보존" {
+    const out = (try runLower("/(?s:.)(?i:x)/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?:[\\s\\S])(?i:x)/", out);
+}
+
+test "#4210: 혼합 (?sm:^.$) — s 만 strip, m 보존 → (?m:^[\\s\\S]$)" {
+    const out = (try runLower("/(?sm:^.$)/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?m:^[\\s\\S]$)/", out);
+}
+
+test "#4210: 혼합 (?si:x.) — s 만 strip, i 보존 → (?i:x[\\s\\S])" {
+    const out = (try runLower("/(?si:x.)/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?i:x[\\s\\S])/", out);
+}
+
+test "#4210: i-only (?i:foo) 는 lowerable 아님 → 변환 없음(.text=null)" {
+    const r = try lower(testing.allocator, "/(?i:foo)/", .{ .unsupported = .{ .regex_modifiers = true } });
+    try testing.expect(r.text == null);
+}
+
+test "#4210: modifier 비트 미set(모던 타겟) → 변환 없음" {
+    const r = try lower(testing.allocator, "/(?s:.)x/", .{ .unsupported = .{} });
+    try testing.expect(r.text == null);
 }


### PR DESCRIPTION
## 무엇을 / 왜

[#4264](https://github.com/ohah/zntc/pull/4264)(PR1, 진단 게이트)의 후속입니다. ES2025 inline modifier 그룹 중 **s-enabling `(?s:…)`** 를 실제로 **다운레벨**합니다 — 영역 안의 `.` 를 `[\s\S]` 로 재작성한 뒤 modifier 그룹을 평범한 `(?:…)` 로 바꿉니다.

```
$ zntc app.js --target=es2024
const re = /(?s:.)x/;        →   const re = /(?:[\s\S])x/;     # 다운레벨, 경고 없음
const re = /a(?s:b.c)d/;     →   const re = /a(?:b[\s\S]c)d/;
const re = /(?sm:^.$)/;      →   const re = /(?m:^[\s\S]$)/;    # s 만 내림, m 보존(+잔여 경고)
const re = /(?i:foo)/;       →   const re = /(?i:foo)/;        # i 는 다음 PR (+경고 유지)
```

## 보수적 스코프 (왜 s 만)

`feedback_minify_semantic_preserving`(절대원칙)·`#3509`("틀린 출력 0") 정신에 따라 **확실히 정확한 s-enabling 만** 내립니다:
- **s 는 fold·global-flag 와 무관** — `.`(dotall) → `[\s\S]` 는 항상 정확.
- **i 는 별도 PR**: zntc 는 전역 `/i` 를 다운레벨하지 않아(flag 유지) `(?-i:)` 를 끌 수 없고, 기존 fold 인프라(`appendEquivalents`)는 **u-flag fold**라 non-u `(?i:k)` 에 Kelvin(U+212A)을 over-fold → 미스컴파일 위험. 정확한 non-u fold 를 갖춘 후속 PR 로 분리.
- **m 은 그 다음 PR**: `^`/`$` → lookbehind/lookahead 재작성(es2018+ 바닥).

내리지 못하는 잔여(i/m/disabling)는 **그룹 보존 + PR1 진단**으로 안전하게 처리합니다.

## 핵심 변경

- **`transform.zig`**: depth-counter(`mod_s_off_depth`/`mod_i_depth`) → **effective-flag**(`mod_s`/`mod_i`: `?bool`, regexpu `modifiersData` 와 동형) 마이그레이션. 비-lowering 경로는 동작을 정확히 보존(`mod_s != false` ⟺ 옛 `==0`, `mod_i != null` ⟺ 옛 `>0`) — #4211/#4225 회귀 가드 통과. 새 `lower_modifiers` 옵션으로 lowering 게이트.
- **`regex_lower.zig`**: `scanModifiers()` 가 modifier 그룹을 `any`/`lowerable`(s-enabling)/`unlowered`(순수 s-enabling 외) 로 분류. `lowerable` 일 때만 transform 실행.
- **`compat.zig`**: `regex_modifiers` 를 `needsRegexLowering()` 에 포함(이제 lowering 을 구동).
- **`options.zig`**: 진단을 `scanModifiers().unlowered` 로 — `(?s:)` 는 내려가니 경고 안 하고, i/m/disabling 잔여만 경고.

## 성능 / 안전

- **모던 타겟(es2025+)은 비트 false → 스캔조차 안 함**(회귀 0). es2024↓ + s-modifier 보유 모듈만 transform.
- 비-lowering 경로(dotall/named) 동작 무변경 — depth→effective 마이그레이션은 동치.

> 🧑‍🏫 Zig 초보자 메모
> - `mod_s: ?bool` 는 **optional bool** — `null`(상속/global flag), `true`(`(?s:)` 로 켜짐), `false`(`(?-s:)` 로 꺼짐) 3-상태입니다. `mod_s != false` 는 "꺼진 영역이 아님"(상속이거나 켜짐)을 뜻해 옛 깊이-카운터 `== 0` 과 동치입니다.
> - modifier 비트는 `i=1, m=2, s=4`(parser `char_helpers` 와 AST `ignore_group` 가 공유하는 인코딩). `en & ~@as(u32, 0b100)` 으로 s(4) 비트만 끕니다.

## 테스트

- 유닛: s-lowering(단순/중첩/혼합 `(?sm:)`·`(?si:)`)·`scanModifiers` 분류·lowerable 아닌 `(?i:)` no-op·#4211/#4225/#4202 회귀. 전체 스위트 통과.
- **node24 런타임 동치 89건**: 원본 modifier regex(node24 ≥23 지원) vs 다운레벨 출력 — 개행·`/m`·capture+backref·quantifier 포함 all match.
- `/code-review max`: 정확성 결함 0(dot 핸들러 12케이스 전수 검증), 혼합 케이스 검증 후 테스트 추가.

관련 #4210
