### PR TITLE
fix(transformer): generator 라벨 continue 가 for-of/for-in/do-while 에서 잘못된 타겟 점프(무한 루프)

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -3376,3 +3376,41 @@ test "ES5: class async method + nested-member optional-call hoists temp decl (re
             std.mem.indexOf(u8, r.output, ",_b") != null);
     }
 }
+
+test "ES5 generator: labeled `continue` in for-of jumps to iterator advance, not cond (#4281)" {
+    // 라벨된 for-of 의 `continue outer` 는 outer iterator advance(_a++)로 가야 한다.
+    // 버그 땐 outer cond 로 점프(`...return[3,3];return[3,1]`)해 _a++ 를 건너뛰어 무한 루프했다.
+    // 수정 후엔 advance case 로 점프(`...return[3,3];return[3,6]`). (런타임: value=4, 종료)
+    var r = try e2eTarget(std.testing.allocator,
+        \\function* g() {
+        \\  let s = 0;
+        \\  outer: for (const x of [1, 2, 3]) {
+        \\    for (const y of [0]) { if (x === 2) continue outer; s += x; }
+        \\  }
+        \\  return s;
+        \\}
+    , .es5);
+    defer r.deinit();
+    // continue outer 가 outer cond(case 1)로 바로 점프하던 버그 시그니처가 없어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "if(!(x===2))return[3,3];return[3,1]") == null);
+    // continue outer 가 outer advance(_a++) case 로 점프.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "if(!(x===2))return[3,3];return[3,6]") != null);
+}
+
+test "ES5 generator: labeled `continue` in do-while jumps to cond, not body (#4281)" {
+    // 라벨된 do-while 의 `continue outer` 는 조건 평가 지점으로 가야 한다.
+    // 버그 땐 body_label 로 점프(`...return[3,2];return[3,1]`)해 조건을 재평가하지 않았다.
+    // 수정 후엔 cond case 로 점프(`...return[3,2];return[3,3]`). (런타임: value=8, 종료)
+    var r = try e2eTarget(std.testing.allocator,
+        \\function* g() {
+        \\  let i = 0, s = 0;
+        \\  outer: do { i++; if (i === 2) continue outer; s += i; } while (i < 4);
+        \\  return s;
+        \\}
+    , .es5);
+    defer r.deinit();
+    // continue outer 가 body_label(case 1)로 점프하던 버그 시그니처가 없어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "if(!(i===2))return[3,2];return[3,1]") == null);
+    // continue outer 가 cond(case 3)로 점프.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "if(!(i===2))return[3,2];return[3,3]") != null);
+}

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -534,7 +534,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             // update (별도 label — continue의 대상)
             const update_label = next_label.*;
             next_label.* += 1;
