### PR TITLE
fix(flow): 리터럴 타입이 binary/octal/exponential 숫자 누락 — isNumericLiteral() 일반화

### DIFF
--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -359,6 +359,17 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         }
     }
 
+    // 숫자 리터럴 타입(decimal/float/binary/octal/hex/exponential/bigint) — 하드코딩 나열이
+    // binary/octal/exponential 을 누락했으므로 TS(D15)와 동일하게 isNumericLiteral() 로 일반화 (#4293).
+    if (self.current().isNumericLiteral()) {
+        try self.advance();
+        return try self.ast.addNode(.{
+            .tag = .flow_literal_type,
+            .span = .{ .start = span.start, .end = self.currentSpan().start },
+            .data = .{ .string_ref = span },
+        });
+    }
+
     switch (self.current()) {
         // void
         .kw_void => {
@@ -418,15 +429,8 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
                 .data = .{ .none = 0 },
             });
         },
-        .decimal,
-        .float,
-        .hex,
-        .string_literal,
-        .decimal_bigint,
-        .hex_bigint,
-        .octal_bigint,
-        .binary_bigint,
-        => {
+        // 숫자 리터럴은 위 isNumericLiteral() guard 가 처리 — 여기선 문자열 리터럴 타입만.
+        .string_literal => {
             try self.advance();
             return try self.ast.addNode(.{
                 .tag = .flow_literal_type,
@@ -471,10 +475,8 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         // 음수 리터럴 타입: -1
         .minus => {
             try self.advance(); // skip -
-            if (self.current() == .decimal or self.current() == .float or self.current() == .hex or
-                self.current() == .decimal_bigint or self.current() == .hex_bigint or
-                self.current() == .octal_bigint or self.current() == .binary_bigint)
-            {
+            // TS(D15)와 동일하게 isNumericLiteral() 로 일반화 — binary/octal/exponential 포함 (#4293).
+            if (self.current().isNumericLiteral()) {
                 try self.advance();
                 return try self.ast.addNode(.{
                     .tag = .flow_literal_type,

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3861,6 +3861,27 @@ test "TS: numeric literal type accepts all numeric kinds (D15)" {
     try expectNoParseErrorWithExt("export type T = -1;", ".ts");
 }
 
+test "Flow: numeric literal type accepts all numeric kinds (#4293)" {
+    // TS(D15)와 동일 — Flow 리터럴 타입 dispatch 도 binary/octal/exponential 누락이 root cause.
+    // isNumericLiteral() 로 일반화돼야 한다.
+    try expectNoParseErrorFlow("type T = 1e3;");
+    try expectNoParseErrorFlow("type T = 1e999;");
+    try expectNoParseErrorFlow("type T = 1e-10;");
+    try expectNoParseErrorFlow("type T = 0b101;");
+    try expectNoParseErrorFlow("type T = 0o77;");
+    // 음수 리터럴
+    try expectNoParseErrorFlow("type T = -1e999;");
+    try expectNoParseErrorFlow("type T = -0b101;");
+    try expectNoParseErrorFlow("type T = -0o77;");
+    // 기존 통과 케이스 회귀 가드
+    try expectNoParseErrorFlow("type T = 1;");
+    try expectNoParseErrorFlow("type T = 1.5;");
+    try expectNoParseErrorFlow("type T = 0xff;");
+    try expectNoParseErrorFlow("type T = 1n;");
+    try expectNoParseErrorFlow("type T = -1;");
+    try expectNoParseErrorFlow("type T = 'str';");
+}
+
 test "TS: type predicate subject accepts contextual keyword (D14)" {
     // immer `src/utils/common.ts` 의 `(target: any): target is Map<...> => ...` 패턴.
     // `target` 은 ECMAScript contextual keyword (`new.target` 용) 라 `.kw_target` 으로


### PR DESCRIPTION
## Summary

Flow 리터럴 타입 파싱(`parsePrimaryType`)이 숫자 토큰을 **하드코딩으로 나열**하면서 `.binary`/`.octal`/`positive_exponential`/`negative_exponential` 을 **누락**해, `0b101`/`0o77`/`1e3`/`-1e999` 같은 Flow 리터럴 타입이 spurious **"Type expected"** 에러로 파스 derail 되던 결함을 수정합니다. (TS 경로는 이미 D15 에서 `isNumericLiteral()` 로 일반화됨 — Flow 미포팅.)

> **초보자 설명**
> - lexer 는 `0b101`→`.binary`, `0o77`→`.octal`, `1e3`→`positive_exponential` 토큰을 만듭니다. dispatch 나열에서 빠지면 "타입 아님"으로 판단해 에러를 냅니다.
> - `Kind.isNumericLiteral()` 은 `decimal..hex_bigint` 전 범위(모든 숫자 종류)를 커버하므로, 나열 대신 이걸 쓰면 누락이 없습니다.

## Changes

- `src/parser/flow.zig`: 양수 경로는 switch 전 `isNumericLiteral()` guard 로 일반화, switch case 는 `.string_literal` 만, 음수(`.minus`) if 도 `isNumericLiteral()` 로 교체.
- `src/parser/parser_test.zig`: Flow 회귀 테스트(양/음수 binary/octal/exponential + 기존 케이스 가드).

### 리터럴 타입 dispatch

```mermaid
flowchart TD
    A["parsePrimaryType"] --> B{"isNumericLiteral()?<br/>(decimal..hex_bigint 전체)"}
    B -- "예 (binary/octal/exp/bigint 포함)" --> C["flow_literal_type"]
    B -- "아니오" --> D["switch: string_literal / minus / 기타 타입"]
    D -- "minus 후 isNumericLiteral()" --> C
```

## Test Plan

- [x] `zig build test` 통과 (5911/5911, 신규 Flow 회귀 포함)
- [x] TDD: 수정 전 `type T = 0o77;` 등 → "Type expected"(red) → 수정 후 통과(green)
- [x] `/simplify` — TS 와 동일 idiom, guard 배치 안전, 다른 하드코딩 list 없음
- [x] `zig fmt --check` 통과

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음

Closes #4293
