### PR TITLE
fix(semantic): visitVariableDeclaration declarator 슬라이스 바운드 가드 누락 — OOB panic

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -3248,15 +3248,19 @@ pub const SemanticAnalyzer = struct {
 
         // 각 declarator에서 바인딩 이름 추출
         // variable_declarator의 data는 extra: [name, type_ann, init_expr]
+        // 형제 declarator-리더(predeclareVarDecl:2230 등)와 동일한 바운드 가드 — 이 함수만 누락해
+        // malformed/truncated AST(error-recovery)에서 OOB panic 했다(방어적 analyzer 설계 일치).
+        if (decl_start + decl_len > extras.len) return;
         const decl_indices = self.ast.extra_data.items[decl_start .. decl_start + decl_len];
         for (decl_indices) |raw_idx| {
             const decl_idx: NodeIndex = @enumFromInt(raw_idx);
             if (decl_idx.isNone()) continue;
             const decl_node = self.ast.getNode(decl_idx);
             if (decl_node.tag == .variable_declarator) {
-                // extra: [name, type_ann, init_expr]
+                // extra: [name, type_ann, init_expr] — 3-슬롯 읽으므로 decl_extra+2 바운드 가드.
                 const decl_extra = decl_node.data.extra;
                 const decl_extras = self.ast.extra_data.items;
+                if (decl_extra + 2 >= decl_extras.len) continue;
                 const binding_idx: NodeIndex = @enumFromInt(decl_extras[decl_extra]);
                 const init_idx: NodeIndex = @enumFromInt(decl_extras[decl_extra + 2]);
 


### PR DESCRIPTION
## 요약 (Summary)

`src/semantic/analyzer.zig` 의 `visitVariableDeclaration` 이 declarator 리스트 슬라이스(`extra_data[decl_start .. decl_start + decl_len]`)에 **바운드 가드가 없습니다**. 같은 파일의 형제 declarator-리더들은 모두 `if (decl_start + decl_len > extras.len) return;` 가드를 갖습니다(`predeclareVarDecl`:2230, `predeclareLexicalVarDecl`, `collectExportedDeclNames`, `markExportedDeclSymbols`). 또 `decl_extras[decl_extra + 2]` 를 바운드 확인 없이 읽습니다. malformed/truncated variable_declaration extra(error-recovery 산물)에서 OOB panic.

## 변경 사항 (Changes)

- 슬라이스 전 `if (decl_start + decl_len > extras.len) return;` (형제 `predeclareVarDecl`:2230 과 동일).
- declarator 3-슬롯 읽기 전 `if (decl_extra + 2 >= decl_extras.len) continue;`.

## 루트커즈 (Root Cause)

이 analyzer 의 **설계가 "lenient parser(error-recovery) + 방어적 analyzer"** 이고 형제 declarator-리더 4곳이 모두 바운드를 가드하는데, `visitVariableDeclaration` 만 그 invariant 에서 이탈했습니다.

> **왜 guard 가 곧 루트커즈 수정인가**: 여기서 "더 깊은 설계"는 이미 확립된 방어적-analyzer 패턴입니다. parser 가 항상 well-formed AST 를 보장하도록 바꾸는 건 이 설계(lenient parser)와 정면 배치되고 훨씬 큰 invariant 입니다. 따라서 형제와 동일한 가드를 더해 **이탈한 함수를 설계에 일치**시키는 것이 올바른 수정이며, 새 band-aid 가 아닙니다.

```mermaid
flowchart LR
    A["malformed variable_declaration<br/>(error-recovery)"] --> B["predeclareVarDecl: decl_start+decl_len 가드 → 안전 ✅"]
    A --> C{"visitVariableDeclaration"}
    C -->|"Before: 가드 없음"| D["slice OOB panic ⚠️ (형제와 불일치)"]
    C -->|"After: 동일 가드"| E["안전 return ✅ (설계 일치)"]
    style D fill:#ffe6e6
    style E fill:#e6ffe6
```

## Test Plan
- [x] 전체 5924/5924 통과 (정상 변수 선언 분석 회귀 없음)
- [x] `zig fmt --check` 통과
- 비고: malformed-AST 직접 구성은 비실용(형제 가드들도 그런 테스트 없음) — 형제 패턴과의 일치 + 무회귀로 검증.

## Decision / 성능 영향 (Impact)
- 정상 경로엔 비교 1~2개 추가(분석 시). 핫패스 영향 미미. 출력 불변.

## AST/IR 체크리스트
- [x] 동작 변경 없음(유효 AST) — malformed AST 에서만 panic→안전 return.

---

### 초보자 설명
- AST 의 가변 자식 목록은 `extra_data` 배열의 `[start..start+len]` 구간으로 표현됩니다. 그 구간이 배열 끝을 넘으면 슬라이스가 OOB 로 죽습니다.
- 같은 파일의 비슷한 함수 4개는 모두 "구간이 배열을 넘으면 그냥 return" 가드를 갖습니다(에러 복구로 깨진 AST 대비). 이 함수만 빠져 있어 추가했습니다 — 즉 동료 코드의 약속을 지킨 것입니다.
