### PR TITLE
perf(bundler): 기본 worker 풀을 8 로 cap — 동일-dir openat vnode 경합 해소

### DIFF
--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -68,7 +68,8 @@ pub fn io() std.Io {
 /// g_threaded 가 *Threaded 를 소유하므로 setAsyncLimit(Threaded.mutex 보호) 가능.
 /// ⚠️ 공유 전역 io 라 동시 in-flight 빌드가 서로 다른 jobs 면 마지막 setter 값을
 /// 공유한다(메모리 안전 — mutex 보호, determinism #3564 무관 — byte-identical).
-/// null(jobs=0)=기본 async_limit(cpu-1) 유지.
+/// jobs=0(미지정): high-core 면 vnode open 경합 회피로 총 8 스레드 cap, 아니면 기본(cpu-1)
+/// 유지(asyncLimitForJobs). 명시값은 그대로 존중.
 pub fn setJobs(max_threads: u32) void {
     if (@import("zntc_lib").bundler.asyncLimitForJobs(max_threads)) |lim| {
         if (g_threaded) |*t| t.setAsyncLimit(lim);

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -94,14 +94,50 @@ pub const OutputExports = enum {
 /// (federation.zig ↔ bundler.zig circular import 회피, types 는 양쪽 공통).
 pub const MfBundleConfig = types.MfBundleConfig;
 
+/// 기본(--jobs 미지정) worker 풀 상한. graph discovery 가 같은 디렉토리의 모듈 파일을
+/// 여러 워커로 동시 `openat` 하면 **커널 디렉토리 vnode 락에서 직렬화**된다(macOS `sample`
+/// 실증: 단일 dir 5000파일에서 jobs=15 의 `__openat` 누적 시간이 jobs=4 대비 17×, 50개
+/// dir 로 분산하면 7× 감소). 따라서 cpu-1 풀은 high-core 에서 open 경합을 증폭해 *음의
+/// 스케일링*(실측 단일dir: jobs=4 119ms → 16스레드 250ms)을 낸다. open 처리량은 vnode
+/// 직렬화로 ~8 스레드에서 포화하므로 기본 총 스레드를 8 로 cap 한다(esbuild/Bun 도 I/O
+/// 스레드를 cpu 수만큼 안 쓰고 바운드). cpu ≤ 8 이면 기본(총 cpu)이 이미 ≤ 8 이라 무변경.
+const DEFAULT_THREAD_CAP = 8;
+
+/// 기본(--jobs 미지정) async_limit *값* 을 cpu 수로 계산. null = 기본(cpu-1) 유지.
+/// 순수 함수라 머신 독립적으로 단위 테스트 가능(아래 test). 총 스레드 = async_limit+1.
+fn defaultAsyncLimitValue(cpu_count: usize) ?u32 {
+    if (cpu_count <= DEFAULT_THREAD_CAP) return null; // 총 cpu ≤ cap → 기본 유지(무변경)
+    return DEFAULT_THREAD_CAP - 1; // 메인 + (cap-1) 워커 = 총 DEFAULT_THREAD_CAP
+}
+
 /// `--jobs`(max_threads) → io 의 `async_limit` 매핑 (#4004). `bundle(io)` 는 io 를
 /// 인터페이스로만 받아 동시성을 못 바꾸므로, io 를 *소유* 한 진입점(CLI main / NAPI
-/// common)에서 빌드 전 `Threaded.setAsyncLimit` 으로 적용한다. `null` 이면 기본값
-/// (생성 시 cpu-1) 유지. async_limit 은 "메인 스레드 제외 최대 풀 크기"라:
-///   0 → 기본 유지 / 1 → `.nothing`(=0, inline 순차, 디버깅) / N → `.limited(N-1)`.
+/// common)에서 빌드 전 `Threaded.setAsyncLimit` 으로 적용한다. async_limit 은 "메인 스레드
+/// 제외 최대 풀 크기"라(총 스레드 = async_limit+1):
+///   --jobs=0(미지정) → high-core 면 [[DEFAULT_THREAD_CAP]] 로 cap, 아니면 기본(cpu-1) 유지
+///   --jobs=1 → `.nothing`(=0, inline 순차, 디버깅) / --jobs=N → `.limited(N-1)`.
+/// 명시 `--jobs` 는 그대로 존중한다(cap 미적용 — 사용자가 의도적으로 고른 값).
 pub fn asyncLimitForJobs(max_threads: u32) ?std.Io.Limit {
-    if (max_threads == 0) return null;
-    return .limited(max_threads - 1);
+    if (max_threads != 0) return .limited(max_threads - 1);
+    // 기본: vnode open 경합 회피로 총 스레드를 cap. getCpuCount 실패 시 기본 유지.
+    const cpu = std.Thread.getCpuCount() catch return null;
+    const val = defaultAsyncLimitValue(cpu) orelse return null;
+    return .limited(val);
+}
+
+test "asyncLimitForJobs: 명시 --jobs 매핑 (#4004)" {
+    try std.testing.expectEqual(@as(?std.Io.Limit, .limited(3)), asyncLimitForJobs(4));
+    try std.testing.expectEqual(@as(?std.Io.Limit, .limited(0)), asyncLimitForJobs(1)); // inline 순차
+}
+
+test "defaultAsyncLimitValue: high-core 만 cap (vnode open 경합 회피)" {
+    // 총 cpu ≤ cap(8) → 무변경(null). cap 초과 → 총 8 스레드(async_limit=7) 로 제한.
+    try std.testing.expectEqual(@as(?u32, null), defaultAsyncLimitValue(2));
+    try std.testing.expectEqual(@as(?u32, null), defaultAsyncLimitValue(4)); // 전형적 CI 러너
+    try std.testing.expectEqual(@as(?u32, null), defaultAsyncLimitValue(8));
+    try std.testing.expectEqual(@as(?u32, DEFAULT_THREAD_CAP - 1), defaultAsyncLimitValue(9));
+    try std.testing.expectEqual(@as(?u32, DEFAULT_THREAD_CAP - 1), defaultAsyncLimitValue(16));
+    try std.testing.expectEqual(@as(?u32, DEFAULT_THREAD_CAP - 1), defaultAsyncLimitValue(64));
 }
 
 pub const BundleOptions = struct {


### PR DESCRIPTION
## 문제 (Problem)

graph discovery 가 같은 디렉토리의 모듈 파일을 `cpu-1` 워커로 동시 `openat` 하면, **커널 디렉토리 vnode 락에서 직렬화**됩니다. 그 결과 **스레드를 늘릴수록 `open()` 이 느려지는 음의 스케일링**이 납니다(producer 를 늘려도 커널이 open 을 직렬화 → 경합만 추가).

## 루트커즈 — macOS `sample` 프로파일러로 실증

단일 디렉토리 20000파일, jobs=15(붕괴) vs jobs=4(정상) top-of-stack:

| 함수 | jobs=4 | jobs=15 | 배수 |
|---|---|---|---|
| `__openat` (파일 open 시스콜) | 313 | **5259** | **17×** |
| `__ulock_wait2` (락 대기) | 1487 | 6580 | 4.4× |

- 파일 수는 동일(20000)인데 **`__openat` 누적 시간이 17×** → 동시 open 들이 커널에서 서로를 기다림. 콜스택: `__openat` ← `Io.Threaded.dirOpenFilePosix`.
- **파일을 50개 dir 로 분산하면 `__openat` 가 5259→752 로 7× 감소** → 원인이 **디렉토리별 vnode 락**임을 확정.
- cap 적용 후: `__openat` 1.9×↓, `__ulock_wait2` 2.5×↓.

스케일링 곡선(단일 dir 5000파일, 16-core): jobs=2 135 · **jobs=4 119(최적)** · 8 150 · 12 234 · **16 250(붕괴)** — `cpu-1` 기본값이 곡선의 최악점.

## 수정 (Fix)

open 처리량이 vnode 직렬화로 **~8 스레드에서 포화**하므로, 기본(--jobs 미지정) 총 스레드를 **8 로 cap**(esbuild/Bun 도 I/O 스레드를 cpu 수만큼 안 쓰고 바운드). `asyncLimitForJobs` 한 곳 수정으로 **CLI(main.zig)·NAPI(napi/common.setJobs) 양쪽 자동 적용**(둘 다 빌드 직전 호출).

- `cpu ≤ 8` 은 무변경 (전형적 CI 러너 2-4코어 등 영향 0).
- 명시 `--jobs=N` 은 그대로 존중(cap 미적용).
- cap 경계 로직을 순수 함수 `defaultAsyncLimitValue(cpu)` 로 분리해 머신 독립 단위 테스트.

## 실측 (16-core, ReleaseFast, 단일 dir 5000 모듈)

| 워크로드 | BEFORE (default=16) | AFTER (cap=8) | 개선 |
|---|---|---|---|
| 작은 모듈 (I/O 지배) | 258.7ms | **144ms** | **1.79×** (-44%) |
| 큰 모듈 (CPU 지배) | 206ms | **178ms** | 1.16× |

- **출력 byte-identical** (default/jobs=16/jobs=1 해시 완전 동일 — 스레드 수만 변경, determinism 불변).
- 큰 모듈(CPU-bound)도 회귀 없음 — 오히려 개선(소비자·vnode 병목으로 CPU 작업도 ~8에서 포화).

## ⚠️ CI 벤치 주의

이 개선은 **고코어 머신(>8, 개발자 로컬)** 에서 나타납니다. **GitHub CI 러너는 보통 2-4코어**라 cap 이 no-op(cpu≤8) → **CI 벤치 댓글엔 변화가 안 보입니다**. 회귀도 없음(저코어 무변경).

## 후속 (Follow-up)

커널 open 직렬화 자체는 OS 레벨이라 제거 불가하나, **I/O 스테이지(바운드 reader) ↔ CPU 스테이지(병렬 parse) 파이프라인 분리**로 경합을 구조적으로 더 줄일 수 있음(별도 에픽).

## Test Plan
- [x] `defaultAsyncLimitValue` 경계 단위 테스트(cpu 2/4/8→무변경, 9/16/64→cap) + 명시 jobs 매핑
- [x] `zig build test` 전체 5920 pass
- [x] 출력 결정론(해시 동일) + CPU-bound 무회귀 실측
- [x] napi/wasm/wasm-bundler/schema 빌드 + `zig fmt`
- [x] `/code-review max` (off-by-one·caller·테스트 전부 SAFE/REFUTED, stale 주석 정정 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)