### PR TITLE
fix(regexp): legacy octal escape 가 3 digit 초과 소비 → byte 범위 넘어 round-trip 깨짐

### DIFF
--- a/src/regexp/parser.zig
+++ b/src/regexp/parser.zig
@@ -852,7 +852,10 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                             return false;
                         }
                         const octal_start = self.pos - 1;
-                        while (!self.isEnd() and self.peek() >= '0' and self.peek() <= '7') {
+                        // Annex B legacy octal: 최대 3 octal digit (값 ≤ 0o377 = 255). 초과 digit 은
+                        // 별도 리터럴로 남긴다 — 무제한 소비 시 `\0777` 이 511 로 디코드돼 byte 범위를
+                        // 넘고 octal 재방출이 round-trip 안 됐다(#4376). '0' 포함 3 자리로 제한.
+                        while (self.pos - octal_start < 3 and !self.isEnd() and self.peek() >= '0' and self.peek() <= '7') {
                             self.advance();
                         }
                         const val = char_helpers.computeOctalValue(self.source, octal_start, self.pos);

--- a/src/regexp/parser_test.zig
+++ b/src/regexp/parser_test.zig
@@ -103,6 +103,29 @@ test "braced quantifier without atom in unicode mode" {
 // Tests — AST 모드 (emit_ast=true)
 // ============================================================
 
+test "#4376 legacy octal escape 는 최대 3 digit (Annex B, 값 ≤ 255)" {
+    // `\0777` 은 `\077`(octal 077 = 63) + 리터럴 '7' 이어야 한다(Annex B: 최대 3 octal digit).
+    // 수정 전엔 4 digit 전부 소비해 511 로 디코드 → byte 범위 초과 + octal round-trip 깨짐.
+    const P = PatternParser(true);
+    var p = P.initWithAllocator("\\0777", .{}, std.testing.allocator);
+    defer p.deinit();
+    const result = p.parse();
+    try std.testing.expect(result != null);
+    var tree = result.?;
+    defer tree.deinit();
+
+    const root = tree.getNode(tree.root);
+    const alts = root.getNodeList();
+    const alt = tree.getNode(@enumFromInt(tree.extra_data[alts.start]));
+    const terms = alt.getNodeList();
+    // octal atom + 리터럴 '7' = 2 terms (수정 전: 1 term, value 511).
+    try std.testing.expectEqual(@as(u32, 2), terms.len);
+    const ch0 = tree.getNode(@enumFromInt(tree.extra_data[terms.start]));
+    try std.testing.expectEqual(@as(u32, 0o77), ch0.data[0]); // 63
+    const ch1 = tree.getNode(@enumFromInt(tree.extra_data[terms.start + 1]));
+    try std.testing.expectEqual(@as(u32, '7'), ch1.data[0]); // literal '7'
+}
+
 test "AST: basic literal pattern" {
     // "abc" → Disjunction > Alternative > [Character('a'), Character('b'), Character('c')]
     const P = PatternParser(true);


### PR DESCRIPTION
## 요약 (Summary)

`\0`-prefixed legacy octal escape 디코딩이 octal digit 을 **무제한** 소비해(`while (peek 0-7) advance`) `\0777` 을 511(4 digit)로 디코드했습니다 — byte 범위(≤255) 초과. AST 는 `.octal` 단일 값만 저장(digit count 미보존)이라 printer 가 511 을 octal 재방출하면 re-parse 시 다른 codepoint 가 됩니다(round-trip miscompile). ECMAScript Annex B: legacy octal 은 최대 3 digit, ≤ 0o377(255).

## 변경 사항 (Changes)
- octal 소비 loop 를 3 digit('0' 포함)으로 제한 → `\0777` = `\077`(octal 63) + 리터럴 '7'.
- `parser_test.zig`: `\0777` → 2 terms(63 + '7') 회귀.

## 루트커즈 (Root Cause)
parser 가 Annex B octal digit 수/값 상한을 강제하지 않음(printer 는 그 잘못된 값을 충실히 재방출).

## Test Plan
- [x] `\0777` → octal(63) + 리터럴 '7' (TDD; revert-verify 로 수정 전 1 term value 511 확인)
- [x] 전체 5933/5933, 유효 octal 회귀 없음, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- octal 파싱(드문 legacy). loop 상한 1개. 유효 ≤3-digit octal 동작 불변.

## AST/IR 체크리스트
- [x] `\0777` AST: octal(63) atom + literal('7') atom — Annex B 정합.

---

### 초보자 설명
- `\077` 같은 8진 escape 는 옛 문법으로 최대 3자리, 값은 1바이트(0~255)입니다. `\0777` 은 `\077`(63) + 평범한 '7' 로 읽혀야 합니다.
- 파서가 자릿수 제한 없이 다 먹어 `\0777` 을 511 로 읽었고, 511 은 8진 1바이트로 표현 못 해 다시 출력→재파싱 시 값이 달라졌습니다. 3자리로 제한해 바로잡았습니다.