### PR TITLE
fix(config): tsconfig target case-sensitive 매칭 — PascalCase(ESNext/ES2020) 다운레벨 비활성화

### DIFF
--- a/src/tsconfig_merge.zig
+++ b/src/tsconfig_merge.zig
@@ -69,8 +69,19 @@ fn mapTsConfigJsxToRuntime(tsconfig_jsx: ?[]const u8) ?codegen.JsxRuntime {
 pub fn merge(ts: *const TsConfig, explicit: ExplicitFlags) MergedFlags {
     const experimental_decorators = explicit.experimental_decorators orelse ts.experimental_decorators;
     const es_target: ?compat.ESTarget = explicit.es_target orelse blk: {
-        if (ts.target) |t_str| break :blk std.meta.stringToEnum(compat.ESTarget, t_str);
-        break :blk null;
+        const t_str = ts.target orelse break :blk null;
+        // tsconfig target 은 대소문자 무관(TS 공식: "ES2020"/"ESNext"/"es2020"). enum 필드명은
+        // 소문자라 입력을 소문자로 정규화해 매칭 — 미정규화 시 PascalCase 가 null→다운레벨 비활성.
+        // 버퍼 크기는 enum 최장 필드명에서 comptime 계산(compat.Engine.fromString 동형).
+        const max_len = comptime blk2: {
+            var m: usize = 0;
+            for (std.meta.fields(compat.ESTarget)) |f| m = @max(m, f.name.len);
+            break :blk2 m;
+        };
+        var buf: [max_len]u8 = undefined;
+        if (t_str.len > buf.len or t_str.len == 0) break :blk null;
+        const lower = std.ascii.lowerString(buf[0..t_str.len], t_str);
+        break :blk std.meta.stringToEnum(compat.ESTarget, lower);
     };
     return .{
         .experimental_decorators = experimental_decorators,
@@ -93,6 +104,29 @@ pub fn merge(ts: *const TsConfig, explicit: ExplicitFlags) MergedFlags {
 }
 
 // ─── 테스트 ───
+
+test "merge: tsconfig target 은 대소문자 무관 (#4287)" {
+    // TS 공식 tsconfig target 은 PascalCase("ES2020"/"ESNext"). enum 은 소문자라
+    // 정규화 없으면 null → 다운레벨 비활성. 대소문자 무관하게 인식돼야 한다.
+    const cases = [_]struct { in: []const u8, want: compat.ESTarget }{
+        .{ .in = "ES2020", .want = .es2020 },
+        .{ .in = "es2020", .want = .es2020 },
+        .{ .in = "ESNext", .want = .esnext },
+        .{ .in = "esnext", .want = .esnext },
+        .{ .in = "ES2015", .want = .es2015 },
+        .{ .in = "ES5", .want = .es5 },
+    };
+    for (cases) |c| {
+        var ts = TsConfig{};
+        ts.target = c.in;
+        const merged = merge(&ts, .{});
+        try std.testing.expectEqual(@as(?compat.ESTarget, c.want), merged.es_target);
+    }
+    // 인식 불가 값은 여전히 null.
+    var bad = TsConfig{};
+    bad.target = "nonsense";
+    try std.testing.expectEqual(@as(?compat.ESTarget, null), merge(&bad, .{}).es_target);
+}
 
 test "merge: explicit values win over tsconfig" {
     var ts = TsConfig{};


### PR DESCRIPTION
## Summary

`src/tsconfig_merge.zig` 가 tsconfig 의 `target` 을 `std.meta.stringToEnum` 으로 **case-sensitive** 매칭해, `ESTarget` enum 필드명(소문자 `es2020`/`esnext`)과 다른 **TS 공식 PascalCase**(`"ES2020"`/`"ESNext"`)가 `null` 로 떨어져 **ES 다운레벨링이 통째로 비활성화**되던 결함을 수정합니다.

> **초보자 설명**
> - `std.meta.stringToEnum` 은 enum 필드 이름과 글자 그대로 일치해야 값을 줍니다. enum 은 `esnext`(소문자)인데 입력이 `"ESNext"` 면 불일치 → null.
> - TypeScript 는 `target` 을 대소문자 무관하게 받습니다(`"ES2020"`, `"es2020"`, `"ESNext"` 모두 유효). es_target 이 null 이면 async/class field/generator 등 다운레벨이 통째로 꺼집니다.

## Changes

- `src/tsconfig_merge.zig`: `target` 문자열을 소문자로 정규화 후 `stringToEnum`. 버퍼 크기는 enum 최장 필드명에서 comptime 계산(`compat.Engine.fromString` 동형 idiom). 빈 문자열/과길이는 null.
- 회귀 테스트(table-driven): `"ES2020"`/`"es2020"`/`"ESNext"`/`"esnext"`/`"ES2015"`/`"ES5"` 모두 매핑 + `"nonsense"` → null.

### target 정규화

```mermaid
flowchart TD
    A["tsconfig target 문자열"] --> B{"explicit --target?"}
    B -- "있음" --> Z["explicit 우선"]
    B -- "없음" --> C["소문자 정규화"]
    C --> D["stringToEnum(ESTarget)"]
    D -- "매칭 (es2020...)" --> E["es_target → compat.fromESTarget 다운레벨"]
    D -- "미매칭 (nonsense)" --> F["null (다운레벨 없음)"]
```

## Test Plan

- [x] `zig build test` 통과 (5909/5909, 신규 회귀 포함)
- [x] TDD: 수정 전 `"ES2020"` → `expected .es2020, found null` 로 실패(red) → 수정 후 통과(green)
- [x] `zig fmt --check` 통과
- [x] `/simplify` — comptime max_len 으로 매직넘버 제거(`Engine.fromString` idiom)

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음

Closes #4287
