### PR TITLE
fix(napi): build/watch async 에러 경로 자원 누수 — full cleanup 통일

### DIFF
--- a/packages/core/src/napi/build_async_entry.zig
+++ b/packages/core/src/napi/build_async_entry.zig
@@ -31,6 +31,9 @@ const BuildAsyncData = struct {
     completion_tsfn: c.napi_threadsafe_function,
     // 소유된 옵션 (워커 스레드에서 유효해야 하므로 복사)
     options: BundleOptions,
+    // options 가 parseBuildOptions 결과로 채워졌는지. 에러 경로에서 undefined-options 의
+    // freeOptionsTypedSlices 크래시를 막는 가드 (#4277).
+    options_set: bool = false,
     // logLevel/logLimit 필터 — buildResultToJS 가 진단 출력 시 사용 (#2158).
     log_opts: LogFilterOptions,
     // 소유된 문자열 목록 (deinit 시 해제)
@@ -45,6 +48,23 @@ const BuildAsyncData = struct {
     result: ?bundler_mod.BundleResult = null,
     err_msg: ?[*:0]const u8 = null,
 };
+
+/// async_data 가 소유한 모든 리소스 해제 + 구조체 free. 완료 콜백과 진입 함수의
+/// 에러 경로가 공유한다(정리 로직 drift 방지). completion_tsfn 의 release 는 생성
+/// 여부가 호출 지점마다 달라 호출자가 직접 처리한다. options typed slices 는
+/// `options_set` 가드로만 해제(에러 경로의 undefined-options 크래시 방지).
+fn deinitAsyncData(async_data: *BuildAsyncData) void {
+    for (async_data.owned_strings.items) |s| native_alloc.free(s);
+    async_data.owned_strings.deinit(native_alloc);
+    for (async_data.owned_string_arrays.items) |arr| native_alloc.free(arr);
+    async_data.owned_string_arrays.deinit(native_alloc);
+    if (async_data.options_set) freeOptionsTypedSlices(&async_data.options);
+    for (async_data.napi_plugins.items) |np| np.deinit();
+    async_data.napi_plugins.deinit(native_alloc);
+    async_data.zig_plugins.deinit(native_alloc);
+    if (async_data.napi_manual_chunks) |mc| mc.deinit();
+    native_alloc.destroy(async_data);
+}
 
 /// 독립 스레드에서 번들링 실행 (libuv 워커 미사용 → TSFN 데드락 방지)
 fn buildWorkerThread(async_data: *BuildAsyncData) void {
@@ -65,22 +85,9 @@ fn buildWorkerThread(async_data: *BuildAsyncData) void {
 fn buildCompleteTsfn(env: c.napi_env, _: c.napi_value, _: ?*anyopaque, data: ?*anyopaque) callconv(.c) void {
     const async_data: *BuildAsyncData = @ptrCast(@alignCast(data.?));
     defer {
-        // TSFN 해제
+        // 완료 시점엔 completion_tsfn 이 항상 생성돼 있으므로 여기서 release.
         _ = c.napi_release_threadsafe_function(async_data.completion_tsfn, c.napi_tsfn_release);
-        // 소유된 문자열 해제 (개별 문자열)
-        for (async_data.owned_strings.items) |s| native_alloc.free(s);
-        async_data.owned_strings.deinit(native_alloc);
-        // 배열 컨테이너만 해제 (내부 문자열은 owned_strings에서 이미 해제됨)
-        for (async_data.owned_string_arrays.items) |arr| native_alloc.free(arr);
-        async_data.owned_string_arrays.deinit(native_alloc);
-        // typed slices (define/module_specifier_map/alias) — native_alloc 소유, 명시 free (#2396).
-        freeOptionsTypedSlices(&async_data.options);
-        // NAPI 플러그인 해제
-        for (async_data.napi_plugins.items) |np| np.deinit();
-        async_data.napi_plugins.deinit(native_alloc);
-        async_data.zig_plugins.deinit(native_alloc);
-        if (async_data.napi_manual_chunks) |mc| mc.deinit();
-        native_alloc.destroy(async_data);
+        deinitAsyncData(async_data);
     }
 
     if (async_data.err_msg) |msg| {
@@ -134,20 +141,23 @@ pub fn napiBuild(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
 
     // 옵션 파싱 (모든 문자열을 소유 메모리로 복사)
     var opts = parseBuildOptions(env, argv[0], &async_data.owned_strings, &async_data.owned_string_arrays) orelse {
-        native_alloc.destroy(async_data);
+        deinitAsyncData(async_data);
         return throwError(env, "invalid build options");
     };
+    // typed slices 를 정리 대상으로 즉시 등록 — 이후 에러 경로의 deinitAsyncData 가 해제.
+    async_data.options = opts;
+    async_data.options_set = true;
 
     // _pluginDispatcher가 있으면 NapiPlugin 생성
     if (getNamedProperty(env, argv[0], "_pluginDispatcher")) |dispatcher_fn| {
         const np = native_alloc.create(NapiPlugin) catch {
-            native_alloc.destroy(async_data);
+            deinitAsyncData(async_data);
             return throwError(env, "OutOfMemory");
         };
         np.* = .{
             .name = native_alloc.dupe(u8, "js-plugin") catch {
                 native_alloc.destroy(np);
-                native_alloc.destroy(async_data);
+                deinitAsyncData(async_data);
                 return throwError(env, "OutOfMemory");
             },
             .tsfn = undefined,
@@ -171,7 +181,7 @@ pub fn napiBuild(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
         ) != c.napi_ok) {
             native_alloc.free(np.name);
             native_alloc.destroy(np);
-            native_alloc.destroy(async_data);
+            deinitAsyncData(async_data);
             return throwError(env, "failed to create threadsafe function");
         }
 
@@ -185,17 +195,18 @@ pub fn napiBuild(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
         if (installManualChunksResolver(env, fn_val, &opts)) |resolver| {
             async_data.napi_manual_chunks = resolver;
         } else {
-            native_alloc.destroy(async_data);
+            deinitAsyncData(async_data);
             return throwError(env, "failed to install manualChunks resolver");
         }
     }
 
+    // opts.plugins / manualChunks resolver 가 채워진 최종 상태로 갱신 (worker 가 읽음).
     async_data.options = opts;
 
     // Promise 생성
     var promise: c.napi_value = undefined;
     if (c.napi_create_promise(env, &async_data.deferred, &promise) != c.napi_ok) {
-        native_alloc.destroy(async_data);
+        deinitAsyncData(async_data);
         return throwError(env, "failed to create promise");
     }
 
@@ -215,14 +226,16 @@ pub fn napiBuild(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
         buildCompleteTsfn,
         &async_data.completion_tsfn,
     ) != c.napi_ok) {
-        native_alloc.destroy(async_data);
+        // completion_tsfn 생성 실패 — 아직 미생성이라 release 불필요.
+        deinitAsyncData(async_data);
         return throwError(env, "failed to create completion tsfn");
     }
 
     // 독립 스레드에서 빌드 실행 (libuv 워커 미사용 → TSFN 데드락 방지)
     const thread = std.Thread.spawn(.{}, buildWorkerThread, .{async_data}) catch {
+        // completion_tsfn 은 생성됐으므로 release 후 나머지 자원 정리.
         _ = c.napi_release_threadsafe_function(async_data.completion_tsfn, c.napi_tsfn_release);
-        native_alloc.destroy(async_data);
+        deinitAsyncData(async_data);
         return throwError(env, "failed to spawn build thread");
     };
     thread.detach();

--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -83,6 +83,9 @@ const WatchAsyncData = struct {
     env: c.napi_env,
     // 소유된 옵션 (워커 스레드에서 유효해야 하므로 복사)
     options: BundleOptions,
+    // options 가 parseBuildOptions 결과로 채워졌는지. 에러 경로에서 undefined-options 의
+    // freeOptionsTypedSlices 크래시를 막는 가드 (#4277).
+    options_set: bool = false,
     owned_strings: std.ArrayList([]const u8),
     owned_string_arrays: std.ArrayList([]const []const u8),
     // NAPI 플러그인 (JS 콜백 기반)
@@ -160,7 +163,8 @@ const WatchAsyncData = struct {
         for (self.owned_string_arrays.items) |arr| native_alloc.free(arr);
         self.owned_string_arrays.deinit(native_alloc);
         // typed slices (define/module_specifier_map/alias) — native_alloc 소유, 명시 free (#2396).
-        freeOptionsTypedSlices(&self.options);
+        // 에러 경로(worker 미기동)에선 options 가 미할당일 수 있어 가드 (#4277).
+        if (self.options_set) freeOptionsTypedSlices(&self.options);
         // NAPI 플러그인 해제
         for (self.napi_plugins.items) |np| np.deinit();
         self.napi_plugins.deinit(native_alloc);
@@ -1932,7 +1936,9 @@ pub fn napiWatch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
                 break :blk true;
             };
             if (!ok) {
-                native_alloc.destroy(async_data);
+                // arr 는 owned_string_arrays 에 미등록 상태 → 컨테이너 직접 해제 후 full cleanup.
+                native_alloc.free(arr);
+                async_data.unref();
                 return throwError(env, "OutOfMemory");
             }
             @field(async_data.*, pair[1]) = arr;
@@ -1941,20 +1947,23 @@ pub fn napiWatch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
 
     // 옵션 파싱
     var opts = parseBuildOptions(env, argv[0], &async_data.owned_strings, &async_data.owned_string_arrays) orelse {
-        native_alloc.destroy(async_data);
+        async_data.unref();
         return throwError(env, "invalid watch options");
     };
+    // typed slices 를 정리 대상으로 즉시 등록 — 이후 에러 경로의 unref→deinit 가 해제.
+    async_data.options = opts;
+    async_data.options_set = true;
 
     // _pluginDispatcher가 있으면 NapiPlugin 생성 (napiBuild와 동일 패턴)
     if (getNamedProperty(env, argv[0], "_pluginDispatcher")) |dispatcher_fn| {
         const np = native_alloc.create(NapiPlugin) catch {
-            native_alloc.destroy(async_data);
+            async_data.unref();
             return throwError(env, "OutOfMemory");
         };
         np.* = .{
             .name = native_alloc.dupe(u8, "js-plugin") catch {
                 native_alloc.destroy(np);
-                native_alloc.destroy(async_data);
+                async_data.unref();
                 return throwError(env, "OutOfMemory");
             },
             .tsfn = undefined,
@@ -1977,7 +1986,7 @@ pub fn napiWatch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
         ) != c.napi_ok) {
             native_alloc.free(np.name);
             native_alloc.destroy(np);
-            native_alloc.destroy(async_data);
+            async_data.unref();
             return throwError(env, "failed to create threadsafe function");
         }
 
@@ -1991,11 +2000,12 @@ pub fn napiWatch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
         if (installManualChunksResolver(env, fn_val, &opts)) |resolver| {
             async_data.napi_manual_chunks = resolver;
         } else {
-            native_alloc.destroy(async_data);
+            async_data.unref();
             return throwError(env, "failed to install manualChunks resolver");
         }
     }
 
+    // opts.plugins / manualChunks resolver 가 채워진 최종 상태로 갱신 (worker 가 읽음).
     async_data.options = opts;
     // `emitDiskSourcemap` 옵션 (기본 true) — bungae 등 lazy 라우트를 갖춘 dev server 는
     // false 로 보내 rebuild 경로의 `.map` 디스크 I/O 를 완전히 제거한다.


### PR DESCRIPTION
## Summary

`napiBuild`/`napiWatch`의 **에러 경로**가 `native_alloc.destroy(async_data)`로 구조체 shell 만 해제하고, 누적된 owned 리소스(소유 문자열/배열, 옵션 typed slices, **NapiPlugin 의 live TSFN**, manualChunks resolver, watch 의 compiled_cache 등)를 해제하지 않아 누수하던 결함을 수정합니다. 가장 심각한 케이스는 manualChunks 설치 실패 경로의 **live TSFN leak**.

> **Zig 초보자 설명**
> - `async_data`는 워커 스레드로 넘길 옵션·문자열·플러그인 TSFN 핸들을 **소유**합니다. 정상 종료 콜백은 이들을 하나씩 free/deinit 한 뒤 구조체를 destroy 합니다.
> - 에러 경로가 `destroy(async_data)`만 하면 구조체 메모리만 반환되고 그 안이 가리키는 owned 메모리/TSFN 은 leak 됩니다.
> - 그냥 정상 경로 정리를 호출하면 될 것 같지만, **에러 시점엔 `async_data.options`가 아직 미할당(undefined)**이라 `freeOptionsTypedSlices(undefined)`가 쓰레기 포인터를 free 하려다 크래시 → `options_set` 플래그로 가드해야 합니다.

## Changes

- `BuildAsyncData`/`WatchAsyncData`에 `options_set: bool = false` 추가 — typed slices 해제를 이 플래그로 가드.
- `parseBuildOptions` 직후 `async_data.options = opts; options_set = true;` (early-assign) — 중간 에러 경로도 typed slices 를 정리 대상으로 본다. (worker 가 읽을 최종 옵션은 plugins/resolver 까지 채운 뒤 한 번 더 갱신.)
- `build_async_entry.zig`: 완료 콜백의 정리 시퀀스를 공유 `deinitAsyncData()`로 추출 → 완료 콜백 + 모든 에러 경로가 동일 정리(로직 drift 제거).
- `watch.zig`: 에러 경로를 정상 경로와 동일한 `async_data.unref()`(refs=1 → deinit)로 통일. watchFolders OOM 경로는 owned_string_arrays 에 미등록된 `arr` 컨테이너도 명시 해제.

### 에러 경로 정리 흐름

```mermaid
flowchart TD
    A["napiBuild/napiWatch 진입"] --> B["async_data 생성 (options_set=false)"]
    B --> C["parseBuildOptions"]
    C -- "실패" --> X1["cleanup (options_set=false → typed slice skip)"]
    C -- "성공" --> D["early-assign: options + options_set=true"]
    D --> E["plugin TSFN / manualChunks 설치"]
    E -- "실패 (이전: raw destroy → leak)" --> X2["cleanup: owned + typed slices + live TSFN 해제"]
    E -- "성공" --> F["completion TSFN + worker spawn"]
    F -- "실패" --> X3["release tsfn + cleanup"]
    F -- "성공" --> G["worker → 완료 콜백 cleanup"]
    X1 & X2 & X3 --> Z["destroy(async_data)"]
    G --> Z
```

## Test Plan

- [x] `zig build napi` 컴파일 통과 (NAPI 애드온)
- [x] `zig build test` 통과 (5904/5904, 공유 코드 회귀 없음)
- [x] `zig fmt --check` 통과
- [x] 완료(happy) 경로는 동일 cleanup 시퀀스를 함수 추출만 한 것이라 동작 불변(`options_set` 는 happy 경로에서 항상 true) — CI 의 "NAPI Build & Test" / "Package Smoke" 가 end-to-end 검증
- [ ] 비고: NAPI 에러 경로(OOM/TSFN 생성 실패)는 in-process 결정적 누수 테스트가 불가(에러 주입 불가) — 경로별 정합성 reasoning + 컴파일 검증으로 보증

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음

Closes #4277
