### PR TITLE
fix(parser): import attribute 비-string value 가 진단 없이 silent 수용 (+ dead 조건)

### DIFF
--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -1095,13 +1095,21 @@ fn parseImportAttributes(self: *Parser) ParseError2!NodeList {
         _ = try self.eat(.colon);
         var value_node: NodeIndex = NodeIndex.none;
         const value_span = self.currentSpan();
-        if (self.current() == .string_literal and self.current() != .r_curly and self.current() != .eof) {
+        // ECMAScript WithClause: attribute value 는 StringLiteral 이어야 한다. (`!= .r_curly`/`.eof`
+        // 는 `== .string_literal` 이면 이미 참이라 dead — 제거.)
+        if (self.current() == .string_literal) {
             value_node = try self.ast.addNode(.{
                 .tag = .string_literal,
                 .span = value_span,
                 .data = .{ .string_ref = value_span },
             });
             try self.advance();
+        } else {
+            // 비-string value(예: `type: json`)는 과거 silent 수용됐다 — 진단 + 잘못된 토큰 1개
+            // 소비해 recovery 진행.
+            try self.addError(value_span, "string literal as import attribute value");
+            if (self.current() != .r_curly and self.current() != .eof and self.current() != .comma)
+                try self.advance();
         }
 
         const attr_node = try self.ast.addNode(.{

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4945,3 +4945,14 @@ test "Parser regression #4108: genuine duplicate import-attribute keys still det
         \\import data from "m" with { "type": "1", "type": "2" };
     )) > 0);
 }
+
+test "Parser regression #4382: import attribute value 는 string literal 이어야 — 비-string 진단" {
+    // identifier value(`type: json`) → 에러(과거 silent 수용).
+    try std.testing.expect((try parseModuleErrCount(
+        \\import x from "m" with { type: json };
+    )) > 0);
+    // string value 는 정상(0 에러).
+    try std.testing.expectEqual(@as(usize, 0), try parseModuleErrCount(
+        \\import x from "m" with { type: "json" };
+    ));
+}


### PR DESCRIPTION
## 요약 (Summary)

import attribute value 파싱이 `if (current == .string_literal and current != .r_curly and current != .eof)` 였습니다. ECMAScript WithClause 는 value 가 **StringLiteral** 이어야 하는데, 비-string(`import x from "m" with { type: json }`)이면 `if` 가 false → value 미처리 + **에러 미보고**(silent 수용). `!= .r_curly`/`!= .eof` 는 `== .string_literal` 이면 이미 참이라 dead.

## 변경 사항 (Changes)
- `if (current == .string_literal)` 로 단순화(dead 조건 제거).
- else: 비-string value 진단(`addError`) + 잘못된 토큰 1개 소비(recovery 진행).
- `parser_test.zig`: `type: json` → 에러, `type: "json"` → 0 에러 회귀.

## 루트커즈 (Root Cause)
비-string value 경로 진단 부재 + dead sub-condition.

## Test Plan
- [x] `with { type: json }` → 에러(>0), `with { type: "json" }` → 0 에러 (TDD)
- [x] 전체 5935/5935, 기존 import-attr(중복/escape 키) 회귀 없음, `zig fmt --check` 통과

## Decision / 성능 영향 (Impact)
- import attribute 파싱(드문 구문)만. 핫패스 무관.

## AST/IR 체크리스트
- [x] 유효 string value 동작 동일. 비-string 만 진단 추가.

---

### 초보자 설명
- `import x from "m" with { type: "json" }` 의 `"json"` 처럼 import attribute 값은 반드시 문자열이어야 합니다. `type: json`(따옴표 없음)은 문법 오류입니다.
- 기존엔 따옴표 없는 값을 조용히 무시했는데, 이제 오류로 알리고 그 토큰을 건너뛰어 복구합니다. 또 항상 참이라 의미 없던 조건(`!= }`, `!= 파일끝`)도 정리했습니다.