### PR TITLE
fix(parser): break/continue 가 expectSemicolon 대신 eat(.semicolon) — ASI 종결 미강제

### DIFF
--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4735,19 +4735,45 @@ test "TS: ternary alternate parenthesized arrow does not consume typed-arrow spe
     try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
 }
 
-// literal keyword (`true`/`false`/`null`) 는 valid label 이 아님. 이전 widening
-// 으로 `canBeBindingName()` 이 literal keyword 도 포함했었고, 그 결과
-// `break true;` 가 `break true` (labeled) 로 잘못 파싱됐었다 (/simplify 사후
-// 리뷰 발견). `isLiteralKeyword()` 가드 추가.
-test "TS: break/continue does not consume literal keyword as label" {
-    var r = try parseTs(std.testing.allocator,
-        \\while (true) break true;
-        \\while (true) continue null;
-    );
-    defer r.deinit();
-    // ASI 가 `break;` / `continue;` 다음에 적용되고 `true;`/`null;` 가 별도
-    // expression-statement 가 된다. parser-level 에러 없음.
-    try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
+// literal keyword (`true`/`false`/`null`) 는 valid label 이 아님 — `isLiteralKeyword()`
+// 가드로 label 로 소비되지 않는다. 따라서 `break`/`continue` 는 라벨 없이 끝나는데, 같은 줄에
+// `true`/`null` 이 이어지므로 restricted production(`break [no LineTerminator here]
+// LabelIdentifier`)도 `break ;`도 성립 안 함 → SyntaxError(#4328 expectSemicolon 이 ASI 종결
+// 강제). 가드가 없었다면 `true` 가 label 로 소비돼 0 에러였을 것 — 에러 존재가 가드 동작을 입증.
+test "Parser #4328: break/continue 라벨 자리 literal keyword 는 ASI 에러" {
+    inline for (.{ "while (true) break true;", "while (true) continue null;" }) |src| {
+        var scanner = try Scanner.init(std.testing.allocator, src);
+        defer scanner.deinit();
+        var parser = Parser.init(std.testing.allocator, &scanner);
+        defer parser.deinit();
+        _ = try parser.parse();
+        try std.testing.expect(parser.errors.items.len > 0);
+    }
+}
+
+test "Parser #4328: break/continue 라벨 뒤 잡토큰은 ASI 에러" {
+    // `break foo` 후 같은 줄 `extra` → expectSemicolon 위반.
+    inline for (.{ "while (true) { break foo extra; }", "while (true) { continue foo extra; }" }) |src| {
+        var scanner = try Scanner.init(std.testing.allocator, src);
+        defer scanner.deinit();
+        var parser = Parser.init(std.testing.allocator, &scanner);
+        defer parser.deinit();
+        _ = try parser.parse();
+        try std.testing.expect(parser.errors.items.len > 0);
+    }
+    // 유효 케이스: `break foo;`(세미콜론), `}` 앞(ASI), 줄바꿈(ASI) → 에러 없음.
+    inline for (.{
+        "foo: while (true) { break foo; }",
+        "foo: while (true) { break foo }",
+        "while (true) { break\n x }",
+    }) |src| {
+        var scanner = try Scanner.init(std.testing.allocator, src);
+        defer scanner.deinit();
+        var parser = Parser.init(std.testing.allocator, &scanner);
+        defer parser.deinit();
+        _ = try parser.parse();
+        try std.testing.expect(parser.errors.items.len == 0);
+    }
 }
 
 // `@(inst["foo"]) method() {}` 같은 parenthesized decorator + computed member

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -975,7 +975,8 @@ fn parseSimpleStatement(self: *Parser, tag: Tag) ParseError2!NodeIndex {
     }
 
     const end = self.currentSpan().end;
-    _ = try self.eat(.semicolon);
+    // ASI 강제 — 라벨/키워드 뒤엔 `;`/줄바꿈/`}`/EOF 만 허용(잡토큰 leniently 수용 금지).
+    try self.expectSemicolon();
     return try self.ast.addNode(.{
         .tag = tag,
         .span = .{ .start = start, .end = end },


### PR DESCRIPTION
## 요약 (Summary)

`src/parser/statement.zig` 의 `parseSimpleStatement`(break/continue/debugger)가 종결 시 `_ = try self.eat(.semicolon)` 를 썼습니다 — 세미콜론이 있으면 소비하고 없으면 그냥 넘어갈 뿐, **ASI 규칙을 강제하지 않습니다**. 따라서 라벨/키워드 뒤에 같은 줄에서 잡토큰이 와도 에러를 내지 않습니다.

```js
while (true) { break foo extra; }  // `break foo` 후 `extra` 가 별도 statement 로 leniently 수용 — 에러 없음
```

스펙상 `break`/`continue [label]` 다음엔 `;` / 줄바꿈(ASI) / `}` / EOF 여야 하고, restricted production `break [no LineTerminator here] LabelIdentifier ;` 을 위반하면 SyntaxError 입니다.

## 변경 사항 (Changes)

- `parseSimpleStatement`: `eat(.semicolon)` → `expectSemicolon()` (parseExpressionStatement 와 동일 — `;`/줄바꿈/`}`/EOF 만 허용).
- 기존 "literal keyword as label" 테스트가 `parseTs`(내부적으로 0 에러 가정)를 써서 **잘못된 leniency 를 박제**(`break true;` 를 0 에러로 기대)했음 → 직접 `Scanner`/`Parser` 패턴으로 교정해 **에러 검출**을 검증. `break true`(같은 줄, `true` 는 라벨 불가)는 실제 SyntaxError 임이 맞음.
- 잡토큰/유효 ASI 케이스 회귀 테스트 추가.

## 루트커즈 (Root Cause)

`eat(.semicolon)` 는 ASI/종결을 검증하지 않음 → 라벨 뒤 잡토큰을 조용히 수용.

```mermaid
flowchart LR
    A["break foo · extra (같은 줄)"] --> B{"종결 처리"}
    B -->|"Before: eat(.semicolon)"| C["extra 미소비 → 별도 stmt, 에러 없음 ⚠️"]
    B -->|"After: expectSemicolon()"| D{"; / 줄바꿈 / } / EOF ?"}
    D -->|"extra (아님)"| E["SyntaxError ✅"]
    style C fill:#ffe6e6
    style E fill:#e6ffe6
```

## Test Plan
- [x] `break foo extra;` / `continue foo extra;` / `break true;` / `continue null;` → 에러(TDD red→green)
- [x] `break foo;` / `break foo`(`}` 앞) / `break\n x`(줄바꿈 ASI) → 에러 없음
- [x] 전체 5920/5920, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- 파싱 종결 처리만. expectSemicolon 은 다른 statement 와 동일 비용. 핫패스 무관.

## AST/IR 체크리스트
- [x] AST 노드 형태 불변 (종결 검증만 강화) — 유효 코드 출력 동일, 잘못된 코드만 진단 추가

---

### 초보자 설명
- **ASI(자동 세미콜론 삽입)**: JS 는 줄바꿈이나 `}`/파일끝에서 세미콜론을 자동 보충합니다. 하지만 `break foo extra` 처럼 같은 줄에 토큰이 더 있으면 보충되지 않아 문법 오류입니다.
- **restricted production**: `break`/`continue` 는 "줄바꿈 없으면 바로 라벨, 그다음 세미콜론"만 허용합니다. `break true` 의 `true` 는 예약어라 라벨이 못 되고, 줄바꿈도 없어 오류입니다.
- 기존 테스트는 `parseTs`(에러 0 가정 헬퍼)를 써서 이 오류를 "정상"으로 잘못 기록했는데, 직접 파서를 돌려 에러 개수를 세는 방식으로 바로잡았습니다.
