### PR TITLE
fix(transformer): worklet makeI32Literal 이 i32 minInt 에서 overflow panic

### DIFF
--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -708,7 +708,9 @@ fn buildStackDetailsArray(self: *Transformer, line_offset: i32, zero_span: Span)
 /// 정수 값을 numeric_literal 노드로 변환. 음수면 unary_expression(`-`)으로 감싼다.
 /// (JS 스펙상 음수 리터럴은 unary minus + 양수 리터럴의 조합)
 fn makeI32Literal(self: *Transformer, value: i32) Error!NodeIndex {
-    const abs_val: u32 = if (value >= 0) @intCast(value) else @intCast(-value);
+    // @abs 는 i32→u32 라 minInt(-2147483648)도 2147483648 로 안전. (기존 @intCast(-value) 는
+    // -minInt 가 i32 범위를 넘어 overflow panic.) 부호는 아래 value>=0 분기가 그대로 처리.
+    const abs_val: u32 = @abs(value);
     var buf: [16]u8 = undefined;
     const s = std.fmt.bufPrint(&buf, "{d}", .{abs_val}) catch return error.OutOfMemory;
     const span = try self.ast.addString(s);


### PR DESCRIPTION
## 요약 (Summary)

`src/transformer/transformer/worklet.zig` 의 `makeI32Literal(value: i32)` 이 절댓값을 `if (value >= 0) @intCast(value) else @intCast(-value)` 로 구합니다. `value == minInt(i32)`(-2147483648)이면 `-value` = 2147483648 이 i32 범위를 초과해 **overflow panic**(safe build).

## 변경 사항 (Changes)

- `const abs_val: u32 = @abs(value);` — `@abs(i32)` → `u32` 라 minInt 도 2147483648(u32 표현 가능)로 안전. 부호 wrapping(`value >= 0`)은 그대로.

## 루트커즈 (Root Cause)

i32 절댓값을 `-value`(i32 연산)로 구해 minInt 에서 overflow. 함수가 선언 입력 타입(전체 i32)의 일부 값에서 틀림.

> **왜 correctness 수정인가(guard 아님)**: 이 함수의 계약은 `i32 → literal` 입니다. minInt 도 정당한 i32 값이므로 함수가 처리해야 합니다. `@abs` 는 i32 전체 도메인을 올바르게 다루는 정확한 변환이지, 특정 입력을 막는 방어 가드가 아닙니다. 변환이 일어나는 곳이 여기뿐이라 더 깊은 설계 지점은 없습니다.

## Test Plan
- [x] 전체 5924/5924 통과 (worklet 변환 회귀 없음)
- [x] `@abs(@as(i32, minInt))) == 2147483648` 표준 동작 확인(standalone)
- [x] `zig fmt --check` 통과
- 비고: `makeI32Literal` 은 `*Transformer` 필요(private) + minInt 가 현재 호출처(bounded line_offset/-27)에서 비도달이라 직접 단위 테스트는 비실용 — `@abs` 불변식 + 무회귀로 검증.

## Decision / 성능 영향 (Impact)
- 절댓값 계산 1줄. 분기 제거(오히려 단순화). 출력 동일.

## AST/IR 체크리스트
- [x] 동작 변경 없음(기존 도달 값) — minInt 에서만 panic→정상 literal.

---

### 초보자 설명
- `i32` 는 -2147483648 ~ 2147483647 입니다. 음수의 부호를 뒤집어 절댓값을 구하려 `-(-2147483648)` 하면 2147483648 이 되는데, 이 값은 i32 양수 최대(2147483647)를 넘어 에러로 죽습니다.
- `@abs` 는 결과를 부호 없는 `u32` 로 주므로 2147483648 을 정상적으로 담아 죽지 않습니다.
