### PR TITLE
fix(parser): decodeStringKey 가 비-ASCII import-attr 키 byte 누락 → 거짓 중복 에러

### DIFF
--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -1148,6 +1148,7 @@ fn decodeStringKey(input: []const u8, buf: *[256]u8) []const u8 {
             if (input[i + 1] == 'u') {
                 // \uHHHH
                 if (i + 5 < input.len) {
+                    const esc_start = i; // '\' 위치 — 인코딩 불가 시 원문 \uHHHH 보존용
                     i += 2; // skip \u
                     var codepoint: u21 = 0;
                     var valid = true;
@@ -1170,9 +1171,19 @@ fn decodeStringKey(input: []const u8, buf: *[256]u8) []const u8 {
                         codepoint = codepoint * 16 + digit;
                         i += 1;
                     }
-                    if (valid and codepoint < 128 and out < 256) {
-                        buf[out] = @intCast(codepoint);
-                        out += 1;
+                    if (valid) {
+                        // codepoint 를 UTF-8 로 정확히 인코딩(비-ASCII 도 보존). 인코딩 불가
+                        // (lone surrogate 등)면 원문 \uHHHH 를 보존 → 정보 손실/거짓 중복 방지.
+                        // surrogate pair(예: 😀)는 각 half 가 인코딩 불가라 원문 escape
+                        // 로 남는다 — dedup 키의 escape-형태 구분성 유지(같은 escape 만 중복).
+                        var utf8: [4]u8 = undefined;
+                        const bytes: []const u8 = if (std.unicode.utf8Encode(codepoint, &utf8)) |n|
+                            utf8[0..n]
+                        else |_|
+                            input[esc_start..i];
+                        const k = @min(bytes.len, 256 - out); // while 가드로 out<256 보장
+                        @memcpy(buf[out .. out + k], bytes[0..k]);
+                        out += k;
                     }
                     continue;
                 }

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4864,6 +4864,22 @@ test "Parser regression #4108: distinct escaped import-attribute keys are not fa
     ));
 }
 
+test "Parser regression #4309: distinct non-ASCII escaped import-attribute keys are not false duplicates" {
+    // é(é) vs è(è): 서로 다른 비-ASCII escape 키 → 중복 아님.
+    // (codepoint<128 만 기록하면 둘 다 ""→거짓 중복)
+    try std.testing.expectEqual(@as(usize, 0), try parseModuleErrCount(
+        \\import data from "m" with { "\u00e9": "1", "\u00e8": "2" };
+    ));
+    // 비-ASCII 가 섞인 escape 키도 구분 (café vs cafè)
+    try std.testing.expectEqual(@as(usize, 0), try parseModuleErrCount(
+        \\import data from "m" with { "caf\u00e9": "1", "caf\u00e8": "2" };
+    ));
+    // 같은 비-ASCII escape 키 2회 → 진짜 중복 검출
+    try std.testing.expect((try parseModuleErrCount(
+        \\import data from "m" with { "\u00e9": "1", "\u00e9": "2" };
+    )) > 0);
+}
+
 test "Parser regression #4108: genuine duplicate import-attribute keys still detected" {
     // 둘 다 escape, 같은 디코드 값(ab) → 진짜 중복 → 검출
     try std.testing.expect((try parseModuleErrCount(


### PR DESCRIPTION
## 요약 (Summary)

`src/parser/module.zig` 의 `decodeStringKey`(import attribute 키 중복 검사용 디코더)가 `\uHHHH` escape 를 **codepoint < 128(ASCII)일 때만** 1byte 기록했습니다. 비-ASCII codepoint(≥128)는 디코드만 하고 아무것도 쓰지 않아 키에서 사라집니다.

→ 서로 다른 비-ASCII escaped 키(`"é"`=é, `"è"`=è)가 둘 다 빈 byte 로 collapse → 같은 키로 오인 → **거짓 "Duplicate import attribute key" 에러**.

## 변경 사항 (Changes)

- `decodeStringKey`: `\uHHHH` → `std.unicode.utf8Encode` 로 정확히 인코딩 후 `@memcpy`(buffer 잔여 공간 bounded). 인코딩 불가(lone surrogate 등)면 원문 `\uHHHH` 보존(`esc_start` 캡처) → 정보 손실/거짓 중복 방지.
- `parser_test.zig`: `é` vs `è` / `café` vs `cafè` 비-중복 + 같은 비-ASCII 키 2회 중복 검출 회귀.

## 루트커즈 (Root Cause)

codepoint 를 UTF-8 인코딩하지 않고 ASCII(<128)만 단일 byte 로 기록 → 비-ASCII 누락.

```mermaid
flowchart LR
    A["키 \uHHHH"] --> B{"codepoint < 128?"}
    B -->|"Before: YES"| C["1 byte 기록"]
    B -->|"Before: NO(é,è)"| D["아무것도 안 씀 ⚠️<br/>→ 빈 키 collapse<br/>→ 거짓 중복"]
    A --> E["After: utf8Encode"]
    E -->|"성공"| F["UTF-8 bytes @memcpy ✅"]
    E -->|"실패(lone surrogate)"| G["원문 \uHHHH 보존 ✅"]
    style D fill:#ffe6e6
    style F fill:#e6ffe6
    style G fill:#e6ffe6
```

## Test Plan
- [x] `é` vs `è`, `café` vs `cafè` → 중복 아님(0 에러) (TDD red→green: 수정 전 found 1)
- [x] 같은 비-ASCII escape 키 2회 → 중복 검출(>0)
- [x] 기존 #4108 ASCII escape 테스트 회귀 없음(20/20)
- [x] 전체 5916/5916, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- import attribute 키 디코드(파싱 cold path)만. 핫패스 무관. 동작 변경은 "비-ASCII 누락 → 정확 보존" 뿐.

## AST/IR 체크리스트
- [x] AST 변경 없음 (키 텍스트 디코드 버퍼 처리만)

---

### 초보자 설명

- **codepoint vs UTF-8 byte**: `é` 는 코드포인트 0xE9 인데, 파일엔 UTF-8 2바이트(0xC3 0xA9)로 저장됩니다. "0xE9 가 128 이상이니 ASCII 가 아니다 → 1바이트로 못 담는다"가 핵심입니다.
- **기존 버그**: 코드가 "128 미만만 1바이트로 기록"하고 나머지는 버려서, é·è 가 둘 다 빈 문자열이 돼 같은 키로 오인했습니다.
- **`std.unicode.utf8Encode`**: 코드포인트를 올바른 UTF-8 바이트열로 바꿔 줍니다(이미 string_escape/regexp 가 쓰는 표준 API). lone surrogate(짝 없는 surrogate)처럼 인코딩 불가한 값은 원문 `\uHHHH` 텍스트를 그대로 둬 서로 다른 키가 구분되게 합니다.
- **`@memcpy` + 잔여공간**: 바깥 `while` 가 `out < 256` 을 보장하므로, `@min(bytes.len, 256 - out)` 만큼만 복사해 256바이트 버퍼를 넘지 않습니다.
