### PR TITLE
fix(core): loadEnv 가 경로를 문자열 연결로 만들어 Windows separator 혼합

### DIFF
--- a/packages/core/src/load-env.ts
+++ b/packages/core/src/load-env.ts
@@ -14,7 +14,7 @@
  * 빈 문자열 prefix `""` 를 포함하면 전체 노출 — 주의해서 사용.
  */
 
-import { resolve as pathResolve } from 'node:path';
+import { join, resolve as pathResolve } from 'node:path';
 
 import { readFileIfExists } from './config-loader.ts';
 
@@ -79,7 +79,8 @@ export function loadEnv(
 
   const merged: Record<string, string> = {};
   for (const file of files) {
-    Object.assign(merged, parseDotenvFile(`${dir}/${file}`));
+    // path.join — `${dir}/${file}` 문자열 연결은 Windows 에서 backslash/슬래시 혼합 경로 생성.
+    Object.assign(merged, parseDotenvFile(join(dir, file)));
   }
 
   const filtered: Record<string, string> = {};


### PR DESCRIPTION
## 요약 (Summary)

`packages/core/src/load-env.ts` 의 `loadEnv` 가 `.env` 파일 경로를 `` `${dir}/${file}` `` 문자열 연결로 만들었습니다. `dir` 는 `pathResolve` 결과(Windows 에선 backslash 포함)라, `/` 연결 시 `C:\proj/.env` 같은 **혼합 separator** 경로가 됩니다.

## 변경 사항 (Changes)
- `parseDotenvFile(\`${dir}/${file}\`)` → `parseDotenvFile(join(dir, file))` (`node:path` 의 `join` import 추가).

## 루트커즈 (Root Cause)
path 유틸 대신 문자열 연결 — 플랫폼 separator 미반영.

## Test Plan
- [x] `load-env.test` 14/14 회귀 없음, tsc/oxlint 통과, 실측 loadEnv 정상(VITE_/ZNTC_ 필터)
- 비고: Windows separator 동작은 macOS 에서 단위테스트 불가(`path.join` 플랫폼 의존) — POSIX 무회귀 + `join` API 정확성으로 검증.

## Decision / 성능 영향 (Impact)
- env 로드(빌드 시작 시) 경로 생성. 핫패스 무관. POSIX 결과 동일.

## AST/IR 체크리스트
- [x] 해당 없음 (env 로더 경로 처리)

---

### 초보자 설명
- Windows 는 경로 구분자가 `\`, macOS/Linux 는 `/` 입니다. `"폴더" + "/" + "파일"` 로 직접 이으면 Windows 에서 `C:\proj/.env` 처럼 섞입니다.
- `path.join` 은 실행 OS 에 맞는 구분자를 써서 올바른 경로를 만듭니다.