### PR TITLE
perf(transformer): isImportSpecifierUnused O(N²)→O(N) — value-use symbol 집합 캐시

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -116,6 +116,15 @@ pub const Transformer = struct {
     /// elision 비활성 (보수적 보존). caller 가 symbols 와 함께 설정.
     references: []const @import("../semantic/symbol.zig").Reference = &.{},
 
+    /// `isImportSpecifierUnused` 가 specifier 마다 `references` 전체를 선형 스캔(O(N²))하지
+    /// 않도록, **value-use 가 있는 symbol_id 집합**을 1회 구축해 캐시한다(대형 fan-out 만).
+    /// `value_used_symbols_built_for` = 집합을 구축한 `references` slice(ptr+len) — 현재
+    /// transformer 는 모듈마다 fresh 생성이라 intra-module 1회 구축이지만, references 가
+    /// 바뀌면(다른 slice) ptr/len 불일치로 자동 재구축(stale 방지). self.allocator 소유,
+    /// deinitExceptAst 에서 해제.
+    value_used_symbols: std.AutoHashMapUnmanaged(u32, void) = .empty,
+    value_used_symbols_built_for: ?[]const @import("../semantic/symbol.zig").Reference = null,
+
     /// Full semantic을 건너뛰는 standalone transpile 경로에서 named import elision만
     /// 판단하기 위한 lightweight binding facts.
     binding_lite: ?*const BindingLite = null,

--- a/src/transformer/transformer/import_export.zig
+++ b/src/transformer/transformer/import_export.zig
@@ -92,7 +92,7 @@ pub fn visitImportDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
 /// visit switch 용 wrapper — `verbatim_module_syntax` 와 symbol table 준비 여부를
 /// 먼저 가드한 뒤 `isImportSpecifierUnused` 에 위임. #1791 Phase D 의 elision 조건을
 /// default/named/namespace 세 switch arm 이 동일하게 적용하도록 모아둔다.
-pub fn shouldElideImportSpecifier(self: *const Transformer, spec_idx: NodeIndex, spec_node: Node) bool {
+pub fn shouldElideImportSpecifier(self: *Transformer, spec_idx: NodeIndex, spec_node: Node) bool {
     if (self.options.verbatim_module_syntax) return false;
     if (!hasImportElisionFacts(self)) return false;
     return isImportSpecifierUnused(self, spec_idx, spec_node);
@@ -304,7 +304,7 @@ fn hasImportElisionFacts(self: *const Transformer) bool {
 /// 있음에도 "미사용" 으로 오판했음 (PR #1793 revert 원인).
 ///
 /// `self.references` 가 비어있으면 보수적으로 "사용 중" 간주. symbol_id 조회 실패도 동일.
-fn isImportSpecifierUnused(self: *const Transformer, spec_idx: NodeIndex, spec_node: Node) bool {
+fn isImportSpecifierUnused(self: *Transformer, spec_idx: NodeIndex, spec_node: Node) bool {
     // #1791: Phase D 를 **named specifier 한정**. default/namespace 는 JSX pragma,
     // CSS-in-JS default export, namespace member access 같은 implicit value use 가
     // 많아 false positive 위험이 큼 (#1793 revert 원인). bungae 의 실제 crash 경로
@@ -334,8 +334,30 @@ fn isImportSpecifierUnused(self: *const Transformer, spec_idx: NodeIndex, spec_n
     const sym_id = self.symbol_ids.items[sym_node_idx] orelse return false;
     if (sym_id >= self.symbols.len) return false;
 
-    // Reference 들 중 value-use 하나라도 있으면 keep. 판정은 `Reference.isValueUse`
-    // 가 공통으로 수행 — linker 의 `isImportBindingTypeOnly` 와 동일 기준.
+    // 대형 모듈(barrel/mega-entry): references 를 specifier 마다 선형 스캔하면
+    // O(specifiers×references)=O(N²). references 가 많을 때만 **value-use symbol_id 집합**을
+    // 1회 구축해 O(1) 멤버십 조회로 전환. references slice(ptr+len) 로 캐시 무효화 → references
+    // 가 바뀌면 자동 재구축. 작은 모듈은 맵 구축 비용을 피해 기존 linear-scan 유지.
+    const VUS_THRESHOLD = 64;
+    if (self.references.len > VUS_THRESHOLD) build: {
+        const need_build = if (self.value_used_symbols_built_for) |bf|
+            (bf.ptr != self.references.ptr or bf.len != self.references.len)
+        else
+            true;
+        if (need_build) {
+            self.value_used_symbols.clearRetainingCapacity();
+            self.value_used_symbols.ensureTotalCapacity(self.allocator, @intCast(self.references.len)) catch break :build;
+            for (self.references) |r| {
+                if (r.isValueUse()) self.value_used_symbols.putAssumeCapacity(@intFromEnum(r.symbol_id), {});
+            }
+            self.value_used_symbols_built_for = self.references;
+        }
+        // value-use 가 하나도 없으면 미사용(elide 가능) → 집합에 없으면 true.
+        return !self.value_used_symbols.contains(sym_id);
+    }
+
+    // 작은 references: 선형 스캔(맵 구축 비용 회피). value-use 하나라도 있으면 keep.
+    // 판정은 `Reference.isValueUse` 가 공통 수행 — linker 의 `isImportBindingTypeOnly` 와 동일.
     for (self.references) |r| {
         if (@intFromEnum(r.symbol_id) != sym_id) continue;
         if (r.isValueUse()) return false;

--- a/src/transformer/transformer/lifecycle.zig
+++ b/src/transformer/transformer/lifecycle.zig
@@ -121,6 +121,7 @@ pub fn deinit(self: *Transformer) void {
 pub fn deinitExceptAst(self: *Transformer) void {
     self.scratch.deinit(self.allocator);
     if (self.temp_collision_set) |*set| set.deinit(self.allocator);
+    self.value_used_symbols.deinit(self.allocator);
     self.pending_nodes.deinit(self.allocator);
     self.symbol_ids.deinit(self.allocator);
     self.helper_ref_nodes.deinit(self.allocator);


### PR DESCRIPTION
## 무엇을 / 왜

`isImportSpecifierUnused`(#1791 import elision Phase D) 가 import specifier 마다 `self.references` **전체를 선형 스캔**해 해당 symbol 의 value-use 를 찾습니다. mega-entry/대형 barrel 에서 specifier N개 × references N개 = **O(N²)**.

[#4406](https://github.com/ohah/zntc/pull/4406)·[#4407](https://github.com/ohah/zntc/pull/4407) 이후 `sample` top-of-stack 잔여 핫스팟(30k 모듈 167 샘플). 같은 루트코즈(대형 fan-out 의 per-module 컬렉션 선형 스캔)의 **세 번째이자 마지막** 건입니다.

## 어떻게

- `references.len > 64`(대형) 모듈만 **value-use 가 있는 symbol_id 집합**을 1회 구축해 O(1) 멤버십 조회로 전환. 작은 모듈은 맵 구축 비용을 피해 **기존 linear-scan 유지**.
- 캐시 키 = `references` slice(ptr+len) → references 가 바뀌면 자동 재구축(stale 방지). 현재 transformer 는 `emitModule` 에서 **모듈마다 fresh 생성**이라 cross-module 재사용/ABA 불가 — ptr+len 키는 미래 재사용 대비 방어.
- OOM(ensureTotalCapacity 실패) 시 `break :build` 로 linear-scan fallback.
- `const → *Transformer` 전파: 두 호출부(`areAllSpecifiersUnused`, `visitNodeInner` 경유 `shouldElideImportSpecifier`) 모두 가변 self 라 안전.

> 집합 = `{ symbol_id : isValueUse }`, 판정 = `!집합.contains(sym_id)` → linear 의 "value-use 하나라도 있으면 keep" 과 모든 케이스 등가.

## 측정 (ReleaseFast, origin/main[#4406+#4407] vs 신, hyperfine)

| 측정 | 구 | 신 | 개선 |
|---|---|---|---|
| **5000-module CI spec** (default jobs) | wall 74.4ms · User 51.9ms | wall 68.9ms · User 46.3ms | **wall −7.4% · User −11%** |
| jobs=1 User CPU 5k | 50ms | 44ms | −12% |
| jobs=1 User CPU 15k | 236ms | 190ms | −19% |
| jobs=1 User CPU 30k | 715ms | **515ms** | **−28%** |

**누적(#4406+#4407+이번, 원본 대비): 30k jobs=1 User CPU 1622 → 515ms (−68%, 3.15× 빠름), 5000-spec wall ~101 → 69ms (~−32%).** `sample` 에서 `isImportSpecifierUnused` 가 top-of-stack 에서 사라짐 확인. (default-jobs wall 이 jobs=1 보다 개선폭 작은 건 trivial fixture 의 I/O floor 때문 — 실코드 빌드는 User CPU 감소가 wall 에 더 직접 반영.)

## 정확성 검증
- 출력 **byte-identical** (5k/15k/30k) — 30000-reference fixture 비교가 **집합 경로 = linear 경로 등가성을 실데이터로 증명**.
- `zig build test` 유닛(minify_test 가 references-scan 경로 직접 커버) 통과, import-elision/tree-shake/JSX 통합 ~500 pass / 0 fail
- `napi`/`wasm`/`wasm-bundler` 빌드 통과
- `/code-review max`: 실제 버그 0건. "OOM→빈 집합 사용" 지적은 오독(`return` 이 `build:` 블록 안이라 `break :build` 가 linear 로 떨어짐)으로 REFUTED. "ABA staleness" 는 transformer fresh-per-module 검증으로 불가 확인 + 방어적으로 캐시 키를 ptr+len slice 로 강화.

## 남은 길
이로써 `sample` 의 같은-클래스 O(N²) 4개 중 3개 해결. 마지막 `metadata.buildMetadataForAst`(168 샘플) 가 남았으나, 그건 이미 emit 병렬(`emitModuleThread`) 안에서 호출되어([[메모리]] NO-GO 기록) 인덱싱 이득이 제한적 — 별도 분석 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)