### PR TITLE
fix(semantic): analyzer OOM 을 alloc_failed 로 표면화 (silent swallow 제거)

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -155,6 +155,13 @@ pub const SemanticAnalyzer = struct {
     /// mangler liveness 및 위치 기반 최적화(dead store, single-use inline 등) consumer의 입력.
     references: std.ArrayList(symbol_mod.Reference),
 
+    /// OOM 표면화 플래그. void 반환 visitor 내부의 allocation 실패(symbol/reference/const
+    /// 기록)는 signature cascade 없이 이 플래그로 잡고, `analyze()` 끝에서
+    /// error.OutOfMemory 로 변환한다. 과거엔 그 실패를 조용히 삼켜 symbol/reference 가
+    /// 누락된 채 성공 반환 → import elision / mangler liveness 가 잘못된 입력으로
+    /// silent miscompile (사용 중 import 제거 등) 위험이 있었다.
+    alloc_failed: bool = false,
+
     /// Annex B: if/else/labeled body에서 function declaration을 만나면
     /// var hoisting conflict check를 건너뛴다.
     /// sloppy mode에서 `if (true) function f() {}` 같은 구문이 let/const와 충돌하지 않도록 한다.
@@ -298,6 +305,10 @@ pub const SemanticAnalyzer = struct {
         const root_idx: NodeIndex = self.ast.transformed_root orelse
             @as(NodeIndex, @enumFromInt(@as(u32, @intCast(self.ast.nodes.items.len - 1))));
         try self.visitNode(root_idx);
+
+        // void visitor 내부에서 삼킨 allocation 실패를 여기서 표면화 — symbol/reference 가
+        // 누락된 분석 결과가 transform/codegen 으로 흘러가 silent miscompile 되는 것 방지.
+        if (self.alloc_failed) return error.OutOfMemory;
     }
 
     // ================================================================
@@ -720,7 +731,9 @@ pub const SemanticAnalyzer = struct {
             .stmt_idx = self.current_top_stmt_idx orelse symbol_mod.Reference.NO_STMT,
             .scope_stmt_idx = self.current_stmt_idx,
             .flags = .{ .declare = true },
-        }) catch {};
+        }) catch {
+            self.alloc_failed = true;
+        };
     }
 
     /// 가장 가까운 var scope(function/global/module)를 찾는다.
@@ -913,7 +926,9 @@ pub const SemanticAnalyzer = struct {
                     .stmt_idx = self.current_top_stmt_idx orelse symbol_mod.Reference.NO_STMT,
                     .scope_stmt_idx = self.current_stmt_idx,
                     .flags = effective,
-                }) catch {};
+                }) catch {
+                    self.alloc_failed = true;
+                };
                 return;
             }
             // helper sym 미등록 = helper import 가 prepend 되지 않은 경로 (예: graph
@@ -953,7 +968,9 @@ pub const SemanticAnalyzer = struct {
                     .stmt_idx = self.current_top_stmt_idx orelse symbol_mod.Reference.NO_STMT,
                     .scope_stmt_idx = self.current_stmt_idx,
                     .flags = effective,
-                }) catch {};
+                }) catch {
+                    self.alloc_failed = true;
+                };
 
                 return;
             }
@@ -1128,7 +1145,9 @@ pub const SemanticAnalyzer = struct {
         const sym_idx = self.findSymbolInCurrentScope(name_span) orelse return;
         self.symbols.items[sym_idx].const_kind = cv.kind;
         if (cv.kind == .number and cv.number_text.len > 0) {
-            self.numeric_const_texts.put(self.allocator, @intCast(sym_idx), cv.number_text) catch {};
+            self.numeric_const_texts.put(self.allocator, @intCast(sym_idx), cv.number_text) catch {
+                self.alloc_failed = true;
+            };
         }
     }
 
@@ -2490,7 +2509,9 @@ pub const SemanticAnalyzer = struct {
                     if (name_idx.isNone() or @intFromEnum(name_idx) >= self.ast.nodes.items.len) continue;
                     const name_node = self.ast.getNode(name_idx);
                     if (name_node.tag != .binding_identifier) continue;
-                    self.declareSymbolWithNode(name_node.span, .class_decl, stmt.span, @intFromEnum(name_idx)) catch {};
+                    self.declareSymbolWithNode(name_node.span, .class_decl, stmt.span, @intFromEnum(name_idx)) catch {
+                        self.alloc_failed = true;
+                    };
                 },
                 else => {},
             }
