### PR TITLE
fix(server): WS 초기 write + 등록을 한 ws_clients.mutex 임계영역으로 — 공유 writer data race

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -861,15 +861,23 @@ pub const DevServer = struct {
     fn handleWebSocket(self: *DevServer, ws: *http.Server.WebSocket, writer: *std.Io.Writer) void {
         self.routineLog("  [ws] client connected\n", .{});
 
-        // broadcast 리스트에 등록
-        self.ws_clients.add(self.io, writer);
-        defer self.ws_clients.remove(self.io, writer);
-
+        // 초기 write(connected + error_state)와 broadcast 등록을 ws_clients.mutex 한 임계영역으로
+        // 묶는다. 이렇게 하면 (1) 초기 write 가 broadcast(같은 mutex 보유 + 같은 writer write)와
+        // 직렬화돼 공유 writer 프레임 인터리브 race 가 없고, (2) write 와 등록이 원자적이라 등록
+        // 직전/직후에 일어난 error_state broadcast 를 놓치는 setup-창 miss 도 없다. broadcast 가
+        // 이미 mutex 보유 중 blocking write 하는 established 패턴과 동일(Io.Mutex 라 경합 시 sleep).
+        // lock 순서는 ws_clients→error_state(sendIfPresent 가 error_state.mutex 중첩) 단방향 —
+        // error_state set/clear 와 broadcast 는 항상 순차(중첩 없음)라 역순 경로가 없어 deadlock-safe. #4302
+        self.ws_clients.mutex.lockUncancelable(self.io);
         ws.writeMessage("{\"type\":\"connected\"}", .text) catch {
+            self.ws_clients.mutex.unlock(self.io);
             self.routineLog("  [ws] failed to send connected message\n", .{});
             return;
         };
         self.error_state.sendIfPresent(self.io, writer);
+        self.ws_clients.addLocked(writer);
+        self.ws_clients.mutex.unlock(self.io);
+        defer self.ws_clients.remove(self.io, writer);
 
         // 클라이언트 메시지 수신 루프 (ping/pong은 std.http가 자동 처리)
         while (true) {

--- a/src/server/events.zig
+++ b/src/server/events.zig
@@ -17,6 +17,12 @@ pub const WsClients = struct {
     pub fn add(self: *WsClients, io: std.Io, writer: *std.Io.Writer) void {
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
+        self.addLocked(writer);
+    }
+
+    /// `add` 의 락-없는 본문. caller 가 `mutex` 보유 가정 — 초기 write 와 등록을 한 임계영역으로
+    /// 묶어 broadcast 와 직렬화하려는 경우(공유 writer race + setup-창 miss 제거)에 쓴다.
+    pub fn addLocked(self: *WsClients, writer: *std.Io.Writer) void {
         if (self.len < max_clients) {
             self.items[self.len] = writer;
             self.len += 1;


### PR DESCRIPTION
## 요약 (Summary)

dev server 의 `handleWebSocket` 이 WebSocket writer 를 broadcast 리스트(`ws_clients`)에 **먼저 등록(`add`)한 뒤** 초기 메시지(`connected` + `error_state`)를 `ws_clients.mutex` 없이 썼습니다. `add` 직후 그 writer 는 broadcast 에 가시화되는데, watch 스레드의 `ws_clients.broadcast`(`ws_clients.mutex` 보유 + `writeWsFrame`)가 같은 writer 에 **동시 write** 하면 setup 창에서 WS 프레임 바이트가 인터리브됩니다(data race).

초기 write + 등록을 **`ws_clients.mutex` 한 임계영역**으로 묶어 race 와 setup-창 miss 를 모두 제거합니다.

## 변경 사항 (Changes)

- `src/server/events.zig`: `WsClients.addLocked(writer)` 추가 — `add` 의 락-없는 본문(caller 가 `mutex` 보유 가정). 기존 `add` 는 이걸 호출하도록 리팩터.
- `src/server/dev_server.zig`: `handleWebSocket` 에서 `ws_clients.mutex` 를 잡고 → `writeMessage(connected)` → `error_state.sendIfPresent` → `addLocked` → unlock 순으로 묶음. `writeMessage` 실패 시에도 unlock 후 return.

## 루트커즈 (Root Cause)

writer 를 **초기 write 완료 전에** broadcast 리스트에 등록 → 등록과 초기 write 사이에 broadcast 가 같은 writer 를 건드릴 수 있는 setup 창이 열렸다. 초기 write 가 `ws_clients.mutex` 를 잡지 않아 broadcast 와 직렬화되지 않았다.

## 왜 atomic 임계영역인가 (vs 단순 reorder)

단순 reorder(초기 write 를 `add` 앞으로)는 race 는 막지만, `sendIfPresent` 와 `add` 사이에 발생한 `error_state` broadcast(clear-error/new-error)를 아직 미등록인 이 클라이언트가 놓치는 작은 miss-창이 남습니다. 초기 write + 등록을 한 임계영역으로 묶으면 broadcast 와 완전히 직렬화돼 **race 와 miss 둘 다** 사라집니다 — 이는 `broadcast` 가 이미 `ws_clients.mutex` 안에서 blocking write 하는 기존 패턴과 동일합니다.

**Deadlock 분석**: 새 lock 순서는 `ws_clients.mutex → error_state.mutex`(`sendIfPresent` 중첩) 단방향입니다. 코드베이스의 error 경로는 `error_state.setCopy/clear`(error_state.mutex) **다음에** `ws_clients.broadcast`(ws_clients.mutex)를 **순차** 호출 — 두 락을 동시 보유하지 않습니다. 따라서 `error_state → ws_clients` 역순 경로가 없어 순환 대기가 불가능 → deadlock-safe.

```mermaid
sequenceDiagram
    participant W as watch 스레드
    participant C as 연결 스레드 (handleWebSocket)
    participant Wr as 공유 writer

    Note over C: Before — 등록 후 mutex 없이 초기 write
    C->>C: ws_clients.add(writer)
    par 동시 write (race)
        W->>Wr: broadcast: writeWsFrame (ws_clients.mutex 보유)
    and
        C->>Wr: writeMessage(connected) — 락 없음 ⚠️ 프레임 인터리브
    end

    Note over C: After — 한 임계영역으로 직렬화
    C->>C: ws_clients.mutex.lock()
    C->>Wr: writeMessage(connected) + sendIfPresent
    C->>C: addLocked(writer)
    C->>C: ws_clients.mutex.unlock()
    W-->>Wr: broadcast 는 락 해제까지 대기 → 직렬화 ✅
```

## Test Plan
- [x] `zig build test` — 5913/5913 통과 (회귀 없음)
- [x] `zig fmt --check` 통과
- 비고: WS 프레임 인터리브는 스레드 타이밍 의존 data race 라 결정적 in-process 재현 테스트가 비실용입니다. race(등록→broadcast 가시 vs mutex-없는 초기 write)와 수정(한 임계영역 직렬화)은 코드/lock-순서로 입증했고, 전체 스위트로 회귀 0 을 확인했습니다.

## Decision / 성능 영향 (Impact)
- 핫패스 아님(연결 1회 setup). 추가 비용은 초기 write 동안 `ws_clients.mutex` 보유 — broadcast 가 이미 같은 패턴으로 잡으므로 동일 특성. 번들/트랜스파일 경로 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (server runtime concurrency)

---

### 초보자 설명 (Zig)

- **여러 스레드 + 하나의 소켓 writer**: WS 메시지는 결국 한 소켓에 바이트로 쓰입니다. 두 스레드가 같은 writer 에 동시에 쓰면 바이트가 섞여 프레임이 깨집니다(JSON 이 반쪽씩 섞임).
- **`Io.Mutex`**: 임계영역을 한 번에 한 스레드만 들어가게 합니다. `lockUncancelable` 으로 잠그고 `unlock` 으로 풉니다. `broadcast` 는 이 락 안에서 모든 클라이언트에 쓰므로, 우리도 초기 write 를 같은 락 안에서 하면 broadcast 와 절대 겹치지 않습니다.
- **`addLocked` 를 따로 둔 이유**: `add` 는 스스로 락을 잡습니다. 우리는 이미 락을 잡은 상태에서 등록해야 하므로(이중 lock 은 재진입 불가라 멈춤), 락을 잡지 않는 본문 `addLocked` 를 분리했습니다.
- **lock 순서와 deadlock**: 두 락(A, B)을 한 스레드는 A→B, 다른 스레드는 B→A 순으로 잡으면 서로 영원히 기다립니다(deadlock). 여기선 모든 경로가 `ws_clients→error_state` 한 방향뿐이라 안전합니다.