-            self.generator_for_update_label = update_label;
+            self.generator_loop_continue_label = update_label;
             try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } }); // mark update_label
             if (!update_idx.isNone()) {
                 const new_update = try self.visitNode(update_idx);
@@ -697,7 +697,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             // update: _i++
             const update_label = next_label.*;
             next_label.* += 1;
-            self.generator_for_update_label = update_label;
+            self.generator_loop_continue_label = update_label;
             try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
             const idx_ref_update = try es_helpers.makeTempVarRef(self, idx_span, idx_span);
             const update_extra = try self.ast.addExtras(&.{
@@ -868,21 +868,25 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 body_node.tag == .for_in_statement or
                 body_node.tag == .for_of_statement;
 
-            const is_for = body_node.tag == .for_statement;
+            // while 을 제외한 모든 루프(for/for-of/for-in/do-while)는 `continue` 타겟
+            // (증분·iterator advance·조건 평가)이 body 수집 *후*에야 정해지므로 sentinel +
+            // generator_loop_continue_label 로 지연 fixup 한다. while 만 `continue` = cond_label
+            // (루프 최상단)이라 즉시 결정.
+            const continue_via_update_label = is_loop and body_node.tag != .while_statement;
             const depth = self.generator_label_stack.items.len;
             const break_sent = breakSentinel(depth);
             const continue_sent = continueSentinel(depth);
 
             const continue_label: ?u32 = if (!is_loop)
                 null
-            else if (is_for)
-                continue_sent // for loop: body 처리 후 fixup
+            else if (continue_via_update_label)
+                continue_sent // body 처리 후 generator_loop_continue_label 로 fixup
             else
-                next_label.*; // while/do-while: cond_label
+                next_label.*; // while: cond_label
 
             const ops_start = ops.items.len;
-            const saved_update_label = self.generator_for_update_label;
-            self.generator_for_update_label = null;
+            const saved_update_label = self.generator_loop_continue_label;
+            self.generator_loop_continue_label = null;
 
             try self.generator_label_stack.append(self.allocator, .{
                 .name = label_name,
@@ -894,8 +898,8 @@ pub fn ES2015Generator(comptime Transformer: type) type {
 
             _ = self.generator_label_stack.pop();
 
-            const actual_continue = if (is_for) self.generator_for_update_label orelse @as(u32, 0) else @as(u32, 0);
-            self.generator_for_update_label = saved_update_label;
+            const actual_continue = if (continue_via_update_label) self.generator_loop_continue_label orelse @as(u32, 0) else @as(u32, 0);
+            self.generator_loop_continue_label = saved_update_label;
 
             const end_label = next_label.*;
             next_label.* += 1;
@@ -903,7 +907,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             // fixup: break sentinel → end_label, continue sentinel → actual_continue
             const ops_slice = ops.items[ops_start..];
             fixupSentinel(ops_slice, break_sent, end_label);
-            if (is_for) {
+            if (continue_via_update_label) {
                 fixupSentinel(ops_slice, continue_sent, actual_continue);
             }
 
@@ -1069,6 +1073,10 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             // continue는 condition 평가 지점으로 점프
             const cond_label = next_label.*;
             next_label.* += 1;
+            // 라벨된 `continue label;` 도 (unlabeled 와 동일하게) 조건 평가 지점으로 가도록
+            // cond_label 을 generator_loop_continue_label 로 노출 — 이전엔 라벨 경로가 body_label 로
+            // 잘못 점프해 조건을 재평가하지 않았다 (#4281).
+            self.generator_loop_continue_label = cond_label;
             try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } }); // mark cond_label
 
             // condition → if true, goto body_label

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -185,7 +185,7 @@ pub const Transformer = struct {
 
     /// ES2015 generator: for loop의 update label (labeled continue 대상).
     /// collectForOperations에서 update nop 추가 직전에 설정.
-    generator_for_update_label: ?u32 = null,
+    generator_loop_continue_label: ?u32 = null,
 
     /// ES2015 generator: for-of 변환에서 생성한 임시 변수 span.
     /// buildGeneratorBody에서 호이스팅 변수에 추가.


### PR DESCRIPTION
## Summary

generator(`function*`) 다운레벨의 라벨된 `continue label;` 이 for-of/for-in/do-while 에서 **잘못된 타겟으로 점프**하던 결함을 수정합니다. `collectLabeledOperations` 의 게이트가 `.for_statement` 만 보고 지연-fixup(`generator_for_update_label`)을 적용해, for-of/for-in 의 라벨 continue 가 iterator advance(`_i++`)를 건너뛰고 **cond 로 점프 → 무한 루프**(#4), do-while 은 **body_label 로 점프 → 조건 미재평가**(#16)했습니다.

> **초보자 설명**
> - generator 는 `__generator` 상태 머신으로 낮춰지고 `continue` 는 특정 라벨로의 점프가 됩니다. `continue` 는 "다음 반복"으로 가야 하는데, for-of/for-in 은 iterator advance 지점, do-while 은 조건 평가 지점입니다.
> - for-of 의 advance 지점은 이미 `generator_for_update_label`로 노출돼 있었는데(머신 존재), 라벨 경로의 게이트가 `for_statement` 만 보고 이를 안 썼습니다.

## Changes

- `src/transformer/es2015_generator.zig`:
  - 게이트를 `is_loop and != while_statement`(while 제외 모든 루프)로 일반화 → 라벨 continue 가 for/for-of/for-in/do-while 에서 지연-fixup 사용.
  - `collectDoWhileOperations` 가 `cond_label` 을 `generator_loop_continue_label` 로 노출(unlabeled 와 동일 타겟).
  - 필드 rename `generator_for_update_label` → `generator_loop_continue_label`(이제 do-while cond_label 도 담아 의미 정확화).
- `src/codegen/codegen_test/es_downlevel.zig`: es5 회귀 테스트 2건(for-of, do-while).

### continue 타겟 라우팅

```mermaid
flowchart TD
    A["라벨된 loop 의 continue label"] --> B{"루프 종류"}
    B -- "while" --> C["cond_label (즉시 — 루프 최상단)"]
    B -- "for / for-of / for-in" --> D["sentinel → generator_loop_continue_label<br/>= 증분/iterator advance (_i++)"]
    B -- "do-while" --> E["sentinel → generator_loop_continue_label<br/>= cond_label (조건 재평가)"]
    D -. "이전 버그: for-of/for-in 이 cond 로 점프 → 무한 루프" .-> X1["💥"]
    E -. "이전 버그: do-while 이 body 로 점프 → 조건 미재평가" .-> X2["💥"]
```

## Test Plan

- [x] `zig build test` 통과 (5907/5907, 신규 회귀 2건 포함)
- [x] **런타임 실행 검증**: for-of repro 를 표준 `__generator` 로 실행 → 수정본 `value=4, done=true`(종료), 버그본 무한 루프(5초+ 미종료) 직접 확인
- [x] do-while repro: 수정본 continue → cond(case 3, 런타임 value=8), 버그본 → body(case 1)
- [x] `zig fmt --check` 통과
- [x] `/simplify` — 게이트를 `is_loop and != while` 로 단순화 + 필드 rename 적용

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음 (AST 노드 추가 없음)

Closes #4281
