### PR TITLE
fix(parser): containsLoneSurrogate 의 도달 불가 보조 loop 제거 (dead code)

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1938,25 +1938,10 @@ fn containsLoneSurrogate(s: []const u8) bool {
             }
         }
     }
-    // 마지막 몇 바이트도 체크
-    while (i < s.len) : (i += 1) {
-        if (s[i] == '\\' and i + 5 < s.len and s[i + 1] == 'u' and s[i + 2] != '{') {
-            const codepoint = parseHex4(s[i + 2 .. i + 6]) orelse continue;
-            if (codepoint >= 0xD800 and codepoint <= 0xDFFF) {
-                if (codepoint >= 0xD800 and codepoint <= 0xDBFF) {
-                    // check for low surrogate
-                    if (i + 11 < s.len and s[i + 6] == '\\' and s[i + 7] == 'u') {
-                        const low = parseHex4(s[i + 8 .. i + 12]) orelse return true;
-                        if (low >= 0xDC00 and low <= 0xDFFF) {
-                            i += 11;
-                            continue;
-                        }
-                    }
-                }
-                return true;
-            }
-        }
-    }
+    // 위 loop 가 `i+5 < s.len`(i ≤ s.len-6)로 완전한 `\uHHHH`(6 byte)가 시작 가능한 모든 위치를
+    // 빠짐없이 검사한다 — 6 byte 가 안 남는 끝부분엔 escape 가 시작될 수 없으므로 추가 검사 불필요.
+    // (과거 "마지막 몇 바이트" 보조 loop 는 inner 가드 `i+5<s.len` 가 i≥s.len-5 에서 절대 참이 될
+    //  수 없어 dead code 였다 — 제거. #4365)
     return false;
 }
 


### PR DESCRIPTION
## 요약 (Summary)

`src/parser/expression.zig` 의 `containsLoneSurrogate` 에 **dead code** 인 두 번째 loop 가 있었습니다. 첫 loop 는 `while (i + 5 < s.len)`(i ≤ s.len-6)로 완전한 `\uHHHH`(6 byte)가 시작 가능한 모든 위치를 빠짐없이 검사합니다. 두 번째 "마지막 몇 바이트도 체크" loop 는 `i ≥ s.len-5` 에서 시작하는데 inner 가드 `i + 5 < s.len` 이 그 범위에서 절대 참이 될 수 없어 body 가 unreachable 입니다.

## 변경 사항 (Changes)

- dead loop 제거 + 첫 loop 가 exhaustive 한 이유(끝부분엔 6 byte escape 시작 불가) 주석화.

## 루트커즈 (Root Cause)

보조 loop 의 inner 가드(`i+5<s.len`)가 loop 진입 조건(`i≥s.len-5`)과 모순 → 영구 unreachable.

## Test Plan
- [x] 전체 5930/5930 통과 (lone-surrogate 검출 회귀 없음 — dead code 제거라 동작 불변)
- [x] `zig fmt --check` 통과
- 비고: dead code(미실행) 제거라 red→green 적용 대상 아님 — 첫 loop 의 exhaustive 성질(끝부분 6 byte escape 불가) + 무회귀로 검증.

## Decision / 성능 영향 (Impact)
- 코드 축소(동작 불변). 핫패스 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (식별자 lone-surrogate 검사)

---

### 초보자 설명
- `\uD800` 같은 "짝 없는 surrogate"를 찾는 함수입니다. 그런 escape 는 6글자라 문자열 끝에서 6글자 미만이 남으면 시작될 수 없습니다.
- 첫 loop 가 이미 끝에서 6글자 전까지 전부 검사하므로, "마지막 몇 바이트" 보조 loop 는 검사할 게 없고 그 안의 조건은 영영 참이 안 됩니다(죽은 코드). 그래서 지웠습니다.
