### PR TITLE
fix(semantic): class body strict if-body Annex B 게이트 누락 (#4418 형제) + /code-review 후속

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -828,7 +828,8 @@ pub fn main(init: std.process.Init) !void {
                 // 전용 ZNTC 코드가 있으면 `[ZNTCxxxx] sev: file: msg` + docs URL 로
                 // 렌더(transpile 진단과 동일하게 코드/문서 링크 노출). 아직 코드가
                 // 없는 진단은 기존 `[sev] file: msg` 평문 유지.
-                if (lib.rich_diagnostic.bundlerErrorCode(d.code)) |zc| {
+                const zntc_code = lib.rich_diagnostic.bundlerErrorCode(d.code);
+                if (zntc_code) |zc| {
                     try stderr.print("[{s}] {s}: {s}: {s}\n", .{ zc.format(), sev_str, d.file_path, d.message });
                 } else {
                     try stderr.print("[{s}] {s}: {s}\n", .{ sev_str, d.file_path, d.message });
@@ -838,7 +839,7 @@ pub fn main(init: std.process.Init) !void {
                 // typo-detector 가 없어 'did you mean' 프레이밍은 항상 오도였다. app
                 // bundle 진단(app/build.zig:719 `hint:`)과 동일하게 중립 hint 로 렌더.
                 if (d.suggestion) |s| try stderr.print("  hint: {s}\n", .{s});
-                if (lib.rich_diagnostic.bundlerErrorCode(d.code)) |zc| {
+                if (zntc_code) |zc| {
                     try stderr.print("  docs: {s}\n", .{zc.docsUrl()});
                 }
             }

--- a/src/rich_diagnostic.zig
+++ b/src/rich_diagnostic.zig
@@ -4,7 +4,8 @@
 //! 진단 정보를 하나의 타입으로 통합한다.
 //!
 //! 기존 Diagnostic/BundlerDiagnostic은 그대로 유지하고,
-//! 렌더링 시 fromDiagnostic()/fromBundlerDiagnostic()으로 변환한다.
+//! 렌더링 시 fromDiagnostic()으로 변환한다. BundlerDiagnostic 의 ZNTC 코드는
+//! bundlerErrorCode()로 매핑한다.
 //!
 //! 설계:
 //!   - severity: error/warning/info

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1445,9 +1445,11 @@ pub const SemanticAnalyzer = struct {
             .if_statement => {
                 try self.visitNode(node.data.ternary.a);
                 // Annex B: if/else body에서 function declaration은 sloppy mode에서
-                // var hoisting conflict check를 건너뛴다.
+                // var hoisting conflict check를 건너뛴다. strict 는 하향 sticky 이므로
+                // class body(항상 strict) 안의 메서드 if-body 까지 반영하도록
+                // isCurrentStrict() 로 판단(canRedeclare 와 동일 기준).
                 const saved_annex_b = self.in_annex_b_context;
-                if (!self.is_strict_mode) self.in_annex_b_context = true;
+                if (!self.isCurrentStrict()) self.in_annex_b_context = true;
                 try self.visitNode(node.data.ternary.b);
                 try self.visitNode(node.data.ternary.c);
                 self.in_annex_b_context = saved_annex_b;

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -84,6 +84,37 @@ test "SemanticAnalyzer: sloppy block duplicate function is allowed (Annex B, #44
     try std.testing.expect(ana.errors.items.len == 0);
 }
 
+test "SemanticAnalyzer: class method if-body inherits strict — Annex B gate off (#4414 sibling)" {
+    // class body strict 는 if/else body 의 Annex B 게이트(in_annex_b_context)에도
+    // 적용돼야 한다. canRedeclare 뿐 아니라 이 게이트도 isCurrentStrict 기준.
+    var scanner = try Scanner.init(std.testing.allocator, "class C { m() { if (x) { function f(){} function f(){} } } }");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    try std.testing.expect(ana.errors.items.len > 0);
+}
+
+test "SemanticAnalyzer: sloppy if-body duplicate function allowed (Annex B, #4414 sibling control)" {
+    // 대조군: class 밖 sloppy if-body 는 Annex B 로 허용.
+    var scanner = try Scanner.init(std.testing.allocator, "if (x) { function f(){} function f(){} }");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    try std.testing.expect(ana.errors.items.len == 0);
+}
+
 test "SemanticAnalyzer: function declaration creates symbol" {
     var scanner = try Scanner.init(std.testing.allocator, "function foo() {}");
     defer scanner.deinit();

--- a/src/transformer/es2019.zig
+++ b/src/transformer/es2019.zig
@@ -45,8 +45,10 @@ pub fn ES2019(comptime Transformer: type) type {
             // body 를 먼저 방문해 body 내부 lowering 이 temp 카운터를 소비하게 한 뒤,
             // 카운터 *너머* 의 이름을 고른다. catch 파라미터는 그 자체로 선언이라
             // hoist 가 불필요하므로 카운터를 bump 하지 않는다(= `var _a;` 누수 없음).
-            // 고른 이름은 body temp(카운터 미만)·사용자 심볼·private field 어느 것과도
-            // 겹치지 않으므로 어떤 외부 참조도 섀도잉하지 않는다.
+            // 고른 이름은 body temp(카운터 미만)·사용자 심볼·private field 와 겹치지
+            // 않는다. (한계: 어디에도 선언/import 안 된 temp-형 전역(`_a`)이나 semantic
+            // 미수집 경로(OOM fallback) 에서는 충돌 집합이 비어 회피가 약해진다 —
+            // makeTempVarSpan 과 동일한 systemic 한계.)
             const new_body = try self.visitNode(body);
             var probe = self.temp_var_counter;
             var name_buf: [16]u8 = undefined;


### PR DESCRIPTION
## 무엇을

내가 머지한 전수조사 수정들을 `/code-review max`(9 finder 앵글 + 검증 + sweep, 24후보→15 findings)로 재점검한 뒤, 그중 **확정된 실 결함 1건 + 정직성/cleanup 3건**을 반영합니다.

## 1. 실 결함 (correctness) — #4434

`#4418`(class body strict 전파)의 **누락된 형제 경로**: `analyzer.zig:1450` 의 `if_statement` Annex B 게이트가 `canRedeclare` 와 달리 아직 모듈-전역 `is_strict_mode` 를 써서, sloppy class 메서드의 **`if`-body** 안 중복 function 선언을 잘못 허용했다.
- fix: `is_strict_mode` → `isCurrentStrict()`.
- 검증: `class C { m() { if(x){ function f(){} function f(){} } } }` → 이제 ZNTC1000(exit 1). sloppy top-level if-body 는 Annex B 유지(exit 0), strict 파일 if-body 는 에러 유지.
- 회귀 테스트 2건 추가(`analyzer_test.zig`).

## 2. 정직성/cleanup

- `es2019.zig`: 합성 catch 이름 주석의 과장("어떤 외부 참조도 섀도잉하지 않는다") 제거 — 미선언 temp-형 전역/semantic-미수집(OOM) 경로에선 회피가 약해지는 systemic 한계(makeTempVarSpan 동일)를 명시.
- `rich_diagnostic.zig`: 헤더가 삭제된 `fromBundlerDiagnostic()` 를 참조하던 stale 주석 → `bundlerErrorCode()` 로 갱신.
- `main.zig`: 진단당 `bundlerErrorCode(d.code)` 2회 호출 → `const` 1회로 hoist(drift 방지).

## 검증

`zig build` + 전체 `zig build test` 통과. 실바이너리로 if-form 게이트 확인.

## 리뷰에서 짚었으나 미수정 (의도)

- es2019 temp-collision systemic 한계(미선언 `_a` 전역/OOM-null-semantic) — makeTempVarSpan 포함 모든 temp 생성의 pre-existing 성질, cross-cutting 별건. 주석으로 정직화만.
- es2019 probe 가 카운터 미bump → 후속 sibling temp 와 이름 공유 — catch param 이 미사용이라 안전(의도).
- minify foldUnary size 가드의 `node.span` 측정에 trailing trivia 포함 — binary fold(`:1352`)와 동일 동작, 값 정확성 무관 size 휴리스틱.
- canRedeclare 이중진단 의심 — 실측상 단일 ZNTC0515(+"previously declared" 라벨), 오탐.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
