### PR TITLE
fix(core): transpile/tokenize 가 빈 소스('')를 거부 — 빈 파일은 유효 입력

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -524,7 +524,8 @@ export function transpile(
   source: string,
   options: TranspileOptions & { cache?: TsconfigCache } = {},
 ): TranspileResult {
-  if (!source) throw new Error('@zntc/core: empty source');
+  // 빈 문자열('')은 유효한 입력(빈 출력) — null/undefined/비-string 만 거부.
+  if (typeof source !== 'string') throw new Error('@zntc/core: source must be a string');
   validateTsConfigRaw(options.tsconfigRaw);
 
   const optionsJson = buildOptionsJson(options, resolveUnsupported(options));
@@ -537,7 +538,8 @@ export function transpile(
 }
 
 export function tokenize(source: string, options: TokenizeOptions = {}): TokenizeToken[] {
-  if (!source) throw new Error('@zntc/core: empty source');
+  // 빈 문자열('')은 유효한 입력(토큰 0개) — null/undefined/비-string 만 거부.
+  if (typeof source !== 'string') throw new Error('@zntc/core: source must be a string');
   return ensureNative().tokenize(source, options.filename ?? 'input.js');
 }
 

--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -163,9 +163,19 @@ pub inline fn unwrapNapi(comptime T: type, env: c.napi_env, value: c.napi_value)
 /// `DebugAllocator` / arena / page 등 size-tracking allocator 로 전환하는 순간
 /// invalid-free panic. 정확 크기로 `dupe` 후 임시 buf 즉시 free 해 contract 준수.
 pub fn getStringArg(env: c.napi_env, value: c.napi_value, alloc: std.mem.Allocator) ?[]const u8 {
+    return getStringArgImpl(env, value, alloc, false);
+}
+
+/// `getStringArg` 와 동일하나 빈 문자열(`''`)을 유효 입력으로 허용한다 — null 은 napi 실패/비-string
+/// 만 의미. transpile/tokenize 의 source 처럼 빈 입력이 정당한(빈 출력) 경우에 쓴다. (#4320)
+pub fn getStringArgAllowEmpty(env: c.napi_env, value: c.napi_value, alloc: std.mem.Allocator) ?[]const u8 {
+    return getStringArgImpl(env, value, alloc, true);
+}
+
+fn getStringArgImpl(env: c.napi_env, value: c.napi_value, alloc: std.mem.Allocator, allow_empty: bool) ?[]const u8 {
     var len: usize = 0;
     if (c.napi_get_value_string_utf8(env, value, null, 0, &len) != c.napi_ok) return null;
-    if (len == 0) return null;
+    if (len == 0) return if (allow_empty) (alloc.dupe(u8, "") catch null) else null;
     const tmp = alloc.alloc(u8, len + 1) catch return null;
     defer alloc.free(tmp);
     var actual: usize = 0;

--- a/packages/core/src/napi/transpile_entry.zig
+++ b/packages/core/src/napi/transpile_entry.zig
@@ -13,6 +13,7 @@ const native_alloc = common.nativeAlloc();
 
 const throwError = common.throwError;
 const getStringArg = common.getStringArg;
+const getStringArgAllowEmpty = common.getStringArgAllowEmpty;
 const setUint32Prop = common.setUint32Prop;
 const setStringProp = common.setStringProp;
 
@@ -31,9 +32,9 @@ pub fn napiTranspile(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c
         return throwError(env, "transpile requires at least 2 arguments (source, filename)");
     }
 
-    // source (필수)
-    const source = getStringArg(env, argv[0], native_alloc) orelse {
-        return throwError(env, "invalid or empty source");
+    // source (필수) — 빈 문자열('')은 유효(빈 출력), null 은 napi 실패/비-string 만.
+    const source = getStringArgAllowEmpty(env, argv[0], native_alloc) orelse {
+        return throwError(env, "invalid source (not a string)");
     };
     defer native_alloc.free(source);
 
@@ -137,8 +138,8 @@ pub fn napiTokenize(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
     }
     if (argc < 1) return throwError(env, "tokenize requires source");
 
-    const source = getStringArg(env, argv[0], native_alloc) orelse {
-        return throwError(env, "invalid or empty source");
+    const source = getStringArgAllowEmpty(env, argv[0], native_alloc) orelse {
+        return throwError(env, "invalid source (not a string)");
     };
     defer native_alloc.free(source);
 

--- a/packages/core/test/core/edge-cases/transpile/syntax.ts
+++ b/packages/core/test/core/edge-cases/transpile/syntax.ts
@@ -1,4 +1,22 @@
+import { tokenize } from '../../../../index';
 import { describe, expect, test, transpile } from '../../helpers';
+
+describe('@zntc/core #4320: 빈 소스는 유효 입력', () => {
+  test("transpile('') → 빈 출력 (에러 아님)", () => {
+    expect(transpile('').code).toBe('');
+  });
+
+  test("tokenize('') → EOF 토큰만 (에러 아님)", () => {
+    const toks = tokenize('');
+    expect(toks.length).toBe(1);
+    expect(toks[0]?.kind).toBe('<eof>');
+  });
+
+  test('null/undefined source 는 여전히 거부', () => {
+    expect(() => transpile(undefined as unknown as string)).toThrow();
+    expect(() => tokenize(null as unknown as string)).toThrow();
+  });
+});
 
 describe('@zntc/core edge cases: transpile syntax coverage', () => {
   test('enum + namespace 병합', () => {


### PR DESCRIPTION
## 요약 (Summary)

`transpile()` / `tokenize()` (`@zntc/core`) 가 빈 문자열(`''`)을 거부했습니다. JS 가드 `if (!source)` 와 네이티브 `getStringArg`(`len == 0` → `null`) 가 **"빈 문자열"과 "source 누락"을 구분하지 못해** `"invalid or empty source"` 를 throw 합니다. 빈 파일은 유효 입력(빈 출력 / EOF 토큰)인데(esbuild/tsc 도 허용) spurious 에러로 거부됩니다 — Vite/Rollup 플러그인이 빈 파일을 넘길 때 발생.

## 변경 사항 (Changes)

- **JS** (`index.ts`): `if (!source)` → `if (typeof source !== 'string')` (transpile·tokenize). `null`/`undefined`/비-string 만 거부, `''` 허용.
- **네이티브** (`common.zig`): `getStringArgAllowEmpty` 추가 — 빈 문자열은 유효(`""` dupe), `null` 은 napi 실패/비-string 만. `getStringArg` 는 공유 `getStringArgImpl(allow_empty)` 에 위임(중복 0, 기존 호출부 동작 불변).
- **네이티브** (`transpile_entry.zig`): `napiTranspile`·`napiTokenize` 의 **source 인자만** `getStringArgAllowEmpty` 사용(filename/options 는 그대로).
- 테스트: `transpile('')→{code:''}`, `tokenize('')→[<eof>]`, `transpile(undefined)→throw`.

## 루트커즈 (Root Cause)

JS·네이티브 양쪽이 "빈 문자열(유효)"과 "source 누락(에러)"을 동일 취급.

```mermaid
flowchart TD
    A["transpile('')"] --> B{"JS: !source"}
    B -->|"Before: true ⚠️"| C["throw 'empty source'"]
    B -->|"After: typeof!=='string' → false"| D{"네이티브 getStringArg"}
    D -->|"Before: len==0 → null ⚠️"| E["throw 'invalid or empty'"]
    D -->|"After: getStringArgAllowEmpty → ''"| F["transpile 파이프라인 → code:'' ✅"]
    style C fill:#ffe6e6
    style E fill:#ffe6e6
    style F fill:#e6ffe6
```

## Test Plan
- [x] `transpile('') → { code: '' }`, `tokenize('') → [<eof>]` (TDD)
- [x] `transpile(undefined)`/`tokenize(null)` 여전히 throw
- [x] transpile edge-case 13/13, zig 5918/5918, tsc/oxlint clean
- [x] napi 재빌드(`zig build napi`) 후 실측 검증

## Decision / 성능 영향 (Impact)
- 입력 검증 분기만. 핫패스 무관. `getStringArg` 는 위임으로 동작 불변(다른 NAPI 진입점 영향 0).

## AST/IR 체크리스트
- [x] 빈 소스 → 빈 AST → 빈 출력(파이프라인 기존 처리, scanner empty-source 테스트 존재)

---

### 초보자 설명
- JS 에서 `!''` 는 `true` 입니다(빈 문자열은 falsy). 그래서 `if (!source)` 는 `undefined` 뿐 아니라 빈 문자열도 함께 막아버립니다. `typeof source !== 'string'` 으로 바꾸면 "문자열이면 통과(빈 문자열 포함), 아니면 거부"가 됩니다.
- 네이티브(Zig)도 길이 0 을 "값 없음"으로 처리했습니다. `getStringArgAllowEmpty` 는 napi 호출이 성공했는지(=문자열이 맞는지)와 길이 0(=빈 문자열)을 구분합니다. 공통 로직은 `getStringArgImpl` 하나로 두고 `allow_empty` 플래그만 다르게 해 중복을 없앴습니다.
