### PR TITLE
fix(parser): Flow conditional type span 이 check type 에서 잘려 false branch 미포함

### DIFF
--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -109,9 +109,11 @@ pub fn parseType(self: *Parser) ParseError2!NodeIndex {
         _ = try parseType(self); // true branch
         try self.expect(.colon);
         _ = try parseType(self); // false branch
+        // span 은 check type `t` 시작 ~ false branch 끝(currentSpan().start)까지 — 다른 composite
+        // type constructor 와 동일. 기존엔 `t` 의 span 만 재사용해 끝이 left operand 에서 잘렸다(#4384).
         return try self.ast.addNode(.{
             .tag = .flow_literal_type,
-            .span = self.ast.getNode(t).span,
+            .span = .{ .start = self.ast.getNode(t).span.start, .end = self.currentSpan().start },
             .data = .{ .none = 0 },
         });
     }

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3468,6 +3468,26 @@ test "Flow: conditional type" {
     try expectNoParseErrorFlow("type X<T> = T extends string ? number : boolean;");
 }
 
+test "#4384 Flow conditional type span 은 false branch 끝까지 커버" {
+    var scanner = try Scanner.init(std.testing.allocator, "type X<T> = T extends string ? number : boolean;");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    parser.is_flow = true;
+    defer parser.deinit();
+    _ = try parser.parse();
+    // conditional type node 의 span 이 false branch(boolean)까지 포함해야 한다.
+    // 수정 전: span 이 check type 'T' 에서 잘려 "boolean" 미포함.
+    var covers_false_branch = false;
+    for (parser.ast.nodes.items) |n| {
+        if (n.tag == .flow_literal_type and
+            std.mem.indexOf(u8, parser.ast.getText(n.span), "boolean") != null)
+        {
+            covers_false_branch = true;
+        }
+    }
+    try std.testing.expect(covers_false_branch);
+}
+
 test "Flow: positional function type params" {
     // () => T as positional param
     try expectNoParseErrorFlow("type X = (() => AnimatedProps, props: $ReadOnly<{[string]: mixed}>) => AnimatedProps;");


### PR DESCRIPTION
## 요약
Flow conditional type(`T extends U ? X : Y`) AST node 가 span 을 check type `t` 의 span 만 재사용해 끝이 left operand 에서 잘렸습니다(다른 composite type constructor 는 `currentSpan().start` 로 끝냄). Flow 는 strip-only 라 JS 출력엔 영향 없으나 진단/sourcemap span 이 부정확.

## 변경
- conditional type span = `[t.start, currentSpan().start]`(false branch 끝까지).

## Test Plan
- [x] conditional type node span 이 "boolean"(false branch) 포함 (TDD; revert-verify 로 수정 전 미포함)
- [x] 전체 5935/5935, flow 회귀 없음, fmt 통과

### 초보자 설명
- AST 노드는 소스의 "범위(span)"를 갖는데, 이게 에러 메시지 밑줄/소스맵에 쓰입니다. 조건부 타입 노드가 `T` 부분만 범위로 잡아 `? number : boolean` 까지 못 덮었습니다. 시작~false 분기 끝으로 바로잡았습니다(출력 JS 는 동일 — Flow 타입은 제거되므로).