### PR TITLE
fix(core): 플러그인 filter g/y 플래그 stateful lastIndex — 파일 격번 skip

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -2040,24 +2040,28 @@ function collectPluginRegistry(plugins: ZntcPlugin[]): PluginRegistry {
       onResolve(opts, cb) {
         registry.hooks.resolveId.push({
           pluginName: plugin.name,
-          filter: opts.filter,
+          filter: stripStatefulFilterFlags(opts.filter),
           callback: cb,
         });
       },
       onLoad(opts, cb) {
-        registry.hooks.load.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
+        registry.hooks.load.push({
+          pluginName: plugin.name,
+          filter: stripStatefulFilterFlags(opts.filter),
+          callback: cb,
+        });
       },
       onTransform(opts, cb) {
         registry.hooks.transform.push({
           pluginName: plugin.name,
-          filter: opts.filter,
+          filter: stripStatefulFilterFlags(opts.filter),
           callback: cb,
         });
       },
       onRenderChunk(opts, cb) {
         registry.hooks.renderChunk.push({
           pluginName: plugin.name,
-          filter: opts.filter,
+          filter: stripStatefulFilterFlags(opts.filter),
           callback: cb,
         });
       },
@@ -2076,14 +2080,14 @@ function collectPluginRegistry(plugins: ZntcPlugin[]): PluginRegistry {
       onAstFunction(opts, cb) {
         registry.astFunctionHooks.push({
           pluginName: plugin.name,
-          filter: opts.filter,
+          filter: stripStatefulFilterFlags(opts.filter),
           callback: cb,
         });
       },
       onResolveContext(opts, cb) {
         registry.hooks.resolveContext.push({
           pluginName: plugin.name,
-          filter: opts.filter,
+          filter: stripStatefulFilterFlags(opts.filter),
           callback: cb,
         });
       },
@@ -2210,6 +2214,16 @@ function getPluginContext(
   slot.__emitFile = emitFile;
   slot.__getFileName = getFileName;
   return ctx;
+}
+
+/**
+ * 플러그인 filter 정규식을 무상태로 정규화. `g`/`y` 플래그 정규식의 `.test()` 는 lastIndex 를
+ * 누적(stateful)해, 같은 정규식으로 여러 파일을 검사하면 격번으로 skip 된다(#4291). 등록 시
+ * 플래그를 제거해 immutable·무상태 정규식으로 저장한다 — 사용자 RegExp 객체는 변형하지 않는다.
+ */
+function stripStatefulFilterFlags(re: RegExp): RegExp {
+  if (!re.global && !re.sticky) return re;
+  return new RegExp(re.source, re.flags.replace(/[gy]/g, ''));
 }
 
 /**

--- a/packages/core/test/core/build-plugins/basic-hooks/transform.ts
+++ b/packages/core/test/core/build-plugins/basic-hooks/transform.ts
@@ -37,4 +37,38 @@ describe('@zntc/core build + plugins - transform hooks', () => {
       rmSync(entryDir, { recursive: true, force: true });
     }
   });
+
+  test('transform filter 가 g 플래그여도 모든 매칭 파일 처리 (#4291)', async () => {
+    // /…/g 정규식의 .test() 는 stateful(lastIndex 누적)이라, 미수정 시 파일을 격번 skip.
+    const transformed: string[] = [];
+    const plugin: ZntcPlugin = {
+      name: 'g-filter-plugin',
+      setup(build) {
+        build.onTransform({ filter: /\.ts$/g }, (args) => {
+          transformed.push(args.path ?? '');
+          return { code: args.code.replace(/OLDVAL/g, 'NEWVAL') };
+        });
+      },
+    };
+
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-gfilter-'));
+    try {
+      writeFileSync(join(dir, 'a.ts'), 'import "./b.ts"; export const a = "OLDVAL";');
+      writeFileSync(join(dir, 'b.ts'), 'import "./c.ts"; export const b = "OLDVAL";');
+      writeFileSync(join(dir, 'c.ts'), 'import "./d.ts"; export const c = "OLDVAL";');
+      writeFileSync(join(dir, 'd.ts'), 'export const d = "OLDVAL";');
+
+      const result = await build({
+        entryPoints: [join(dir, 'a.ts')],
+        plugins: [plugin],
+      });
+      expect(result.errors.length).toBe(0);
+      // 모든 .ts 파일(4개)이 transform 콜백을 받아야 한다 — 격번 skip 이면 4 미만.
+      expect(transformed.length).toBe(4);
+      // 어떤 파일도 변환 누락(OLDVAL 잔존)되면 안 된다.
+      expect(result.outputFiles[0].text).not.toContain('OLDVAL');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

플러그인 hook 의 `filter` RegExp 에 **`g`/`y` 플래그**가 붙어 있으면 `.test()` 가 stateful(`lastIndex` 누적)이 되어, 같은 정규식으로 여러 파일을 검사할 때 **파일을 격번(every-other)으로 건너뛰던** 결함을 수정합니다.

> **초보자 설명**
> - `g`/`y` 정규식의 `re.test(s)` 는 호출마다 `re.lastIndex` 를 옮깁니다. `/\.ts$/g.test("a.ts")`→true(lastIndex=4), 이어서 `.test("b.ts")`→lastIndex 4부터 검색→no match→false. 결과적으로 절반의 파일만 매칭됩니다.
> - 정규식의 플래그(`g`/`y`)를 등록 시 제거하면 무상태가 되어 모든 파일이 일관되게 검사됩니다.

## Changes

- `packages/core/index.ts`: `stripStatefulFilterFlags(re)` 추가 — 등록 시점(6개 hook push: resolveId/load/transform/renderChunk/astFunction/resolveContext)에서 `g`/`y` 플래그를 제거해 immutable·무상태 정규식으로 저장. **사용자 RegExp 객체는 변형하지 않음**(경계에서 한 번 정규화 — /simplify altitude 권장).
- `.../basic-hooks/transform.ts`: 회귀 테스트(`/\.ts$/g` filter + 4개 파일 → 전부 transform).

### filter 정규화 (등록 경계)

```mermaid
flowchart TD
    A["plugin: onTransform({ filter: /…/g })"] --> B["등록: stripStatefulFilterFlags"]
    B --> C{"g/y 플래그?"}
    C -- "예" --> D["new RegExp(source, flags 제거) — 무상태 저장"]
    C -- "아니오" --> E["그대로 저장"]
    D & E --> F["dispatch: filter.test(path) — 매 파일 일관 매칭"]
```

## Test Plan

- [x] `bun test`(packages/core) — 신규 회귀 포함, transform 테스트 통과
- [x] TDD: 수정 전 `/\.ts$/g` + 4파일 → `transformed.length` Expected 4 Received 2 (red) → 수정 후 4 (green)
- [x] `oxlint` 0 error
- [x] `/simplify` — call-site lastIndex 리셋 대신 **등록 시점 정규화**로 전환(user regex 무변이, 4 dispatch 사이트 모두 커버 확인)
- [ ] 비고: packages/core 의 config-schema-sync 4건은 본 PR 무관한 사전 존재 drift(main 동일)

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음

Closes #4291
