### PR TITLE
fix(bundler): makeModuleKeyBuf 스택 버퍼 오버플로 — ModuleKey heap-spill로 교체

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -304,7 +304,7 @@ pub const Linker = struct {
     unified_module_scopes: []std.DynamicBitSet = &.{},
 
     /// resolveExportChain 메모이제이션 캐시.
-    /// 키: makeModuleKeyBuf 형식 (4바이트 module_index + 0x00 + name).
+    /// 키: ModuleKey 형식 (4바이트 module_index + 0x00 + name).
     /// Phase 1(fixpoint) + Phase 2(BFS) 간 중복 resolve를 제거.
     /// re-export chain이 있을 때만 활성화 (단순 그래프에서는 오버헤드).
     chain_cache: std.StringHashMapUnmanaged(ChainCacheEntry) = .empty,
@@ -2182,8 +2182,11 @@ pub const Linker = struct {
         // re-export chain이 없는 단순 그래프에서는 캐시 오버헤드가 이득보다 큼.
         // depth=0에서만 캐시 (재귀 호출은 chain 내부라 캐시 불필요).
         if (depth == 0 and self.chain_cache_enabled) {
-            var cache_key_buf: [4096]u8 = undefined;
-            const cache_key = types.makeModuleKeyBuf(&cache_key_buf, @intCast(mod_i), name);
+            var cache_mk: types.ModuleKey = .{};
+            defer cache_mk.deinit(self.allocator);
+            // 키 생성 실패(OOM)는 캐시를 우회하고 직접 계산 — 정확성에는 영향 없음.
+            const cache_key = cache_mk.make(self.allocator, @intCast(mod_i), name) catch
+                return self.resolveExportChainInner(module_idx, name, depth, true);
             if (self.chain_cache.get(cache_key)) |entry| {
                 return entry.result;
             }
@@ -2218,9 +2221,10 @@ pub const Linker = struct {
         const mod_i = @intFromEnum(module_idx);
         const m_any = self.graph.getModule(module_idx) orelse return null;
 
-        // 1. 직접 export 확인
-        var key_buf: [4096]u8 = undefined;
-        const key = makeExportKeyBuf(&key_buf, @intCast(mod_i), name);
+        // 1. 직접 export 확인 (조회 전용 — OOM 시 빈 키 → export_map 미스 → re-export 해석 계속)
+        var key_mk: types.ModuleKey = .{};
+        defer key_mk.deinit(self.allocator);
+        const key = key_mk.makeOrEmpty(self.allocator, @intCast(mod_i), name);
         if (self.export_map.get(key)) |entry| {
             if (entry.binding.kind == .re_export) {
                 // re-export: 소스 모듈로 재귀
@@ -2348,8 +2352,10 @@ pub const Linker = struct {
     /// resolveStarExport 판정을 공유해 drift 를 막는다. #3982
     /// 직접 export(또는 named re-export)면 그 정의가 우선이라 ambiguous 아님.
     pub fn isAmbiguousStarExport(self: *const Linker, module_idx: ModuleIndex, name: []const u8) bool {
-        var key_buf: [4096]u8 = undefined;
-        const dk = makeExportKeyBuf(&key_buf, module_idx.toU32(), name);
+        var key_mk: types.ModuleKey = .{};
+        defer key_mk.deinit(self.allocator);
+        // 조회 전용 — OOM 시 빈 키 → contains 미스 → resolveStarExport로 계속 판정.
+        const dk = key_mk.makeOrEmpty(self.allocator, module_idx.toU32(), name);
         if (self.export_map.contains(dk)) return false;
         return self.resolveStarExport(module_idx, name, 0) == .ambiguous;
     }
@@ -3285,7 +3291,6 @@ pub const Linker = struct {
     }
 
     pub const makeExportKey = types.makeModuleKey;
-    pub const makeExportKeyBuf = types.makeModuleKeyBuf;
 };
 
 /// CJS 모듈의 require_xxx 변수명을 캐시에서 가져오거나 새로 생성.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -21,7 +21,6 @@ const ResolvedBinding = linker_mod.ResolvedBinding;
 const profile = @import("../../profile.zig");
 const debug_log = @import("../../debug_log.zig");
 const makeExportKey = types.makeModuleKey;
-const makeExportKeyBuf = types.makeModuleKeyBuf;
 const PreambleWriter = linker_mod.PreambleWriter;
 const NsExportPair = Linker.NsExportPair;
 const getOrCreateRequireVar = linker_mod.getOrCreateRequireVar;
@@ -1620,8 +1619,10 @@ pub fn buildCrossModuleConstValuesProfiled(
             // export_name → local_name 매핑. namespace object export 는 scalar const 가 아니므로
             // symbol lookup 전에 제외한다.
             const local_name = local: {
-                var key_buf: [4096]u8 = undefined;
-                const key = makeExportKeyBuf(&key_buf, canon.module_index.toU32(), canon.export_name);
+                var key_mk: types.ModuleKey = .{};
+                defer key_mk.deinit(self.allocator);
+                // 조회 전용 — OOM 시 빈 키 → export_map 미스 → 아래 export_name 폴백과 동일 경로.
+                const key = key_mk.makeOrEmpty(self.allocator, canon.module_index.toU32(), canon.export_name);
                 if (self.export_map.get(key)) |entry| {
                     if (entry.binding.kind == .re_export_namespace) continue;
                     break :local target_module.exportBindingLocalName(entry.binding);

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -792,8 +792,10 @@ pub const TreeShaker = struct {
     }
 
     pub fn isExportUsed(self: *const TreeShaker, module_index: u32, export_name: []const u8) bool {
-        var key_buf: [4096]u8 = undefined;
-        const key = types.makeModuleKeyBuf(&key_buf, module_index, export_name);
+        var mk: types.ModuleKey = .{};
+        defer mk.deinit(self.allocator);
+        // 조회 전용 — OOM 시 빈 키(항상 miss) → "사용 안 됨"으로 안전 폴백.
+        const key = mk.makeOrEmpty(self.allocator, module_index, export_name);
         return self.used_exports.contains(key);
     }
 
@@ -2309,8 +2311,9 @@ pub const TreeShaker = struct {
     }
 
     fn markExportUsed(self: *TreeShaker, module_index: u32, export_name: []const u8) !void {
-        var key_buf: [4096]u8 = undefined;
-        const lookup_key = types.makeModuleKeyBuf(&key_buf, module_index, export_name);
+        var mk: types.ModuleKey = .{};
+        defer mk.deinit(self.allocator);
+        const lookup_key = try mk.make(self.allocator, module_index, export_name);
         if (self.used_exports.contains(lookup_key)) return;
 
         const key = try types.makeModuleKey(self.allocator, module_index, export_name);

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -937,23 +937,65 @@ pub fn spanKey(span: Span) u64 {
     return @as(u64, span.start) << 32 | span.end;
 }
 
+/// 복합 키 바이트를 `dst`에 기록: [4 bytes module_index][0x00][name bytes].
+/// `dst.len == 5 + name.len` 이어야 한다. `makeModuleKey`/`ModuleKey.make` 공용.
+fn writeModuleKeyInto(dst: []u8, module_index: u32, name: []const u8) void {
+    @memcpy(dst[0..4], std.mem.asBytes(&module_index));
+    dst[4] = 0;
+    @memcpy(dst[5..], name);
+}
+
 /// 모듈 인덱스 + 이름 → 복합 키 (힙 할당). linker/tree_shaker의 export 맵에서 사용.
 /// 형식: [4 bytes module_index][0x00][name bytes]
 pub fn makeModuleKey(allocator: std.mem.Allocator, module_index: u32, name: []const u8) ![]const u8 {
-    var buf = try allocator.alloc(u8, 4 + 1 + name.len);
-    @memcpy(buf[0..4], std.mem.asBytes(&module_index));
-    buf[4] = 0;
-    @memcpy(buf[5..], name);
+    const buf = try allocator.alloc(u8, 5 + name.len);
+    writeModuleKeyInto(buf, module_index, name);
     return buf;
 }
 
-/// 모듈 인덱스 + 이름 → 복합 키 (스택 버퍼, 조회용). 할당 없음.
-/// name이 4091바이트를 초과하면 assert 실패.
-pub fn makeModuleKeyBuf(buf: *[4096]u8, module_index: u32, name: []const u8) []const u8 {
-    const total = 5 + name.len;
-    std.debug.assert(total <= 4096);
-    @memcpy(buf[0..4], std.mem.asBytes(&module_index));
-    buf[4] = 0;
-    @memcpy(buf[5 .. 5 + name.len], name);
-    return buf[0..total];
-}
+/// 모듈 인덱스 + 이름 → 복합 키 (조회/저장용 임시 키). 키 형식은 `makeModuleKey`와 동일:
+/// [4 bytes module_index][0x00][name bytes].
+///
+/// 이름이 내부 스택 버퍼(4091바이트)에 맞으면 **할당 없이** 버퍼를 쓰고, 초과하면 heap으로
+/// spill 한다. export/import 이름은 문자열 리터럴(`export { x as "..." }`)로 길이 제한이
+/// 없으므로, 고정 버퍼 + `std.debug.assert`(ReleaseFast에서 소거됨) 만으로는 stack-smashing
+/// 위험이 있었다. spill 된 메모리는 `deinit`으로 해제해야 한다.
+///
+/// 사용 패턴:
+/// ```
+/// var mk: types.ModuleKey = .{};
+/// defer mk.deinit(allocator);
+/// const key = try mk.make(allocator, module_index, name);
+/// ```
+pub const ModuleKey = struct {
+    buf: [4096]u8 = undefined,
+    /// 이름이 버퍼를 초과할 때만 set 되는 heap 할당분. `deinit`에서 해제.
+    spill: ?[]u8 = null,
+
+    pub fn make(self: *ModuleKey, allocator: std.mem.Allocator, module_index: u32, name: []const u8) std.mem.Allocator.Error![]const u8 {
+        const total = 5 + name.len;
+        const dst = if (total <= self.buf.len)
+            self.buf[0..total]
+        else dst: {
+            const spilled = try allocator.alloc(u8, total);
+            self.spill = spilled;
+            break :dst spilled;
+        };
+        writeModuleKeyInto(dst, module_index, name);
+        return dst;
+    }
+
+    /// `make`의 **조회 전용** 편의판: OOM 시 빈 키를 반환한다. 실제 키는 최소 5바이트라
+    /// 빈 키는 어떤 키와도 일치하지 않으므로 해시맵 조회에서 항상 miss → 안전한 폴백.
+    /// 캐시/맵에 *저장*하는 경로엔 쓰지 말 것(빈 키로 저장하면 충돌) — `make` + 명시적 처리.
+    pub fn makeOrEmpty(self: *ModuleKey, allocator: std.mem.Allocator, module_index: u32, name: []const u8) []const u8 {
+        return self.make(allocator, module_index, name) catch &[_]u8{};
+    }
+
+    pub fn deinit(self: *ModuleKey, allocator: std.mem.Allocator) void {
+        if (self.spill) |spilled| {
+            allocator.free(spilled);
+            self.spill = null;
+        }
+    }
+};

--- a/src/bundler/types_test.zig
+++ b/src/bundler/types_test.zig
@@ -57,6 +57,43 @@ test "ImportRecord: default resolved is none" {
     try std.testing.expect(record.resolved.isNone());
 }
 
+test "ModuleKey: 긴 이름은 heap으로 spill되어 makeModuleKey와 동일한 키를 만든다" {
+    const allocator = std.testing.allocator;
+
+    // 4091바이트(= 4096 - 5)를 초과하는 이름은 기존 고정 스택 버퍼를 넘긴다.
+    // (이전 구현은 ReleaseFast에서 assert가 소거되어 stack-smashing이 발생했다.)
+    const long_name = try allocator.alloc(u8, 5000);
+    defer allocator.free(long_name);
+    @memset(long_name, 'a');
+
+    var mk = types.ModuleKey{};
+    defer mk.deinit(allocator);
+    const key = try mk.make(allocator, 7, long_name);
+
+    // 긴 이름이므로 heap으로 spill되어야 한다 (스택 버퍼 오버플로 방지).
+    try std.testing.expect(mk.spill != null);
+
+    // heap 버전(makeModuleKey)과 바이트가 정확히 같아야 map 조회가 일치한다.
+    const heap_key = try types.makeModuleKey(allocator, 7, long_name);
+    defer allocator.free(heap_key);
+    try std.testing.expectEqualSlices(u8, heap_key, key);
+}
+
+test "ModuleKey: 짧은 이름은 할당 없이 스택 버퍼를 쓴다" {
+    const allocator = std.testing.allocator;
+
+    var mk = types.ModuleKey{};
+    defer mk.deinit(allocator);
+    const key = try mk.make(allocator, 3, "foo");
+
+    // 버퍼에 맞으므로 spill이 없어야 한다 (일반 경로 = 무할당).
+    try std.testing.expect(mk.spill == null);
+
+    const heap_key = try types.makeModuleKey(allocator, 3, "foo");
+    defer allocator.free(heap_key);
+    try std.testing.expectEqualSlices(u8, heap_key, key);
+}
+
 test "BundlerDiagnostic: default suggestion is null" {
     const diag = BundlerDiagnostic{
         .code = .unresolved_import,


### PR DESCRIPTION
## Summary

`makeModuleKeyBuf`가 **4096B 고정 스택 버퍼**에 길이 무제한 export/import 이름을 복사하면서, 유일한 경계 보호로 `std.debug.assert`(ReleaseFast에서 소거)만 쓰던 **stack-smashing 결함**을 수정합니다. 버퍼 초과 시 heap으로 spill하는 `ModuleKey` 구조체로 교체했습니다.

> **Zig 초보자 설명**
> - `std.debug.assert(x)`는 Debug/ReleaseSafe에서만 검사하고 **ReleaseFast/ReleaseSmall에서는 통째로 제거**됩니다. NAPI는 ReleaseFast로 빌드되므로, assert를 "유일한 안전장치"로 쓰면 릴리스에서 무방비가 됩니다.
> - `buf: *[4096]u8`는 스택의 고정 4096B 배열 포인터입니다. 여기에 더 긴 데이터를 `@memcpy`하면 인접 스택(리턴 주소 등)을 덮어써 크래시/취약점이 됩니다.
> - 해결: 이름이 버퍼에 맞으면 **할당 없이**(기존처럼 빠르게) 쓰고, 넘치면 **heap으로 spill**한 뒤 `deinit`으로 해제합니다. `defer mk.deinit(alloc)` 패턴으로 함수가 어떻게 끝나든 spill을 정리합니다.

## Changes

- `src/bundler/types.zig`: `makeModuleKeyBuf`(고정 버퍼) 제거 → `ModuleKey` 구조체 추가
  - `make`: 버퍼에 맞으면 무할당, 초과 시 heap spill (키 형식은 `makeModuleKey`와 바이트 동일 → 조회 정합성 보장)
  - `makeOrEmpty`: 조회 전용 편의판 — OOM 시 빈 키(항상 miss)로 안전 폴백
  - `writeModuleKeyInto`: `makeModuleKey`/`make`가 공유하는 키 기록 헬퍼(중복 제거)
- 호출부 6곳 갱신 (`tree_shaker.zig` 2, `linker.zig` 3, `linker/metadata.zig` 1)
  - 순수 조회 4곳 → `makeOrEmpty`(빈 키=miss), 캐시(`chain_cache`) → OOM 시 캐시 우회, 삽입(`markExportUsed`) → `try` 전파
- 사용처 사라진 alias `makeExportKeyBuf` 제거 (linker.zig / metadata.zig)
- 회귀 테스트 2개 (`types_test.zig`)

### 제어 흐름

```mermaid
flowchart TD
    A["호출부: 모듈키 필요"] --> B{"5 + name.len<br/>≤ 4096?"}
    B -- "예 (일반 경로)" --> C["스택 버퍼 사용<br/>(할당 없음)"]
    B -- "아니오 (긴 이름)" --> D["heap spill 할당"]
    C --> E["writeModuleKeyInto<br/>[u32 idx][0x00][name]"]
    D --> E
    E --> F{"용도?"}
    F -- "조회 (makeOrEmpty)" --> G["OOM → 빈 키 = 항상 miss"]
    F -- "캐시 저장" --> H["OOM → 캐시 우회 후 직접 계산"]
    F -- "삽입 (markExportUsed)" --> I["OOM → try 전파"]
    G --> Z["defer deinit: spill 해제"]
    H --> Z
    I --> Z
```

## Test Plan

- [x] `zig build test` 통과 (5902/5902)
- [x] `zig build test -Doptimize=ReleaseFast` — 5901 통과 (잔여 leak 1건은 `getCanonicalByRef` 테스트의 **기존 chain_cache leak**으로 main에서도 동일 재현, 본 PR과 무관)
- [x] `zig fmt --check src/` 통과
- [x] 신규 회귀 테스트: 4091B 초과 이름이 heap spill되고 `makeModuleKey`와 바이트 동일한 키를 만드는지 + 짧은 이름은 무할당 검증 (의도적 실패로 실제 실행 확인)

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음 (AST 노드 추가 없음)

Closes #4269
