### PR TITLE
fix(regexp): 빈 character class(negated full range) 가 (?:)(빈 매치)로 다운레벨 — never-match 여야

### DIFF
--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -440,6 +440,16 @@ const T = struct {
 
         const dl = try self.b.addList(alts.items);
         const disj = try self.b.add(.{ .tag = .disjunction, .span = span, .data = .{ dl.start, dl.len, 0 } });
+        if (alts.items.len == 0) {
+            // 빈 집합(예: `[^\u{0}-\u{10FFFF}]` = 전체 범위의 complement)은 *아무것도* 매치하지
+            // 않아야 한다. `(?:)` 는 빈 문자열을 매치하므로 의미 반전 — empty 의 negative lookahead
+            // `(?!)` 로 never-match 표현. (#4374)
+            return self.b.add(.{
+                .tag = .lookaround_assertion,
+                .span = span,
+                .data = .{ @intFromEnum(ast.LookAroundAssertionKind.negative_lookahead), @intFromEnum(disj), 0 },
+            });
+        }
         // ignore_group: enabling=0, disabling=0 → `(?:…)`
         return self.b.add(.{ .tag = .ignore_group, .span = span, .data = .{ 0, 0, @intFromEnum(disj) } });
     }

--- a/src/regexp/transform_test.zig
+++ b/src/regexp/transform_test.zig
@@ -106,6 +106,13 @@ test "#3511 i+u negated — fold-확장 후 complement (게이트 해제)" {
     }
 }
 
+test "#4374 빈 character class(negated full range) → never-match (?!) (not (?:))" {
+    const o = transform.Options{ .unicode_brace = true };
+    // [^\u{0}-\u{10FFFF}] = 전체 범위 complement = 빈 집합 → 아무것도 매치 안 함.
+    // `(?:)`(빈 문자열 매치)가 아니라 negative-lookahead-of-empty `(?!)`(never-match)여야 한다.
+    try expectTransform("[^\\u{0}-\\u{10FFFF}]", "u", o, "(?!)");
+}
+
 test "#4307 v-flag intersection/subtraction class → bail (union miscompile 금지)" {
     const a = std.testing.allocator;
     const o = transform.Options{ .unicode_brace = true, .ignore_case = true };


### PR DESCRIPTION
## 요약 (Summary)

`buildAstralClassRewrite` 가 set 이 비었을 때(예: `[^\u{0}-\u{10FFFF}]` = 전체 범위 complement) 빈 disjunction 을 `(?:)` 로 감쌌습니다. `(?:)` 는 **빈 문자열을 모든 위치에서 매치**하지만, 빈 character class 는 **아무것도 매치하지 않아야** 합니다 → semantic 반전.

## 변경 사항 (Changes)
- 빈 집합 → negative-lookahead-of-empty `(?!)`(never-match). 빈 disjunction 을 `lookaround_assertion(.negative_lookahead)` 로 감쌈.

## 루트커즈 (Root Cause)
빈 집합을 match-empty(`(?:)`)로 표현(never-match 여야).

## Test Plan
- [x] `[^\u{0}-\u{10FFFF}]/u` → `(?!)` (TDD; 수정 전 `(?:)`)
- [x] regexp 135/135, 전체 5932/5932, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- 빈 set edge 만(드묾). 핫패스 무관. 비-빈 class 출력 불변.

## AST/IR 체크리스트
- [x] 빈 set → `(?!)`(never-match) 정확. 비-빈은 기존 surrogate-alternation 불변.

---

### 초보자 설명
- `(?:)` 는 "빈 그룹"이라 어디서나 "빈 문자열"에 매치합니다(즉 항상 성공). 반면 `[^\u{0}-\u{10FFFF}]` 처럼 "가능한 모든 문자를 제외한" 클래스는 매치할 게 없어 **절대 매치 안 함**입니다.
- 둘은 정반대인데 같은 `(?:)` 로 바꿔버렸습니다. "절대 매치 안 함"은 `(?!)`(빈 패턴의 부정 선읽기 = 항상 실패)로 표현합니다.