### PR TITLE
fix(transformer): 잔여 template data.none==0 alias 사이트 5곳 (#47 sweep)

### DIFF
--- a/src/transformer/minify/unused_expr.zig
+++ b/src/transformer/minify/unused_expr.zig
@@ -611,9 +611,13 @@ fn rewriteObjectUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, changed: 
 ///   - 끝에 남은 pending 도 새 template_literal 로 flush.
 /// transformed 를 최종 sequence / single / empty 로 환원.
 ///
-/// `data.none == 0` (substitution 없는 단순 `` `static` ``) 는 그대로 removable.
+/// `data.list.len == 0` (transformer raw-span shorthand) 는 그대로 removable. parser
+/// no-substitution `` `static` `` 은 quasi 1개(len>0)라 아래 loop 가 template_element 만
+/// 보고 removable 판정. (과거 `data.none == 0` 은 data.list.start 와 alias 라, 보간 template
+/// 이 extra_data[0] 에서 시작하면 start==0 → 무조건 removable 오판 → `` `${sideEffect()}` `` 의
+/// 부작용까지 DCE 로 삭제. node_dispatch/codegen 과 동일하게 list.len 기준.)
 fn rewriteTemplateLiteralUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, changed: *bool, depth: u32) bool {
-    if (node.data.none == 0) return true;
+    if (node.data.list.len == 0) return true;
     const list = node.data.list;
     if (list.start + list.len > ast.extra_data.items.len) return false;
     const items = ast.extra_data.items[list.start .. list.start + list.len];
@@ -797,8 +801,11 @@ fn isStmtRemovableDepth(ast: *const Ast, idx: NodeIndex, ctx: MinifyCtx, depth: 
         },
 
         .template_literal => blk: {
-            // 단순 문자열 template (data.none = 0) — substitution 없음, removable.
-            if (node.data.none == 0) break :blk true;
+            // raw-span shorthand(list.len==0) — substitution 없음, removable. parser
+            // no-sub `` `static` `` 은 len>0 라 아래 loop 가 template_element 만 보고 판정.
+            // (`data.none == 0` 은 list.start alias → 보간 template@start==0 이 부작용
+            // 검사 없이 removable 오판되던 버그.)
+            if (node.data.list.len == 0) break :blk true;
             const list = node.data.list;
             if (list.start + list.len > ast.extra_data.items.len) break :blk false;
             for (ast.extra_data.items[list.start .. list.start + list.len]) |raw| {

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -552,7 +552,11 @@ fn transformEmotionTemplate(
     const node = self.ast.getNode(template_idx);
     if (node.tag != .template_literal) return template_idx;
 
-    if (node.data.none == 0) {
+    // list.len==0 = transformer raw-span shorthand(text in node.span). parser-created
+    // template 은 quasi 최소 1개라 항상 len>0. (과거 `data.none == 0` 은 data.list.start
+    // 와 alias 라, 보간 template 이 extra_data[0] 에서 시작하면 start==0 → no-interp 오판
+    // → 보간 expression 변환 누락. node_dispatch/codegen 과 동일하게 list.len 기준.)
+    if (node.data.list.len == 0) {
         return try transformNoInterpTemplate(self, template_idx, node, label_text, source_map_text);
     }
     return try transformInterpTemplate(self, template_idx, node, label_text, source_map_text);

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -737,15 +737,16 @@ fn scanObjectKeys(self: *Transformer, obj_idx: NodeIndex) ObjectKeyScan {
 }
 
 /// template_literal 의 CSS whitespace 를 minify. no-interp / 보간 있는 케이스 모두 처리.
-/// codegen.zig:2270 convention — `data.none == 0` 이면 no-interp (text in node.span),
-/// 그 외엔 children 이 alternating template_element + expression.
+/// codegen emitTemplateLiteral convention — `list.len == 0` (transformer raw-span shorthand)
+/// 이면 no-interp (text in node.span), 그 외엔 children 이 alternating template_element +
+/// expression. (과거 `data.none == 0` 은 list.start alias → 보간 template@start==0 오판.)
 /// 변경 없으면 identity (template_idx).
 fn minifyCssTemplate(self: *Transformer, template_idx: NodeIndex) Error!NodeIndex {
     if (template_idx.isNone()) return template_idx;
     const node = self.ast.getNode(template_idx);
     if (node.tag != .template_literal) return template_idx;
 
-    if (node.data.none == 0) {
+    if (node.data.list.len == 0) {
         // no-interp: text 는 node.span 에 직접 — `\`text\`` 형태.
         return try minifyNoInterpTemplate(self, template_idx, node);
     }
@@ -1408,7 +1409,7 @@ fn forwardObjectInterpolations(
 /// 의 expressions reduce 와 동등 (단, ZNTC 는 binding/function 검출 없이 모든 expression
 /// 을 forward — closure capture 회피, 사용자가 props 기반 동적 스타일링 가능).
 ///
-/// no-interp template (data.none == 0) 은 input 그대로 반환.
+/// no-interp template (list.len == 0) 은 input 그대로 반환.
 fn forwardTemplateInterpolations(
     self: *Transformer,
     template_idx: NodeIndex,
@@ -1417,7 +1418,8 @@ fn forwardTemplateInterpolations(
     if (template_idx.isNone()) return template_idx;
     const template = self.ast.getNode(template_idx);
     if (template.tag != .template_literal) return template_idx;
-    if (template.data.none == 0) return template_idx; // no-interp
+    // (과거 `template.data.none == 0` no-interp 가드는 list.start alias 라 보간
+    //  template@start==0 을 오판 → 아래 list.len==0 체크가 정본. 중복분기 제거.)
     const list = template.data.list;
     if (list.len == 0) return template_idx;
 


### PR DESCRIPTION
## 요약
`/code-review max` 가 직전 세션 수정건을 재검토하다, **#4397(#47)의 sibling 누락**을 발견했습니다. `data.none` 은 extern union 에서 `data.list.start` 와 같은 바이트라, 보간 template 의 자식 list 가 `extra_data[0]` 에서 시작하면 `start==0` → `data.none==0` → **no-substitution 오판**. #4397 은 `node_dispatch` 만 고쳤고 5곳이 남아 있었습니다.

| 파일:라인 | 함수 | 영향 |
|---|---|---|
| `minify/unused_expr.zig:616` | rewriteTemplateLiteralUnused | 🔴 보간 template@start==0 을 removable 오판 → `${sideEffect()}` 부작용째 DCE 삭제(#1577 위반) |
| `minify/unused_expr.zig:801` | isStmtRemovableDepth | 🔴 동일 |
| `styled_components.zig:748` | minifyCssTemplate | 🟠 보간 styled → no-interp 라우팅 → `${p=>p.c}` 손상 |
| `styled_components.zig:1420` | forwardTemplateInterpolations | 🟠 아래 1422 `list.len==0` 가 정본 → 버그 중복분기 삭제 |
| `emotion.zig:555` | transformEmotionTemplate | 🟠 보간 emotion → no-interp 라우팅 → `${}`/label/sourcemap 누락 |

## 수정 (더 깊은 설계)
- 5곳 모두 `data.list.len == 0` (codegen `emitTemplateLiteral` / `node_dispatch` #47 과 동일 기준)으로 통일. parser-created template 은 quasi 최소 1개라 항상 `len>0`; `len==0` 은 transformer raw-span shorthand(emotion/styled 합성)만.

## 검증
- **클래스 가드**: 이 alias 버그 클래스는 #4397 의 `#4396` 테스트(`${a ?? b}` @start==0 의 ES 다운레벨)가 이미 RED/GREEN 으로 보증. 5곳은 동일 루트커즈의 동일 한-토큰 수정.
- transform-pass 사이트(emotion/styled)는 #47 과 동일하게 reachable. minify 사이트(unused_expr)는 transform **출력** ast 에서 start==0 을 결정적으로 재현하진 못했으나(post-transform 할당 순서 의존), 필드 자체가 객관적으로 틀려 동일 클래스 latent 오류 → 통일.
- 전체 5946/5946, fmt 통과, reachable 비-버그 케이스 출력 무변경(동등).

```mermaid
flowchart TD
    A["보간 template (list.len>0)"] --> B{"data.none==0?<br/>(= list.start==0?)"}
    B -- "start==0 (첫 list 노드)" --> C["no-sub 오판 → 부작용 삭제 / 보간 변환 누락 ❌"]
    A --> D{"data.list.len==0?"}
    D -- "항상 false (실제 template)" --> E["보간 경로 정상 ✅"]
    style C fill:#fdd
```

### 초보자 설명
- `data` 는 `extern union` 이라 `none: u32` 으로 읽으면 사실상 `list.start`(자식이 저장된 배열 위치)를 봅니다. 그 template 이 파일에서 가장 먼저 배열을 쓰면 위치가 0이라, "자식 없음" 으로 착각합니다.
- 그러면 (a) minify 가 `${부작용()}` 을 "순수한 문자열" 로 보고 통째로 지우거나, (b) styled/emotion 이 보간을 일반 문자열로 처리해 `${...}` 변환을 빼먹습니다.
- 자식 "개수"(`list.len`)로 판단하면 위치와 무관하게 정확합니다 — codegen 과 node_dispatch 가 이미 쓰는 방식으로 나머지 5곳도 맞췄습니다.