### PR TITLE
fix(core): writeOutputFiles 가 모든 .map 을 outfile.map 으로 broad-match — 다중 map 충돌(잠재)

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -4,6 +4,7 @@ import './test/core/api';
 import './test/core/build-sync';
 import './test/core/build-async';
 import './test/core/output-file-shape';
+import './test/core/resolve-output-path';
 import './test/core/build-plugins';
 import './test/core/edge-cases';
 import './test/core/plugin-advanced';

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -2806,6 +2806,27 @@ function postProcessCssOutputs(result: BuildResult, options: BuildOptions): void
 }
 
 /**
+ * 단일 출력 파일의 디스크 경로를 결정한다(순수 함수 — 단위 테스트용 분리).
+ *
+ * outfile 모드에선 메인 번들(`bundle.js`)을 outfile 로, 그 짝 sourcemap(`bundle.js.map`)을
+ * `outfile.map` 으로 보낸다. **메인 map 에만 특정**(`=== 'bundle.js.map'`) — 과거 `endsWith('.map')`
+ * 광범위 매칭은 메인이 아닌 map(다중 청크 등)도 같은 `outfile.map` 으로 보내 덮어썼다. 그 외
+ * 파일은 outdir 가 있으면 그 아래로, 없으면 cwd 기준으로 해석.
+ *
+ * @internal
+ */
+export function resolveOutputPath(
+  filePath: string,
+  opts: { outfileResolved: string | null; outdir?: string },
+): string {
+  const { outfileResolved, outdir } = opts;
+  if (outfileResolved && filePath === 'bundle.js') return outfileResolved;
+  if (outfileResolved && filePath === 'bundle.js.map') return `${outfileResolved}.map`;
+  if (outdir) return join(resolve(outdir), filePath);
+  return resolve(filePath);
+}
+
+/**
  * write/outdir/outfile 옵션에 따라 빌드 결과를 디스크에 기록한다.
  */
 function writeOutputFiles(result: BuildResult, options: BuildOptions): void {
@@ -2828,18 +2849,7 @@ function writeOutputFiles(result: BuildResult, options: BuildOptions): void {
   const outfileResolved = options.outfile ? resolve(options.outfile) : null;
 
   for (const file of result.outputFiles) {
-    let outPath: string;
-    if (outfileResolved && file.path === 'bundle.js') {
-      // 메인 번들 → outfile 경로로 출력
-      outPath = outfileResolved;
-    } else if (outfileResolved && file.path.endsWith('.map')) {
-      // 소스맵 → outfile 옆에 .map으로 출력
-      outPath = outfileResolved + '.map';
-    } else if (options.outdir) {
-      outPath = join(resolve(options.outdir), file.path);
-    } else {
-      outPath = resolve(file.path);
-    }
+    const outPath = resolveOutputPath(file.path, { outfileResolved, outdir: options.outdir });
     const dir = dirname(outPath);
     if (!createdDirs.has(dir)) {
       mkdirSync(dir, { recursive: true });

--- a/packages/core/test/core/resolve-output-path.ts
+++ b/packages/core/test/core/resolve-output-path.ts
@@ -1,0 +1,36 @@
+import { resolve } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+import { resolveOutputPath } from '../../index';
+
+describe('#4334 resolveOutputPath — outfile .map 충돌 방지', () => {
+  const outfileResolved = resolve('/out/app.js');
+
+  test('메인 번들 bundle.js → outfile 경로', () => {
+    expect(resolveOutputPath('bundle.js', { outfileResolved })).toBe(outfileResolved);
+  });
+
+  test('메인 map bundle.js.map → outfile.map', () => {
+    expect(resolveOutputPath('bundle.js.map', { outfileResolved })).toBe(`${outfileResolved}.map`);
+  });
+
+  test('메인이 아닌 .map 은 outfile.map 으로 hijack 되지 않음(충돌 방지)', () => {
+    // 과거 endsWith('.map') 는 이걸 outfile.map 으로 보내 메인 map 을 덮어썼다.
+    const got = resolveOutputPath('dynamic-abc123.js.map', { outfileResolved });
+    expect(got).not.toBe(`${outfileResolved}.map`);
+    expect(got).toBe(resolve('dynamic-abc123.js.map'));
+  });
+
+  test('outdir 모드: 비-메인 파일은 outdir 아래 자기 경로', () => {
+    const got = resolveOutputPath('dynamic-abc123.js.map', {
+      outfileResolved,
+      outdir: '/out',
+    });
+    expect(got).toBe(resolve('/out', 'dynamic-abc123.js.map'));
+  });
+
+  test('outfile 없으면 cwd 기준 해석', () => {
+    expect(resolveOutputPath('chunk.js', { outfileResolved: null })).toBe(resolve('chunk.js'));
+  });
+});


### PR DESCRIPTION
## 요약 (Summary)

`packages/core/index.ts` 의 `writeOutputFiles` 가 outfile 모드에서 출력 경로를 정할 때 **모든** `.map` 파일을 `file.path.endsWith('.map')` 로 잡아 `outfileResolved + '.map'` 하나로 보냈습니다. 메인 번들(`bundle.js`)의 map(`bundle.js.map`)만 가야 하는데, 메인이 아닌 `.map`(다중 청크 map 등)도 같은 경로로 보내 **서로 덮어쓸 수 있습니다**.

## 재현 검증 (Reachability)

**현재는 도달 불가** — 실측: 단일 파일(map 1개), 스플리팅(map 0개), CSS import(map 1개) 모두 `outfile` 와 다중 map 이 공존하지 않음. sourceMappingURL 링크도 정상(절대경로로 올바른 map 가리킴). 다만 `endsWith('.map')` 의 정밀도 부족은 **잠재 충돌 버그**이며, `=== 'bundle.js.map'` 정밀 매칭이 정확합니다(동작 보존 + 방어).

## 변경 사항 (Changes)

- 경로 결정 로직을 순수 함수 `resolveOutputPath(filePath, { outfileResolved, outdir })` 로 추출(`@internal`, 단위 테스트용).
- `.map` 분기: `endsWith('.map')` → `=== 'bundle.js.map'` (메인 map 에만 특정 — `=== 'bundle.js'` 메인 rename 과 짝).
- `resolve-output-path.ts`: 메인/비-메인 map / outdir / no-outfile 케이스 단위 테스트(충돌 방지 포함).

## 루트커즈 (Root Cause)

`.map` 매칭이 `endsWith`(광범위) — 메인 번들 map 에 특정돼야 함.

```mermaid
flowchart TD
    A["dynamic-X.js.map (비-메인)"] --> B{".map 매칭"}
    B -->|"Before: endsWith('.map')"| C["outfile.map 으로 → 메인 map 덮어씀 ⚠️"]
    B -->|"After: === 'bundle.js.map' (불일치)"| D["자기 경로 → 충돌 0 ✅"]
    E["bundle.js.map (메인)"] -->|"=== 'bundle.js.map'"| F["outfile.map ✅"]
    style C fill:#ffe6e6
    style D fill:#e6ffe6
```

## Test Plan
- [x] `bundle.js.map` → `outfile.map`, `dynamic-X.js.map` → 자기 경로(≠ outfile.map) — 충돌 방지(단위 테스트; 구 endsWith 로직에선 실패)
- [x] outdir/no-outfile 케이스, 단일 파일 빌드 동작 보존(empirical: app.js + app.js.map)
- [x] core 단위 5/5, tsc/oxlint clean

## Decision / 성능 영향 (Impact)
- 디스크 write 경로 결정만(빌드 후 1회). 핫패스 무관. 현재 동작 불변(방어적 정밀화).

## AST/IR 체크리스트
- [x] 해당 없음 (출력 파일 write 경로)

---

### 초보자 설명
- `endsWith('.map')` 은 "이름이 .map 으로 끝나는 모든 파일"을 잡습니다. 그런데 map 이 여러 개면 전부 같은 `outfile.map` 으로 보내 마지막 하나만 남고 나머지는 사라집니다.
- 메인 번들의 map 은 정확히 `bundle.js.map` 이므로, `=== 'bundle.js.map'` 로 그것만 골라 outfile 옆으로 보내면 다른 map 과 충돌하지 않습니다.
- 경로 계산을 `resolveOutputPath` 함수로 떼어내 "이 입력엔 이 경로"를 단위 테스트로 못 박았습니다.
