### PR TITLE
fix(lexer): decodeUtf8 continuation byte 미검증 → overlong/후속바이트 오소비

### DIFF
--- a/src/lexer/unicode.zig
+++ b/src/lexer/unicode.zig
@@ -14,9 +14,13 @@
 
 const std = @import("std");
 
+/// `decodeUtf8` 결과 — 코드포인트 + 소비 바이트 수. (named: invalid sentinel 을 const 로 공유하려면
+/// 반환 타입이 명명돼야 함 — 익명 struct 리터럴은 nominal 타입이 매번 달라 coerce 실패.)
+pub const Utf8Decoded = struct { codepoint: u21, len: u3 };
+
 /// UTF-8 바이트 시퀀스에서 코드포인트 하나를 디코딩한다.
 /// 반환: (코드포인트, 소비한 바이트 수). 유효하지 않으면 (0xFFFD, 1).
-pub fn decodeUtf8(bytes: []const u8) struct { codepoint: u21, len: u3 } {
+pub fn decodeUtf8(bytes: []const u8) Utf8Decoded {
     if (bytes.len == 0) return .{ .codepoint = 0, .len = 0 };
 
     const b0 = bytes[0];
@@ -24,33 +28,46 @@ pub fn decodeUtf8(bytes: []const u8) struct { codepoint: u21, len: u3 } {
     // ASCII (0xxxxxxx)
     if (b0 < 0x80) return .{ .codepoint = b0, .len = 1 };
 
+    const invalid = Utf8Decoded{ .codepoint = 0xFFFD, .len = 1 };
+    // continuation byte: 10xxxxxx. 미검증 시 비-continuation(예: 후속 ASCII)을 잘못 흡수해
+    // codepoint 오디코드 + 후속 바이트 오소비. 위반 시 lead 1바이트만 소비(invalid)해 다음 재처리.
+    const isCont = struct {
+        fn f(b: u8) bool {
+            return (b & 0xC0) == 0x80;
+        }
+    }.f;
+
     // 2바이트 (110xxxxx 10xxxxxx)
     if (b0 >= 0xC0 and b0 < 0xE0) {
-        if (bytes.len < 2) return .{ .codepoint = 0xFFFD, .len = 1 };
+        if (bytes.len < 2 or !isCont(bytes[1])) return invalid;
         const cp = (@as(u21, b0 & 0x1F) << 6) | @as(u21, bytes[1] & 0x3F);
+        if (cp < 0x80) return invalid; // overlong
         return .{ .codepoint = cp, .len = 2 };
     }
 
     // 3바이트 (1110xxxx 10xxxxxx 10xxxxxx)
     if (b0 >= 0xE0 and b0 < 0xF0) {
-        if (bytes.len < 3) return .{ .codepoint = 0xFFFD, .len = 1 };
+        if (bytes.len < 3 or !isCont(bytes[1]) or !isCont(bytes[2])) return invalid;
         const cp = (@as(u21, b0 & 0x0F) << 12) |
             (@as(u21, bytes[1] & 0x3F) << 6) |
             @as(u21, bytes[2] & 0x3F);
+        if (cp < 0x800) return invalid; // overlong
+        if (cp >= 0xD800 and cp <= 0xDFFF) return invalid; // surrogate (UTF-8 불법)
         return .{ .codepoint = cp, .len = 3 };
     }
 
     // 4바이트 (11110xxx 10xxxxxx 10xxxxxx 10xxxxxx)
     if (b0 >= 0xF0 and b0 < 0xF8) {
-        if (bytes.len < 4) return .{ .codepoint = 0xFFFD, .len = 1 };
+        if (bytes.len < 4 or !isCont(bytes[1]) or !isCont(bytes[2]) or !isCont(bytes[3])) return invalid;
         const cp = (@as(u21, b0 & 0x07) << 18) |
             (@as(u21, bytes[1] & 0x3F) << 12) |
             (@as(u21, bytes[2] & 0x3F) << 6) |
             @as(u21, bytes[3] & 0x3F);
+        if (cp < 0x10000 or cp > 0x10FFFF) return invalid; // overlong / 범위 초과
         return .{ .codepoint = cp, .len = 4 };
     }
 
-    return .{ .codepoint = 0xFFFD, .len = 1 };
+    return invalid;
 }
 
 /// ECMAScript IdentifierStart 문자인지 판별한다.

--- a/src/lexer/unicode_test.zig
+++ b/src/lexer/unicode_test.zig
@@ -31,6 +31,41 @@ test "decodeUtf8: 4-byte UTF-8 (emoji)" {
     try std.testing.expectEqual(@as(u3, 4), result.len);
 }
 
+test "#4345 decodeUtf8: malformed 시퀀스는 (U+FFFD, len=1) — 후속 바이트 오소비/overlong 금지" {
+    // 2-byte lead + 비-continuation('A') → 'A' 를 삼키면 안 됨. (U+FFFD, 1) 로 lead 만 소비.
+    {
+        const r = decodeUtf8("\xC0\x41");
+        try std.testing.expectEqual(@as(u21, 0xFFFD), r.codepoint);
+        try std.testing.expectEqual(@as(u3, 1), r.len);
+    }
+    // overlong null (C0 80) → 거부.
+    {
+        const r = decodeUtf8("\xC0\x80");
+        try std.testing.expectEqual(@as(u21, 0xFFFD), r.codepoint);
+        try std.testing.expectEqual(@as(u3, 1), r.len);
+    }
+    // overlong 3-byte (E0 80 80) → 거부.
+    {
+        const r = decodeUtf8("\xE0\x80\x80");
+        try std.testing.expectEqual(@as(u21, 0xFFFD), r.codepoint);
+    }
+    // surrogate (ED A0 80 = U+D800) → UTF-8 에서 불법.
+    {
+        const r = decodeUtf8("\xED\xA0\x80");
+        try std.testing.expectEqual(@as(u21, 0xFFFD), r.codepoint);
+        try std.testing.expectEqual(@as(u3, 1), r.len);
+    }
+    // truncated 3-byte 의 두 번째가 비-continuation → 거부.
+    {
+        const r = decodeUtf8("\xE0\x41\x42");
+        try std.testing.expectEqual(@as(u21, 0xFFFD), r.codepoint);
+        try std.testing.expectEqual(@as(u3, 1), r.len);
+    }
+    // 유효 시퀀스는 그대로.
+    try std.testing.expectEqual(@as(u21, 0xE9), decodeUtf8("\xC3\xA9").codepoint); // é
+    try std.testing.expectEqual(@as(u21, 0x1F600), decodeUtf8("\xF0\x9F\x98\x80").codepoint); // 😀
+}
+
 test "isIdentifierStart: ASCII" {
     try std.testing.expect(isIdentifierStart('a'));
     try std.testing.expect(isIdentifierStart('Z'));


### PR DESCRIPTION
## 요약 (Summary)

`src/lexer/unicode.zig` 의 `decodeUtf8` 가 continuation byte(0x80–0xBF)를 **검증하지 않아** 잘못 디코딩했습니다. multi-byte lead 뒤 임의 바이트를 마스킹해 codepoint 를 만들고 정해진 len 만큼 소비했습니다.

- `C0 41`(2-byte lead + ASCII 'A') → 'A' 를 continuation 으로 흡수 → codepoint 1, **len 2** → 다음 ASCII 'A' 를 삼킴(식별자 스캔 오류).
- overlong(`C0 80`), surrogate(`ED A0 80`), >U+10FFFF 미거부.

## 변경 사항 (Changes)

- continuation 검증(`(b & 0xC0) == 0x80`) + overlong(최소 codepoint) + surrogate(D800–DFFF) + max(>10FFFF) 검증 추가. 위반 시 `(U+FFFD, len=1)` — lead 1바이트만 소비해 다음 바이트 재처리.
- 반환 타입을 named `Utf8Decoded` 로(invalid sentinel const 를 타입 일치로 공유).
- `unicode_test.zig`: malformed(`C0 41`/`C0 80`/`E0 80 80`/`ED A0 80`/truncated) → (U+FFFD,1), 유효 시퀀스 회귀.

## 루트커즈 (Root Cause)

UTF-8 디코더가 continuation/overlong/surrogate/max 를 검증하지 않음 = 잘못된 디코딩. (guard 가 아니라 **디코더의 정확한 동작** — 입력이 임의 바이트라 malformed 는 정당한 입력이고 U+FFFD 반환이 spec 동작.)

```mermaid
flowchart LR
    A["C0 41 (lead + 'A')"] --> B{"continuation 검증"}
    B -->|"Before: 미검증"| C["'A' 흡수 → cp=1, len=2 ⚠️<br/>다음 'A' 삼킴"]
    B -->|"After: 0x41 비-continuation"| D["(U+FFFD, len=1) → 'A' 재처리 ✅"]
    style C fill:#ffe6e6
    style D fill:#e6ffe6
```

## Test Plan
- [x] `C0 41`/`C0 80`/`E0 80 80`/`ED A0 80`/truncated → (U+FFFD, 1) (TDD red→green: 수정 전 cp=1)
- [x] 유효 ASCII/2/3/4-byte(é/한/😀) 회귀 없음, 식별자 스캔 전체 5924/5924 통과
- [x] `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- 디코드당 분기 몇 개 추가(continuation/range 검사). lexer 식별자 스캔 경로지만 ASCII fast-path 불변. 유효 UTF-8 동작 동일.

## AST/IR 체크리스트
- [x] 해당 없음 (lexer UTF-8 디코더)

---

### 초보자 설명
- UTF-8 은 첫 바이트가 길이를 알려주고, 뒤따르는 바이트는 반드시 `10xxxxxx`(continuation) 형식이어야 합니다.
- 검증 안 하면 `C0`(2바이트 시작) 뒤에 일반 문자 'A'(`01000001`)가 와도 그걸 두 번째 바이트로 써버려, 'A' 가 사라지고 엉뚱한 글자가 됩니다.
- 잘못된 바이트면 "대체 문자(U+FFFD)" 하나로 보고 1바이트만 넘어가, 다음 글자를 정상 처리합니다 — 이게 표준 디코더 동작입니다.
