### PR TITLE
fix(core): readFileOrThrowNotFound 가 workspace 부재도 'config file not found' 로 오안내

### DIFF
--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -205,7 +205,7 @@ export async function loadModuleDefault<T>(
   const allowArray = options?.allowArray === true;
   const ext = extname(absPath).toLowerCase();
   if (ext === '.json') {
-    const raw = readFileOrThrowNotFound(absPath);
+    const raw = readFileOrThrowNotFound(absPath, kind);
     try {
       return JSON.parse(raw) as T;
     } catch (err) {
@@ -242,7 +242,7 @@ async function loadTsModule(
   allowArray: boolean,
 ): Promise<unknown> {
   init();
-  const source = readFileOrThrowNotFound(absPath);
+  const source = readFileOrThrowNotFound(absPath, kind);
   // ZNTC parser 는 filename 의 `.cts` 확장자를 보고 CommonJS Script 모드로 진입해
   // 최상위 `export default` 를 거부한다 (`src/parser/parser.zig:283` 부근). 사용자가
   // `.cts` 에 `export default {...}` 를 쓴 의도는 TS 식 ESM 이므로 파싱 단계에서만
@@ -313,12 +313,12 @@ export async function importAndResolveDefault<T = UserConfig>(
   return value as T;
 }
 
-function readFileOrThrowNotFound(absPath: string): string {
+function readFileOrThrowNotFound(absPath: string, kind: ModuleKind): string {
   try {
     return readFileSync(absPath, 'utf8');
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      throw new Error(`@zntc/core: config file not found: ${absPath}`);
+      throw new Error(`@zntc/core: ${kind} file not found: ${absPath}`);
     }
     throw err;
   }

--- a/packages/core/src/workspace.test.ts
+++ b/packages/core/src/workspace.test.ts
@@ -62,6 +62,11 @@ describe('loadWorkspace', () => {
     expect(ws).toEqual(['./pkg-a', { name: 'shared' }]);
   });
 
+  test('#4332: 없는 workspace 파일 → "workspace file not found" (config 아님)', () => {
+    const p = join(dir, 'does-not-exist.workspace.ts');
+    expect(loadWorkspace(p)).rejects.toThrow(/workspace file not found/);
+  });
+
   test('.json: 배열 export', async () => {
     const p = join(dir, 'b.workspace.json');
     writeFileSync(p, JSON.stringify(['./pkg-x', { name: 'y' }]));


### PR DESCRIPTION
## 요약 (Summary)

`packages/core/src/config-loader.ts` 의 `readFileOrThrowNotFound` 가 파일 부재(ENOENT) 시 항상 `"config file not found"` 를 던졌습니다. 이 함수는 `loadTsModule(absPath, kind, ...)` 와 JSON 경로 양쪽에서 호출되고 `kind` 는 `'config' | 'workspace'` 인데, workspace 파일이 없을 때도 **"config file not found"** 로 잘못 안내했습니다(doc 주석은 kind 별 메시지를 의도).

## 변경 사항 (Changes)

- `readFileOrThrowNotFound(absPath, kind)` 로 `kind` 파라미터 추가 → `@zntc/core: ${kind} file not found`.
- 두 호출부(208 JSON / 245 TS)에 `kind` 전달.
- `workspace.test.ts`: 없는 workspace 파일 → `/workspace file not found/` 회귀.

## 루트커즈 (Root Cause)

`readFileOrThrowNotFound` 가 `kind` 를 받지 않고 "config" 하드코딩.

```mermaid
flowchart LR
    A["loadWorkspace(없는파일)"] --> B["loadTsModule(kind='workspace')"]
    B --> C["readFileOrThrowNotFound(absPath)"]
    C -->|"Before: 'config file not found' ⚠️"| D["오안내"]
    C -->|"After: '<kind> file not found'"| E["'workspace file not found' ✅"]
    style D fill:#ffe6e6
    style E fill:#e6ffe6
```

## Test Plan
- [x] 없는 workspace 파일 → `/workspace file not found/` (TDD red→green: 수정 전 "config file not found")
- [x] 없는 config 파일 → `/config file not found/` 유지 (config-loader.test.ts)
- [x] core 91/91, tsc/oxlint clean

## Decision / 성능 영향 (Impact)
- 에러 메시지 분기만(파일 부재 경로). 핫패스 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (config/workspace 로더)

---

### 초보자 설명
- `config-loader` 는 `zntc.config.*` 와 `*.workspace.*` 두 종류 파일을 같은 로직으로 읽습니다(`kind` 로 구분).
- 파일이 없을 때 메시지를 "config"로 고정해 두면 workspace 파일을 못 찾았을 때 엉뚱하게 "config 파일 없음"이라 떠 혼란스럽습니다. `kind` 를 메시지에 넣어 정확히 안내합니다.
