### PR TITLE
fix(cli): --proxy https 대상 기본 포트 443 + 파싱 중복 제거

### DIFF
--- a/src/cli/app.zig
+++ b/src/cli/app.zig
@@ -147,21 +147,8 @@ fn parseProxy(opts: *Options, allocator: std.mem.Allocator, value: []const u8, s
         try stderr.print("zntc {s}: --proxy requires PATH=TARGET\n", .{@tagName(opts.command)});
         std.process.exit(1);
     };
-    const path_str = value[0..eq_pos];
-    const target_str = value[eq_pos + 1 ..];
-    const after_scheme = if (std.mem.indexOf(u8, target_str, "://")) |s| target_str[s + 3 ..] else target_str;
-    var target_host: []const u8 = after_scheme;
-    var target_port: u16 = 80;
-    if (std.mem.indexOf(u8, after_scheme, ":")) |colon| {
-        target_host = after_scheme[0..colon];
-        target_port = std.fmt.parseInt(u16, after_scheme[colon + 1 ..], 10) catch 80;
-    }
-    try opts.proxy_list.append(allocator, .{
-        .path = path_str,
-        .target = target_str,
-        .target_host = target_host,
-        .target_port = target_port,
-    });
+    // host/port 추출 + scheme 기본 포트(https=443)는 ProxyRule.fromTarget 공유.
+    try opts.proxy_list.append(allocator, lib.server.DevServer.ProxyRule.fromTarget(value[0..eq_pos], value[eq_pos + 1 ..]));
 }
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io, opts: Options) !void {

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -653,22 +653,8 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator,
                 i += 1;
                 const kv = args[i];
                 if (std.mem.indexOf(u8, kv, "=")) |eq_pos| {
-                    const path_str = kv[0..eq_pos];
-                    const target_str = kv[eq_pos + 1 ..];
-                    // target에서 host:port 추출 (http://host:port)
-                    const after_scheme = if (std.mem.indexOf(u8, target_str, "://")) |s| target_str[s + 3 ..] else target_str;
-                    var target_host: []const u8 = after_scheme;
-                    var target_port: u16 = 80;
-                    if (std.mem.indexOf(u8, after_scheme, ":")) |colon| {
-                        target_host = after_scheme[0..colon];
-                        target_port = std.fmt.parseInt(u16, after_scheme[colon + 1 ..], 10) catch 80;
-                    }
-                    try opts.proxy_list.append(allocator, .{
-                        .path = path_str,
-                        .target = target_str,
-                        .target_host = target_host,
-                        .target_port = target_port,
-                    });
+                    // host/port 추출 + scheme 기본 포트(https=443)는 ProxyRule.fromTarget 공유.
+                    try opts.proxy_list.append(allocator, lib.server.DevServer.ProxyRule.fromTarget(kv[0..eq_pos], kv[eq_pos + 1 ..]));
                 } else {
                     try stderr.print("zntc: --proxy requires PATH=TARGET format (e.g. /api=http://localhost:8080)\n", .{});
                     std.process.exit(1);

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -176,6 +176,21 @@ pub const DevServer = struct {
         target_host: []const u8,
         /// target에서 추출한 port
         target_port: u16,
+
+        /// `--proxy PATH=TARGET` 의 target(`http(s)://host[:port]`)에서 host/port 추출.
+        /// 명시 port 가 없으면 scheme 기본값(https=443, 그 외=80). host/target 은 입력 슬라이스
+        /// borrow — caller 가 수명 보장. cli/options.zig·cli/app.zig 공유(중복·발산 제거).
+        pub fn fromTarget(path: []const u8, target: []const u8) ProxyRule {
+            const default_port: u16 = if (std.mem.startsWith(u8, target, "https://")) 443 else 80;
+            const after_scheme = if (std.mem.indexOf(u8, target, "://")) |s| target[s + 3 ..] else target;
+            var host: []const u8 = after_scheme;
+            var port: u16 = default_port;
+            if (std.mem.indexOf(u8, after_scheme, ":")) |colon| {
+                host = after_scheme[0..colon];
+                port = std.fmt.parseInt(u16, after_scheme[colon + 1 ..], 10) catch default_port;
+            }
+            return .{ .path = path, .target = target, .target_host = host, .target_port = port };
+        }
     };
 
     /// PR-3b-iii: lazy on-demand 컴파일 상태. entry 빌드가 채운 seed 경로 목록(역참조용)과
@@ -2125,6 +2140,22 @@ pub fn sanitizePath(raw: []const u8) ?[]const u8 {
 // ──────────────────────────────────────────────────────────────────
 // Tests
 // ──────────────────────────────────────────────────────────────────
+
+test "#4316 ProxyRule.fromTarget: scheme 기본 포트(https=443) + 명시 포트 우선" {
+    const testing = std.testing;
+    const R = DevServer.ProxyRule;
+    // https + port 생략 → 443
+    try testing.expectEqual(@as(u16, 443), R.fromTarget("/api", "https://example.com").target_port);
+    try testing.expectEqualStrings("example.com", R.fromTarget("/api", "https://example.com").target_host);
+    // http + port 생략 → 80
+    try testing.expectEqual(@as(u16, 80), R.fromTarget("/api", "http://example.com").target_port);
+    // 명시 포트는 scheme 기본값보다 우선
+    try testing.expectEqual(@as(u16, 8080), R.fromTarget("/api", "http://localhost:8080").target_port);
+    try testing.expectEqual(@as(u16, 9443), R.fromTarget("/api", "https://example.com:9443").target_port);
+    try testing.expectEqualStrings("localhost", R.fromTarget("/api", "http://localhost:8080").target_host);
+    // scheme 없으면 80 (기존 동작 유지)
+    try testing.expectEqual(@as(u16, 80), R.fromTarget("/api", "localhost").target_port);
+}
 
 // PR-3b-iii: lazy on-demand 라우트의 역참조 핵심. 요청 청크 이름의 pathhash 8-hex 가
 // seed 경로의 truncate(Wyhash) 와 일치하면 그 seed 경로를 돌려준다(chunk_names 패턴 무관).


### PR DESCRIPTION
## 요약 (Summary)

`--proxy PATH=TARGET` 파싱이 `src/cli/options.zig` 와 `src/cli/app.zig` 두 곳에 **중복**돼 있고, 둘 다 명시 port 가 없을 때 **scheme 무관 기본 port 80** 을 썼습니다. `--proxy /api=https://example.com`(port 생략)은 443 이어야 하는데 80 으로 연결돼 프록시가 실패합니다.

## 변경 사항 (Changes)

- `DevServer.ProxyRule.fromTarget(path, target)` 공유 헬퍼 신설 — `https://` 면 기본 443, 그 외 80. 명시 port(`:9443`)는 우선.
- `cli/options.zig`·`cli/app.zig` 의 인라인 파싱(각 ~12줄)을 헬퍼 호출로 교체 → 중복·발산 위험 제거.
- `dev_server.zig`: `fromTarget` 단위 테스트(https=443/http=80/명시포트/무scheme).

## 루트커즈 (Root Cause)

기본 port 가 scheme 를 반영하지 않음 + 파싱 로직이 두 파일에 중복.

```mermaid
flowchart LR
    A["https://example.com<br/>(port 생략)"] --> B{"기본 포트"}
    B -->|"Before: 80 ⚠️"| C["443 서버에 80 연결 → 실패"]
    B -->|"After: scheme=https → 443 ✅"| D["정상 연결"]
    E["http://x:8080"] --> F["명시 포트 8080 우선 (불변)"]
    style C fill:#ffe6e6
    style D fill:#e6ffe6
```

## Test Plan
- [x] `https://example.com`→443, `http://x`→80, `http://x:8080`→8080, `https://x:9443`→9443, `localhost`→80 (TDD)
- [x] 전체 5918/5918, `zig build`(CLI 바이너리) + `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- CLI 인자 파싱(1회). 핫패스 무관. 중복 제거로 유지보수성↑.

## AST/IR 체크리스트
- [x] 해당 없음 (CLI/server runtime)

---

### 초보자 설명
- URL `https://` 의 기본 포트는 443, `http://` 는 80 입니다. 포트를 안 적으면 scheme 에 맞는 기본값을 써야 합니다.
- 같은 파싱 코드가 두 파일에 복붙돼 있어, 한 곳만 고치면 다른 곳이 어긋납니다. 그래서 `ProxyRule.fromTarget` 한 함수로 모아 두 곳이 같은 로직을 쓰게 했습니다.
