### PR TITLE
fix(diagnostic): 번들러 진단이 ZNTCxxxx 코드 + docs URL 방출 (dead fromBundlerDiagnostic 정리)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,19 @@ jobs:
       - name: Audit recursive AST walkers (#4123)
         run: bun scripts/audit-recursive-ast-walkers.mjs
 
+      # error_codes.zig 에 코드를 추가하고 generate-error-docs.mjs 를 재실행하지 않으면
+      # docsUrl() 이 존재하지 않는 페이지로 404 링크를 만든다 (#4421). 생성기를 돌려
+      # 산출물이 커밋과 일치하는지 검사 — 불일치(신규/수정 페이지)면 fail.
+      - name: Audit error docs sync (#4421)
+        run: |
+          bun scripts/generate-error-docs.mjs
+          changed="$(git status --porcelain documents/src/content/docs/reference/errors documents/src/content/docs/en/reference/errors)"
+          if [ -n "$changed" ]; then
+            echo "::error::error 문서가 error_codes.zig 와 동기화되지 않았습니다. 'node scripts/generate-error-docs.mjs' 실행 후 커밋하세요."
+            echo "$changed"
+            exit 1
+          fi
+
   napi:
     name: NAPI Build & Test
     runs-on: ${{ matrix.os }}

--- a/src/main.zig
+++ b/src/main.zig
@@ -825,12 +825,22 @@ pub fn main(init: std.process.Init) !void {
                     .warning => "warning",
                     .info => "info",
                 };
-                try stderr.print("[{s}] {s}: {s}\n", .{ sev_str, d.file_path, d.message });
+                // 전용 ZNTC 코드가 있으면 `[ZNTCxxxx] sev: file: msg` + docs URL 로
+                // 렌더(transpile 진단과 동일하게 코드/문서 링크 노출). 아직 코드가
+                // 없는 진단은 기존 `[sev] file: msg` 평문 유지.
+                if (lib.rich_diagnostic.bundlerErrorCode(d.code)) |zc| {
+                    try stderr.print("[{s}] {s}: {s}: {s}\n", .{ zc.format(), sev_str, d.file_path, d.message });
+                } else {
+                    try stderr.print("[{s}] {s}: {s}\n", .{ sev_str, d.file_path, d.message });
+                }
                 // (#3986) suggestion 은 *교정된 이름*이 아니라 unresolved specifier 또는
                 // 조언 문장(producer 가 record.specifier / 전체 문장을 넣음)이다. ZNTC 엔
                 // typo-detector 가 없어 'did you mean' 프레이밍은 항상 오도였다. app
                 // bundle 진단(app/build.zig:719 `hint:`)과 동일하게 중립 hint 로 렌더.
                 if (d.suggestion) |s| try stderr.print("  hint: {s}\n", .{s});
+                if (lib.rich_diagnostic.bundlerErrorCode(d.code)) |zc| {
+                    try stderr.print("  docs: {s}\n", .{zc.docsUrl()});
+                }
             }
         }
 

--- a/src/rich_diagnostic.zig
+++ b/src/rich_diagnostic.zig
@@ -137,28 +137,30 @@ pub fn fromDiagnostic(d: Diagnostic, file_path: []const u8) RichDiagnostic {
     };
 }
 
-/// BundlerDiagnostic을 RichDiagnostic으로 변환한다.
-pub fn fromBundlerDiagnostic(d: BundlerDiagnostic) RichDiagnostic {
-    return .{
-        .severity = switch (d.severity) {
-            .@"error" => .@"error",
-            .warning => .warning,
-            .info => .info,
-        },
-        .code = switch (d.code) {
-            .unresolved_import => error_codes.Code.unresolved_import.format(),
-            .missing_export => error_codes.Code.missing_export.format(),
-            .circular_dependency => error_codes.Code.circular_dependency.format(),
-            .parse_error => error_codes.Code.import_in_script.format(),
-            .read_error => error_codes.Code.read_error.format(),
-            .json_parse_error => error_codes.Code.json_parse_error.format(),
-            .no_loader => error_codes.Code.no_loader.format(),
-            .resolve_error => error_codes.Code.resolve_error.format(),
-        },
-        .message = d.message,
-        .span = d.span,
-        .file_path = d.file_path,
-        .help = d.suggestion,
+/// `BundlerDiagnostic.ErrorCode` → 대응하는 `ZNTCxxxx` error_codes.Code.
+/// 아직 전용 코드가 없는 진단은 null — 호출부가 코드/docs URL 없이 렌더한다.
+/// (exhaustive switch — ErrorCode 추가 시 여기서 컴파일 에러로 누락을 잡는다.)
+pub fn bundlerErrorCode(code: BundlerDiagnostic.ErrorCode) ?error_codes.Code {
+    return switch (code) {
+        .unresolved_import => .unresolved_import,
+        .missing_export => .missing_export,
+        .circular_dependency => .circular_dependency,
+        .circular_reexport => .circular_reexport,
+        .parse_error => .import_in_script,
+        .read_error => .read_error,
+        .resolve_error => .resolve_error,
+        .json_parse_error => .json_parse_error,
+        .no_loader => .no_loader,
+        .assign_to_import => .assign_to_import,
+        // 아직 전용 ZNTC 코드 미할당 — 코드/페이지 추가는 follow-up.
+        .ambiguous_export,
+        .require_context_invalid,
+        .require_context_no_handler,
+        .plugin_error,
+        .output_exports_conflict,
+        .jsx_pragma_ignored,
+        .regex_modifier_unsupported,
+        => null,
     };
 }
 


### PR DESCRIPTION
## 무엇을

번들러 진단이 설계(ARCHITECTURE.md:138 / D066 / D100)가 약속한 `[ZNTCxxxx]` 코드 + docs URL 을 CLI 에서 방출하도록 하고, 죽은 `fromBundlerDiagnostic`(8/17 non-exhaustive switch — wire 시 컴파일 불가 trap)을 정리합니다.

## 어떻게

- `rich_diagnostic.zig`: 죽은 `fromBundlerDiagnostic` 을 **exhaustive `bundlerErrorCode(ec) ?error_codes.Code`** 로 교체. 17개 ErrorCode 전부 처리(전용 코드 있는 10개 → Code, 나머지 7개 → null). ErrorCode 추가 시 컴파일 에러로 누락 포착.
- `main.zig`: 번들러 진단 출력을 코드가 있으면 `[ZNTCxxxx] sev: file: msg` + `docs: <url>` 로, 없으면 기존 `[sev] file: msg` 평문으로 렌더. `hint:` 라인 유지.

## 검증

- 실제 바이너리: unresolved import →
  ```
  [ZNTC0100] error: entry.ts: Cannot resolve module
    hint: ./does-not-exist.js
    docs: https://ohah.github.io/zntc/reference/errors/zntc0100/
  ```
- `resolve-fallback.test.ts` 7/7 통과(메시지·hint 포맷 호환). 전체 `zig build test` 통과.

## 잔여 (follow-up #4432)

전용 코드가 없는 7개 진단(ambiguous_export/require_context_*/plugin_error/output_exports_conflict/jsx_pragma_ignored/regex_modifier_unsupported)에 코드 할당 + 페이지 생성 + app/build·wasm 출력 일관성.

Closes #4423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
