### PR TITLE
feat(transformer): ES2025 regex (?m:…) multiline 앵커 다운레벨 — i/s/m 트리오 완성 (#4210)

### DIFF
--- a/packages/shared/compat-engines.ts
+++ b/packages/shared/compat-engines.ts
@@ -64,6 +64,7 @@ export const FEATURES = [
   'unicode_brace_escape', // ES2015
   'regex_duplicate_named_groups', // ES2025
   'regex_modifiers', // ES2025
+  'regex_lookbehind', // ES2018 (query-only — m-modifier 앵커 재작성 가능 여부)
 ] as const;
 
 export type Feature = (typeof FEATURES)[number];
@@ -309,6 +310,17 @@ export const SUPPORT: Partial<Record<Feature, Partial<Record<Engine, [number, nu
     ios: [26, 0],
     node: [23, 0],
     deno: [1, 44],
+  },
+  regex_lookbehind: {
+    // ES2018 lookbehind `(?<=…)` (#4210 m-modifier 앵커 재작성 의존). compat.zig 거울.
+    // safari 가 16.4 로 늦음(named-group 11.1 과 다름). hermes 미지원.
+    chrome: [62, 0],
+    edge: [79, 0],
+    firefox: [78, 0],
+    safari: [16, 4],
+    ios: [16, 4],
+    node: [8, 10],
+    deno: [1, 0],
   },
 };
 

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -177,15 +177,16 @@ export interface TranspileResult {
 //   27    ES2015 (unicode_brace_escape)
 //   28    ES2025 (regex_duplicate_named_groups)
 //   29    ES2025 (regex_modifiers)
+//   30    ES2018 (regex_lookbehind — query-only)
 //
 // 타겟 T 에 대해 "T 이후 도입된" 모든 feature 비트를 set 한다.
 // Feature 추가 시 compat.zig 와 함께 갱신.
 export const ES_TARGET_BITS: Record<string, number> = {
-  es5: 0x3fffffff, // bits 0-29 (모든 feature)
-  es2015: 0x36fff800, // bits 11-23, 25, 26, 28, 29 (ES2015/regex_sticky/unicode_brace_escape 제외)
-  es2016: 0x36fff000, // bits 12-23, 25, 26, 28, 29
-  es2017: 0x36ffe000, // bits 13-23, 25, 26, 28, 29
-  es2018: 0x30ffc000, // bits 14-23, 28, 29 (ES2018 features 도 제외)
+  es5: 0x7fffffff, // bits 0-30 (모든 feature)
+  es2015: 0x76fff800, // bits 11-23, 25, 26, 28, 29, 30 (ES2015/regex_sticky/unicode_brace_escape 제외)
+  es2016: 0x76fff000, // bits 12-23, 25, 26, 28, 29, 30
+  es2017: 0x76ffe000, // bits 13-23, 25, 26, 28, 29, 30
+  es2018: 0x30ffc000, // bits 14-23, 28, 29 (ES2018 features 도 제외 — lookbehind 지원)
   es2019: 0x30ff8000, // bits 15-23, 28, 29
   es2020: 0x30fe0000, // bits 17-23, 28, 29
   es2021: 0x30fc0000, // bits 18-23, 28, 29

--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -45,6 +45,9 @@ pub const Options = struct {
     /// regex 가 `u`/`v` 플래그를 가졌는가 (#4210). i-fold 는 non-u(ASCII) 전용이라
     /// /u 영역에선 bail — 파서가 unicode_brace 를 끈 재변환에도 정확히 게이트.
     global_u: bool = false,
+    /// 타겟이 lookbehind `(?<=…)`(ES2018)를 지원하는가 (#4210 PR3). m-modifier 의
+    /// `^` 앵커 재작성이 lookbehind 를 출력하므로, false 면 m-lowering bail(보존).
+    lookbehind_ok: bool = false,
 };
 
 pub const NamedGroup = struct {
@@ -145,6 +148,9 @@ const T = struct {
     ///   - lowering 경로(#4210): effective 값으로 dot 재작성 / fold 확장.
     mod_s: ?bool = null,
     mod_i: ?bool = null,
+    /// 영역별 effective m (#4210 PR3). `(?m:)` 영역의 `^`/`$` 는 multiline 앵커 →
+    /// lookbehind/lookahead 로 재작성.
+    mod_m: ?bool = null,
     /// 현재 i-enabling 영역에서 fold 못한 atom(비-ASCII/negated/복잡 class)을 만났는가
     /// (#4210 PR2b). 영역별 save/restore — true 면 ignore_group 이 i 비트를 보존(bail).
     i_fold_incomplete: bool = false,
@@ -222,6 +228,71 @@ const T = struct {
     fn inAsciiIFoldRegion(self: *T) bool {
         return self.opts.lower_modifiers and self.mod_i == true and
             !self.opts.ignore_case and !self.opts.global_u;
+    }
+
+    // ── #4210 PR3: ES2025 `(?m:…)` multiline 앵커 재작성 ──
+
+    /// m-enabling 영역의 `^`/`$` 를 재작성하는 컨텍스트인가. lookbehind 출력에
+    /// 의존하므로 lookbehind 미지원 타겟(es2017↓)에선 false → m bail(보존).
+    fn inMRewriteRegion(self: *T) bool {
+        return self.opts.lower_modifiers and self.mod_m == true and self.opts.lookbehind_ok;
+    }
+
+    /// `[\n\r  ]` (ECMAScript LineTerminator 집합) character_class.
+    fn makeNewlineClass(self: *T, span: ast.Span) TransformError!NodeIndex {
+        const SE = @intFromEnum(ast.CharacterKind.single_escape);
+        const nl = [_]struct { cp: u32, kind: u32 }{
+            .{ .cp = 0x0A, .kind = SE }, // \n
+            .{ .cp = 0x0D, .kind = SE }, // \r
+            .{ .cp = 0x2028, .kind = UESC }, //
+            .{ .cp = 0x2029, .kind = UESC }, //
+        };
+        var kids: [4]u32 = undefined;
+        for (nl, 0..) |e, k| {
+            kids[k] = @intFromEnum(try self.b.add(.{ .tag = .character, .span = span, .data = .{ e.cp, e.kind, 0 } }));
+        }
+        const l = try self.b.addList(&kids);
+        return self.b.add(.{ .tag = .character_class, .span = span, .data = .{ 0, l.start, l.len } });
+    }
+
+    /// `^`(multiline) → `(?:^|(?<=[\n\r  ]))` (입력시작 OR 줄종결자 뒤).
+    fn makeMLineStart(self: *T, span: ast.Span) TransformError!NodeIndex {
+        const caret = try self.b.add(.{ .tag = .boundary_assertion, .span = span, .data = .{ @intFromEnum(ast.BoundaryAssertionKind.start), 0, 0 } });
+        const lb = try self.makeLookaround(.lookbehind, span);
+        return self.makeAltGroup(caret, lb, span);
+    }
+
+    /// `$`(multiline) → `(?:$|(?=[\n\r  ]))` (입력끝 OR 줄종결자 앞).
+    fn makeMLineEnd(self: *T, span: ast.Span) TransformError!NodeIndex {
+        const dollar = try self.b.add(.{ .tag = .boundary_assertion, .span = span, .data = .{ @intFromEnum(ast.BoundaryAssertionKind.end), 0, 0 } });
+        const la = try self.makeLookaround(.lookahead, span);
+        return self.makeAltGroup(dollar, la, span);
+    }
+
+    /// `(?<=[\n\r…])` / `(?=[\n\r…])` — body 는 파서 관례대로 disjunction 으로 감싼다.
+    fn makeLookaround(self: *T, kind: ast.LookAroundAssertionKind, span: ast.Span) TransformError!NodeIndex {
+        const body = try self.singleDisjunction(try self.makeNewlineClass(span), span);
+        return self.b.add(.{ .tag = .lookaround_assertion, .span = span, .data = .{ @intFromEnum(kind), @intFromEnum(body), 0 } });
+    }
+
+    /// atom 하나를 `disjunction→alternative→atom` 으로 감싼다 (lookaround body 가
+    /// 기대하는 파서 출력 구조). 단일 alt·단일 term 이라 인쇄는 atom 그대로.
+    fn singleDisjunction(self: *T, atom: NodeIndex, span: ast.Span) TransformError!NodeIndex {
+        const al = try self.b.addList(&.{@intFromEnum(atom)});
+        const alt = try self.b.add(.{ .tag = .alternative, .span = span, .data = .{ al.start, al.len, 0 } });
+        const dl = try self.b.addList(&.{@intFromEnum(alt)});
+        return self.b.add(.{ .tag = .disjunction, .span = span, .data = .{ dl.start, dl.len, 0 } });
+    }
+
+    /// 두 atom 을 `(?:a|b)` 로 묶는다 (alternation in non-capturing group).
+    fn makeAltGroup(self: *T, a: NodeIndex, b: NodeIndex, span: ast.Span) TransformError!NodeIndex {
+        const a1l = try self.b.addList(&.{@intFromEnum(a)});
+        const alt1 = try self.b.add(.{ .tag = .alternative, .span = span, .data = .{ a1l.start, a1l.len, 0 } });
+        const a2l = try self.b.addList(&.{@intFromEnum(b)});
+        const alt2 = try self.b.add(.{ .tag = .alternative, .span = span, .data = .{ a2l.start, a2l.len, 0 } });
+        const dl = try self.b.addList(&.{ @intFromEnum(alt1), @intFromEnum(alt2) });
+        const disj = try self.b.add(.{ .tag = .disjunction, .span = span, .data = .{ dl.start, dl.len, 0 } });
+        return self.b.add(.{ .tag = .ignore_group, .span = span, .data = .{ 0, 0, @intFromEnum(disj) } });
     }
 
     fn isAstralUnicodeEscape(n: Node) bool {
@@ -413,7 +484,18 @@ const T = struct {
                 const l = try self.expandList(n.getNodeList());
                 return self.b.add(.{ .tag = .alternative, .span = n.span, .data = .{ l.start, l.len, 0 } });
             },
-            .boundary_assertion,
+            .boundary_assertion => {
+                // #4210 PR3: (?m:) 영역의 `^`/`$` → multiline 앵커 재작성.
+                // `\b`/`\B` 는 m 무관 → 그대로.
+                if (self.inMRewriteRegion()) {
+                    switch (@as(ast.BoundaryAssertionKind, @enumFromInt(n.data[0]))) {
+                        .start => return try self.makeMLineStart(n.span),
+                        .end => return try self.makeMLineEnd(n.span),
+                        else => {},
+                    }
+                }
+                return self.b.add(n);
+            },
             .character_class_escape,
             .unicode_property_escape,
             .indexed_reference,
@@ -582,15 +664,19 @@ const T = struct {
                 // effective: enabling→true, disabling→false, 무관→상속(불변).
                 const saved_s = self.mod_s;
                 const saved_i = self.mod_i;
+                const saved_m = self.mod_m;
                 const saved_ifi = self.i_fold_incomplete;
                 if (en & 0b100 != 0) self.mod_s = true;
                 if (dis & 0b100 != 0) self.mod_s = false;
                 if (en & 0b001 != 0) self.mod_i = true;
                 if (dis & 0b001 != 0) self.mod_i = false;
+                if (en & 0b010 != 0) self.mod_m = true;
+                if (dis & 0b010 != 0) self.mod_m = false;
                 self.i_fold_incomplete = false; // 이 영역의 fold-bail 만 집계
                 defer {
                     self.mod_s = saved_s;
                     self.mod_i = saved_i;
+                    self.mod_m = saved_m;
                     self.i_fold_incomplete = saved_ifi; // 내부 bail 은 상위로 누설 안 함
                 }
                 const body = try self.node(@enumFromInt(n.data[2]));
@@ -600,11 +686,14 @@ const T = struct {
                 // #4210 lowering: s-enabling 은 dot 이 body 에서 [\s\S] 로 baked-in →
                 // 항상 strip. i-enabling 은 이 영역의 모든 atom 이 fold 됐을 때만
                 // (비-bail, non-u, 전역 /i off) strip — bail 시 i 보존(이미 fold 된
-                // atom 은 [cC] 라 i 적용이 no-op 이라 의미 동치). m/disabling 보존.
+                // atom 은 [cC] 라 i 적용이 no-op 이라 의미 동치). m-enabling 은
+                // lookbehind 지원 시 `^`/`$` 가 앵커로 재작성됐으니 strip. disabling 보존.
                 var kept_en = en & ~@as(u32, 0b100); // s-enabling 제거
                 const i_lowered = (en & 0b001 != 0) and !self.i_fold_incomplete and
                     !self.opts.ignore_case and !self.opts.global_u;
                 if (i_lowered) kept_en &= ~@as(u32, 0b001); // i-enabling 제거
+                const m_lowered = (en & 0b010 != 0) and self.opts.lookbehind_ok;
+                if (m_lowered) kept_en &= ~@as(u32, 0b010); // m-enabling 제거
                 // 보존된 modifier 비트가 남으면 진단 신호(transpile/prepass 가 경고).
                 if (kept_en != 0 or dis != 0) self.kept_modifier = true;
                 return self.b.add(.{ .tag = .ignore_group, .span = n.span, .data = .{ kept_en, dis, @intFromEnum(body) } });

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -102,9 +102,14 @@ pub const Feature = enum(u5) {
     /// regex_named_groups 와 같은 strip+__wrapRegExp 경로로 다운레벨 (#4199).
     /// NOTE: Feature enum 과 UnsupportedFeatures 필드는 비트 위치가 1:1 — 끝에만 추가.
     regex_duplicate_named_groups,
-    /// ES2025 inline modifier group `(?ims-ims:...)` (#4210). 미지원 타겟에선
-    /// 다운레벨 부재 — verbatim 패스스루 + loud 진단으로 silent SyntaxError 방지.
+    /// ES2025 inline modifier group `(?ims-ims:...)` (#4210). s/i enabling 은
+    /// 다운레벨, m 은 lookbehind 지원 타겟에서 앵커 재작성, 그 외 잔여는 진단.
     regex_modifiers,
+    /// ES2018 lookbehind assertion `(?<=…)`/`(?<!…)`. zntc 는 lookbehind 를 다운레벨
+    /// 하지 *않는다* — 이 비트는 "타겟이 lookbehind 를 지원하는가" 쿼리 전용
+    /// (#4210 m-modifier 앵커 재작성이 lookbehind 출력에 의존). needsRegexLowering
+    /// 에 넣지 않음.
+    regex_lookbehind,
 
     /// 이 feature가 도입된 ES 버전.
     pub fn esVersion(self: Feature) ESTarget {
@@ -112,7 +117,7 @@ pub const Feature = enum(u5) {
             .arrow, .class, .template_literal, .destructuring, .for_of, .spread, .object_extensions, .default_params, .block_scoping, .generator, .new_target, .regex_sticky, .unicode_brace_escape => .es2015,
             .exponentiation => .es2016,
             .async_await => .es2017,
-            .object_spread, .regex_dotall, .regex_named_groups => .es2018,
+            .object_spread, .regex_dotall, .regex_named_groups, .regex_lookbehind => .es2018,
             .optional_catch_binding => .es2019,
             .nullish_coalescing, .optional_chaining => .es2020,
             .logical_assignment => .es2021,
@@ -169,11 +174,14 @@ pub const UnsupportedFeatures = packed struct(u32) {
     regex_named_groups: bool = false,
     unicode_brace_escape: bool = false,
     regex_duplicate_named_groups: bool = false,
-    /// ES2025 inline modifier group `(?ims-ims:...)` (#4210). s-enabling `(?s:)` 는
-    /// 다운레벨(needsRegexLowering 포함), i/m/disabling 잔여는 보존 + 진단.
+    /// ES2025 inline modifier group `(?ims-ims:...)` (#4210). s/i enabling 다운레벨,
+    /// m 은 lookbehind 지원 시 앵커 재작성, 그 외 잔여는 진단.
     regex_modifiers: bool = false,
+    /// ES2018 lookbehind `(?<=…)` 미지원 (#4210). 쿼리 전용 — m-modifier 앵커
+    /// 재작성(`^`→`(?<=…)`)이 가능한 타겟인지 판별. lowering 트리거 아님.
+    regex_lookbehind: bool = false,
 
-    _: u2 = 0,
+    _: u1 = 0,
 
     /// regex literal lowering 이 필요한 비트가 하나라도 set 인지.
     /// node_dispatch 조기탈출/graph prepass 게이트가 공유 — 새 regex 비트는
@@ -628,6 +636,16 @@ const compat_table = [_]CompatEntry{
     .{ .feature = .regex_modifiers, .engine = .ios, .major = 26 },
     .{ .feature = .regex_modifiers, .engine = .node, .major = 23 },
     .{ .feature = .regex_modifiers, .engine = .deno, .major = 1, .minor = 44 },
+
+    // ── ES2018: lookbehind assertion `(?<=…)` (#4210 m-modifier 앵커 재작성 의존) ──
+    // BCD: safari 가 16.4 로 늦음(named-group 11.1 과 다름 → 프록시 불가). hermes 미지원.
+    .{ .feature = .regex_lookbehind, .engine = .chrome, .major = 62 },
+    .{ .feature = .regex_lookbehind, .engine = .edge, .major = 79 },
+    .{ .feature = .regex_lookbehind, .engine = .firefox, .major = 78 },
+    .{ .feature = .regex_lookbehind, .engine = .safari, .major = 16, .minor = 4 },
+    .{ .feature = .regex_lookbehind, .engine = .ios, .major = 16, .minor = 4 },
+    .{ .feature = .regex_lookbehind, .engine = .node, .major = 8, .minor = 10 },
+    .{ .feature = .regex_lookbehind, .engine = .deno, .major = 1 },
 
     // ── ES2015: regex_sticky (/y) ──
     .{ .feature = .regex_sticky, .engine = .chrome, .major = 49 },
@@ -1166,4 +1184,21 @@ test "regex_modifiers — safari 26 경계 (dup-named 의 17.4 와 다름, #4210
     try std.testing.expect(!unsupportedFeatures(&.{.{ .engine = .node, .major = 23 }}).regex_modifiers);
     // hermes: compat table 미등록 → 항상 미지원
     try std.testing.expect(unsupportedFeatures(&.{.{ .engine = .hermes, .major = 0, .minor = 12 }}).regex_modifiers);
+}
+
+test "regex_lookbehind — safari 16.4 경계 + es2018 (#4210 m-anchor 게이트)" {
+    // es2017 미지원, es2018 지원 (m-modifier 앵커 재작성 가능 여부)
+    try std.testing.expect(fromESTarget(.es2017).regex_lookbehind);
+    try std.testing.expect(!fromESTarget(.es2018).regex_lookbehind);
+    try std.testing.expect(fromESTarget(.es5).regex_lookbehind);
+    // Safari 16.3 < 16.4 → lookbehind 미지원 (named-group 11.1 과 경계 다름)
+    const s163 = unsupportedFeatures(&.{.{ .engine = .safari, .major = 16, .minor = 3 }});
+    try std.testing.expect(s163.regex_lookbehind);
+    try std.testing.expect(!s163.regex_named_groups); // named 는 11.1 부터 지원
+    const s164 = unsupportedFeatures(&.{.{ .engine = .safari, .major = 16, .minor = 4 }});
+    try std.testing.expect(!s164.regex_lookbehind);
+    // hermes: 미등록 → 미지원(m-modifier bail)
+    try std.testing.expect(unsupportedFeatures(&.{.{ .engine = .hermes, .major = 0, .minor = 12 }}).regex_lookbehind);
+    // regex_lookbehind 는 lowering 트리거가 아님 — needsRegexLowering 에 미포함.
+    try std.testing.expect(!(UnsupportedFeatures{ .regex_lookbehind = true }).needsRegexLowering());
 }

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -98,6 +98,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
             .ignore_case = has_i,
             .lower_modifiers = need_modifier,
             .global_u = has_u,
+            .lookbehind_ok = !opts.unsupported.regex_lookbehind,
         }, allocator);
         astral_u_incomplete = tr.astral_u_incomplete;
         kept_modifier = tr.kept_modifier;
@@ -114,6 +115,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
                 .ignore_case = has_i,
                 .lower_modifiers = need_modifier,
                 .global_u = has_u,
+                .lookbehind_ok = !opts.unsupported.regex_lookbehind,
             }, allocator);
             kept_modifier = tr.kept_modifier;
         }
@@ -767,10 +769,10 @@ test "#4210: 혼합 (?s:.)(?i:x) — s·i 둘 다 다운레벨 (PR2b)" {
     try testing.expectEqualStrings("/(?:[\\s\\S])(?:[xX])/", out);
 }
 
-test "#4210: 혼합 (?sm:^.$) — s 만 strip, m 보존 → (?m:^[\\s\\S]$)" {
+test "#4210: 혼합 (?sm:^.$) — s·m 둘 다 다운레벨 (PR3)" {
     const out = (try runLower("/(?sm:^.$)/", .{ .regex_modifiers = true })).?;
     defer testing.allocator.free(out);
-    try testing.expectEqualStrings("/(?m:^[\\s\\S]$)/", out);
+    try testing.expectEqualStrings("/(?:(?:^|(?<=[\\n\\r\\u2028\\u2029]))[\\s\\S](?:$|(?=[\\n\\r\\u2028\\u2029])))/", out);
 }
 
 test "#4210: 혼합 (?si:x.) — s·i 둘 다 strip → (?:[xX][\\s\\S]) (PR2b)" {
@@ -822,4 +824,37 @@ test "#4210 PR2b: 순수 s-enabling 은 kept_modifier 없음(완전 다운레벨
 test "#4210: modifier 비트 미set(모던 타겟) → 변환 없음" {
     const r = try lower(testing.allocator, "/(?s:.)x/", .{ .unsupported = .{} });
     try testing.expect(r.text == null);
+}
+
+test "#4210 PR3: (?m:^a$) → multiline 앵커 재작성 (lookbehind 지원)" {
+    // regex_lookbehind 미set = lookbehind 지원(es2018+).
+    const out = (try runLower("/(?m:^a$)/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?:(?:^|(?<=[\\n\\r\\u2028\\u2029]))a(?:$|(?=[\\n\\r\\u2028\\u2029])))/", out);
+}
+
+test "#4210 PR3: (?im:^a) — m 앵커 + i fold" {
+    const out = (try runLower("/(?im:^a)/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?:(?:^|(?<=[\\n\\r\\u2028\\u2029]))[aA])/", out);
+}
+
+test "#4210 PR3: (?m:abc) 앵커 없음 → m strip(no-op)" {
+    const out = (try runLower("/(?m:abc)/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?:abc)/", out);
+}
+
+test "#4210 PR3: lookbehind 미지원(es2017) → m bail + kept_modifier" {
+    const r = try lower(testing.allocator, "/(?m:^a$)/", .{ .unsupported = .{ .regex_modifiers = true, .regex_lookbehind = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(r.kept_modifier);
+    try testing.expect(std.mem.indexOf(u8, r.text.?, "(?m:") != null);
+}
+
+test "#4210 PR3: \\b 는 m 무관 — (?m:\\bx) 의 \\b 그대로" {
+    const out = (try runLower("/(?m:\\bx)/", .{ .regex_modifiers = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?:\\bx)/", out);
 }


### PR DESCRIPTION
## 무엇을 / 왜

[#4266](https://github.com/ohah/zntc/pull/4266)(PR2b, `(?i:…)`)의 후속이며 **#4210 시리즈를 종결**합니다. ES2025 inline modifier `(?m:…)` enabling 의 multiline 앵커를 lookbehind/lookahead 로 재작성합니다 (regexpu/Babel 동형).

```
$ zntc app.js --target=es2024
/(?m:^a$)/   →  /(?:(?:^|(?<=[\n\r  ]))a(?:$|(?=[\n\r  ])))/
/(?im:^a)/   →  /(?:(?:^|(?<=[\n\r  ]))[aA])/      # m 앵커 + i fold
/(?m:abc)/   →  /(?:abc)/                                    # 앵커 없으면 m no-op
/(?m:^a$)/   (target=es2017)  →  /(?m:^a$)/  (+경고)         # lookbehind 미지원 → bail
```

`^` → `(?:^|(?<=[\n\r  ]))` (입력 시작 OR 줄종결자 뒤), `$` → `(?:$|(?=[\n\r  ]))` (입력 끝 OR 줄종결자 앞). `\b`/`\B` 는 m 과 무관하므로 그대로 둡니다.

## lookbehind 의존 게이트 (새 compat 비트)

`^` 재작성이 **lookbehind(ES2018)** 를 출력하므로, lookbehind 를 지원하는 타겟에서만 m 을 내립니다. 미지원(es2017↓·**Safari 16.3↓**·Hermes)이면 m 을 보존하고 진단합니다.

정확한 게이트를 위해 `regex_lookbehind` compat 비트(es2018)를 신설했습니다 — **Safari 가 lookbehind 를 16.4 에서야 지원**(named-group 은 11.1)이라 기존 es2018 비트를 프록시로 쓰면 Safari 11.1–16.3 에서 미스컴파일이 납니다. 이 비트는 **쿼리 전용**입니다(zntc 는 lookbehind 를 다운레벨하지 않음 — `needsRegexLowering` 에 미포함).

## #4210 i/s/m 다운레벨 완성

| modifier | 다운레벨 | PR |
|---|---|---|
| `s` `(?s:.)` | → `[\s\S]` | [#4265](https://github.com/ohah/zntc/pull/4265) |
| `i` `(?i:foo)` | → `[fF][oO][oO]` (ASCII non-u fold) | [#4266](https://github.com/ohah/zntc/pull/4266) |
| `m` `(?m:^$)` | → lookbehind/lookahead 앵커 (es2018+) | **본 PR** |

내리지 못하는 잔여(es2017↓ m · `/u` i · 비-ASCII i · disabling `-i`/`-s`/`-m` · 전역 /i)는 **transform-driven 진단**으로 정확히 loud 경고합니다(silent SyntaxError 0).

## 핵심 변경

- **`transform.zig`**: `mod_m` effective-flag(save/restore), `boundary_assertion`(`^`/`$`) 핸들러의 m-재작성, `ignore_group` 의 m-enabling strip(`lookbehind_ok` 게이트). helper: `makeMLineStart`/`End`·`makeNewlineClass`·`makeLookaround`·`singleDisjunction`·`makeAltGroup`. `Options.lookbehind_ok`.
- **`compat.zig`**: `regex_lookbehind` 비트(es2018) + 엔진 테이블. JS 미러(`compat-engines.ts`·`index.ts` bit 30).
- **`regex_lower.zig`**: `lookbehind_ok = !regex_lookbehind` 전달(양 transform 경로).

## 검증

- 유닛: m-anchor 출력(단순·`(?im:)`·앵커없음·`\b`)·lookbehind 경계(Safari 16.3/16.4·es2017/es2018)·#4211/#4225/#4202 회귀. 전체 스위트 통과.
- **node24 런타임 동치 85건**: multiline `^`/`$` 줄 경계·**U+2028/U+2029 줄종결자**·m+i 조합·`\b` 무관 all pass.
- `/code-review max`: lookaround body 를 파서 관례대로 disjunction 으로 정정(출력 무변경), 그 외 결함 0.

> 🧑‍🏫 Zig 초보자 메모
> - `(?m:)` 의 `^` 는 "줄 시작" 을 뜻하는데, lookbehind 없이는 "직전 문자가 줄종결자" 를 표현할 수 없습니다. 그래서 `(?<=[\n\r  ])`(lookbehind)가 필요하고, 이게 ES2018 기능이라 그보다 낮은 타겟에선 내리지 못해 보존+경고합니다.
> - `regex_lookbehind` 비트는 **무언가를 변환하려는 게 아니라** "이 타겟이 lookbehind 를 쓸 수 있나?" 를 묻는 용도입니다. 그래서 다른 regex 비트와 달리 `needsRegexLowering` 에 들어가지 않습니다.

Closes #4210
