### PR TITLE
perf(linker): buildMetadataForAst wrapped 경로 O(N²)→O(N) — record별 binding 비트셋

### DIFF
--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -359,6 +359,19 @@ fn mergeUnifiedPhaseB(
     }
 }
 
+/// record `rec_i` 에 속한 import binding 이 있는지 — `namespace_only=true` 면 namespace
+/// binding 한정. 대형 모듈은 precompute 된 비트셋으로 O(1), 작은 모듈(bitset=null)은
+/// import_bindings 선형 스캔(맵 alloc 회피). 두 호출처(has_binding/has_namespace)가 동일
+/// 분기 로직을 공유해 드리프트 차단.
+fn recordHasBindingAt(bitset: ?std.DynamicBitSet, import_bindings: []const ImportBinding, rec_i: usize, namespace_only: bool) bool {
+    if (bitset) |b| return b.isSet(rec_i);
+    for (import_bindings) |ib| {
+        if (ib.import_record_index != rec_i) continue;
+        if (!namespace_only or ib.kind == .namespace) return true;
+    }
+    return false;
+}
+
 /// transformer 이후의 ast를 기반으로 LinkingMetadata를 생성한다.
 /// skip_nodes와 renames가 ast의 노드 인덱스와 일치.
 pub fn buildMetadataForAst(
@@ -1136,6 +1149,25 @@ pub fn buildMetadataForAst(
             defer hoisted_specifiers.deinit(self.allocator);
             var linked_specifiers: std.StringHashMapUnmanaged(void) = .empty;
             defer linked_specifiers.deinit(self.allocator);
+            // record 별 binding/namespace-binding 존재 여부를 1회 precompute → 아래 record
+            // 루프가 record 마다 `import_bindings` 전체를 선형 스캔(O(records×bindings)=O(N²))
+            // 하지 않도록. mega-entry/대형 barrel 의 wrapped 경로 핫스팟(dev=전 모듈 wrap).
+            // **임계값 초과(대형 fan-out)만** 비트셋 — dev 의 수많은 작은 wrapped 모듈마다
+            // (병렬 emit 에서 locked) alloc 이 누적되지 않도록 작은 모듈은 inline 스캔 유지.
+            const REC_INDEX_THRESHOLD = 64;
+            var rec_has_binding: ?std.DynamicBitSet = null;
+            var rec_has_namespace: ?std.DynamicBitSet = null;
+            defer if (rec_has_binding) |*b| b.deinit();
+            defer if (rec_has_namespace) |*b| b.deinit();
+            if (m.import_records.len > REC_INDEX_THRESHOLD) {
+                rec_has_binding = try std.DynamicBitSet.initEmpty(self.allocator, m.import_records.len);
+                rec_has_namespace = try std.DynamicBitSet.initEmpty(self.allocator, m.import_records.len);
+                for (m.import_bindings) |ib| {
+                    if (ib.import_record_index >= m.import_records.len) continue;
+                    rec_has_binding.?.set(ib.import_record_index);
+                    if (ib.kind == .namespace) rec_has_namespace.?.set(ib.import_record_index);
+                }
+            }
             for (m.import_records, 0..) |rec, rec_i| {
                 try linked_specifiers.put(self.allocator, rec.specifier, {});
                 if (rec.resolved.isNone()) {
@@ -1160,9 +1192,7 @@ pub fn buildMetadataForAst(
                     // 처리한다. 원본 import_declaration을 남기면 body에서 raw
                     // require/destructuring이 다시 emit된다. side-effect-only import는
                     // binding 처리가 없으므로 유지한다.
-                    const has_binding = for (m.import_bindings) |ib| {
-                        if (ib.import_record_index == rec_i) break true;
-                    } else false;
+                    const has_binding = recordHasBindingAt(rec_has_binding, m.import_bindings, rec_i, false);
                     if (has_binding) {
                         try hoisted_specifiers.put(self.allocator, rec.specifier, {});
                     }
@@ -1174,10 +1204,7 @@ pub fn buildMetadataForAst(
                     // `(init_removed(), __toCommonJS(exports_removed))` orphan 호출이 남아
                     // RN release 런타임에서 ReferenceError 가 난다.
                     // self-import는 제외 (순환 자기 참조 시 body codegen이 처리).
-                    const has_namespace = for (m.import_bindings) |ib| {
-                        if (ib.import_record_index == rec_i and ib.kind == .namespace)
-                            break true;
-                    } else false;
+                    const has_namespace = recordHasBindingAt(rec_has_namespace, m.import_bindings, rec_i, true);
                     if (!has_namespace or (self.tree_shaker_active and !tmod.is_included)) {
                         try hoisted_specifiers.put(self.allocator, rec.specifier, {});
                     }


### PR DESCRIPTION
## 무엇을 / 왜

wrapped 모듈(__esm/CJS)의 metadata 빌드에서 record 루프가 record 마다 `has_binding`/`has_namespace` 를 구하려고 `import_bindings` **전체를 선형 스캔** → mega-entry 에서 records N × bindings N = **O(N²)**. `m.wrap_kind.isWrapped()` 일 때만 도는 경로라 **dev 모드(전 모듈 wrap)·RN·대형 barrel** 에서 발현.

[#4406](https://github.com/ohah/zntc/pull/4406)·[#4407](https://github.com/ohah/zntc/pull/4407)·[#4408](https://github.com/ohah/zntc/pull/4408) 이후 `sample` 의 같은-클래스 O(N²) 4개 중 마지막 건. **앞 3개와 도메인이 다릅니다**: 앞 3개는 직렬 소비자라 CI production(splitting)에 직접 반영됐지만, 이 경로는 **importer 가 wrapped 일 때만** 돕니다.

## 어떻게

`import_records.len > 64`(대형 fan-out) 모듈만 `record→binding` / `record→namespace` 존재 비트셋(`std.DynamicBitSet`, record index 0..N 에 dense)을 1회 precompute → O(1) 조회. **작은 모듈은 inline 스캔 유지** — dev 는 전 모듈 wrap 이라 수많은 작은 모듈마다 (병렬 emit 에서 locked) alloc 이 누적되는 것을 방지. 두 호출처는 `recordHasBindingAt` 헬퍼로 분기 로직 공유.

## 측정 — 도메인별로 다름

| 워크로드 | 구 | 신 | 개선 |
|---|---|---|---|
| **CI production** (5000-spec, splitting) | — | — | **~0** (entry unwrapped → 경로 dead, 의도된 결과) |
| **dev 모드** (30k mega-entry, 전 모듈 wrap) | wall 2.499s · User 2.074s | wall 1.810s · User 1.421s | **wall −27.6% · User −31%** |

이 PR 의 이득은 **dev/HMR/RN 도메인**(이 프로젝트 핵심 — lazy compilation·RN·dev server)입니다. CI production "1위" 벤치는 안 움직입니다(그쪽은 앞 3 PR 로 누적 wall ~−32% 확보).

## 정확성 검증
- **production 출력 byte-identical (5k/30k, 직렬 AND 병렬)** — 비트셋 경로 = inline 스캔 등가 + thread-safe(병렬=직렬 동일) 실증. (dev 출력은 module ID/HMR 주입이 본질적 비결정이라 byte-compare 대신 아래 테스트로 검증.)
- `zig build test` 유닛 + wrapped/CJS/RN/dev 통합(cjs-code-splitting·cross-chunk·ns-var-collision·rn-refresh·preserve-modules-cjs 등) pass / 0 fail
- `napi`/`wasm`/`wasm-bundler` 빌드 통과
- 병렬 안전: 비트셋은 함수-로컬(기존 skip_nodes/hoisted_specifiers 와 동일 self.allocator 패턴), self 불변
- `/code-review max`: 실제 버그 0건(등가성·메모리누수·동시성 모두 REFUTED). 리뷰 지적대로 두 dual-path 를 `recordHasBindingAt` 헬퍼로 dedup.

## 남은 길
dev 재샘플에서 **더 큰 dev 전용 O(N²) `findImportRecord`(657 샘플, dev #1)** 발견 — 다음 PR 후보(dev/HMR rebuild 추가 단축).

🤖 Generated with [Claude Code](https://claude.com/claude-code)