### PR TITLE
fix(cli): bench worker 가 transpile 에러를 swallow → 무의미한 측정값 + 신호 없음

### DIFF
--- a/src/cli/bench.zig
+++ b/src/cli/bench.zig
@@ -108,13 +108,29 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) !
     };
     defer allocator.free(source);
 
+    // pre-flight: 입력이 transpile 되는지 1회 검증. 실패하거나 진단이 있으면 측정이 무의미하므로
+    // 명확히 에러로 알린다(과거엔 worker 가 catch return 으로 조용히 swallow 해 거짓 sub-ms 수치).
+    {
+        var probe = lib.transpile.transpileWithCallback(allocator, source, input_file, .{}, null) catch |err| {
+            try stderr.print("zntc bench: transpile failed for '{s}': {}\n", .{ input_file, err });
+            std.process.exit(1);
+        };
+        defer probe.deinit(allocator);
+        if (probe.diagnostics.len > 0) {
+            try stderr.print("zntc bench: '{s}' 에 {d}개 진단 — 측정 무의미, 유효한 입력으로 실행하세요\n", .{ input_file, probe.diagnostics.len });
+            std.process.exit(1);
+        }
+    }
+
     // Benchmark 실행 — bench.zig 의 공용 runner (NAPI 와 공유).
     const Ctx = struct {
         source: []const u8,
         filename: []const u8,
         fn run(a: std.mem.Allocator, raw_ctx: ?*anyopaque) anyerror!void {
             const self: *@This() = @ptrCast(@alignCast(raw_ctx.?));
-            var result = lib.transpile.transpileWithCallback(a, self.source, self.filename, .{}, null) catch return;
+            // 에러는 swallow(catch return) 하지 않고 전파 — runBenchmark 가 해당 iteration 을
+            // 스킵(catch continue)해 bogus near-zero 샘플 기록을 막는다.
+            var result = try lib.transpile.transpileWithCallback(a, self.source, self.filename, .{}, null);
             result.deinit(a);
         }
     };


### PR DESCRIPTION
## 요약 (Summary)

`src/cli/bench.zig` 의 worker 가 `transpileWithCallback(...) catch return` 으로 transpile 에러를 조용히 삼켰습니다(117). transpile 이 hard-fail(OOM 등)하거나 입력이 유효하지 않으면 각 iteration 이 거의 작업 없이 반환 → **측정값이 무의미**(거짓 sub-ms)한데 **사용자에게 신호가 없습니다**. 더구나 `catch return` 은 void(성공)를 돌려줘 `runBenchmark` 가 bogus near-zero 샘플을 기록합니다.

## 변경 사항 (Changes)

- 벤치 루프 전 **pre-flight** transpile 1회로 입력 검증 — Zig 에러면 `transpile failed: {err}` + exit(1), 진단(diagnostics)이 있으면 `N개 진단 — 측정 무의미` + exit(1).
- worker 의 `catch return` → `try` — 드문 비결정적 실패 시 `runBenchmark`(공용, NAPI 공유)가 해당 iteration 을 **스킵**(catch continue)해 bogus 0 샘플 기록 방지.

## 루트커즈 (Root Cause)

worker 가 에러를 swallow + 유효성 검증 부재 → 측정 왜곡 + 신호 없음.

```mermaid
flowchart LR
    A["zntc bench bad.ts"] --> B{"transpile"}
    B -->|"Before: catch return"| C["void 반환 → near-zero 샘플 기록 ⚠️<br/>거짓 sub-ms, 에러 없음"]
    B -->|"After: pre-flight 검증"| D["transpile failed: ParseError → exit(1) ✅"]
    style C fill:#ffe6e6
    style D fill:#e6ffe6
```

## Test Plan (CLI 통합 — bench 는 dev 도구라 유닛 테스트 부재)
- [x] 유효 입력 → 정상 벤치 출력, exit 0
- [x] syntax-error 입력 → `transpile failed for '...': error.ParseError`, **exit 1** (거짓 수치 없음)
- [x] 전체 5920/5920, `zig build`(CLI) + `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- pre-flight 는 벤치 시작 1회(측정 전, warmup 밖). 측정 수치 영향 0. `runBenchmark`(공용 runner) 미변경.

## AST/IR 체크리스트
- [x] 해당 없음 (벤치 CLI 도구)

---

### 초보자 설명
- 벤치마크는 "이 작업이 얼마나 빠른가"를 재는데, 작업이 에러로 즉시 끝나면 "엄청 빠름"으로 잘못 나옵니다. 그걸 조용히 넘기면 사용자는 거짓 수치를 믿게 됩니다.
- 그래서 벤치 시작 전에 입력을 한 번 변환해 보고, 실패하면 그 자리에서 명확히 알리고 멈춥니다(`exit(1)`).
- 측정 루프 안에서는 `catch return`(에러를 성공처럼 처리) 대신 `try`(에러 전파)로 바꿔, 혹시 실패한 회차가 있으면 그 회차를 빼고(0 샘플 기록 안 함) 계속합니다.
