### PR TITLE
fix(core): identifyWorkspaceEntries 가 다중 inline 워크스페이스를 cwd-dedup 으로 누락

### DIFF
--- a/packages/core/src/workspace.test.ts
+++ b/packages/core/src/workspace.test.ts
@@ -198,6 +198,32 @@ describe('identifyWorkspaceEntries', () => {
     expect(r[0]?.source).toBe('inline');
   });
 
+  test('다중 inline 엔트리 — 모두 식별 (cwd 동일이어도 name 으로 dedup) (#4285)', () => {
+    const r = identifyWorkspaceEntries(
+      [
+        { name: 'a', entryPoints: ['./a.ts'] },
+        { name: 'b', entryPoints: ['./b.ts'] },
+        { name: 'c', entryPoints: ['./c.ts'] },
+      ],
+      dir,
+    );
+    // 버그 땐 cwd(=rootDir) dedup 으로 'a' 만 남았다.
+    expect(r.map((e) => e.name)).toEqual(['a', 'b', 'c']);
+    // name 필터가 두 번째 이후 inline 도 찾을 수 있어야 한다.
+    expect(filterWorkspaces(r, 'b').map((e) => e.name)).toEqual(['b']);
+  });
+
+  test('다중 inline — 같은 name 은 첫 번째만 (dedup)', () => {
+    const r = identifyWorkspaceEntries(
+      [
+        { name: 'dup', entryPoints: ['./1.ts'] },
+        { name: 'dup', entryPoints: ['./2.ts'] },
+      ],
+      dir,
+    );
+    expect(r).toHaveLength(1);
+  });
+
   test('3종 형식 동시 사용', () => {
     const r = identifyWorkspaceEntries(
       ['./packages/app', './packages/lib-*', { name: 'inline-x', entryPoints: ['x'] }],

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -224,8 +224,11 @@ export function identifyWorkspaceEntries(
   const seen = new Set<string>();
   const out: IdentifiedWorkspace[] = [];
   const push = (w: IdentifiedWorkspace) => {
-    if (seen.has(w.cwd)) return;
-    seen.add(w.cwd);
+    // path/glob 은 같은 cwd 매칭을 dedup. inline 엔트리는 모두 cwd=rootDir 라 cwd 로
+    // dedup 하면 첫 개만 남으므로 name 으로 식별한다(여러 inline preset 공존 허용).
+    const key = w.source === 'inline' ? `inline:${w.name}` : w.cwd;
+    if (seen.has(key)) return;
+    seen.add(key);
     out.push(w);
   };
 


### PR DESCRIPTION
## Summary

`packages/core/src/workspace.ts` 의 `identifyWorkspaceEntries` 가 dedup 키로 `w.cwd` 를 쓰는데, **inline 엔트리는 모두 `cwd: rootDir`** 라 첫 inline 만 남고 나머지가 전부 drop 되던 결함을 수정합니다.

> **초보자 설명**
> - dedup 의 원래 의도는 "같은 디렉토리(`cwd`)가 path + glob 양쪽에 매칭되면 첫 번째만 유지"입니다.
> - inline 엔트리(`{ name, ...config }`)는 디렉토리가 아니라 객체라 모두 같은 `cwd(rootDir)` 를 갖습니다 → cwd 로 dedup 하면 첫 inline 만 살아남습니다. inline 은 **name** 으로 구별해야 합니다.

## Changes

- `packages/core/src/workspace.ts`: dedup 키를 `source === 'inline' ? \`inline:${name}\` : cwd` 로 분기. inline 은 name(여러 preset 공존), path/glob 은 cwd(기존 동작 유지). `inline:` 접두사는 절대경로 cwd 와 충돌 불가.
- `packages/core/src/workspace.test.ts`: 회귀 테스트 2건.

### dedup 키 결정

```mermaid
flowchart TD
    A["push(workspace)"] --> B{"source"}
    B -- "path / glob" --> C["key = cwd (디렉토리 dedup)"]
    B -- "inline" --> D["key = inline:name<br/>(이전 버그: cwd=rootDir 공유 → 첫 개만)"]
    C & D --> E{"seen.has(key)?"}
    E -- "예" --> F["drop"]
    E -- "아니오" --> G["push"]
```

## Test Plan

- [x] `bun test`(packages/core) — workspace 테스트 35 pass / 0 fail (신규 2건 포함)
- [x] 다중 inline `[{name:a},{name:b},{name:c}]` → 3개 모두 식별 + `filterWorkspaces(_,'b')` 동작
- [x] 같은 name inline 은 첫 번째만 (dedup 유지), path/glob cwd dedup 동작 유지
- [x] 회귀 검증: cwd-dedup 복원 시 multi-inline 테스트 실패 → 수정 시 통과
- [x] `oxlint` 0 error
- [ ] 비고: packages/core 의 config-schema-sync 테스트 4건은 본 PR 과 무관한 **사전 존재 drift**(main 에서도 동일 4 fail 재현)

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음

Closes #4285
