### PR TITLE
fix(react-native): metro-resolve 가 빈 assetFiles 시 bare specifier 를 경로로 반환

### DIFF
--- a/packages/react-native/src/plugins/metro-resolve-request.test.ts
+++ b/packages/react-native/src/plugins/metro-resolve-request.test.ts
@@ -49,12 +49,11 @@ describe('createMetroResolveRequestPlugin', () => {
     });
   });
 
-  test('Resolution.assetFiles 빈 배열 → 원래 path 유지', () => {
+  test('Resolution.assetFiles 빈 배열 → null (기본 해석기 위임, bare specifier 누출 금지)', () => {
     const resolver: CustomResolver = () => ({ type: 'assetFiles', filePaths: [] });
     const handler = captureHandler({ resolveRequest: resolver, platform: 'android' });
-    expect(handler({ path: './missing.png', importer: '/abs/x' })).toEqual({
-      path: './missing.png',
-    });
+    // 빈 filePaths 는 해석 실패 — 원래 specifier(./missing.png)를 경로로 반환하면 안 됨.
+    expect(handler({ path: './missing.png', importer: '/abs/x' })).toBeNull();
   });
 
   test('Resolution.empty → `{ disabled: true }`', () => {

--- a/packages/react-native/src/plugins/metro-resolve-request.ts
+++ b/packages/react-native/src/plugins/metro-resolve-request.ts
@@ -59,7 +59,12 @@ export function createMetroResolveRequestPlugin(opts: MetroResolveRequestOptions
             metroPlatform,
           );
           if (result.type === 'sourceFile') return { path: result.filePath };
-          if (result.type === 'assetFiles') return { path: result.filePaths[0] ?? args.path };
+          if (result.type === 'assetFiles') {
+            // 빈 filePaths 는 해석 실패 — bare specifier(args.path)를 경로로 반환하면 안 된다.
+            // 첫 asset 이 있으면 그 경로로, 없으면 null 로 ZNTC 기본 해석기에 위임.
+            const assetPath = result.filePaths[0];
+            return assetPath ? { path: assetPath } : null;
+          }
           // Metro `{ type: 'empty' }` → ZNTC `disabled` flag (빈 모듈로 처리 —
           // ZNTC 가 자동으로 module.exports = {} 출력, 별도 onLoad 불필요).
           if (result.type === 'empty') return { disabled: true };


### PR DESCRIPTION
## 요약 (Summary)

`packages/react-native/src/plugins/metro-resolve-request.ts` 의 onResolve 핸들러가 Metro custom resolver 의 `assetFiles` 결과를 처리할 때 `filePaths` 가 **빈 배열**이면 `result.filePaths[0] ?? args.path` 로 **원래 specifier(`args.path`)를 해석된 파일 경로처럼 반환**했습니다. `./missing.png` 같은 미해석 specifier 가 "해석된 경로"인 척 번들러로 전달돼 혼란스러운 downstream 에러를 유발합니다.

## 변경 사항 (Changes)

- `assetFiles` 분기: 첫 asset 경로가 있으면 `{ path }`, 없으면 `null`(ZNTC 기본 해석기 위임). bare specifier fallback 제거.
- 테스트: 기존 "빈 배열 → 원래 path 유지"(버그 박제)를 "빈 배열 → null(위임)"로 교정.

## 루트커즈 (Root Cause)

빈 `filePaths` 를 "해석 실패"로 보지 않고 원본 specifier 로 fallback.

```mermaid
flowchart LR
    A["assetFiles { filePaths: [] }"] --> B{"filePaths[0]"}
    B -->|"Before: undefined ?? args.path"| C["{ path: './missing.png' } ⚠️<br/>미해석 specifier 누출"]
    B -->|"After: undefined → null"| D["기본 해석기 위임 ✅"]
    E["assetFiles { filePaths: ['/a@2x.png'] }"] --> F["{ path: '/a@2x.png' } (불변)"]
    style C fill:#ffe6e6
    style D fill:#e6ffe6
```

## Test Plan
- [x] 빈 `assetFiles` → `null`(위임) (TDD red→green: 기존 버그-박제 테스트 교정)
- [x] 비-빈 `assetFiles` → 첫 경로, sourceFile/empty/위임 등 기존 9 케이스 회귀 없음
- [x] tsc/oxlint 통과

## Decision / 성능 영향 (Impact)
- 모듈 해석 경로(요청당). 분기 1개. 핫패스 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (RN resolver 어댑터)

---

### 초보자 설명
- Metro resolver 가 "에셋 파일들"을 돌려주는데 그 목록이 비어 있으면, 사실상 "못 찾음"입니다. 그런데 원래 요청 문자열(`./missing.png`)을 마치 찾은 경로처럼 돌려주면 번들러가 그 가짜 경로를 열려다 엉뚱한 에러를 냅니다.
- `null` 을 반환하면 "나는 해석 못 했으니 기본 해석기가 처리하라"는 위임 신호가 됩니다(이 플러그인의 다른 위임 경로와 동일).
