### PR TITLE
feat(cache): semantic HashMap 5개 직렬화 — 디스크 캐시 #4438 PR3

### DIFF
--- a/src/bundler/semantic_codec.zig
+++ b/src/bundler/semantic_codec.zig
@@ -6,7 +6,8 @@
 //!   (`[]const u8`, 합성 심볼만 non-empty)만 별도 — memcpy 후 ""로 리셋하고 사이드테이블에서
 //!   복원(arena dupe).
 //! - HashMap 5개(scope_maps/exported_names/unresolved_references/numeric_const_texts/
-//!   helper_scope_map)는 **PR3**. 여기선 빈 맵으로 복원.
+//!   helper_scope_map)는 **PR3**에서 복원한다. 키 문자열은 source/string_table(parse_arena)
+//!   슬라이스라 deserialize 가 주입 arena 에 dupe; 값은 심볼인덱스(usize→u32)/Span/void/텍스트.
 //!
 //! 소유권: `ModuleSemanticData` 는 deinit 이 없고 원본은 `parse_arena` 가 일괄 소유한다.
 //! deserialize 본은 parse_arena 가 없으므로 **caller 가 arena 를 주입** — 모든 배열·문자열을
@@ -22,6 +23,7 @@ const symbol_mod = @import("../semantic/symbol.zig");
 const Symbol = symbol_mod.Symbol;
 const Reference = symbol_mod.Reference;
 const Scope = @import("../semantic/scope.zig").Scope;
+const Span = @import("../lexer/token.zig").Span;
 const wyhash = @import("../util/wyhash.zig");
 
 pub const MAGIC: u32 = 0x5A53454D; // "ZSEM"
@@ -36,6 +38,21 @@ comptime {
         if (@typeInfo(f.type) == .pointer and !std.mem.eql(u8, f.name, "synthetic_name")) {
             @compileError("Symbol." ++ f.name ++ ": semantic_codec 는 synthetic_name 외 슬라이스를 round-trip 처리하지 않는다 — codec 복원 로직 추가 필요.");
         }
+    }
+    // Scope/Reference 는 사이드테이블 없이 통째로 memcpy 한다(synthetic_name 같은 예외 없음).
+    // 슬라이스/포인터 필드가 추가되면 dangling 을 복사 → UAF. 컴파일 에러로 복원 로직을 강제.
+    for (.{ Scope, Reference }) |T| {
+        for (@typeInfo(T).@"struct".fields) |f| {
+            if (@typeInfo(f.type) == .pointer) {
+                @compileError(@typeName(T) ++ "." ++ f.name ++ ": semantic_codec 는 통째 memcpy 한다 — 슬라이스/포인터는 round-trip 시 dangling. side-table 복원 로직 추가 필요.");
+            }
+        }
+    }
+    // serialize/deserialize 는 ModuleSemanticData 의 9개 필드를 손으로 열거한다. 필드가 추가되면
+    // 직렬화에서 silently 누락 → PR4 cache-hit 연결 시 그 필드만 default 로 stale miscompile.
+    // 필드 수를 못박아 새 필드 추가를 컴파일 에러로 만들어 codec 갱신을 강제한다.
+    if (@typeInfo(ModuleSemanticData).@"struct".fields.len != 9) {
+        @compileError("ModuleSemanticData 필드 수가 바뀜 — semantic_codec 의 serialize/deserialize 에 새 필드 직렬화 추가 후 이 가드를 갱신.");
     }
 }
 
