### PR TITLE
fix(codegen): private mangler 가 생존 원본 이름과 충돌하는 generated 이름 할당 (중복 #a SyntaxError)

### DIFF
--- a/src/codegen/mod.zig
+++ b/src/codegen/mod.zig
@@ -38,5 +38,6 @@ test {
     _ = @import("codegen_test.zig");
     _ = @import("sourcemap_test.zig");
     _ = @import("mangler_test.zig");
+    _ = @import("private_mangler_test.zig");
     _ = @import("precedence_test.zig");
 }

--- a/src/codegen/private_mangler.zig
+++ b/src/codegen/private_mangler.zig
@@ -71,17 +71,23 @@ fn processClass(ast: *Ast, class_ni: u32) void {
     var renames: std.StringHashMapUnmanaged(Span) = .empty;
     defer renames.deinit(ast.allocator);
     var counter: u32 = 0;
-    for (names.keys()) |orig| {
+    outer: for (names.keys()) |orig| {
         var buf: [8]u8 = undefined;
-        const new_text = formatPrivateName(&buf, counter) orelse break;
+        // generated 이름이 rename 되지 않고 *생존하는 다른* 원본 이름과 같으면 중복 private
+        // 선언(JS SyntaxError)이 되므로 건너뛰고 다음 counter 를 쓴다. `names` 가 원본 전체
+        // 집합 = reserved set — 긴 원본은 짧은 generated 와 겹치지 않아 over-reserve 무해.
+        const new_text = candidate: while (true) {
+            const c = formatPrivateName(&buf, counter) orelse break :outer; // 이름 풀 소진
+            counter += 1;
+            if (names.contains(c) and !std.mem.eql(u8, c, orig)) continue;
+            break :candidate c;
+        };
         if (new_text.len >= orig.len) {
             // 원본보다 길어지면 rename 이득 없음 — skip (원본 유지)
-            counter += 1;
             continue;
         }
         const new_span = ast.addString(new_text) catch break;
         renames.put(ast.allocator, orig, new_span) catch break;
-        counter += 1;
     }
 
     if (renames.count() == 0) return;

--- a/src/codegen/private_mangler_test.zig
+++ b/src/codegen/private_mangler_test.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+const Scanner = @import("../lexer/scanner.zig").Scanner;
+const Parser = @import("../parser/parser.zig").Parser;
+const Transformer = @import("../transformer/transformer.zig").Transformer;
+const Codegen = @import("codegen.zig").Codegen;
+const manglePrivateFields = @import("private_mangler.zig").manglePrivateFields;
+
+fn mangleAndGen(allocator: std.mem.Allocator, source: []const u8) ![]const u8 {
+    var scanner = try Scanner.init(allocator, source);
+    var parser = Parser.init(allocator, &scanner);
+    _ = try parser.parse();
+    var t = try Transformer.init(allocator, &parser.ast, .{});
+    const root = try t.transform();
+    manglePrivateFields(t.ast);
+    var cg = Codegen.initWithOptions(allocator, t.ast, .{ .minify_whitespace = true });
+    return try cg.generate(root);
+}
+
+test "private mangle: generated 이름이 생존 원본과 충돌 안 함 (#4283)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    // `#zzzzz` 는 `#a` 로 줄지만 원본 `#a` 가 생존 → reserved 라 `#b` 로 배정.
+    // 버그 땐 `#zzzzz`→`#a` + 원본 `#a` 가 둘 다 `#a` (중복 private = SyntaxError).
+    const out = try mangleAndGen(a,
+        \\class C { #zzzzz = 1; #a = 2; m() { return this.#zzzzz + this.#a; } }
+    );
+    try std.testing.expectEqualStrings("class C{#b=1;#a=2;m(){return this.#b+this.#a;}}", out);
+}


### PR DESCRIPTION
## Summary

`src/codegen/private_mangler.zig` 의 private field mangler 가 generated 이름(`#a`, `#b`, …)을 할당할 때, 그 이름이 rename 되지 않고 **생존하는 다른 원본 private 이름과 충돌하는지** 확인하지 않아, 같은 class 에 중복 private 선언 → JS `SyntaxError` 가 발생하던 결함을 수정합니다.

> **초보자 설명**
> - `class C { #zzzzz = 1; #a = 2; }` mangle 시: `#zzzzz` 는 길어서 `#a` 로 줄이는데, 원본 `#a` 는 2글자라 그대로 둡니다 → `class C { #a = 1; #a = 2; }` (같은 class 에 `#a` 둘 = 문법 오류).
> - private name 은 class body 안에서 유일해야 합니다. 줄이는 이름이 "그대로 남는 다른 이름"과 안 겹치게 예약해야 합니다.

## Changes

- `src/codegen/private_mangler.zig`: Phase 2 에서 원본 이름 집합(`names`)을 reserved set 으로 삼아, generated 이름이 *다른* 원본과 충돌하면 `counter` 를 advance. 긴 원본은 짧은 generated 와 겹치지 않아 over-reserve 무해(/simplify altitude 검토 확인).
- `src/codegen/private_mangler_test.zig`(신규) + `mod.zig` 등록: 회귀 단위 테스트.

### 이름 할당

```mermaid
flowchart TD
    A["원본 private 이름 순회"] --> B["generated 후보 = formatPrivateName(counter)"]
    B --> C{"후보가 *다른* 생존 원본과 충돌?"}
    C -- "예 (예: 후보 #a == 생존 원본 #a)" --> D["counter++ → 다음 후보 (#b)"]
    D --> B
    C -- "아니오" --> E{"후보가 원본보다 짧음?"}
    E -- "예" --> F["rename 원본 → 후보"]
    E -- "아니오" --> G["원본 유지 (생존)"]
```

## Test Plan

- [x] `zig build test` 통과 (5908/5908, 신규 회귀 포함)
- [x] `class C { #zzzzz=1; #a=2; ... }` mangle 출력 = `class C{#b=1;#a=2;...}` (중복 없음)
- [x] 회귀 검증: reserved 체크를 제거하면 신규 테스트가 중복 `#a` 로 실패 → 체크 시 통과
- [x] `zig fmt --check` 통과
- [x] `/simplify` — clean (over-reserve sound, per-class scope 정확, identifier mangler 와 별개)

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음

Closes #4283
