### PR TITLE
fix(bundler): clearCanonicalNames 가 ns_export_cache 미무효화 — canonical_strings borrow UAF

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -468,13 +468,7 @@ pub const Linker = struct {
         while (cc_it.next()) |key| self.allocator.free(key.*);
         self.chain_cache.deinit(self.allocator);
         // ns_export_cache: 슬라이스 + owned local 해제
-        var nec_it = self.ns_export_cache.iterator();
-        while (nec_it.next()) |entry| {
-            for (entry.value_ptr.*) |exp| {
-                if (exp.owned) self.allocator.free(exp.local);
-            }
-            self.allocator.free(entry.value_ptr.*);
-        }
+        self.freeNsExportCacheEntries();
         self.ns_export_cache.deinit(self.allocator);
         // ns_inline_cache: 문자열 해제
         var nic_it = self.ns_inline_cache.valueIterator();
@@ -3085,6 +3079,22 @@ pub const Linker = struct {
         self.canonical_names_used.clearRetainingCapacity();
         // 값이 방금 free 된 stale slice 를 가리키지 않도록 rename_table 도 함께 clear.
         self.rename_table.clear();
+        // ns_export_cache 의 non-owned local 도 rename_table → canonical_strings 를 borrow 하므로
+        // (collectExportsRecursive "default" 경로) canonical_strings free 뒤엔 stale → 함께 무효화. #4297
+        self.freeNsExportCacheEntries();
+        self.ns_export_cache.clearRetainingCapacity();
+    }
+
+    /// ns_export_cache 의 모든 엔트리 해제(owned local + 슬라이스). 컨테이너 정리
+    /// (deinit vs clearRetainingCapacity)는 호출자가 한다. deinit/clearCanonicalNames 공용.
+    fn freeNsExportCacheEntries(self: *Linker) void {
+        var nec_it = self.ns_export_cache.iterator();
+        while (nec_it.next()) |entry| {
+            for (entry.value_ptr.*) |exp| {
+                if (exp.owned) self.allocator.free(exp.local);
+            }
+            self.allocator.free(entry.value_ptr.*);
+        }
     }
 
     /// RFC #3940 Sub-PR-L.5a — graph carry-over 가 `module.pending_renames` 에 stash 한 rename

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -2078,3 +2078,25 @@ test "reuse: F5 — rename_table 키의 symbolLocalName 이 null 이면 스냅�
         try std.testing.expect(false); // 도달 불가 — null 이어야 한다.
     }
 }
+
+test "clearCanonicalNames: ns_export_cache 도 무효화 (non-owned local canonical_strings UAF, #4297)" {
+    const allocator = std.testing.allocator;
+    var cache = resolve_cache_mod.ResolveCache.init(allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(allocator, &cache);
+    defer graph.deinit();
+    var linker = Linker.init(allocator, &graph, .esm);
+    defer linker.deinit();
+
+    // ns_export_cache 의 non-owned local 은 canonical_strings 를 borrow → clearCanonicalNames 가
+    // canonical_strings 를 free 하면 stale. 캐시도 무효화돼야 한다. owned 엔트리로 free 까지 검증.
+    const owned_local = try allocator.dupe(u8, "_default");
+    const slice = try allocator.alloc(Linker.NsExportPair, 1);
+    slice[0] = .{ .exported = "x", .local = owned_local, .owned = true };
+    try linker.ns_export_cache.put(allocator, 0, slice);
+
+    linker.clearCanonicalNames();
+
+    // 버그: 캐시 미정리 → stale 엔트리 잔존(+owned local leak, testing allocator 감지).
+    try std.testing.expectEqual(@as(usize, 0), linker.ns_export_cache.count());
+}


### PR DESCRIPTION
## Summary

per-chunk rename 초기화 `clearCanonicalNames` 가 `canonical_strings` 를 free 하고 `rename_table` 을 clear 하면서, **같은 `canonical_strings` 를 borrow 하는 `ns_export_cache` 는 무효화하지 않아** code-splitting 시 다음 청크에서 stale 캐시를 읽는 **use-after-free** 를 수정합니다.

> **초보자 설명**
> - `rename_table` 의 값과 `ns_export_cache` 의 일부 엔트리(`default` namespace export 의 non-owned `.local`)는 둘 다 `canonical_strings` 안의 문자열을 가리킵니다.
> - `clearCanonicalNames` 는 `canonical_strings` 를 해제하면서 stale 방지로 `rename_table` 만 비우고 `ns_export_cache` 는 빠뜨렸습니다(주석에 stale 위험을 인지했으면서 — 방어 누락).
> - 다음 청크가 그 캐시 엔트리를 읽으면 해제된 메모리를 봅니다.

## Changes

- `src/bundler/linker.zig`: `clearCanonicalNames` 에서 `ns_export_cache` 의 owned local + 슬라이스 해제 후 `clearRetainingCapacity`. 중복 정리 루프(deinit 과 동일)를 `freeNsExportCacheEntries` 헬퍼로 추출(공용).
- `src/bundler/linker_test.zig`: 단위 테스트(owned 엔트리 put → clearCanonicalNames → 비어야 + leak 없음).

### canonical_strings 수명

```mermaid
flowchart TD
    A["clearCanonicalNames (per-chunk)"] --> B["canonical_strings free"]
    B --> C["rename_table.clear (값이 stale → 무효화)"]
    B --> D["ns_export_cache.freeNsExportCacheEntries + clear<br/>(non-owned local 도 canonical_strings borrow)"]
    D -. "이전: 누락 → 다음 청크 stale read UAF" .-> X["💥"]
```

## Test Plan

- [x] `zig build test` 통과 (5913/5913, 신규 단위 테스트 포함)
- [x] TDD: 수정 전 clearCanonicalNames 후 `ns_export_cache.count()` Expected 0 Found 1(red) → 수정 후 0(green)
- [x] `/simplify` — 중복 루프를 `freeNsExportCacheEntries` 헬퍼로 추출, 다른 stale 캐시(chain_cache/ns_inline_cache) 없음 확인
- [x] `zig fmt --check` 통과

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음

Closes #4297
