### PR TITLE
feat(cache): AST 직렬화 codec — 디스크 캐시 #4438 PR1

### DIFF
--- a/src/parser/ast_codec.zig
+++ b/src/parser/ast_codec.zig
@@ -1,0 +1,223 @@
+//! AST 직렬화 codec — 디스크 캐시(#4438) PR1.
+//!
+//! zts AST 는 인덱스/오프셋 기반(relocatable)이라 `nodes`/`extra_data`/`string_table`
+//! 을 flat memcpy 하고 `source` 베이스만 새로 잡으면 완전 복원된다 (Span 이 offset+len
+//! 기반이라 노드 내 텍스트 참조가 베이스와 무관). 따라서 rkyv 같은 무거운 직렬화 라이브러리
+//! 없이 단순 바이트 복사로 충분하다.
+//!
+//! 안전: `[MAGIC][FORMAT_VERSION][checksum(payload)]` 헤더로 버전 스큐/손상을 방어한다.
+//! 검증 실패는 항상 `error` 를 반환 — 호출자는 캐시를 버리고 재파싱(fail-safe). 잘못된
+//! 캐시를 조용히 사용해 stale 출력을 내는 것보다 재파싱(느림)이 항상 안전하다는 비대칭 원칙.
+//!
+//! PR1 범위 = AST 만. semantic(symbols/scopes/references) / import_records / Module 레벨은
+//! 후속 PR. `string_interns`(parse dedup 최적화 — codegen/transformer 가 read 안 함, 확인됨)
+//! 는 빈 맵으로 복원. `declare_only_names`(transpile.zig 의 type-only export 판정이 read)는
+//! 직렬화한다 — 누락 시 `declare const X; export {X}` 가 value export 로 잘못 출력된다.
+//!
+//! 포맷은 host endian/정렬 native — cross-arch 캐시 공유엔 부적합(magic 불일치 시 fail-safe
+//! 재파싱으로 안전, silent corruption 아님). 로컬 캐시 전제.
+
+const std = @import("std");
+const ast_mod = @import("ast.zig");
+const Ast = ast_mod.Ast;
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+const wyhash = @import("../util/wyhash.zig");
+
+pub const MAGIC: u32 = 0x5A4E5443; // "ZNTC"
+pub const FORMAT_VERSION: u32 = 1;
+
+/// null `?[]const u8` 표식 (jsx_pragma offset 자리).
+const NULL_OFFSET: u32 = std.math.maxInt(u32);
+/// header = magic(4) + version(4) + checksum(8)
+const HEADER_LEN: usize = 16;
+
+pub const Error = error{
+    BadMagic,
+    UnsupportedVersion,
+    ChecksumMismatch,
+    Truncated,
+} || std.mem.Allocator.Error;
+
+// ── serialize ───────────────────────────────────────────────────────────────
+
+fn putU32(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u32) !void {
+    try buf.appendSlice(alloc, std.mem.asBytes(&v));
+}
+fn putU64(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u64) !void {
+    try buf.appendSlice(alloc, std.mem.asBytes(&v));
+}
+/// length-prefixed 바이트열.
+fn putBytes(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, b: []const u8) !void {
+    try putU32(buf, alloc, @intCast(b.len));
+    try buf.appendSlice(alloc, b);
+}
+/// jsx_pragma 등 source-backed optional slice → (offset, len). null 이면 offset=NULL_OFFSET.
+fn putPragma(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, ast: *const Ast, p: ?[]const u8) !void {
+    if (p) |s| {
+        const off: usize = @intFromPtr(s.ptr) - @intFromPtr(ast.source.ptr);
+        try putU32(buf, alloc, @intCast(off));
+        try putU32(buf, alloc, @intCast(s.len));
+    } else {
+        try putU32(buf, alloc, NULL_OFFSET);
+        try putU32(buf, alloc, 0);
+    }
+}
+
+/// AST 를 `out` 에 직렬화한다 (append). 헤더(magic/version/checksum) + payload.
+pub fn serialize(ast: *const Ast, out: *std.ArrayList(u8), alloc: std.mem.Allocator) !void {
+    // payload 를 먼저 별도 버퍼에 만들고 checksum 을 계산한 뒤 헤더와 함께 기록.
+    var payload: std.ArrayList(u8) = .empty;
+    defer payload.deinit(alloc);
+
+    try putBytes(&payload, alloc, ast.source);
+    try putBytes(&payload, alloc, std.mem.sliceAsBytes(ast.nodes.items));
+    try putBytes(&payload, alloc, std.mem.sliceAsBytes(ast.extra_data.items));
+    try putBytes(&payload, alloc, ast.string_table.items);
+
+    // declare_only_names 키 (transpile.zig type-only export 판정용). 키는 source/string_table
+    // backed slice 라 문자열 자체를 저장하고, deserialize 가 string_table 에 귀속시켜 복원.
+    try putU32(&payload, alloc, @intCast(ast.declare_only_names.count()));
+    var decl_it = ast.declare_only_names.keyIterator();
+    while (decl_it.next()) |k| try putBytes(&payload, alloc, k.*);
+
+    // 메타 플래그 7개 (1바이트씩)
+    const flags = [_]bool{
+        ast.has_jsx,                   ast.has_jsx_key_after_spread,
+        ast.has_decorator,             ast.has_ts_namespace_or_enum,
+        ast.has_ts_import_equals,      ast.has_ts_export_equals,
+        ast.has_flow_enum_declaration,
+    };
+    for (flags) |f| try payload.append(alloc, if (f) @as(u8, 1) else 0);
+
+    // jsx_pragma 4개 (source-backed offset/len)
+    try putPragma(&payload, alloc, ast, ast.jsx_pragma_factory);
+    try putPragma(&payload, alloc, ast, ast.jsx_pragma_fragment);
+    try putPragma(&payload, alloc, ast, ast.jsx_pragma_runtime);
+    try putPragma(&payload, alloc, ast, ast.jsx_pragma_import_source);
+
+    // transform 상태 (?u32 / ?NodeIndex) — present 바이트 + 값
+    try putU32(&payload, alloc, if (ast.transform_boundary) |b| b else NULL_OFFSET);
+    try putU32(&payload, alloc, if (ast.transformed_root) |r| @intFromEnum(r) else NULL_OFFSET);
+
+    const checksum = wyhash.hashU64(payload.items);
+    try putU32(out, alloc, MAGIC);
+    try putU32(out, alloc, FORMAT_VERSION);
+    try putU64(out, alloc, checksum);
+    try out.appendSlice(alloc, payload.items);
+}
+
+// ── deserialize ──────────────────────────────────────────────────────────────
+
+const Reader = struct {
+    buf: []const u8,
+    pos: usize = 0,
+
+    fn take(self: *Reader, n: usize) Error![]const u8 {
+        // checked add — 손상된 length-prefix 가 pos+n 을 오버플로우시켜 경계검사를 우회하는 것 방지.
+        const end = std.math.add(usize, self.pos, n) catch return error.Truncated;
+        if (end > self.buf.len) return error.Truncated;
+        const b = self.buf[self.pos..][0..n];
+        self.pos = end;
+        return b;
+    }
+    fn u32v(self: *Reader) Error!u32 {
+        return std.mem.bytesToValue(u32, (try self.take(4))[0..4]);
+    }
+    fn bytes(self: *Reader) Error![]const u8 {
+        const n = try self.u32v();
+        return self.take(n);
+    }
+    fn byte(self: *Reader) Error!u8 {
+        return (try self.take(1))[0];
+    }
+    fn pragma(self: *Reader, source: []const u8) Error!?[]const u8 {
+        const off = try self.u32v();
+        const len = try self.u32v();
+        if (off == NULL_OFFSET) return null;
+        const end = std.math.add(u32, off, len) catch return error.Truncated;
+        if (end > source.len) return error.Truncated;
+        return source[off..][0..len];
+    }
+};
+
+/// flat bytes → 새 Ast. magic/version/checksum 검증 후 복원. 검증 실패는 error(재파싱 fallback).
+/// 반환된 `ast.source` 는 새로 dupe 된 메모리이며 `Ast.deinit` 가 해제하지 않으므로,
+/// 호출자가 `ast.deinit()` 전에 `allocator.free(ast.source)` 책임을 진다.
+pub fn deserialize(data: []const u8, alloc: std.mem.Allocator) Error!Ast {
+    if (data.len < HEADER_LEN) return error.Truncated;
+    const magic = std.mem.bytesToValue(u32, data[0..4]);
+    if (magic != MAGIC) return error.BadMagic;
+    const version = std.mem.bytesToValue(u32, data[4..8]);
+    if (version != FORMAT_VERSION) return error.UnsupportedVersion;
+    const checksum = std.mem.bytesToValue(u64, data[8..16]);
+    const payload = data[HEADER_LEN..];
+    if (wyhash.hashU64(payload) != checksum) return error.ChecksumMismatch;
+
+    var r = Reader{ .buf = payload };
+
+    const source = try alloc.dupe(u8, try r.bytes());
+    errdefer alloc.free(source);
+    const nodes_bytes = try r.bytes();
+    const extra_bytes = try r.bytes();
+    const strtab_bytes = try r.bytes();
+
+    var ast: Ast = .{
+        .nodes = .empty,
+        .extra_data = .empty,
+        .source = source,
+        .string_table = .empty,
+        .string_interns = .empty,
+        .allocator = alloc,
+    };
+    errdefer ast.deinit();
+
+    // 손상된 캐시가 비배수 길이를 주면 @memcpy(dest.len != src.len) 가 패닉 → fail-safe 위반.
+    if (nodes_bytes.len % @sizeOf(Node) != 0) return error.Truncated;
+    try ast.nodes.resize(alloc, nodes_bytes.len / @sizeOf(Node));
+    @memcpy(std.mem.sliceAsBytes(ast.nodes.items), nodes_bytes);
+
+    if (extra_bytes.len % @sizeOf(u32) != 0) return error.Truncated;
+    try ast.extra_data.resize(alloc, extra_bytes.len / @sizeOf(u32));
+    @memcpy(std.mem.sliceAsBytes(ast.extra_data.items), extra_bytes);
+
+    try ast.string_table.appendSlice(alloc, strtab_bytes);
+
+    // declare_only_names: 키를 string_table 에 append 후 슬라이스로 등록 (소유권=string_table,
+    // ast.deinit 가 일괄 해제). append 가 realloc 할 수 있으니 전부 append 후 offset 으로 슬라이스
+    // 를 만들어 put (2-pass — 1-pass 면 먼저 만든 슬라이스가 realloc 으로 dangling).
+    const decl_count = try r.u32v();
+    if (decl_count > 0) {
+        const KeySpan = struct { off: usize, len: usize };
+        const spans = try alloc.alloc(KeySpan, decl_count);
+        defer alloc.free(spans);
+        for (spans) |*sp| {
+            const kb = try r.bytes();
+            sp.* = .{ .off = ast.string_table.items.len, .len = kb.len };
+            try ast.string_table.appendSlice(alloc, kb);
+        }
+        for (spans) |sp| {
+            try ast.declare_only_names.put(alloc, ast.string_table.items[sp.off..][0..sp.len], {});
+        }
+    }
+
+    ast.has_jsx = (try r.byte()) != 0;
+    ast.has_jsx_key_after_spread = (try r.byte()) != 0;
+    ast.has_decorator = (try r.byte()) != 0;
+    ast.has_ts_namespace_or_enum = (try r.byte()) != 0;
+    ast.has_ts_import_equals = (try r.byte()) != 0;
+    ast.has_ts_export_equals = (try r.byte()) != 0;
+    ast.has_flow_enum_declaration = (try r.byte()) != 0;
+
+    ast.jsx_pragma_factory = try r.pragma(source);
+    ast.jsx_pragma_fragment = try r.pragma(source);
+    ast.jsx_pragma_runtime = try r.pragma(source);
+    ast.jsx_pragma_import_source = try r.pragma(source);
+
+    const tb = try r.u32v();
+    ast.transform_boundary = if (tb == NULL_OFFSET) null else tb;
+    const tr = try r.u32v();
+    ast.transformed_root = if (tr == NULL_OFFSET) null else @enumFromInt(tr);
+
+    return ast;
+}

