### PR TITLE
fix(minify): unary-minus fold size 가드 추가 (-1e21 등 음수 리터럴 팽창 방지)

### DIFF
--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -1813,11 +1813,18 @@ fn foldUnary(ast: *Ast, node_idx: u32, node: Node, changed: *bool) void {
             if (operand.tag == .numeric_literal) {
                 if (numeric.parseLiteral(ast, operand)) |val| {
                     if (numeric.formatNumber(ast, -val)) |span| {
-                        replaceNode(ast, node_idx, .{
-                            .tag = .numeric_literal,
-                            .span = span,
-                            .data = .{ .none = 0 },
-                        }, changed);
+                        // binary fold 와 동일한 size 가드: fold 결과가 원본보다 길면
+                        // 접지 않는다. `-1e21` 의 {d} 전개(`-1000…0`, 23자)가 원본
+                        // `-1e21`(5자)보다 커지는 팽창을 막는다 (esbuild 기준).
+                        const orig_len = (node.span.end & ~ast_mod.Ast.STRING_TABLE_BIT) -| (node.span.start & ~ast_mod.Ast.STRING_TABLE_BIT);
+                        const new_len = (span.end & ~ast_mod.Ast.STRING_TABLE_BIT) -| (span.start & ~ast_mod.Ast.STRING_TABLE_BIT);
+                        if (new_len <= orig_len) {
+                            replaceNode(ast, node_idx, .{
+                                .tag = .numeric_literal,
+                                .span = span,
+                                .data = .{ .none = 0 },
+                            }, changed);
+                        }
                     }
                 }
             }

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -459,6 +459,19 @@ test "minify: non-literal not folded" {
     try expectMinify("const x = a + b;", "const x = a + b;");
 }
 
+test "minify: unary minus fold guarded against expansion (-1e21 / -2e3 stay)" {
+    // -리터럴 fold 가 {d} 전개로 원본보다 길어지면 접지 않는다(binary fold 와 동일 가드).
+    // `-1e21` → `-1000…0`(23자), `-2e3` → `-2000`(5자) 팽창 방지.
+    try expectMinify("const x = -1e21;", "const x = -1e21;");
+    try expectMinify("const x = -2e3;", "const x = -2e3;");
+}
+
+test "minify: unary minus fold kept when shorter or equal (-0x10 → -16)" {
+    // 축소/동일 길이는 그대로 fold.
+    try expectMinify("const x = -0x10;", "const x = -16;");
+    try expectMinify("const x = -1;", "const x = -1;");
+}
+
 // ================================================================
 // Phase 2: Dead Code Elimination
 // ================================================================


### PR DESCRIPTION
## 무엇을

minify 의 unary-minus 수치 fold 가 size 가드 없이 `-1e21` → `-1000000000000000000000`(23자), `-2e3` → `-2000` 로 **팽창**시키던 회귀를 수정합니다(값은 맞지만 미니파이 목적 위반).

## 어떻게

`src/transformer/minify.zig` `foldUnary` `.minus` 분기에 binary fold 와 동일한 size 가드(`new_len <= orig_len`)를 추가. fold 결과가 원본 unary span 보다 길면 접지 않습니다.

## 검증

- 실제 바이너리(`--minify`): `-1e21`/`-2e3` 유지, `-0x10`→`-16`(축소)·`-1`(동일) fold 유지.
- main 대조: 이전엔 `-1e21`→`-1000…0`(23자) 팽창 확인.
- 회귀 테스트 2건(`minify_test.zig`). `minify:`/`tree` 테스트 통과.

Closes #4428

🤖 Generated with [Claude Code](https://claude.com/claude-code)
