### PR TITLE
fix(bundler): buildPlaceholder 가 chunk index-hash 를 u32 절단 → placeholder 충돌 시 silent mislink

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -2080,7 +2080,7 @@ fn finalizeChunkSourceMaps(
 }
 
 const PlaceholderInfo = struct {
-    placeholder: [HASH_PLACEHOLDER_PREFIX.len + HASH_PLACEHOLDER_LEN]u8,
+    placeholder: [HASH_PLACEHOLDER_PREFIX.len + PLACEHOLDER_HASH_LEN]u8,
     real_hash: [HASH_PLACEHOLDER_LEN]u8,
 };
 
@@ -2128,7 +2128,7 @@ fn resolveContentHashes(
     // 가 replaceAllPlaceholders 의 byte-window 매칭에서 garbage 와 충돌해 silent
     // corruption 을 일으키지 않게 한다. chunks_to_outputs[0..out_idx] 슬라이싱과
     // 동형.
-    const ph_total = HASH_PLACEHOLDER_PREFIX.len + HASH_PLACEHOLDER_LEN;
+    const ph_total = HASH_PLACEHOLDER_PREFIX.len + PLACEHOLDER_HASH_LEN;
     const infos_init = infos[0..out_idx];
     for (outputs) |*out| {
         // contents: 모든 placeholder를 한 번의 스캔으로 치환
@@ -2173,18 +2173,24 @@ fn resolveContentHashes(
     }
 }
 
-/// placeholder 해시 길이 (8자리 hex).
+/// 최종 content hash 길이 (8자리 hex) — 출력 파일명에 들어가는 hash.
 const HASH_PLACEHOLDER_LEN = 8;
+/// **중간** placeholder 의 hash 부분 길이 (16자리 hex = full u64 chunkIndexHash). 출력 전 content
+/// hash 로 치환되므로 사용자에게 안 보인다. content hash(8)보다 넓게 둬 chunkIndexHash 를 u32 로
+/// 절단하지 않는다 — 절단 시 두 청크가 low-32 충돌하면 같은 placeholder 가 돼 cross-chunk import
+/// 가 잘못 치환(silent mislink)됐다(#4353). replaceAllPlaceholders 는 이미 길이변경 치환 지원.
+const PLACEHOLDER_HASH_LEN = 16;
 /// placeholder 구분 문자열. 최종 출력에서 content hash로 치환된다.
 /// 다른 코드에서 절대 등장하지 않을 문자열을 사용.
 const HASH_PLACEHOLDER_PREFIX = "\x00ZH";
 
 /// 청크의 인덱스 해시로 placeholder 바이트를 생성한다.
 /// chunkPlaceholderStem과 resolveContentHashes에서 공용.
-fn buildPlaceholder(chunk: *const Chunk, ph: *[HASH_PLACEHOLDER_PREFIX.len + HASH_PLACEHOLDER_LEN]u8) void {
+fn buildPlaceholder(chunk: *const Chunk, ph: *[HASH_PLACEHOLDER_PREFIX.len + PLACEHOLDER_HASH_LEN]u8) void {
     @memcpy(ph[0..HASH_PLACEHOLDER_PREFIX.len], HASH_PLACEHOLDER_PREFIX);
     const idx_hash = chunkIndexHash(chunk);
-    _ = std.fmt.bufPrint(ph[HASH_PLACEHOLDER_PREFIX.len..], "{x:0>8}", .{@as(u32, @truncate(idx_hash))}) catch unreachable;
+    // full u64 를 16-hex 로 — u32 절단 시 low-32 충돌로 placeholder 가 겹쳐 오치환됐다(#4353).
+    _ = std.fmt.bufPrint(ph[HASH_PLACEHOLDER_PREFIX.len..], "{x:0>16}", .{idx_hash}) catch unreachable;
 }
 
 /// ASCII JS 식별자 여부(보수적: 비-ASCII 는 false → 호출부가 quote, 객체
@@ -2420,7 +2426,7 @@ fn chunkPlaceholderStem(
         return;
     }
 
-    var hash_buf: [HASH_PLACEHOLDER_PREFIX.len + HASH_PLACEHOLDER_LEN]u8 = undefined;
+    var hash_buf: [HASH_PLACEHOLDER_PREFIX.len + PLACEHOLDER_HASH_LEN]u8 = undefined;
     buildPlaceholder(chunk, &hash_buf);
 
     try applyNamingPatternWithDir(out, allocator, pattern, base_name, &hash_buf, dir);
@@ -2444,7 +2450,9 @@ fn chunkIndexHash(chunk: *const Chunk) u64 {
 /// content hash 계산: 청크의 최종 출력 코드를 Wyhash하여 8자리 hex 반환.
 /// placeholder 바이트를 건너뛰어 자기 참조 순환을 방지한다.
 pub fn contentHash(content: []const u8, buf: *[HASH_PLACEHOLDER_LEN]u8) void {
-    const ph_total = HASH_PLACEHOLDER_PREFIX.len + HASH_PLACEHOLDER_LEN;
+    // ph_total 은 *placeholder* 를 건너뛰기 위한 폭이므로 PLACEHOLDER_HASH_LEN(16). 출력 buf 는
+    // content hash 폭(HASH_PLACEHOLDER_LEN=8) 유지.
+    const ph_total = HASH_PLACEHOLDER_PREFIX.len + PLACEHOLDER_HASH_LEN;
     var hasher = std.hash.Wyhash.init(0);
     var i: usize = 0;
     var run_start: usize = 0; // 현재 non-placeholder 구간의 시작
@@ -2510,9 +2518,9 @@ fn replaceAllPlaceholders(allocator: std.mem.Allocator, input: []const u8, infos
 /// 단일 placeholder를 실제 content hash로 치환한다.
 /// 반환값은 allocator 소유.
 fn replacePlaceholders(allocator: std.mem.Allocator, input: []const u8, placeholder_hash: []const u8, real_hash: []const u8) ![]const u8 {
-    // placeholder_hash는 "\x00ZH" + 8hex, real_hash는 8hex
+    // placeholder_hash는 "\x00ZH" + 16hex, real_hash는 8hex
     // 치환 대상: placeholder_hash 전체 → real_hash
-    const ph_len = HASH_PLACEHOLDER_PREFIX.len + HASH_PLACEHOLDER_LEN;
+    const ph_len = HASH_PLACEHOLDER_PREFIX.len + PLACEHOLDER_HASH_LEN;
     if (placeholder_hash.len != ph_len) return try allocator.dupe(u8, input);
 
     // 치환 횟수 카운트


### PR DESCRIPTION
## 요약 (Summary)

`src/bundler/emitter/chunks.zig` 의 `buildPlaceholder` 가 content-hash **중간 placeholder** 를 `chunkIndexHash`(u64)를 **u32 로 절단**(8 hex)해 만들었습니다. 두 청크의 index-hash 가 low-32 비트에서 충돌하면 같은 placeholder 가 되어, `replaceAllPlaceholders` 의 단일패스 치환이 cross-chunk import 경로에 **틀린 content hash 를 substitute**(silent mislink — 빌드 에러 아님)할 수 있습니다.

## 변경 사항 (Changes)

- 절단 제거(방어 코드 아님): placeholder hash 폭을 `PLACEHOLDER_HASH_LEN = 16`(full u64) 별도 상수로 분리. `buildPlaceholder` 가 `{x:0>16}` 로 full u64 를 기록.
- 최종 content hash(출력 파일명)는 `HASH_PLACEHOLDER_LEN = 8` 그대로 → **출력 불변**.
- placeholder 폭을 쓰는 사이트(field/ph_total/hash_buf/contentHash skip)만 `PLACEHOLDER_HASH_LEN`, content/path-hash 폭(real_hash/contentHash 출력/lazy path_hash)은 `HASH_PLACEHOLDER_LEN` 유지.

## 루트커즈 (Root Cause)

placeholder(중간 식별 토큰)를 u32 로 절단해 식별력이 32비트로 제한 → low-32 충돌.

> **왜 절단 제거(deeper)인가**: 충돌 감지/재해시 같은 방어 대신, 충돌의 원인(절단)을 없앴습니다. placeholder 는 출력 전 content hash 로 치환되는 내부 토큰이라 폭을 넓혀도 사용자 출력에 영향 없고, `replaceAllPlaceholders` 가 이미 길이변경 치환(prefix+hash → content)을 하므로 placeholder 폭만 키우면 됩니다.

```mermaid
flowchart LR
    A["chunkIndexHash (u64)"] --> B{"placeholder"}
    B -->|"Before: u32 절단 (8hex)"| C["low-32 충돌 시 동일 placeholder<br/>→ cross-chunk import 오치환 ⚠️"]
    B -->|"After: full u64 (16hex)"| D["충돌 0 ✅"]
    D --> E["최종 content hash 는 8hex 유지 (출력 불변)"]
    style C fill:#ffe6e6
    style D fill:#e6ffe6
```

## Test Plan
- [x] 전체 5926/5926 통과 — splitting/chunk **golden 테스트**가 최종 8-hex 파일명을 정확히 검증 → 출력 불변 확인
- [x] `zig fmt --check` 통과
- 비고: 충돌(77k+ 청크) 직접 트리거는 비실용 — placeholder/content 폭 split 의 일관성 + golden 무변경 + 절단 제거(full u64 = 충돌 무시 가능)로 검증.

## Decision / 성능 영향 (Impact)
- 중간 placeholder 가 8→16 hex(출력 전 치환되므로 사용자 무관). 최종 파일명 hash 8 hex 불변. emit 경로지만 무시 가능.

## AST/IR 체크리스트
- [x] 해당 없음 (bundler chunk emit)

---

### 초보자 설명
- 코드 스플리팅 시 각 청크 파일은 내용 기반 해시가 붙습니다. 최종 해시를 넣기 전, "이 자리에 청크 X 의 해시가 올 것"이라는 **임시 표식(placeholder)** 을 먼저 박고 나중에 한 번에 치환합니다.
- 그 임시 표식을 32비트로 줄여 만들다 보니, 청크가 아주 많으면(생일 문제) 두 청크의 표식이 우연히 같아져 엉뚱한 해시로 치환될 수 있었습니다.
- 표식을 64비트(전체 해시)로 넓혀 겹칠 일을 없앴습니다. 사용자가 보는 최종 파일명 해시 길이(8자리)는 그대로입니다(표식은 출력 전에 사라지므로).
