### PR TITLE
fix(transformer): ES2015 class 식 IIFE 재빌드가 _this alias 누락 — 재빌드 제거

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -788,6 +788,20 @@ test "ES5: class with async method + non-async method" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty(Foo.prototype,\"sync\"") != null);
 }
 
+test "ES5: class expression with arrow `this` field declares _this alias (#4279)" {
+    // class 식(expression) + 메서드(has_extra → IIFE) + 화살표 this 필드.
+    // 과거 IIFE 재빌드가 `var _this = this;` alias prepend 를 누락 → 화살표 필드가
+    // `_this is not defined` 로 런타임 크래시했다. 재빌드 제거 후 alias 가 보존돼야 한다.
+    var r = try e2eTarget(std.testing.allocator,
+        \\const C = class {
+        \\  m() { return 1; }
+        \\  f = () => this;
+        \\};
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _this=this") != null);
+}
+
 test "ES5: async with while(true) + await + break" {
     var r = try e2eTarget(std.testing.allocator, "async function foo() { while (true) { var x = await next(); if (!x) break; } }", .es5);
     defer r.deinit();

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -439,29 +439,12 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
 
             // IIFE (lowerClassDeclaration과 동일 패턴) — name_span을 재사용.
-            const expr_fresh_name = try es_helpers.makeBindingIdentifier(self, name_span);
+            // func_node 는 위에서 이미 fresh name(`func_name` = makeBindingIdentifier, symbol
+            // 무연결)으로 빌드되고 instance_fields → `_this` alias → __classCallCheck prepend 까지
+            // 끝난 상태이므로 그대로 사용한다. 이전엔 여기서 재빌드하며 `_this` alias prepend 를
+            // 누락해, 화살표-함수 인스턴스 필드(`f = () => this`)가 `_this is not defined` 로
+            // 런타임 크래시했다 (#4279). 재빌드 제거로 비대칭을 구조적으로 차단.
             const expr_super_param = "_super";
-
-            // func_node를 fresh name으로 재생성 (symbol 연결 없음)
-            func_node = if (cm.constructor_idx) |ctor_idx|
-                try buildFunctionFromConstructor(self, ctor_idx, expr_fresh_name, cm.instance_fields.items, has_super and super_span != null, span)
-            else if (has_super and super_span != null)
-                try buildDefaultSuperConstructor(self, expr_fresh_name, super_span.?, cm.instance_fields.items, span)
-            else
-                try buildEmptyFunction(self, expr_fresh_name, span);
-
-            if (cm.instance_fields.items.len > 0 and !(has_super and super_span != null)) {
-                func_node = try prependToFunctionBody(self, func_node, cm.instance_fields.items);
-            }
-            // classCallCheck
-            {
-                const check_id = try es_helpers.makeRuntimeHelperRef(self, "__classCallCheck");
-                const this_expr = try self.ast.addNode(.{ .tag = .this_expression, .span = span, .data = .{ .none = 0 } });
-                const class_ref = try es_helpers.makeIdentifierRefFromSpan(self, name_span);
-                const call = try es_helpers.makeCallExpr(self, check_id, &.{ this_expr, class_ref }, span);
-                func_node = try prependToFunctionBody(self, func_node, &.{try es_helpers.makeExprStmt(self, call, span)});
-                self.runtime_helpers.class_call_check = true;
-            }
 
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);


### PR DESCRIPTION
## Summary

ES2015 class **식(expression)** 다운레벨에서, IIFE 가 필요한 경우 `func_node`를 **재빌드**하며 첫 빌드에 있던 `var _this = this;` alias prepend 를 **누락**해, 비파생 클래스의 화살표-함수 인스턴스 필드가 `this`를 참조하면 런타임에서 `_this is not defined` 로 크래시하던 결함을 수정합니다.

> **Zig 초보자 설명**
> - 비파생 클래스의 인스턴스 필드 초기화는 다운레벨 시 `_this`(= `var _this = this;`)를 통해 `this`에 접근합니다. 특히 화살표 함수 필드(`f = () => this`)는 클로저로 `this`를 캡처하므로 `_this` alias 선언이 필수입니다.
> - 선언문(declaration) 경로는 올바르게 alias 를 넣는데, **식(expression) 경로의 IIFE 재빌드만** 빠뜨려 비대칭이 있었습니다.
> - 근본 원인은 주석("func_node를 한 번만 빌드")과 달리 **func_node 를 두 번 빌드**한 것 — 첫 빌드는 alias 까지 올바르게 넣는데, IIFE 경로가 그걸 버리고 재빌드하며 누락했습니다. `has_extra`일 때 첫 빌드의 이름은 이미 fresh `makeBindingIdentifier`(심볼 무연결)라 재빌드는 동등하고 불필요합니다.

## Changes

- `src/transformer/es2015_class.zig`: 식 경로의 **IIFE func_node 재빌드 제거**(~23줄). 첫 빌드(instance_fields → `_this` alias → `__classCallCheck` prepend 완료)를 그대로 사용 → 선언/식 경로 비대칭을 구조적으로 차단(#17), `_this` alias 누락 해소(#3).
- `src/codegen/codegen_test/es_downlevel.zig`: es5 회귀 테스트 추가.

### 변환 흐름

```mermaid
flowchart TD
    A["class 식 다운레벨"] --> B["func_node 빌드 (func_name)"]
    B --> C["prepend: instance_fields → _this alias → __classCallCheck"]
    C --> D{"has_extra?"}
    D -- "아니오" --> E["function_expression 반환"]
    D -- "예 (IIFE)" --> F0
    subgraph 이전["이전 (버그)"]
      F0["func_node 재빌드 (expr_fresh_name)"] --> F1["prepend: instance_fields → __classCallCheck"]
      F1 --> F2["❌ _this alias 누락 → 화살표 필드 _this is not defined"]
    end
    subgraph 이후["이후 (수정)"]
      G0["재빌드 제거 — 위 func_node 그대로 사용"] --> G1["✅ _this alias 보존"]
    end
```

## Test Plan

- [x] `zig build test` 통과 (5905/5905, 신규 es5 회귀 포함)
- [x] es5 다운레벨 출력: `var C=(function(){function _Class(){...var _this=this;this.f=function(){return _this;};}...})()` — alias 보존 확인
- [x] 회귀 검증: 재빌드를 복원하면 신규 테스트가 정확히 실패(`var _this=this` 부재) → 재빌드 제거 시 통과
- [x] `zig fmt --check` 통과
- [x] `/simplify` — clean (dead code 없음, 선언 경로는 이미 single-build, 비대칭 구조적 제거)

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음 (AST 노드 추가 없음)

Closes #4279
