### PR TITLE
fix(config): tsconfig extends + 양쪽 paths 시 base paths 컨테이너 leak

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -82,6 +82,14 @@ pub const TsConfig = struct {
         };
     };
 
+    /// paths 슬라이스 + 각 entry.targets 컨테이너를 해제한다. 내부 문자열(key/target)은
+    /// `_allocated_strings` 가 소유하므로 여기서 만지지 않는다. deinit 과 paths overwrite(mergeFrom
+    /// 으로 승계한 base paths 를 child paths 로 덮어쓸 때) 양쪽이 공유 — 컨테이너 leak 방지.
+    fn freePathsContainers(allocator: std.mem.Allocator, paths: []const PathEntry) void {
+        for (paths) |p| if (p.targets.len > 0) allocator.free(p.targets);
+        if (paths.len > 0) allocator.free(paths);
+    }
+
     /// TsConfig가 소유한 동적 메모리를 해제한다.
     /// load()로 생성한 TsConfig는 반드시 deinit()을 호출해야 한다.
     pub fn deinit(self: *TsConfig) void {
@@ -92,10 +100,7 @@ pub const TsConfig = struct {
                 }
                 list.deinit(allocator);
             }
-            // paths 슬라이스 + 각 entry.targets 슬라이스는 allocator 에 별도 할당. 내부 문자열은
-            // _allocated_strings 가 소유하므로 여기서는 컨테이너만 해제.
-            for (self.paths) |p| if (p.targets.len > 0) allocator.free(p.targets);
-            if (self.paths.len > 0) allocator.free(self.paths);
+            freePathsContainers(allocator, self.paths);
         }
         self.paths = &.{};
         self._allocated_strings = null;
@@ -299,6 +304,9 @@ pub const TsConfig = struct {
         if (co.get("paths")) |v| {
             if (v == .object) {
                 const entries = try parsePathsObject(v.object, allocator, &config._allocated_strings.?);
+                // mergeFrom 이 base tsconfig 의 paths 를 먼저 승계했을 수 있다 — child paths 로
+                // 덮어쓰기 전 이전 컨테이너 해제(내부 문자열은 _allocated_strings 소유라 안전). #4359
+                freePathsContainers(allocator, config.paths);
                 config.paths = entries;
             }
         }

--- a/src/config_test.zig
+++ b/src/config_test.zig
@@ -224,6 +224,34 @@ test "TsConfig.load - extends inheritance" {
     try std.testing.expectEqualStrings("./build", config.out_dir.?);
 }
 
+test "#4359 TsConfig.load - extends + 양쪽 paths overwrite leak 없음" {
+    const allocator = std.testing.allocator;
+    const tmp_dir = "/tmp/zntc_test_config_paths_overwrite";
+    std.Io.Dir.cwd().createDirPath(std.testing.io, tmp_dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(std.testing.io, tmp_dir) catch {};
+
+    // base 와 child 둘 다 paths 정의 → mergeFrom 이 base paths 를 승계한 뒤 child paths 가 덮어쓴다.
+    // overwrite 전 컨테이너 해제 안 하면 base PathEntry 배열/targets leak (testing.allocator 검출).
+    const base_content =
+        \\{ "compilerOptions": { "paths": { "@base/*": ["./base-src/*"] } } }
+    ;
+    const base_path = try std.fs.path.join(allocator, &.{ tmp_dir, "base.json" });
+    defer allocator.free(base_path);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = base_path, .data = base_content });
+
+    const tsconfig_content =
+        \\{ "extends": "./base.json", "compilerOptions": { "paths": { "@app/*": ["./app-src/*"], "@util/*": ["./util/*"] } } }
+    ;
+    const tsconfig_path = try std.fs.path.join(allocator, &.{ tmp_dir, "tsconfig.json" });
+    defer allocator.free(tsconfig_path);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = tsconfig_path, .data = tsconfig_content });
+
+    var config = try TsConfig.load(allocator, std.testing.io, tmp_dir);
+    defer config.deinit();
+    // child paths 가 이김. (핵심 검증은 testing.allocator 의 leak 미검출.)
+    try std.testing.expect(config.paths.len >= 1);
+}
+
 test "TsConfig.load - partial compilerOptions" {
     const allocator = std.testing.allocator;
 


### PR DESCRIPTION
## 요약 (Summary)

`src/config.zig` 의 `extractCompilerOptions` 가 child tsconfig 의 `paths` 로 `config.paths` 를 덮어쓸 때(`config.paths = entries`), `mergeFrom` 이 먼저 승계한 base tsconfig 의 `paths`(PathEntry 배열 + 각 entry.targets, `allocator.alloc`)를 **free 하지 않아 leak**합니다. 내부 문자열은 `_allocated_strings` 가 소유하지만 컨테이너 배열은 deinit 이 최종 `config.paths` 만 해제하므로, 덮어쓰인 base 컨테이너가 샙니다.

## 변경 사항 (Changes)

- deinit 의 컨테이너 해제 로직을 `freePathsContainers(allocator, paths)` 헬퍼로 추출(내부 문자열 제외).
- `extractCompilerOptions` 의 `config.paths` overwrite 직전에 `freePathsContainers` 호출.
- `config_test.zig`: extends + base/child 양쪽 paths → `testing.allocator` leak 미검출 회귀.

## 루트커즈 (Root Cause)

base paths 승계 후 child paths overwrite 시 이전 컨테이너 미해제.

```mermaid
flowchart LR
    A["mergeFrom: config.paths = base paths (컨테이너 alloc)"] --> B["extractCompilerOptions: config.paths = child paths"]
    B -->|"Before: 덮어쓰기만 → base 컨테이너 leak ⚠️"| C[2 allocations leaked]
    B -->|"After: freePathsContainers(old) 후 overwrite"| D[leak 0 ✅]
    style C fill:#ffe6e6
    style D fill:#e6ffe6
```

## Test Plan
- [x] extends + base/child 양쪽 paths → `testing.allocator` leak 미검출 (TDD; revert-verify 로 fix 전 **2 allocations leaked** 확인)
- [x] 기존 extends 상속 테스트 회귀 없음, 전체 5928/5928, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- config 로드(빌드 시작 1회)에서 overwrite 시 이전 컨테이너 해제. 핫패스 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (tsconfig 로더 메모리 소유권)

---

### 초보자 설명
- tsconfig 가 `extends` 로 부모 설정을 물려받을 때, 부모의 `paths` 를 먼저 복사해 둡니다. 그런데 자식도 `paths` 를 가지면 그 위에 덮어쓰는데, 덮어쓰기 전에 부모 것을 해제하지 않으면 메모리가 샙니다.
- deinit(전체 해제)에 있던 "paths 컨테이너 해제" 코드를 함수로 빼서, 덮어쓰기 직전에도 같은 방식으로 해제하게 했습니다(문자열은 별도 추적되므로 컨테이너만).
