### PR TITLE
feat(transformer): ES2025 regex (?i:…) modifier ASCII non-u 다운레벨 + transform-driven 진단 (#4210)

### DIFF
--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -121,10 +121,6 @@ pub fn run(self: anytype, module: *Module, arena_alloc: std.mem.Allocator) void 
     if (opts.jsxClassicPragmaIgnoredUnderAutomatic(ast_ptr)) {
         self.addDiag(.jsx_pragma_ignored, .warning, module.path, Span.EMPTY, .parse, TransformOptions.jsx_pragma_ignored_msg, null);
     }
-    // #4210: ES2025 regex inline modifier 미지원 타겟 사용 → verbatim 패스스루. loud 진단.
-    if (opts.usesUnsupportedRegexModifier(ast_ptr)) {
-        self.addDiag(.regex_modifier_unsupported, .warning, module.path, Span.EMPTY, .parse, TransformOptions.regex_modifier_unsupported_msg, null);
-    }
     // #1961 PR 1h 후 splitting / single-bundle 양쪽에서 helper module virtual import
     // 모델 활성. mangler 가 helper module top-level 식별자를 reserved 처리
     // (linker.zig 의 candidates collect 에서 isVirtualId 분기) — cross-module binding
@@ -141,6 +137,11 @@ pub fn run(self: anytype, module: *Module, arena_alloc: std.mem.Allocator) void 
     transformer.line_offsets = module.line_offsets;
 
     const root = transformer.transform() catch return;
+    // #4210: 다운레벨 못한 ES2025 inline modifier 가 출력에 보존됨 → loud 진단
+    // (transform-driven — 실제 fold bail 반영). transpile path 와 동일 메시지.
+    if (transformer.used_unsupported_modifier) {
+        self.addDiag(.regex_modifier_unsupported, .warning, module.path, Span.EMPTY, .parse, TransformOptions.regex_modifier_unsupported_msg, null);
+    }
     if (self.ignore_annotations) {
         purity.clearPureCallFlags(transformer.ast);
     } else {

--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -18,6 +18,7 @@ const NodeIndex = ast.NodeIndex;
 const Node = ast.Node;
 const UNNAMED = std.math.maxInt(u32);
 const UESC = @intFromEnum(ast.CharacterKind.unicode_escape);
+const SYM = @intFromEnum(ast.CharacterKind.symbol);
 
 /// ECMAScript `\s` 집합 (WhiteSpace + LineTerminator). 전부 BMP.
 const WS_RANGES = [_][2]u32{
@@ -39,8 +40,11 @@ pub const Options = struct {
     /// ES2025 inline modifier 그룹 `(?i:…)`/`(?s:…)` 다운레벨 (#4210). 켜지면
     /// enabling i/s 영역을 fold/dot 재작성으로 baked-in 한 뒤 modifier 비트를
     /// strip 한다. disabling(`-i`/`-s`)·`m`·전역 /i on·u/astral 은 보수적 bail
-    /// (그룹 보존 → lower() 가 진단). global /s 플래그(=`s` flag 존재) 여부.
+    /// (그룹 보존 → kept_modifier → 호출자가 진단).
     lower_modifiers: bool = false,
+    /// regex 가 `u`/`v` 플래그를 가졌는가 (#4210). i-fold 는 non-u(ASCII) 전용이라
+    /// /u 영역에선 bail — 파서가 unicode_brace 를 끈 재변환에도 정확히 게이트.
+    global_u: bool = false,
 };
 
 pub const NamedGroup = struct {
@@ -55,6 +59,9 @@ pub const Result = struct {
     /// (negated/\p{}/class_string 등)을 만났는가. true 면 호출자는 `u`
     /// flag 를 strip 하면 안 된다 (silent 오변환 방지 — 부분 커버리지).
     astral_u_incomplete: bool,
+    /// lower_modifiers 요청 시, 다운레벨 못해 출력에 보존된 modifier 그룹이 있는가
+    /// (#4210). 호출자(lower→transpile/prepass)가 loud 진단을 띄운다.
+    kept_modifier: bool,
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *Result) void {
@@ -138,6 +145,13 @@ const T = struct {
     ///   - lowering 경로(#4210): effective 값으로 dot 재작성 / fold 확장.
     mod_s: ?bool = null,
     mod_i: ?bool = null,
+    /// 현재 i-enabling 영역에서 fold 못한 atom(비-ASCII/negated/복잡 class)을 만났는가
+    /// (#4210 PR2b). 영역별 save/restore — true 면 ignore_group 이 i 비트를 보존(bail).
+    i_fold_incomplete: bool = false,
+    /// 다운레벨 못해 출력에 보존된 modifier 그룹이 있는가 (#4210). transpile/prepass 가
+    /// transform 후 이 값으로 진단을 띄운다 (source-scan 보다 정확 — escape/flag/내용
+    /// 의존 bail 을 정확 반영).
+    kept_modifier: bool = false,
 
     /// surrogate pair 2 노드를 list 에 push (cp>0xFFFF).
     fn pushSurrogate(self: *T, span: ast.Span, cp: u32, out: *std.ArrayList(u32)) TransformError!void {
@@ -156,6 +170,58 @@ const T = struct {
         const list = try self.b.addList(&.{ @intFromEnum(e_s), @intFromEnum(e_ns) });
         // character_class data: [flags, list_start, list_len], flags bit0=neg, bits1-2=kind(union=0)
         return self.b.add(.{ .tag = .character_class, .span = span, .data = .{ 0, list.start, list.len } });
+    }
+
+    // ── #4210 PR2b: ES2025 `(?i:…)` non-u ASCII case-fold ──
+
+    /// ASCII 글자 c1·c2(대/소) → 리터럴 `[c1c2]` (.symbol 이라 글자는 escape 불필요).
+    fn makeAsciiFoldClass(self: *T, c1: u32, c2: u32, span: ast.Span) TransformError!NodeIndex {
+        const x = try self.b.add(.{ .tag = .character, .span = span, .data = .{ c1, SYM, 0 } });
+        const y = try self.b.add(.{ .tag = .character, .span = span, .data = .{ c2, SYM, 0 } });
+        const l = try self.b.addList(&.{ @intFromEnum(x), @intFromEnum(y) });
+        return self.b.add(.{ .tag = .character_class, .span = span, .data = .{ 0, l.start, l.len } });
+    }
+
+    /// non-u ASCII case-fold: set 의 ASCII 글자에 대/소 swap 을 추가. set 에 비-ASCII
+    /// (>=0x80) 멤버가 있으면 false(= fold 불가, 호출자 bail). regexpu 와 달리 Kelvin
+    /// (U+212A)·ſ(U+017F) 같은 u-전용 special fold 는 포함하지 않음 — non-u Canonicalize
+    /// 는 toUpperCase 기반이라 이들이 ASCII 로 collapse 되지 않는다.
+    fn asciiFoldExpand(self: *T, set: *cps.CodePointSet) TransformError!bool {
+        var extra: std.ArrayList(u32) = .empty;
+        defer extra.deinit(self.b.a);
+        for (set.items()) |r| {
+            if (r.max >= 0x80) return false; // 비-ASCII 멤버 → fold 불가
+            var cp = r.min;
+            while (true) : (cp += 1) {
+                if (cp >= 'A' and cp <= 'Z') {
+                    try extra.append(self.b.a, cp + 0x20);
+                } else if (cp >= 'a' and cp <= 'z') {
+                    try extra.append(self.b.a, cp - 0x20);
+                }
+                if (cp == r.max) break;
+            }
+        }
+        for (extra.items) |e| try set.addOne(self.b.a, e);
+        try set.normalize(self.b.a);
+        return true;
+    }
+
+    /// BMP CodePointSet → 단일 `[…]` (범위/단일 자식, \uXXXX 표기 — 모든 특수문자 안전).
+    fn buildBmpClass(self: *T, set: *cps.CodePointSet, span: ast.Span) TransformError!NodeIndex {
+        var kids: std.ArrayList(u32) = .empty;
+        defer kids.deinit(self.b.a);
+        for (set.items()) |r| {
+            try kids.append(self.b.a, @intFromEnum(try self.rangeChild(r.min, r.max, span)));
+        }
+        const l = try self.b.addList(kids.items);
+        return self.b.add(.{ .tag = .character_class, .span = span, .data = .{ 0, l.start, l.len } });
+    }
+
+    /// i-enabling 영역에서 atom 을 fold 할 수 있는 컨텍스트인가 (#4210 PR2b).
+    /// non-u(`!global_u`) + 전역 /i off(`!ignore_case`) + (?i:) 영역(mod_i==true).
+    fn inAsciiIFoldRegion(self: *T) bool {
+        return self.opts.lower_modifiers and self.mod_i == true and
+            !self.opts.ignore_case and !self.opts.global_u;
     }
 
     fn isAstralUnicodeEscape(n: Node) bool {
@@ -375,6 +441,15 @@ const T = struct {
                         iu_fold.hasEntry(n.data[0]);
                     if (fold_risk) self.astral_u_incomplete = true;
                 }
+                // #4210 PR2b: i-enabling 영역의 ASCII 글자 → [cC] non-u fold.
+                if (self.inAsciiIFoldRegion()) {
+                    const cp = n.data[0];
+                    if (cp >= 'A' and cp <= 'Z') return try self.makeAsciiFoldClass(cp, cp + 0x20, n.span);
+                    if (cp >= 'a' and cp <= 'z') return try self.makeAsciiFoldClass(cp, cp - 0x20, n.span);
+                    // 비-ASCII atom 은 non-u fold 불가 → 영역 bail(그룹 i 비트 보존).
+                    // ASCII 비-글자(숫자·기호·control)는 identity(그대로, bail 아님).
+                    if (cp >= 0x80) self.i_fold_incomplete = true;
+                }
                 return self.b.add(n);
             },
             .dot => {
@@ -454,6 +529,21 @@ const T = struct {
                         self.astral_u_incomplete = true;
                     }
                 }
+                // #4210 PR2b: non-u i-enabling 영역의 positive class → ASCII case-fold.
+                // negated/비-ASCII/복잡(\p{}·class_string·\D\W\S·\s 포함) 는 bail(보존).
+                if (self.inAsciiIFoldRegion()) {
+                    const negative = (n.data[0] & 1) != 0;
+                    if (negative) {
+                        self.i_fold_incomplete = true; // negated non-u fold 미묘 → bail
+                    } else {
+                        var set = cps.CodePointSet{};
+                        defer set.deinit(self.b.a);
+                        if ((try self.collectClassSet(n, &set)) and (try self.asciiFoldExpand(&set))) {
+                            return try self.buildBmpClass(&set, n.span);
+                        }
+                        self.i_fold_incomplete = true; // collect 실패 또는 비-ASCII → bail
+                    }
+                }
                 const saved = self.in_class;
                 self.in_class = true;
                 const l = try self.expandList(n.getClassBody());
@@ -492,24 +582,32 @@ const T = struct {
                 // effective: enabling→true, disabling→false, 무관→상속(불변).
                 const saved_s = self.mod_s;
                 const saved_i = self.mod_i;
+                const saved_ifi = self.i_fold_incomplete;
                 if (en & 0b100 != 0) self.mod_s = true;
                 if (dis & 0b100 != 0) self.mod_s = false;
                 if (en & 0b001 != 0) self.mod_i = true;
                 if (dis & 0b001 != 0) self.mod_i = false;
+                self.i_fold_incomplete = false; // 이 영역의 fold-bail 만 집계
                 defer {
                     self.mod_s = saved_s;
                     self.mod_i = saved_i;
+                    self.i_fold_incomplete = saved_ifi; // 내부 bail 은 상위로 누설 안 함
                 }
                 const body = try self.node(@enumFromInt(n.data[2]));
-                // #4210 lowering: s-enabling 영역의 `.` 는 body 에서 [\s\S] 로
-                // baked-in(dot 핸들러) → s-enabling 비트만 strip. i/m/모든
-                // disabling 은 보수적으로 보존(lower() 진단이 잔여 경고). 모든
-                // 비트가 빠지면 평범한 `(?:…)`.
-                if (self.opts.lower_modifiers) {
-                    const kept_en = en & ~@as(u32, 0b100); // s-enabling(4) 제거
-                    return self.b.add(.{ .tag = .ignore_group, .span = n.span, .data = .{ kept_en, dis, @intFromEnum(body) } });
+                if (!self.opts.lower_modifiers) {
+                    return self.b.add(.{ .tag = .ignore_group, .span = n.span, .data = .{ en, dis, @intFromEnum(body) } });
                 }
-                return self.b.add(.{ .tag = .ignore_group, .span = n.span, .data = .{ en, dis, @intFromEnum(body) } });
+                // #4210 lowering: s-enabling 은 dot 이 body 에서 [\s\S] 로 baked-in →
+                // 항상 strip. i-enabling 은 이 영역의 모든 atom 이 fold 됐을 때만
+                // (비-bail, non-u, 전역 /i off) strip — bail 시 i 보존(이미 fold 된
+                // atom 은 [cC] 라 i 적용이 no-op 이라 의미 동치). m/disabling 보존.
+                var kept_en = en & ~@as(u32, 0b100); // s-enabling 제거
+                const i_lowered = (en & 0b001 != 0) and !self.i_fold_incomplete and
+                    !self.opts.ignore_case and !self.opts.global_u;
+                if (i_lowered) kept_en &= ~@as(u32, 0b001); // i-enabling 제거
+                // 보존된 modifier 비트가 남으면 진단 신호(transpile/prepass 가 경고).
+                if (kept_en != 0 or dis != 0) self.kept_modifier = true;
+                return self.b.add(.{ .tag = .ignore_group, .span = n.span, .data = .{ kept_en, dis, @intFromEnum(body) } });
             },
             .quantifier => {
                 const body = try self.node(n.getQuantifierBody());
@@ -548,6 +646,7 @@ pub fn transform(in: ast.RegExpAst, opts: Options, allocator: std.mem.Allocator)
         },
         .named_groups = named,
         .astral_u_incomplete = t.astral_u_incomplete,
+        .kept_modifier = t.kept_modifier,
         .allocator = allocator,
     };
 }

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -383,22 +383,9 @@ pub const TransformOptions = struct {
         "@jsx / @jsxFrag pragma ignored — the effective JSX runtime is automatic; " ++
         "add /** @jsxRuntime classic */ to use a custom factory, or remove the pragma";
 
-    /// ES2025 inline modifier group `(?ims-ims:...)` 중 *다운레벨 안 되는* 그룹을 미지원
-    /// 타겟에서 쓰고 있는지 (#4210). PR2 가 s-enabling `(?s:)` 는 내리므로, 잔여
-    /// (i/m/disabling = `scanModifiers().unlowered`)만 verbatim 패스스루 → 구형 엔진
-    /// SyntaxError → caller 가 loud 진단. `regex_modifiers` 비트가 set 인 (es2024↓)
-    /// 타겟에서만 스캔 — 모던 타겟(es2025+)은 비트 false 라 스캔조차 안 한다.
-    pub fn usesUnsupportedRegexModifier(self: @This(), ast: *const Ast) bool {
-        if (!self.unsupported.regex_modifiers) return false;
-        for (ast.nodes.items) |node| {
-            if (node.tag == .regexp_literal and
-                regex_lower.scanModifiers(ast.getText(node.span)).unlowered) return true;
-        }
-        return false;
-    }
-
-    /// `usesUnsupportedRegexModifier` 가 true 일 때 caller 가 띄우는 메시지.
-    /// graph pre-pass(structured diagnostic) 와 transpile(`std.log.warn`) 양쪽이 공유.
+    /// ES2025 inline modifier(#4210) 중 다운레벨 못한 잔여가 보존됐을 때 caller 가
+    /// 띄우는 메시지. 진단은 transform-driven(`transformer.used_unsupported_modifier`)
+    /// — graph pre-pass(structured diagnostic) 와 transpile(`std.log.warn`) 공유.
     pub const regex_modifier_unsupported_msg =
         "regular expression inline modifier group ((?i:...) / (?ims-ims:...)) is an " ++
         "ES2025 feature not supported by the configured target — it is emitted unchanged " ++

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -32,6 +32,9 @@ pub const Result = struct {
     /// 사용. free 책임은 호출자. `name` 슬라이스는 호출자가 lower 에 전달한 raw
     /// 텍스트의 lifetime 에 의존 — owner 가 살아있는 동안만 유효.
     named_groups: ?[]const NamedGroupMapping = null,
+    /// ES2025 modifier 다운레벨(#4210) 시, 못 내려 출력에 보존된 modifier 그룹이
+    /// 있는가. 호출자(node_dispatch→transformer)가 진단 신호로 모은다.
+    kept_modifier: bool = false,
 };
 
 /// regex literal 원본 텍스트(`/pattern/flags`)를 받아 변환이 필요하면 새 슬라이스를 반환.
@@ -64,10 +67,10 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
     // `u` flag 자체는 runtime 지원 대상이 아니지만, `\u{X}` brace escape 는 `u` flag 하에서만
     // 허용된다. brace escape 를 surrogate pair 로 내리면서 flag 도 함께 strip 한다.
     const need_unicode = has_u and opts.unsupported.unicode_brace_escape;
-    // #4210: ES2025 inline modifier 다운레벨. PR2 는 s-enabling `(?s…:…)` 만
-    // 내린다(dot→[\s\S] 후 s 비트 strip). i/m/disabling 잔여는 그룹 보존 +
-    // 진단(usesUnsupportedRegexModifier). lowerable 일 때만 transform 실행.
-    const need_modifier = opts.unsupported.regex_modifiers and scanModifiers(pattern).lowerable;
+    // #4210: ES2025 inline modifier 다운레벨. modifier 가 있으면 transform 을 거쳐
+    // 내릴 수 있는 것(s-enabling, ASCII i-enabling)은 내리고 못 내리는 잔여
+    // (m/disabling/비-ASCII/`/u`/전역 /i)는 보존+kept_modifier 로 진단 신호.
+    const need_modifier = opts.unsupported.regex_modifiers and hasModifierGroup(pattern);
 
     if (!need_dotall and !need_named and !need_sticky and !need_unicode and !need_modifier) return .{ .text = null };
 
@@ -84,6 +87,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
     // #3509: astral 을 정확히 ES5 로 못 내린 경우(negated/\p{}/class_string)
     // u flag 를 strip 하면 silent 오변환 → u 보존(부분 커버리지, 틀린 출력 0).
     var astral_u_incomplete = false;
+    var kept_modifier = false;
     const pattern_text: []const u8 = if (need_pattern_xform) blk: {
         var in_ast = regexp.parse(pattern, flags, allocator) orelse return .{ .text = null };
         defer in_ast.deinit();
@@ -93,8 +97,10 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
             .unicode_brace = need_unicode,
             .ignore_case = has_i,
             .lower_modifiers = need_modifier,
+            .global_u = has_u,
         }, allocator);
         astral_u_incomplete = tr.astral_u_incomplete;
+        kept_modifier = tr.kept_modifier;
         // #4211: u 를 보존하기로 결정되면(incomplete) 패턴 *전체*가 u-유효해야
         // 한다 — 이미 적용된 surrogate-alternation/complement 재작성은 u-strip
         // 전제라 부분 적용 시 비일관 miscompile (kept-u 아래서 lone surrogate
@@ -106,7 +112,10 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
                 .strip_named = need_named,
                 .unicode_brace = false,
                 .ignore_case = has_i,
+                .lower_modifiers = need_modifier,
+                .global_u = has_u,
             }, allocator);
+            kept_modifier = tr.kept_modifier;
         }
         defer tr.deinit();
         owned_pattern = regexp.printer.print(tr.ast, allocator) catch return .{ .text = null };
@@ -136,7 +145,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
         if (strip_u and c == 'u') continue;
         try out.append(allocator, c);
     }
-    return .{ .text = try out.toOwnedSlice(allocator), .named_groups = named_groups };
+    return .{ .text = try out.toOwnedSlice(allocator), .named_groups = named_groups, .kept_modifier = kept_modifier };
 }
 
 /// `String.prototype.replace` replacement string 의 `$<name>` 변환을 위한 매핑 항목.
@@ -296,23 +305,13 @@ fn hasNamedGroup(pattern: []const u8) bool {
     return false;
 }
 
-/// 패턴의 inline modifier 그룹(ES2025) 스캔 결과.
-pub const ModifierScan = struct {
-    /// modifier 그룹이 하나라도 있는가 (`(?:`·`(?<name>`·lookaround 와 구분).
-    any: bool = false,
-    /// PR2 가 다운레벨 가능한 s-enabling 그룹(`(?s…:…)`)이 있는가 → transform 실행.
-    lowerable: bool = false,
-    /// 완전 다운레벨 안 되는 그룹(순수 s-enabling 외 — i/m/disabling 포함)이
-    /// 있는가 → 미지원 타겟에서 진단 대상.
-    unlowered: bool = false,
-};
-
-/// `(?ims-ims:...)` inline modifier 그룹을 스캔. char class 안과 escape 는 제외하고,
-/// `(?:`·`(?<name>`·lookaround 와 구분한다 — `(?` 뒤가 modifier 문자(i/m/s) ≥1 개
-/// (선택적 `-[ims]+`) + `:` 로 끝나야 한다. 비트 정의(i=1,m=2,s=4)는 파서
-/// char_helpers 와 공유 — 어긋나면 검출/파싱 불일치.
-pub fn scanModifiers(pattern: []const u8) ModifierScan {
-    var r = ModifierScan{};
+/// `(?ims-ims:...)` inline modifier 그룹(ES2025)이 패턴에 하나라도 있는가. char class
+/// 안과 escape 는 제외하고, `(?:`·`(?<name>`·lookaround 와 구분한다 — `(?` 뒤가 modifier
+/// 문자(i/m/s) ≥1 개 (선택적 `-[ims]+`) + `:` 로 끝나야 한다. 비트 정의(i=1,m=2,s=4)는
+/// 파서 char_helpers 와 공유. 이건 transform 실행/prepass 게이트일 뿐 — 실제 다운레벨
+/// 가능 여부·잔여 진단은 transform 결과(kept_modifier)가 결정한다(byte-scan 은 fold
+/// bail = 비-ASCII/`\u`escape/`/u`/전역 /i 를 판별 못 함).
+pub fn hasModifierGroup(pattern: []const u8) bool {
     var i: usize = 0;
     var in_class: bool = false;
     while (i < pattern.len) : (i += 1) {
@@ -331,28 +330,16 @@ pub fn scanModifiers(pattern: []const u8) ModifierScan {
         }
         if (c == '(' and i + 1 < pattern.len and pattern[i + 1] == '?') {
             var j = i + 2;
-            var en: u8 = 0;
-            var dis: u8 = 0;
-            while (j < pattern.len and char_helpers.isModifierChar(pattern[j])) : (j += 1)
-                en |= char_helpers.modifierBit(pattern[j]);
+            var mods: u32 = 0;
+            while (j < pattern.len and char_helpers.isModifierChar(pattern[j])) : (j += 1) mods += 1;
             if (j < pattern.len and pattern[j] == '-') {
                 j += 1;
-                while (j < pattern.len and char_helpers.isModifierChar(pattern[j])) : (j += 1)
-                    dis |= char_helpers.modifierBit(pattern[j]);
+                while (j < pattern.len and char_helpers.isModifierChar(pattern[j])) : (j += 1) mods += 1;
             }
-            if ((en != 0 or dis != 0) and j < pattern.len and pattern[j] == ':') {
-                r.any = true;
-                if (en & 0b100 != 0) r.lowerable = true; // s-enabling (s=4)
-                if (!(en == 0b100 and dis == 0)) r.unlowered = true; // 순수 s-enabling 외
-            }
+            if (mods > 0 and j < pattern.len and pattern[j] == ':') return true;
         }
     }
-    return r;
-}
-
-/// modifier 그룹이 하나라도 있는가 (graph prepass 게이트 / 진단 후보).
-pub fn hasModifierGroup(pattern: []const u8) bool {
-    return scanModifiers(pattern).any;
+    return false;
 }
 
 // ─── 테스트 ───
@@ -762,27 +749,6 @@ test "hasModifierGroup — char class 안 / escape 는 제외 (#4210)" {
     try testing.expect(hasModifierGroup("[abc](?i:x)"));
 }
 
-test "scanModifiers — lowerable(s-enabling) / unlowered 분류 (#4210)" {
-    // 순수 s-enabling → lowerable, NOT unlowered
-    const s = scanModifiers("(?s:.)x");
-    try testing.expect(s.any and s.lowerable and !s.unlowered);
-    // i-enabling → unlowered, NOT lowerable
-    const i = scanModifiers("(?i:a)");
-    try testing.expect(i.any and !i.lowerable and i.unlowered);
-    // 혼합 (?is:) → lowerable(s strip) + unlowered(i 잔여)
-    const is = scanModifiers("(?is:a)");
-    try testing.expect(is.any and is.lowerable and is.unlowered);
-    // disabling (?-s:) → NOT lowerable(enabling 아님), unlowered
-    const ds = scanModifiers("(?-s:a)");
-    try testing.expect(ds.any and !ds.lowerable and ds.unlowered);
-    // (?s-i:) → s-enabling lowerable + disabling 으로 unlowered
-    const sdi = scanModifiers("(?s-i:a)");
-    try testing.expect(sdi.any and sdi.lowerable and sdi.unlowered);
-    // modifier 없음
-    const none = scanModifiers("(?:a)(?<n>b)");
-    try testing.expect(!none.any and !none.lowerable and !none.unlowered);
-}
-
 test "#4210: (?s:.) → (?:[\\s\\S]) 다운레벨 + s-enabling strip" {
     const out = (try runLower("/(?s:.)x/", .{ .regex_modifiers = true })).?;
     defer testing.allocator.free(out);
@@ -795,10 +761,10 @@ test "#4210: 중첩 dot — a(?s:b.c)d 내부 dot 만 dotall" {
     try testing.expectEqualStrings("/a(?:b[\\s\\S]c)d/", out);
 }
 
-test "#4210: 혼합 (?s:.)(?i:x) — s 다운레벨, i 보존" {
+test "#4210: 혼합 (?s:.)(?i:x) — s·i 둘 다 다운레벨 (PR2b)" {
     const out = (try runLower("/(?s:.)(?i:x)/", .{ .regex_modifiers = true })).?;
     defer testing.allocator.free(out);
-    try testing.expectEqualStrings("/(?:[\\s\\S])(?i:x)/", out);
+    try testing.expectEqualStrings("/(?:[\\s\\S])(?:[xX])/", out);
 }
 
 test "#4210: 혼합 (?sm:^.$) — s 만 strip, m 보존 → (?m:^[\\s\\S]$)" {
@@ -807,15 +773,50 @@ test "#4210: 혼합 (?sm:^.$) — s 만 strip, m 보존 → (?m:^[\\s\\S]$)" {
     try testing.expectEqualStrings("/(?m:^[\\s\\S]$)/", out);
 }
 
-test "#4210: 혼합 (?si:x.) — s 만 strip, i 보존 → (?i:x[\\s\\S])" {
+test "#4210: 혼합 (?si:x.) — s·i 둘 다 strip → (?:[xX][\\s\\S]) (PR2b)" {
     const out = (try runLower("/(?si:x.)/", .{ .regex_modifiers = true })).?;
     defer testing.allocator.free(out);
-    try testing.expectEqualStrings("/(?i:x[\\s\\S])/", out);
+    try testing.expectEqualStrings("/(?:[xX][\\s\\S])/", out);
 }
 
-test "#4210: i-only (?i:foo) 는 lowerable 아님 → 변환 없음(.text=null)" {
-    const r = try lower(testing.allocator, "/(?i:foo)/", .{ .unsupported = .{ .regex_modifiers = true } });
-    try testing.expect(r.text == null);
+test "#4210 PR2b: (?i:foo) → (?:[fF][oO][oO]) ASCII non-u fold" {
+    const out = (try runLower("/(?i:foo)bar/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?:[fF][oO][oO])bar/", out);
+}
+
+test "#4210 PR2b: (?i:Hello\\d) — 글자만 fold, \\d identity" {
+    const out = (try runLower("/(?i:Hello\\d)/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?:[Hh][eE][lL][lL][oO]\\d)/", out);
+}
+
+test "#4210 PR2b: (?i:[a-z]) class ASCII fold" {
+    const out = (try runLower("/(?i:[a-z])/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?:[\\u0041-\\u005A\\u0061-\\u007A])/", out);
+}
+
+test "#4210 PR2b: 비-ASCII (?i:café) → fold bail, i 보존 + kept_modifier" {
+    const r = try lower(testing.allocator, "/(?i:caf\u{00E9})/", .{ .unsupported = .{ .regex_modifiers = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(r.kept_modifier); // é 가 non-u fold 불가 → 보존
+    try testing.expect(std.mem.indexOf(u8, r.text.?, "(?i:") != null);
+}
+
+test "#4210 PR2b: /u 플래그면 i-fold bail + kept_modifier" {
+    const r = try lower(testing.allocator, "/(?i:foo)/u", .{ .unsupported = .{ .regex_modifiers = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(r.kept_modifier);
+}
+
+test "#4210 PR2b: 순수 s-enabling 은 kept_modifier 없음(완전 다운레벨)" {
+    const r = try lower(testing.allocator, "/(?s:.)x/", .{ .unsupported = .{ .regex_modifiers = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(!r.kept_modifier);
 }
 
 test "#4210: modifier 비트 미set(모던 타겟) → 변환 없음" {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -226,6 +226,11 @@ pub const Transformer = struct {
     /// 번들러 emitter가 이 비트맵을 읽어 필요한 헬퍼만 출력에 주입한다.
     runtime_helpers: RuntimeHelpers = .{},
 
+    /// ES2025 inline modifier 다운레벨(#4210) 중, 못 내려 출력에 보존된 modifier
+    /// 그룹을 만났는가. transform 후 transpile/prepass 가 이 값으로 loud 진단을
+    /// 띄운다 (source-scan 보다 정확 — 실제 fold bail 을 반영).
+    used_unsupported_modifier: bool = false,
+
     /// 런타임 헬퍼를 ES5 문법으로 출력 (arrow, rest params 제거).
     /// unsupported.arrow일 때 자동 설정.
     runtime_es5_compat: bool = false,

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -728,6 +728,8 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
             const raw = self.ast.getText(node.span);
             const result = try regex_lower.lower(self.allocator, raw, .{ .unsupported = u });
             defer if (result.named_groups) |ng| self.allocator.free(ng);
+            // #4210: 다운레벨 못해 보존된 modifier 그룹 → 진단 신호(transpile/prepass).
+            if (result.kept_modifier) self.used_unsupported_modifier = true;
             const new_text = result.text orelse break :blk self.copyNodeDirect(idx);
             defer self.allocator.free(new_text);
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1444,11 +1444,6 @@ fn transpileWithCallbackInternal(
     if (effective_opts.jsxClassicPragmaIgnoredUnderAutomatic(&parser.ast)) {
         std.log.warn("zntc: {s}: {s}", .{ file_path, TransformOptions.jsx_pragma_ignored_msg });
     }
-    // #4210: ES2025 regex inline modifier 를 미지원 타겟에서 사용 → verbatim 패스스루.
-    // silent SyntaxError 대신 loud 진단 (graph pre-pass 와 동일 메시지/경로).
-    if (effective_opts.usesUnsupportedRegexModifier(&parser.ast)) {
-        std.log.warn("zntc: {s}: {s}", .{ file_path, TransformOptions.regex_modifier_unsupported_msg });
-    }
     // RFC_TRANSFORMER_OWN_AST PR-2: clone 회피 — transformer 가 parser.ast 의 ownership 을
     // 양도받아 *동일 instance* 를 직접 mutate. cloneForTransformer 의 deep copy 회피로
     // 87MB synthetic 기준 peak RSS -84 MB (-2.6%, n=30 p<0.0001) 절감 (clone 배열이
@@ -1467,6 +1462,12 @@ fn transpileWithCallbackInternal(
     transformer.line_offsets = scanner.line_offsets.items;
     const root = transformer.transform() catch return error.TransformError;
     mem_profile.snap(&arena, "transform");
+
+    // #4210: 다운레벨 못한 ES2025 inline modifier 그룹이 출력에 보존됨 → loud 진단
+    // (transform-driven — 실제 fold bail 을 정확 반영, graph pre-pass 와 동일 메시지).
+    if (transformer.used_unsupported_modifier) {
+        std.log.warn("zntc: {s}: {s}", .{ file_path, TransformOptions.regex_modifier_unsupported_msg });
+    }
 
     if (options.stop_after == .transform) {
         return .{ .code = try allocator.dupe(u8, "") };


### PR DESCRIPTION
## 무엇을 / 왜

[#4265](https://github.com/ohah/zntc/pull/4265)(PR2, `(?s:…)` 다운레벨)의 후속입니다. ES2025 inline modifier `(?i:…)` enabling 을 **non-unicode ASCII case-fold** 로 다운레벨합니다.

```
$ zntc app.js --target=es2024
/(?i:foo)bar/      →  /(?:[fF][oO][oO])bar/          # 리터럴 fold
/(?i:[a-z]+)/      →  /(?:[A-Za-z]+)/                # class fold
/(?i:Hello\d)/     →  /(?:[Hh][eE][lL][lL][oO]\d)/   # 글자만 fold, \d identity
/(?s:.)(?i:x)/     →  /(?:[\s\S])(?:[xX])/           # s·i 둘 다
/(?i:café)/        →  /(?i:[cC][aA][fF]é)/  (+경고)  # é non-ASCII → bail
/(?i:foo)/u        →  /(?i:foo)/u           (+경고)  # /u → bail
```

## 왜 ASCII non-u fold 를 새로 만들었나 (미스컴파일 방지)

기존 fold 인프라(`appendEquivalents`)는 **`/u` 플래그용 Unicode simple fold** 라 Kelvin(U+212A)·ſ(U+017F) 같은 special fold 를 포함합니다. 하지만 **non-u `(?i:k)` 는 Kelvin 을 매치하면 안 됩니다**(ECMAScript non-u Canonicalize 는 `toUpperCase` 기반 — Kelvin 의 대문자는 자기 자신이라 `k` 와 캐논이 다름). 기존 인프라를 그대로 쓰면 `(?i:k)` → `[kKK]` over-fold → **silent 미스컴파일**.

그래서 `asciiFoldExpand`(ASCII 글자만 대/소 swap, special fold 제외)를 신설했습니다. **런타임 검증으로 `(?:[kK])` 가 Kelvin 을 매치 안 함을 확인**했습니다.

## 보수적 bail (#3509 "틀린 출력 0")

확실히 정확한 ASCII 글자만 내리고, 나머지는 그룹 보존 + 진단:
- **비-ASCII atom**·`\u`escape 가 비-ASCII → bail (`café` 의 `é`)
- **`/u`·`/v` 플래그** → ASCII fold 부적용 → bail
- **전역 `/i`** on → `(?-i:)` 못 끔 → bail
- **negated class** `[^…]`·복잡 class(`\p{}`·class_string·`\D\W\S`·`\s` 포함) → bail

bail 시 i 비트를 보존합니다 — 이미 fold 된 atom 은 `[cC]` 라 i 적용이 no-op 이므로 `(?i:[cC][aA][fF]é)` 는 원본 `(?i:café)` 와 **런타임 동치**(보존된 `(?i:` 때문에 진단은 정상 발동).

## 진단을 transform-driven 으로 전환

PR1/PR2 의 source-scan 진단은 **fold bail(비-ASCII/escape/flag 의존)을 byte-scan 으로 판별 못 해** silent SyntaxError 위험이 있었습니다. 이제 **transform 이 실제로 보존한 modifier**(`Transformer.used_unsupported_modifier`, `kept_modifier` 신호)만 정확히 경고합니다:
- 완전 다운레벨된 `(?i:foo)` → 경고 **안 함**
- 잔여(`café`·`/u`·`m`·disabling) → 경고

## 핵심 변경

- **`transform.zig`**: `.character`/`.character_class` 핸들러에 ASCII i-fold, `ignore_group` 의 i-enabling strip(영역별 `i_fold_incomplete` save/restore 로 bail 추적 — 내부 bail 이 상위로 누설 안 함), `Result.kept_modifier`, `Options.global_u`. helper: `makeAsciiFoldClass`/`asciiFoldExpand`/`buildBmpClass`/`inAsciiIFoldRegion`.
- **`regex_lower.zig`**: `need_modifier = regex_modifiers ∧ hasModifierGroup`(가능한 건 transform 이 판단), `kept_modifier` 전파(양 transform 경로). `ModifierScan` 제거.
- **`transformer.zig`/`node_dispatch.zig`**: `used_unsupported_modifier` 플래그.
- **`transpile.zig`/`transform_prepass.zig`**: 진단을 transform **후** 플래그로 emit.

## 검증

- 유닛: i-fold 출력(리터럴/class/혼합)·`kept_modifier` 신호·#4211/#4225/#4202 회귀. 전체 **5892/5892 통과**.
- **node24 런타임 동치 96건**: case-insensitivity·**non-u Kelvin 정확성**·class·`\d` identity 포함 all pass.
- `/code-review max`: 정확성 결함 0(hybrid 출력 동치·kept_modifier 양 경로·escape kind·`/u` 게이트 전수 검증), cleanup 6건은 의도된 설계/minor.

> 🧑‍🏫 Zig 초보자 메모
> - `i_fold_incomplete` 는 "현재 `(?i:…)` 영역에서 fold 못한 atom 을 만났는가"를 추적합니다. `ignore_group` 진입 시 `false` 로 두고 body 순회 후 값을 읽어, true 면 i 비트를 strip 하지 않습니다(그룹 보존). `defer` 로 진입 전 값을 복원해 **중첩된 안쪽 영역의 bail 이 바깥으로 새지 않게** 합니다.

관련 #4210
