### PR TITLE
perf(linker): export_map 문자열 키 → (module_index, name) struct 키

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -146,6 +146,23 @@ pub const ResolvedBinding = struct {
     canonical: SymbolRef,
 };
 
+/// export_map 키 — 과거 "module_index\x00name" 문자열을 조회마다 버퍼에 빌드+문자열 해싱
+/// 하던 것을 (module_index, name) struct 키로 대체. name 은 export_bindings(parse_arena,
+/// graph 수명) 슬라이스를 borrow → put 시 alloc/dupe 도, 조회 시 키 빌드도 없음. ② 심볼
+/// 모델(Ref) 방향의 측정-우선 스파이크.
+const ExportKey = struct { module_index: u32, name: []const u8 };
+const ExportKeyContext = struct {
+    pub fn hash(_: ExportKeyContext, k: ExportKey) u64 {
+        var h = std.hash.Wyhash.init(0);
+        h.update(std.mem.asBytes(&k.module_index));
+        h.update(k.name);
+        return h.final();
+    }
+    pub fn eql(_: ExportKeyContext, a: ExportKey, b: ExportKey) bool {
+        return a.module_index == b.module_index and std.mem.eql(u8, a.name, b.name);
+    }
+};
+
 pub const Linker = struct {
     allocator: std.mem.Allocator,
     /// Module storage 접근 포인터 (#1779 PR #2). 기존 `[]const Module` slice
@@ -155,8 +172,8 @@ pub const Linker = struct {
     /// 출력 포맷.
     format: types.Format,
 
-    /// 모듈별 export 맵: "module_index\x00exported_name" → ExportEntry
-    export_map: std.StringHashMapUnmanaged(ExportEntry) = .empty,
+    /// 모듈별 export 맵: (module_index, exported_name) → ExportEntry. 키는 name 을 borrow.
+    export_map: std.HashMapUnmanaged(ExportKey, ExportEntry, ExportKeyContext, 80) = .empty,
 
     /// import→export 바인딩 결과: (module_index, local_span_key) → ResolvedBinding
     resolved_bindings: std.AutoHashMapUnmanaged(BindingKey, ResolvedBinding) = .empty,
@@ -446,10 +463,7 @@ pub const Linker = struct {
         for (self.unified_module_scopes) |*b| b.deinit();
         if (self.unified_module_scopes.len > 0) self.allocator.free(self.unified_module_scopes);
 
-        var eit = self.export_map.keyIterator();
-        while (eit.next()) |key| {
-            self.allocator.free(key.*);
-        }
+        // 키 name 은 borrow(export_bindings 소유) → 개별 free 불필요.
         self.export_map.deinit(self.allocator);
         self.resolved_bindings.deinit(self.allocator);
         for (self.canonical_strings.items) |s| self.allocator.free(s);
@@ -2005,12 +2019,8 @@ pub const Linker = struct {
             const mod_idx: ModuleIndex = @enumFromInt(@as(u32, @intCast(i)));
             for (m.export_bindings) |eb| {
                 if (std.mem.eql(u8, eb.exported_name, "*")) continue;
-                const key = try makeExportKey(self.allocator, @intCast(i), eb.exported_name);
-                // C2 수정: 중복 키 시 이전 키 해제
-                if (self.export_map.fetchRemove(key)) |old| {
-                    self.allocator.free(old.key);
-                }
-                try self.export_map.put(self.allocator, key, .{
+                // 키는 name borrow → 중복 키는 put 이 value 만 덮어씀(free 불필요).
+                try self.export_map.put(self.allocator, .{ .module_index = @intCast(i), .name = eb.exported_name }, .{
                     .binding = eb,
                     .module_index = mod_idx,
                 });
@@ -2247,11 +2257,8 @@ pub const Linker = struct {
         const mod_i = @intFromEnum(module_idx);
         const m_any = self.graph.getModule(module_idx) orelse return null;
 
-        // 1. 직접 export 확인 (조회 전용 — OOM 시 빈 키 → export_map 미스 → re-export 해석 계속)
-        var key_mk: types.ModuleKey = .{};
-        defer key_mk.deinit(self.allocator);
-        const key = key_mk.makeOrEmpty(self.allocator, @intCast(mod_i), name);
-        if (self.export_map.get(key)) |entry| {
+        // 1. 직접 export 확인 — struct 키 (조회마다 문자열 빌드/해싱 없음).
+        if (self.export_map.get(.{ .module_index = @intCast(mod_i), .name = name })) |entry| {
             if (entry.binding.kind == .re_export) {
                 // re-export: 소스 모듈로 재귀
                 if (entry.binding.import_record_index) |rec_idx| {
@@ -2378,11 +2385,7 @@ pub const Linker = struct {
     /// resolveStarExport 판정을 공유해 drift 를 막는다. #3982
     /// 직접 export(또는 named re-export)면 그 정의가 우선이라 ambiguous 아님.
     pub fn isAmbiguousStarExport(self: *const Linker, module_idx: ModuleIndex, name: []const u8) bool {
-        var key_mk: types.ModuleKey = .{};
-        defer key_mk.deinit(self.allocator);
-        // 조회 전용 — OOM 시 빈 키 → contains 미스 → resolveStarExport로 계속 판정.
-        const dk = key_mk.makeOrEmpty(self.allocator, module_idx.toU32(), name);
-        if (self.export_map.contains(dk)) return false;
+        if (self.export_map.contains(.{ .module_index = module_idx.toU32(), .name = name })) return false;
         return self.resolveStarExport(module_idx, name, 0) == .ambiguous;
     }
 
@@ -3331,8 +3334,6 @@ pub const Linker = struct {
         // cross-chunk import 경계 → collectUnifiedInput 이 reserved 로 보호.
         try self.runUnifiedMangle(&chunk_set, occupied_names);
     }
-
-    pub const makeExportKey = types.makeModuleKey;
 };
 
 /// CJS 모듈의 require_xxx 변수명을 캐시에서 가져오거나 새로 생성.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -20,7 +20,6 @@ const SymbolRef = linker_mod.SymbolRef;
 const ResolvedBinding = linker_mod.ResolvedBinding;
 const profile = @import("../../profile.zig");
 const debug_log = @import("../../debug_log.zig");
-const makeExportKey = types.makeModuleKey;
 const PreambleWriter = linker_mod.PreambleWriter;
 const NsExportPair = Linker.NsExportPair;
 const getOrCreateRequireVar = linker_mod.getOrCreateRequireVar;
@@ -1649,11 +1648,7 @@ pub fn buildCrossModuleConstValuesProfiled(
             // export_name → local_name 매핑. namespace object export 는 scalar const 가 아니므로
             // symbol lookup 전에 제외한다.
             const local_name = local: {
-                var key_mk: types.ModuleKey = .{};
-                defer key_mk.deinit(self.allocator);
-                // 조회 전용 — OOM 시 빈 키 → export_map 미스 → 아래 export_name 폴백과 동일 경로.
-                const key = key_mk.makeOrEmpty(self.allocator, canon.module_index.toU32(), canon.export_name);
-                if (self.export_map.get(key)) |entry| {
+                if (self.export_map.get(.{ .module_index = canon.module_index.toU32(), .name = canon.export_name })) |entry| {
                     if (entry.binding.kind == .re_export_namespace) continue;
                     break :local target_module.exportBindingLocalName(entry.binding);
                 }


### PR DESCRIPTION
## 무엇을 / 왜

`Linker.export_map` 이 `"module_index\x00name"` **문자열 키**를 (1) build 시 export 마다 `alloc`+`dupe`, (2) 조회마다 4096바이트 `ModuleKey` 버퍼에 빌드+문자열 해싱했습니다. 키를 `(module_index: u32, name: []const u8)` **struct** 로 바꾸고 `name` 은 `export_bindings`(parse_arena, graph 수명) 슬라이스를 **borrow** → build alloc/dupe/free 제거 + 조회 시 키 빌드 제거.

esbuild Ref 심볼 방향(②)을 **측정-우선 스파이크**로 검증한 결과물입니다.

## 성격 — 작은 cleanup + 소폭 perf (솔직)

`②` 의 진짜 win 은 parse 시점에 이름을 정수 ID 로 intern 해야 나옵니다. 이 변경은 해싱 바이트가 동일(struct 키도 name 해싱) → **lookup 자체는 비슷**하고, 이득은 주로 **per-export build alloc 제거**입니다. 그래서 측정값이 작습니다.

## 측정 (ReleaseFast, 50회 interleave hyperfine, 구/신 별도 바이너리)

| 실 빌드 | 구 | 신 | 비율 (±σ) |
|---|---|---|---|
| **13-package** | 227.0±3.4ms | 221.2±3.4ms | **1.03±0.02× (유의미, ~3%)** |
| effect+rxjs | 49.0 | 49.5 | 1.01±0.03× (노이즈) |
| 5-barrel | 160.7 | 163.3 | 1.02±0.06× (노이즈) |

→ **대체로 노이즈, 가장 큰 빌드만 유의미 ~3%.** barrel(export 해석 최대) 에서 win 0 인 게 "이득은 lookup 이 아니라 build alloc 제거"임을 실증합니다.

## 정확성
- 출력 **byte-identical** (effect/13pkg 동일 fixture, 합성 30k 직렬), export 해석 통합 216 pass / 0 fail, 유닛 통과, napi/wasm/wasm-bundler 빌드 통과.
- `/code-review max`: **버그 0건**. UAF/lifetime 검증됨(파싱 완료 후 Linker 생성 → export_map 은 parse_arena 안정 구간에서만 사용 → `Linker.deinit` 이 `graph.deinit` 보다 먼저). OOM-fallback 제거 안전(real lookup ≥ forced-miss). dead alias `makeExportKey` 2개 제거(리뷰 지적).

## 부수 효과
코드 단순화(키 alloc/dupe/free·ModuleKey 버퍼 3곳 제거), 메모리 소폭 감소.

> 전략 결론(별도): 실 빌드 3.24× gap 은 1.55×(파서) × ~1.67×(모듈그래프 발산: scan/semantic/metadata/link 분산)이라, ②·①·metadata 단일 lever 로는 안 닫힘. 닫으려면 esbuild식 전면 재작성=플러그인/RN/Flow 차별점 포기. 이 PR 은 그 결론을 바꾸지 않는 작은 cleanup 입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)