--- a/src/parser/ast_codec_test.zig
+++ b/src/parser/ast_codec_test.zig
@@ -1,0 +1,139 @@
+// ast_codec_test.zig — #4438 PR1 AST 직렬화 round-trip + fail-safe 테스트.
+
+const std = @import("std");
+const testing = std.testing;
+const codec = @import("ast_codec.zig");
+const Scanner = @import("../lexer/scanner.zig").Scanner;
+const Parser = @import("parser.zig").Parser;
+const Codegen = @import("../codegen/codegen.zig").Codegen;
+
+test "ast_codec: serialize→deserialize round-trip == codegen byte-identical" {
+    const alloc = testing.allocator;
+    const cases = [_][]const u8{
+        "const x = 1 + 2; let y = x * 3; const z = y - x;",
+        "function add(a, b) { return a + b; } const r = add(1, 2);",
+        "const obj = { a: 1, b: [2, 3], c: { d: 'hi' } }; const { a, ...rest } = obj;",
+        "class C { p = 1; method(n) { return this.p + n; } } const c = new C();",
+        "async function f() { for (const x of [1, 2, 3]) { await g(x); } }",
+        "const ts: number = 1; let s: string = 'x'; interface I { a: number }",
+        "export const list = [1, 2, 3].map((n) => n * 2).filter((n) => n > 2);",
+        "declare const ext: number; const used = ext + 1;",
+        "const tpl = `a${x}b${y}c`; const re = /ab+c/gi; const big = 100_000n;",
+        "try { f(); } catch (e) { g(e); } finally { h(); } switch (x) { case 1: break; default: }",
+    };
+    for (cases, 0..) |source, i| {
+        errdefer std.debug.print("FAILED case [{d}]: {s}\n", .{ i, source });
+
+        var scanner = try Scanner.init(alloc, source);
+        defer scanner.deinit();
+        var parser = Parser.init(alloc, &scanner);
+        defer parser.deinit();
+        const root = try parser.parse();
+
+        var cg1 = Codegen.init(alloc, &parser.ast);
+        defer cg1.deinit();
+        const out1 = try cg1.generate(root);
+
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        try codec.serialize(&parser.ast, &buf, alloc);
+
+        var ast2 = try codec.deserialize(buf.items, alloc);
+        defer {
+            alloc.free(ast2.source);
+            ast2.deinit();
+        }
+
+        var cg2 = Codegen.init(alloc, &ast2);
+        defer cg2.deinit();
+        const out2 = try cg2.generate(root);
+
+        try testing.expectEqualStrings(out1, out2);
+    }
+}
+
+test "ast_codec: 변조/버전/매직/truncated 거부 (fail-safe)" {
+    const alloc = testing.allocator;
+    const source = "const x = 1 + 2; function f() { return x; }";
+
+    var scanner = try Scanner.init(alloc, source);
+    defer scanner.deinit();
+    var parser = Parser.init(alloc, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try codec.serialize(&parser.ast, &buf, alloc);
+
+    // 정상 경로는 성공
+    {
+        var ast2 = try codec.deserialize(buf.items, alloc);
+        alloc.free(ast2.source);
+        ast2.deinit();
+    }
+    // bad magic
+    {
+        const dup = try alloc.dupe(u8, buf.items);
+        defer alloc.free(dup);
+        dup[0] ^= 0xFF;
+        try testing.expectError(error.BadMagic, codec.deserialize(dup, alloc));
+    }
+    // unsupported version
+    {
+        const dup = try alloc.dupe(u8, buf.items);
+        defer alloc.free(dup);
+        dup[4] = 0xEE;
+        try testing.expectError(error.UnsupportedVersion, codec.deserialize(dup, alloc));
+    }
+    // checksum mismatch (payload 변조)
+    {
+        const dup = try alloc.dupe(u8, buf.items);
+        defer alloc.free(dup);
+        dup[dup.len - 1] ^= 0xFF;
+        try testing.expectError(error.ChecksumMismatch, codec.deserialize(dup, alloc));
+    }
+    // truncated (header 미만)
+    {
+        try testing.expectError(error.Truncated, codec.deserialize(buf.items[0..8], alloc));
+    }
+}
+
+test "ast_codec: declare_only_names + jsx_pragma round-trip 보존" {
+    const alloc = testing.allocator;
+    const source =
+        "/** @jsx h @jsxFrag Frag */\n" ++
+        "declare const X: number;\n" ++
+        "export { X };\n" ++
+        "const y = 1;\n";
+
+    var scanner = try Scanner.init(alloc, source);
+    defer scanner.deinit();
+    var parser = Parser.init(alloc, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    // 이 소스가 실제로 두 필드를 채워야 검증이 의미있다 (안 채우면 trivially-pass 갭).
+    try testing.expect(parser.ast.declare_only_names.count() > 0);
+    try testing.expect(parser.ast.jsx_pragma_factory != null);
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try codec.serialize(&parser.ast, &buf, alloc);
+
+    var ast2 = try codec.deserialize(buf.items, alloc);
+    defer {
+        alloc.free(ast2.source);
+        ast2.deinit();
+    }
+
+    // declare_only_names 보존 (transpile.zig type-only export 판정의 입력)
+    try testing.expectEqual(parser.ast.declare_only_names.count(), ast2.declare_only_names.count());
+    try testing.expect(ast2.declare_only_names.contains("X"));
+
+    // jsx_pragma 보존 (source offset 재설정 path 검증)
+    try testing.expectEqualStrings(parser.ast.jsx_pragma_factory.?, ast2.jsx_pragma_factory.?);
+    if (parser.ast.jsx_pragma_fragment) |fr| {
+        try testing.expectEqualStrings(fr, ast2.jsx_pragma_fragment.?);
+    }
+}

--- a/src/parser/mod.zig
+++ b/src/parser/mod.zig
@@ -24,4 +24,5 @@ test {
     _ = @import("parser_test.zig");
     _ = @import("ast_test.zig");
     _ = @import("ast_walk_test.zig");
+    _ = @import("ast_codec_test.zig");
 }


### PR DESCRIPTION
## 요약
디스크 캐시(#4438) **PR1 — AST 직렬화 codec**. [PoC](https://github.com/ohah/zntc/issues/4438) 에서 zts AST 가 relocatable(swizzle≈0)임을 실측 확인했고, 이 PR 은 그 직렬화 코어를 정식 모듈로 구현한다.

## 무엇을
`src/parser/ast_codec.zig` — `serialize(ast) → bytes` / `deserialize(bytes) → Ast`
- AST 가 인덱스/오프셋 기반이라 `nodes`/`extra_data`/`string_table` 통째 **memcpy** + `source` 베이스만 새로 잡으면 복원 (Span=offset+len 이라 노드 내 텍스트 참조가 메모리 주소와 무관 → relocatable). rkyv 같은 무거운 직렬화 라이브러리 불필요.
- `[magic][version][checksum(wyhash)]` 헤더 — 버전 스큐/손상 시 `error` 반환.
- `declare_only_names` 직렬화 (transpile 의 type-only export 판정 입력) — 키를 string_table 에 귀속시켜 소유권 일원화.

## 안전 (rspack persistent cache 전략 참고)
디스크 캐시의 최대 위험은 stale 캐시 오용 → **silent miscompile**. 비대칭 원칙(false miss=느릴 뿐 안전 / false hit=사고)에 따라 **검증 실패는 항상 재파싱**:
- magic/version 불일치 → `error` (rspack 의 version-hash 디렉토리 격리와 동일 목적)
- checksum 불일치 → `error.ChecksumMismatch`
- 비배수 길이 / 정수 오버플로우 → `error.Truncated` (패닉 대신 — fail-safe 유지)

## /code-review max 반영 (6 findings)
| 결함 | 처리 |
|---|---|
| `declare_only_names` 누락 (HIGH, silent miscompile) | 직렬화 + 보존 테스트 |
| 비배수 → `@memcpy` 패닉 (HIGH) | 길이 검증 → `error.Truncated` |
| pragma/take 정수 오버플로우 (MED) | `std.math.add` checked |
| jsx_pragma offset path 미검증 (MED) | jsx 케이스 추가(실제 채워짐 assert) |
| endianness native (LOW) | 문서화 (magic 이 fail-safe) |
| Node relocatability | PASS 확인 (포인터/슬라이스 없음) |

## 테스트
round-trip 11 케이스 codegen byte-identical + fail-safe(magic/version/checksum/truncated) + declare/jsx_pragma 보존. Debug 21/21 · ReleaseFast 21/21 · parser 회귀 569/569.

## 범위
PR1 = **AST 만**. semantic(symbols/scopes/references) / import_records / graph 통합(`buildIncremental` 디스크 분기) / 무효화 키(버전·옵션·tsconfig·.env) / cache ON==OFF 동등성 CI 테스트는 후속 PR.

Part of #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)