### PR TITLE
fix(server): watchLoop changed_set/paths 가 watcher event path alias — intake dupe

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -983,6 +983,15 @@ pub const DevServer = struct {
             // 수 있어 dedup 가드 (StringHashMap 기반 set).
             var changed_set: std.StringHashMapUnmanaged(void) = .empty;
             defer changed_set.deinit(self.allocator);
+            // ev.path 는 watcher 내부 메모리 alias(kqueue: fd_to_path 슬라이스) — 같은 iteration 의
+            // rescan 삭제가 removePath→free(kv.key) 하면 dangling 된다. intake 에서 dupe 로 소유해
+            // changed_set key / changed_paths 가 이 dupe 를 참조하고, iteration 끝에서 일괄 free
+            // (deletion_dupes 와 동일 UAF-fix 패턴). #4299
+            var event_path_dupes: std.ArrayList([]const u8) = .empty;
+            defer {
+                for (event_path_dupes.items) |d| self.allocator.free(d);
+                event_path_dupes.deinit(self.allocator);
+            }
             var needs_rescan = false;
             for (events) |ev| {
                 self.routineLog("  [watch] changed: {s}\n", .{std.fs.path.basename(ev.path)});
@@ -992,9 +1001,16 @@ pub const DevServer = struct {
                         continue; // dir entry event 는 changed_paths 에 넣지 않음 (caller 가 file path 만 처리).
                     }
                 }
-                const gop = changed_set.getOrPut(self.allocator, ev.path) catch continue;
+                const path_dupe = self.allocator.dupe(u8, ev.path) catch continue;
+                // 소유권을 먼저 free-list 에 등록 — 이후 어느 단계가 실패해도 iteration 끝에서
+                // 일괄 free 되어 leak/dangling 없음 (deletion_dupes 와 동일 순서).
+                event_path_dupes.append(self.allocator, path_dupe) catch {
+                    self.allocator.free(path_dupe);
+                    continue;
+                };
+                const gop = changed_set.getOrPut(self.allocator, path_dupe) catch continue;
                 if (gop.found_existing) continue; // dedup
-                changed_paths.append(self.allocator, ev.path) catch {};
+                changed_paths.append(self.allocator, path_dupe) catch {};
 
                 // SSE: watch_change 이벤트. 0.16: std.io.fixedBufferStream 제거
                 // → std.Io.Writer.fixed (고정 버퍼 writer, buffered() 로 결과 조회).


### PR DESCRIPTION
## Summary

dev server watch loop 가 watcher event 의 `ev.path` 를 dupe 없이 `changed_set`/`changed_paths` 에 저장하던 **use-after-free** 를 수정합니다. kqueue 백엔드는 `ev.path = fd_to_path.get(fd)`(watcher 내부 메모리 alias)를 emit 하고, 같은 iteration 의 rescan 삭제가 `removePath → allocator.free(kv.key)` 로 그 메모리를 해제하면 alias 가 dangling 됩니다.

> **초보자 설명**
> - watcher 는 이벤트의 path 를 새로 복사하지 않고 내부 맵의 문자열 슬라이스를 줍니다(`ev.path`).
> - 그 path 를 그대로 보관하다 watcher 가 `removePath`(파일 삭제)로 그 메모리를 해제하면 보관본이 dangling 됩니다 → 해제된 메모리 read.
> - intake 시점에 `dupe` 로 소유 복사하면 watcher 의 free 와 무관해집니다.

## Changes

- `src/server/dev_server.zig`: intake 에서 `ev.path` 를 `dupe` 해 `event_path_dupes`(소유 free-list)에 등록 후 `changed_set` key / `changed_paths` 가 참조, iteration 끝에서 일괄 free. free-list 등록을 먼저 해 어느 단계 실패에도 leak/dangling 없음. 기존 `deletion_dupes`(삭제 path UAF-fix)와 동일 패턴.

### path 소유권

```mermaid
flowchart TD
    A["watcher event ev.path<br/>(내부 fd_to_path alias)"] --> B["intake: dupe → event_path_dupes 소유"]
    B --> C["changed_set key / changed_paths 가 dupe 참조"]
    C --> D["rescan removePath → watcher 내부 free"]
    D --> E["dupe 는 무관 → broadcast 안전 ✅"]
    A -. "이전: alias 직접 저장 → removePath free 시 dangling" .-> X["💥 UAF"]
```

## Test Plan

- [x] `zig build test` 통과 (5913/5913, testing allocator 가 dev_server 테스트에서 leak/double-free 검사 — 통과)
- [x] `/simplify` — 초기 구현의 append-실패 leak 경로를 잡아 free-list-우선 순서로 교정(deletion_dupes 동형)
- [x] `zig fmt --check` 통과
- [ ] 비고: watchLoop 은 file-watcher 통합이라 결정적 in-process UAF 통합 red 는 비실용 — alias(kqueue `fd_to_path`→`removePath` `free(kv.key)`)는 코드로 입증, 기존 deletion_dupes UAF-fix 와 동일 부류의 누락

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음

Closes #4299
