### PR TITLE
fix(server): mime lookup 이 대문자 확장자(.JS/.PNG) 미매칭 → 잘못된 Content-Type

### DIFF
--- a/src/server/mime.zig
+++ b/src/server/mime.zig
@@ -52,8 +52,9 @@ fn lookup(ext: []const u8) []const u8 {
         .{ ".ogg", "audio/ogg" },
     };
 
+    // 확장자는 대소문자 무관(`.JS`/`.PNG` 등) — 맵 키는 소문자이므로 ignore-case 비교.
     inline for (map) |entry| {
-        if (std.mem.eql(u8, ext, entry[0])) return entry[1];
+        if (std.ascii.eqlIgnoreCase(ext, entry[0])) return entry[1];
     }
 
     return "application/octet-stream";

--- a/src/server/mime_test.zig
+++ b/src/server/mime_test.zig
@@ -16,6 +16,15 @@ test "기본 MIME type 매핑" {
     try testing.expectEqualStrings("application/json", fromExtension("bundle.js.map"));
 }
 
+test "#4314 대문자/혼합 확장자 case-insensitive 매칭" {
+    const testing = std.testing;
+    try testing.expectEqualStrings("application/javascript; charset=utf-8", fromExtension("app.JS"));
+    try testing.expectEqualStrings("image/png", fromExtension("logo.PNG"));
+    try testing.expectEqualStrings("text/css; charset=utf-8", fromExtension("style.CSS"));
+    try testing.expectEqualStrings("font/woff2", fromExtension("font.WOFF2"));
+    try testing.expectEqualStrings("image/jpeg", fromExtension("photo.Jpg"));
+}
+
 test "알 수 없는 확장자" {
     const testing = std.testing;
     try testing.expectEqualStrings("application/octet-stream", fromExtension("file.xyz"));


### PR DESCRIPTION
## 요약 (Summary)

`src/server/mime.zig` 의 `lookup` 이 `std.mem.eql`(대소문자 구분)로 확장자를 비교했습니다. `std.fs.path.extension` 은 원본 대소문자를 반환하므로 `image.PNG`·`app.JS`·`style.CSS` 같은 대문자 확장자가 소문자 키 맵과 매칭되지 않아 `application/octet-stream` 으로 잘못 응답합니다.

## 변경 사항 (Changes)

- `lookup`: `std.mem.eql` → `std.ascii.eqlIgnoreCase` (맵 키는 소문자, 입력은 대소문자 무관).
- `mime_test.zig`: `.JS`/`.PNG`/`.CSS`/`.WOFF2`/`.Jpg` 대문자·혼합 케이스 회귀.

## 루트커즈 (Root Cause)

확장자 비교가 case-sensitive인데 맵 키는 소문자만 존재.

```mermaid
flowchart LR
    A["logo.PNG"] --> B["extension() → '.PNG'"]
    B --> C{"비교"}
    C -->|"Before: eql('.PNG','.png')=false"| D["octet-stream ⚠️"]
    C -->|"After: eqlIgnoreCase=true"| E["image/png ✅"]
    style D fill:#ffe6e6
    style E fill:#e6ffe6
```

## Test Plan
- [x] 대문자/혼합 확장자(.JS/.PNG/.CSS/.WOFF2/.Jpg) 올바른 MIME (TDD red→green)
- [x] 소문자/디렉토리/미지원 확장자 회귀 없음
- [x] 전체 5917/5917, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- 정적 파일 서빙(cold). `eqlIgnoreCase` 는 동일 O(len). 핫패스 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (server runtime)

---

### 초보자 설명
- 파일 확장자는 OS/사용자에 따라 `.PNG` 처럼 대문자일 수 있습니다. MIME 맵은 `.png` 소문자만 갖고 있어 글자 그대로 비교하면 안 맞습니다.
- `std.ascii.eqlIgnoreCase` 는 대소문자를 무시하고 비교하므로 `.PNG`↔`.png` 가 같다고 판단합니다.