@@ -2554,7 +2575,9 @@ pub const SemanticAnalyzer = struct {
         const n = self.ast.getNode(idx);
         switch (n.tag) {
             .binding_identifier => {
-                self.declareSymbolWithNode(n.span, sym_kind, decl_span, @intFromEnum(idx)) catch {};
+                self.declareSymbolWithNode(n.span, sym_kind, decl_span, @intFromEnum(idx)) catch {
+                    self.alloc_failed = true;
+                };
             },
             .array_pattern, .object_pattern => {
                 if (n.data.list.start + n.data.list.len > self.ast.extra_data.items.len) return;
@@ -3610,7 +3633,9 @@ pub const SemanticAnalyzer = struct {
                     if (cv.kind != .none) {
                         self.symbols.items[sym_index].const_kind = cv.kind;
                         if (cv.kind == .number and cv.number_text.len > 0) {
-                            self.numeric_const_texts.put(self.allocator, @intCast(sym_index), cv.number_text) catch {};
+                            self.numeric_const_texts.put(self.allocator, @intCast(sym_index), cv.number_text) catch {
+                                self.alloc_failed = true;
+                            };
                         }
                     }
                 }

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1026,6 +1026,82 @@ test "#4398 export binding: forward module-scope 선언/import 는 여전히 val
     try analyzeNoErrors("export { Z };\nimport { Z } from \"./m\";");
 }
 
+/// 정확히 N 번째 alloc 만 실패시키는 테스트용 allocator. std.testing.FailingAllocator 는
+/// fail_index 이후 *모든* alloc 을 실패시켜, catch 가 삼킨 직후의 try-alloc 까지 실패→error
+/// 로 cascade 되므로 "삼킴" 자체를 격리하지 못한다. 이건 한 번만 실패시키고 나머지는 통과.
+const OneShotFailAllocator = struct {
+    child: std.mem.Allocator,
+    fail_at: usize,
+    count: usize = 0,
+
+    fn allocator(self: *OneShotFailAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = oafAlloc,
+            .resize = oafResize,
+            .remap = oafRemap,
+            .free = oafFree,
+        } };
+    }
+    fn oafAlloc(ctx: *anyopaque, n: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *OneShotFailAllocator = @ptrCast(@alignCast(ctx));
+        const cur = self.count;
+        self.count += 1;
+        if (cur == self.fail_at) return null; // 이 번째 alloc 만 실패
+        return self.child.rawAlloc(n, alignment, ra);
+    }
+    fn oafResize(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *OneShotFailAllocator = @ptrCast(@alignCast(ctx));
+        return self.child.rawResize(buf, alignment, new_len, ra);
+    }
+    fn oafRemap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *OneShotFailAllocator = @ptrCast(@alignCast(ctx));
+        return self.child.rawRemap(memory, alignment, new_len, ra);
+    }
+    fn oafFree(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *OneShotFailAllocator = @ptrCast(@alignCast(ctx));
+        self.child.rawFree(buf, alignment, ra);
+    }
+};
+
+test "#4400 analyzer: 분석 중 allocation 실패는 OutOfMemory 로 표면화 (silent swallow 금지)" {
+    // symbol/reference/const 기록의 allocation 실패가 누락된 채 성공 반환되면 import
+    // elision / mangler liveness 가 잘못된 입력을 받아 silent miscompile 위험. 과거
+    // catch {} 가 이를 삼켰다. 이제 어느 allocation 하나가 실패해도(그게 catch-site 여도)
+    // analyze() 는 반드시 error.OutOfMemory 를 반환해야 한다.
+    //
+    // references 는 analyze() 가 nodes/4 만큼 미리 예약하므로, catch-site(references.append)
+    // 가 실제 grow-alloc 하도록 참조 밀집(같은 변수 다수 사용) 소스를 쓴다.
+    const source =
+        "let a = 1;\n" ++
+        ("a;\n" ** 60);
+
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    // 1) 실패 없는 run 으로 analyzer 의 총 alloc 횟수 측정.
+    var counting = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = std.math.maxInt(usize) });
+    {
+        var ana = SemanticAnalyzer.init(counting.allocator(), &parser.ast);
+        defer ana.deinit();
+        try ana.analyze();
+    }
+    const total = counting.allocations;
+    try std.testing.expect(total > 0);
+
+    // 2) 각 alloc 을 *하나씩* 실패시킨다 — catch-site 든 try-site 든 전부 OutOfMemory.
+    //    한 곳이라도 success 면 그 alloc 실패가 조용히 삼켜졌다는 뜻(RED).
+    var i: usize = 0;
+    while (i < total) : (i += 1) {
+        var oaf = OneShotFailAllocator{ .child = std.testing.allocator, .fail_at = i };
+        var ana = SemanticAnalyzer.init(oaf.allocator(), &parser.ast);
+        defer ana.deinit();
+        try std.testing.expectError(error.OutOfMemory, ana.analyze());
+    }
+}
+
 // ====================================================================
 // D5: import type declaration + 다른 import → export 검증
 // ====================================================================


