### PR TITLE
fix(regexp): \p{name=value}의 =value 손실로 인한 런타임 SyntaxError 수정

### DIFF
--- a/src/regexp/ast.zig
+++ b/src/regexp/ast.zig
@@ -69,7 +69,9 @@ pub const Tag = enum(u8) {
     character_class_escape,
 
     /// Unicode property escape: `\p{...}`, `\P{...}`.
-    /// data: [name_start, name_end, flags]
+    /// data: [prop_start, prop_end, flags]
+    ///   prop_start..prop_end: `{...}` 안의 프로퍼티 텍스트 전체 — lone(`Letter`)
+    ///   이든 name=value(`Script=Greek`)이든 printer 가 그대로 재출력한다.
     ///   flags: bit 0 = negative
     unicode_property_escape,
 

--- a/src/regexp/parser.zig
+++ b/src/regexp/parser.zig
@@ -1018,12 +1018,16 @@ pub fn PatternParser(comptime emit_ast: bool) type {
 
                         self.last_class_is_class_escape = true; // property escape도 range endpoint 불가
                         if (emit_ast) {
+                            // data[0..1] 은 printer 가 그대로 재출력할 프로퍼티 텍스트 범위다.
+                            // `\p{name=value}` 는 value_end 까지 저장해야 `=value` 가 round-trip
+                            // 시 보존된다(name_end 만 저장하면 `\p{name}` 으로 축약 → miscompile).
+                            const prop_end = if (has_value) value_end else name_end;
                             self.last_node = self.addNode(.unicode_property_escape, .{
                                 .start = bs_pos,
                                 .end = self.pos,
                             }, .{
                                 name_start,
-                                name_end,
+                                prop_end,
                                 @as(u32, @intFromBool(negative)),
                             });
                         }

--- a/src/regexp/printer.zig
+++ b/src/regexp/printer.zig
@@ -11,8 +11,6 @@
 //! 아니라 "print 멱등 + 구조 보존" 이다 (printer_test.zig 참조).
 //!
 //! 알려진 비-라운드트립 (AST layout 한계, printer 책임 아님):
-//!   - `\p{Script=Greek}` 의 `=value` 는 parser 가 name 범위만 보존하므로
-//!     `\p{Script}` 로 축약된다 (#1475 후속 PR 에서 AST 확장 시 해소).
 //!   - octal escape 는 parser 가 단일 `octal` kind 만 보존(자릿수 미보존)하므로
 //!     최소 자릿수로 출력 (`\07`→`\7`). 값은 동일.
 

--- a/src/regexp/printer_test.zig
+++ b/src/regexp/printer_test.zig
@@ -103,6 +103,8 @@ test "printer roundtrip — atoms / classes / quantifiers" {
         .{ "\\uD83D", "" },
         .{ "\\p{Letter}", "u" },
         .{ "\\P{ASCII}", "u" },
+        .{ "\\p{Script=Greek}", "u" },
+        .{ "\\p{Script_Extensions=Greek}", "u" },
         .{ "[\\q{abc|de}]", "v" },
         .{ "[\\w&&[a-z]]", "v" },
         .{ "[\\w--[a-z]]", "v" },
@@ -118,6 +120,17 @@ test "printer exact — canonical input unchanged" {
     try expectExact("(?:x|y)\\d*", "", "(?:x|y)\\d*");
     try expectExact("\\bfoo\\B", "", "\\bfoo\\B");
     try expectExact("(?i-s:Ab)", "", "(?i-s:Ab)");
+}
+
+test "printer exact — unicode property name=value preserved (#4413)" {
+    // `\p{name=value}` 의 `=value` 가 재출력 시 보존되어야 한다. 이전엔 parser 가
+    // name 범위만 노드에 저장해 `\p{Script}` 로 축약 → 런타임 SyntaxError(유효 입력
+    // miscompile). 이제 프로퍼티 텍스트 전체(name..value)를 저장한다.
+    try expectExact("\\p{Script=Greek}", "u", "\\p{Script=Greek}");
+    try expectExact("\\P{Script=Greek}", "u", "\\P{Script=Greek}");
+    try expectExact("\\p{Script_Extensions=Greek}", "u", "\\p{Script_Extensions=Greek}");
+    // lone property(값 없음)는 동작 불변.
+    try expectExact("\\p{Letter}", "u", "\\p{Letter}");
 }
 
 test "printer hex case — oxc canonical UPPERCASE (#1475 R2 제거)" {


### PR DESCRIPTION
## 무엇을

`\p{name=value}` 유니코드 프로퍼티의 `=value` 가 AST-transform 재출력 시 조용히 손실되어 `\p{name}` 으로 축약되던 문제를 수정합니다(예: `\p{Script=Greek}` → `\p{Script}`). `\p{Script}` 는 유효하지 않은 lone property 라 런타임에 V8 이 `SyntaxError: Invalid property name` 을 던집니다 — 유효 입력의 silent miscompile. 패턴이 다른 lowering(dotAll/named group/astral 등)을 동반해 서브트리를 재구성할 때 발생했습니다.

## 어떻게 (슬롯 추가 없이)

`unicode_property_escape` 노드의 `data[0..1]` 은 printer 가 `\p{` 와 `}` 사이에 그대로 재출력하는 프로퍼티 텍스트 범위입니다. 기존엔 parser 가 `name_end` 까지만 저장해 `=value` 가 빠졌습니다.

- `src/regexp/parser.zig`: `has_value` 면 `data[1]` 을 `value_end` 로 저장 → `source[name_start..value_end]` 가 `name=value` 전체를 가리킴. lone property(`\p{Letter}`)는 `name_end` 그대로라 동작 불변.
- `src/regexp/ast.zig` / `printer.zig`: 노드 layout 주석 갱신 + 해소된 "알려진 비-라운드트립" 주석 제거.

> 3개 data 슬롯이 모두 차 있어 value 범위를 위한 추가 슬롯이 없었습니다. *무엇을 저장하는지*만 바꿔(name 범위 → 프로퍼티 텍스트 전체 범위) 슬롯 추가/노드 인코딩 변경 없이 해결했습니다. `unicode_property_escape` 노드는 printer 만 data 를 읽고 transform 은 그대로 통과시키므로(name 을 해석하는 다운스트림 소비자 없음) 안전합니다.

## 검증

- 실제 바이너리 (`--target=es2017`, dotAll lowering 으로 패턴 재구성 유발):
  - `/\p{Script=Greek}./su` → `/\p{Script=Greek}[\s\S]/u` (이전: `\p{Script}[\s\S]`) ✅
  - `/\p{Script_Extensions=Greek}./su` → 보존 ✅
  - `/\p{Letter}./su` → `\p{Letter}[\s\S]` (lone 불변) ✅
- 회귀 테스트 (`printer_test.zig`): `\p{Script=Greek}` / `\P{Script=Greek}` / `\p{Script_Extensions=Greek}` round-trip + idempotent. **전체 `zig build test` 통과**.

> 별개: OPEN 상태인 #3512 는 `\p{}` astral 확장 데이터 건으로 `astral_u_incomplete` 게이트가 별도 처리 — 본 value-drop 과 무관.

전수조사(2026-06-15) confirmed-broken (HIGH).

Closes #4413

🤖 Generated with [Claude Code](https://claude.com/claude-code)
