### PR TITLE
fix(transformer): 치환 template expression 변환이 list.start==0 에서 누락

### DIFF
--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -135,9 +135,13 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
             if (self.options.unsupported.template_literal) {
                 return es2015_template.ES2015Template(Transformer).lowerTemplateLiteral(self, node);
             }
-            // no-substitution template (data.none == 0)은 리프 노드 — visitListNode으로 처리하면
-            // data.list = {start: X, len: 0}이 되어 codegen의 data.none == 0 체크가 깨짐
-            if (node.data.none == 0) return self.copyNodeDirect(idx);
+            // raw-span shorthand (#2957): transformer(emotion/styled) 가 만든 list.len==0
+            // template 만 리프로 복사. parser-created template 은 quasi 가 최소 1개라
+            // 항상 list.len>0 이므로 children 을 visit 한다. (과거 `data.none == 0` 은
+            // data.list.start 와 alias 라, 치환 template 이 extra_data[0] 에서 시작하면
+            // start==0 → 리프 오판 → expression 의 transform-pass 변환(ES 다운레벨 등)이
+            // 통째로 누락됐다. codegen emitTemplateLiteral 과 동일한 list.len 기준으로 통일.)
+            if (node.data.list.len == 0) return self.copyNodeDirect(idx);
             return self.visitListNode(idx);
         },
 

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1043,6 +1043,24 @@ test "ES5 downlevel: labeled for-of retains label on inner for_statement" {
     try std.testing.expect(std.mem.indexOf(u8, code, "continue OUTER") != null);
 }
 
+test "#4396 template literal: 치환 expression ES 다운레벨이 list.start==0 에서도 적용" {
+    // `${a ?? b}` 가 파일 첫 노드면 template 의 list.start 가 0 이 될 수 있다.
+    // 과거 node_dispatch 의 `data.none == 0`(= list.start==0 와 alias) 체크가 이를
+    // no-substitution 리프로 오판해 expression 의 nullish 다운레벨이 통째로 누락됐다.
+    const source = "`${a ?? b}`;";
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .nullish_coalescing = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // ?? 가 다운레벨돼야 한다 (`!= null` ternary). raw ?? 가 남으면 miscompile.
+    try std.testing.expect(std.mem.indexOf(u8, code, "??") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "!= null") != null);
+}
+
 test "ES5 downlevel: nested labeled for-of preserves `break OUTER`" {
     const source =
         \\OUTER: for (const row of data) {


### PR DESCRIPTION
## 요약
`node_dispatch` 의 `template_literal` 처리가 no-substitution 판별을 `node.data.none == 0` 으로 합니다. `data.none` 은 extern union 에서 `data.list.start` 와 **같은 바이트**라, 치환 template 의 quasi/expr list 가 `extra_data[0]` 에서 시작하면(= 파일에서 가장 먼저 list 를 할당하는 노드일 때 발생) `start==0` → `data.none==0` → **no-substitution 리프로 오판** → `copyNodeDirect` 로 children 을 visit 하지 않아 expression 의 transform-pass 변환(ES 다운레벨 등)이 통째로 누락됩니다.

## 재현 (계측으로 확인)
```
`${a ?? b}`;          // 파일 첫 노드 → template list.start = 0
--target=es2019
→ `${a ?? b}`;        // ❌ ?? 다운레벨 누락 (invalid for es2019)

let z = 0; `${a ?? b}`;   // start = 7
→ let z = 0; `${a != null ? a : b}`;  // ✅ 정상
```

## 루트커즈 & 수정
- 잘못된 필드(`data.none` = `list.start` alias)로 판별. **codegen `emitTemplateLiteral` 은 이미 동일 이유로 `list.len` 기준으로 수정됨(#2957)** — `node_dispatch` 만 옛 방식이 남아 있었습니다.
- `if (node.data.list.len == 0)` 으로 통일: parser-created template 은 quasi 최소 1개라 항상 `len>0` → children visit. transformer 의 raw-span shorthand(emotion/styled, `len==0`)만 리프 복사.

## Test Plan
- [x] `#4396` `${a ?? b}`(첫 노드) + `nullish_coalescing` 미지원 → `!= null` 다운레벨 / raw `??` 부재 (TDD: 수정 전 RED, 후 GREEN)
- [x] 전체 5942/5942, fmt 통과

```mermaid
flowchart TD
    A["치환 template (list.len=3)"] --> B{"이전: data.none==0?<br/>(= list.start==0?)"}
    B -- "start≠0" --> C[visitListNode → children 변환]
    B -- "start==0 (첫 list 노드)" --> D["copyNodeDirect → 변환 누락 ❌"]
    A --> E{"이후: list.len==0?"}
    E -- "len>0 (모든 실제 template)" --> C
    E -- "len==0 (emotion raw-span)" --> F[copyNodeDirect]
    style D fill:#fdd
```

### 초보자 설명
- AST 노드의 `data` 는 `extern union` 이라 같은 메모리를 `none: u32` 로도 `list: {start, len}` 로도 읽습니다. `data.none` 을 읽으면 사실상 `list.start` 값을 보는 셈입니다.
- 템플릿의 자식들(`${...}` 조각)은 `extra_data` 라는 공용 배열에 저장되고, `start` 는 그 배열에서의 시작 위치입니다. 파일에서 그 템플릿이 가장 먼저 배열을 쓰면 `start` 가 0 이 됩니다.
- 기존 코드는 "start(=none)가 0이면 자식 없는 템플릿" 이라고 착각해, 실제로는 `${a ?? b}` 처럼 자식이 있는 템플릿을 통째로 건너뛰어 `??` 같은 문법 변환을 빼먹었습니다.
- 자식 개수(`len`)로 판별하면 위치(`start`)와 무관하게 정확합니다. codegen 은 이미 이렇게 고쳐져 있었고, 이번에 transformer 도 같은 기준으로 맞췄습니다.