@@ -57,6 +74,40 @@ fn putU64(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u64) !void {
 fn putBytes(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, b: []const u8) !void {
     try putU32(buf, alloc, @intCast(b.len));
     try buf.appendSlice(alloc, b);
+}
+
+// HashMap 직렬화 (PR3). 모두 `[count][entry…]`. 키 문자열은 putBytes 로 그대로 (deserialize
+// 가 arena dupe). 값 usize 는 심볼 인덱스(symbol_ids 와 동일하게 u32 범위)라 u32 로 고정 —
+// disk 크기 절감 + host arch 무관.
+fn putStrMapUsize(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, m: *const std.StringHashMapUnmanaged(usize)) !void {
+    try putU32(buf, alloc, m.count());
+    var it = m.iterator();
+    while (it.next()) |e| {
+        try putBytes(buf, alloc, e.key_ptr.*);
+        try putU32(buf, alloc, @intCast(e.value_ptr.*));
+    }
+}
+fn putStrMapSpan(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, m: *const std.StringHashMapUnmanaged(Span)) !void {
+    try putU32(buf, alloc, m.count());
+    var it = m.iterator();
+    while (it.next()) |e| {
+        try putBytes(buf, alloc, e.key_ptr.*);
+        try putU32(buf, alloc, e.value_ptr.start);
+        try putU32(buf, alloc, e.value_ptr.end);
+    }
+}
+fn putStrSet(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, m: *const std.StringHashMapUnmanaged(void)) !void {
+    try putU32(buf, alloc, m.count());
+    var it = m.keyIterator();
+    while (it.next()) |k| try putBytes(buf, alloc, k.*);
+}
+fn putNumTexts(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, m: *const std.AutoHashMapUnmanaged(u32, []const u8)) !void {
+    try putU32(buf, alloc, m.count());
+    var it = m.iterator();
+    while (it.next()) |e| {
+        try putU32(buf, alloc, e.key_ptr.*);
+        try putBytes(buf, alloc, e.value_ptr.*);
+    }
 }
 
 /// semantic 의 relocatable 부분을 `out` 에 직렬화 (append).
@@ -82,6 +133,14 @@ pub fn serialize(sem: *const ModuleSemanticData, out: *std.ArrayList(u8), alloc:
             try putBytes(&payload, alloc, s.synthetic_name);
         }
     }
+
+    // HashMap 5개 (PR3). scope_maps 는 scopes 와 동일 인덱스를 공유하는 맵 배열.
+    try putU32(&payload, alloc, @intCast(sem.scope_maps.len));
+    for (sem.scope_maps) |*m| try putStrMapUsize(&payload, alloc, m);
+    try putStrMapSpan(&payload, alloc, &sem.exported_names);
+    try putStrSet(&payload, alloc, &sem.unresolved_references);
+    try putNumTexts(&payload, alloc, &sem.numeric_const_texts);
+    try putStrMapUsize(&payload, alloc, &sem.helper_scope_map);
 
     const checksum = wyhash.hashU64(payload.items);
     try putU32(out, alloc, MAGIC);
@@ -112,13 +171,63 @@ const Reader = struct {
     }
 };
 
-/// `arena` 에 모든 배열·문자열을 alloc 하여 ModuleSemanticData 복원. HashMap 5개는 빈 맵(PR3).
-/// caller 가 `arena.deinit()` 로 일괄 해제(원본 parse_arena 모델과 동일). 검증 실패는 error.
+// HashMap 역직렬화 (PR3). checksum 통과 후 호출되므로 count 는 신뢰 가능 → ensureTotalCapacity
+// 후 putAssumeCapacity. 키는 payload 슬라이스를 arena 에 dupe(arena.deinit 이 일괄 해제).
+fn readStrMapUsize(r: *Reader, arena: std.mem.Allocator) Error!std.StringHashMapUnmanaged(usize) {
+    var m: std.StringHashMapUnmanaged(usize) = .empty;
+    const n = try r.u32v();
+    try m.ensureTotalCapacity(arena, n);
+    var i: u32 = 0;
+    while (i < n) : (i += 1) {
+        const key = try arena.dupe(u8, try r.bytes());
+        m.putAssumeCapacity(key, @intCast(try r.u32v()));
+    }
+    return m;
+}
+fn readStrMapSpan(r: *Reader, arena: std.mem.Allocator) Error!std.StringHashMapUnmanaged(Span) {
+    var m: std.StringHashMapUnmanaged(Span) = .empty;
+    const n = try r.u32v();
+    try m.ensureTotalCapacity(arena, n);
+    var i: u32 = 0;
+    while (i < n) : (i += 1) {
+        const key = try arena.dupe(u8, try r.bytes());
+        const start = try r.u32v();
+        const end = try r.u32v();
+        m.putAssumeCapacity(key, .{ .start = start, .end = end });
+    }
+    return m;
+}
+fn readStrSet(r: *Reader, arena: std.mem.Allocator) Error!std.StringHashMapUnmanaged(void) {
+    var m: std.StringHashMapUnmanaged(void) = .empty;
+    const n = try r.u32v();
+    try m.ensureTotalCapacity(arena, n);
+    var i: u32 = 0;
+    while (i < n) : (i += 1) {
+        const key = try arena.dupe(u8, try r.bytes());
+        m.putAssumeCapacity(key, {});
+    }
+    return m;
+}
+fn readNumTexts(r: *Reader, arena: std.mem.Allocator) Error!std.AutoHashMapUnmanaged(u32, []const u8) {
+    var m: std.AutoHashMapUnmanaged(u32, []const u8) = .empty;
+    const n = try r.u32v();
+    try m.ensureTotalCapacity(arena, n);
+    var i: u32 = 0;
+    while (i < n) : (i += 1) {
+        const key = try r.u32v();
+        const text = try arena.dupe(u8, try r.bytes());
+        m.putAssumeCapacity(key, text);
+    }
+    return m;
+}
+
+/// `arena` 에 모든 배열·문자열·HashMap 을 alloc 하여 ModuleSemanticData 전체를 복원(PR3 로
+/// HashMap 5개 포함). caller 가 `arena.deinit()` 로 일괄 해제(원본 parse_arena 모델과 동일).
+/// 검증 실패는 항상 error(fail-safe 재파싱).
 ///
