### PR TITLE
fix(server): resolveLazySeedPath 가 대문자 hex 청크 요청 404 — case-insensitive 비교

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -1658,7 +1658,8 @@ pub const DevServer = struct {
             var hash_buf: [8]u8 = undefined;
             const h: u32 = @truncate(std.hash.Wyhash.hash(0, sp));
             _ = std.fmt.bufPrint(&hash_buf, "{x:0>8}", .{h}) catch continue;
-            if (std.mem.eql(u8, seg, &hash_buf)) return sp;
+            // hash 생성은 소문자(`{x}`)지만 isHex 는 대문자도 허용 → 비교도 case-insensitive 로 일관.
+            if (std.ascii.eqlIgnoreCase(seg, &hash_buf)) return sp;
         }
         return null;
     }
@@ -2172,6 +2173,15 @@ test "resolveLazySeedPath: 청크 이름의 pathhash 로 seed 역참조" {
 
     const got = DevServer.resolveLazySeedPath(&seeds, name) orelse return error.TestUnexpectedResult;
     try testing.expectEqualStrings(seeds[0], got);
+
+    // #4318: 대문자 hex 요청도 같은 seed 로 역참조. isHex 는 대문자를 허용하므로 비교도
+    // case-insensitive 여야 일관(프록시/대소문자 정규화 경유 요청 404 방지).
+    var upper_buf: [8]u8 = undefined;
+    _ = std.ascii.upperString(&upper_buf, &hash_buf);
+    var uname_buf: [64]u8 = undefined;
+    const uname = std.fmt.bufPrint(&uname_buf, "heavy-{s}.js", .{upper_buf}) catch unreachable;
+    const ugot = DevServer.resolveLazySeedPath(&seeds, uname) orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings(seeds[0], ugot);
 
     // 매칭 seed 없는 8-hex → null (static fallback).
     try testing.expect(DevServer.resolveLazySeedPath(&seeds, "stranger-12345678.js") == null);


### PR DESCRIPTION
## 요약 (Summary)

`src/server/dev_server.zig` 의 `resolveLazySeedPath`(lazy on-demand 청크 라우트 역참조)가 요청 청크 이름의 8-hex 세그먼트를 `std.ascii.isHex`(대문자 A-F 허용)로 검증하지만, seed 의 기대 hash 는 `{x:0>8}`(소문자) 생성 + `std.mem.eql`(대소문자 구분) 비교입니다.

→ 대문자 hex 요청(`heavy-DEADBEEF.js`)은 isHex 검증을 통과하나 소문자 hash 와 eql 비교에 실패 → `null` → **404**.

## 변경 사항 (Changes)

- 비교를 `std.mem.eql` → `std.ascii.eqlIgnoreCase` (isHex 의 대문자 허용과 정합).
- 기존 테스트에 대문자 hex 요청 역참조 케이스 추가.

## 루트커즈 (Root Cause)

검증(`isHex` — 대문자 허용)과 비교(소문자 exact eql)의 대소문자 처리 불일치.

```mermaid
flowchart LR
    A["요청: heavy-DEADBEEF.js"] --> B["isHex('DEADBEEF') = true (대문자 허용)"]
    B --> C{"비교 vs 'deadbeef'(소문자 생성)"}
    C -->|"Before: eql=false ⚠️"| D["null → 404"]
    C -->|"After: eqlIgnoreCase=true"| E["seed 반환 ✅"]
    style D fill:#ffe6e6
    style E fill:#e6ffe6
```

## Test Plan
- [x] 대문자 hex 요청이 같은 seed 로 역참조 (TDD red→green)
- [x] 소문자/non-match/non-.js/strict 세그먼트(중간 hash·7hex) 회귀 없음
- [x] 전체 5918/5918, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- lazy 청크 라우트 매칭(요청당). `eqlIgnoreCase` 동일 O(8). 핫패스 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (server runtime)

---

### 초보자 설명
- 16진수 `deadbeef` 와 `DEADBEEF` 는 같은 값입니다. 검증 함수(`isHex`)는 둘 다 받아주는데, 실제 비교는 글자 그대로(소문자만) 해서 대문자 요청을 놓쳤습니다.
- `eqlIgnoreCase` 로 대소문자 무시 비교를 하면 둘이 같다고 판단해 올바른 청크를 찾습니다.
