### PR TITLE
perf(linker): forEachTopLevelOwnerName O(N²)→O(N) — 대형 fan-out local_name 인덱스

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -592,6 +592,36 @@ pub const Linker = struct {
         try entry.value_ptr.append(self.allocator, owner);
     }
 
+    /// import binding 이 번들 top-level 변수를 생성하는지 — `forEachTopLevelOwnerName` 의
+    /// 충돌 후보 판정. 과거 inline 루프(local_name 으로 매칭한 *첫* binding 으로 판정)와 동일
+    /// 로직을 추출해 linear-scan 경로와 index-lookup 경로가 공유한다(드리프트 차단).
+    fn importBindingGeneratesTopLevelVar(self: *const Linker, m: *const Module, ib: ImportBinding) bool {
+        if (ib.kind == .namespace) return true;
+        if (ib.import_record_index >= m.import_records.len) return false;
+        const rec = m.import_records[ib.import_record_index];
+        if (rec.resolved.isNone()) return !rec.is_lazy_resolved;
+        const target_idx = @intFromEnum(rec.resolved);
+        if (target_idx >= self.graph.moduleCount()) return m.wrap_kind == .esm;
+        const target_module = self.getModule(target_idx).?;
+        const helper_modules = @import("../runtime_helper_modules.zig");
+        if (helper_modules.isVirtualId(target_module.path)) return false;
+        const target_wrap = target_module.wrap_kind;
+        if (m.wrap_kind == .esm) {
+            // CJS named import 는 `require_xxx().prop` 직접 참조로 치환하므로 별도 top-level
+            // var 미생성. helper binding (JSX runtime 등) 은 call site 가 식별자라 var 할당 필요.
+            if (target_wrap == .cjs and ib.kind == .named and !ib.is_helper and
+                !isMetroNonInlinedRequireSpecifier(rec.specifier))
+            {
+                return false;
+            }
+            // __esm: scope-hoisted 타겟의 import 는 skip 되어 var 미생성.
+            return target_wrap != .none;
+        } else {
+            // non-esm: CJS 타겟만 require() preamble 에서 var 생성.
+            return target_wrap == .cjs;
+        }
+    }
+
     /// 모듈의 top-level owner 이름을 **단일 출처**로 열거한다 (perf/hmr-link-rename-reuse).
     ///
     /// `collectModuleNames`(deconflict 입력 수집) 와 `buildRenameSnapshot` 의 fingerprint
