### PR TITLE
fix(cli): zntc.config.json 머지 우선순위 정정 (CLI > config — define/배열 옵션)

### DIFF
--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -435,6 +435,36 @@ fn applyZntcConfigJson(opts: *CliOptions, io: std.Io, allocator: std.mem.Allocat
     }
 }
 
+/// 배열 옵션 머지 정책: CLI 가 하나라도 값을 지정하면 config 분(앞쪽 `cfg_len`
+/// 개)을 버리고 CLI 값만 남긴다(concat 금지). CONFIG.md case 4 / D099(CLI > config).
+/// CLI 가 아무 것도 안 지정하면 config 분을 그대로 둔다.
+fn mergeArrayReplace(list: anytype, cfg_len: usize) void {
+    if (cfg_len == 0 or list.items.len <= cfg_len) return;
+    const T = @TypeOf(list.items[0]);
+    const keep = list.items.len - cfg_len;
+    std.mem.copyForwards(T, list.items[0..keep], list.items[cfg_len..]);
+    list.shrinkRetainingCapacity(keep);
+}
+
+/// 객체 옵션 머지 정책: 같은 key 가 여러 번 있으면 *마지막* 것만 남긴다.
+/// config 항목이 앞, CLI 항목이 뒤에 쌓이므로 결과적으로 CLI 가 키 단위로 config 를
+/// override 한다(CONFIG.md case 2). key_field 는 비교할 `[]const u8` 필드 이름.
+fn dedupKeepLast(list: anytype, comptime key_field: []const u8) void {
+    const items = list.items;
+    var write: usize = 0;
+    var read: usize = 0;
+    outer: while (read < items.len) : (read += 1) {
+        const key = @field(items[read], key_field);
+        var later = read + 1;
+        while (later < items.len) : (later += 1) {
+            if (std.mem.eql(u8, @field(items[later], key_field), key)) continue :outer;
+        }
+        items[write] = items[read];
+        write += 1;
+    }
+    list.shrinkRetainingCapacity(write);
+}
+
 /// CLI 인자를 파싱하여 CliOptions를 반환한다.
 /// --help 출력이나 파싱 에러로 프로그램을 종료해야 하면 null을 반환한다.
 pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator, io: std.Io) !?CliOptions {
@@ -458,6 +488,13 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator,
             try stderr.print("[zntc] zntc.config.json load failed: {}\n", .{err});
         },
     };
+
+    // config 가 채운 배열 옵션 길이 스냅샷 — 아래 CLI 루프가 끝난 뒤 CLI > config
+    // 우선순위로 머지하기 위함(배열은 CLI 가 비어있지 않으면 config 를 대체).
+    const cfg_external_len = opts.external_list.items.len;
+    const cfg_conditions_len = opts.conditions_list.items.len;
+    const cfg_resolve_ext_len = opts.resolve_extensions_list.items.len;
+    const cfg_main_fields_len = opts.main_fields_list.items.len;
 
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
@@ -1059,6 +1096,17 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator,
             });
         }
     }
+
+    // ─── CLI ↔ config 머지 우선순위 적용 (CONFIG.md / D099: CLI > config) ────────
+    // 배열 옵션: CLI 가 하나라도 지정하면 config 분을 버린다(concat 금지).
+    mergeArrayReplace(&opts.external_list, cfg_external_len);
+    mergeArrayReplace(&opts.conditions_list, cfg_conditions_len);
+    mergeArrayReplace(&opts.resolve_extensions_list, cfg_resolve_ext_len);
+    mergeArrayReplace(&opts.main_fields_list, cfg_main_fields_len);
+    // 객체 옵션: 키 기준 last-wins — config(앞) 항목을 동일 키의 CLI(뒤) 항목이 override.
+    dedupKeepLast(&opts.define_list, "key");
+    dedupKeepLast(&opts.alias_list, "from");
+    dedupKeepLast(&opts.loader_list, "ext");
 
     return opts;
 }

--- a/tests/integration/tests/zntc-config-bundler.test.ts
+++ b/tests/integration/tests/zntc-config-bundler.test.ts
@@ -211,6 +211,48 @@ describe('Zig CLI: zntc.config.json bundler-only 옵션 (#2105)', () => {
     expect(out).not.toContain('FROM_CONFIG');
   });
 
