### PR TITLE
fix(transformer): _s(Component, "sig") 가 mangler rename 따라가도록 symbol_id 전파

### DIFF
--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -50,6 +50,10 @@ pub const RefreshSignature = struct {
     handle_span: Span,
     /// 컴포넌트 이름 (문자열)
     component_name: []const u8,
+    /// 등록 대상 컴포넌트 binding node. linker/mangler rename 이 `_s(Component, "sig")`
+    /// 의 Component 참조에도 적용되도록 symbol_id 를 이 노드에서 복사한다
+    /// (`RefreshRegistration.component_idx` 와 동일 역할 — 없으면 rename 후 dangling ref).
+    component_idx: NodeIndex,
     /// Hook 시그니처 문자열 ("useState{[foo, setFoo](0)}\nuseEffect{}")
     signature: []const u8,
 };

--- a/src/transformer/transformer/declarations.zig
+++ b/src/transformer/transformer/declarations.zig
@@ -308,7 +308,7 @@ pub fn visitFunction(self: *Transformer, node: Node) Error!NodeIndex {
             if (name_node.tag != .binding_identifier and name_node.tag != .identifier_reference) break :blk null;
             break :blk self.ast.getText(name_node.data.string_ref);
         };
-        try self.maybeRegisterRefreshSignature(fn_name_for_sig, old_body_idx, &new_body);
+        try self.maybeRegisterRefreshSignature(fn_name_for_sig, new_name, old_body_idx, &new_body);
     }
 
     const none = @intFromEnum(NodeIndex.none);

--- a/src/transformer/transformer/refresh.zig
+++ b/src/transformer/transformer/refresh.zig
@@ -340,12 +340,16 @@ pub fn buildRefreshSigCall(self: *Transformer, sig: RefreshSignature) Error!Node
         .data = .{ .string_ref = sig.handle_span },
     });
 
-    // Component 식별자
+    // Component 식별자. buildRefreshAssignment 의 `_c = Component` 와 동일하게
+    // component binding 의 symbol_id 를 복사해 linker/mangler rename 을 따라가게 한다
+    // (없으면 컴포넌트가 rename 됐을 때 _s(원본이름, ...) 로 남아 dangling ref).
+    const comp_span = try self.ast.addString(sig.component_name);
     const comp_ref = try self.ast.addNode(.{
         .tag = .identifier_reference,
-        .span = zero_span,
-        .data = .{ .string_ref = try self.ast.addString(sig.component_name) },
+        .span = comp_span,
+        .data = .{ .string_ref = comp_span },
     });
+    self.copySymbolId(sig.component_idx, comp_ref);
 
     // "signature" 문자열 리터럴
     var quoted_buf: [1024]u8 = undefined;
@@ -561,6 +565,7 @@ pub fn makeSigHandle(self: *Transformer) Error!Span {
 pub fn maybeRegisterRefreshSignature(
     self: *Transformer,
     func_name: ?[]const u8,
+    component_idx: NodeIndex,
     old_body_idx: NodeIndex,
     new_body: *NodeIndex,
 ) Error!void {
@@ -575,6 +580,7 @@ pub fn maybeRegisterRefreshSignature(
     try self.plugins.refresh.signatures.append(self.allocator, .{
         .handle_span = handle_span,
         .component_name = name,
+        .component_idx = component_idx,
         .signature = signature,
     });
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -2833,3 +2833,27 @@ test "TransformPlan: full-route guards for binding-lite follow-up" {
         };
     }
 }
+
+test "#4390 refresh hook-sig: _s component ref follows mangler rename" {
+    // 컴포넌트 App 이 minify_identifiers 로 rename 되면 _s(Component, "sig") 의
+    // Component 참조도 같은 이름을 따라야 한다. symbol_id 미전파 시 _s(App, ...) 로
+    // 남아 dangling reference (App 는 rename 되어 더 이상 존재하지 않음).
+    const src =
+        \\function App() {
+        \\  const x = useState(0);
+        \\  useEffect(() => {}, []);
+        \\  return null;
+        \\}
+    ;
+    var r = try transpile(std.testing.allocator, src, "/src/App.tsx", .{
+        .react_refresh = true,
+        .react_refresh_hook_signatures = true,
+        .minify_identifiers = true,
+    });
+    defer r.deinit(std.testing.allocator);
+    // 컴포넌트가 rename 됐고(_c = t / function t), _s 의 첫 인자도 같은 t 를 가리켜야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "_c = t;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "_s(t,") != null);
+    // dangling 원본 이름 참조가 남으면 안 된다.
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "_s(App,") == null);
+}


### PR DESCRIPTION
## 요약
`react_refresh_hook_signatures` opt-in 시 `buildRefreshSigCall` 이 `_s(Component, "sig")` 의 `Component` 참조를 **symbol_id 없이** `string_ref`(원본 이름)로만 만듭니다. 반면 `_c = Component` 할당(`buildRefreshAssignment`)은 `RefreshRegistration.component_idx` 에서 symbol_id 를 복사해 rename 을 따라갑니다. 결과적으로 컴포넌트가 minify/linker 로 rename(App→t)되면:

```js
function t() { _s(); ... }     // 컴포넌트는 t 로 rename
_c = t;                        // ✅ rename 따라감 (symbol_id 복사됨)
_s(App, "useState{...}");      // ❌ dangling — App 는 더 이상 존재하지 않음
$RefreshReg$(_c, "App");       // ("App" 은 display 문자열이라 정상)
```

## 루트커즈 & 수정 (더 깊은 설계)
- 루트커즈: `RefreshSignature` 가 `RefreshRegistration` 과 달리 component binding node(`component_idx`)를 안 들고 있어 `copySymbolId` 가 불가능 → 구조적 불일치.
- 수정: `RefreshSignature` 에 `component_idx` 추가 → `maybeRegisterRefreshSignature` 가 `new_name`(컴포넌트 binding node) 전달 → `buildRefreshSigCall` 에서 `copySymbolId(sig.component_idx, comp_ref)` (이미 검증된 `_c = Component` 경로와 동일).

## Test Plan
- [x] `#4390` refresh+hook-sig+minify_identifiers: `_s(t,` 존재 / `_s(App,` 부재 (TDD: 수정 전 RED)
- [x] 전체 5939/5939, fmt 통과

```mermaid
flowchart LR
    A["component binding node (new_name)"] -->|component_idx| B[RefreshSignature]
    B --> C[buildRefreshSigCall]
    C -->|copySymbolId| D["_s(comp_ref, sig)"]
    D -->|mangler rename 적용| E["_s(t, sig) ✅"]
```

### 초보자 설명
- AST 의 식별자 노드는 두 가지로 이름을 정합니다: (1) `symbol_id`(어떤 "심볼"을 가리키는지) — minify 가 이름을 바꾸면 이걸 따라 새 이름으로 출력, (2) `string_ref`(원본 텍스트) — symbol_id 가 없을 때의 fallback.
- 기존 `_s(Component)` 노드는 symbol_id 가 없어서 항상 원본 이름(App)을 출력했습니다. 컴포넌트가 t 로 바뀌면 App 은 사라졌는데도 `_s(App)` 라고 적어 깨졌죠.
- 이미 잘 동작하던 `_c = Component` 코드가 "컴포넌트 노드(component_idx)를 들고 다니며 symbol_id 를 복사" 하고 있었기에, signature 쪽도 똑같이 그 노드를 들고 다니게 만들어 동일하게 고쳤습니다.