### PR TITLE
fix(transformer): top-level-await wrap 이 styled-components css-prop 추출 decl 소실

### DIFF
--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -1594,6 +1594,32 @@ test "styled (cssProp): intrinsic tag + template_literal css value 추출" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red") != null);
 }
 
+test "styled (cssProp) #4339: top-level-await wrap 시에도 추출된 module-level decl 보존" {
+    // TLA 다운레벨(async IIFE wrap)과 cssProp 추출이 동시에 일어나는 파일. 과거엔 program 의
+    // TLA wrap 이 early-return 해 css_prop_pending_decls 가 hoist 되지 않고 소실(undefined ref).
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const el = <div css={`color: red;`}>x</div>;
+        \\await Promise.resolve(1);
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_css_prop = true,
+            .jsx_transform = true,
+            .jsx_runtime = .automatic,
+            .jsx_filename = "test.tsx",
+            .unsupported = .{ .top_level_await = true },
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // 추출된 generated decl 이 소실되지 않아야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled_0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red") != null);
+}
+
 test "styled (cssProp): 옵션 비활성 시 변환 없음 (안전한 기본 동작)" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -78,13 +78,16 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
         .program => {
             // Plugin visitor 훅 선취권 (file-level worklet directive 등)
             if (try self.dispatchVisitor(.on_program, idx)) |replacement| return replacement;
-            // ES2022 top-level await 다운레벨링: 미지원 타겟에서 async IIFE 로 wrap. (#1384)
-            if (self.options.unsupported.top_level_await) {
-                if (try es2022_tla.lowerProgram(Transformer, self, node)) |wrapped| {
-                    return wrapped;
+            // ES2022 top-level await 다운레벨링: 미지원 타겟에서 async IIFE 로 wrap (#1384).
+            // wrap 결과도 `.program` 노드라 아래 css_prop hoist 가 동일 적용돼야 한다 — 과거엔
+            // 여기서 early-return 해 TLA+styled-components(css-prop) 동시 사용 시 추출된
+            // module-level decl 이 hoist 되지 않고 소실됐다.
+            const result = blk: {
+                if (self.options.unsupported.top_level_await) {
+                    if (try es2022_tla.lowerProgram(Transformer, self, node)) |wrapped| break :blk wrapped;
                 }
-            }
-            const result = try self.visitListNode(idx);
+                break :blk try self.visitListNode(idx);
+            };
             // styled-components cssProp transform 으로 추출된 module-level decl 들을
             // program body 끝에 hoist. trailing_nodes 가 nearest list (declarator list 등)
             // 에 들어가는 케이스 회피.


### PR DESCRIPTION
## 요약 (Summary)

`src/transformer/transformer/node_dispatch.zig` 의 `.program` 케이스가 top-level-await 다운레벨(`es2022_tla.lowerProgram` → async IIFE wrap)이 적용되면 wrap 결과를 **early-return** 해, 아래의 styled-components cssProp 추출 decl(`css_prop_pending_decls`)을 program body 에 hoist 하는 로직을 건너뛰었습니다.

→ TLA + styled-components `cssProp` 를 동시에 쓰는 파일에서, 추출된 module-level decl(예: `_styled_0`)이 소실 → 런타임 undefined reference.

## 변경 사항 (Changes)

- `.program` 의 TLA-wrap 경로와 일반 방문 경로를 `blk` 로 묶어 `result` 로 통합 → css_prop_pending_decls hoist 가 **양쪽 모두** 적용(TLA-wrap 결과도 `.program` 노드라 동일하게 hoist 가능).
- `styled_components_test.zig`: TLA + cssProp 조합 → 추출 decl 보존 테스트(#4339).

## 루트커즈 (Root Cause)

TLA wrap 경로가 pending decl flush 전에 early-return.

```mermaid
flowchart TD
    A[".program 방문"] --> B{"TLA 미지원?"}
    B -->|"yes → lowerProgram"| C["wrapped (.program)"]
    B -->|"no"| D["visitListNode"]
    C --> E{"css_prop_pending hoist"}
    D --> E
    E -->|"Before: TLA 경로는 early-return 으로 건너뜀 ⚠️"| F["_styled_0 소실"]
    E -->|"After: 양쪽 result 에 flush"| G["_styled_0 program body 에 hoist ✅"]
    style F fill:#ffe6e6
    style G fill:#e6ffe6
```

## Test Plan
- [x] TLA + cssProp 조합 소스 → `_styled_0`/`color: red` 보존 (TDD; revert-verify 로 버그 시 실패 확인)
- [x] cssProp-only / TLA-only 기존 테스트 회귀 없음
- [x] 전체 5922/5922, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- program 방문 경로 통합(분기 동일). 핫패스 무관. TLA-only/cssProp-only 동작 불변.

## AST/IR 체크리스트
- [x] TLA-wrap 결과 program 에도 css_prop decl 이 정확히 hoist. 단일/조합 모두 동일 출력.

---

### 초보자 설명
- styled-components 의 `<div css={...}>` 변환은 `const _styled_0 = styled.div...` 같은 모듈 최상위 선언을 만들어 program 끝에 붙입니다.
- top-level await 다운레벨은 코드를 `(async()=>{...})()` 로 감쌉니다. 그런데 감싸고 나서 바로 함수가 끝나버려, 위에서 만든 styled 선언을 붙이는 단계를 건너뛰었습니다.
- 두 경로(감쌈/안 감쌈)를 하나의 `result` 로 모은 뒤 선언 붙이기를 공통으로 실행하게 고쳐, 어느 경우든 선언이 보존됩니다.
