### PR TITLE
fix(semantic): class body strict mode 중첩 스코프 전파 (중복선언 early-error 누락)

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -331,13 +331,22 @@ pub const SemanticAnalyzer = struct {
     }
 
     /// 새 스코프를 생성하고 진입한다. 반환값: 이전 스코프 ID (나갈 때 복원용).
+    ///
+    /// strict mode 는 하향 sticky 다(ECMAScript): 부모 스코프가 strict 면 자식도
+    /// strict. 호출부는 모듈-전역 플래그(`self.is_strict_mode`)만 넘기므로, class
+    /// body(항상 strict, 10.2.1) 안의 메서드/블록이 strict 를 잃지 않도록 여기서
+    /// 부모의 `is_strict` 를 OR 한다.
     fn enterScope(self: *SemanticAnalyzer, kind: ScopeKind, is_strict: bool) AllocError!ScopeId {
         const parent = self.current_scope;
+        const parent_strict = if (!parent.isNone())
+            self.scopes.items[parent.toIndex()].is_strict
+        else
+            false;
         const new_id: ScopeId = @enumFromInt(@as(u32, @intCast(self.scopes.items.len)));
         try self.scopes.append(self.allocator, .{
             .parent = parent,
             .kind = kind,
-            .is_strict = is_strict,
+            .is_strict = is_strict or parent_strict,
         });
         // scope_maps는 scopes와 동일 인덱스를 공유 — 빈 HashMap 추가
         try self.scope_maps.append(self.allocator, .empty);
@@ -834,12 +843,15 @@ pub const SemanticAnalyzer = struct {
         // existing의 flags가 new의 excludes와 겹치면 재선언 불가
         if (existing_flags.intersects(new_flags.excludes())) {
             // 특수 케이스: parameter + parameter → non-strict에서 허용 (function f(a, a) {})
-            if (existing == .parameter and new == .parameter and !self.is_strict_mode) {
+            // isCurrentStrict() 로 판단해야 sloppy .js 의 class 메서드(항상 strict) 안
+            // 중복 파라미터가 올바르게 거부된다.
+            if (existing == .parameter and new == .parameter and !self.isCurrentStrict()) {
                 return true;
             }
             // sloppy mode var scope에서 function/var 재선언 허용 (ECMAScript B.3.2-B.3.5):
-            // function + function, var + function, function + var 조합
-            if (!self.is_strict_mode) {
+            // function + function, var + function, function + var 조합. Annex B 는 sloppy
+            // 전용이므로 현재 스코프 기준(class body strict 상속 반영)으로 판단한다.
+            if (!self.isCurrentStrict()) {
                 const is_fn_fn = existing.isFunctionLike() and new.isFunctionLike();
                 const is_var_fn = (existing == .variable_var and new.isFunctionLike()) or
                     (existing.isFunctionLike() and new == .variable_var);

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -53,6 +53,37 @@ test "SemanticAnalyzer: var redeclaration is allowed" {
     try std.testing.expect(ana.errors.items.len == 0);
 }
 
+test "SemanticAnalyzer: class method body inherits strict — duplicate block function is error (#4414)" {
+    // class body 는 항상 strict(10.2.1) 이고 strict 는 하향 sticky 다. sloppy 파일이라도
+    // 메서드 body 안 블록에서 중복 function 선언은 거부되어야 한다(Annex B 미적용).
+    var scanner = try Scanner.init(std.testing.allocator, "class C { m() { { function f(){} function f(){} } } }");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    try std.testing.expect(ana.errors.items.len > 0);
+}
+
+test "SemanticAnalyzer: sloppy block duplicate function is allowed (Annex B, #4414 control)" {
+    // 대조군: class 밖 sloppy 블록은 strict 가 아니므로 Annex B B.3.2 로 허용되어야 한다.
+    var scanner = try Scanner.init(std.testing.allocator, "{ function f(){} function f(){} }");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    try std.testing.expect(ana.errors.items.len == 0);
+}
+
 test "SemanticAnalyzer: function declaration creates symbol" {
     var scanner = try Scanner.init(std.testing.allocator, "function foo() {}");
     defer scanner.deinit();


### PR DESCRIPTION
## 무엇을

class body 의 strict mode 가 중첩 메서드/함수/블록 스코프로 전파되지 않아, sloppy `.js` 의 class 메서드 body 안에서 spec(ECMAScript 10.2.1)상 금지된 중복 선언을 조용히 허용하던 early-error 누락을 수정합니다.

```js
// 이전: ZNTC exit 0 (에러 없음) / Node --check: SyntaxError
class C { m() { { function f(){} function f(){} } } }
```

## 어떻게

strict mode 는 하향 sticky 입니다(한 번 strict 면 모든 중첩 스코프가 strict). analyzer 는 호출부가 넘기는 모듈-전역 플래그(`self.is_strict_mode`)로만 스코프 strict 를 정했고, class body 가 `enterScope(.class_body, true)` 로 strict 를 켜도 그 안의 메서드/블록은 다시 모듈 플래그(sloppy=false)로 진입해 strict 를 잃었습니다.

- `enterScope`: 새 스코프의 `is_strict` 를 **부모 스코프의 `is_strict` 와 OR** 하도록 변경. class body(strict) → 메서드 → 블록 체인이 strict 를 상속.
- `canRedeclare`: 중복 파라미터(837)와 Annex B function/var 재선언(842) 판정을 `!self.is_strict_mode` → `!self.isCurrentStrict()` 로 통일. 이미 block function 재선언(881)은 `isCurrentStrict()` 를 쓰고 있었어 — 내부 비일관 해소.

> Zig 메모: `isCurrentStrict()` 는 `is_strict_mode || is_module || 현재_스코프.is_strict` 를 반환합니다. enterScope 상속 수정으로 "현재 스코프"가 class body 의 strict 를 정확히 반영하게 되어, 세 군데가 같은 기준으로 동작합니다.

## 검증

- 실제 바이너리:
  - `class C { m() { { function f(){} function f(){} } } }` → ZNTC1000 (exit 1) ✅
  - 대조군 sloppy top-level `{ function f(){} function f(){} }` → 통과 (Annex B 유지) ✅
  - 대조군 `"use strict"` 파일 중복 function → ZNTC1000 유지 ✅
  - class 메서드 안 중복 파라미터 `function g(a,a)` → ZNTC0515 (strict 적용) ✅
- 회귀 테스트 2건 (`analyzer_test.zig`): class 메서드 중복 function = error, sloppy 블록 중복 function = 허용.
- **전체 `zig build test` 통과** (redeclaration 로직은 영향 범위가 넓어 전수 실행).

> 참고: sloppy top-level `function g(a, a)` 가 ZNTC0515 로 거부되는 것은 main 에서도 동일한 **기존 동작**이며 본 PR 의 변경과 무관합니다(별도 검토 대상).

전수조사(2026-06-15) confirmed-broken (MEDIUM, early-error 누락).

Closes #4414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
