### PR TITLE
perf(graph): requestDependencyExports O(N²)→O(N) — record→bindings CSR 인덱스

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -119,6 +119,17 @@ pub const ModuleGraph = struct {
     exec_counter: u32 = 0,
     cycle_counter: u32 = 0,
 
+    /// `requestDependencyExports` 의 per-importer 캐시 (record_index → binding 인덱스, CSR).
+    /// 과거엔 record 마다 `import_bindings` 전체를 선형 스캔 → mega-entry/대형 barrel(한 모듈이
+    /// N개 import)에서 record N개 × binding N개 = **O(N²)**. `resolveModuleImports` 가 한 모듈의
+    /// record 를 연속 처리하므로 importer 가 바뀔 때만 1회 O(N) 재구축 → 전체 O(N).
+    /// `rdx_offsets[rec]..rdx_offsets[rec+1]` 범위가 `rdx_order` 안의 binding 인덱스(원래 순서 보존).
+    /// self.allocator 소유(arena 아님), clearRetainingCapacity 로 재사용, graph deinit 에서 해제.
+    /// `rdx_cache_owner` = 캐시가 담은 importer_idx (null = 비어있음/무효).
+    rdx_cache_owner: ?usize = null,
+    rdx_offsets: std.ArrayListUnmanaged(u32) = .empty,
+    rdx_order: std.ArrayListUnmanaged(u32) = .empty,
+
     /// Incremental rebuild path 여부. bundler 가 `module_store` / `changed_files`
     /// / `compiled_cache` 중 하나라도 주입한 경우 true — `readModuleSourceWithMtime`
     /// 가 fstat 호출로 mtime 을 채워야 cache invalidation 이 동작. fresh build

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -1557,6 +1557,8 @@ fn resetPerBuildStateForPreserved(self: *ModuleGraph) void {
     var req_it = self.requested_exports.valueIterator();
     while (req_it.next()) |req| req.deinit(self.allocator);
     self.requested_exports.clearRetainingCapacity();
+    // requestDependencyExports CSR 캐시 무효화 (preserve-topology rebuild — 변경 모듈의 binding 변동).
+    self.rdx_cache_owner = null;
 }
 
 /// 변경 모듈을 **edge 보존**하며 재파싱한다. dependencies/importers/dynamic_imports/

--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -70,6 +70,10 @@ pub fn reset(self: *ModuleGraph) void {
 
     self.exec_counter = 0;
     self.cycle_counter = 0;
+
+    // requestDependencyExports CSR 캐시 무효화 — rebuild 후 같은 importer_idx 의 binding 이
+    // 바뀌어도 stale 캐시를 재사용하지 않도록. backing 은 보존(clearRetainingCapacity 재사용).
+    self.rdx_cache_owner = null;
 }
 
 /// 단일 모듈의 state 부분 reset (path 보존, graph slot 유지). 변경 감지된 모듈을
@@ -203,4 +207,7 @@ pub fn deinit(self: *ModuleGraph) void {
     self.runtime_polyfill_roots.deinit(self.allocator);
     // PR-3a lazy seeds — path 는 path_arena 소유라 리스트 자체만 해제.
     self.lazy_seeds.deinit(self.allocator);
+    // requestDependencyExports per-importer CSR 캐시 (self.allocator 소유).
+    self.rdx_offsets.deinit(self.allocator);
+    self.rdx_order.deinit(self.allocator);
 }

--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -303,6 +303,43 @@ pub fn requestedExportsForReExportRecord(
     return changed;
 }
 
+/// `requestDependencyExports` 의 static_import 경로가 record 마다 `import_bindings` 전체를
+/// 선형 스캔하던 것을 제거하기 위한 per-importer CSR 인덱스(record_index → binding 인덱스)를
+/// 보장한다. importer 가 바뀔 때만 1회 O(bindings) 재구축하고, `resolveModuleImports` 가 한
+/// 모듈의 record 를 연속 처리하므로 전체적으로 O(total bindings) (과거 O(records×bindings)).
+/// scatter 는 binding 인덱스 오름차순으로 채워 record 내 원래 순서를 보존 → 출력 byte-identical.
+fn ensureBindingsByRecord(self: anytype, importer_idx: usize, importer: *const Module) !void {
+    if (self.rdx_cache_owner) |owner| {
+        if (owner == importer_idx) return;
+    }
+    const num_records = importer.import_records.len;
+    self.rdx_offsets.clearRetainingCapacity();
+    self.rdx_order.clearRetainingCapacity();
+    try self.rdx_offsets.appendNTimes(self.allocator, 0, num_records + 1);
+    // record 별 binding 개수 → offsets[rec+1] 에 누적
+    for (importer.import_bindings) |ib| {
+        if (ib.import_record_index < num_records)
+            self.rdx_offsets.items[ib.import_record_index + 1] += 1;
+    }
+    // prefix sum → offsets[rec] = record rec 구간의 시작 위치
+    for (1..num_records + 1) |k|
+        self.rdx_offsets.items[k] += self.rdx_offsets.items[k - 1];
+    const valid_total = self.rdx_offsets.items[num_records];
+    try self.rdx_order.appendNTimes(self.allocator, 0, valid_total);
+    // counting-sort scatter — cursor 는 offsets 복사본(record 당 다음 쓰기 위치)
+    const cursor = try self.allocator.alloc(u32, num_records);
+    defer self.allocator.free(cursor);
+    @memcpy(cursor, self.rdx_offsets.items[0..num_records]);
+    for (importer.import_bindings, 0..) |ib, bi| {
+        if (ib.import_record_index < num_records) {
+            const rec = ib.import_record_index;
+            self.rdx_order.items[cursor[rec]] = @intCast(bi);
+            cursor[rec] += 1;
+        }
+    }
+    self.rdx_cache_owner = importer_idx;
+}
+
 pub fn requestDependencyExports(
     self: anytype,
     importer_idx: usize,
@@ -317,12 +354,18 @@ pub fn requestDependencyExports(
             defer s.end();
             var changed = false;
             var found_binding = false;
-            for (importer.import_bindings) |ib| {
-                if (ib.import_record_index != rec_i) continue;
-                found_binding = true;
-                switch (ib.kind) {
-                    .namespace => changed = (try requestAll(self, dep_idx)) or changed,
-                    .default, .named => changed = (try requestNamed(self, dep_idx, ib.imported_name)) or changed,
+            // O(records×bindings) → O(bindings): record rec_i 에 속한 binding 만 순회.
+            try ensureBindingsByRecord(self, importer_idx, importer);
+            if (rec_i + 1 < self.rdx_offsets.items.len) {
+                const start = self.rdx_offsets.items[rec_i];
+                const end = self.rdx_offsets.items[rec_i + 1];
+                for (self.rdx_order.items[start..end]) |bi| {
+                    const ib = importer.import_bindings[bi];
+                    found_binding = true;
+                    switch (ib.kind) {
+                        .namespace => changed = (try requestAll(self, dep_idx)) or changed,
+                        .default, .named => changed = (try requestNamed(self, dep_idx, ib.imported_name)) or changed,
+                    }
                 }
             }
             if (!found_binding) {
@@ -391,7 +434,71 @@ pub fn reExportRecordMatchesRequest(m: *const Module, rec_i: usize, req: *const 
 
 const binding_scanner = @import("../binding_scanner.zig");
 const ExportBinding = binding_scanner.ExportBinding;
+const ImportBinding = binding_scanner.ImportBinding;
 const Span = @import("../../lexer/token.zig").Span;
+
+/// `ensureBindingsByRecord` 단위 테스트용 최소 stub — 실제 ModuleGraph 없이
+/// CSR 인덱스 필드(+allocator)만 노출. ensureBindingsByRecord 는 self 에서 이 4개와
+/// importer 인자만 읽으므로 full graph 불필요.
+const RdxStub = struct {
+    allocator: std.mem.Allocator,
+    rdx_cache_owner: ?usize = null,
+    rdx_offsets: std.ArrayListUnmanaged(u32) = .empty,
+    rdx_order: std.ArrayListUnmanaged(u32) = .empty,
+};
+
+test "ensureBindingsByRecord: record 별 그룹화 + 원래 순서 보존 + 캐시 hit" {
+    const testing = std.testing;
+    var module = Module.init(@enumFromInt(0), "idx.ts");
+    defer module.deinit(testing.allocator);
+
+    // 4 records — Module.deinit 가 record.kind(.require_context) 만 보므로 zeroes(=.static_import) 안전.
+    var recs: [4]ImportRecord = undefined;
+    for (&recs) |*r| r.* = std.mem.zeroes(ImportRecord);
+    module.import_records = &recs;
+
+    // 6 bindings, record 분포: rec0=1(bi3) · rec1=2(bi0,bi2) · rec2=0 · rec3=3(bi1,bi4,bi5).
+    // import_record_index 가 뒤섞여 있어 counting-sort scatter 의 순서 보존을 검증.
+    const recmap = [_]u32{ 1, 3, 1, 0, 3, 3 };
+    const ibs = try testing.allocator.alloc(ImportBinding, recmap.len);
+    defer testing.allocator.free(ibs);
+    for (ibs, 0..) |*ib, i| {
+        ib.* = .{ .kind = .named, .local_name = "x", .imported_name = "x", .local_span = Span.EMPTY, .import_record_index = recmap[i] };
+    }
+    module.import_bindings = ibs;
+
+    var stub = RdxStub{ .allocator = testing.allocator };
+    defer stub.rdx_offsets.deinit(testing.allocator);
+    defer stub.rdx_order.deinit(testing.allocator);
+
+    try ensureBindingsByRecord(&stub, 0, &module);
+
+    try testing.expectEqual(@as(?usize, 0), stub.rdx_cache_owner);
+    const off = stub.rdx_offsets.items;
+    try testing.expectEqual(@as(usize, 5), off.len); // num_records+1
+    try testing.expectEqual(@as(u32, 1), off[1] - off[0]); // rec0
+    try testing.expectEqual(@as(u32, 2), off[2] - off[1]); // rec1
+    try testing.expectEqual(@as(u32, 0), off[3] - off[2]); // rec2 (binding 없음)
+    try testing.expectEqual(@as(u32, 3), off[4] - off[3]); // rec3
+
+    const ord = stub.rdx_order.items;
+    try testing.expectEqual(@as(u32, 3), ord[off[0]]); // rec0 → bi3
+    try testing.expectEqual(@as(u32, 0), ord[off[1]]); // rec1 → bi0 (작은 인덱스 먼저)
+    try testing.expectEqual(@as(u32, 2), ord[off[1] + 1]); // rec1 → bi2
+    try testing.expectEqual(@as(u32, 1), ord[off[3]]); // rec3 → bi1
+    try testing.expectEqual(@as(u32, 4), ord[off[3] + 1]); // rec3 → bi4
+    try testing.expectEqual(@as(u32, 5), ord[off[3] + 2]); // rec3 → bi5
+
+    // 같은 importer 재호출 = 재구축 skip(cache hit): 센티넬이 보존되면 clear 안 된 것.
+    try stub.rdx_order.append(testing.allocator, 999);
+    try ensureBindingsByRecord(&stub, 0, &module);
+    try testing.expectEqual(@as(u32, 999), stub.rdx_order.items[stub.rdx_order.items.len - 1]);
+
+    // importer 변경 = 재구축: owner 갱신 + 센티넬 사라짐.
+    try ensureBindingsByRecord(&stub, 1, &module);
+    try testing.expectEqual(@as(?usize, 1), stub.rdx_cache_owner);
+    try testing.expectEqual(@as(usize, recmap.len), stub.rdx_order.items.len); // 999 제거됨
+}
 
 test "populateExportIndexByName: 빈 export_bindings 면 null" {
     const testing = std.testing;


### PR DESCRIPTION
## 무엇을 / 왜

대형 fan-out 모듈(mega-entry / 큰 barrel 파일 — 한 모듈이 N개를 import)에서 `requestDependencyExports` 가 **static_import record 마다 `import_bindings` 전체를 선형 스캔**해 `import_record_index == rec_i` 인 binding 을 찾았습니다. record N개 × binding N개 = **O(N²)**.

CI `bundle-perf` 벤치의 **5000-module spec** (entry 가 5000개 `import { vN } from "./mN"`)이 정확히 이 경로를 탑니다. 즉 우리가 1등을 노리는 그 벤치가 이 O(N²)에 직접 발목 잡혀 있었습니다.

### 측정으로 O(N²) 확정 (외부 도구)
`/usr/bin/time -l` + `hyperfine` + macOS `sample` 로 추적:
- jobs=1 User CPU 스케일링: **5k 77ms → 15k 456ms → 30k 1622ms** (6× 파일에 **21×** = 명백한 초선형, 지수 ~1.8)
- `sample` top-of-stack 1위가 `requestDependencyExports` (30k 에서 421 샘플)

## 어떻게

ModuleGraph 에 **per-importer CSR 인덱스**(record_index → binding 인덱스)를 추가했습니다.
- `resolveModuleImports` 가 한 모듈의 record 를 **연속 처리**하므로, importer 가 바뀔 때만 1회 O(bindings) 재구축 → 전체 **O(total bindings)**.
- counting-sort scatter 를 **binding 인덱스 오름차순**으로 채워 record 내 순회 순서를 기존과 동일하게 보존 → **출력 byte-identical**.
- backing 버퍼는 `clearRetainingCapacity` 로 재사용(빌드당 단일 버퍼), graph deinit 에서 해제.
- 증분 rebuild 의 stale 캐시 방지: `reset()` / preserve-topology rebuild 에서 `rdx_cache_owner` 무효화.

> Zig 초보자용 설명: CSR(Compressed Sparse Row)은 "그룹별 목록"을 두 배열로 압축하는 표준 기법입니다. `offsets[rec]..offsets[rec+1]` 가 `order` 배열에서 record `rec` 에 속한 항목들의 구간을 가리킵니다. 매번 전체를 훑는 대신 그 구간만 보면 됩니다. 구축은 counting sort 와 같아 O(항목 수) 1회면 끝납니다.

## 측정 (ReleaseFast, 구 origin/main vs 신, hyperfine)

| 케이스 | 구 | 신 | 개선 |
|---|---|---|---|
| **5000-module CI spec** (default jobs) | wall 101.2ms · User 79ms | wall 86.4ms · User 64ms | **wall −14.6% · User −19%** |
| jobs=1 User CPU 5k | 77ms | 62ms | −19% |
| jobs=1 User CPU 15k | 456ms | 336ms | −26% |
| jobs=1 User CPU 30k | 1622ms | 1129ms | **−30%** |

## 정확성 검증
- 출력 **byte-identical** (5k/15k/30k fixture, 단일·다중 dir)
- `zig build test` 유닛 통과 (+ `ensureBindingsByRecord` CSR 그룹화·순서보존·캐시 hit/무효화 단위 테스트 신규)
- bundler 통합 230 pass / 0 fail (cross-chunk reexport, cjs, export-star, dynamic-import, circular 등)
- `napi` / `wasm` / `wasm-bundler` / `test262` 빌드 통과
- `/code-review max`: 실제 버그 0건 (동시성 data race·동작 분기 모두 증거와 함께 REFUTED — `requestDependencyExports` 는 메인스레드 전용, 모든 rebuild 진입점이 캐시 무효화)

## 후속 (별도 PR)
같은 루트코즈(대형 fan-out 의 `import_bindings`/references 선형 스캔)의 잔여 O(N²) 가 `sample` 에 보입니다 — `Linker.collectModuleNames`(`forEachTopLevelOwnerName`), `metadata.buildMetadataForAst`, `transformer.isImportSpecifierUnused`. 각각 별도 PR 로 같은 방식(인덱싱)으로 처리 예정. 누적되면 5000-module spec 을 Bun(~55ms) 에 더 근접시킬 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)