### PR TITLE
fix(parser): parseImportDeclaration 의 도달 불가 dynamic-import 블록 제거 (dead + 잠재 divergence)

### DIFF
--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -306,27 +306,12 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
         );
     }
 
-    // import(...) — dynamic import는 expression. expression statement로 파싱.
-    if (self.current() == .l_paren) {
-        // import 키워드는 이미 advance()됨. parsePrimaryExpression에 위임하기 위해
-        // 수동으로 import expression 생성.
-        try self.expect(.l_paren);
-        const arg = try self.parseAssignmentExpression();
-        const options = try parseImportCallOptions(self);
-        try self.expect(.r_paren);
-        const import_expr = try self.ast.addNode(.{
-            .tag = .import_expression,
-            .span = .{ .start = start, .end = self.currentSpan().start },
-            .data = .{ .binary = .{ .left = arg, .right = options, .flags = 0 } },
-        });
-        // 후속 .then() 등의 member/call 체이닝 처리
-        _ = try self.eat(.semicolon);
-        return try self.ast.addNode(.{
-            .tag = .expression_statement,
-            .span = .{ .start = start, .end = self.currentSpan().start },
-            .data = .{ .unary = .{ .operand = import_expr, .flags = 0 } },
-        });
-    }
+    // NOTE: dynamic import `import(...)` / `import.meta` 는 parseStatement(statement.zig)가
+    // `import` 다음 `(`/`.` 를 보고 parseExpressionStatement 로 라우팅한다(parseImportCallArgs 가
+    // appendImportRecord 까지 수행). 따라서 parseImportDeclaration 은 절대 `.l_paren` 상태로
+    // 진입하지 않는다 — 과거 여기 있던 `l_paren` 블록은 dead code 였고, parseImportCallArgs 와 달리
+    // appendImportRecord 가 없어 도달 시 dynamic import 가 그래프에서 누락될 잠재 divergence 였다.
+    // 제거. (#4366)
 
     // 스펙ifier 파싱
     const scratch_top = self.saveScratch();


### PR DESCRIPTION
## 요약 (Summary)

`src/parser/module.zig` 의 `parseImportDeclaration` 안 `if (self.current() == .l_paren)` 블록은 **dead code** 였습니다. `parseStatement`(statement.zig:193-199)가 `import` 다음 `(`/`.` 를 `parseExpressionStatement` 로 라우팅하므로(이쪽 `parseImportCallArgs` 가 `appendImportRecord` 수행), `parseImportDeclaration` 은 절대 `.l_paren` 상태로 진입하지 않습니다(유일 호출 경로: statement.zig:198).

게다가 이 dead 블록은 `parseImportCallArgs` 와 달리 `appendImportRecord` 가 없어, 도달 시 dynamic import 가 import 그래프에서 **누락될 잠재 divergence** 였습니다.

## 변경 사항 (Changes)

- dead `l_paren` 블록 제거 + dynamic import 라우팅 사실 주석화. dynamic import 는 `parseExpressionStatement` 경로가 계속 처리.

## 루트커즈 (Root Cause)

dynamic import 라우팅이 statement.zig 로 이동한 뒤 남은 미도달 중복 블록.

```mermaid
flowchart TD
    A["import (...)"] --> B["parseStatement: next == ( → parseExpressionStatement"]
    B --> C["parseImportCallArgs (appendImportRecord ✅)"]
    D["parseImportDeclaration"] -->|"진입 시 current() 는 specifier (never l_paren)"| E["l_paren 블록 = dead (appendImportRecord 없음) ⚠️ → 제거"]
    style E fill:#ffe6e6
```

## Test Plan
- [x] 전체 5930/5930 통과 (dynamic import `import(...)` 회귀 없음 — dead code 제거라 동작 불변)
- [x] `zig fmt --check` 통과, 미사용 함수 경고 없음(parseImportCallOptions 는 parseImportCallArgs 가 계속 사용)
- 비고: dead(미도달) 블록 제거라 red→green 대상 아님 — 유일 호출 경로(statement.zig)의 라우팅 분석 + 무회귀로 검증.

## Decision / 성능 영향 (Impact)
- 코드 축소(동작 불변). 핫패스 무관.

## AST/IR 체크리스트
- [x] dynamic import AST(import_expression)는 parseExpressionStatement 경로가 동일하게 생성 — 출력 불변.

---

### 초보자 설명
- `import(...)`(동적 import)는 표현식이라 파서가 `import` 뒤에 `(` 가 보이면 "표현식 파싱" 쪽으로 보냅니다. 그쪽은 import 그래프 등록(appendImportRecord)까지 합니다.
- 그래서 "import 선언 파싱" 함수는 `(` 상태로 절대 안 들어오는데, 거기 `(` 처리 코드가 남아 있었습니다(죽은 코드). 게다가 그 코드엔 그래프 등록이 빠져 있어, 혹시라도 도달하면 동적 import 가 누락될 위험이라 지웠습니다.
