### PR TITLE
fix(transformer): es2019 optional catch binding의 _unused 섀도잉 miscompile 수정

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -180,9 +180,11 @@ test "ES2016: **= no transform on es2016" {
 // --- catch binding (ES2019) ---
 
 test "ES2019: optional catch binding" {
+    // 합성 binding 은 hoist 없는 유일 임시 이름(_a)을 쓴다. 고정 `_unused` 는 외부
+    // 동명 변수를 섀도잉하는 miscompile 이라 제거됨(#4415).
     var r = try e2eTarget(std.testing.allocator, "try { x; } catch { y; }", .es2018);
     defer r.deinit();
-    try std.testing.expectEqualStrings("try{x;}catch(_unused){y;}", r.output);
+    try std.testing.expectEqualStrings("try{x;}catch(_a){y;}", r.output);
 }
 
 test "ES2019: catch with binding preserved" {

--- a/src/transformer/es2019.zig
+++ b/src/transformer/es2019.zig
@@ -17,6 +17,7 @@ const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
+const es_helpers = @import("es_helpers.zig");
 
 pub fn ES2019(comptime Transformer: type) type {
     return struct {
@@ -37,14 +38,25 @@ pub fn ES2019(comptime Transformer: type) type {
                 });
             }
 
-            // binding 없음 → _unused 합성
-            const unused_span = try self.ast.addString("_unused");
-            const unused_binding = try self.ast.addNode(.{
-                .tag = .binding_identifier,
-                .span = unused_span,
-                .data = .{ .string_ref = unused_span },
-            });
+            // binding 없음 → 유일한 임시 이름 합성. 고정 문자열(`_unused`)을 쓰면
+            // catch body 가 같은 이름의 외부 변수를 참조할 때 섀도잉되어 잡힌 에러
+            // 객체를 읽는 silent miscompile 이 된다.
+            //
+            // body 를 먼저 방문해 body 내부 lowering 이 temp 카운터를 소비하게 한 뒤,
+            // 카운터 *너머* 의 이름을 고른다. catch 파라미터는 그 자체로 선언이라
+            // hoist 가 불필요하므로 카운터를 bump 하지 않는다(= `var _a;` 누수 없음).
+            // 고른 이름은 body temp(카운터 미만)·사용자 심볼·private field 어느 것과도
+            // 겹치지 않으므로 어떤 외부 참조도 섀도잉하지 않는다.
             const new_body = try self.visitNode(body);
+            var probe = self.temp_var_counter;
+            var name_buf: [16]u8 = undefined;
+            const unused_span = while (true) : (probe += 1) {
+                const name = es_helpers.tempVarName(probe, &name_buf);
+                if (es_helpers.collidesWithPrivateField(self, name)) continue;
+                if (try es_helpers.collidesWithUserSymbol(self, name)) continue;
+                break try self.ast.addString(name);
+            };
+            const unused_binding = try es_helpers.makeBindingIdentifier(self, unused_span);
             return self.ast.addNode(.{
                 .tag = .catch_clause,
                 .span = node.span,

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -2106,6 +2106,28 @@ test "TransformPlan: semantic-sensitive options keep full semantic" {
     try std.testing.expectEqual(SemanticPlanReason.target_requires_downlevel, downlevel_plan.reason);
 }
 
+test "ES2019 optional catch binding: synthesized name avoids outer variable shadow (#4415)" {
+    // target < es2019 의 빈 catch{} lowering 이 합성하는 binding 이름이 catch body 가
+    // 참조하는 외부 변수(_a)를 섀도잉하면, body 가 잡힌 에러 객체를 읽는 silent
+    // miscompile 이 된다. full semantic 경로에서 충돌 회피가 동작하는지 검증.
+    const compat = @import("transformer/compat.zig");
+    var result = try transpileWithCallbackInternal(
+        std.testing.allocator,
+        "let _a = 5;\ntry { x(); } catch { _a; }\n",
+        "input.ts",
+        .{ .unsupported = compat.fromESTarget(.es2018), .es_target = .es2018 },
+        null,
+        true,
+    );
+    defer result.deinit(std.testing.allocator);
+
+    // 외부 _a 를 피해 다른 이름을 써야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "catch (_b)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "catch (_a)") == null);
+    // catch 파라미터는 그 자체로 선언이므로 hoist 된 `var _` 누수가 없어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.code, "var _") == null);
+}
+
 test "TransformPlan parity: fast TS strip matches full semantic output" {
     const cases = [_]struct {
         name: []const u8,


### PR DESCRIPTION
## 무엇을

ES2019 optional-catch-binding 다운레벨(`catch {}` → `catch (binding) {}`)이 고정 문자열 `_unused` 를 binding 이름으로 합성하던 문제를 수정합니다. catch body 가 같은 이름의 외부 변수를 참조하면 합성 binding 이 그것을 섀도잉해 잡힌 에러 객체를 읽는 silent miscompile 이 발생했습니다.

```js
// 이전 (target es2018)
let _unused = 5;
try { x(); } catch { console.log(_unused); }
// → catch(_unused){console.log(_unused)}  ← 외부 _unused(=5) 대신 에러 객체를 읽음
```

## 어떻게

`src/transformer/es2019.zig` 에서 하드코딩 `_unused` 대신 **hoist 없는 유일 임시 이름**을 합성합니다.

- catch body 를 먼저 방문해 body 내부 lowering 이 temp 카운터를 소비하게 한 뒤, **카운터를 bump 하지 않고**(catch 파라미터는 그 자체가 선언이라 `var` hoist 가 불필요) 카운터 너머의 이름을 고릅니다.
- 고른 이름은 ① body temp(카운터 미만), ② 사용자 심볼(`collidesWithUserSymbol`), ③ private field(`collidesWithPrivateField`) 어느 것과도 겹치지 않아 어떤 외부 참조도 섀도잉하지 않습니다.

> Zig 메모: `makeTempVarSpan` 은 의도적으로 카운터를 증가시켜 program 상단에 `var _a;` 를 hoist 합니다(destructuring/async temp 용). catch 파라미터엔 그 hoist 가 불필요하므로 카운터를 건드리지 않고 이름만 고르는 방식으로, esbuild 가 `catch (e)` 만 내보내는 것과 동일하게 잉여 `var` 선언이 없습니다.

## 검증

- 실제 바이너리 (`--target=es2018`):
  - `try { x; } catch { y; }` → `catch (_a)` (hoist 없음)
  - `let _a = 5; ... catch { _a; }` → `catch (_b)` (외부 `_a` 회피)
  - `let _a, _b; ... catch { _a, _b; }` → `catch (_c)`
- 회귀 테스트:
  - `transpile.zig`: full-semantic 경로에서 외부 `_a` 를 피해 `catch (_b)` 를 쓰고 `var _` hoist 누수가 없는지 가드 (#4415).
  - `es_downlevel.zig`: 기존 `_unused` 기대값을 `_a` 로 갱신.
- `catch`/`ES2019`/`downlevel` 테스트 그룹 전부 통과.

전수조사(2026-06-15) confirmed-broken (MEDIUM).

Closes #4415

🤖 Generated with [Claude Code](https://claude.com/claude-code)
