### PR TITLE
fix(bundler): matchGlob brace 확장이 4096 초과 alternative 를 silent skip → 매치 누락

### DIFF
--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -1111,12 +1111,23 @@ pub fn matchGlob(pattern: []const u8, text: []const u8) bool {
             while (true) {
                 const comma = std.mem.indexOfScalar(u8, rest, ',');
                 const alt = if (comma) |idx| rest[0..idx] else rest;
+                const total = prefix.len + alt.len + suffix.len;
                 var expanded_buf: [4096]u8 = undefined;
-                if (prefix.len + alt.len + suffix.len <= expanded_buf.len) {
+                if (total <= expanded_buf.len) {
                     @memcpy(expanded_buf[0..prefix.len], prefix);
                     @memcpy(expanded_buf[prefix.len .. prefix.len + alt.len], alt);
-                    @memcpy(expanded_buf[prefix.len + alt.len .. prefix.len + alt.len + suffix.len], suffix);
-                    if (matchGlob(expanded_buf[0 .. prefix.len + alt.len + suffix.len], text)) return true;
+                    @memcpy(expanded_buf[prefix.len + alt.len .. total], suffix);
+                    if (matchGlob(expanded_buf[0..total], text)) return true;
+                } else {
+                    // 4096 초과(매우 긴 패턴): stack buffer 부족 → heap 으로 정확히 매치. 과거엔 silent
+                    // skip 해 긴 alternative 가 매치 안 되는 correctness gap 이었다. matchGlob 은 pure
+                    // fn(allocator 인자 없음) + 이 경로는 극히 드물어 page_allocator 사용.
+                    const heap = std.heap.page_allocator.alloc(u8, total) catch break;
+                    defer std.heap.page_allocator.free(heap);
+                    @memcpy(heap[0..prefix.len], prefix);
+                    @memcpy(heap[prefix.len .. prefix.len + alt.len], alt);
+                    @memcpy(heap[prefix.len + alt.len .. total], suffix);
+                    if (matchGlob(heap, text)) return true;
                 }
                 if (comma) |idx| {
                     rest = rest[idx + 1 ..];

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -23,6 +23,15 @@ test "matchGlob: wildcard" {
     try std.testing.expect(!matchGlob("@mui/*", "@mui/icons/filled"));
 }
 
+test "#4380 matchGlob: 긴 brace alternative(>4096) 도 silent skip 없이 매치" {
+    // prefix+alt+suffix 가 4096 stack buffer 를 초과하는 긴 alternative. 과거엔 silent skip 해
+    // 매치 실패(false)였다 — heap fallback 으로 정확히 매치.
+    const long = "x" ** 5000;
+    try std.testing.expect(matchGlob("{" ++ long ++ "}", long));
+    // 매치 안 되는 긴 alt 는 정상적으로 false (crash/skip 없이).
+    try std.testing.expect(!matchGlob("{" ++ long ++ "}", "y" ** 5000));
+}
+
 test "matchGlob: doublestar and brace alternates" {
     try std.testing.expect(matchGlob("**/runtimeKind.{js,ts}", "src/runtimeKind.ts"));
     try std.testing.expect(matchGlob("**/runtimeKind.{js,ts}", "lib/module/runtimeKind.js"));


### PR DESCRIPTION
## 요약 (Summary)

`matchGlob` brace 확장이 `prefix+alt+suffix` 를 고정 `[4096]u8` stack buffer 에 복사하는데, 4096 을 초과하면 `if` 에 else 가 없어 그 alternative 를 **silent skip** 했습니다 → 긴 alternative 를 가진 glob 패턴(예: `external` 패턴)이 매치되지 않아 모듈이 external 로 표시 안 되는 잘못된 번들(diagnostic 없음).

## 변경 사항 (Changes)
- 초과 시 `page_allocator` 로 heap 확장해 정확히 매치. `matchGlob` 은 pure fn(allocator 인자 없음) + 이 경로는 극히 드물어 page_allocator. 고정 버퍼 상한 제거.

## 루트커즈 (Root Cause)
고정 stack buffer 초과 케이스 미처리(silent skip).

## Test Plan
- [x] 5000자 alternative `{xxx...}` 가 동일 text 에 매치(true), 비매치 text false (TDD; 수정 전 silent skip→false)
- [x] 전체 5934/5934, 기존 glob 매치(exact/wildcard/doublestar/brace) 회귀 없음, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- normal 경로(≤4096)는 기존 stack buffer 그대로 — alloc 0. >4096 인 드문 경우만 heap. 핫패스 무관.

## AST/IR 체크리스트
- [x] 해당 없음 (resolver glob 매칭)

---

### 초보자 설명
- glob 패턴 `{a,b,c}` 는 각 후보(a/b/c)를 풀어 "앞부분+후보+뒷부분"을 만들어 매칭합니다. 이걸 4096바이트 고정 버퍼에 담는데, 후보가 그보다 길면 그냥 건너뛰어(매치 안 함) 잘못된 결과를 냈습니다.
- 4096을 넘는 드문 경우엔 힙 메모리를 잠깐 빌려 정확히 매칭하도록 했습니다.