### PR TITLE
fix(rn): in-flight refreshBundle 완료가 새 staleness 마스킹 방지 — generation guard

### DIFF
--- a/packages/react-native/src/dev-server/platform-state.test.ts
+++ b/packages/react-native/src/dev-server/platform-state.test.ts
@@ -7,6 +7,7 @@ import type { WatchHandle } from '@zntc/core';
 
 import { buildRnDevServerOptions } from './options.ts';
 import {
+  createBundleRefresher,
   createPlatformStateRegistry,
   getCachedSourceMap,
   type PlatformState,
@@ -48,6 +49,76 @@ function fakeState(overrides: Partial<PlatformState> = {}): PlatformState {
     ...overrides,
   };
 }
+
+describe('createBundleRefresher — in-flight staleness generation guard (Finding #26)', () => {
+  function makeHarness() {
+    let stale = false;
+    let buildCount = 0;
+    const resolvers: Array<() => void> = [];
+    const refresher = createBundleRefresher({
+      // bundle 은 항상 존재 가정 — staleness 만으로 refresh 여부 결정.
+      isFresh: () => !stale,
+      build: () => {
+        buildCount += 1;
+        return new Promise<void>((resolve) => resolvers.push(resolve));
+      },
+      setStale: () => {
+        stale = true;
+      },
+      clearStale: () => {
+        stale = false;
+      },
+    });
+    return {
+      refresher,
+      isStale: () => stale,
+      buildCount: () => buildCount,
+      finishBuild: (i: number) => resolvers[i]?.(),
+    };
+  }
+
+  test('in-flight build 중 markStale 재호출 시 완료가 stale 을 clear 하지 않음', async () => {
+    const h = makeHarness();
+    // 1. 첫 staleness + refresh → build #1 in-flight
+    h.refresher.markStale();
+    expect(h.isStale()).toBe(true);
+    const p1 = h.refresher.refresh();
+    expect(h.buildCount()).toBe(1);
+
+    // 2. in-flight 중 두 번째 staleness 신호 (generation bump)
+    h.refresher.markStale();
+
+    // 3. build #1 완료 → 새 staleness 가 있었으므로 stale 유지(다음 요청 rebuild). 마스킹 금지.
+    h.finishBuild(0);
+    await p1;
+    expect(h.isStale()).toBe(true);
+  });
+
+  test('in-flight 중 markStale 없으면 완료가 stale 을 정상 clear', async () => {
+    const h = makeHarness();
+    h.refresher.markStale();
+    const p1 = h.refresher.refresh();
+    h.finishBuild(0);
+    await p1;
+    expect(h.isStale()).toBe(false);
+  });
+
+  test('in-flight refresh 는 coalesce — 동시 refresh 가 build 를 중복 트리거하지 않음', async () => {
+    const h = makeHarness();
+    h.refresher.markStale();
+    const a = h.refresher.refresh();
+    const b = h.refresher.refresh();
+    expect(h.buildCount()).toBe(1);
+    h.finishBuild(0);
+    await Promise.all([a, b]);
+  });
+
+  test('이미 신선하면 build 스킵', () => {
+    const h = makeHarness();
+    void h.refresher.refresh();
+    expect(h.buildCount()).toBe(0);
+  });
+});
 
 describe('getCachedSourceMap', () => {
   test('cache 미존재 + handle 결과 → postProcess 반영', () => {

--- a/packages/react-native/src/dev-server/platform-state.ts
+++ b/packages/react-native/src/dev-server/platform-state.ts
@@ -59,6 +59,59 @@ function getBundleSourceMapText(result: Awaited<ReturnType<typeof bundleRn>>): s
   return result.outputFiles.find((file) => file.path.endsWith('.map'))?.text ?? null;
 }
 
+export interface BundleRefresher {
+  /** stale 신호 — generation 을 bump 해 in-flight build 가 이 변경을 마스킹하지 못하게 한다. */
+  markStale(): void;
+  /** stale 이면 build, in-flight 면 coalesce. */
+  refresh(): Promise<void>;
+}
+
+/**
+ * in-flight build coalescing + generation guard. `build` 는 시작 시점 소스를 빌드하므로,
+ * 진행 중 `markStale()` 이 또 불리면(파일 재변경) 그 build 완료가 stale 을 clear 하면 안 된다
+ * (더 새로운 변경을 마스킹 → stale bundle 제공). generation 으로 가드: build 시작 시 generation
+ * 을 캡처, 완료 시 generation 이 그대로일 때만 `clearStale`. 새 staleness 가 들어왔으면 stale 을
+ * 유지해 다음 `refresh()` 가 최신 소스로 rebuild 한다. `bundleRn`/state 의존을 콜백으로 주입해
+ * race-safety 로직만 결정적으로 유닛 테스트할 수 있게 분리.
+ */
+export function createBundleRefresher(deps: {
+  /** 이미 신선(!bundleStale && bundle≠null)하면 build 스킵. */
+  isFresh: () => boolean;
+  /** bundleRn + state.bundle/buildError 갱신. 내부 try/catch 라 reject 하지 않음. */
+  build: () => Promise<void>;
+  /** stale=true. */
+  setStale: () => void;
+  /** stale=false. */
+  clearStale: () => void;
+}): BundleRefresher {
+  let inFlight: Promise<void> | null = null;
+  let generation = 0;
+
+  function markStale(): void {
+    deps.setStale();
+    generation += 1;
+  }
+
+  function refresh(): Promise<void> {
+    if (deps.isFresh()) return Promise.resolve();
+    if (inFlight) return inFlight;
+    const startGen = generation;
+    inFlight = deps
+      .build()
+      .then(() => {
+        // build 시작 후 새 staleness(markStale)가 없었을 때만 clear. 들어왔다면 그 변경은
+        // 이 build 결과에 없으므로 stale 유지 → 다음 refresh 가 최신 소스로 rebuild.
+        if (generation === startGen) deps.clearStale();
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+    return inFlight;
+  }
+
+  return { markStale, refresh };
+}
+
 /**
  * platform 별 watch + state 생성. 첫 build 는 비동기 — caller 가
  * `waitForBuild(state)` 로 대기. RN runtime 이 ios+android 동시 요청 시
@@ -74,7 +127,8 @@ export function createPlatformState(
 
   // bundle 의 RnBundleInput 의 rnPlatform 만 override — 다른 필드 그대로 유지.
   const platformBundle = { ...options.bundle, rnPlatform: platform };
-  let refreshPromise: Promise<void> | null = null;
+  // build 끝까지 채워짐 — refreshBundle/onRebuild 콜백(모두 lazy)에서만 참조.
+  let refresher: BundleRefresher;
 
   const state: PlatformState = {
     platform,
@@ -86,34 +140,34 @@ export function createPlatformState(
     handle: undefined as unknown as WatchHandle,
     bundle: null,
     bundleStale: false,
-    refreshBundle: () => refreshPlatformBundle(),
+    refreshBundle: () => refresher.refresh(),
     sourceMapCache: null,
     buildError: null,
     fileCount: 1,
     lastRebuildTime: Date.now(),
   };
 
-  function refreshPlatformBundle(): Promise<void> {
-    if (!state.bundleStale && state.bundle !== null) return Promise.resolve();
-    if (refreshPromise) return refreshPromise;
-    refreshPromise = bundleRn(platformBundle)
-      .then((result) => {
-        state.bundle = getBundleText(result);
-        const sourceMap = getBundleSourceMapText(result);
-        state.sourceMapCache = sourceMap ? postProcessSourceMap(sourceMap) : null;
-        state.buildError = null;
-        state.bundleStale = false;
-      })
-      .catch((err) => {
-        state.bundle = null;
-        state.buildError = err instanceof Error ? err.message : String(err);
-        state.bundleStale = false;
-      })
-      .finally(() => {
-        refreshPromise = null;
-      });
-    return refreshPromise;
-  }
+  refresher = createBundleRefresher({
+    isFresh: () => !state.bundleStale && state.bundle !== null,
+    build: () =>
+      bundleRn(platformBundle)
+        .then((result) => {
+          state.bundle = getBundleText(result);
+          const sourceMap = getBundleSourceMapText(result);
+          state.sourceMapCache = sourceMap ? postProcessSourceMap(sourceMap) : null;
+          state.buildError = null;
+        })
+        .catch((err) => {
+          state.bundle = null;
+          state.buildError = err instanceof Error ? err.message : String(err);
+        }),
+    setStale: () => {
+      state.bundleStale = true;
+    },
+    clearStale: () => {
+      state.bundleStale = false;
+    },
+  });
 
   if (process.env.ZNTC_DEBUG_TERMINAL === '1') {
     process.stderr.write(
@@ -127,6 +181,7 @@ export function createPlatformState(
       if (event.files) state.fileCount = event.files;
       if (existsSync(outputPath)) {
         state.bundle = readFileSync(outputPath, 'utf-8').replace(SOURCE_MAPPING_URL_RE, '');
+        // 초기 build 1회 — 어떤 refresh 보다 먼저라 in-flight 가 없다. generation 가드 불필요(직접 clear).
         state.bundleStale = false;
       } else {
         state.buildError = 'Build produced no output';
@@ -145,7 +200,7 @@ export function createPlatformState(
       state.sourceMapCache = null;
       if (platformBundle.dev) {
         if (event.graphChanged) {
-          state.bundleStale = true;
+          refresher.markStale();
           return state.refreshBundle().then(() => {
             if (state.buildError) {
               callbacks?.onRebuild?.(state, {
@@ -159,11 +214,14 @@ export function createPlatformState(
           });
         }
         if (event.updates && event.updates.length > 0) {
-          state.bundleStale = true;
+          refresher.markStale();
         }
         callbacks?.onRebuild?.(state, event);
         return;
       }
+      // non-dev 경로: 위 `if (platformBundle.dev)` 가 false 라 markStale/refresh 가 호출되지
+      // 않는다 → in-flight refresher build 가 없어 generation 가드 불필요(직접 clear). dev in-flight
+      // race 는 dev 분기 안에서만 refresher 로 처리.
       if (existsSync(outputPath)) {
         state.bundle = readFileSync(outputPath, 'utf-8').replace(SOURCE_MAPPING_URL_RE, '');
         state.bundleStale = false;


### PR DESCRIPTION
## 요약 (Summary)

RN dev server 의 `platform-state.ts` 가 in-flight `bundleRn` 완료 시 `state.bundleStale = false` 를 **무조건** 설정했습니다. 그 build 가 진행 중일 때 새 rebuild 가 또 staleness 를 신호하면, in-flight 완료가 그 새 staleness 를 마스킹 → 더 새로운 소스 변경이 rebuild 되지 않고 **stale bundle 이 제공**됩니다(빌드보다 빠른 연속 저장 시).

coalescing + **generation guard** 를 `createBundleRefresher` 로 추출해 race 를 막고, race-safety 로직을 결정적 유닛 테스트로 가드합니다.

## 변경 사항 (Changes)

- `createBundleRefresher(deps)` 신설 — `{isFresh, build, setStale, clearStale}` 주입, `{markStale, refresh}` 반환. generation 으로 in-flight 완료의 stale clear 를 가드.
- `createPlatformState`: inline `refreshPlatformBundle` + 직접 `bundleStale=true`(onRebuild 2곳)를 refresher 로 배선.
- onReady(초기) / non-dev 경로의 직접 `bundleStale=false` 는 refresh 경로 밖(in-flight 없음)이라 의도 비대칭임을 주석화.
- 유닛 테스트 4건(제어 가능 build promise) — generation guard / 정상 clear / coalesce / fresh-skip.

## 루트커즈 (Root Cause)

in-flight build 완료가 "build 시작 후 들어온 staleness" 를 구분하지 못하고 무조건 stale 을 clear → 더 새로운 변경 마스킹.

## 수정 원리

```
generation: staleness 신호마다 +1
refresh 시작 → startGen = generation 캡처
build 완료 → generation === startGen 일 때만 clearStale
            (다르면 = build 중 새 staleness 도착 → stale 유지 → 다음 refresh 가 rebuild)
```

```mermaid
sequenceDiagram
    participant F as 파일 변경
    participant R as refresher
    participant B as bundleRn (build #1)

    F->>R: markStale (gen=1)
    R->>B: refresh → build #1 시작 (startGen=1)
    F->>R: markStale (gen=2)  // build #1 진행 중 또 변경
    B-->>R: build #1 완료
    alt Before (버그)
        R->>R: bundleStale=false (무조건) ⚠️ gen=2 변경 마스킹 → stale 제공
    else After (generation guard)
        R->>R: gen(2) ≠ startGen(1) → clear 안 함, stale 유지 ✅
        Note over R: 다음 refresh 가 startGen=2 로 최신 rebuild
    end
```

## Test Plan
- [x] 신규 유닛 4건: in-flight 중 markStale → 완료가 stale clear 안 함 (TDD red→green 확인) / 정상 clear / coalesce / fresh-skip
- [x] refresh 경로 integration(dev HMR rebuild·graphChanged) 3건 통과 — 실 build 경로 회귀 없음
- [x] `tsc --noEmit` / `oxlint` clean
- 비고: 기존 `createPlatformStateRegistry — 캐싱` 3건은 sandbox 에서 real watch handle 이 hang 하는 **기존** 환경 flakiness(main 동일 timeout 확인). 신규 로직은 build 주입으로 env 독립.

## Decision / 성능 영향 (Impact)
- generation 은 정수 1개. 핫패스 아님(rebuild 시 1회). 번들/트랜스파일 경로 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (RN dev server runtime)

---

### 초보자 설명

- **왜 generation 인가**: 비동기 빌드는 "시작 시점의 소스" 를 빌드합니다. 빌드 도중 파일이 또 바뀌면 그 변경은 이 빌드 결과에 없습니다. 완료 시 무턱대고 "최신" 이라 표시하면 그 변경이 사라집니다. generation(변경 카운터)으로 "내가 빌드 시작한 뒤 새 변경이 있었나?" 를 확인해, 있으면 stale 을 유지합니다.
- **왜 `createBundleRefresher` 로 분리했나**: 이 race-safety 는 타이밍 의존이라 실제 빌드로는 결정적으로 테스트하기 어렵습니다. `build` 를 주입받게 분리하면, 테스트에서 `Promise.withResolvers` 로 빌드 완료 시점을 손으로 제어해 "빌드 중 또 stale → 완료가 마스킹 안 함" 을 정확히 검증할 수 있습니다(TDD red→green).
- **의도 비대칭**: 초기 build(onReady)와 non-dev 경로는 동시 진행 중인 refresh build 가 없으므로 generation 가드 없이 바로 clear 해도 안전합니다(주석으로 명시).
