### PR TITLE
fix(transformer): generator for-in 이 Object.keys(own-only/shadow) snapshot → for-in 의미 위반

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -3303,7 +3303,9 @@ test "ES5: async for-in body extracts await into state machine" {
         \\}
     );
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.keys") != null);
+    // #4337: for-in 은 native for-in 으로 키 수집(own+상속, shadow-safe) — Object.keys(own-only) 아님.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.keys") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, " in fields)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "(yield validateField") == null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "validateField(field)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_state.sent()") != null);

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -579,12 +579,14 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 try visitExprWithYieldExtraction(self, right, ops, next_label)
             else
                 try self.visitNode(right);
-            const iterable_value = if (stmt.tag == .for_in_statement) blk: {
-                const object_ref = try es_helpers.makeIdentifierRef(self, "Object");
-                const keys_ref = try es_helpers.makeIdentifierRef(self, "keys");
-                const keys_member = try es_helpers.makeStaticMember(self, object_ref, keys_ref, span);
-                break :blk try es_helpers.makeCallExpr(self, keys_member, &.{new_right}, span);
-            } else new_right;
+            // for-of: _arr = iterable. for-in: _arr = [] 후 native `for (_k in obj) _arr.push(_k)`
+            // 로 own+상속 enumerable 키를 수집한다. `Object.keys` 는 own 만 + `Object` shadow 취약
+            // 이라 for-in 의미(own+상속, shadow 무관)에 어긋났다. 수집 for-in 은 yield 없는
+            // self-contained 문 → 아래에서 statement op 으로 verbatim 방출.
+            const iterable_value = if (stmt.tag == .for_in_statement)
+                try self.ast.addListNode(.array_expression, span, .{ .start = 0, .len = 0 })
+            else
+                new_right;
 
             // init: _i = 0, _arr = iterable (assignment)
             // __generator 콜백은 매 호출마다 새 실행 컨텍스트이므로
@@ -608,6 +610,26 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             });
             const arr_stmt = try es_helpers.makeExprStmt(self, arr_assign, span);
             try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = arr_stmt } });
+
+            // for-in: `for (_k in obj) _arr.push(_k)` 로 own+상속 enumerable 키를 _arr 에 수집.
+            // hoist 된 _k 사용(기존 _i/_arr 와 동일). yield 없는 문이라 statement op 으로 verbatim.
+            if (stmt.tag == .for_in_statement) {
+                const key_span = try es_helpers.makeTempVarSpan(self);
+                try self.generator_temp_var_spans.append(self.allocator, key_span);
+                const key_ref_left = try es_helpers.makeTempVarRef(self, key_span, key_span);
+                const arr_ref_push = try es_helpers.makeTempVarRef(self, arr_span, arr_span);
+                const push_prop = try es_helpers.makeIdentifierRef(self, "push");
+                const push_member = try es_helpers.makeStaticMember(self, arr_ref_push, push_prop, span);
+                const key_arg = try es_helpers.makeTempVarRef(self, key_span, key_span);
+                const push_call = try es_helpers.makeCallExpr(self, push_member, &.{key_arg}, span);
+                const push_stmt = try es_helpers.makeExprStmt(self, push_call, span);
+                const collect = try self.ast.addNode(.{
+                    .tag = .for_in_statement,
+                    .span = span,
+                    .data = .{ .ternary = .{ .a = key_ref_left, .b = new_right, .c = push_stmt } },
+                });
+                try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = collect } });
+            }
 
             // cond_label
             const cond_label = next_label.*;

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -2353,6 +2353,24 @@ test "TLA: import declarations are kept outside of wrapper" {
     try std.testing.expect(import_pos < async_pos);
 }
 
