### PR TITLE
fix(codegen): export default sequence 괄호 drop — emitExpr(.comma) 로 wrap

### DIFF
--- a/src/codegen/codegen_test/cjs_importmeta.zig
+++ b/src/codegen/codegen_test/cjs_importmeta.zig
@@ -239,3 +239,13 @@ test "import.meta: unknown property CJS browser" {
 }
 
 // ============================================================
+
+test "Codegen CJS: export default sequence 는 괄호 보존 (#4289)" {
+    // `export default (1, 2)` 의 default 는 sequence 전체(=2). 괄호 없이 `module.exports=1,2`
+    // 로 내면 `(module.exports=1),2` 로 파싱돼 default 가 1 이 된다 → 괄호 필수.
+    var r = try e2eCJS(std.testing.allocator, "export default (1, 2);");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "module.exports=(1,2)") != null);
+    // 버그 시그니처(괄호 없는 bare sequence)가 없어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "module.exports=1,2;") == null);
+}

--- a/src/codegen/modules.zig
+++ b/src/codegen/modules.zig
@@ -484,7 +484,8 @@ pub fn emitExportDefault(self: anytype, node: Node) !void {
                         if (!self.options.esm_var_assign_only) try self.write("var ");
                         try self.write(def_name);
                         try self.writeByte('=');
-                        try self.emitNode(inner);
+                        // sequence(comma) inner 는 괄호 wrap 필요 — `=a,b` 가 `(=a),b` 로 깨짐 (#4289).
+                        try self.emitExpr(inner, .comma, .{});
                         try self.writeByte(';');
                     } else if (!self.isExportDefaultSelfRef(inner, def_name)) {
                         // namespace import이면 ns var name을 직접 사용 (rename과 다름).
@@ -492,7 +493,7 @@ pub fn emitExportDefault(self: anytype, node: Node) !void {
                             // mangling으로 이름이 바뀐 경우 (View → View$44) 할당 필요.
                             try self.write(def_name);
                             try self.writeByte('=');
-                            try self.emitNode(inner);
+                            try self.emitExpr(inner, .comma, .{});
                             try self.writeByte(';');
                         }
                     }
@@ -502,7 +503,7 @@ pub fn emitExportDefault(self: anytype, node: Node) !void {
         }
         try self.write(self.options.cjs_module_name);
         try self.write(".exports=");
-        try self.emitNode(node.data.unary.operand);
+        try self.emitExpr(node.data.unary.operand, .comma, .{});
         try self.writeByte(';');
         return;
     }
@@ -596,7 +597,8 @@ pub fn emitDefaultVarAssignment(self: anytype, name: []const u8, inner: NodeInde
         try self.write(name);
         try self.write(" = ");
     }
-    try self.emitNode(inner);
+    // sequence(comma) inner 는 괄호 wrap — `var x = a,b` 가 두 선언으로 깨짐 (#4289).
+    try self.emitExpr(inner, .comma, .{});
     try self.writeByte(';');
 }
 


### PR DESCRIPTION
## Summary

`export default` 출력이 inner expression 을 precedence 없는 `emitNode` 로 내, **sequence(comma) inner 일 때 괄호가 누락**되던 miscompile 을 수정합니다.

```
export default (1, 2);
→  module.exports=1,2;     // (module.exports=1),2 로 파싱 → default = 1 (2 여야 함)
```

> **초보자 설명**
> - `=`(할당)은 `,`(comma)보다 우선순위가 높아 `x = a, b` 는 `(x = a), b` 입니다. `export default (a,b)` 의 default 는 sequence 전체(=b)라 `module.exports = (a, b)` 처럼 괄호를 보존해야 합니다.
> - codegen 의 `emitExpr(node, .comma, .{})` 는 sequence 를 자동으로 괄호 wrap 합니다(esbuild LComma parity). precedence 컨텍스트 없는 `emitNode` 는 bare 출력 → 버그.

## Changes

- `src/codegen/modules.zig`: default-export 할당 4사이트(`_default` 합성 / mangled name / cjs `module.exports` / bundle `var`)의 `emitNode(inner)` → `emitExpr(inner, .comma, .{})`.
- `src/codegen/codegen_test/cjs_importmeta.zig`: CJS 회귀 테스트.

### emit precedence

```mermaid
flowchart TD
    A["export default inner"] --> B{"inner 가 sequence(comma)?"}
    B -- "예" --> C["emitExpr(.comma) → 괄호 wrap: (a,b)"]
    B -- "아니오" --> D["그대로 출력 (괄호 불필요)"]
    C --> E["module.exports=(a,b)  ✅ default=b"]
    D --> F["module.exports=expr"]
```

## Test Plan

- [x] `zig build test` 통과 (5910/5910, 신규 회귀 포함)
- [x] TDD: 수정 전 `export default (1,2)` → `module.exports=1,2;`(red) → 수정 후 `module.exports=(1,2)`(green)
- [x] `/simplify` — idiom 일치, 누락 사이트 없음 확인
- [x] `zig fmt --check` 통과

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음

Closes #4289
