### PR TITLE
fix(semantic): checkExportBinding 을 module-scope 조회로 한정

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -3821,12 +3821,17 @@ pub const SemanticAnalyzer = struct {
     /// export { x } (without from) — x가 선언된 바인딩인지 검증한다.
     /// module scope에서 VarDeclaredNames + LexicallyDeclaredNames에 없으면 에러.
     fn checkExportBinding(self: *SemanticAnalyzer, name: []const u8, span: Span) AllocError!void {
-        // RFC #3310 (D20): import 는 module top hoist 라 forward `export { X };
-        // import X` 도 valid — predeclareImportDecl 가 1st-pass 에서 user import 를
-        // .import_binding symbol 로 등록하므로 이 symbol scan 이 forward import 도 hit.
-        for (self.symbols.items) |sym| {
-            const sym_name = self.ast.getText(sym.name);
-            if (std.mem.eql(u8, sym_name, name)) return; // 존재
+        // module scope 에서만 조회한다 (markSymbolExported 와 동일 기준). 함수 파라미터나
+        // 중첩 스코프 로컬은 module export 를 만족하지 못하므로, 전체 symbol 을 이름으로
+        // 스캔하던 과거 방식은 그런 이름을 hit 해 false-negative(에러 누락) 였다.
+        // RFC #3310 (D20): import 는 module top hoist 라 forward `export { X }; import X`
+        // 도 valid — predeclareImportDecl 가 1st-pass 에서 user import 를 .import_binding
+        // symbol 로 module scope 에 등록하므로 이 module-scope 조회가 forward import 도 hit.
+        const module_scope = self.findVarScope();
+        if (!module_scope.isNone()) {
+            const scope_idx = module_scope.toIndex();
+            if (scope_idx < self.scope_maps.items.len and
+                self.scope_maps.items[scope_idx].get(name) != null) return; // 존재
         }
         // 찾지 못함 → 에러
         try self.addErrorMsgCode(span, try std.fmt.allocPrint(

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1009,6 +1009,23 @@ test "Enum: undefined export still errors" {
     try analyzeHasError("export { Nonexistent };", "not defined");
 }
 
+test "#4398 export binding: 함수 파라미터 이름은 module export 를 만족 못함" {
+    // x 는 함수 파라미터(함수 스코프) 일 뿐 module-scope binding 이 아니므로
+    // export { x } 는 에러여야 한다. 과거엔 모든 스코프 심볼을 이름으로 스캔해
+    // 파라미터를 hit → false-negative (에러 미발생).
+    try analyzeHasError("function f(x) { return x; }\nexport { x };", "not defined");
+}
+
+test "#4398 export binding: 중첩 로컬 이름도 module export 를 만족 못함" {
+    try analyzeHasError("function f() { let inner = 1; return inner; }\nexport { inner };", "not defined");
+}
+
+test "#4398 export binding: forward module-scope 선언/import 는 여전히 valid" {
+    // 모듈 스코프 binding 의 forward 참조(선언이 export 뒤) 는 유효 — 회귀 가드.
+    try analyzeNoErrors("export { y };\nlet y = 1;");
+    try analyzeNoErrors("export { Z };\nimport { Z } from \"./m\";");
+}
+
 // ====================================================================
 // D5: import type declaration + 다른 import → export 검증
 // ====================================================================


### PR DESCRIPTION
## 요약
`checkExportBinding`(`export { x }` without `from` 의 local binding 검증)이 `self.symbols.items` **전체**를 이름으로 선형 스캔합니다. 함수 파라미터나 중첩 스코프의 로컬이 같은 이름이면 hit 되어, module-scope 에 선언되지 않았는데도 "존재"로 판정 → **false-negative**(에러 누락).

```js
function f(x) { return x; }
export { x };   // ❌ 에러여야 함 (x 는 파라미터, module-scope 아님) — 기존엔 통과
```

바로 위 `markSymbolExported` 는 올바르게 module scope(`findVarScope` + `scope_maps`)만 조회합니다.

## 루트커즈 & 수정
- 잘못된 조회 범위(전체 symbol) → module scope 한정 조회로 통일(`markSymbolExported` 와 동일 기준).
- forward 참조(`export { y }; let y`, `export { Z }; import { Z }`)는 let/import 가 module scope 에 hoist/predeclare 되므로 scope_maps 에 있어 그대로 valid.

## Test Plan
- [x] `#4398` 파라미터/중첩 로컬 이름 export → `not defined` 에러 (TDD: 수정 전 RED)
- [x] `#4398` forward module-scope 선언/import export 는 valid (회귀 가드)
- [x] 전체 5945/5945 (기존 export 테스트 회귀 0), fmt 통과

```mermaid
flowchart TD
    A["export { x } 검증"] --> B{"이전: 전체 symbol 이름 스캔"}
    B -- "어느 스코프든 x 있음" --> C["통과 (파라미터도 hit ❌)"]
    A --> D{"이후: module scope_map 조회"}
    D -- "module-scope binding/import" --> E[통과 ✅]
    D -- "없음" --> F["'x' is not defined 에러 ✅"]
    style C fill:#fdd
```

### 초보자 설명
- JS 의 `export { x }` 는 **모듈 최상위(module scope)** 에 선언된 `x` 만 내보낼 수 있습니다. 함수 안의 파라미터나 지역변수 `x` 는 대상이 아닙니다.
- 기존 코드는 "이름이 `x` 인 심볼이 프로그램 어디든 있으면 OK" 라고 검사해서, 함수 파라미터 `x` 까지 통과시켰습니다(잘못된 코드를 에러로 못 잡음).
- 스코프 맵(`scope_maps`)은 "각 스코프에서 선언된 이름 → 심볼" 표입니다. 모듈 스코프의 표에서만 `x` 를 찾도록 바꿔 정확해졌습니다. (`let`/`import` 는 선언이 뒤에 와도 모듈 스코프 표에 먼저 올라가므로 forward export 는 그대로 동작합니다.)