### PR TITLE
fix(semantic): checkImportMutation member-target OOB panic 가드

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1236,11 +1236,18 @@ pub const SemanticAnalyzer = struct {
         return idx;
     }
 
+    /// `unwrapTarget` 후 노드를 안전하게 반환. 내부 노드가 없어 인덱스가 .none/범위초과면 null.
+    /// getNode 직접 호출 시의 OOB panic 을 막고, 호출부마다 가드를 복붙하다 한쪽을 빠뜨리는
+    /// 분기 비대칭(이 함수의 과거 OOB 버그 원인)을 구조적으로 차단한다.
+    fn unwrapTargetNode(self: *const SemanticAnalyzer, start: NodeIndex) ?Node {
+        const idx = self.unwrapTarget(start);
+        if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return null;
+        return self.ast.getNode(idx);
+    }
+
     fn checkImportMutation(self: *SemanticAnalyzer, target_idx: NodeIndex, is_delete: bool) AllocError!void {
         if (!self.check_import_mutation) return;
-        const ti = self.unwrapTarget(target_idx);
-        if (ti.isNone() or @intFromEnum(ti) >= self.ast.nodes.items.len) return;
-        const t = self.ast.getNode(ti);
+        const t = self.unwrapTargetNode(target_idx) orelse return;
         switch (t.tag) {
             .identifier_reference, .assignment_target_identifier => {
                 const flags = self.lookupBindingFlags(self.ast.identifierNameText(t)) orelse return;
@@ -1249,7 +1256,8 @@ pub const SemanticAnalyzer = struct {
             .static_member_expression, .computed_member_expression, .private_field_expression => {
                 // object 도 wrapper 언래핑 후 *직접* namespace import 식별자인지. `ns.a.b`(중첩)·
                 // named import 멤버(`obj.x`)는 object 가 namespace import 가 아니라 제외.
-                const obj = self.ast.getNode(self.unwrapTarget(self.ast.readExtraNode(t.data.extra, 0)));
+                // unwrapTargetNode 가 .none/범위초과를 null 로 흡수 → getNode OOB 방지.
+                const obj = self.unwrapTargetNode(self.ast.readExtraNode(t.data.extra, 0)) orelse return;
                 if (obj.tag != .identifier_reference) return;
                 const flags = self.lookupBindingFlags(self.ast.identifierNameText(obj)) orelse return;
                 if (flags.is_namespace_import) try self.addImportMutationError(t.span, is_delete);

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -2195,3 +2195,26 @@ test "#2474 regression: 20-element catch destructure conflicts with body let —
     }
     try std.testing.expect(found);
 }
+
+test "SemanticAnalyzer: bundle-mode member-target with none object does not OOB (#4271)" {
+    // `().x = 1` 류 error-recovery 입력에서 member-target 의 object 가 .none 으로
+    // 언래핑되어 checkImportMutation 이 getNode(.none) → OOB panic 하던 회귀.
+    // 가드 적용 후에는 panic 없이 완료되어야 한다.
+    const sources = [_][]const u8{
+        "().x = 1;",
+        "delete ().x;",
+        "().x++;",
+        "import * as ns from \"m\"; ().x = ns;",
+    };
+    for (sources) |src| {
+        var scanner = try Scanner.init(std.testing.allocator, src);
+        defer scanner.deinit();
+        var parser = Parser.init(std.testing.allocator, &scanner);
+        defer parser.deinit();
+        _ = parser.parse() catch continue; // 파서가 완전히 거부하면 이 케이스 스킵
+        var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+        defer ana.deinit();
+        ana.check_import_mutation = true; // 번들 모드에서만 검사 활성
+        ana.analyze() catch {}; // analyzer 에러는 무관 — 핵심은 OOB panic 부재
+    }
+}


### PR DESCRIPTION
## Summary

번들 모드(`check_import_mutation = true`)에서 `checkImportMutation`의 **member-expression target 분기**가 `unwrapTarget(...)` 결과를 범위 검사 없이 `getNode`에 넘겨, object가 `.none`(=`maxInt(u32)`)이면 **`index out of bounds 4294967295` panic**(번들 중단)하던 결함을 수정합니다.

> **Zig 초보자 설명**
> - `NodeIndex`는 `enum(u32)`이고 `.none = maxInt(u32)`를 "없음" 표식으로 씁니다. `getNode(.none)`은 `nodes.items[4294967295]`라 배열을 한참 넘어 **out-of-bounds**가 됩니다.
> - `unwrapTarget`은 `(x)`/`x!`/`x as T` 같은 wrapper를 벗기는데, 내부 노드가 없으면 `.none`을 그대로 반환합니다. 그래서 호출부는 `getNode` 전에 반드시 범위를 검사해야 합니다.
> - 식별자 분기는 이 가드가 있었지만 member 분기엔 빠져 있던 **방어 가드 비대칭**이 근본 원인입니다.
> - `?Node`는 "Node 이거나 없음(null)" 옵셔널 타입입니다. `... orelse return`은 "null이면 즉시 함수 종료"라 가드 + getNode를 한 줄로 안전하게 묶습니다.

## Changes

- `src/semantic/analyzer.zig`:
  - `unwrapTargetNode(start) ?Node` 헬퍼 추가 — `unwrapTarget` + 범위 가드 + `getNode`를 캡슐화. 인덱스가 `.none`/범위초과면 `null` 반환.
  - `checkImportMutation`의 **두 분기**(entry target + member object)를 헬퍼로 통일 → 가드 비대칭을 구조적으로 차단(같은 버그류 재발 방지).
- `src/semantic/analyzer_test.zig`: 회귀 테스트 추가 — 번들 모드에서 `().x = 1` 등 error-recovery 입력이 panic 없이 처리되는지 검증.

### 수정 전후 흐름

```mermaid
flowchart TD
    subgraph 이전["이전 (member 분기)"]
      A1["unwrapTarget(obj)"] --> A2["getNode(idx)"]
      A2 --> A3{"idx == .none?"}
      A3 -- "예" --> A4["💥 OOB panic<br/>index 4294967295"]
      A3 -- "아니오" --> A5["정상"]
    end
    subgraph 이후["이후 (헬퍼 통일)"]
      B1["unwrapTargetNode(obj)"] --> B2{"idx .none/범위초과?"}
      B2 -- "예" --> B3["null → orelse return<br/>(안전 종료)"]
      B2 -- "아니오" --> B4["getNode(idx) → 정상"]
    end
```

## Test Plan

- [x] `zig build test` 통과 (5903/5903, 신규 회귀 테스트 포함)
- [x] `zig fmt --check src/` 통과
- [x] 회귀 검증: fix를 일시 revert하면 신규 테스트가 정확히 `index out of bounds: index 4294967295` panic으로 실패함을 확인(트리거 경로 입증) → fix 적용 시 통과

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음 (AST 노드 추가 없음)

Closes #4271
