### PR TITLE
perf(graph): mergeImportRecords O(N²)→O(N) — import record identity 해시맵

### DIFF
--- a/src/bundler/graph/parse_helpers.zig
+++ b/src/bundler/graph/parse_helpers.zig
@@ -38,6 +38,23 @@ pub fn isFlowPath(path: []const u8) bool {
     return std.mem.endsWith(u8, path, ".js.flow") or std.mem.endsWith(u8, path, ".jsx.flow");
 }
 
+/// import record identity(kind + span + specifier) 해시맵 컨텍스트 — `mergeImportRecords` 의
+/// 대형 fan-out O(N²) 선형 스캔을 O(1) 조회로 바꾸기 위함. zero-sized(필드 없음)라 Unmanaged
+/// 해시맵의 non-Context 메서드를 그대로 쓴다.
+const ImportRecordIdentityCtx = struct {
+    pub fn hash(_: ImportRecordIdentityCtx, rec: ImportRecord) u64 {
+        var h = std.hash.Wyhash.init(0);
+        h.update(std.mem.asBytes(&rec.kind));
+        h.update(std.mem.asBytes(&rec.span.start));
+        h.update(std.mem.asBytes(&rec.span.end));
+        h.update(rec.specifier);
+        return h.final();
+    }
+    pub fn eql(_: ImportRecordIdentityCtx, a: ImportRecord, b: ImportRecord) bool {
+        return sameImportRecordIdentity(a, b);
+    }
+};
+
 pub fn mergeImportRecords(
     arena_alloc: std.mem.Allocator,
     previous: []const ImportRecord,
@@ -45,9 +62,42 @@ pub fn mergeImportRecords(
 ) ![]ImportRecord {
     var records: std.ArrayList(ImportRecord) = .empty;
     errdefer records.deinit(arena_alloc);
+
+    // 대형 fan-out(mega-entry — HMR/resync 경로): previous/records 를 record 마다 identity 로
+    // 선형 스캔하면 O(transformed×previous)+O(transformed×records)=O(N²). 임계값 초과 시
+    // identity 해시맵으로 O(1) 조회. arena_alloc 은 module parse_arena(long-lived)라 개별
+    // deinit 안 함(arena 일괄 해제 — #1287); 임계값으로 대형 모듈만 인덱싱해 arena 누적 제한.
+    const Ctx = ImportRecordIdentityCtx;
+    const use_index = previous.len + transformed.len > 64;
+    var prev_index: std.HashMapUnmanaged(ImportRecord, ImportRecord, Ctx, 80) = .empty;
+    var added: std.HashMapUnmanaged(ImportRecord, void, Ctx, 80) = .empty;
+    // 이 함수는 arena 를 소유하지 않으므로(caller 가 deinit) 여기 deinit 은 함수 반환 시
+    // 실행 = caller arena.deinit 보다 먼저라 #1287 순서 문제 없음. 실제 arena 면 free 는
+    // 안전한 no-op(일괄 해제), non-arena caller(테스트 등)는 누수 방지. 미사용 시 .empty no-op.
+    defer prev_index.deinit(arena_alloc);
+    defer added.deinit(arena_alloc);
+    if (use_index) {
+        try prev_index.ensureTotalCapacity(arena_alloc, @intCast(previous.len));
+        // `added` 는 loop1(transformed) + loop2(synthetic previous 만)에서 추가되므로
+        // transformed.len + synthetic 수가 정확한 상한. previous 순회 김에 synthetic 카운트
+        // (별도 스캔 없음) → previous.len 전체 예약 대비 과다예약 제거.
+        var synthetic_prev: usize = 0;
+        for (previous) |rec| {
+            const gop = prev_index.getOrPutAssumeCapacity(rec);
+            if (!gop.found_existing) gop.value_ptr.* = rec; // 첫 매칭 우선(findImportRecord 와 동일)
+            if (isSyntheticImportRecord(rec)) synthetic_prev += 1;
+        }
+        try added.ensureTotalCapacity(arena_alloc, @intCast(transformed.len + synthetic_prev));
+    }
+
     for (transformed) |rec| {
-        if (hasImportRecord(records.items, rec)) continue;
-        const merged = if (findImportRecord(previous, rec)) |prev| prev else rec;
+        if (use_index) {
+            if (added.getOrPutAssumeCapacity(rec).found_existing) continue;
+        } else if (hasImportRecord(records.items, rec)) continue;
+        const merged = if (use_index)
+            (prev_index.get(rec) orelse rec)
+        else
+            (findImportRecord(previous, rec) orelse rec);
         try records.append(arena_alloc, merged);
     }
     for (previous) |rec| {
@@ -55,7 +105,9 @@ pub fn mergeImportRecords(
         // strictExecutionOrder 가 타입 전용 모듈까지 평가한다. AST 에 없는 record 는 버리고,
         // AST 노드가 없는 synthetic record(Flow enum runtime 등)만 보존한다.
         if (!isSyntheticImportRecord(rec)) continue;
-        if (hasImportRecord(records.items, rec)) continue;
+        if (use_index) {
+            if (added.getOrPutAssumeCapacity(rec).found_existing) continue;
+        } else if (hasImportRecord(records.items, rec)) continue;
         try records.append(arena_alloc, rec);
     }
     return records.toOwnedSlice(arena_alloc);
@@ -129,6 +181,31 @@ test "mergeImportRecords keeps previous resolved state for unchanged record" {
 
     try std.testing.expectEqual(@as(usize, 1), merged.len);
     try std.testing.expectEqual(@as(u32, 7), @intFromEnum(merged[0].resolved));
+}
+
+test "mergeImportRecords: index 경로(>64 records) — dedup + previous 보존 + synthetic 보존" {
+    const Span = @import("../../lexer/token.zig").Span;
+    const N = 70; // > 64 임계값 → identity 해시맵(index) 경로 강제
+    var prev_buf: [N + 1]ImportRecord = undefined;
+    var trans_buf: [N + 1]ImportRecord = undefined;
+    for (0..N) |i| {
+        const s = Span{ .start = @intCast(i + 1), .end = @intCast(i + 1) }; // start!=0 → non-synthetic, 유니크 identity
+        prev_buf[i] = .{ .specifier = "./dep", .kind = .static_import, .span = s, .resolved = @enumFromInt(@as(u32, @intCast(i + 100))) };
+        trans_buf[i] = .{ .specifier = "./dep", .kind = .static_import, .span = s };
+    }
+    prev_buf[N] = .{ .specifier = "\x00synth", .kind = .require, .span = Span.EMPTY }; // synthetic, transformed 에 없음 → 보존
+    trans_buf[N] = trans_buf[0]; // 첫 record 와 동일 identity → dedup 대상
+
+    const merged = try mergeImportRecords(std.testing.allocator, prev_buf[0 .. N + 1], trans_buf[0 .. N + 1]);
+    defer std.testing.allocator.free(merged);
+
+    // transformed N개(중복 1개 제거) + synthetic 1개
+    try std.testing.expectEqual(@as(usize, N + 1), merged.len);
+    // 매칭된 transformed 는 previous 의 resolved 를 보존 (index 경로 = linear 경로 등가)
+    for (0..N) |i| {
+        try std.testing.expectEqual(@as(u32, @intCast(i + 100)), @intFromEnum(merged[i].resolved));
+    }
+    try std.testing.expectEqualStrings("\x00synth", merged[N].specifier);
 }
 
 /// `ExportBinding[]` -> `[]const []const u8` 평탄 이름 슬라이스 (#1883).


### PR DESCRIPTION
## 무엇을 / 왜

`mergeImportRecords`(HMR/resync 후 previous+transformed import record 병합)가 record 마다 `findImportRecord`/`hasImportRecord` 로 previous·이미-추가된 records 를 identity 선형 스캔 → mega-entry 에서 O(transformed×previous)+O(transformed×records) = **O(N²)**.

[#4406](https://github.com/ohah/zntc/pull/4406)~[#4409](https://github.com/ohah/zntc/pull/4409) 이후 **dev 모드 `sample` top-of-stack #1**(전 모듈 resync, 30k 657 샘플).

## 어떻게

`previous.len + transformed.len > 64`(대형 fan-out)이면 identity(kind+span+specifier) 해시맵으로:
- `prev_index`: identity → previous record (findImportRecord 대체, 첫 매칭 우선)
- `added`: identity dedup set (hasImportRecord 대체)
→ O(1) 조회. 작은 모듈은 기존 선형 스캔 유지. arena 비소유 함수라 함수 내 `defer deinit`(실제 arena=안전 no-op, non-arena caller 누수 방지; caller arena.deinit 보다 먼저 실행이라 #1287 무관). `added` 예약은 transformed.len + synthetic-previous 수로 정확히(previous 순회 김에 카운트).

## 측정 (ReleaseFast, origin/main[#4406~#4409 포함] vs 신)

| dev 30k mega-entry rebuild | 구 | 신 | 개선 |
|---|---|---|---|
| wall | 1.801s | 1.001s | **−44% (1.80× 빠름)** |
| User CPU | 1.414s | 0.616s | **−56%** |

`findImportRecord` 가 dev top-of-stack 에서 제거됨(657→<5).

## 정확성 검증
- **index 경로(>64 records) 신규 유닛 테스트**: dedup + previous(resolved) 보존 + synthetic 보존 → index 경로 = linear 경로 등가 실증. 기존 3개 유닛이 linear 경로(<64) 커버.
- production(splitting) 출력 **byte-identical** (5k/30k, 직렬+병렬) — 이 경로는 production resync 시에도 호출됨.
- resync/enum/flow/dev/HMR 통합 140 pass / 0 fail, napi/wasm/wasm-bundler 빌드 통과.
- `/code-review max`: 실제 버그 0건(등가성·메모리·hash-eql 일관성·capacity·동시성 모두 REFUTED). `added` 과다예약은 synthetic 카운트로 타이트닝.

## 도메인
CI production(splitting)의 trivial entry 는 resync 시 호출되나 record 수가 적어 영향 작음(byte-identical). 주 이득은 **dev/HMR/RN**(전 모듈 resync, mega-entry).

> 이로써 `sample` 의 같은-클래스 O(N²) 5개 중 5개 제거(graph requestDependencyExports·linker forEachTopLevelOwnerName·transformer isImportSpecifierUnused·linker buildMetadataForAst-wrapped·graph mergeImportRecords). dev 30k rebuild 누적 ~2.5s → ~1.0s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)