### PR TITLE
fix(vite-plugin): Vite 버전 게이트가 ESM require 실패 + parseInt 취약 → Vite 5 이중변환

### DIFF
--- a/packages/vite-plugin/src/index.test.ts
+++ b/packages/vite-plugin/src/index.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+
+import { shouldDisableEsbuildForVite } from './index';
+
+describe('#4322 shouldDisableEsbuildForVite — Vite major 버전 게이트', () => {
+  test('Vite 5 이하 → esbuild 비활성화(true)', () => {
+    expect(shouldDisableEsbuildForVite('5.4.2')).toBe(true);
+    expect(shouldDisableEsbuildForVite('5.0.0')).toBe(true);
+    expect(shouldDisableEsbuildForVite('4.5.0')).toBe(true);
+  });
+
+  test('Vite 6 이상 → 비활성화 안 함(false)', () => {
+    expect(shouldDisableEsbuildForVite('6.0.0')).toBe(false);
+    expect(shouldDisableEsbuildForVite('6.0.0-beta.1')).toBe(false);
+    expect(shouldDisableEsbuildForVite('7.1.3')).toBe(false);
+  });
+
+  test('파싱 불가 버전 → 보수적으로 false', () => {
+    expect(shouldDisableEsbuildForVite('vite-5')).toBe(false);
+    expect(shouldDisableEsbuildForVite('')).toBe(false);
+    expect(shouldDisableEsbuildForVite('latest')).toBe(false);
+  });
+});

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -46,6 +46,16 @@ const DEFAULT_EXCLUDE = /node_modules/;
 /// jsx: 'preserve' 모드에서 ZNTC 가 위임할 파일 패턴 — JSX 가 있을 수 있는 확장자.
 const JSX_EXT_PATTERN = /\.[jt]sx$/;
 
+/**
+ * Vite 5 이하에서만 esbuild 변환을 비활성화해야 하는지 판단(Vite 6+ 는 Rolldown 기반이라 불필요).
+ * version 문자열의 major 세그먼트만 robust 파싱 — `parseInt('6.0.0-beta')` 류 취약성 회피, 파싱
+ * 불가 시 보수적으로 false(비활성화 안 함). 순수 함수로 분리해 단위 테스트 가능.
+ */
+export function shouldDisableEsbuildForVite(version: string): boolean {
+  const major = Number.parseInt(version.split('.', 1)[0] ?? '', 10);
+  return Number.isFinite(major) && major < 6;
+}
+
 export function zntc(options: ZntcPluginOptions = {}): Plugin {
   const include = options.include ?? DEFAULT_INCLUDE;
   const exclude = options.exclude ?? DEFAULT_EXCLUDE;
@@ -61,11 +71,12 @@ export function zntc(options: ZntcPluginOptions = {}): Plugin {
     name: '@zntc/vite-plugin',
 
     // Vite 5: esbuild transform 비활성화, Vite 6+: 이미 Rolldown 기반이므로 불필요
-    config(_, _env) {
-      // Vite 5 이하에서만 esbuild 비활성화 (Vite 6+는 Rolldown 사용)
+    async config(_, _env) {
+      // ESM/CJS 양쪽에서 동작하도록 dynamic import 의 `version` named export 사용
+      // (CJS require 는 ESM 패키지에서 throw → 기존엔 catch 가 삼켜 Vite 5 에서 미비활성).
       try {
-        const viteVersion = parseInt(require('vite/package.json').version);
-        if (viteVersion < 6) return { esbuild: false };
+        const { version } = await import('vite');
+        if (shouldDisableEsbuildForVite(version)) return { esbuild: false };
       } catch {}
       return {};
     },


### PR DESCRIPTION
## 요약 (Summary)

`packages/vite-plugin/src/index.ts` 의 `config` 훅이 Vite 버전을 `parseInt(require('vite/package.json').version)` 로 감지했습니다.

1. **CJS `require` in ESM** — `"type": "module"` 패키지에서 `require` 미정의 → throw → `catch {}` 가 삼킴 → **Vite 5 에서 esbuild 비활성화 누락** → ZNTC + Vite esbuild 이중 변환.
2. **`parseInt(version)` 취약** — major 숫자로 시작 안 하면 `NaN`, `NaN < 6` 은 `false` → 비활성화 누락.

## 변경 사항 (Changes)

- `config` 를 `async` 로, `await import('vite')` 의 `version` named export 사용(ESM/CJS 양쪽 동작).
- major 파싱 + `Number.isFinite` 가드를 순수 함수 `shouldDisableEsbuildForVite(version)` 로 추출 → 단위 테스트.
- `index.test.ts`: Vite 5↓→true / 6↑·prerelease→false / 파싱불가→false.

## 루트커즈 (Root Cause)

CJS `require` 를 ESM 에서 사용(throw 삼킴) + `parseInt` 의 비-robust 버전 파싱.

```mermaid
flowchart LR
    A["config()"] --> B{"버전 취득"}
    B -->|"Before: require('vite/package.json')"| C["ESM서 throw → catch{} → 미비활성 ⚠️"]
    B -->|"After: await import('vite').version"| D["shouldDisableEsbuildForVite(version)"]
    D -->|"major < 6"| E["esbuild: false ✅"]
    D -->|"major ≥ 6 / 파싱불가"| F["{} (그대로)"]
    style C fill:#ffe6e6
    style E fill:#e6ffe6
```

## Test Plan
- [x] `'5.4.2'`→true, `'6.0.0'`/`'6.0.0-beta.1'`/`'7.1.3'`→false, `'vite-5'`/`''`→false
- [x] tsc/oxlint 통과. async config 는 Vite Plugin 타입 허용.

## Decision / 성능 영향 (Impact)
- 플러그인 init 1회. `import('vite')` 는 이미 로드된 모듈 재사용. 핫패스 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (Vite plugin 어댑터)

---

### 초보자 설명
- `require` 는 CommonJS, `import` 는 ES Module 방식입니다. 이 패키지는 ESM(`"type": "module"`)이라 `require` 가 없어 throw 했고, `catch {}` 가 그 에러를 조용히 삼켜 Vite 5 처리가 누락됐습니다.
- `await import('vite')` 는 동적 import 로 두 방식 모두에서 동작하고, `vite` 가 내보내는 `version` 을 바로 읽습니다.
- 버전 비교 로직을 `shouldDisableEsbuildForVite` 함수로 떼어내 `'6.0.0-beta'` 같은 까다로운 문자열까지 테스트로 검증합니다.
