### PR TITLE
fix(parser): directive prologue 가 .none(stripped) 문 뒤 string literal 을 directive 로 오인

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1125,7 +1125,13 @@ pub const Parser = struct {
         stmt: NodeIndex,
         in_prologue: *bool,
     ) !void {
-        if (stmt.isNone()) return;
+        if (stmt.isNone()) {
+            // 실재하지만 .none 으로 stripped 된 문(global{}, export type, declare 등)도 directive
+            // 가 아니므로 prologue 를 종료한다 — 안 하면 이후 string literal 이 directive 로 오인돼
+            // strict 가 소급 적용된다(ECMAScript: 선행 비-string-literal 문이 prologue 를 끝낸다). #4368
+            in_prologue.* = false;
+            return;
+        }
         if (in_prologue.* and self.tryConvertToDirective(stmt).isNone()) {
             in_prologue.* = false;
         }

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4238,6 +4238,22 @@ fn parseTs(alloc: std.mem.Allocator, source: []const u8) !ParsedSource {
     return parseSource(alloc, source, .ts);
 }
 
+test "#4368 directive prologue: stripped .none 문 뒤 string literal 은 directive 아님" {
+    // `declare const` 은 TS strip → .none(실재하는 비-directive 문). 그 뒤 "use strict" 가
+    // directive 로 오변환되면 strict 가 소급 적용된다 — prologue 가 .none 에서 종료돼야 한다.
+    var r = try parseTs(std.testing.allocator,
+        \\declare const a: number;
+        \\"use strict";
+    );
+    defer r.deinit();
+    var dir_count: usize = 0;
+    for (r.parser.ast.nodes.items) |n| {
+        if (n.tag == .directive) dir_count += 1;
+    }
+    // .none 문 뒤라 "use strict" 는 directive 가 아님(.directive 노드 0). 수정 전: 1.
+    try std.testing.expectEqual(@as(usize, 0), dir_count);
+}
+
 test "#4355 generic-arrow speculation 실패 시 orphan binding 노드 없음" {
     // `<T>(a, b)` 는 generic-arrow speculation 을 트리거하지만 `=>` 가 없어 실패 → type-assertion
     // 으로 re-parse. 실패 speculation 의 param binding(a, b)을 AST 에서 truncate 하지 않으면 orphan.


### PR DESCRIPTION
## 요약 (Summary)

`src/parser/parser.zig` 의 `appendStatementTrackingPrologue` 가 `if (stmt.isNone()) return;` 로 조기 반환해, 실재하지만 `.none` 으로 stripped 된 문(`global { }`, `export type`, TS `declare`, 인덱스 시그니처 등) 뒤에서 **`in_prologue` 를 false 로 내리지 않습니다**. 그 결과 이후 string literal(`"use strict";`)이 여전히 directive prologue 항목으로 취급돼 `.directive` 로 변환되고 strict 가 소급 적용됩니다.

ECMAScript: directive prologue 는 선행 string-literal 문의 연속이며, 비-string-literal 문(stripped 문 포함)이 나오면 종료됩니다.

## 변경 사항 (Changes)

- `stmt.isNone()` 시 `in_prologue.* = false` 후 return — 다른 비-directive 문(empty statement 등)이 prologue 를 종료하는 것과 동일하게.
- `parser_test.zig`: `declare const a; "use strict";` → `.directive` 노드 0(오변환 없음) 회귀.

## 루트커즈 (Root Cause)

`.none`(비-directive 실재 문) 발생 시 prologue 미종료.

```mermaid
flowchart LR
    A["declare const a; (→ .none)"] --> B{"appendStatementTrackingPrologue"}
    B -->|"Before: isNone → return (in_prologue 유지)"| C['"use strict" → .directive 오변환 → strict 소급 ⚠️']
    B -->|"After: isNone → in_prologue=false"| D['"use strict" → 일반 expr (directive 아님) ✅']
    style C fill:#ffe6e6
    style D fill:#e6ffe6
```

## Test Plan
- [x] `declare const a; "use strict";` → `.directive` 노드 0 (TDD red→green; revert-verify 로 수정 전 1 확인)
- [x] 전체 5931/5931, directive/strict 회귀 없음, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- prologue 추적 분기 1개. 핫패스 무관. 정상 directive(선행 string literal) 동작 불변.

## AST/IR 체크리스트
- [x] stripped 문 뒤 string literal 이 `.expression_statement` 로 유지(과거 `.directive` 오변환).

---

### 초보자 설명
- 파일/함수 맨 앞의 `"use strict"` 같은 문자열 문은 "지시어(directive)"로, strict 모드를 켭니다. 단 **맨 앞 연속**일 때만입니다. 중간에 일반 문이 하나라도 오면 그 뒤 문자열은 평범한 식입니다.
- TS `declare`/`export type` 같은 문은 출력에선 사라지지만(`.none`) 문법상 "문"입니다. 그래서 그 뒤 `"use strict"` 는 지시어가 아닌데, 코드가 `.none` 을 "문 없음"처럼 처리해 지시어로 잘못 봤습니다. `.none` 도 일반 문처럼 지시어 구간을 끝내게 고쳤습니다.