-/// ⚠️ HashMap 5개(scope_maps/exported_names/unresolved_references/numeric_const_texts/
-/// helper_scope_map)가 빈 채로 복원되므로, 이 결과를 linker 의 cache-hit 경로에 연결하면
-/// import 미링크 / 글로벌 shadowing / 잘못된 export 판정으로 **silent miscompile** 한다.
-/// PR3(HashMap 복원) 전까지 파이프라인 연결 금지 — 현재는 codec 단위 테스트 전용.
+/// ⚠️ codec 자체는 완전하나 graph 통합(buildIncremental 의 디스크 cache-hit 분기)은 **PR4**
+/// 에서 한다 — 무효화 키(버전·옵션·tsconfig·.env) 정합성이 PR5 전까지 미비하므로 그 전에
+/// 파이프라인에 연결하면 stale 캐시로 잘못된 결과가 나온다. 현재는 codec 단위 테스트 전용.
 pub fn deserialize(data: []const u8, arena: std.mem.Allocator) Error!ModuleSemanticData {
     if (data.len < HEADER_LEN) return error.Truncated;
     if (std.mem.bytesToValue(u32, data[0..4]) != MAGIC) return error.BadMagic;
@@ -165,15 +274,24 @@ pub fn deserialize(data: []const u8, arena: std.mem.Allocator) Error!ModuleSeman
         symbols_slice[idx].synthetic_name = try arena.dupe(u8, text);
     }
 
+    // HashMap 5개 (PR3). scope_maps 는 맵 배열 — 길이만큼 alloc 후 각 맵 복원.
+    const scope_maps_len = try r.u32v();
+    const scope_maps = try arena.alloc(std.StringHashMapUnmanaged(usize), scope_maps_len);
+    for (scope_maps) |*m| m.* = try readStrMapUsize(&r, arena);
+    const exported_names = try readStrMapSpan(&r, arena);
+    const unresolved_references = try readStrSet(&r, arena);
+    const numeric_const_texts = try readNumTexts(&r, arena);
+    const helper_scope_map = try readStrMapUsize(&r, arena);
+
     return .{
         .symbols = .{ .items = symbols_slice, .capacity = symbols_slice.len },
         .scopes = scopes,
-        .scope_maps = &.{}, // PR3
-        .exported_names = .empty, // PR3
+        .scope_maps = scope_maps,
+        .exported_names = exported_names,
         .symbol_ids = symbol_ids,
-        .unresolved_references = .empty, // PR3
+        .unresolved_references = unresolved_references,
         .references = references,
-        .numeric_const_texts = .empty, // PR3
-        .helper_scope_map = .empty, // PR3
+        .numeric_const_texts = numeric_const_texts,
+        .helper_scope_map = helper_scope_map,
     };
 }

--- a/src/bundler/semantic_codec_test.zig
+++ b/src/bundler/semantic_codec_test.zig
@@ -7,6 +7,7 @@ const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 const Scope = @import("../semantic/scope.zig").Scope;
 const Reference = @import("../semantic/symbol.zig").Reference;
+const Span = @import("../lexer/token.zig").Span;
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
 const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
