### PR TITLE
fix(semantic): addUnresolvedReference OOM 삼킴 표면화 (#40 sweep)

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -986,9 +986,16 @@ pub const SemanticAnalyzer = struct {
         // 쪽(getTextStable)과 대칭으로 stable 사본 키 사용. 이미 등록된 키면
         // 사본을 만들지 않는다.
         if (self.unresolved_references.contains(name)) return;
-        const stable_name = self.allocator.dupe(u8, name) catch return;
+        // OOM 으로 미해결 글로벌 이름이 누락되면 linker 가 그 이름을 예약하지 못해
+        // scope hoisting 시 shadowing → silent miscompile. alloc_failed 로 표면화
+        // (analyze() 끝에서 error.OutOfMemory). 다른 OOM-삼킴 catch 들과 동일 정책.
+        const stable_name = self.allocator.dupe(u8, name) catch {
+            self.alloc_failed = true;
+            return;
+        };
         self.unresolved_references.put(self.allocator, stable_name, {}) catch {
             self.allocator.free(stable_name);
+            self.alloc_failed = true;
         };
     }
 

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1071,8 +1071,10 @@ test "#4400 analyzer: 분석 중 allocation 실패는 OutOfMemory 로 표면화 
     //
     // references 는 analyze() 가 nodes/4 만큼 미리 예약하므로, catch-site(references.append)
     // 가 실제 grow-alloc 하도록 참조 밀집(같은 변수 다수 사용) 소스를 쓴다.
+    // `undeclaredGlobal;` 로 addUnresolvedReference 의 dupe/put catch-site 도 커버.
     const source =
         "let a = 1;\n" ++
+        "undeclaredGlobal;\n" ++
         ("a;\n" ** 60);
 
     var scanner = try Scanner.init(std.testing.allocator, source);


### PR DESCRIPTION
## 요약
`/code-review max` 가 **#4401(#40)의 sweep 누락**을 발견했습니다. #4401 은 analyzer 의 `catch {}` 리터럴 7곳을 `alloc_failed` 로 표면화했지만, `addUnresolvedReference`(analyzer.zig:989-990)의 OOM 삼킴은 형태가 달라(`catch return` / `catch { free }`) 빠졌습니다.

```zig
const stable_name = self.allocator.dupe(u8, name) catch return;          // ← 삼킴
self.unresolved_references.put(self.allocator, stable_name, {}) catch {
    self.allocator.free(stable_name);                                    // ← 삼킴
};
```

OOM 으로 미해결 글로벌 이름이 `unresolved_references` 에서 드롭되면, 번들러 linker 가 그 이름을 예약하지 못해 scope hoisting 시 사용자 로컬이 글로벌을 shadow → **silent miscompile** — #40 이 막으려던 바로 그 클래스입니다.

## 수정
- 두 catch-site 에 `self.alloc_failed = true;` 추가 (analyze() 끝에서 error.OutOfMemory 로 표면화, 다른 6곳과 동일 정책).

## Test Plan
- [x] `#4400` 테스트 소스에 `undeclaredGlobal;` 추가 → addUnresolvedReference 의 dupe/put alloc 이 one-shot fail 대상에 포함. (TDD: 989/990 swallow 복원 시 RED — dupe@989 실패가 삼켜져 analyze 가 success 반환, fix 시 GREEN)
- [x] 전체 5946/5946, fmt 통과

```mermaid
flowchart TD
    A["addUnresolvedReference (미해결 글로벌)"] --> B{"dupe/put OOM?"}
    B -- "이전: catch return / catch{free}" --> C["삼킴 → 이름 드롭 → analyze success ❌"]
    C --> D["linker 미예약 → scope hoist shadowing → silent miscompile"]
    B -- "이후: alloc_failed=true" --> E["analyze() 끝: error.OutOfMemory ✅"]
    style C fill:#fdd
    style D fill:#fdd
```

### 초보자 설명
- #4401 에서 "메모리 부족을 조용히 넘기지 말고 위로 알리자" 고 7곳을 고쳤는데, 검색을 `catch {}`(빈 중괄호) 문자열로만 해서 `catch return`·`catch { 해제만 }` 같은 변형 2곳을 놓쳤습니다.
- 이 두 곳은 "이 이름은 우리 모듈에 선언이 없는 외부(글로벌) 이름" 이라는 기록을 메모리 부족으로 빠뜨릴 수 있습니다. 그러면 번들러가 그 이름을 보호하지 못해, 합쳐진 코드에서 같은 이름의 지역 변수가 글로벌을 가려버립니다.
- 같은 `alloc_failed` 깃발을 세워 분석이 끝날 때 깔끔히 실패하도록 통일했습니다.