### PR TITLE
fix(react-native): open-url 미검증 입력 — scheme allowlist + win32 non-shell opener

### DIFF
--- a/packages/react-native/src/dev-server/routes/open-url.test.ts
+++ b/packages/react-native/src/dev-server/routes/open-url.test.ts
@@ -65,7 +65,7 @@ describe('handleOpenUrl — happy path', () => {
     expect(res.payload).toEqual({ success: true });
   });
 
-  test('win32 → cmd /c start', async () => {
+  test('win32 → rundll32 (cmd 인젝션 회피)', async () => {
     const rec: Recorded[] = [];
     await handleOpenUrl(
       streamReq('{"url":"https://w.test"}') as never,
@@ -73,7 +73,10 @@ describe('handleOpenUrl — happy path', () => {
       fakeSpawner(rec),
       'win32',
     );
-    expect(rec[0]).toMatchObject({ command: 'cmd', args: ['/c', 'start', '', 'https://w.test'] });
+    expect(rec[0]).toMatchObject({
+      command: 'rundll32',
+      args: ['url.dll,FileProtocolHandler', 'https://w.test'],
+    });
   });
 
   test('linux → xdg-open', async () => {
@@ -128,5 +131,50 @@ describe('handleOpenUrl — error path', () => {
     );
     expect(res.statusCode).toBe(500);
     expect(res.payload).toEqual({ error: 'Failed to open URL' });
+  });
+});
+
+describe('handleOpenUrl — URL 검증(보안) #4275', () => {
+  const rejected = [
+    ['file:// 임의 파일', 'file:///etc/passwd'],
+    ['javascript: 스킴', 'javascript:alert(1)'],
+    ['커스텀 스킴', 'myapp://launch'],
+    ['cmd 메타문자 + 공백', 'https://x.test & calc'],
+    ['공백 포함', 'https://x.test/ a'],
+    ['백슬래시', 'https://x.test\\foo'],
+    ['따옴표', 'https://x.test"q'],
+    ['제어문자(CR)', 'https://x.test\r'],
+    ['scheme 없음', 'x.test'],
+  ] as const;
+
+  for (const [label, url] of rejected) {
+    test(`거부: ${label} → 400, spawner 미호출`, async () => {
+      const rec: Recorded[] = [];
+      const res = makeRes();
+      await handleOpenUrl(
+        streamReq(JSON.stringify({ url })) as never,
+        res as never,
+        fakeSpawner(rec),
+        'win32',
+      );
+      expect(rec).toHaveLength(0);
+      expect(res.statusCode).toBe(400);
+    });
+  }
+
+  test('허용: 쿼리스트링(&) 정상 URL → 200 + rundll32 에 그대로 전달', async () => {
+    const rec: Recorded[] = [];
+    const res = makeRes();
+    await handleOpenUrl(
+      streamReq('{"url":"https://x.test/?a=1&b=2"}') as never,
+      res as never,
+      fakeSpawner(rec),
+      'win32',
+    );
+    expect(res.statusCode).toBe(200);
+    expect(rec[0]).toMatchObject({
+      command: 'rundll32',
+      args: ['url.dll,FileProtocolHandler', 'https://x.test/?a=1&b=2'],
+    });
   });
 });

--- a/packages/react-native/src/dev-server/routes/open-url.ts
+++ b/packages/react-native/src/dev-server/routes/open-url.ts
@@ -1,5 +1,5 @@
 // POST /open-url — RN runtime 의 "open in browser" 액션. body { url } 받아서
-// platform native opener 로 spawn (darwin: open, win32: cmd start, linux: xdg-open).
+// platform native opener 로 spawn (darwin: open, win32: rundll32, linux: xdg-open).
 
 import { spawn } from 'node:child_process';
 import type { IncomingMessage, ServerResponse } from 'node:http';
@@ -17,8 +17,33 @@ interface PlatformOpener {
 
 function resolveOpener(platform: NodeJS.Platform = process.platform): PlatformOpener {
   if (platform === 'darwin') return { command: 'open', args: (t) => [t] };
-  if (platform === 'win32') return { command: 'cmd', args: (t) => ['/c', 'start', '', t] };
+  // win32: `cmd /c start` 는 cmd.exe 가 인자를 재파싱해 `&`/`|` 등으로 명령 인젝션이
+  // 가능하다(shell:false 여도). rundll32 는 인자를 셸로 재해석하지 않으므로 안전하게
+  // 기본 브라우저로 URL 을 연다.
+  if (platform === 'win32')
+    return { command: 'rundll32', args: (t) => ['url.dll,FileProtocolHandler', t] };
   return { command: 'xdg-open', args: (t) => [t] };
+}
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+// "open in browser" 액션의 안전한 입력인지 검증.
+// - http/https 만 허용 (file:// 임의 파일 오픈, javascript:/커스텀 스킴 등 차단).
+// - 제어문자·공백·따옴표·백슬래시 거부: 정상 인코딩된 http(s) URL 엔 없는 문자이며,
+//   OS opener 의 명령줄 인자 구성/파싱 오용을 막는 추가 방어선.
+function isSafeBrowserUrl(target: string): boolean {
+  for (let i = 0; i < target.length; i += 1) {
+    const c = target.charCodeAt(i);
+    // 0x20=space 이하(제어문자/공백), 0x22=", 0x27=', 0x5c=\
+    if (c <= 0x20 || c === 0x22 || c === 0x27 || c === 0x5c) return false;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    return false;
+  }
+  return ALLOWED_PROTOCOLS.has(parsed.protocol);
 }
 
 export async function handleOpenUrl(
@@ -37,6 +62,10 @@ export async function handleOpenUrl(
   const target = body.url;
   if (typeof target !== 'string' || target.length === 0) {
     sendJson(res, 400, { error: 'Invalid URL' });
+    return;
+  }
+  if (!isSafeBrowserUrl(target)) {
+    sendJson(res, 400, { error: 'URL must be an http(s) URL without control characters' });
     return;
   }
   try {


### PR DESCRIPTION
## Summary

RN dev server의 `POST /open-url`이 입력 URL을 `typeof string && length>0`로만 검증하고 OS opener에 전달하던 **보안 결함**을 수정합니다. 인증/CSRF 보호가 없는 dev 라우트라, 악성 페이지가 `localhost:<port>/open-url`로 POST하면:
- **win32**: `cmd /c start "" <url>` — cmd.exe가 인자를 재파싱해 `&`/`|`로 **명령 인젝션**(plausible RCE)
- **darwin/linux**: `open`/`xdg-open`으로 `file:///...`·로컬 앱·커스텀 스킴 등 **임의 오픈**

> **초보자 설명**
> - `spawn(cmd, args, {shell:false})`는 셸을 거치지 않지만, **`cmd.exe /c start`는 그 자체가 인자를 명령줄로 재해석**합니다. 그래서 `&`가 들어가면 추가 명령이 실행됩니다.
> - `rundll32 url.dll,FileProtocolHandler <url>`는 인자를 셸로 재해석하지 않고 기본 브라우저로 URL만 엽니다 → 인젝션 불가.
> - `new URL(target).protocol`로 스킴을 확인해 `http:`/`https:`만 허용하면 `file://`(파일 노출)·`javascript:`(스크립트)·커스텀 스킴을 차단합니다.

## Changes

- `packages/react-native/src/dev-server/routes/open-url.ts`:
  - `isSafeBrowserUrl(target)` 추가 — 제어문자/공백/따옴표/백슬래시 거부 + `new URL`로 `http:`/`https:`만 허용. 통과 못 하면 400.
  - win32 opener를 `cmd /c start` → `rundll32 url.dll,FileProtocolHandler`(셸 미재파싱)로 교체.
- `packages/react-native/src/dev-server/routes/open-url.test.ts`: 보안 회귀 테스트 9건(악성 스킴/문자 거부) + 허용 케이스(쿼리스트링) + 기존 win32 테스트를 rundll32로 갱신.

### 요청 처리 흐름

```mermaid
flowchart TD
    A["POST /open-url { url }"] --> B{"string & length>0?"}
    B -- "아니오" --> E["400 Invalid URL"]
    B -- "예" --> C{"isSafeBrowserUrl?<br/>(http/https + 제어문자 없음)"}
    C -- "아니오 (file:/javascript:/&/공백…)" --> F["400 — spawner 미호출"]
    C -- "예" --> D{"platform"}
    D -- "darwin" --> G["open url"]
    D -- "win32" --> H["rundll32 url.dll,FileProtocolHandler url<br/>(셸 재파싱 없음)"]
    D -- "linux" --> I["xdg-open url"]
    G & H & I --> J["200 success"]
```

## Test Plan

- [x] `bun test`(packages/react-native, open-url) — 22 pass / 0 fail
- [x] 악성 스킴(`file://`/`javascript:`/커스텀)·제어문자·공백·따옴표·백슬래시 → 400 + spawner 미호출
- [x] win32가 rundll32 사용, 쿼리스트링(`?a=1&b=2`) 정상 URL은 200 통과
- [x] `oxlint` 0 error (변경 파일)
- [ ] 비고: 동일 패키지의 사전 존재 HMR 테스트 flakiness(`zntc-hmr-client.test.mjs`)는 본 PR과 무관(main에서도 동일 재현)

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음

Closes #4275
