### PR TITLE
refactor(cache): codec IO 원시함수 공유 util 추출 #4438

### DIFF
--- a/src/bundler/module_codec.zig
+++ b/src/bundler/module_codec.zig
@@ -34,6 +34,7 @@ const ast_codec = @import("../parser/ast_codec.zig");
 const semantic_codec = @import("semantic_codec.zig");
 const Ast = @import("../parser/ast.zig").Ast;
 const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
+const codec_io = @import("../util/codec_io.zig");
 
 pub const MAGIC: u32 = 0x5A4D4F44; // "ZMOD"
 pub const FORMAT_VERSION: u32 = 1;
@@ -67,9 +68,8 @@ comptime {
 
 // ── serialize ───────────────────────────────────────────────────────────────
 
-fn putU32(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u32) !void {
-    try buf.appendSlice(alloc, std.mem.asBytes(&v));
-}
+// IO 원시함수/Reader 는 공유 `util/codec_io.zig` 사용(하위 codec 들과 동일 1벌).
+const putU32 = codec_io.putU32;
 
 /// `out.items[at..][0..4]` 에 u32 를 덮어쓴다(길이 prefix backpatch).
 fn patchU32(out: *std.ArrayList(u8), at: usize, v: u32) void {
@@ -109,26 +109,7 @@ pub fn serialize(
 
 // ── deserialize ──────────────────────────────────────────────────────────────
 
-const Reader = struct {
-    buf: []const u8,
-    pos: usize = 0,
-
-    fn take(self: *Reader, n: usize) Error![]const u8 {
-        // checked add — 손상된 length-prefix 가 pos+n 을 오버플로우시켜 경계검사를 우회하는 것 방지.
-        const end = std.math.add(usize, self.pos, n) catch return error.Truncated;
-        if (end > self.buf.len) return error.Truncated;
-        const b = self.buf[self.pos..][0..n];
-        self.pos = end;
-        return b;
-    }
-    fn u32v(self: *Reader) Error!u32 {
-        return std.mem.bytesToValue(u32, (try self.take(4))[0..4]);
-    }
-    fn block(self: *Reader) Error![]const u8 {
-        const n = try self.u32v();
-        return self.take(n);
-    }
-};
+const Reader = codec_io.Reader;
 
 /// flat bytes → source+AST+semantic. magic/version 검증 후 두 하위 블록을 같은 `arena` 에
 /// 복원한다(소유권 단일화 — 위 doc 참조). 검증/손상 실패는 항상 error 이며, 부분 복원분은
@@ -146,8 +127,8 @@ pub fn deserialize(data: []const u8, arena: std.mem.Allocator) Error!Deserialize
     if (std.mem.bytesToValue(u32, data[4..8]) != FORMAT_VERSION) return error.UnsupportedVersion;
 
     var r = Reader{ .buf = data[HEADER_LEN..] };
-    const ast_block = try r.block();
-    const sem_block = try r.block();
+    const ast_block = try r.bytes();
+    const sem_block = try r.bytes();
 
     // 같은 arena 주입 → ast(source 포함)+semantic 이 한 소유권. 하위 codec 의 errdefer/free 는
     // arena 에서 no-op 이고, ast 가 성공한 뒤 semantic 이 실패해도 caller 의 arena.deinit 이 회수.

--- a/src/bundler/semantic_codec.zig
+++ b/src/bundler/semantic_codec.zig
@@ -25,6 +25,7 @@ const Reference = symbol_mod.Reference;
 const Scope = @import("../semantic/scope.zig").Scope;
 const Span = @import("../lexer/token.zig").Span;
 const wyhash = @import("../util/wyhash.zig");
+const codec_io = @import("../util/codec_io.zig");
 
 pub const MAGIC: u32 = 0x5A53454D; // "ZSEM"
 pub const FORMAT_VERSION: u32 = 1;
@@ -65,16 +66,10 @@ pub const Error = error{
 
 // ── serialize ───────────────────────────────────────────────────────────────
 
-fn putU32(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u32) !void {
-    try buf.appendSlice(alloc, std.mem.asBytes(&v));
-}
-fn putU64(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u64) !void {
-    try buf.appendSlice(alloc, std.mem.asBytes(&v));
-}
-fn putBytes(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, b: []const u8) !void {
-    try putU32(buf, alloc, @intCast(b.len));
-    try buf.appendSlice(alloc, b);
-}
+// IO 원시함수/Reader 는 공유 `util/codec_io.zig` 사용(ast_codec/module_codec 와 동일 1벌).
+const putU32 = codec_io.putU32;
+const putU64 = codec_io.putU64;
+const putBytes = codec_io.putBytes;
 
 // HashMap 직렬화 (PR3). 모두 `[count][entry…]`. 키 문자열은 putBytes 로 그대로 (deserialize
 // 가 arena dupe). 값 usize 는 심볼 인덱스(symbol_ids 와 동일하게 u32 범위)라 u32 로 고정 —
@@ -151,25 +146,7 @@ pub fn serialize(sem: *const ModuleSemanticData, out: *std.ArrayList(u8), alloc:
 
 // ── deserialize ──────────────────────────────────────────────────────────────
 
-const Reader = struct {
-    buf: []const u8,
-    pos: usize = 0,
-
-    fn take(self: *Reader, n: usize) Error![]const u8 {
-        const end = std.math.add(usize, self.pos, n) catch return error.Truncated;
-        if (end > self.buf.len) return error.Truncated;
-        const b = self.buf[self.pos..][0..n];
-        self.pos = end;
-        return b;
-    }
-    fn u32v(self: *Reader) Error!u32 {
-        return std.mem.bytesToValue(u32, (try self.take(4))[0..4]);
-    }
-    fn bytes(self: *Reader) Error![]const u8 {
-        const n = try self.u32v();
-        return self.take(n);
-    }
-};
+const Reader = codec_io.Reader;
 
 // HashMap 역직렬화 (PR3). checksum 통과 후 호출되므로 count 는 신뢰 가능 → ensureTotalCapacity
 // 후 putAssumeCapacity. 키는 payload 슬라이스를 arena 에 dupe(arena.deinit 이 일괄 해제).

--- a/src/parser/ast_codec.zig
+++ b/src/parser/ast_codec.zig
@@ -23,6 +23,7 @@ const Ast = ast_mod.Ast;
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const wyhash = @import("../util/wyhash.zig");
+const codec_io = @import("../util/codec_io.zig");
 
 pub const MAGIC: u32 = 0x5A4E5443; // "ZNTC"
 pub const FORMAT_VERSION: u32 = 1;
@@ -41,17 +42,11 @@ pub const Error = error{
 
 // ── serialize ───────────────────────────────────────────────────────────────
 
-fn putU32(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u32) !void {
-    try buf.appendSlice(alloc, std.mem.asBytes(&v));
-}
-fn putU64(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u64) !void {
-    try buf.appendSlice(alloc, std.mem.asBytes(&v));
-}
-/// length-prefixed 바이트열.
-fn putBytes(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, b: []const u8) !void {
-    try putU32(buf, alloc, @intCast(b.len));
-    try buf.appendSlice(alloc, b);
-}
+// IO 원시함수/Reader 는 공유 `util/codec_io.zig` 사용(semantic_codec/module_codec 와 동일 1벌).
+const putU32 = codec_io.putU32;
+const putU64 = codec_io.putU64;
+const putBytes = codec_io.putBytes;
+
 /// jsx_pragma 등 source-backed optional slice → (offset, len). null 이면 offset=NULL_OFFSET.
 fn putPragma(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, ast: *const Ast, p: ?[]const u8) !void {
     if (p) |s| {
@@ -109,37 +104,18 @@ pub fn serialize(ast: *const Ast, out: *std.ArrayList(u8), alloc: std.mem.Alloca
 
 // ── deserialize ──────────────────────────────────────────────────────────────
 
-const Reader = struct {
-    buf: []const u8,
-    pos: usize = 0,
+const Reader = codec_io.Reader;
 
-    fn take(self: *Reader, n: usize) Error![]const u8 {
-        // checked add — 손상된 length-prefix 가 pos+n 을 오버플로우시켜 경계검사를 우회하는 것 방지.
-        const end = std.math.add(usize, self.pos, n) catch return error.Truncated;
-        if (end > self.buf.len) return error.Truncated;
-        const b = self.buf[self.pos..][0..n];
-        self.pos = end;
-        return b;
-    }
-    fn u32v(self: *Reader) Error!u32 {
-        return std.mem.bytesToValue(u32, (try self.take(4))[0..4]);
-    }
-    fn bytes(self: *Reader) Error![]const u8 {
-        const n = try self.u32v();
-        return self.take(n);
-    }
-    fn byte(self: *Reader) Error!u8 {
-        return (try self.take(1))[0];
-    }
-    fn pragma(self: *Reader, source: []const u8) Error!?[]const u8 {
-        const off = try self.u32v();
-        const len = try self.u32v();
-        if (off == NULL_OFFSET) return null;
-        const end = std.math.add(u32, off, len) catch return error.Truncated;
-        if (end > source.len) return error.Truncated;
-        return source[off..][0..len];
-    }
-};
+/// jsx_pragma 복원: `(offset, len)` → source-backed slice. off==NULL_OFFSET 이면 null.
+/// ast-specific(source 베이스 의존)이라 codec_io.Reader 가 아닌 ast_codec 의 free 헬퍼.
+fn readPragma(r: *Reader, source: []const u8) Error!?[]const u8 {
+    const off = try r.u32v();
+    const len = try r.u32v();
+    if (off == NULL_OFFSET) return null;
+    const end = std.math.add(u32, off, len) catch return error.Truncated;
+    if (end > source.len) return error.Truncated;
+    return source[off..][0..len];
+}
 
 /// flat bytes → 새 Ast. magic/version/checksum 검증 후 복원. 검증 실패는 error(재파싱 fallback).
 /// 반환된 `ast.source` 는 새로 dupe 된 메모리이며 `Ast.deinit` 가 해제하지 않으므로,
@@ -209,10 +185,10 @@ pub fn deserialize(data: []const u8, alloc: std.mem.Allocator) Error!Ast {
     ast.has_ts_export_equals = (try r.byte()) != 0;
     ast.has_flow_enum_declaration = (try r.byte()) != 0;
 
-    ast.jsx_pragma_factory = try r.pragma(source);
-    ast.jsx_pragma_fragment = try r.pragma(source);
-    ast.jsx_pragma_runtime = try r.pragma(source);
-    ast.jsx_pragma_import_source = try r.pragma(source);
+    ast.jsx_pragma_factory = try readPragma(&r, source);
+    ast.jsx_pragma_fragment = try readPragma(&r, source);
+    ast.jsx_pragma_runtime = try readPragma(&r, source);
+    ast.jsx_pragma_import_source = try readPragma(&r, source);
 
     const tb = try r.u32v();
     ast.transform_boundary = if (tb == NULL_OFFSET) null else tb;

--- a/src/root.zig
+++ b/src/root.zig
@@ -50,6 +50,7 @@ test {
     _ = @import("test_arena.zig");
     _ = @import("env_flag.zig");
     _ = util.wyhash;
+    _ = util.codec_io;
 
     // diagnostic system
     _ = ansi_mod;

--- a/src/util/codec_io.zig
+++ b/src/util/codec_io.zig
@@ -1,0 +1,97 @@
+//! codec IO 원시함수 — 디스크 캐시(#4438) codec 들의 공유 직렬화/역직렬화 빌딩블록.
+//!
+//! `ast_codec`(PR1) / `semantic_codec`(PR2/PR3) / `module_codec`(PR4) 가 각자 들고 있던
+//! byte-identical 한 `putU32`/`putU64`/`putBytes` + bounds-checked `Reader` 를 한 곳으로 모은다.
+//! 특히 `Reader.take` 의 오버플로우-guard 는 손상된 length-prefix 에 대한 유일한 방어선이라
+//! 사본이 흩어지면 한쪽만 고쳐지는 drift 가 보안/정합성 구멍이 된다 — 단일 지점화.
+//!
+//! 모든 codec 은 host endian/정렬 native 전제(로컬 캐시). 검증 실패는 항상 error(fail-safe).
+
+const std = @import("std");
+
+/// `Reader` 가 낼 수 있는 유일한 error. 각 codec 의 Error 집합은 이 멤버를 포함하므로(전부
+/// `Truncated` 보유) `try` 로 자동 coercion 된다.
+pub const ReadError = error{Truncated};
+
+// ── write ────────────────────────────────────────────────────────────────────
+
+pub fn putU32(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u32) std.mem.Allocator.Error!void {
+    try buf.appendSlice(alloc, std.mem.asBytes(&v));
+}
+pub fn putU64(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, v: u64) std.mem.Allocator.Error!void {
+    try buf.appendSlice(alloc, std.mem.asBytes(&v));
+}
+/// length-prefixed 바이트열: `[len:u32][bytes]`.
+pub fn putBytes(buf: *std.ArrayList(u8), alloc: std.mem.Allocator, b: []const u8) std.mem.Allocator.Error!void {
+    try putU32(buf, alloc, @intCast(b.len));
+    try buf.appendSlice(alloc, b);
+}
+
+// ── read ─────────────────────────────────────────────────────────────────────
+
+pub const Reader = struct {
+    buf: []const u8,
+    pos: usize = 0,
+
+    pub fn take(self: *Reader, n: usize) ReadError![]const u8 {
+        // checked add — 손상된 length-prefix 가 pos+n 을 오버플로우시켜 경계검사를 우회하는 것 방지.
+        const end = std.math.add(usize, self.pos, n) catch return error.Truncated;
+        if (end > self.buf.len) return error.Truncated;
+        const b = self.buf[self.pos..][0..n];
+        self.pos = end;
+        return b;
+    }
+    pub fn u32v(self: *Reader) ReadError!u32 {
+        return std.mem.bytesToValue(u32, (try self.take(4))[0..4]);
+    }
+    /// `putBytes` 의 짝 — `[len:u32][bytes]` 를 읽어 슬라이스 반환(`buf` 를 가리킴, 복사 아님).
+    pub fn bytes(self: *Reader) ReadError![]const u8 {
+        const n = try self.u32v();
+        return self.take(n);
+    }
+    pub fn byte(self: *Reader) ReadError!u8 {
+        return (try self.take(1))[0];
+    }
+};
+
+// ── tests ──────────────────────────────────────────────────────────────────────
+
+test "codec_io: write/read round-trip" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(alloc);
+
+    try putU32(&buf, alloc, 0xDEADBEEF);
+    try putU64(&buf, alloc, 0x0123456789ABCDEF);
+    try putBytes(&buf, alloc, "hello");
+    try putBytes(&buf, alloc, ""); // 빈 슬라이스 경계
+
+    var r = Reader{ .buf = buf.items };
+    try testing.expectEqual(@as(u32, 0xDEADBEEF), try r.u32v());
+    // u64 는 codec 들의 checksum 처럼 take(8)+bytesToValue 로 읽는다(Reader 에 u64v 미제공).
+    try testing.expectEqual(@as(u64, 0x0123456789ABCDEF), std.mem.bytesToValue(u64, (try r.take(8))[0..8]));
+    try testing.expectEqualStrings("hello", try r.bytes());
+    try testing.expectEqualStrings("", try r.bytes());
+    try testing.expectError(error.Truncated, r.byte()); // 소진 후 추가 read
+}
+
+test "codec_io: take 경계/오버플로우 거부 (fail-safe)" {
+    const testing = std.testing;
+    // 짧은 버퍼: 길이 prefix 가 실제보다 큰 경우 → Truncated (OOB 슬라이스 금지).
+    {
+        var r = Reader{ .buf = &[_]u8{ 0xFF, 0xFF, 0xFF, 0xFF } }; // len=0xFFFFFFFF
+        try testing.expectError(error.Truncated, r.bytes());
+    }
+    // pos+n 오버플로우 직접 검증: pos 를 끝 근처로 두고 거대한 take.
+    {
+        var r = Reader{ .buf = &[_]u8{ 1, 2, 3 }, .pos = 2 };
+        try testing.expectError(error.Truncated, r.take(std.math.maxInt(usize)));
+        try testing.expectEqual(@as(usize, 2), r.pos); // 실패 시 pos 불변
+    }
+    // u32v/u64v 가 4/8 바이트 미만에서 Truncated.
+    {
+        var r = Reader{ .buf = &[_]u8{ 1, 2, 3 } };
+        try testing.expectError(error.Truncated, r.u32v());
+    }
+}

--- a/src/util/mod.zig
+++ b/src/util/mod.zig
@@ -1,6 +1,7 @@
 //! 공용 유틸리티 모음.
 
 pub const wyhash = @import("wyhash.zig");
+pub const codec_io = @import("codec_io.zig");
 pub const string_list = @import("string_list.zig");
 pub const spin_lock = @import("spin_lock.zig");
 pub const SpinLock = spin_lock.SpinLock;


### PR DESCRIPTION
## 요약

`#4438` 디스크 캐시 codec 시리즈(PR1~4)가 각자 들고 있던 **byte-identical 한 IO 원시함수**(`putU32`/`putU64`/`putBytes` + bounds-checked `Reader`)를 공유 `src/util/codec_io.zig` 한 곳으로 모으는 정리 PR입니다. PR4 리뷰에서 식별된 deferred 항목입니다.

## 동기

`Reader.take` 의 오버플로우 guard(`std.math.add(usize, pos, n) catch Truncated`)는 손상된 length-prefix가 경계검사를 우회하는 것을 막는 **유일한 방어선**입니다. 이게 ast_codec/semantic_codec/module_codec 3곳에 복제돼 있었고, 이미 semantic_codec 쪽 주석이 drift(설명 주석 누락)되기 시작했습니다. 한쪽만 고쳐지면 보안/정합성 구멍이 되므로 단일 지점화합니다.

## 변경

- **신규 `src/util/codec_io.zig`**: `ReadError = error{Truncated}`, `putU32`/`putU64`/`putBytes`, `Reader`(`take`/`u32v`/`bytes`/`byte`). 인라인 round-trip + 오버플로우 거부(pos 불변 검증 포함) 테스트. `util/mod.zig` 배선 + `root.zig` 테스트 수집(`_ = util.codec_io;`, wyhash 패턴 동일).
- **3개 codec**: `const putU32 = codec_io.putU32` 별칭 + `const Reader = codec_io.Reader` 로 **호출부 무변경**. codec 전용 헬퍼는 유지:
  - ast_codec: `putPragma`(직렬화)/`readPragma`(역직렬화) — source 베이스 offset 의존.
  - module_codec: `patchU32`/`appendBlock` — 결합 레이어 backpatch framing.
- **에러셋**: `Reader` 는 `error{Truncated}` 만 내고 각 codec 의 wider `Error` 가 이를 포함 → `try` 자동 coercion(컴파일 + 전체 테스트로 확인).

## `/code-review max` 반영

`Reader.u64v` 는 **caller 0**(3개 codec 모두 checksum 을 raw `bytesToValue(u64, data[8..16])` 로 직접 읽음 — semantic 은 PR3 에서 u64→u32 전환)이라 dead code → **제거**. 필요한 후속 PR 이 caller 와 함께 한 줄로 재추가. 헤더 파싱을 Reader 로 바꾸는 건 리팩터 범위를 넘으므로 제외.

## 검증

- 동작 보존: **전체 5981 테스트 통과** + Debug/ReleaseFast 모두 통과(byte-identical 보장).
- 리뷰 4개 앵글 중 3개 `[]`(동작 동일성/신규 모듈 정확성/크로스파일·테스트수집 모두 클린), 1건(u64v dead code) 반영 완료.

⚠️ 기능 변화 없음 — codec 들은 여전히 파이프라인 미연결(단위 테스트 전용). HMR/RN/빌드 출력에 영향 0(codec 은 graph/emitter 경로에서 참조되지 않음).

Part of #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)