### PR TITLE
fix(lexer): getLineColumn 이 BOM 영역 offset 에서 u32 underflow + OOB panic

### DIFF
--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -264,6 +264,10 @@ pub const Scanner = struct {
                 hi = mid;
             }
         }
+        // lo == 0: offset 이 첫 line_offset(BOM 파일은 3)보다 앞 — BOM 영역. line_idx = lo-1 의
+        // u32 underflow + OOB 를 방지하기 위해 line 0, column 0 으로 clamp(BOM 바이트엔 의미있는
+        // 행/열이 없다). 일반 파일은 offsets[0]=0 이라 항상 lo>=1.
+        if (lo == 0) return .{ .line = 0, .column = 0 };
         const line_idx = lo - 1;
         return .{
             .line = line_idx,

--- a/src/lexer/scanner_test.zig
+++ b/src/lexer/scanner_test.zig
@@ -194,6 +194,25 @@ test "Scanner: getLineColumn" {
     try std.testing.expectEqual(@as(u32, 0), lc2.column);
 }
 
+test "Scanner #4343: BOM 영역 offset getLineColumn underflow 없음" {
+    // BOM(3 byte) 후 코드. line_offsets[0]=3 이므로 offset<3(BOM 영역) 조회 시 lo=0 →
+    // line_idx=lo-1 u32 underflow + OOB 였다. clamp 로 panic 없이 line 0 col 0.
+    const source = "\xEF\xBB\xBFab\ncd";
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    try drainTokensToEof(&scanner);
+
+    inline for (.{ 0, 1, 2 }) |off| {
+        const lc = scanner.getLineColumn(off);
+        try std.testing.expectEqual(@as(u32, 0), lc.line);
+        try std.testing.expectEqual(@as(u32, 0), lc.column);
+    }
+    // BOM 이후 'a'(offset 3) → line 0, col 0 (BOM-투명 컬럼).
+    const lc_a = scanner.getLineColumn(3);
+    try std.testing.expectEqual(@as(u32, 0), lc_a.line);
+    try std.testing.expectEqual(@as(u32, 0), lc_a.column);
+}
+
 test "Scanner: hashbang" {
     const source = "#!/usr/bin/env node\nconst x = 1;";
     var scanner = try Scanner.init(std.testing.allocator, source);


### PR DESCRIPTION
## 요약 (Summary)

`src/lexer/scanner.zig` 의 `getLineColumn` 이 BOM 파일에서 BOM 영역 offset(0~2) 조회 시 **u32 underflow + OOB read** 로 panic 합니다.

BOM 파일은 init 에서 `line_offsets.items[0] = 3` 으로 설정합니다(BOM 이후가 line 0 시작). 이진 탐색은 `offsets[mid] <= offset` 인 가장 큰 인덱스를 찾는데, `offset < 3` 이면 `offsets[0]=3 <= offset` 가 거짓이라 `lo` 가 0 에 머뭅니다. 그 뒤 `const line_idx = lo - 1` → `0 - 1` u32 underflow(4294967295) → `offsets[line_idx]` OOB.

## 변경 사항 (Changes)

- `getLineColumn`: `lo == 0`(offset < 첫 line_offset)이면 `{ line: 0, column: 0 }` 으로 clamp — underflow/OOB 방지.
- `scanner_test.zig`: BOM 파일 offset 0/1/2 → panic 없이 line 0 col 0 회귀.

## 루트커즈 (Root Cause)

`lo == 0`(offset 이 첫 line_offset 보다 앞 = BOM 영역) 케이스 미처리 → `lo - 1` underflow.

```mermaid
flowchart LR
    A["getLineColumn(offset=1)<br/>(BOM 파일, offsets[0]=3)"] --> B{"이진탐색: offsets[0]=3 ≤ 1?"}
    B -->|"거짓 → lo=0"| C{"line_idx = lo - 1"}
    C -->|"Before: 0-1 u32 underflow → OOB panic ⚠️"| D[panic]
    C -->|"After: lo==0 → line 0 col 0 clamp"| E["안전 반환 ✅"]
    style D fill:#ffe6e6
    style E fill:#e6ffe6
```

## Test Plan
- [x] BOM 파일 getLineColumn(0/1/2) → panic 없이 line 0 col 0 (TDD red→green: 수정 전 integer overflow panic)
- [x] BOM 이후/일반 파일 getLineColumn 회귀 없음
- [x] 전체 5923/5923, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- 분기 1개(diagnostics/sourcemap 좌표 계산 시). 핫패스 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (lexer 좌표 변환)

---

### 초보자 설명
- `u32` 는 음수가 없는 정수라 `0 - 1` 은 에러(integer overflow)로 프로그램이 죽습니다.
- BOM(파일 맨 앞 3바이트 표식) 파일에서 "0번째 줄은 3번 바이트부터"라고 기록해 둡니다. 그래서 0/1/2번 바이트(BOM 자체)를 조회하면 "줄 인덱스"가 0보다 작아져 underflow 했습니다.
- `lo == 0`(첫 줄보다 앞)이면 그냥 0번 줄 0번 칸으로 처리해 안전하게 만들었습니다.
