### PR TITLE
fix(server): dev proxy 가 POST/PUT 바디 미전달 + Host 무조건 :port

### DIFF
--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -620,29 +620,56 @@ pub const DevServer = struct {
         try req.appendSlice(allocator, request.head.target);
         try req.appendSlice(allocator, " HTTP/1.1\r\n");
 
-        // Host 헤더
+        // Host 헤더 — 표준 포트(80)면 `:port` 생략(엄격한 backend / virtual-host 호환).
         try req.appendSlice(allocator, "Host: ");
         try req.appendSlice(allocator, rule.target_host);
-        try req.append(allocator, ':');
-        var port_buf: [5]u8 = undefined;
-        const port_str = std.fmt.bufPrint(&port_buf, "{d}", .{rule.target_port}) catch unreachable;
-        try req.appendSlice(allocator, port_str);
+        if (rule.target_port != 80) {
+            try req.append(allocator, ':');
+            var port_buf: [5]u8 = undefined;
+            const port_str = std.fmt.bufPrint(&port_buf, "{d}", .{rule.target_port}) catch unreachable;
+            try req.appendSlice(allocator, port_str);
+        }
         try req.appendSlice(allocator, "\r\nConnection: close\r\n");
 
-        // 원본 요청 헤더 전달 (Host, Connection 제외)
+        // 바디 유무는 reader 가 head 문자열을 invalidate 하기 전에 캡처(숫자/enum 필드라 안전).
+        const has_body = request.head.content_length != null or request.head.transfer_encoding != .none;
+
+        // 원본 요청 헤더 전달 (Host/Connection 제외). Content-Length/Transfer-Encoding 도 제외 —
+        // 바디는 아래에서 디코드(chunked 포함)해 단일 Content-Length 로 다시 보내므로, 원본 framing
+        // 헤더를 그대로 두면 backend 가 바디를 잘못 해석한다.
         var header_iter = request.iterateHeaders();
         while (header_iter.next()) |h| {
             if (std.ascii.eqlIgnoreCase(h.name, "host")) continue;
             if (std.ascii.eqlIgnoreCase(h.name, "connection")) continue;
+            // 항상 제외 — 바디가 있으면 디코드 후 단일 Content-Length 로 재구성, 없으면 어차피 부재.
+            if (std.ascii.eqlIgnoreCase(h.name, "content-length")) continue;
+            if (std.ascii.eqlIgnoreCase(h.name, "transfer-encoding")) continue;
             try req.appendSlice(allocator, h.name);
             try req.appendSlice(allocator, ": ");
             try req.appendSlice(allocator, h.value);
             try req.appendSlice(allocator, "\r\n");
         }
-        try req.appendSlice(allocator, "\r\n");
 
-        // NOTE: POST/PUT 바디 전달은 Zig 0.15.2 HTTP Server API 제약으로 미지원.
-        // GET/DELETE 프록시는 정상 동작.
+        // POST/PUT/PATCH 등 바디 전달: client 바디(chunked 면 디코드)를 읽어 단일 Content-Length
+        // 로 backend 에 보낸다. (0.16 HTTP API 로 가능 — 과거 0.15.2 제약 주석은 무효.) 주의:
+        // readerExpectContinue/None 이 head 문자열을 invalidate 하므로 위 헤더 구성 *뒤* 에 호출.
+        var req_body: []const u8 = "";
+        var req_body_owned = false;
+        defer if (req_body_owned) allocator.free(req_body);
+        if (has_body) {
+            var body_buf: [4096]u8 = undefined;
+            const body_reader = request.readerExpectContinue(&body_buf) catch return error.ProxyBodyReadFailed;
+            req_body = body_reader.allocRemaining(allocator, .unlimited) catch return error.ProxyBodyReadFailed;
+            req_body_owned = true;
+            var len_buf: [20]u8 = undefined;
+            const len_str = std.fmt.bufPrint(&len_buf, "{d}", .{req_body.len}) catch unreachable;
+            try req.appendSlice(allocator, "Content-Length: ");
+            try req.appendSlice(allocator, len_str);
+            try req.appendSlice(allocator, "\r\n");
+        }
+
+        try req.appendSlice(allocator, "\r\n");
+        if (req_body.len > 0) try req.appendSlice(allocator, req_body);
 
         // 0.16: net.Stream 직접 writeAll/read 제거 → writer/reader 인터페이스.
         var backend_send_buf: [4096]u8 = undefined;


### PR DESCRIPTION
## 요약 (Summary)

dev server 의 `handleProxy` 가 POST/PUT 등 **요청 바디를 backend 로 전달하지 않았습니다**(코드에 "Zig 0.15.2 HTTP Server API 제약" 주석 — 0.16 마이그레이션 후 무효). 헤더만 전달하므로 Content-Length 가 선언된 요청을 받은 backend 가 바디를 기다리며 행/실패합니다. 또 Host 헤더에 항상 `:port` 를 붙였습니다.

## 변경 사항 (Changes)

- **바디 전달**: client 요청 바디를 `readerExpectContinue` 로 읽어(chunked 면 자동 디코드) backend 에 **단일 Content-Length** 로 전달.
- **invalidate 순서**: `readerExpectContinue`/`readerExpectNone` 이 `request.head` 문자열을 invalidate 하므로, head 를 읽는 헤더 구성을 **바디 읽기 전** 에 완료(`has_body` 는 숫자/enum 필드라 미리 캡처).
- **framing 재구성**: forward 에서 `Content-Length`/`Transfer-Encoding` 제외 후 디코드 길이로 `Content-Length` 재구성 — chunked 요청도 backend 가 올바르게 해석.
- **Host**: 표준 포트(80)면 `:port` 생략.

## 루트커즈 (Root Cause)

요청 바디 read/forward 로직 부재(과거 API 제약 가정). Host 포트 무조건 부착.

```mermaid
sequenceDiagram
    participant C as client
    participant P as dev proxy
    participant B as backend
    Note over P: Before
    C->>P: POST /api (Content-Length: N, body)
    P->>B: POST (헤더만, 바디 X) ⚠️
    B-->>P: 바디 대기 → 행/실패
    Note over P: After
    C->>P: POST /api (body)
    P->>P: 바디 read(chunked 디코드) + 단일 Content-Length
    P->>B: POST (헤더 + 바디) ✅
    B-->>C: 정상 응답
```

## Test Plan
- [x] echo backend + `zntc dev --proxy /api=...` → POST 바디 end-to-end 전달 확인(`BODY FORWARDED: YES`, method=POST, body 일치)
- [x] 전체 5922/5922, `zig build`(CLI) + `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- dev server 프록시 경로만(런타임). 바디는 메모리 버퍼링(dev 용도 적정). 번들/트랜스파일 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (server runtime)

---

### 초보자 설명
- POST 요청은 헤더 + **바디**(보낼 데이터)로 구성됩니다. 프록시가 헤더만 전달하면, 받는 서버는 "바디가 올 거야"(Content-Length)라고 알고 기다리다 멈춥니다.
- 그래서 client 바디를 읽어 그대로 backend 로 넘깁니다. 바디 길이가 chunked(조각 전송)면 합쳐서 정확한 Content-Length 로 다시 보냅니다.
- 주의점: 바디를 읽는 함수가 요청 헤더 문자열 메모리를 무효화해서, 헤더를 다 구성한 *뒤* 에 바디를 읽도록 순서를 맞췄습니다.