@@ -611,6 +641,26 @@ pub const Linker = struct {
         const sem = m.semantic orelse return;
         if (sem.scope_maps.len == 0) return;
         const module_scope = sem.scope_maps[0];
+
+        // 대형 fan-out(배럴/mega-entry): 아래 루프가 import 심볼마다 `import_bindings` 전체를
+        // local_name 으로 스캔하면 O(symbols×bindings)=O(N²). bindings 가 많을 때만 local_name→
+        // 첫 binding 인덱스를 1회 구축해 O(1) 조회로 전환. 작은 모듈은 맵 alloc 비용을 피하려
+        // 기존 linear-scan 유지(임계값 미만은 K² 가 어차피 저렴). 직렬(메인스레드) 단계라 로컬
+        // 맵으로 충분 — 동시성 무관.
+        const INDEX_THRESHOLD = 64;
+        // name_index 를 먼저 .empty 로 두고 그 안에 빌드 → defer 가 빌드 중 error(OOM 등)까지
+        // 커버해 누수 불가. ensureTotalCapacity 실패 시에도 .empty deinit 은 안전한 no-op.
+        var name_index: ?std.StringHashMapUnmanaged(u32) = null;
+        defer if (name_index) |*idx| idx.deinit(self.allocator);
+        if (m.import_bindings.len > INDEX_THRESHOLD) {
+            name_index = .empty;
+            const idx = &name_index.?;
+            try idx.ensureTotalCapacity(self.allocator, @intCast(m.import_bindings.len));
+            for (m.import_bindings, 0..) |ib, bi| {
+                const gop = idx.getOrPutAssumeCapacity(ib.local_name);
+                if (!gop.found_existing) gop.value_ptr.* = @intCast(bi); // 첫 binding 우선(루프와 동일)
+            }
+        }
 
         var scope_it = module_scope.iterator();
         while (scope_it.next()) |scope_entry| {
@@ -647,33 +697,15 @@ pub const Linker = struct {
                 // - namespace import 의 inline ns_var (`var z = external_ns;`) 는
                 //   wrap_kind 에 무관하게 emit 되므로 collision detection 대상.
                 const generates_top_level_var = blk: {
+                    // index 경로: local_name → 첫 binding O(1) 조회 (대형 fan-out).
+                    if (name_index) |*idx| {
+                        const bi = idx.get(sym_name) orelse break :blk m.wrap_kind == .esm;
+                        break :blk self.importBindingGeneratesTopLevelVar(&m, m.import_bindings[bi]);
+                    }
+                    // linear 경로: local_name 으로 첫 매칭 binding 검색 (작은 모듈).
                     for (m.import_bindings) |ib| {
                         if (!std.mem.eql(u8, ib.local_name, sym_name)) continue;
-                        if (ib.kind == .namespace) break :blk true;
-                        if (ib.import_record_index >= m.import_records.len) break :blk false;
-                        const rec = m.import_records[ib.import_record_index];
-                        if (rec.resolved.isNone()) break :blk !rec.is_lazy_resolved;
-                        const target_idx = @intFromEnum(rec.resolved);
-                        if (target_idx >= self.graph.moduleCount()) break :blk m.wrap_kind == .esm;
-                        const target_module = self.getModule(target_idx).?;
-                        const helper_modules = @import("../runtime_helper_modules.zig");
-                        if (helper_modules.isVirtualId(target_module.path)) break :blk false;
-                        const target_wrap = target_module.wrap_kind;
-                        if (m.wrap_kind == .esm) {
-                            // CJS named import는 `require_xxx().prop` 직접 참조로 치환하므로
-                            // 별도 top-level var를 만들지 않는다. helper binding (JSX runtime
-                            // 등) 은 call site 가 식별자 (`_jsx(...)`) 라 var 할당이 필요.
-                            if (target_wrap == .cjs and ib.kind == .named and !ib.is_helper and
-                                !isMetroNonInlinedRequireSpecifier(rec.specifier))
-                            {
-                                break :blk false;
-                            }
-                            // __esm: scope-hoisted 타겟의 import는 skip되어 var 미생성
-                            break :blk target_wrap != .none;
-                        } else {
-                            // non-esm: CJS 타겟만 require() preamble에서 var 생성
-                            break :blk target_wrap == .cjs;
-                        }
+                        break :blk self.importBindingGeneratesTopLevelVar(&m, ib);
                     }
                     // import_bindings에 매칭 없음: __esm은 기본 호이스팅, 그 외는 미생성
                     break :blk m.wrap_kind == .esm;


### PR DESCRIPTION
## 무엇을 / 왜

`collectModuleNames`(deconflict 입력) 와 `buildRenameSnapshot`(fingerprint) 가 공유하는 `forEachTopLevelOwnerName` 이, top-level import 심볼마다 `import_bindings` **전체를 local_name 으로 선형 스캔**해 매칭 binding 을 찾습니다. mega-entry/대형 barrel(한 모듈이 N개 import)에서 심볼 N개 × binding N개 = **O(N²)**.

[#4406](https://github.com/ohah/zntc/pull/4406)(requestDependencyExports O(N²) 제거) 이후 `sample` top-of-stack **#1 핫스팟**(30k 모듈 jobs=1 에서 343 샘플)이었습니다. 같은 루트코즈(대형 fan-out 의 `import_bindings` 선형 스캔)의 두 번째 건입니다.

## 어떻게

- `import_bindings.len > 64`(대형 fan-out)인 모듈만 `local_name → 첫 binding 인덱스` 해시맵을 **1회 구축**해 O(1) 조회로 전환. 작은 모듈은 맵 alloc 비용을 피해 **기존 linear-scan 유지**(K² 가 어차피 저렴, per-module alloc 없음).
- 충돌 판정 본문을 `importBindingGeneratesTopLevelVar` 헬퍼로 **추출** → linear/index 두 경로가 동일 로직 공유(드리프트 차단).
- index 는 binding 순서대로 **첫 항목만 등록**(`!found_existing`) → linear 의 "첫 매칭" 과 **동일 binding 선택** → 출력 byte-identical.

> 직렬 안전: `forEachTopLevelOwnerName` 의 모든 호출 경로(`computeRenames`·per-chunk `computeRenamesForModules`(emitChunks 내 순차 루프)·`buildRenameSnapshot`)는 메인스레드. 병렬 emit(`emitModuleThread`)은 이 경로를 타지 않음 → 로컬 맵으로 충분(공유 상태 없음).

## 측정 (ReleaseFast, origin/main[#4406 포함] vs 신, hyperfine)

| 측정 | 구 | 신 | 개선 |
|---|---|---|---|
| **5000-module CI spec** (default jobs) | wall 90.7ms · User 65.1ms | wall 74.8ms · User 52.3ms | **wall −17.5% · User −20%** |
| jobs=1 User CPU 5k | 62ms | 50ms | −19% |
| jobs=1 User CPU 15k | 336ms | 236ms | −30% |
| jobs=1 User CPU 30k | 1129ms | 715ms | **−37%** |

**누적(#4406 + 이번, 원본 대비): 30k jobs=1 User CPU 1622 → 715ms (−56%), 5000-spec wall ~101 → ~75ms (~−26%).** `sample` 에서 `collectModuleNames` 가 top-of-stack 에서 사라짐 확인.

## 정확성 검증
- 출력 **byte-identical** (5k/15k/30k) — 30000-binding fixture 비교가 **index 경로 = linear 경로 등가성을 실데이터로 증명**(원본은 index 없던 linear).
- `zig build test` 유닛 통과, rename/충돌 민감 통합 299 pass / 0 fail (cross-chunk·cjs·export-star·ns-var-collision·mangle 등)
- `napi`/`wasm`/`wasm-bundler` 빌드 통과
- `/code-review max`: 실제 버그 0건 (동시성·동작분기 REFUTED). "OOM 누수" 지적은 `ensureTotalCapacity` alloc-atomic 이라 무효였으나, defer 가 빌드 중 error 까지 커버하도록 방어적 재구성 반영.

## 후속 (별도 PR)
남은 같은-클래스 O(N²): `metadata.buildMetadataForAst`, `transformer.isImportSpecifierUnused`(references 전체 스캔). 또한 본 인덱스를 per-Module 캐시(`export_index_by_name` 대칭)로 올리면 동일 모듈의 다중 호출에서 재구축 회피 가능(이 PR 은 ephemeral 로컬 = staleness 불가·저위험 우선).

🤖 Generated with [Claude Code](https://claude.com/claude-code)