### PR TITLE
ci: error 문서 동기화 가드 추가 (404 재발 방지, #4421 후속)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,19 @@ jobs:
       - name: Audit recursive AST walkers (#4123)
         run: bun scripts/audit-recursive-ast-walkers.mjs
 
+      # error_codes.zig 에 코드를 추가하고 generate-error-docs.mjs 를 재실행하지 않으면
+      # docsUrl() 이 존재하지 않는 페이지로 404 링크를 만든다 (#4421). 생성기를 돌려
+      # 산출물이 커밋과 일치하는지 검사 — 불일치(신규/수정 페이지)면 fail.
+      - name: Audit error docs sync (#4421)
+        run: |
+          bun scripts/generate-error-docs.mjs
+          changed="$(git status --porcelain documents/src/content/docs/reference/errors documents/src/content/docs/en/reference/errors)"
+          if [ -n "$changed" ]; then
+            echo "::error::error 문서가 error_codes.zig 와 동기화되지 않았습니다. 'node scripts/generate-error-docs.mjs' 실행 후 커밋하세요."
+            echo "$changed"
+            exit 1
+          fi
+
   napi:
     name: NAPI Build & Test
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## 무엇을

`error_codes.zig` 에 코드 추가 후 `generate-error-docs.mjs` 를 재실행하지 않으면 `docsUrl()` 이 404 링크를 만든다(#4421). CI `lint` 잡에 동기화 가드를 추가해 재발을 막는다.

## 어떻게
생성기 실행 후 `git status --porcelain documents/.../errors`(ko/en) 로 신규/수정 페이지 감지 → 있으면 fail. 기존 audit 스텝과 동일 패턴, bun 으로 실행.

## 검증
- 현재 main: 생성기 실행 후 diff 0 → 가드 통과.
- desync 시뮬레이션(임시 코드 998 추가, 미재생성): 가드가 새 zntc0998 페이지 + index 변경 감지 → fail. YAML 유효성 확인.

Closes #4430

🤖 Generated with [Claude Code](https://claude.com/claude-code)