+  test('define: CLI --define 가 config 의 같은 키를 override, config-only 키는 유지 (#4412)', async () => {
+    // 이전엔 config define 이 CLI 보다 앞에 쌓이고 소비자가 first-match-wins 라
+    // config 값이 이겼다(CLI > config 위반). 키 단위 last-wins 로 CLI 가 이겨야 한다.
+    const r = await runConfigBundle({
+      files: {
+        'index.ts': `console.log(__BUILD__, __VER__);`,
+        'zntc.config.json': JSON.stringify({
+          define: [
+            { key: '__BUILD__', value: '"production"' },
+            { key: '__VER__', value: '"v1.0"' },
+          ],
+        }),
+      },
+      args: ['--define:__BUILD__="staging"'],
+    });
+    cleanup = r.cleanup;
+
+    expect(r.exitCode).toBe(0);
+    const out = readFileSync(r.outFile!, 'utf8');
+    expect(out).toContain('"staging"'); // CLI 가 같은 키를 override
+    expect(out).toContain('"v1.0"'); // config-only 키는 유지
+    expect(out).not.toContain('"production"'); // config 값은 덮임
+    expect(out).not.toContain('__BUILD__');
+  });
+
+  test('external: CLI --external 가 config external 을 대체 (concat 아님, #4412)', async () => {
+    // config 의 external(ext-a)은 CLI --external 이 주어지면 버려진다(concat 금지).
+    // 따라서 ext-a 는 더 이상 external 이 아니어서 resolve 실패로 빌드가 실패해야 한다.
+    // concat(이전 버그)이었다면 ext-a 가 external 로 남아 성공했을 것.
+    const r = await runConfigBundle({
+      files: {
+        'index.ts': `import "ext-a";\nconsole.log(1);`,
+        'zntc.config.json': JSON.stringify({ external: ['ext-a'] }),
+      },
+      args: ['--format=esm', '--external=ext-b'],
+    });
+    cleanup = r.cleanup;
+
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stdout + r.stderr).toContain('ext-a');
+  });
+
   test('config 부재: 기존 동작 회귀 없음', async () => {
     const fixture = await createFixture({
       'index.ts': "console.log('NO_CONFIG');",


### PR DESCRIPTION
## 무엇을

Zig CLI 의 `zntc.config.json` ↔ CLI 플래그 머지가 문서·D099·JS CLI 와 반대로 동작하던 것을 수정합니다. 루트커즈는 하나: `applyZntcConfigJson` 이 CLI arg 루프보다 **먼저** 공유 리스트에 config 값을 쌓고, CLI 가 같은 리스트에 append 하지만 override/clear 가 없었습니다.

- **define (broken)**: 소비자가 first-match-wins 라 config 항목이 앞에 있어 같은 키면 **config 값이 이김** → `--define:KEY=v` 가 조용히 무시됨.
- **external 등 배열 (diverge)**: config + CLI 가 **concat** → `--external` 이 config 를 대체하지 못함.

## 어떻게 (구조적)

CLI 루프가 끝난 뒤 JS CLI(`zntc.mjs`) 의미와 일치하도록 머지합니다.

- **배열-replace** (`external`/`conditions`/`resolveExtensions`/`mainFields`): config 가 채운 길이를 스냅샷해 두고, CLI 가 하나라도 지정했으면 config 분을 버립니다(`mergeArrayReplace`, alloc-free in-place 압축).
- **객체-머지 last-wins** (`define`/`alias`/`loader`): key 기준으로 마지막 항목만 남깁니다(`dedupKeepLast`). config(앞) 항목을 동일 키의 CLI(뒤) 항목이 override 하고, config-only 키는 유지됩니다.

> Zig 메모: 두 헬퍼는 `anytype` 으로 리스트 원소 타입을 추론하고 `shrinkRetainingCapacity` 로 in-place 압축만 합니다(allocator 불필요). `CliOptions.deinit` 이 개별 문자열을 해제하지 않으므로(기존부터) 항목을 드롭해도 이중해제·새 누수가 없습니다.

## 검증 (실제 바이너리 + config 파일)

- define: `config {__BUILD__:"production", __VER__:"v1.0"}` + `--define:__BUILD__='"staging"'`
  - 이전(main): `console.log("production", "v1.0")` — CLI 무시 (버그)
  - 이후: `console.log("staging", "v1.0")` — CLI 가 키 단위 override, config-only 유지 ✅
- external: `config external=[ext-a]` + `--external=ext-b`
  - 이전(main): concat → ext-a 도 external → 성공 (diverge)
  - 이후: replace → ext-a 는 external 아님 → resolve 실패로 빌드 실패 (CONFIG.md case 4 준수) ✅
- 회귀 테스트 2건 추가 (`tests/integration/tests/zntc-config-bundler.test.ts`). 같은 파일 **19개 전부 통과**.

> 참고: zntc.config.json 의 `define` 은 Zig CLI DTO 상 **배열 형식**(`[{key,value}]`)이어야 합니다(object 형식은 JS config 로더가 변환). 본 PR 은 머지 우선순위만 다룹니다.

전수조사(2026-06-15): define=confirmed-broken (HIGH), external 배열=confirmed-code-diverges (HIGH). 동일 루트커즈라 한 PR.

Closes #4412

🤖 Generated with [Claude Code](https://claude.com/claude-code)
