### PR TITLE
fix(transformer): buildRefreshSigCall 긴 signature 가짜 OOM 중단 제거

### DIFF
--- a/src/transformer/transformer/refresh.zig
+++ b/src/transformer/transformer/refresh.zig
@@ -351,9 +351,12 @@ pub fn buildRefreshSigCall(self: *Transformer, sig: RefreshSignature) Error!Node
     });
     self.copySymbolId(sig.component_idx, comp_ref);
 
-    // "signature" 문자열 리터럴
-    var quoted_buf: [1024]u8 = undefined;
-    const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{sig.signature}) catch return error.OutOfMemory;
+    // "signature" 문자열 리터럴. hook 이 많은 컴포넌트는 signature 가 길이 상한이
+    // 없으므로 고정 스택 버퍼 대신 힙에 빌드한다 — 과거 [1024]u8 버퍼는 초과 시
+    // 가짜 OOM 으로 refresh 변환을 중단시켰다 (#4389 buildRefreshRegCall 과 동일 클래스).
+    // addString 이 intern(복사)하므로 임시 버퍼는 즉시 해제해도 안전.
+    const quoted = try std.fmt.allocPrint(self.allocator, "\"{s}\"", .{sig.signature});
+    defer self.allocator.free(quoted);
     const quoted_span = try self.ast.addString(quoted);
     const sig_str = try self.ast.addNode(.{
         .tag = .string_literal,

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -2857,3 +2857,28 @@ test "#4390 refresh hook-sig: _s component ref follows mangler rename" {
     // dangling 원본 이름 참조가 남으면 안 된다.
     try std.testing.expect(std.mem.indexOf(u8, r.code, "_s(App,") == null);
 }
+
+test "#4392 refresh hook-sig: long signature (>1024B) not truncated/aborted" {
+    // hook 이 많은 컴포넌트는 signature 문자열이 1024바이트를 넘는다. 과거
+    // buildRefreshSigCall 의 고정 [1024]u8 버퍼는 초과 시 가짜 OOM 으로 transpile
+    // 전체를 중단시켰다.
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(std.testing.allocator);
+    try src.appendSlice(std.testing.allocator, "function App() {\n");
+    var i: usize = 0;
+    while (i < 120) : (i += 1) {
+        var line: [40]u8 = undefined;
+        const s = try std.fmt.bufPrint(&line, "  useHookNumber{d}();\n", .{i});
+        try src.appendSlice(std.testing.allocator, s);
+    }
+    try src.appendSlice(std.testing.allocator, "  return null;\n}\n");
+
+    var r = try transpile(std.testing.allocator, src.items, "/src/App.tsx", .{
+        .react_refresh = true,
+        .react_refresh_hook_signatures = true,
+    });
+    defer r.deinit(std.testing.allocator);
+    // 가짜 OOM abort 없이 signature 전체(마지막 hook 포함)가 emit 되어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "$RefreshSig$") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "useHookNumber119") != null);
+}


### PR DESCRIPTION
## 요약
`buildRefreshSigCall` 은 hook signature 문자열을 고정 `[1024]u8` 스택 버퍼에 `bufPrint` 한 뒤 `catch return error.OutOfMemory` 합니다. hook 이 많은 컴포넌트(또는 긴 hook 이름)는 signature 가 1024바이트를 쉽게 넘겨 **실제 OOM 이 아닌데도** refresh 변환(나아가 transpile)이 통째로 중단됩니다. #4389(`buildRefreshRegCall` [256]u8) 와 동일 클래스의 형제 버그입니다.

## 변경 (더 깊은 설계 수정)
- 고정 스택 버퍼 → `self.allocator` 힙 할당(`allocPrint`). `addString` 이 intern(복사)하므로 임시 버퍼는 `defer free`.
- 길이 체크 후 truncate/skip(guard)이 아니라, 버퍼 자체를 가변 길이로(나쁜 값이 생기지 않게).

## Test Plan
- [x] `#4392` hook 120개(signature >1024B) — `$RefreshSig$` + 마지막 hook 전부 emit (TDD: 수정 전 OOM 으로 RED)
- [x] 전체 5940/5940, fmt 통과

```mermaid
flowchart TD
    A["sig.signature (hook 수만큼 길어짐)"] --> B{"이전: [1024]u8 bufPrint"}
    B -- "≤1022B" --> C[OK]
    B -- ">1022B" --> D["가짜 OutOfMemory → transpile 중단"]
    A --> E["이후: allocPrint(self.allocator) → 가변 길이"]
    E --> C
    style D fill:#fdd
```

### 초보자 설명
- `var buf: [1024]u8` 는 스택 위 고정 1024바이트입니다. signature 가 더 길면 `bufPrint` 가 `error.NoSpaceLeft` 를 내고, 기존 코드는 이를 `OutOfMemory` 로 바꿔 던져 React Fast Refresh 변환 전체를 멈췄습니다.
- `allocPrint` 은 힙에서 필요한 만큼 받아 길이 제한이 없습니다. 만든 문자열은 `addString` 이 내부 저장소로 복사하므로 임시 메모리는 `defer free` 로 즉시 반환합니다.
- 직전 PR #4391(`_s` symbol_id) 작업 중 같은 함수에서 발견한 형제 버그입니다.