@@ -26,16 +27,18 @@ test "semantic_codec: analyzer round-trip — relocatable 필드 보존" {
 
     try testing.expect(ana.symbols.items.len > 0); // 비어있으면 검증 무의미
 
+    try testing.expect(ana.scope_maps.items.len > 0); // 맵 round-trip 검증 의미 보장
+
     const sem = ModuleSemanticData{
         .symbols = ana.symbols,
         .scopes = ana.scopes.items,
-        .scope_maps = &.{},
-        .exported_names = .empty,
+        .scope_maps = ana.scope_maps.items,
+        .exported_names = ana.exported_names,
         .symbol_ids = ana.symbol_ids.items,
-        .unresolved_references = .empty,
+        .unresolved_references = ana.unresolved_references,
         .references = ana.references.items,
-        .numeric_const_texts = .empty,
-        .helper_scope_map = .empty,
+        .numeric_const_texts = ana.numeric_const_texts,
+        .helper_scope_map = ana.helper_scope_map,
     };
 
     var buf: std.ArrayList(u8) = .empty;
@@ -64,6 +67,18 @@ test "semantic_codec: analyzer round-trip — relocatable 필드 보존" {
         try testing.expectEqual(s1.declaration_span, s2.declaration_span);
         try testing.expectEqualStrings(s1.synthetic_name, s2.synthetic_name);
     }
+
+    // scope_maps: 실 analyzer 출력 — 맵 개수 + 각 키→심볼인덱스 동일
+    try testing.expectEqual(sem.scope_maps.len, sem2.scope_maps.len);
+    for (sem.scope_maps, sem2.scope_maps) |*m1, *m2| {
+        try testing.expectEqual(m1.count(), m2.count());
+        var it = m1.iterator();
+        while (it.next()) |e| {
+            try testing.expectEqual(e.value_ptr.*, m2.get(e.key_ptr.*).?);
+        }
+    }
+    try testing.expectEqual(sem.unresolved_references.count(), sem2.unresolved_references.count());
+    try testing.expectEqual(sem.numeric_const_texts.count(), sem2.numeric_const_texts.count());
 }
 
 test "semantic_codec: synthetic_name 보존 (합성 심볼)" {
@@ -97,6 +112,75 @@ test "semantic_codec: synthetic_name 보존 (합성 심볼)" {
     try testing.expectEqual(@as(usize, 2), sem2.symbols.items.len);
     try testing.expectEqualStrings("", sem2.symbols.items[0].synthetic_name);
     try testing.expectEqualStrings("__syn_helper", sem2.symbols.items[1].synthetic_name);
+}
+
+test "semantic_codec: HashMap 5개 round-trip (값 타입별)" {
+    const alloc = testing.allocator;
+
+    // scope_maps: 2개 스코프(StringHashMap usize). 빈 맵도 1개 섞어 경계 확인.
+    var sm0: std.StringHashMapUnmanaged(usize) = .empty;
+    var sm1: std.StringHashMapUnmanaged(usize) = .empty;
+    defer sm0.deinit(alloc);
+    defer sm1.deinit(alloc);
+    try sm0.put(alloc, "a", 0);
+    try sm0.put(alloc, "f", 1);
+    try sm1.put(alloc, "x", 2);
+    var scope_maps = [_]std.StringHashMapUnmanaged(usize){ sm0, sm1, .empty };
+
+    var exported: std.StringHashMapUnmanaged(Span) = .empty;
+    defer exported.deinit(alloc);
+    try exported.put(alloc, "f", .{ .start = 9, .end = 10 });
+
+    var unres: std.StringHashMapUnmanaged(void) = .empty;
+    defer unres.deinit(alloc);
+    try unres.put(alloc, "globalThis", {});
+
+    var nums: std.AutoHashMapUnmanaged(u32, []const u8) = .empty;
+    defer nums.deinit(alloc);
+    try nums.put(alloc, 0, "1");
+    try nums.put(alloc, 2, "42");
+
+    var helper: std.StringHashMapUnmanaged(usize) = .empty;
+    defer helper.deinit(alloc);
+    try helper.put(alloc, "_jsx", 3);
+
+    const sem = ModuleSemanticData{
+        .symbols = .empty,
+        .scopes = &.{},
+        .scope_maps = &scope_maps,
+        .exported_names = exported,
+        .symbol_ids = &.{},
+        .unresolved_references = unres,
+        .references = &.{},
+        .numeric_const_texts = nums,
+        .helper_scope_map = helper,
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+    try codec.serialize(&sem, &buf, alloc);
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const sem2 = try codec.deserialize(buf.items, arena.allocator());
+
+    try testing.expectEqual(@as(usize, 3), sem2.scope_maps.len);
+    try testing.expectEqual(@as(?usize, 0), sem2.scope_maps[0].get("a"));
+    try testing.expectEqual(@as(?usize, 1), sem2.scope_maps[0].get("f"));
+    try testing.expectEqual(@as(?usize, 2), sem2.scope_maps[1].get("x"));
+    try testing.expectEqual(@as(u32, 0), sem2.scope_maps[2].count());
+
+    const exp = sem2.exported_names.get("f").?;
+    try testing.expectEqual(@as(u32, 9), exp.start);
+    try testing.expectEqual(@as(u32, 10), exp.end);
+
+    try testing.expect(sem2.unresolved_references.contains("globalThis"));
+    try testing.expectEqual(@as(u32, 1), sem2.unresolved_references.count());
+
+    try testing.expectEqualStrings("1", sem2.numeric_const_texts.get(0).?);
+    try testing.expectEqualStrings("42", sem2.numeric_const_texts.get(2).?);
+
+    try testing.expectEqual(@as(?usize, 3), sem2.helper_scope_map.get("_jsx"));
 }
 
 test "semantic_codec: 변조/버전/매직/truncated 거부 (fail-safe)" {


### PR DESCRIPTION
## 요약

`#4438` cold-build 디스크 캐시 epic 의 **PR3**. PR2 가 `ModuleSemanticData` 의 relocatable 부분(symbols/scopes/symbol_ids/references)만 직렬화했는데, 이번 PR 에서 나머지 **HashMap 5개**를 추가해 semantic 전체를 round-trip 가능하게 한다.

## 변경 내용

`src/bundler/semantic_codec.zig`:

| 필드 | 타입 | 직렬화 |
|---|---|---|
| `scope_maps` | `[]StringHashMap(usize)` | 맵 배열 — 길이 + 각 맵 `[count][key,val…]` |
| `exported_names` | `StringHashMap(Span)` | key + `Span(start,end)` 2×u32 |
| `unresolved_references` | `StringHashMap(void)` | key 만 (set) |
| `numeric_const_texts` | `AutoHashMap(u32, []const u8)` | u32 key + 텍스트 |
| `helper_scope_map` | `StringHashMap(usize)` | key + 심볼인덱스 |

- **키 소유권**: 키 문자열은 `source`/`string_table`(parse_arena) 슬라이스라, deserialize 가 주입 arena 에 `dupe` → `arena.deinit()` 가 일괄 해제(원본 parse_arena 소유권 모델과 동일). 소비자는 전부 string-equality 조회라 fresh 복사본이어도 안전.
- **값 폭**: `usize` 값(scope_maps/helper_scope_map)은 심볼 인덱스라 **u32 로 고정** — `symbol_ids: []const ?u32` 와 동일 폭, disk 크기 절감 + host arch 무관.
- checksum 통과 후 count 는 신뢰 가능 → `ensureTotalCapacity` + `putAssumeCapacity` (맵당 1회 alloc).

## `/code-review max` 반영 (구조 가드)

- **`ModuleSemanticData` 필드 수(9) comptime 가드**: serialize/deserialize 가 9개 필드를 손으로 열거하므로, 새 필드가 추가되면 직렬화에서 silently 누락된다. 필드 수를 못박아 컴파일 에러로 codec 갱신을 강제 — PR4 에서 cache-hit 을 연결할 때 그 필드만 default 로 채워지는 stale miscompile 을 예방.
- **Symbol 가드를 Scope/Reference 로 확장**: 이 둘은 사이드테이블 없이 통째 memcpy 되므로, 슬라이스/포인터 필드가 추가되면 dangling UAF. 컴파일 에러로 차단.

## 테스트

`zig build test -Dtest-filter=semantic_codec` (Debug + ReleaseFast 모두 통과):
- analyzer 실출력 round-trip — scope_maps 맵 개수 + 각 키→심볼인덱스 동일 검증 추가
- HashMap 5개 값 타입별 round-trip(빈 맵 경계 포함) 전용 테스트 추가
- 기존 fail-safe(매직/버전/checksum/truncated) 유지

## 다음 단계

- **PR4**: graph 통합 — `buildIncremental` 의 디스크 cache-hit 분기. **이때 비로소** 파이프라인에 연결(PR3 선행 필수).
- **PR5**: 무효화 키(버전·옵션·tsconfig·.env) + cache ON==OFF byte-identical 동등성 테스트.

⚠️ codec 자체는 완전하나 무효화 정합성이 PR5 전까지 미비하므로 그 전에 파이프라인 연결 금지 — 현재는 codec 단위 테스트 전용.

Part of #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)