### PR TITLE
fix(parser): tryReinterpretAsTypedArrow 의 죽은 is_empty_paren 분기 제거

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -498,15 +498,13 @@ fn tryReinterpretAsTypedArrow(self: *Parser, paren_expr: NodeIndex) ParseError2!
     const paren_node = self.ast.getNode(paren_expr);
     const arrow_start = paren_node.span.start;
 
-    // Empty parens `()` are stored with data.none = 0 (no inner expression).
-    // Non-empty parens `(expr)` store data.unary.operand = inner expression node index.
-    // data.none reads the same bytes as unary.operand via extern union — 0 means empty
-    // because node index 0 is always the program root, never a valid sub-expression.
-    const is_empty_paren = (paren_node.data.none == 0);
-    const normalized_params: NodeIndex = if (is_empty_paren)
-        try self.coverExpressionToArrowParams(.none)
-    else
-        try self.coverExpressionToArrowParams(paren_expr);
+    // parenthesized_expression(빈 `()` 포함)을 arrow 파라미터로 정규화.
+    // coverExpressionToArrowParams 가 paren 의 operand 를 재귀로 풀고, 빈 괄호는
+    // operand 가 NodeIndex.none 이라 자동으로 빈 FormalParameters 로 처리한다.
+    // (빈 괄호는 operand=NodeIndex.none(=maxInt), 비-빈은 0 이 될 수 없는 실제
+    //  노드 인덱스이므로 `data.none == 0` 으로 empty 를 가르려던 과거 분기는 항상
+    //  false 인 죽은 코드였다 — 단일 경로로 일임.)
+    const normalized_params = try self.coverExpressionToArrowParams(paren_expr);
 
     try self.advance(); // skip =>
     const body = try parseArrowBody(self, false, normalized_params);

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2530,6 +2530,15 @@ test "TS arrow: empty params with return type" {
     try expectNoParseError("const f = (): void => {};");
 }
 
+test "#4386 TS empty-paren typed arrow in ternary/speculative position" {
+    // 빈 `()` 의 parenthesized_expression 은 operand=NodeIndex.none 으로 저장된다.
+    // tryReinterpretAsTypedArrow 의 빈/비-빈 단일 경로 정규화가 빈 괄호도 올바른
+    // arrow params(빈 FormalParameters)로 풀어야 한다 (speculative 경로 포함).
+    try expectNoParseError("const b = true ? (): number => 1 : 2;");
+    try expectNoParseError("const c = [(): void => {}];");
+    try expectNoParseError("const d = foo((): string => \"x\");");
+}
+
 test "TS arrow: contextual keyword as param name (get/set/number)" {
     // contextual keyword는 import default specifier와 arrow param 모두에서 식별자로 유효
     try expectNoParseError("const f = (get: number) => get;");


### PR DESCRIPTION
## 요약
빈 `()` 의 `parenthesized_expression` 은 `addUnaryNode(..., .none, 0)` 으로 `operand = NodeIndex.none`(= `maxInt(u32)`) 를 저장합니다. 그런데 `tryReinterpretAsTypedArrow` 는 `is_empty_paren = (paren_node.data.none == 0)` 으로 **0** 과 비교 → 빈 괄호에서도 항상 `false`(비-빈 operand 도 0 이 될 수 없음, 0 은 program root). 이 `if` 분기는 **증명상 죽은 코드**였고, `else` 의 `coverExpressionToArrowParams(paren_expr)` 가 operand(빈 괄호면 `.none`)를 재귀로 풀어 동일한 빈 `FormalParameters` 를 만들어 '운으로' 맞아왔습니다.

## 변경 (더 깊은 설계 수정)
- 잘못된 전제(empty=0)에 기댄 죽은 특수분기 제거 → 빈/비-빈을 모두 처리하는 단일 경로(`coverExpressionToArrowParams`)에 일임.

## 동작 영향
- **없음.** `if` 가 항상 false 였으므로 기존에도 항상 `else` 가 실행됐고, 빈 괄호도 `else` 가 동일 처리. 출력 byte-identical.

## Test Plan
- [x] `#4386` 빈-paren typed arrow(ternary/배열/콜인자) 정규화 (parse-no-error)
- [x] 전체 5937/5937, fmt 통과
- [x] `true ? (): number => 1 : 2` 등 ReleaseFast 출력 무변경 확인

```mermaid
flowchart TD
    A["빈 () → parenthesized_expression<br/>operand = NodeIndex.none (maxInt)"] --> B{"data.none == 0 ?"}
    B -- "항상 false (maxInt≠0)" --> C["else: coverExpressionToArrowParams(paren_expr)"]
    C --> D["operand(.none) 재귀 → 빈 FormalParameters"]
    B -. "도달 불가 (죽은 분기)" .-> E["coverExpressionToArrowParams(.none)"]
    style E stroke-dasharray: 5 5
```

### 초보자 설명
- AST 노드는 `data` 라는 `extern union` 에 자식 정보를 저장합니다. 같은 메모리를 `none: u32` 로도, `unary.operand: NodeIndex` 로도 읽을 수 있죠.
- 빈 괄호 `()` 는 "자식 없음" 을 `operand = NodeIndex.none`(특수값 = `u32` 최대값) 으로 표시합니다. **0 이 아닙니다.**
- 기존 코드는 "0 이면 빈 괄호" 라고 가정했지만 실제 sentinel 은 `maxInt` 라 그 비교는 절대 참이 되지 않았습니다 — 즉 쓸모없는 분기였고, 바로 아래 일반 경로가 빈 괄호까지 알아서 처리하고 있었습니다.
- 그래서 헷갈리는 죽은 분기를 지우고 "하나의 경로가 빈/안-빈 모두 처리" 하도록 정리했습니다(동작은 그대로).