+test "#4337 generator for-in 은 native for-in 으로 키 수집 (Object.keys 아님)" {
+    // generator 안 for-in 다운레벨: Object.keys(own-only/shadow 취약) 대신 native for-in 으로
+    // own+상속 enumerable 키를 수집해야 한다(for-in 의미 보존).
+    const source = "function* g(o){ for (var k in o) yield k; }";
+    var r = try parseAsModuleAndTransform(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .generator = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // Object.keys 미사용(own-only/shadow). native for-in 으로 객체 `o` 의 키 수집 + push.
+    try std.testing.expect(std.mem.indexOf(u8, code, "Object.keys") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, " in o)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, ".push(") != null);
+}
+
 test "TLA: ES5 downlevel produces __async + __generator wrap, no bare yield" {
     // target=es5 (async_await + top_level_await + generator 전부 unsupported) 에서
     // bare yield leak 이 없어야 한다 (#1384 재현 케이스).


### PR DESCRIPTION
## 요약 (Summary)

`src/transformer/es2015_generator.zig` 의 `collectForOfOperations` 가 generator/async `for-in` 을 다운레벨할 때 `Object.keys(obj)` snapshot 을 순회했습니다.

1. **`Object.keys` 는 own enumerable 키만** 반환 — `for-in` 은 own + **상속** enumerable 키를 순회. 상속 enumerable 프로퍼티(예: `Object.create(proto)`) 가 있으면 키 누락.
2. **`Object` 참조 shadow 취약** — 사용자가 `Object` 를 가리면 깨짐.

## 변경 사항 (Changes)

- for-in 다운레벨을 native for-in 키 수집으로 교체: `_arr = []` 후 `for (_k in obj) _arr.push(_k)`. 이는 own+상속 enumerable 키를 정확히 모으고(=for-in 의미), `Object` 참조가 없어 shadow-safe.
- 수집 for-in 은 yield 없는 self-contained 문 → state-machine 의 `.statement` op 으로 verbatim 방출. `_k` 는 기존 `_i`/`_arr` 처럼 hoist.
- 테스트: generator for-in 출력 검증(#4337) + async for-in 공유 경로 테스트 교정(Object.keys 기대 → native for-in).

## 출력 (Before → After)

```
Before: _b = Object.keys(o);            // own only, Object shadow 취약
After:  _b = []; for (_c in o) _b.push(_c);   // own+상속, shadow-safe
```

## 루트커즈 (Root Cause)

`Object.keys`(own-only, shadow 가능) ≠ `for-in`(own+상속, shadow 무관) 의미.

```mermaid
flowchart LR
    A["for (k in obj) yield k"] --> B{"키 수집"}
    B -->|"Before: Object.keys(obj)"| C["own 키만 + Object shadow 취약 ⚠️"]
    B -->|"After: for (_k in obj) _arr.push(_k)"| D["own+상속 enumerable + shadow-safe ✅"]
    style C fill:#ffe6e6
    style D fill:#e6ffe6
```

## Test Plan
- [x] generator for-in 출력: `Object.keys` 미사용, native `for (… in o)` + `.push(` 사용 (TDD; 구 코드선 실패)
- [x] async for-in 공유 경로 테스트 교정(상태머신 await 추출 검증 유지)
- [x] 전체 5921/5921, for-of 경로 회귀 없음, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- generator/async for-in 다운레벨 경로만(드문 구문). state-machine op 1개 추가(키 수집). 핫패스 무관. for-of 불변.

## AST/IR 체크리스트
- [x] for-in 다운레벨 출력 변경(Object.keys call → native for-in 수집 문). own+상속 키 정확.
- [x] `_k` temp hoist(기존 _i/_arr 패턴). 노드 공유 없음(left/arg 각각 fresh ref).

---

### 초보자 설명
- `for (k in obj)` 는 obj 자신의 속성뿐 아니라 **프로토타입에서 물려받은** 열거 가능 속성도 훑습니다. `Object.keys(obj)` 는 자신의 것만 줍니다 — 그래서 상속 속성이 빠집니다.
- generator 안에서는 yield 때문에 for-in 을 그대로 못 두고 "키 목록을 미리 모아 배열로 도는" 형태로 바꿉니다. 그 목록을 `Object.keys` 대신 진짜 `for...in` 으로 모으면 상속 키까지 정확히 담깁니다.
- 또 `Object` 라는 이름을 사용자가 다른 값으로 덮어쓰면 `Object.keys` 가 깨지는데, 네이티브 `for...in` 은 그런 의존이 없어 안전합니다.
