### PR TITLE
feat(cache): semantic 직렬화 codec (relocatable 부분) — 디스크 캐시 #4438 PR2

### DIFF
--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -38,6 +38,7 @@ pub const mpsc_channel = @import("mpsc_channel.zig");
 pub const json_to_esm = @import("json_to_esm.zig");
 pub const plugin = @import("plugin.zig");
 pub const module_store = @import("module_store.zig");
+pub const semantic_codec = @import("semantic_codec.zig");
 pub const css_scanner = @import("css_scanner.zig");
 pub const css_emitter = @import("css_emitter.zig");
 pub const symbol = @import("symbol.zig");
@@ -126,6 +127,7 @@ test {
 
     // test files
     _ = @import("bundler_test.zig");
+    _ = @import("semantic_codec_test.zig");
     _ = @import("tree_shaker_test.zig");
     _ = @import("linker_test.zig");
     _ = @import("emitter_test.zig");

--- a/src/bundler/semantic_codec.zig
+++ b/src/bundler/semantic_codec.zig
@@ -1,0 +1,179 @@
+//! semantic 직렬화 codec — 디스크 캐시(#4438) PR2.
+//!
+//! `ModuleSemanticData` 의 **relocatable 부분만** 직렬화한다 (사용자 결정: 점진 PR).
+//! - `scopes` / `symbol_ids` / `references`: 전부 인덱스·스칼라라 통째 memcpy.
+//! - `symbols`(ArrayList): Symbol 도 대부분 인덱스/Span 이라 memcpy, 단 `synthetic_name`
+//!   (`[]const u8`, 합성 심볼만 non-empty)만 별도 — memcpy 후 ""로 리셋하고 사이드테이블에서
+//!   복원(arena dupe).
+//! - HashMap 5개(scope_maps/exported_names/unresolved_references/numeric_const_texts/
+//!   helper_scope_map)는 **PR3**. 여기선 빈 맵으로 복원.
+//!
+//! 소유권: `ModuleSemanticData` 는 deinit 이 없고 원본은 `parse_arena` 가 일괄 소유한다.
+//! deserialize 본은 parse_arena 가 없으므로 **caller 가 arena 를 주입** — 모든 배열·문자열을
+//! 그 arena 에 alloc 하고 `arena.deinit()` 가 일괄 해제(원본 모델과 동일).
+//!
+//! 안전: PR1 ast_codec 과 동일하게 `[MAGIC][VERSION][checksum]` 헤더 + 비배수/오버플로우
+//! 검증 → 실패는 항상 error(fail-safe). host endian/정렬 native(로컬 캐시 전제).
+
+const std = @import("std");
+const module = @import("module.zig");
+const ModuleSemanticData = module.ModuleSemanticData;
+const symbol_mod = @import("../semantic/symbol.zig");
+const Symbol = symbol_mod.Symbol;
+const Reference = symbol_mod.Reference;
+const Scope = @import("../semantic/scope.zig").Scope;
+const wyhash = @import("../util/wyhash.zig");
+
+pub const MAGIC: u32 = 0x5A53454D; // "ZSEM"
+pub const FORMAT_VERSION: u32 = 1;
+const HEADER_LEN: usize = 16;
+
+comptime {
+    // memcpy round-trip 안전성: Symbol 의 top-level 슬라이스/포인터 필드는 `synthetic_name`
+    // 하나만이어야 한다(deserialize 가 별도 복원). 새 슬라이스/포인터 필드가 추가되면 memcpy 가
+    // dangling 을 복사하므로, 여기서 컴파일 에러로 codec 복원 로직 추가를 강제한다.
+    for (@typeInfo(Symbol).@"struct".fields) |f| {
+        if (@typeInfo(f.type) == .pointer and !std.mem.eql(u8, f.name, "synthetic_name")) {
+            @compileError("Symbol." ++ f.name ++ ": semantic_codec 는 synthetic_name 외 슬라이스를 round-trip 처리하지 않는다 — codec 복원 로직 추가 필요.");
+        }
+    }
+}
+
+pub const Error = error{
+    BadMagic,
+    UnsupportedVersion,
+    ChecksumMismatch,
+    Truncated,
+} || std.mem.Allocator.Error;
+
+// ── serialize ───────────────────────────────────────────────────────────────
+
+fn putU32(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u32) !void {
+    try buf.appendSlice(alloc, std.mem.asBytes(&v));
+}
+fn putU64(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u64) !void {
+    try buf.appendSlice(alloc, std.mem.asBytes(&v));
+}
+fn putBytes(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, b: []const u8) !void {
+    try putU32(buf, alloc, @intCast(b.len));
+    try buf.appendSlice(alloc, b);
+}
+
+/// semantic 의 relocatable 부분을 `out` 에 직렬화 (append).
+pub fn serialize(sem: *const ModuleSemanticData, out: *std.ArrayList(u8), alloc: std.mem.Allocator) !void {
+    var payload: std.ArrayList(u8) = .empty;
+    defer payload.deinit(alloc);
+
+    try putBytes(&payload, alloc, std.mem.sliceAsBytes(sem.symbols.items));
+    try putBytes(&payload, alloc, std.mem.sliceAsBytes(sem.scopes));
+    try putBytes(&payload, alloc, std.mem.sliceAsBytes(sem.symbol_ids));
+    try putBytes(&payload, alloc, std.mem.sliceAsBytes(sem.references));
+
+    // synthetic_name 사이드 (non-empty symbol 의 index + text). memcpy 로 온 dangling ptr 를
+    // deserialize 가 ""로 리셋 후 여기서 복원.
+    var syn_count: u32 = 0;
+    for (sem.symbols.items) |s| {
+        if (s.synthetic_name.len > 0) syn_count += 1;
+    }
+    try putU32(&payload, alloc, syn_count);
+    for (sem.symbols.items, 0..) |s, i| {
+        if (s.synthetic_name.len > 0) {
+            try putU32(&payload, alloc, @intCast(i));
+            try putBytes(&payload, alloc, s.synthetic_name);
+        }
+    }
+
+    const checksum = wyhash.hashU64(payload.items);
+    try putU32(out, alloc, MAGIC);
+    try putU32(out, alloc, FORMAT_VERSION);
+    try putU64(out, alloc, checksum);
+    try out.appendSlice(alloc, payload.items);
+}
+
+// ── deserialize ──────────────────────────────────────────────────────────────
+
+const Reader = struct {
+    buf: []const u8,
+    pos: usize = 0,
+
+    fn take(self: *Reader, n: usize) Error![]const u8 {
+        const end = std.math.add(usize, self.pos, n) catch return error.Truncated;
+        if (end > self.buf.len) return error.Truncated;
+        const b = self.buf[self.pos..][0..n];
+        self.pos = end;
+        return b;
+    }
+    fn u32v(self: *Reader) Error!u32 {
+        return std.mem.bytesToValue(u32, (try self.take(4))[0..4]);
+    }
+    fn bytes(self: *Reader) Error![]const u8 {
+        const n = try self.u32v();
+        return self.take(n);
+    }
+};
+
+/// `arena` 에 모든 배열·문자열을 alloc 하여 ModuleSemanticData 복원. HashMap 5개는 빈 맵(PR3).
+/// caller 가 `arena.deinit()` 로 일괄 해제(원본 parse_arena 모델과 동일). 검증 실패는 error.
+///
+/// ⚠️ HashMap 5개(scope_maps/exported_names/unresolved_references/numeric_const_texts/
+/// helper_scope_map)가 빈 채로 복원되므로, 이 결과를 linker 의 cache-hit 경로에 연결하면
+/// import 미링크 / 글로벌 shadowing / 잘못된 export 판정으로 **silent miscompile** 한다.
+/// PR3(HashMap 복원) 전까지 파이프라인 연결 금지 — 현재는 codec 단위 테스트 전용.
+pub fn deserialize(data: []const u8, arena: std.mem.Allocator) Error!ModuleSemanticData {
+    if (data.len < HEADER_LEN) return error.Truncated;
+    if (std.mem.bytesToValue(u32, data[0..4]) != MAGIC) return error.BadMagic;
+    if (std.mem.bytesToValue(u32, data[4..8]) != FORMAT_VERSION) return error.UnsupportedVersion;
+    const checksum = std.mem.bytesToValue(u64, data[8..16]);
+    const payload = data[HEADER_LEN..];
+    if (wyhash.hashU64(payload) != checksum) return error.ChecksumMismatch;
+
+    var r = Reader{ .buf = payload };
+
+    const symbols_bytes = try r.bytes();
+    const scopes_bytes = try r.bytes();
+    const symbol_ids_bytes = try r.bytes();
+    const references_bytes = try r.bytes();
+
+    // 비배수 길이는 @memcpy 패닉 → fail-safe 위반. error 로 거른다.
+    if (symbols_bytes.len % @sizeOf(Symbol) != 0) return error.Truncated;
+    if (scopes_bytes.len % @sizeOf(Scope) != 0) return error.Truncated;
+    if (symbol_ids_bytes.len % @sizeOf(?u32) != 0) return error.Truncated;
+    if (references_bytes.len % @sizeOf(Reference) != 0) return error.Truncated;
+
+    const symbols_slice = try arena.alloc(Symbol, symbols_bytes.len / @sizeOf(Symbol));
+    @memcpy(std.mem.sliceAsBytes(symbols_slice), symbols_bytes);
+
+    const scopes = try arena.alloc(Scope, scopes_bytes.len / @sizeOf(Scope));
+    @memcpy(std.mem.sliceAsBytes(scopes), scopes_bytes);
+
+    const symbol_ids = try arena.alloc(?u32, symbol_ids_bytes.len / @sizeOf(?u32));
+    @memcpy(std.mem.sliceAsBytes(symbol_ids), symbol_ids_bytes);
+
+    const references = try arena.alloc(Reference, references_bytes.len / @sizeOf(Reference));
+    @memcpy(std.mem.sliceAsBytes(references), references_bytes);
+
+    // synthetic_name: symbols memcpy 는 원본 arena 를 가리키는 dangling slice ptr 를 그대로
+    // 복사하므로, 전부 ""(len 0, ptr 무관)로 리셋한 뒤 사이드테이블에서 복원(arena dupe). 이
+    // 리셋을 제거하면 UAF — 위 comptime 가드가 synthetic_name 이 유일한 슬라이스임을 보장한다.
+    for (symbols_slice) |*s| s.synthetic_name = "";
+    const syn_count = try r.u32v();
+    var k: u32 = 0;
+    while (k < syn_count) : (k += 1) {
+        const idx = try r.u32v();
+        const text = try r.bytes();
+        if (idx >= symbols_slice.len) return error.Truncated;
+        symbols_slice[idx].synthetic_name = try arena.dupe(u8, text);
+    }
+
+    return .{
+        .symbols = .{ .items = symbols_slice, .capacity = symbols_slice.len },
+        .scopes = scopes,
+        .scope_maps = &.{}, // PR3
+        .exported_names = .empty, // PR3
+        .symbol_ids = symbol_ids,
+        .unresolved_references = .empty, // PR3
+        .references = references,
+        .numeric_const_texts = .empty, // PR3
+        .helper_scope_map = .empty, // PR3
+    };
+}

--- a/src/bundler/semantic_codec_test.zig
+++ b/src/bundler/semantic_codec_test.zig
@@ -1,0 +1,149 @@
+// semantic_codec_test.zig — #4438 PR2 semantic 직렬화 round-trip + fail-safe.
+
+const std = @import("std");
+const testing = std.testing;
+const codec = @import("semantic_codec.zig");
+const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
+const Symbol = @import("../semantic/symbol.zig").Symbol;
+const Scope = @import("../semantic/scope.zig").Scope;
+const Reference = @import("../semantic/symbol.zig").Reference;
+const Scanner = @import("../lexer/scanner.zig").Scanner;
+const Parser = @import("../parser/parser.zig").Parser;
+const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
+
+test "semantic_codec: analyzer round-trip — relocatable 필드 보존" {
+    const alloc = testing.allocator;
+    const source = "const a = 1; function f(x) { let y = x + a; return y; } class C { m() {} } let z = f(2);";
+
+    var scanner = try Scanner.init(alloc, source);
+    defer scanner.deinit();
+    var parser = Parser.init(alloc, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+    var ana = SemanticAnalyzer.init(alloc, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    try testing.expect(ana.symbols.items.len > 0); // 비어있으면 검증 무의미
+
+    const sem = ModuleSemanticData{
+        .symbols = ana.symbols,
+        .scopes = ana.scopes.items,
+        .scope_maps = &.{},
+        .exported_names = .empty,
+        .symbol_ids = ana.symbol_ids.items,
+        .unresolved_references = .empty,
+        .references = ana.references.items,
+        .numeric_const_texts = .empty,
+        .helper_scope_map = .empty,
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try codec.serialize(&sem, &buf, alloc);
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const sem2 = try codec.deserialize(buf.items, arena.allocator());
+
+    try testing.expectEqual(sem.symbols.items.len, sem2.symbols.items.len);
+    try testing.expectEqual(sem.scopes.len, sem2.scopes.len);
+    try testing.expectEqual(sem.symbol_ids.len, sem2.symbol_ids.len);
+    try testing.expectEqual(sem.references.len, sem2.references.len);
+
+    // relocatable 슬라이스는 byte 동일
+    try testing.expectEqualSlices(Scope, sem.scopes, sem2.scopes);
+    try testing.expectEqualSlices(?u32, sem.symbol_ids, sem2.symbol_ids);
+    try testing.expectEqualSlices(Reference, sem.references, sem2.references);
+
+    // Symbol: synthetic_name(슬라이스)은 content 비교, 나머지는 memcpy 동일
+    for (sem.symbols.items, sem2.symbols.items) |s1, s2| {
+        try testing.expectEqual(s1.name, s2.name);
+        try testing.expectEqual(s1.scope_id, s2.scope_id);
+        try testing.expectEqual(s1.kind, s2.kind);
+        try testing.expectEqual(s1.declaration_span, s2.declaration_span);
+        try testing.expectEqualStrings(s1.synthetic_name, s2.synthetic_name);
+    }
+}
+
+test "semantic_codec: synthetic_name 보존 (합성 심볼)" {
+    const alloc = testing.allocator;
+
+    var symbols: std.ArrayList(Symbol) = .empty;
+    defer symbols.deinit(alloc);
+    try symbols.append(alloc, std.mem.zeroInit(Symbol, .{ .synthetic_name = @as([]const u8, "") }));
+    try symbols.append(alloc, std.mem.zeroInit(Symbol, .{ .synthetic_name = @as([]const u8, "__syn_helper") }));
+
+    const sem = ModuleSemanticData{
+        .symbols = symbols,
+        .scopes = &.{},
+        .scope_maps = &.{},
+        .exported_names = .empty,
+        .symbol_ids = &.{},
+        .unresolved_references = .empty,
+        .references = &.{},
+        .numeric_const_texts = .empty,
+        .helper_scope_map = .empty,
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try codec.serialize(&sem, &buf, alloc);
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const sem2 = try codec.deserialize(buf.items, arena.allocator());
+
+    try testing.expectEqual(@as(usize, 2), sem2.symbols.items.len);
+    try testing.expectEqualStrings("", sem2.symbols.items[0].synthetic_name);
+    try testing.expectEqualStrings("__syn_helper", sem2.symbols.items[1].synthetic_name);
+}
+
+test "semantic_codec: 변조/버전/매직/truncated 거부 (fail-safe)" {
+    const alloc = testing.allocator;
+
+    var symbols: std.ArrayList(Symbol) = .empty;
+    defer symbols.deinit(alloc);
+    try symbols.append(alloc, std.mem.zeroInit(Symbol, .{ .synthetic_name = @as([]const u8, "") }));
+
+    const sem = ModuleSemanticData{
+        .symbols = symbols,
+        .scopes = &.{},
+        .scope_maps = &.{},
+        .exported_names = .empty,
+        .symbol_ids = &.{},
+        .unresolved_references = .empty,
+        .references = &.{},
+        .numeric_const_texts = .empty,
+        .helper_scope_map = .empty,
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try codec.serialize(&sem, &buf, alloc);
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+
+    // 정상은 성공
+    _ = try codec.deserialize(buf.items, arena.allocator());
+
+    inline for (.{
+        .{ 0, @as(u8, 0xFF), error.BadMagic },
+        .{ 4, @as(u8, 0xEE), error.UnsupportedVersion },
+    }) |tc| {
+        const dup = try alloc.dupe(u8, buf.items);
+        defer alloc.free(dup);
+        dup[tc[0]] ^= tc[1];
+        try testing.expectError(tc[2], codec.deserialize(dup, arena.allocator()));
+    }
+    // checksum (payload 변조)
+    {
+        const dup = try alloc.dupe(u8, buf.items);
+        defer alloc.free(dup);
+        dup[dup.len - 1] ^= 0xFF;
+        try testing.expectError(error.ChecksumMismatch, codec.deserialize(dup, arena.allocator()));
+    }
+    // truncated
+    try testing.expectError(error.Truncated, codec.deserialize(buf.items[0..8], arena.allocator()));
+}


### PR DESCRIPTION
## 요약
디스크 캐시(#4438) **PR2 — semantic 직렬화 codec (relocatable 부분)**. PR1(#4439, AST codec) 후속.

## 무엇을
`src/bundler/semantic_codec.zig` — `serialize(sem)` / `deserialize(bytes, arena)`
- `ModuleSemanticData` 의 **relocatable 부분**: `scopes`/`symbol_ids`/`references`(인덱스·스칼라 통째 memcpy) + `symbols`(Symbol 의 `synthetic_name` 슬라이스만 사이드테이블 arena dupe).
- **소유권**: deserialize 는 arena 주입받아 alloc → `arena.deinit()` 일괄(원본 `parse_arena` 모델과 동일, `ModuleSemanticData` 는 deinit 없음).
- format header(magic `ZSEM`/version/checksum=wyhash) + 비배수/오버플로우 검증 → 실패는 error(fail-safe, PR1 패턴).

## 범위 / 안전
- **HashMap 5개**(scope_maps/exported_names/unresolved_references/numeric_const_texts/helper_scope_map)는 **PR3**. 이 PR 은 빈 맵으로 복원.
- ⚠️ HashMap 미복원이라 **PR3 전까지 linker cache-hit 경로 연결 금지** — 연결 시 import 미링크 / 글로벌 shadowing / 잘못된 export 판정으로 silent miscompile. `deserialize` 문서에 명시.
- **comptime 가드**: Symbol 에 `synthetic_name` 외 슬라이스/포인터 필드가 추가되면 컴파일 에러 → 미래 memcpy dangling(UAF) 예방.

## /code-review max 반영
| 결함 | 처리 |
|---|---|
| HashMap empty → linker miscompile (CRITICAL) | consumer 연결 경고 문서화 + PR3 선행 명시 |
| synthetic_name memcpy dangling 의존 (code smell) | comptime 가드(미래 슬라이스 강제 검토) + 리셋 의도 주석 |
| Scope/Reference/?u32 relocatability | PASS 확인(포인터/슬라이스 없음) |

## 테스트
analyzer round-trip(실측 semantic, `ana.symbols.len > 0` 검증) + synthetic_name 보존(합성 심볼) + fail-safe 4종. Debug 21/21 · ReleaseFast 21/21 · bundler 회귀 2357/2357 · analyzer 68/68.

Part of #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)