### PR DESCRIPTION
## 요약
`SemanticAnalyzer` 의 void 반환 visitor 들이 allocation 실패를 `catch {}` 로 **조용히 삼킵니다**(references.append 2곳, recordDeclareRef 1곳, declareSymbolWithNode 2곳, numeric_const_texts.put 2곳). symbol/reference 가 누락된 채 `analyze()` 가 **성공 반환**되면, 이 결과를 입력으로 쓰는 import elision / mangler liveness 가 잘못 판단 → 사용 중인 import 를 제거하는 등 **silent miscompile** 위험이 있습니다.

## 루트커즈 & 수정 (더 깊은 설계)
- 루트커즈: 정확성에 영향을 주는 allocation 실패를 삼킴.
- `resolveIdentifier` 호출 체인에 `bool` 반환 helper(`tryResolveNodeAsRef`)가 있어 `try` 전파는 시그니처 cascade 가 광범위 → 비현실적.
- `alloc_failed: bool` 플래그로 catch-site 에서 표시하고, `analyze()` 끝에서 `if (self.alloc_failed) return error.OutOfMemory;`. "나쁜(누락된) 분석 결과" 가 transform/codegen 으로 흘러가지 못하게 입구에서 차단.

## Test Plan
- [x] `#4400` 참조 밀집 소스에서 alloc 을 하나씩(one-shot) 실패시켜 — catch-site(references grow) 포함 모든 alloc 실패가 `error.OutOfMemory` 로 표면화 (TDD: 표면화 제거 시 RED, fix 시 GREEN)
  - `std.testing.FailingAllocator` 는 fail_index 이후 전부 실패시켜 cascade 로 swallow 를 가리므로, "정확히 N번째만 실패" 하는 `OneShotFailAllocator` 를 테스트에 도입
- [x] 전체 5946/5946, OOM 경로 leak 없음(testing.allocator), fmt 통과

```mermaid
flowchart TD
    A["visitor: references/symbol/const 기록"] --> B{"alloc 실패?"}
    B -- "이전: catch {}" --> C["삼킴 → 누락된 채 analyze() 성공 ❌"]
    C --> D["import elision/mangler 가 오판 → silent miscompile"]
    B -- "이후: catch { alloc_failed = true }" --> E["analyze() 끝: return error.OutOfMemory ✅"]
    style C fill:#fdd
    style D fill:#fdd
```

### 초보자 설명
- Zig 에서 `something() catch {}` 는 "에러가 나도 무시하고 넘어가라" 입니다. 여기선 메모리 부족(OOM)으로 "이 변수를 썼다" 는 기록(reference)이나 심볼 등록이 실패해도 그냥 넘어갔습니다.
- 그러면 분석기는 "이 import 는 아무도 안 써" 라고 잘못 결론내고 번들에서 빼버릴 수 있습니다 → 런타임에 `ReferenceError`.
- 함수 반환 타입을 바꿔 에러를 위로 던지는 건(`try`) 중간에 `bool` 을 돌려주는 헬퍼 때문에 너무 많은 곳을 고쳐야 합니다. 그래서 `alloc_failed` 라는 깃발을 세우고, 분석이 끝나는 지점에서 그 깃발이 켜져 있으면 `error.OutOfMemory` 로 깔끔히 실패시킵니다 — 잘못된 분석 결과가 다음 단계로 새어나가지 않게요.