### PR TITLE
fix(parser): #4328 break/continue/debugger 종결을 expectSemicolon 으로 — ASI 강제

### DIFF
--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -1656,6 +1656,59 @@ test "Parser: break in nested function inside loop is error" {
     try std.testing.expectEqualStrings("'break' outside of loop or switch", parser.errors.items[0].message);
 }
 
+// #4328: break/continue 종결이 expectSemicolon 을 거쳐 ASI 를 강제해야 한다.
+// `break <label>` 다음 같은 줄 잡토큰은 spec 위반 → 에러여야 함(이전엔 eat(.semicolon)
+// 라 leniently 별도 statement 로 수용).
+test "Parser: break label followed by junk on same line is error (#4328)" {
+    var scanner = try Scanner.init(std.testing.allocator, "while (true) { break foo extra; }");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    try std.testing.expect(parser.errors.items.len > 0);
+}
+
+test "Parser: continue label followed by junk on same line is error (#4328)" {
+    var scanner = try Scanner.init(std.testing.allocator, "for (;;) { continue foo extra; }");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    try std.testing.expect(parser.errors.items.len > 0);
+}
+
+test "Parser: debugger followed by junk on same line is error (#4328)" {
+    var scanner = try Scanner.init(std.testing.allocator, "debugger extra;");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    try std.testing.expect(parser.errors.items.len > 0);
+}
+
+// 유효 종결(세미콜론/줄바꿈 ASI/`}`/label)은 회귀 없이 통과해야 한다.
+test "Parser: labelled break/continue valid terminations have no error (#4328)" {
+    const cases = [_][]const u8{
+        "foo: while (true) { break foo; }", // 세미콜론
+        "foo: while (true) { break foo\n}", // 줄바꿈 ASI
+        "foo: while (true) { continue foo }", // `}` 앞 ASI
+        "while (true) { break\nx; }", // 라벨 없는 break + 줄바꿈
+        "debugger;", // debugger 세미콜론
+    };
+    for (cases) |src| {
+        var scanner = try Scanner.init(std.testing.allocator, src);
+        defer scanner.deinit();
+        var parser = Parser.init(std.testing.allocator, &scanner);
+        defer parser.deinit();
+
+        _ = try parser.parse();
+        try std.testing.expect(parser.errors.items.len == 0);
+    }
+}
+
 test "Parser: with statement in strict mode is error" {
     var scanner = try Scanner.init(std.testing.allocator,
         \\"use strict";
@@ -4739,15 +4792,25 @@ test "TS: ternary alternate parenthesized arrow does not consume typed-arrow spe
 // 으로 `canBeBindingName()` 이 literal keyword 도 포함했었고, 그 결과
 // `break true;` 가 `break true` (labeled) 로 잘못 파싱됐었다 (/simplify 사후
 // 리뷰 발견). `isLiteralKeyword()` 가드 추가.
-test "TS: break/continue does not consume literal keyword as label" {
-    var r = try parseTs(std.testing.allocator,
-        \\while (true) break true;
-        \\while (true) continue null;
-    );
-    defer r.deinit();
-    // ASI 가 `break;` / `continue;` 다음에 적용되고 `true;`/`null;` 가 별도
-    // expression-statement 가 된다. parser-level 에러 없음.
-    try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
+test "Parser: break/continue with literal keyword on same line is error (#4328)" {
+    // `true`/`null` 은 literal keyword 라 label position 에서 제외된다(label 미소비).
+    // 그 결과 `break`/`continue` (라벨 없음) 뒤 같은 줄에 잡토큰이 남아 expectSemicolon
+    // 이 거부 — spec/엔진과 일치한다(node: `SyntaxError: Unexpected token 'true'`).
+    // 이전엔 eat(.semicolon) 라 `true;`/`null;` 를 별도 statement 로 leniently 수용했음.
+    // (parseTs 헬퍼는 내부에서 0-error 를 강제하므로 에러 기대 테스트엔 직접 Parser 사용.)
+    const cases = [_][]const u8{
+        "while (true) break true;",
+        "while (true) continue null;",
+    };
+    for (cases) |src| {
+        var scanner = try Scanner.init(std.testing.allocator, src);
+        defer scanner.deinit();
+        var parser = Parser.init(std.testing.allocator, &scanner);
+        defer parser.deinit();
+
+        _ = try parser.parse();
+        try std.testing.expect(parser.errors.items.len > 0);
+    }
 }
 
 // `@(inst["foo"]) method() {}` 같은 parenthesized decorator + computed member

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -975,7 +975,11 @@ fn parseSimpleStatement(self: *Parser, tag: Tag) ParseError2!NodeIndex {
     }
 
     const end = self.currentSpan().end;
-    _ = try self.eat(.semicolon);
+    // break/continue/debugger 도 다른 statement 와 동일하게 ASI 를 강제한다(#4328).
+    // eat(.semicolon) 은 `;` 만 소비할 뿐 종결을 검증 안 해, `break foo extra;` 의
+    // `extra` 같은 라벨 뒤 잡토큰을 leniently 수용했다. expectSemicolon 은
+    // `;`/줄바꿈/`}`/EOF 만 허용하고 그 외엔 에러.
+    try self.expectSemicolon();
     return try self.ast.addNode(.{
         .tag = tag,
         .span = .{ .start = start, .end = end },


### PR DESCRIPTION
Closes #4328

## 문제 (Problem)

`src/parser/statement.zig` 의 `parseSimpleStatement`(break/continue/**debugger** 공용)이 종결에 `_ = try self.eat(.semicolon)` 를 썼다 — `;` 가 있으면 소비하고 없으면 그냥 넘어갈 뿐 **ASI 규칙을 강제하지 않는다**(다른 statement 는 `expectSemicolon()` 사용). 그래서 라벨 뒤 같은 줄에 잡토큰이 와도 에러를 내지 않았다.

```js
while (true) { break foo extra; }   // `break foo` 후 `extra` 가 별도 expression statement 로 leniently 파싱 — 에러 없음
while (true) break true;            // 거부돼야 하는데 통과
```

스펙상 `break`/`continue [label]` · `debugger` 다음엔 `;` / 줄바꿈(ASI) / `}` / EOF 여야 한다.

**node 검증**:
```
while (true) break true;     → SyntaxError: Unexpected token 'true'
while (true) continue null;  → SyntaxError: Unexpected token 'null'
```

## 루트커즈 & 수정 (Root cause / Fix)

루트커즈는 `eat(.semicolon)` 이 **종결을 검증하지 않는다**는 것. 다른 statement 와 동일하게 `expectSemicolon()` 으로 교체했다 (`;`/줄바꿈/`}`/EOF 허용, 그 외 에러). break·continue·debugger 셋 다 spec 상 ASI 가 필요하므로 일관 적용.

```zig
-    _ = try self.eat(.semicolon);
+    try self.expectSemicolon();
```

## 기존 테스트 정정 (수반)

기존 `"TS: break/continue does not consume literal keyword as label"` 테스트가 `while (true) break true;` 를 **0-error(유효)** 로 단정하고 있었는데, 이는 **leniency 버그를 코드화**한 것이다. node/spec 기준 `break true` 는 SyntaxError 이므로 **에러 기대로 정정**했다 (`true`/`null` 이 literal keyword 라 label 로 소비되지 않는다는 핵심 의도는 유지 — 라벨 미소비 + 같은 줄 잡토큰이라 거부).

## 초보자 설명 (Zig)

- `eat(token)` 은 "그 토큰이 있으면 먹고 없으면 그냥 false 반환" — 검증을 안 한다.
- `expectSemicolon()` 은 "세미콜론을 먹거나, 없으면 ASI 가 허용되는 자리(줄바꿈 직전/`}`/파일 끝)인지 확인하고, 아니면 에러" — JS 의 자동 세미콜론 삽입(ASI) 규칙을 구현한다.
- 다른 statement 는 전부 `expectSemicolon()` 을 쓰는데 break/continue/debugger 만 `eat` 를 써서 느슨했던 게 이 버그.

## Test Plan
- [x] `while(true){break foo extra;}` / `continue foo extra` / `debugger extra;` → 에러(>0)
- [x] `while(true) break true;` / `continue null;` → 에러(literal keyword, node 일치)
- [x] 유효 종결 회귀: `break foo;`(세미콜론) / `break foo\n}`(줄바꿈 ASI) / `continue foo }`(`}` ASI) / `break\nx;` / `debugger;`
- [x] `zig build test` 전체 5919 pass
- [x] `zig fmt --check src/` 통과
- [x] 통합 테스트 4105 pass (남은 1 fail = `watch-stress` RSS 임계값 — 변경 stash 한 clean main 에서도 동일 실패하는 pre-existing flaky, 파서 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)