### PR TITLE
fix(minify): Infinity/NaN 상수 폴딩이 inf/nan 식별자를 방출하는 회귀 수정

### DIFF
--- a/src/transformer/minify/numeric.zig
+++ b/src/transformer/minify/numeric.zig
@@ -26,7 +26,12 @@ pub fn parseLiteral(ast: *const Ast, node: Node) ?f64 {
 }
 
 /// 숫자를 문자열로 포맷하여 string_table에 추가하고 span을 반환한다.
+///
+/// Infinity / NaN 은 JS 숫자 리터럴이 아니므로(`{d}` 가 `inf`/`nan` 을 내뱉음)
+/// fold 를 포기한다(null). 모든 fold 경로가 이 함수의 null 을 "폴딩 안 함"
+/// 으로 처리하므로 원본 식이 그대로 유지되어 semantic-preserving 이 보장된다.
 pub fn formatNumber(ast: *Ast, value: f64) ?Span {
+    if (!std.math.isFinite(value)) return null;
     var buf: [32]u8 = undefined;
     const text = std.fmt.bufPrint(&buf, "{d}", .{value}) catch return null;
     return ast.addString(text) catch null;

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -436,6 +436,25 @@ test "minify: division by zero not folded" {
     try expectMinify("const x = 1 / 0;", "const x = 1 / 0;");
 }
 
+test "minify: overflow to Infinity not folded (inf is not a JS literal)" {
+    // `1e308 * 10` 는 +Infinity 로 오버플로한다. fold 하면 `{d}` 가 `inf` 를 내뱉어
+    // 런타임 ReferenceError 가 되므로 폴딩을 포기하고 원본 식을 유지해야 한다.
+    try expectMinify("const x = 1e308 * 10;", "const x = 1e308 * 10;");
+}
+
+test "minify: exponentiation overflow to Infinity not folded" {
+    try expectMinify("const x = 2 ** 1024;", "const x = 2 ** 1024;");
+}
+
+test "minify: NaN-producing fold not folded (nan is not a JS literal)" {
+    // 중첩 fold 가 +Infinity 를 만든 뒤 빼면 NaN 이다. 최종 결과가 유한하지 않으면
+    // 어떤 fold 도 커밋하지 않아 `nan`/`inf` 가 출력에 새지 않는다.
+    try expectMinify(
+        "const x = 1e308 * 1e308 - 1e308 * 1e308;",
+        "const x = 1e308 * 1e308 - 1e308 * 1e308;",
+    );
+}
+
 test "minify: non-literal not folded" {
     try expectMinify("const x = a + b;", "const x = a + b;");
 }


### PR DESCRIPTION
## 무엇을

상수 폴딩이 `Infinity`/`NaN` 결과를 유효하지 않은 JS 식별자 `inf`/`-inf`/`nan` 으로 방출하던 회귀를 수정합니다. `inf`/`nan` 은 JS 숫자 리터럴이 아니므로 런타임 `ReferenceError` 가 발생하고, `--minify` 뿐 아니라 일반 `--bundle`(tree-shaker 의 비-minify 숫자 사전 폴딩 경로)에서도 기본 산출물을 깨뜨렸습니다.

## 어떻게

`src/transformer/minify/numeric.zig` 의 `formatNumber` 진입부에 가드 한 줄을 추가했습니다.

```zig
if (!std.math.isFinite(value)) return null;
```

모든 fold 경로(`minify.zig` 의 `foldBinary`, tree-shaker 가 쓰는 `foldLiteralExpression`)가 `formatNumber` 를 거치고, 반환값 `null` 을 이미 "폴딩 안 함"(원본 식 유지)으로 처리합니다. 따라서 **중앙 한 지점**에서 비유한 결과면 fold 를 포기시키는 것이 구조적 수정입니다. 유한한 값은 영향 없습니다.

> Zig 메모: `std.math.isFinite` 는 `±Infinity`·`NaN` 이면 `false` 를 반환합니다. `{d}` 포맷이 이 값들을 각각 `inf`/`-inf`/`nan` 텍스트로 내뱉던 것이 근본 원인이었습니다.

## 검증

- 회귀 테스트 3건 추가 (`minify_test.zig`): `1e308 * 10`(+Infinity), `2 ** 1024`(+Infinity), `1e308 * 1e308 - 1e308 * 1e308`(NaN) 모두 폴딩되지 않고 원본 유지.
- 실제 바이너리:
  - `zntc inftest.js --minify` → `console.log(1e308*10,2**1024,1e308*1e308-1e308*1e308);` (이전: `console.log(inf,inf,...)`)
  - `zntc entry.js --bundle` → `const x = 1e308 * 10,y = 2 ** 1024;` (이전: `const x = inf,...`)
- 정상 fold 회귀 없음: `1 + 2 → 3`, `6 * 7 → 42` 유지. `minify:`/`tree`/`const`/`fold` 테스트 그룹 전부 통과.

전수조사(2026-06-15) confirmed-broken (CRITICAL).

Closes #4411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
