### PR TITLE
fix(schema): #4223 CLI flag ↔ BuildOptions schema sync drift 4건 해소

### DIFF
--- a/packages/core/bin/zntc-cli-schema-sync.test.ts
+++ b/packages/core/bin/zntc-cli-schema-sync.test.ts
@@ -298,6 +298,9 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
     '--no-tree-shaking',
     '--no-scope-hoist',
     '--no-emit-disk-sourcemap',
+    // positive `--react-refresh`(string-bool)가 BuildOptions.reactRefresh 와 직접 매핑.
+    // negation 형은 flag 이름이 `noReactRefresh` 로 추론돼 키 매칭이 안 되므로 CLI-only.
+    '--no-react-refresh',
     '--open',
     '--clean',
     // #4062 PR-C-3 — `zntc dev --lazy`: dev 서버 오케스트레이션 플래그(JS dev 서버가 on-demand
@@ -459,6 +462,9 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
     // dev 활성 스위치 `zntc dev --lazy`(PR-C-3, cliOnlyFlags) 가 이 둘을 내부적으로 켠다.
     'lazyCompilation',
     'lazyForceParse',
+    // HMR 위상 보존 plugin 게이트 완화 — RN preset 이 내장 plugin 구성에 자동 set 하는
+    // build-level opt-in. 임의 custom plugin 은 비결정적이라 CLI flag 미노출(config/preset 전용).
+    'preserveSafePlugins',
   ]);
 
   test('CLI flag 가 BuildOptions / TranspileOptions 키와 매칭되거나 cliOnlyFlags 에 등록', () => {

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -258,7 +258,11 @@ function parseArgs(argv) {
     bundle: false,
     watch: false,
     watchJson: false,
-    watchDelay: 16,
+    // SCALAR_KEYS 머지 키 — config.watchDelay 가 적용되려면 default 가 `undefined`
+    // 여야 한다(머지 조건 `opts[key] === undefined`). 16ms 디바운스 default 는
+    // 소비처(setTimeout)에서 `?? 16` 으로 보정(#4223 — 이전 `16` default 라 config
+    // watchDelay 가 silent 무시되던 schema-drift 가드 발동).
+    watchDelay: undefined,
     serve: false,
     serveDir: '.',
     port: undefined,
@@ -1359,6 +1363,8 @@ function mergeConfigIntoOpts(opts, config) {
     'runtimePolyfills',
     'coreJs',
     'tokenizeFormat',
+    // #4223 — config.watchDelay 가 머지되도록(opts default=undefined, 소비처 `?? 16`).
+    'watchDelay',
   ];
   for (const key of SCALAR_KEYS) {
     if (opts[key] === undefined && config[key] !== undefined) {
@@ -1421,7 +1427,10 @@ function mergeConfigIntoOpts(opts, config) {
   // tristate bool: false 가 명시적 의미를 가져서 default 를 undefined 로 두는 키.
   // CLI 가 미지정(undefined)일 때만 config 값(true/false)을 채택한다 (CLI flag 우선).
   // inlineDynamicImports=false 의 single-file 보정은 applySingleFileDynamicImportDefault.
-  for (const key of ['inlineDynamicImports']) {
+  // reactRefresh(#4223): `zntc dev` 는 default on(parseArgs 가 opts.reactRefresh=true) →
+  //   그 경우 머지 skip(opts defined). build/transpile 은 opts undefined 라 config(true/
+  //   false) 채택 — 이전 머지 리스트 누락으로 silent 무시되던 schema-drift 해소.
+  for (const key of ['inlineDynamicImports', 'reactRefresh']) {
     if (opts[key] === undefined && config[key] !== undefined) {
       opts[key] = config[key];
     }
@@ -1772,7 +1781,7 @@ async function runWatch(opts, config) {
       }
 
       clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(rebuild, opts.watchDelay);
+      debounceTimer = setTimeout(rebuild, opts.watchDelay ?? 16);
     });
     attachWatcherErrorHandler(watcher, dir, opts.logLevel);
   }
@@ -2734,7 +2743,7 @@ async function runServe(opts, config, { appDev = null } = {}) {
         }
         dirty.add(absPath);
         clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(drain, opts.watchDelay);
+        debounceTimer = setTimeout(drain, opts.watchDelay ?? 16);
       });
       attachWatcherErrorHandler(watcher, dir, opts.logLevel);
     }

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -135,6 +135,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   // ─── 모듈 / Resolve ───
   'external',
   'alias',
+  // alias 의 exact-match 변형 (프로그램틱/config 전용 — `--alias` 만 CLI 노출).
+  'aliasExact',
   'define',
   'server',
   'loader',
@@ -211,6 +213,11 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'watchDelay',
   'jobs',
   'codegenTransform',
+  // ─── lazy compilation (D105) — build()/watch() 프리미티브, dev 서버가 오케스트레이션 ───
+  'lazyCompilation',
+  'lazyForceParse',
+  // ─── HMR 위상 보존 plugin 게이트 완화 (RN preset 자동 set, build-level opt-in) ───
+  'preserveSafePlugins',
   // ─── config-only ───
   'extends',
   // ─── React Native dev server (#2605) — top-level keys for RN config ───


### PR DESCRIPTION
Closes #4223

## 문제 (Problem)

`packages/core` 의 `bun test` 가 schema-sync / typo-suggest 가드 **4건 fail** (`#4199` 작업 중 적발, 4f559fe9 react Fast Refresh 커밋 유래). main 이 green 인데 로컬 fail 하는 silent CI gap.

```
1. [schema drift] CLI flag 가 BuildOptions 키와 매칭 안 됨: --no-react-refresh → noReactRefresh
2. [schema drift] BuildOptions 키가 CLI flag 로 노출 안 됨: preserveSafePlugins
3. [schema drift] config-mergeable BuildOption flag 가 mergeConfigIntoOpts 누락 → config 값 silent 무시: reactRefresh, watchDelay
4. [schema drift] BuildOptionsCommon fields missing from KNOWN_CONFIG_KEYS: lazyCompilation, lazyForceParse, aliasExact, preserveSafePlugins
```

## 수정 (Fix)

각 가드가 안내하는 올바른 위치에 키를 **실제 동작까지** 동기화:

| 키 | 처리 | 이유 |
|---|---|---|
| `reactRefresh` | `mergeConfigIntoOpts` **tristate** 그룹 추가 | `zntc dev` 는 default on(opts 정의됨 → 머지 skip, CLI/dev 우선), build/transpile 은 opts undefined 라 config(true/false) 채택 |
| `watchDelay` | **SCALAR_KEYS** 머지 + opts default `16`→`undefined` + 소비처 `?? 16` | default 가 `16`(정의됨)이면 머지 조건 `opts[key]===undefined` 이 안 걸려 **config 가 여전히 silent 무시**됨. default 를 내리고 setTimeout 에서 `?? 16` 보정해야 실제로 머지됨 |
| `lazyCompilation`·`lazyForceParse`·`aliasExact`·`preserveSafePlugins` | **KNOWN_CONFIG_KEYS** 추가 | config 인지(typo 오경고 제거). build()/watch() 프리미티브·preset/programmatic 전용이라 CLI 머지는 안 함(dev `--lazy`/preset 오케스트레이션) |
| `--no-react-refresh` | 테스트 **cliOnlyFlags** 등록 | positive `--react-refresh`(string-bool)가 BuildOptions.reactRefresh 와 매핑. negation 형은 이름이 `noReactRefresh` 로 추론돼 키 미매칭 → CLI-only (`--no-tree-shaking` 등과 동일 패턴) |
| `preserveSafePlugins` | 테스트 **buildOptionsOnlyKeys** 등록 | RN preset 이 자동 set 하는 build-level opt-in, 임의 custom plugin 비결정적이라 CLI flag 미노출 |

### watchDelay precedence (CLI > config > 16)

- `--watch-delay=50`: flag 파싱이 opts.watchDelay=50 → 머지 skip(정의됨) → CLI 우선
- config `{ watchDelay: 300 }`, flag 없음: opts undefined → 머지로 300 적용
- 둘 다 없음: `opts.watchDelay ?? 16` = 16
- `--watch-delay=0`(즉시 rebuild): `0 ?? 16 === 0` — `??`(not `||`)라 `0` 보존

## 초보자 설명

- `mergeConfigIntoOpts` 는 CLI 로 명시 안 된 옵션을 `zntc.config` 값으로 채웁니다. 채우는 조건이 `opts[key] === undefined` 라, opts 기본값이 이미 숫자(`16`)면 config 가 들어갈 자리가 없어 **조용히 무시**됩니다. 그래서 기본값을 `undefined` 로 내리고, 실제 사용하는 곳(`setTimeout`)에서 `?? 16` 으로 16ms 기본을 보정합니다.
- `KNOWN_CONFIG_KEYS` 는 "오타 검출"용 알려진 키 목록입니다. 여기에 없으면 `config` 에 적었을 때 "unknown config key" 경고가 뜹니다.

## 범위 밖 (Out of scope)

전체 `bun test` 에 남은 1 fail(`ES2023/hashbang > hashbang 유지`)은 본 변경을 stash 한 clean main 에서도 동일하게 fail 하는 **pre-existing 이슈**(별도 `fix/import-attributes-hashbang` 작업 중). 본 PR 과 무관.

## Test Plan
- [x] `bun test bin/zntc-cli-schema-sync.test.ts src/typo-suggest.test.ts` — 36 pass / 0 fail (이전 32 pass / 4 fail)
- [x] 전체 `packages/core` `bun test` — 1046 pass (남은 1 fail = 무관 pre-existing hashbang)
- [x] `tsc --noEmit` / `oxfmt format --check` / `oxlint` 통과
- [x] watchDelay/reactRefresh precedence + `0 ?? 16` 보존 `/code-review max` 2-앵글 실증

🤖 Generated with [Claude Code](https://claude.com/claude-code)