### PR TITLE
fix(minify): simplifySequence raw-slice realloc use-after-free — iterateExtraList 전환

### DIFF
--- a/src/transformer/minify/unused_expr.zig
+++ b/src/transformer/minify/unused_expr.zig
@@ -51,21 +51,25 @@ pub fn simplifySequence(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node, ch
     if (list.len < 2) return;
     if (list.start + list.len > ast.extra_data.items.len) return;
 
-    const indices = ast.extra_data.items[list.start .. list.start + list.len];
-    const last_raw = indices[list.len - 1];
+    // 마지막 원소(값)는 항상 유지 대상. u32 값 복사라 이후 extra_data realloc 과 무관.
+    const last_raw = ast.extra_data.items[list.start + list.len - 1];
     if (last_raw >= ast.nodes.items.len) return;
 
-    // Phase 1 (collect only, no mutation): 유지할 원소 / 제거할 원소 분류.
+    // Phase 1 (collect only, no list mutation): 유지할 원소 / 제거할 원소 분류.
     var kept_buf: std.ArrayListUnmanaged(u32) = .empty;
     defer kept_buf.deinit(ast.allocator);
     var removed_buf: std.ArrayListUnmanaged(u32) = .empty;
     defer removed_buf.deinit(ast.allocator);
 
-    for (indices[0 .. list.len - 1]) |raw| {
+    // realloc-safe 순회 — simplifyUnusedInPlace 재귀가 extra_data 를 grow → ArrayList realloc
+    // → 캡처된 raw-slice invalid (#2422/#2426 동일 패턴). 마지막 원소를 제외한 prefix 만 순회.
+    var iter = ast.iterateExtraList(.{ .start = list.start, .len = list.len - 1 });
+    while (iter.next()) |idx| {
+        const raw = @intFromEnum(idx);
         if (raw >= ast.nodes.items.len) return;
         // 내부 부분 rewrite 도 동시에 수행 (`a ? b : c` → `a || c` 등).
         // rewriter 가 내부 제거분은 이미 감산함 — 최종 removable 로 판정되면 호출자가 raw 전체 감산.
-        if (simplifyUnusedInPlace(ast, ctx, @enumFromInt(raw), changed, 0)) {
+        if (simplifyUnusedInPlace(ast, ctx, idx, changed, 0)) {
             removed_buf.append(ast.allocator, raw) catch return;
         } else {
             kept_buf.append(ast.allocator, raw) catch return;

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -2651,3 +2651,12 @@ test "dead-brace: var in esm_var_assign_only mode — abandon (hoist scan 미커
         .{ .minify_whitespace = true, .esm_var_assign_only = true },
     );
 }
+
+test "minify: statement-position sequence with rewritable middle element (#4273 UAF 회귀)" {
+    // 중간 배열이 (x(), y())로 축약되며 extra_data를 grow → 과거 simplifySequence가
+    // raw-slice를 잡은 채 순회해 realloc 시 use-after-free(프로덕션 freeing allocator).
+    // iterateExtraList 전환 후 안전 + 올바른 축약. (이 경로를 정확히 통과)
+    try expectMinifyFull("(a, [x(), y()], z());", "a,x(),y(),z();");
+    // 여러 rewritable 중간 원소로 extra_data grow를 누적 (realloc 유발 가능성 ↑).
+    try expectMinifyFull("(a, [x()], [y()], [w()], z());", "a,x(),y(),w(),z();");
+}


### PR DESCRIPTION
## Summary

`simplifySequence`가 `ast.extra_data.items`의 **원시 슬라이스**를 잡은 채 Phase-1 루프에서 자식을 rewrite하던 **use-after-free**를 수정합니다. 자식 rewrite(`simplifyUnusedInPlace`)가 `extra_data`를 grow시키면 `ArrayList` realloc으로 옛 버퍼가 해제되어 슬라이스가 dangling → 이후 반복이 freed 메모리를 읽습니다.

> **Zig 초보자 설명**
> - `ast.extra_data.items[a..b]`는 ArrayList 내부 버퍼를 **직접 가리키는 슬라이스**(포인터+길이)입니다. ArrayList가 커지며 재할당(realloc)하면 버퍼가 새 주소로 이동하고 옛 버퍼는 해제됩니다 → 잡고 있던 슬라이스는 dangling.
> - 같은 파일 형제 함수들(`rewriteArrayUnused` 등)은 이미 `iterateExtraList`로 **매 반복마다 live 배열을 다시 읽어**(realloc-safe) 이 문제를 피합니다(`#2422/#2426`). `simplifySequence`만 옛 raw-slice 패턴이 남아 있었습니다.
> - arena allocator는 realloc 시 옛 버퍼를 즉시 free하지 않아 테스트에선 크래시가 안 보이지만, **프로덕션 freeing allocator(GPA/mimalloc)**에서는 옛 버퍼가 해제되어 실제 UAF로 드러납니다.

## Changes

- `src/transformer/minify/unused_expr.zig`: `simplifySequence`의 Phase-1 순회를 raw-slice → `ast.iterateExtraList(.{ .start = list.start, .len = list.len - 1 })`로 전환(형제 함수들과 동일한 realloc-safe 패턴). 마지막 원소는 `u32` 값으로 한 번만 복사.
- `src/transformer/minify_test.zig`: 정합성 회귀 테스트 2건(extra_data grow를 유발하는 중간 rewritable 원소 패턴).

### 수정 전후

```mermaid
flowchart TD
    subgraph 이전["이전 (raw-slice)"]
      A1["indices = extra_data.items[..] (슬라이스 캡처)"] --> A2["루프: 자식 rewrite"]
      A2 --> A3{"extra_data grow → realloc?"}
      A3 -- "예" --> A4["옛 버퍼 free<br/>→ indices dangling"]
      A4 --> A5["💥 다음 반복: freed 메모리 read (UAF)"]
      A3 -- "아니오" --> A6["우연히 정상"]
    end
    subgraph 이후["이후 (iterateExtraList)"]
      B1["iter = iterateExtraList(prefix)"] --> B2["루프: 자식 rewrite"]
      B2 --> B3{"extra_data grow → realloc?"}
      B3 -- "예/아니오" --> B4["next()가 매번 live 배열 재읽기<br/>→ 항상 유효"]
    end
```

## Test Plan

- [x] `zig build test` 통과 (5904/5904, 신규 회귀 2건 포함)
- [x] `zig fmt --check src/` 통과
- [x] `/simplify` 4-각도 리뷰 — clean (패턴 일치, 다른 raw-slice holdout 없음 확인)

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음 (AST 노드 추가 없음)

Closes #4273
