### PR TITLE
fix(codegen): export-default 합성 placeholder 판별을 이름 prefix 추론 → linker flag

### DIFF
--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -1294,9 +1294,11 @@ pub fn buildMetadataForAst(
 
     // collectModuleNames에서 등록한 _default 충돌의 canonical name을 조회.
     var default_export_name: []const u8 = "_default";
+    var default_export_is_synthetic = false;
     for (m.export_bindings) |eb| {
         if (eb.hasSyntheticDefault(m.semanticSymbols())) {
             default_export_name = self.getCanonicalName(module_index, "_default") orelse "_default";
+            default_export_is_synthetic = true;
             break;
         }
         if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, "default")) {
@@ -1361,6 +1363,7 @@ pub fn buildMetadataForAst(
         .cjs_import_preamble = combined_preamble,
         .require_rewrites = require_rewrites,
         .default_export_name = default_export_name,
+        .default_export_is_synthetic = default_export_is_synthetic,
         .ns_member_rewrites = ns_rewrites,
         .ns_inline_objects = ns_inlines,
         .const_values = const_values,

--- a/src/bundler/linker/metadata_types.zig
+++ b/src/bundler/linker/metadata_types.zig
@@ -28,6 +28,10 @@ pub const LinkingMetadata = struct {
     /// export default의 합성 변수명. 이름 충돌 시 "_default$1" 등으로 변경됨.
     /// codegen이 `export default X` → `var <이름> = X;` 출력할 때 사용.
     default_export_name: []const u8 = "_default",
+    /// default export 가 합성 placeholder(`export default <expr>` → `var _default = expr`)인지.
+    /// codegen 분기(var 선언+할당 vs 기존 binding 할당) 선택용 — 과거엔 이름이 "_default" 로
+    /// 시작하는지로 재추론했으나 mangler/linker 가 그 이름을 쓰면 오판하므로 의도를 flag 로 명시.
+    default_export_is_synthetic: bool = false,
     /// namespace import의 member access 직접 치환 맵 (esbuild 방식).
     /// key: namespace 식별자의 symbol_id, value: export_name → canonical_local_name.
     /// codegen이 `ns.prop`를 만나면 이 맵으로 직접 치환 (namespace 객체 생성 불필요).

--- a/src/codegen/modules.zig
+++ b/src/codegen/modules.zig
@@ -479,7 +479,10 @@ pub fn emitExportDefault(self: anytype, node: Node) !void {
                     try self.emitNode(inner);
                 } else {
                     const def_name = if (self.options.linking_metadata) |md| md.default_export_name else "_default";
-                    if (std.mem.startsWith(u8, def_name, "_default")) {
+                    // 합성 placeholder 여부는 linker 가 설정한 flag 로 판별 — 이름 prefix 재추론 금지
+                    // (mangler/linker 가 그 이름을 쓰면 오판). metadata 없으면(비-bundle) 합성 간주.
+                    const is_synthetic_default = if (self.options.linking_metadata) |md| md.default_export_is_synthetic else true;
+                    if (is_synthetic_default) {
                         // 합성 변수 (_default, _default$1 등): var 선언 + 할당 필요.
                         if (!self.options.esm_var_assign_only) try self.write("var ");
                         try self.write(def_name);


### PR DESCRIPTION
## 요약 (Summary)

`src/codegen/modules.zig` 가 `export default <expr>` 합성 placeholder 여부를 `startsWith(def_name, "_default")` 로 **이름 prefix 추론**해 분기했습니다. 이 의도는 linker(`metadata.zig`)의 `hasSyntheticDefault` 가 이미 결정하는데, codegen 이 이름으로 재추론합니다. mangler/linker 가 prefix 를 바꾸거나 실제 default 를 `_default*` 로 rename 하면 오판 → 이미 선언된 binding 에 `var <name>=expr;` double-declaration.

## 변경 사항 (Changes)
- `metadata_types.zig`: `default_export_is_synthetic: bool` 필드 추가.
- `metadata.zig`: `hasSyntheticDefault` 분기에서 flag = true 설정 + struct 에 전달.
- `modules.zig`: `startsWith("_default")` → flag(`md.default_export_is_synthetic`) 로 분기. metadata 없으면 합성 간주(기존 fallback 동일).

## 루트커즈 (Root Cause)
의도를 flag 가 아닌 이름 text 로 재추론(coupling/fragility).

## Test Plan
- [x] 전체 5933/5933 — export default(합성/local/namespace/mangled) 회귀 없음
- [x] `zig fmt --check` 통과
- 비고: 오판 시나리오(실제 default→`_default*` rename)는 현재 미도달(mangler base54 가 `_default` 미생성)이라 red-test 비실용 — flag 가 `hasSyntheticDefault` 를 정확히 mirror + 무회귀로 검증.

## Decision / 성능 영향 (Impact)
- 분기 조건을 string-prefix 검사 → bool 읽기(더 빠르고 정확). 출력 불변.

## AST/IR 체크리스트
- [x] export default 출력 동일(합성=var decl+assign, 실제=binding assign).

---

### 초보자 설명
- `export default 42` 같은 건 이름이 없어 컴파일러가 `var _default = 42` 처럼 임시 변수를 만듭니다(합성). 반대로 `export default foo`(이미 있는 변수)는 새 변수 선언이 필요 없습니다.
- codegen 이 "이름이 `_default` 로 시작하나?"로 둘을 구분했는데, 이는 이름 규칙에 의존해 깨지기 쉽습니다. linker 가 이미 아는 "합성인가?"를 boolean 으로 넘겨 정확히 판단하게 했습니다.