### PR TITLE
fix(codegen): sourcemap encodeVLQ 가 i32 minInt 에서 overflow panic

### DIFF
--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -39,11 +39,13 @@ const base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345
 ///     → 둘째 digit: 00001 | continuation=0 → 'B' (1)
 ///     → "gB"
 pub fn encodeVLQ(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), value: i32) !void {
-    // 부호 처리: bit 0 = sign, 나머지 = magnitude
-    var v: u32 = if (value < 0)
-        (@as(u32, @intCast(-value)) << 1) | 1
+    // 부호 처리: bit 0 = sign, 나머지 = magnitude. @abs(i32)→u32 라 minInt 도 안전(기존
+    // @intCast(-value) 는 -minInt 가 i32 초과로 overflow panic). magnitude<<1 은 minInt 시
+    // 2^32 라 u32 를 넘으므로 v 를 u64 로 — VLQ 는 continuation bit 로 임의 폭 인코딩 가능.
+    var v: u64 = if (value < 0)
+        (@as(u64, @abs(value)) << 1) | 1
     else
-        @as(u32, @intCast(value)) << 1;
+        @as(u64, @abs(value)) << 1;
 
     // 5비트씩 잘라서 base64 인코딩
     while (true) {

--- a/src/codegen/sourcemap_test.zig
+++ b/src/codegen/sourcemap_test.zig
@@ -38,6 +38,23 @@ test "VLQ: encode -16" {
     try std.testing.expectEqualStrings("hB", buf.items);
 }
 
+test "#4351 VLQ: encode i32 minInt — overflow panic 없이 인코딩" {
+    // -2147483648 의 magnitude(2147483648)<<1 = 2^32 라 u32 를 넘는다. 기존 @intCast(-value)/u32
+    // 는 panic. u64 + @abs 로 33비트 VLQ 인코딩.
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    try encodeVLQ(std.testing.allocator, &buf, -2147483648);
+    try std.testing.expectEqualStrings("hgggggE", buf.items);
+}
+
+test "#4351 VLQ: encode i32 maxInt 회귀" {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(std.testing.allocator);
+    try encodeVLQ(std.testing.allocator, &buf, 2147483647);
+    // magnitude 2147483647 → <<1 = 4294967294 (33-bit). non-empty + 결정적.
+    try std.testing.expect(buf.items.len > 0);
+}
+
 test "SourceMapBuilder: simple mapping" {
     var builder = SourceMapBuilder.init(std.testing.allocator);
     defer builder.deinit();


### PR DESCRIPTION
## 요약 (Summary)

`src/codegen/sourcemap.zig` 의 `encodeVLQ(value: i32)` 가 `value < 0` 일 때 magnitude 를 `@as(u32, @intCast(-value))` 로 구합니다. `value == minInt(i32)`(-2147483648)이면 `-value` = 2147483648 이 i32 범위를 초과해 **overflow panic**. 게다가 magnitude(2^31) `<< 1` = 2^32 라 u32 도 초과합니다.

## 변경 사항 (Changes)

- magnitude 를 `@abs(value)`(i32→u32)로 — minInt 도 2147483648 로 안전.
- shift 누적값 `v` 를 `u32` → `u64` 로 — minInt 의 33비트 VLQ(`(2^31 << 1) | 1`)를 continuation bit 로 정상 인코딩(VLQ 는 임의 폭 가능).

## 루트커즈 (Root Cause)

i32 magnitude 를 `-value`(i32)로 구해 minInt overflow + `magnitude << 1` 이 u32 를 초과.

> **왜 correctness 수정인가**: encodeVLQ 의 계약은 `i32 → VLQ` 입니다. minInt 도 정당한 i32 이므로 인코딩해야 하고, 디코더는 continuation bit 로 33비트 값을 정상 복원합니다. u64 + @abs 는 i32 전체 도메인을 올바르게 인코딩하는 정확한 구현이지 방어 가드가 아닙니다.

## Test Plan
- [x] `encodeVLQ(minInt)` → panic 없이 `"hgggggE"` (TDD red→green; revert-verify 로 버그 시 integer overflow panic 확인)
- [x] `maxInt`/기존 0·±1·±16 회귀 없음
- [x] 전체 5926/5926, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- 누적 변수 폭 u32→u64(인코딩당). sourcemap emit 경로지만 값/출력 동일(유효 범위). 핫패스 영향 미미.

## AST/IR 체크리스트
- [x] 동작 변경 없음(기존 도달 값) — minInt 에서만 panic→정상 VLQ.

---

### 초보자 설명
- VLQ 는 부호를 최하위 비트에, 크기를 그 위에 둡니다. `minInt` 의 크기는 2^31 인데, 부호 비트를 위해 한 칸 왼쪽으로 밀면 2^32 가 되어 32비트 정수(u32)에 안 들어갑니다.
- 그래서 누적값을 64비트(u64)로 두면 33비트 값이 들어가고, VLQ 는 원래 "이어짐 표시(continuation bit)"로 임의 길이를 표현하므로 디코더가 정상 복원합니다.
