### PR TITLE
fix(mangler): isReservedOrGlobal 에 strict 예약어 eval 추가 — base54 eval 배정 SyntaxError 방지

### DIFF
--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -495,17 +495,18 @@ pub fn isReservedOrGlobal(name: []const u8) bool {
         // 3글자
         "for",    "let",    "new",    "try",
         "var",    "NaN",
-        // 4글자
+        // 4글자 (`eval` 은 strict mode BindingIdentifier 금지 — #4312)
            "case",   "else",
-        "enum",   "null",   "this",   "true",
-        "void",   "with",
+        "enum",   "eval",   "null",   "this",
+        "true",   "void",   "with",
         // 5글자
-          "await",  "break",
-        "catch",  "class",  "const",  "false",
-        "super",  "throw",  "while",  "yield",
+          "await",
+        "break",  "catch",  "class",  "const",
+        "false",  "super",  "throw",  "while",
+        "yield",
         // 6글자
-        "delete", "export", "import", "return",
-        "switch", "typeof",
+         "delete", "export", "import",
+        "return", "switch", "typeof",
     };
     for (reserved) |r| {
         if (std.mem.eql(u8, name, r)) return true;

--- a/src/codegen/mangler_test.zig
+++ b/src/codegen/mangler_test.zig
@@ -43,6 +43,8 @@ test "isReservedOrGlobal" {
     try std.testing.expect(isReservedOrGlobal("return"));
     try std.testing.expect(!isReservedOrGlobal("a"));
     try std.testing.expect(!isReservedOrGlobal("foo"));
+    // #4312: strict mode(ESM) 에서 `eval` 은 BindingIdentifier 금지 → base54 가 배정 못 하게 reserve.
+    try std.testing.expect(isReservedOrGlobal("eval"));
     // 'e', 'm' 은 legacy CJS alias path 용으로 reserved.
     try std.testing.expect(isReservedOrGlobal("e"));
     try std.testing.expect(isReservedOrGlobal("m"));


### PR DESCRIPTION
## 요약 (Summary)

`src/codegen/mangler.zig` 의 `isReservedOrGlobal` 예약어 테이블에 **`eval`** 이 빠져 있었습니다. base54 이름 생성기(`nextBase54Name`)는 이 함수가 true 인 이름만 skip 하므로, base54 가 4글자 `eval` 을 생성하면 그대로 binding 이름으로 배정합니다.

strict mode(ESM 은 항상 strict)에서 `eval` 은 `arguments` 처럼 **BindingIdentifier 로 사용 금지**(early SyntaxError) → 출력이 `const eval=...` 이 되어 런타임 SyntaxError.

## 변경 사항 (Changes)

- `isReservedOrGlobal` 4글자 섹션에 `eval` 추가.
- `mangler_test.zig`: `isReservedOrGlobal("eval") == true` 회귀.

## 루트커즈 (Root Cause)

reserved 테이블이 strict-mode 예약 binding `eval` 을 누락 → base54 가 해당 슬롯을 skip 하지 않음.

```mermaid
flowchart LR
    A["base54 counter → 'eval'"] --> B{"isReservedOrGlobal?"}
    B -->|"Before: false ⚠️"| C["binding 에 'eval' 배정<br/>→ const eval=… → strict SyntaxError"]
    B -->|"After: true ✅"| D["skip → 다음 이름"]
    style C fill:#ffe6e6
    style D fill:#e6ffe6
```

## 왜 eval 만? (static/public 등은?)

`eval`(4글자)은 base54 가 ~225k+ 이름에서 도달 가능합니다(대형 번들). 같은 class 의 strict 예약어 `static`/`public`(6글자)은 ~9억 개 이름 이후라 사실상 도달 불가 — 테이블의 기존 길이-한정(2~6, "7글자+ 도달 어려움") 실용 범위와 일관되게 reachable 한 `eval` 만 추가합니다(speculative 확장 회피). `arguments`(9글자)도 base54 도달 불가이며, 원본 이름은 이미 `shouldSkip` 가 보존합니다.

## Test Plan
- [x] `isReservedOrGlobal("eval") == true` (TDD red→green)
- [x] 기존 예약어/`!foo`/`e`·`m` 회귀 없음
- [x] 전체 5916/5916 통과 (base54 snapshot 회귀 없음)
- [x] `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- base54 시퀀스에서 `eval` 슬롯 1개 skip(4글자→다음 4글자, 동일 길이) → 크기 영향 0. cold path(mangle 1회).

## AST/IR 체크리스트
- [x] 해당 없음 (이름 생성 예약어 테이블)

---

### 초보자 설명

- **mangler 와 base54**: 변수명을 `a`, `b`, … `aa`, `ab`, … 처럼 짧은 이름으로 차례 배정해 번들 크기를 줄입니다. 이 짧은 이름 발급기가 base54 입니다.
- **왜 `eval` 이 문제**: strict 모드(ES module 은 자동 strict)에서는 `eval`/`arguments` 를 변수명으로 못 씁니다(`var eval` = SyntaxError). 그런데 base54 가 우연히 `eval` 을 만들어 배정하면 깨집니다.
- **고치는 법**: 예약어 목록에 `eval` 을 넣으면 발급기가 그 이름을 건너뜁니다. 비용은 거의 없습니다(이름 하나 건너뜀).
