### PR TITLE
fix(bundler): buildEntrySet symlink arm 이 put 실패 시 entry.name leak

### DIFF
--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -211,9 +211,11 @@ pub const DirEntryCache = struct {
                 .symlink => {
                     // symlink는 대상이 파일인지 디렉토리인지 readdir만으로 알 수 없으므로 양쪽에 등록.
                     // Linux의 bun install이 node_modules에 symlink 디렉토리를 만들기 때문에 필수.
-                    set.files.put(self.allocator, entry.name, {}) catch {};
-                    const name2 = self.allocator.dupe(u8, entry.name) catch continue;
-                    set.dirs.put(self.allocator, name2, {}) catch self.allocator.free(name2);
+                    // dupe 를 *먼저* — entry.name 을 put 실패 시 free 해도 name2 가 dangling 안 되게.
+                    const name2 = self.allocator.dupe(u8, entry.name) catch null;
+                    // files.put 실패 시 entry.name free — file/directory arm 과 동일 소유권(leak 방지).
+                    set.files.put(self.allocator, entry.name, {}) catch self.allocator.free(entry.name);
+                    if (name2) |n2| set.dirs.put(self.allocator, n2, {}) catch self.allocator.free(n2);
                 },
                 else => self.allocator.free(entry.name),
             }


### PR DESCRIPTION
## 요약 (Summary)

`src/bundler/resolver.zig` 의 `buildEntrySet` 가 symlink entry 처리 시 `set.files.put(... entry.name ...) catch {}` 로 put 실패(OOM)를 삼키면서 **`entry.name` 을 free 하지 않아 leak**합니다. `.file`/`.directory` arm 은 put 실패 시 `catch self.allocator.free(entry.name)` 로 해제하는데 symlink arm 만 누락(소유권 불일치).

## 변경 사항 (Changes)

- `dupe(entry.name)` 를 **먼저** 수행(name2) → entry.name 을 free 해도 dangling 없음.
- `set.files.put(...) catch self.allocator.free(entry.name)` 로 형제 arm 과 동일 소유권.
- name2 는 OOM 시 null → dirs 등록 skip(기존 `dupe catch continue` 와 동등).

## 루트커즈 (Root Cause)

symlink arm 의 files.put 실패 경로가 형제 arm 과 달리 entry.name 미해제.

> **UAF 주의**: 단순히 `catch free(entry.name)` 만 추가하면, 그 다음 줄 `dupe(entry.name)` 이 방금 free 한 메모리를 읽습니다. 그래서 dupe 를 put 보다 먼저 수행하도록 순서를 바꿔 UAF 없이 leak 만 고쳤습니다.

```mermaid
flowchart TD
    A["symlink entry"] --> B["Before: files.put(name) catch {} ⚠️"]
    B --> C["put 실패 시 name leak"]
    A --> D["After: name2 = dupe(name) (먼저)"]
    D --> E["files.put(name) catch free(name) (UAF 없음)"]
    E --> F["dirs.put(name2) catch free(name2)"]
    style C fill:#ffe6e6
    style F fill:#e6ffe6
```

## Test Plan
- [x] 전체 5927/5927 통과 (symlink 성공경로 회귀 없음)
- [x] `zig fmt --check` 통과
- 비고: OOM-path leak 은 temp dir+symlink + 정확한 put 지점 FailingAllocator 구성이 비실용 — 형제 arm 패턴 일치 + UAF 방지(dupe-first) + 무회귀로 검증.

## Decision / 성능 영향 (Impact)
- symlink entry 처리(디렉토리 스캔 cold path). dupe 순서만 조정. 성공경로 동작 동일.

## AST/IR 체크리스트
- [x] 해당 없음 (resolver 디렉토리 캐시)

---

### 초보자 설명
- `entry.name` 문자열은 누군가 소유(나중에 해제)해야 합니다. 해시맵에 `put` 하면 맵이 소유하지만, `put` 이 실패하면 아무도 소유하지 않으므로 직접 `free` 해야 leak 이 안 납니다.
- file/directory 는 그렇게 했는데 symlink 만 빠뜨렸습니다. 그런데 그 줄 바로 뒤에서 `entry.name` 을 복사(dupe)하므로, 먼저 free 하면 죽은 메모리를 복사하게 됩니다 — 그래서 복사를 먼저 하고 free 하도록 순서를 맞췄습니다.
