### PR TITLE
fix(codegen): sourcemap addMapping dedup 이 name_index 무시 → 명명 매핑 소실

### DIFF
--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -340,6 +340,14 @@ pub const SourceMapBuilder = struct {
                 last.original_line == mapping.original_line and
                 last.original_column == mapping.original_column)
             {
+                // 좌표가 모두 같음. name_index 까지 같으면 진짜 중복 → 생략. 좌표는 같지만 last 엔
+                // 이름이 없고 new 에 있으면 last 를 교체(이름 정보가 더 유용 — Sentry/DevTools 의
+                // 식별자 복원). 위치당 segment 1 개 유지. 그 외(new 무명/다른 이름)는 last 유지.
+                if (!std.meta.eql(last.name_index, mapping.name_index) and
+                    last.name_index == null and mapping.name_index != null)
+                {
+                    self.mappings.items[self.mappings.items.len - 1] = mapping;
+                }
                 return;
             }
             if (self.is_sorted) {

--- a/src/codegen/sourcemap_test.zig
+++ b/src/codegen/sourcemap_test.zig
@@ -57,6 +57,25 @@ test "SourceMapBuilder: simple mapping" {
     try std.testing.expect(std.mem.indexOf(u8, json, "\"sources\":[\"input.ts\"]") != null);
 }
 
+test "#4326 dedup 은 name_index 를 고려 — 같은 좌표 named 매핑 보존" {
+    var builder = SourceMapBuilder.init(std.testing.allocator);
+    defer builder.deinit();
+    _ = try builder.addSource("input.ts");
+    const nm = try builder.addName("originalName");
+
+    // 같은 좌표(0,0,0,0,0)에 unnamed → named 순서로 추가.
+    try builder.addMapping(.{ .generated_line = 0, .generated_column = 0, .original_line = 0, .original_column = 0 });
+    try builder.addMapping(.{ .generated_line = 0, .generated_column = 0, .original_line = 0, .original_column = 0, .name_index = nm });
+
+    // 이름 있는 매핑이 보존돼야 한다(dedup 이 버리면 안 됨). 위치당 1 segment 유지.
+    try std.testing.expectEqual(@as(usize, 1), builder.mappings.items.len);
+    try std.testing.expectEqual(@as(?u32, nm), builder.mappings.items[0].name_index);
+
+    // 완전 동일(이름 포함) 중복은 여전히 생략.
+    try builder.addMapping(.{ .generated_line = 0, .generated_column = 0, .original_line = 0, .original_column = 0, .name_index = nm });
+    try std.testing.expectEqual(@as(usize, 1), builder.mappings.items.len);
+}
+
 test "SourceMapBuilder: multi-line mapping" {
     var builder = SourceMapBuilder.init(std.testing.allocator);
     defer builder.deinit();


### PR DESCRIPTION
## 요약 (Summary)

`src/codegen/sourcemap.zig` 의 `addMapping` 중복 억제가 직전 mapping 과 5개 좌표(generated_line/column, source_index, original_line/column)만 비교하고 **`name_index` 를 무시**했습니다. 같은 좌표에 이름 없는 mapping 뒤에 이름 있는 mapping 이 오면(outer wrapper → 첫 자식 식별자 패턴) dedup 이 named mapping 을 버려 **이름 링크가 소실**됩니다.

## 변경 사항 (Changes)

- `addMapping` dedup: 좌표가 모두 같을 때 — `name_index` 도 같으면 생략(진짜 중복), `last` 무명+`new` 명명이면 `last` 를 `new` 로 교체(이름 보존 + 위치당 1 segment), 그 외 `last` 유지.
- `sourcemap_test.zig`: unnamed→named 같은 좌표 → 이름 보존 / 완전 동일 중복은 생략 회귀.

## 루트커즈 (Root Cause)

dedup 술어가 `name_index` 를 제외 — 좌표만 같으면 이름 차이를 무시하고 생략.

```mermaid
flowchart LR
    A["addMapping(0,0, name=null)"] --> M["mappings"]
    B["addMapping(0,0, name=X)"] --> C{"좌표 동일?"}
    C -->|"Before: name_index 무시"| D["dedup 생략 → name=X 소실 ⚠️"]
    C -->|"After: last 무명+new 명명"| E["last 교체 → name=X 보존 ✅"]
    style D fill:#ffe6e6
    style E fill:#e6ffe6
```

## Test Plan
- [x] (0,0) unnamed→named → `name_index` 보존, 위치당 1 segment (TDD red→green: 수정 전 found null)
- [x] 완전 동일(이름 포함) 중복은 여전히 생략
- [x] 전체 5919/5919, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- dedup 분기에 조건 1개 추가(같은 좌표일 때만). mappings 수는 동일하거나 감소(교체이므로 증가 없음). VLQ size 영향 없음.

## AST/IR 체크리스트
- [x] 해당 없음 (sourcemap mapping 집계)

---

### 초보자 설명
- 소스맵은 "출력 위치 → 원본 위치 (+선택적으로 원본 이름)" 매핑의 모음입니다. 같은 출력 위치에 매핑이 둘 박히면 중복이라 하나를 버리는데, 그 둘 중 하나만 "원본 이름"을 갖고 있으면 이름 있는 쪽을 살려야 디버거가 변수 원래 이름을 복원합니다.
- 기존 dedup 은 좌표만 보고 이름을 안 봐서, 이름 없는 매핑이 먼저 박히면 이름 있는 매핑을 버렸습니다. 이제 이름이 새로 생기면 그쪽으로 교체합니다.
