### PR TITLE
fix(core): serializeFunctionInfo 가 OOM 시 buf backing leak (errdefer 누락)

### DIFF
--- a/packages/core/src/napi/plugin_bridge.zig
+++ b/packages/core/src/napi/plugin_bridge.zig
@@ -1393,6 +1393,9 @@ fn serializeFunctionInfo(
 ) ![]const u8 {
     var buf: std.ArrayList(u8) = .empty;
     const alloc = native_alloc;
+    // 아래 try 들이 OOM 으로 실패하면 buf 의 grown backing 이 새므로 errdefer 로 해제. 성공 경로는
+    // toOwnedSlice 가 buf 를 비워 ownership 을 caller 로 이전하므로 errdefer 가 실행되지 않는다.
+    errdefer buf.deinit(alloc);
 
     try buf.appendSlice(alloc, "{\"name\":");
     if (func.name) |name| {


### PR DESCRIPTION
## 요약 (Summary)

`packages/core/src/napi/plugin_bridge.zig` 의 `serializeFunctionInfo` 가 `var buf: std.ArrayList(u8) = .empty;` 로 시작해 다수 `try buf.append...` 로 채운 뒤 `return buf.toOwnedSlice(alloc)` 합니다. 중간 `try`(`appendJsonEscaped`/`getClosureVars`/append 등)가 `error.OutOfMemory` 면 buf 의 이미-grown backing 을 **free 하지 않고 return** → leak. 호출부 `pluginAstFunction` 이 `... catch return` 으로 에러를 삼켜 회수되지 않습니다.

## 변경 사항 (Changes)

- `errdefer buf.deinit(alloc);` 추가. 에러 경로에서 buf backing 해제. 성공 경로는 `toOwnedSlice` 가 buf 를 비워(ownership 이전) errdefer 가 실행되지 않음.

## 루트커즈 (Root Cause)

errdefer 부재 — 에러 경로에서 buf 미해제.

```mermaid
flowchart LR
    A["buf = .empty; 다수 try append"] --> B{"try OOM?"}
    B -->|"Before: return err"| C["buf backing leak ⚠️"]
    B -->|"After: errdefer buf.deinit"| D["해제 ✅"]
    A --> E["성공: toOwnedSlice → caller 소유 (errdefer skip)"]
    style C fill:#ffe6e6
    style D fill:#e6ffe6
```

## Test Plan
- [x] `zig build napi`(plugin_bridge 컴파일) + 전체 5930/5930 통과
- [x] `zig fmt --check` 통과
- 비고: OOM-path leak 은 `AstTransformCtx` + `FunctionInfo` + 정확한 try 지점 `FailingAllocator` 구성이 비실용 — 표준 errdefer 패턴(에러 deinit + 성공 toOwnedSlice) + 무회귀로 검증.

## Decision / 성능 영향 (Impact)
- errdefer 1줄(에러 경로만). 성공 경로 동작 불변(toOwnedSlice). 핫패스 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (NAPI 플러그인 직렬화)

---

### 초보자 설명
- `ArrayList` 는 내용을 담으려 메모리를 점점 키웁니다. 중간에 메모리 부족(OOM)으로 함수가 빠져나가면 그 키워둔 메모리를 아무도 안 비워 leak 입니다.
- `errdefer` 는 "에러로 함수가 끝날 때만 실행"입니다. `errdefer buf.deinit()` 을 두면 에러 시 자동 해제되고, 정상적으로 끝날 땐(소유권을 호출자에게 넘기는 `toOwnedSlice`) 실행되지 않습니다.
