### PR TITLE
fix(regexp): collectClassSet 이 v-flag intersection/subtraction 을 union 으로 miscompile

### DIFF
--- a/src/regexp/ast.zig
+++ b/src/regexp/ast.zig
@@ -206,6 +206,12 @@ pub const Node = struct {
         return .{ .start = self.data[1], .len = self.data[2] };
     }
 
+    /// character_class의 결합 종류(union/intersection/subtraction).
+    /// data[0]: bit 0 = negative, bits 1-2 = CharacterClassContentsKind (parser.zig).
+    pub fn classKind(self: Node) CharacterClassContentsKind {
+        return @enumFromInt((self.data[0] >> 1) & 0b11);
+    }
+
     /// quantifier의 body NodeIndex를 가져온다.
     /// data[2]의 bits 0-30.
     pub fn getQuantifierBody(self: Node) NodeIndex {

--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -335,6 +335,10 @@ const T = struct {
     /// class body → CodePointSet. 단순 positive(character/range/\d\w\s)만
     /// 지원. negative-escape(\D\W\S)/property/class_string/nested → false.
     fn collectClassSet(self: *T, n: Node, set: *cps.CodePointSet) TransformError!bool {
+        // 이 함수는 union 의미 전용 — v-flag 의 `[a&&b]`(intersection)/`[a--b]`(subtraction)를
+        // 평탄 union 으로 수집하면 교집합/차집합이 합집합으로 뒤집힌다(silent miscompile). non-union
+        // 은 bail → 호출부가 원본 /u·/v 를 보존(astral_u_incomplete/i_fold_incomplete) → 오변환 0. #4307
+        if (n.classKind() != .@"union") return false;
         const a = self.b.a;
         for (self.in.getNodeList(n.getClassBody())) |cid| {
             const m = self.in.getNode(@enumFromInt(cid));

--- a/src/regexp/transform_test.zig
+++ b/src/regexp/transform_test.zig
@@ -106,6 +106,40 @@ test "#3511 i+u negated — fold-확장 후 complement (게이트 해제)" {
     }
 }
 
+test "#4307 v-flag intersection/subtraction class → bail (union miscompile 금지)" {
+    const a = std.testing.allocator;
+    const o = transform.Options{ .unicode_brace = true, .ignore_case = true };
+    // [\d&&\w]/iv = 교집합 = \d. collectClassSet 이 kind 무시하면 union(\w)으로 오변환.
+    // kind!=union 이면 bail → /v 보존(astral_u_incomplete) → 오변환 0.
+    {
+        var in = mod.parse("[\\d&&\\w]", "iv", a) orelse return error.ParseFailed;
+        defer in.deinit();
+        var r = try transform.transform(in, o, a);
+        defer r.deinit();
+        try std.testing.expect(r.astral_u_incomplete); // bail (union 으로 안 내림)
+        const out = try printer.print(r.ast, a);
+        defer a.free(out);
+        // union 확장(\w = A-Z/a-z/_)이 새어 나오면 안 됨.
+        try std.testing.expect(std.mem.indexOf(u8, out, "\\u005A") == null); // 'Z'
+    }
+    // [\w--\d]/iv = 차집합. 마찬가지로 bail.
+    {
+        var in = mod.parse("[\\w--\\d]", "iv", a) orelse return error.ParseFailed;
+        defer in.deinit();
+        var r = try transform.transform(in, o, a);
+        defer r.deinit();
+        try std.testing.expect(r.astral_u_incomplete);
+    }
+    // union(기본) class 는 회귀 없이 다운레벨 — bail 아님.
+    {
+        var in = mod.parse("[\\d]", "iv", a) orelse return error.ParseFailed;
+        defer in.deinit();
+        var r = try transform.transform(in, o, a);
+        defer r.deinit();
+        try std.testing.expect(!r.astral_u_incomplete); // 정상 처리
+    }
+}
+
 test "transform 조합 — dotall + strip_named" {
     const o = transform.Options{ .dotall = true, .strip_named = true };
     try expectTransform("(?<a>.)b", "", o, "([\\s\\S])b"); // dotall 은 group 안에도 적용


### PR DESCRIPTION
## 요약 (Summary)

`src/regexp/transform.zig` 의 `collectClassSet` 이 character class body 를 평탄 union(CodePointSet)으로 수집하면서 class 의 **contents kind**(union/intersection/subtraction)를 검사하지 않았습니다. v-flag 의 `[a&&b]`(교집합)·`[a--b]`(차집합)는 body `[a, b]` + kind 비트로 표현되는데, 이를 union 으로 모으면 **교집합/차집합이 합집합으로 silent miscompile** 됩니다.

**경험적 재현** — `/[\d&&\w]/iv` (unicode_brace + ignore_case 다운레벨):
```
출력:  (?:[0-9 A-Z _ a-z ſ K])   ← union(\d,\w)=\w (+i fold)
정답:  intersection(\d,\w) = \d = [0-9]
astral_u_incomplete = false       ← 진단도 없이 틀린 출력
```

## 변경 사항 (Changes)

- `src/regexp/transform.zig`: `collectClassSet` 시작에서 `n.classKind() != .union` 이면 `return false`(bail).
- `src/regexp/ast.zig`: `Node.classKind()` 헬퍼 추가 — `data[0]` bit1-2 의 kind 추출을 중앙화(기존 `getQuantifierBody()`/`isGreedy()` 패턴, raw bit math 제거).
- `src/regexp/transform_test.zig`: `[\d&&\w]/iv`·`[\w--\d]/iv` bail / union 회귀 없음 테스트.

## 루트커즈 (Root Cause)

`collectClassSet` 은 union 의미 전용인데 kind 검사 없이 모든 kind 의 body 를 union 으로 수집.

## 왜 bail 인가 (vs 실제 set 연산 구현)

`collectClassSet` 호출부는 false 시 `astral_u_incomplete`/`i_fold_incomplete = true` 로 원본 /u·/v 를 **보존**합니다(다운레벨 포기 → 런타임이 /v 처리). 주변 코드는 이미 `\p{}`(백로그 #3512)·`class_string`·`\D\W\S`·nested class 를 같은 방식으로 bail 하며 **"미지원→보존, 오변환 0"** 원칙을 따릅니다. intersection/subtraction 의 완전한 다운레벨(set 대수 구현)은 별도 epic 범위이고, 이 PR 은 **silent miscompile 을 제거**하는 루트커즈 수정입니다.

```mermaid
flowchart TD
    A["character_class n<br/>data0 = negative | kind&lt;&lt;1"] --> B{"collectClassSet"}
    B --> C{"n.classKind()"}
    C -->|"union (0)"| D["body 를 CodePointSet 으로 수집<br/>(기존 다운레벨 경로)"]
    C -->|"intersection (1)<br/>subtraction (2)"| E["return false (bail)"]
    E --> F["호출부: astral_u_incomplete /<br/>i_fold_incomplete = true"]
    F --> G["원본 /u·/v 보존 → 오변환 0 ✅"]
    style E fill:#ffe6e6
    style G fill:#e6ffe6
```

## Test Plan
- [x] 신규: `[\d&&\w]/iv`·`[\w--\d]/iv` → bail(`astral_u_incomplete==true`), union 확장(`Z` 등) 누출 없음 (TDD red→green)
- [x] union class `[\d]/iv` 는 회귀 없이 정상 다운레벨
- [x] `zig build test` 전체 5915/5915 통과, regexp 134/134
- [x] `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- 분기 1개(정수 비트). 핫패스 무관. 동작 변경은 "틀린 union 출력 → 안전한 /v 보존" 뿐 — union class 경로 불변.

## AST/IR 체크리스트
- [x] `Node.classKind()` 추가(기존 비트 레이아웃 그대로, 읽기 전용 헬퍼)
- [x] transform 출력: intersection/subtraction 은 보존(이전 잘못된 union 다운레벨 제거)

---

### 초보자 설명

- **v 플래그 집합 연산**: `/.../v` 는 클래스에서 교집합 `&&`, 차집합 `--` 를 지원합니다. `[\d&&\w]` = "숫자이면서 단어문자" = 숫자(`\d`). `[\w--\d]` = "단어문자에서 숫자 제외" = 글자/밑줄.
- **AST 표현**: `[a&&b]` 는 자식 `[a, b]` + "kind=intersection" 표시(정수 비트)로 저장됩니다. 수집 함수가 kind 를 안 보면 `a`·`b` 를 둘 다 합쳐(합집합) 의미가 뒤집힙니다.
- **bail = 안전한 후퇴**: 이 변환기는 "정확히 못 내리면 원본을 그대로 둔다"가 원칙입니다(틀린 결과 0). 그래서 교집합/차집합은 다운레벨하지 않고 /v 그대로 둬, 런타임이 올바르게 처리하게 합니다.
- **`classKind()` 헬퍼**: `(data[0] >> 1) & 0b11` 같은 비트 계산을 여기저기 흩지 않고 한 곳(`Node` 메서드)에 모아 둡니다. 기존 `getQuantifierBody()`·`isGreedy()` 와 같은 패턴입니다.
