### PR TITLE
fix(transformer): ES2025 (?i:[…]) 비-ASCII class fold bail 시 중첩 class miscompile (#4210)

### DIFF
--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -142,7 +142,7 @@ const T = struct {
     astral_u_incomplete: bool = false,
     /// 영역별 effective s/i (#4211/#4225 → #4210). null=상속(global flag),
     /// true=(?s:)/(?i:) 으로 켜짐, false=(?-s:)/(?-i:) 으로 꺼짐. enclosing
-    /// modifier group 진입 시 save/restore (regexpu `modifiersData` 동형).
+    /// modifier group 진입 시 save/restore.
     ///   - 비-lowering 경로: `mod_s != false` ⟺ 옛 `mod_s_off_depth==0`,
     ///     `mod_i != null` ⟺ 옛 `mod_i_depth>0` (동작 보존).
     ///   - lowering 경로(#4210): effective 값으로 dot 재작성 / fold 확장.
@@ -189,9 +189,9 @@ const T = struct {
     }
 
     /// non-u ASCII case-fold: set 의 ASCII 글자에 대/소 swap 을 추가. set 에 비-ASCII
-    /// (>=0x80) 멤버가 있으면 false(= fold 불가, 호출자 bail). regexpu 와 달리 Kelvin
-    /// (U+212A)·ſ(U+017F) 같은 u-전용 special fold 는 포함하지 않음 — non-u Canonicalize
-    /// 는 toUpperCase 기반이라 이들이 ASCII 로 collapse 되지 않는다.
+    /// (>=0x80) 멤버가 있으면 false(= fold 불가, 호출자 bail). Kelvin(U+212A)·ſ(U+017F)
+    /// 같은 u-전용 special fold 는 포함하지 않음 — non-u Canonicalize 는 toUpperCase
+    /// 기반이라 이들이 ASCII 로 collapse 되지 않는다(over-fold 미스컴파일 방지).
     fn asciiFoldExpand(self: *T, set: *cps.CodePointSet) TransformError!bool {
         var extra: std.ArrayList(u32) = .empty;
         defer extra.deinit(self.b.a);
@@ -225,9 +225,12 @@ const T = struct {
 
     /// i-enabling 영역에서 atom 을 fold 할 수 있는 컨텍스트인가 (#4210 PR2b).
     /// non-u(`!global_u`) + 전역 /i off(`!ignore_case`) + (?i:) 영역(mod_i==true).
+    /// `!in_class`: character class 내부에선 per-char fold 금지 — class fold 가
+    /// 통째로 처리(성공)하거나 bail(보존)한다. 안 막으면 fold 가 fall-through
+    /// (bail) class body 안에서 글자를 `[cC]` 로 바꿔 중첩 class `[[cC]…]` 생성(#4210).
     fn inAsciiIFoldRegion(self: *T) bool {
         return self.opts.lower_modifiers and self.mod_i == true and
-            !self.opts.ignore_case and !self.opts.global_u;
+            !self.opts.ignore_case and !self.opts.global_u and !self.in_class;
     }
 
     // ── #4210 PR3: ES2025 `(?m:…)` multiline 앵커 재작성 ──

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -89,7 +89,9 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
     var astral_u_incomplete = false;
     var kept_modifier = false;
     const pattern_text: []const u8 = if (need_pattern_xform) blk: {
-        var in_ast = regexp.parse(pattern, flags, allocator) orelse return .{ .text = null };
+        // parse/print 실패 시 원본(modifier 포함) verbatim 유지 → need_modifier 면
+        // 잔여로 보고해 진단(silent SyntaxError 방지). #4210.
+        var in_ast = regexp.parse(pattern, flags, allocator) orelse return .{ .text = null, .kept_modifier = need_modifier };
         defer in_ast.deinit();
         var tr = try regexp.transform.transform(in_ast, .{
             .dotall = need_dotall,
@@ -120,7 +122,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
             kept_modifier = tr.kept_modifier;
         }
         defer tr.deinit();
-        owned_pattern = regexp.printer.print(tr.ast, allocator) catch return .{ .text = null };
+        owned_pattern = regexp.printer.print(tr.ast, allocator) catch return .{ .text = null, .kept_modifier = need_modifier };
         break :blk owned_pattern.?;
     } else pattern;
     const strip_u = need_unicode and !astral_u_incomplete;
@@ -824,6 +826,24 @@ test "#4210 PR2b: 순수 s-enabling 은 kept_modifier 없음(완전 다운레벨
 test "#4210: modifier 비트 미set(모던 타겟) → 변환 없음" {
     const r = try lower(testing.allocator, "/(?s:.)x/", .{ .unsupported = .{} });
     try testing.expect(r.text == null);
+}
+
+test "#4210 회귀: i-영역 비-ASCII class 는 중첩 class 미생성 — 보존 + 진단" {
+    // class fold bail(é 비-ASCII) 시 fall-through 로 글자가 [cC] 로 fold 되어
+    // `[[cC]…]` 중첩 class 가 생기던 miscompile (종합 리뷰 적발). !in_class 가드로 보존.
+    const r = try lower(testing.allocator, "/(?i:[caf\u{00E9}])/", .{ .unsupported = .{ .regex_modifiers = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(r.kept_modifier);
+    try testing.expect(std.mem.indexOf(u8, r.text.?, "[[") == null); // 중첩 class 없음
+    try testing.expect(std.mem.indexOf(u8, r.text.?, "(?i:") != null);
+}
+
+test "#4210 회귀: i-영역 \\D class(collect bail)도 중첩 class 미생성" {
+    const r = try lower(testing.allocator, "/(?i:[a\\D])/", .{ .unsupported = .{ .regex_modifiers = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(std.mem.indexOf(u8, r.text.?, "[[") == null);
 }
 
 test "#4210 PR3: (?m:^a$) → multiline 앵커 재작성 (lookbehind 지원)" {


### PR DESCRIPTION
## 무엇을 / 왜

#4210(ES2025 regex modifier 다운레벨, [#4264](https://github.com/ohah/zntc/pull/4264)·[#4265](https://github.com/ohah/zntc/pull/4265)·[#4266](https://github.com/ohah/zntc/pull/4266)·[#4267](https://github.com/ohah/zntc/pull/4267)) 시리즈의 **종합 `/code-review max`** 가 잡은 silent miscompile 수정입니다 (per-PR 리뷰는 놓침 — 통합 리뷰의 가치).

**버그**: i-enabling 영역의 character class 가 비-ASCII 멤버를 가지면(또는 `\D`·`\W`·`\S`·`\p{}` 등 set 수집 불가), class-level fold 가 bail 한 뒤 fall-through 로 class body 를 순회하는데, 이때 `.character` 핸들러의 ASCII i-fold 가 *클래스 내부에서* 글자를 `[cC]` 로 바꿔 **중첩 class** 를 생성했습니다:

```
$ zntc app.js --target=es2024   # 수정 전
/(?i:[café])/   →  /(?i:[[cC][aA][fF]é])/   ← 무효 정규식 (SyntaxError), silent miscompile
/(?i:[a-zé])/   →  /(?i:[[aA]-[zZ]é])/       ← 더 심각 (class 사이 range)
```

## 수정

`inAsciiIFoldRegion()` 에 `!in_class` 가드를 추가 — **character class 내부에선 per-char fold 를 하지 않습니다.** class fold 는 class-level 에서 통째로 처리(성공)하거나 bail(보존)하므로, 클래스 안 개별 글자를 fold 하면 중첩 class 가 됩니다.

```
$ zntc app.js --target=es2024   # 수정 후
/(?i:[café])/   →  /(?i:[café])/   (+경고)   # 보존 + 진단 (é fold 불가)
/(?i:[a-z])/    →  /(?:[A-Za-z])/             # all-ASCII 는 여전히 정상 fold (회귀 없음)
```

**추가 fix**: `lower()` 의 `parse`/`print` 실패 bail-out 이 `kept_modifier` 신호를 흘려 (rare) silent SyntaxError 가능 → `need_modifier` 로 보고(원본 modifier 보존 시 진단).

## 검증

- 회귀 유닛: 비-ASCII class·`\D` class 가 중첩 class(`[[`) 를 만들지 않고 보존+진단. all-ASCII class fold 회귀 없음.
- 전체 스위트 **5900/5900 통과**.

관련 #4210
