### PR TITLE
fix(transformer): buildRefreshRegCall 긴 컴포넌트명에서 가짜 OOM 중단 제거

### DIFF
--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -1715,6 +1715,33 @@ test "Bundler: dev mode refresh registration" {
     try std.testing.expect(std.mem.indexOf(u8, output, "_s(App") == null);
 }
 
+test "#4388 Bundler: refresh registration with 254-byte+ component name" {
+    // 컴포넌트 이름은 길이 상한이 없다. 과거 buildRefreshRegCall 은 "name" 을
+    // 고정 [256]u8 스택 버퍼에 bufPrint → 254바이트 초과 시 가짜 OOM 으로
+    // refresh 변환(나아가 번들) 전체를 중단시켰다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const long_name = "C" ++ ("o" ** 300); // 301 byte PascalCase 식별자
+    try writeFile(tmp.dir, "App.ts", "function " ++ long_name ++ "() { return null; }\n");
+
+    const entry = try absPath(&tmp, "App.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .react_refresh = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 전체 이름이 truncate/abort 없이 $RefreshReg$ 에 등록되어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"" ++ long_name ++ "\"") != null);
+}
+
 // ----------------------------------------------------------------
 // react-refresh Vite plugin-react 호환 path filter 회귀 가드
 // ----------------------------------------------------------------

--- a/src/transformer/transformer/refresh.zig
+++ b/src/transformer/transformer/refresh.zig
@@ -262,9 +262,12 @@ pub fn buildRefreshRegCall(self: *Transformer, reg: RefreshRegistration, refresh
         .data = .{ .string_ref = reg.handle_span },
     });
 
-    // "ComponentName" 문자열 리터럴 (따옴표 포함)
-    var quoted_buf: [256]u8 = undefined;
-    const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{reg.name}) catch return error.OutOfMemory;
+    // "ComponentName" 문자열 리터럴 (따옴표 포함). 컴포넌트 이름은 길이 상한이
+    // 없으므로(긴 namespaced/generated 이름) 고정 스택 버퍼 대신 힙에 빌드한다 —
+    // 과거 [256]u8 버퍼는 254바이트 초과 시 가짜 OOM 으로 refresh 변환을 중단시켰다.
+    // addString 이 문자열을 intern(복사)하므로 임시 버퍼는 즉시 해제해도 안전.
+    const quoted = try std.fmt.allocPrint(self.allocator, "\"{s}\"", .{reg.name});
+    defer self.allocator.free(quoted);
     const quoted_span = try self.ast.addString(quoted);
     const name_str = try self.ast.addNode(.{
         .tag = .string_literal,


### PR DESCRIPTION
## 요약
`buildRefreshRegCall` 은 `$RefreshReg$(_c, "Name")` 의 `"Name"` 을 고정 `[256]u8` 스택 버퍼에 `bufPrint` 한 뒤 `catch return error.OutOfMemory` 합니다. 컴포넌트 이름은 길이 상한이 없으므로(긴 namespaced/generated 이름) **254바이트 초과 시 실제 OOM 이 아닌데도** refresh 변환(나아가 번들/HMR)이 통째로 OOM 으로 중단됩니다.

## 변경 (더 깊은 설계 수정)
- 고정 스택 버퍼 → `self.allocator` 힙 할당(`allocPrint`)으로 빌드. `addString` 이 문자열을 intern(복사)하므로 임시 버퍼는 `defer free`.
- guard(길이 체크 후 truncate/skip)가 아니라 "나쁜 값이 못 생기게" 버퍼 자체를 가변 길이로.

## Test Plan
- [x] `#4388` 301바이트 PascalCase 컴포넌트명 번들 — 전체 이름이 `$RefreshReg$` 에 등록 (TDD: 수정 전 OOM 으로 RED)
- [x] 전체 5938/5938, fmt 통과
- [x] 짧은 이름 기존 refresh 테스트 회귀 없음

```mermaid
flowchart TD
    A["reg.name (길이 상한 없음)"] --> B{"이전: [256]u8 bufPrint"}
    B -- "≤254B" --> C["OK"]
    B -- ">254B" --> D["가짜 error.OutOfMemory → refresh/번들 중단"]
    A --> E["이후: allocPrint(self.allocator) → 가변 길이"]
    E --> F["addString intern-복사 → defer free"]
    F --> C
    style D fill:#fdd
```

### 초보자 설명
- Zig 에서 `var buf: [256]u8` 는 **스택 위의 고정 256바이트 배열**입니다. `std.fmt.bufPrint` 은 여기에 글자를 채우는데, 들어갈 내용이 버퍼보다 크면 `error.NoSpaceLeft` 를 돌려줍니다.
- 기존 코드는 그 실패를 `error.OutOfMemory`(메모리 부족)로 바꿔 위로 던졌습니다. 하지만 실제론 메모리가 부족한 게 아니라 "버퍼가 작았을" 뿐이라 오해를 부르고, React Fast Refresh 변환 전체를 멈춰버렸습니다.
- `std.fmt.allocPrint(allocator, ...)` 은 필요한 만큼 **힙에서** 메모리를 받아 문자열을 만들기 때문에 길이 제한이 없습니다. 만든 문자열은 `addString` 이 내부 저장소로 복사하므로, 우리가 빌린 임시 메모리는 `defer free` 로 바로 돌려줍니다.