### PR TITLE
feat(cache): 디스크 캐시 IO 레이어 (atomic write + 샤딩) #4438

### DIFF
--- a/src/bundler/disk_cache.zig
+++ b/src/bundler/disk_cache.zig
@@ -1,0 +1,90 @@
+//! 디스크 캐시 IO 레이어 — #4438. 캐시 키(u64) → 캐시 파일 atomic read/write.
+//!
+//! codec(module_codec)이 만든 바이트를 실제 디스크에 영속화하는 순수 IO 레이어다.
+//!
+//! ## 책임
+//! - **샤딩 경로**: key(u64)를 16-hex 로 찍어 git-objects 식 2-level 로 나눈다
+//!   (`<root>/<ab>/<cdef0123456789>`). 한 디렉토리에 파일이 폭증하는 것을 막는다(생태계 표준).
+//! - **atomic write**: 유니크 tmp 파일에 쓰고 `rename` 으로 교체한다. POSIX rename 은 원자적이라
+//!   reader 가 half-written 파일을 보지 못한다. tmp 이름에 프로세스 전역 단조 카운터(seq)를
+//!   박아 같은 프로세스 내 동시 쓰기끼리 충돌하지 않는다.
+//! - **fail-open get**: 캐시 읽기 실패(없음/권한/손상/크기초과)는 전부 cache miss(`null`)로
+//!   degrade 해 재파싱하게 한다 — 캐시는 no-cache 보다 빌드를 더 깨뜨리면 안 된다. 시스템 자원
+//!   고갈(`OutOfMemory`)만 전파한다.
+//!
+//! ## 비책임 (후속 PR)
+//! - **위치 정책**: 캐시 루트를 어디(`node_modules/.cache/zntc/` 등)에 둘지는 caller 가
+//!   `root` 로 주입한다 — graph 통합 PR 이 결정. 여기선 "주어진 root 에 읽고 쓴다"만.
+//! - **무효화 키**: key 가 옵션/tsconfig/.env/컴파일러버전을 반영하는지는 무효화 키 PR 의 몫.
+//! - graph cache-hit 경로 연결도 후속. 현재는 단위 테스트 전용.
+//!
+//! ## 안전
+//! 한 프로세스 내 동시 쓰기는 seq(전역 atomic)가 tmp 이름의 유일성을 보장한다. 멀티프로세스가
+//! 같은 key 를 동시에 쓰면 tmp 이름이 충돌할 수 있으나, ①같은 key = 같은 콘텐츠(무효화 키가
+//! 내용 기반)이고 ②rename 이 원자적이라 최종 파일은 항상 온전한 한 writer 의 것이며, ③설령 tmp
+//! 가 섞여 깨진 파일이 남아도 codec 의 magic/checksum 검증이 읽을 때 이를 걸러 fail-safe
+//! 재파싱한다 — silent miscompile 은 불가능하다.
+//!
+//! 한 DiskCache 인스턴스를 여러 스레드가 공유해 동시 호출하려면 thread-safe allocator 를
+//! 주입해야 한다(put/get 이 self.allocator 로 임시 경로 문자열을 할당).
+
+const std = @import("std");
+
+/// put 마다 1씩 증가하는 프로세스 전역 단조 카운터. 같은 프로세스 내 모든 put 의 tmp 이름을
+/// 유일하게 만든다(atomic fetchAdd 라 두 put 이 같은 값을 받지 않음).
+var put_seq = std.atomic.Value(u64).init(0);
+
+pub const DiskCache = struct {
+    allocator: std.mem.Allocator,
+    /// 캐시 루트 디렉토리(`Dir.cwd()` 기준 상대 또는 절대). init 에서 dupe 해 소유.
+    root: []const u8,
+
+    pub fn init(allocator: std.mem.Allocator, root_dir: []const u8) std.mem.Allocator.Error!DiskCache {
+        return .{ .allocator = allocator, .root = try allocator.dupe(u8, root_dir) };
+    }
+
+    pub fn deinit(self: *DiskCache) void {
+        self.allocator.free(self.root);
+    }
+
+    /// key → "<root>/<ab>/<cdef0123456789>" (2-level hex 샤딩). caller 가 free.
+    fn pathFor(self: *const DiskCache, allocator: std.mem.Allocator, key: u64) ![]u8 {
+        var hex: [16]u8 = undefined;
+        _ = std.fmt.bufPrint(&hex, "{x:0>16}", .{key}) catch unreachable; // 16자리 고정
+        return std.fs.path.join(allocator, &.{ self.root, hex[0..2], hex[2..16] });
+    }
+
+    /// `bytes` 를 key 에 atomic 하게 쓴다(샤드 디렉토리 생성 → 유니크 tmp 쓰기 → rename).
+    pub fn put(self: *const DiskCache, io: std.Io, key: u64, bytes: []const u8) !void {
+        // final 경로는 get 과 동일하게 pathFor 로 계산(샤딩 로직 단일 소스 — 분기 시 silent miss 방지).
+        const final = try self.pathFor(self.allocator, key);
+        defer self.allocator.free(final);
+
+        // 샤드 디렉토리 = final 의 부모(`<root>/<ab>`). pathFor 가 항상 shard/name 2-component 라 non-null.
+        const shard_dir = std.fs.path.dirname(final) orelse ".";
+        try std.Io.Dir.cwd().createDirPath(io, shard_dir); // 멱등(이미 있으면 통과)
+
+        // 유니크 tmp: 전역 atomic seq 가 같은 프로세스 내 모든 put 에 distinct 값을 보장.
+        const seq = put_seq.fetchAdd(1, .monotonic);
+        const tmp = try std.fmt.allocPrint(self.allocator, "{s}.{d}.tmp", .{ final, seq });
+        defer self.allocator.free(tmp);
+
+        errdefer std.Io.Dir.cwd().deleteFile(io, tmp) catch {}; // 실패 시 tmp 잔재 정리
+        try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = tmp, .data = bytes });
+        // rename 은 0.16 에서 (old_dir, old_sub, new_dir, new_sub, io) — io 가 마지막 인자.
+        try std.Io.Dir.cwd().rename(tmp, std.Io.Dir.cwd(), final, io);
+    }
+
+    /// key 의 캐시 바이트를 `allocator` 로 읽어 반환. **fail-open**: 읽기 실패(없음/권한/손상/
+    /// `max_bytes` 초과 등)는 전부 `null`(cache miss)로 degrade 해 재파싱하게 한다 — 캐시가
+    /// no-cache 보다 빌드를 더 깨뜨리지 않게. 시스템 자원 고갈(`OutOfMemory`)만 전파한다.
+    /// `max_bytes` 는 손상/거대 파일 방어 상한(초과 시 miss).
+    pub fn get(self: *const DiskCache, io: std.Io, allocator: std.mem.Allocator, key: u64, max_bytes: usize) !?[]u8 {
+        const path = try self.pathFor(self.allocator, key);
+        defer self.allocator.free(path);
+        return std.Io.Dir.cwd().readFileAlloc(io, path, allocator, std.Io.Limit.limited(max_bytes)) catch |err| switch (err) {
+            error.OutOfMemory => return err, // 자원 고갈은 캐시 문제 아님 → 전파
+            else => null, // 그 외 모든 read 실패는 cache miss → 재파싱
+        };
+    }
+};

--- a/src/bundler/disk_cache_test.zig
+++ b/src/bundler/disk_cache_test.zig
@@ -1,0 +1,141 @@
+// disk_cache_test.zig — #4438 디스크 캐시 IO 레이어 put/get round-trip + miss + overwrite.
+//
+// std.testing.tmpDir 로 격리된 임시 디렉토리를 캐시 root 로 쓴다.
+
+const std = @import("std");
+const testing = std.testing;
+const DiskCache = @import("disk_cache.zig").DiskCache;
+
+const KEY_A: u64 = 0xABCDEF0123456789;
+const KEY_B: u64 = 0x00000000000000FF; // shard "00", 작은 값(0 패딩 확인)
+const MAX: usize = 1 << 20;
+
+fn openCache(tmp: *std.testing.TmpDir) !DiskCache {
+    const root = try tmp.dir.realPathFileAlloc(testing.io, ".", testing.allocator);
+    defer testing.allocator.free(root);
+    return DiskCache.init(testing.allocator, root);
+}
+
+test "disk_cache: put/get round-trip" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var cache = try openCache(&tmp);
+    defer cache.deinit();
+
+    try cache.put(testing.io, KEY_A, "hello disk cache");
+
+    const got = (try cache.get(testing.io, testing.allocator, KEY_A, MAX)).?;
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("hello disk cache", got);
+}
+
+test "disk_cache: miss 는 null" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var cache = try openCache(&tmp);
+    defer cache.deinit();
+
+    try testing.expect((try cache.get(testing.io, testing.allocator, KEY_A, MAX)) == null);
+
+    // 다른 key 만 채우고 조회 — 여전히 miss.
+    try cache.put(testing.io, KEY_B, "x");
+    try testing.expect((try cache.get(testing.io, testing.allocator, KEY_A, MAX)) == null);
+}
+
+test "disk_cache: overwrite 는 atomic 교체" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var cache = try openCache(&tmp);
+    defer cache.deinit();
+
+    try cache.put(testing.io, KEY_A, "first version AAAA");
+    try cache.put(testing.io, KEY_A, "second longer version BBBBBBBB");
+
+    const got = (try cache.get(testing.io, testing.allocator, KEY_A, MAX)).?;
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("second longer version BBBBBBBB", got);
+}
+
+test "disk_cache: 빈 데이터 + 작은-key 샤딩" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var cache = try openCache(&tmp);
+    defer cache.deinit();
+
+    try cache.put(testing.io, KEY_B, ""); // 빈 바이트 경계
+    const got = (try cache.get(testing.io, testing.allocator, KEY_B, MAX)).?;
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("", got);
+}
+
+test "disk_cache: max_bytes 초과는 miss (fail-open)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var cache = try openCache(&tmp);
+    defer cache.deinit();
+
+    try cache.put(testing.io, KEY_A, "0123456789"); // 10 바이트
+    // 상한 4 바이트로 읽으면 StreamTooLong → hard error 가 아니라 miss(null).
+    try testing.expect((try cache.get(testing.io, testing.allocator, KEY_A, 4)) == null);
+    // 충분한 상한이면 정상.
+    const got = (try cache.get(testing.io, testing.allocator, KEY_A, MAX)).?;
+    defer testing.allocator.free(got);
+    try testing.expectEqualStrings("0123456789", got);
+}
+
+test "disk_cache: 동시 put (seq 유일성 + 같은-샤드 createDirPath race)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // 여러 스레드가 한 인스턴스를 공유 → thread-safe allocator 필요(경로 문자열 할당).
+    // smp_allocator 는 전역 thread-safe; leak 감지는 다른 테스트(testing.allocator)가 커버.
+    const alloc = std.heap.smp_allocator;
+    const root = try tmp.dir.realPathFileAlloc(testing.io, ".", alloc);
+    defer alloc.free(root);
+    var cache = try DiskCache.init(alloc, root);
+    defer cache.deinit();
+
+    const N = 16;
+    const Worker = struct {
+        // key 0..15 는 hex 앞 2자리가 전부 "00" → 같은 샤드에 동시 createDirPath(멱등성 검증).
+        fn run(c: *const DiskCache, k: u64) void {
+            var buf: [24]u8 = undefined;
+            const data = std.fmt.bufPrint(&buf, "payload-{d}", .{k}) catch return;
+            c.put(testing.io, k, data) catch {};
+        }
+    };
+    var threads: [N]std.Thread = undefined;
+    for (&threads, 0..) |*t, i| t.* = try std.Thread.spawn(.{}, Worker.run, .{ &cache, @as(u64, i) });
+    for (&threads) |t| t.join();
+
+    // 전부 성공·독립 보관됐는지(put 실패 시 get 이 null → .? 패닉으로 드러남).
+    var i: u64 = 0;
+    while (i < N) : (i += 1) {
+        const got = (try cache.get(testing.io, alloc, i, MAX)).?;
+        defer alloc.free(got);
+        var buf: [24]u8 = undefined;
+        const want = try std.fmt.bufPrint(&buf, "payload-{d}", .{i});
+        try testing.expectEqualStrings(want, got);
+    }
+}
+
+test "disk_cache: 여러 key 독립 보관" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var cache = try openCache(&tmp);
+    defer cache.deinit();
+
+    var k: u64 = 0;
+    while (k < 8) : (k += 1) {
+        var buf: [16]u8 = undefined;
+        const data = try std.fmt.bufPrint(&buf, "payload-{d}", .{k});
+        try cache.put(testing.io, k *% 0x9E3779B97F4A7C15, data);
+    }
+    k = 0;
+    while (k < 8) : (k += 1) {
+        const got = (try cache.get(testing.io, testing.allocator, k *% 0x9E3779B97F4A7C15, MAX)).?;
+        defer testing.allocator.free(got);
+        var buf: [16]u8 = undefined;
+        const want = try std.fmt.bufPrint(&buf, "payload-{d}", .{k});
+        try testing.expectEqualStrings(want, got);
+    }
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -40,6 +40,7 @@ pub const plugin = @import("plugin.zig");
 pub const module_store = @import("module_store.zig");
 pub const semantic_codec = @import("semantic_codec.zig");
 pub const module_codec = @import("module_codec.zig");
+pub const disk_cache = @import("disk_cache.zig");
 pub const css_scanner = @import("css_scanner.zig");
 pub const css_emitter = @import("css_emitter.zig");
 pub const symbol = @import("symbol.zig");
@@ -130,6 +131,7 @@ test {
     _ = @import("bundler_test.zig");
     _ = @import("semantic_codec_test.zig");
     _ = @import("module_codec_test.zig");
+    _ = @import("disk_cache_test.zig");
     _ = @import("tree_shaker_test.zig");
     _ = @import("linker_test.zig");
     _ = @import("emitter_test.zig");


### PR DESCRIPTION
## 요약

`#4438` 디스크 캐시 epic 의 다음 단계. codec(`module_codec`)이 만든 바이트를 **실제 디스크에 영속화**하는 순수 IO 레이어 `DiskCache` 를 추가합니다.

## API

```zig
pub const DiskCache = struct {
    pub fn init(allocator, root_dir) !DiskCache   // root dupe
    pub fn deinit(self) void
    pub fn put(self, io, key: u64, bytes) !void    // atomic
    pub fn get(self, io, allocator, key: u64, max_bytes) !?[]u8  // miss=null
};
```

- **샤딩 경로**: key(u64) → `<root>/<ab>/<cdef0123456789>` (16-hex, git-objects 식 2-level). 한 디렉토리 파일 폭증 방지 — Metro/cacache 와 동일.
- **atomic write**: 샤드 생성 → 유니크 tmp(`<final>.<seq>.tmp`) 쓰기 → `rename`. POSIX rename 은 원자적이라 reader 가 half-written 파일을 못 봄. 전역 atomic `seq` 가 같은 프로세스 동시 쓰기 충돌을 막음.

## 범위 (의도적 분리)

- **위치 정책은 caller 주입(`root`)** — `node_modules/.cache/zntc/`(생태계 표준: babel-loader/webpack/swc-loader/find-cache-dir) 등 실제 위치 계산은 graph 통합 PR 이 결정. DiskCache 는 "주어진 root 에 읽고 쓴다"만.
- **무효화 키**(옵션·tsconfig·.env·컴파일러버전)는 무효화 키 PR(기존 `compiled_cache.zig` `InputHasher` 재사용).
- graph cache-hit 연결도 후속. 현재 단위 테스트 전용 — HMR/RN/빌드 출력 영향 0.

## `/code-review max` 반영

- **get fail-open**: 읽기 실패(없음/권한/손상/`max_bytes` 초과)를 전부 cache miss(`null`)로 degrade. **캐시는 no-cache 보다 빌드를 더 깨뜨리면 안 된다**는 원칙. `OutOfMemory` 만 전파. (리뷰: `FileNotFound` 외 에러를 hard-fail 하던 것을 수정 — `StreamTooLong` 등이 빌드를 깨뜨리는 문제.)
- **경로 단일 소스화**: `put`/`get` 이 같은 final 경로를 다른 코드로 계산하던 것을 `pathFor` 하나로 통일 — 샤딩 변경 시 한쪽만 고쳐 100% silent cache miss 가 되는 drift 방지. 중복 hex 포맷도 제거.
- **tid 제거**: tmp 이름의 `std.Thread.getCurrentId()` 는 전역 atomic `seq` 앞에서 무용(inert) → 제거.
- **동시 put 테스트 추가**: 16-thread 가 같은 샤드("00")에 동시 put → `createDirPath` 멱등성 race + `seq` 유일성 검증. + `max_bytes` 초과 miss 테스트.

## 테스트

`zig build test -Dtest-filter=disk_cache` (Debug + ReleaseFast): round-trip / miss / overwrite(atomic 교체) / 빈 데이터 / 다수 key / fail-open(크기초과) / **동시 16-thread put**. 전체 5988 통과.

⚠️ graph cache-hit 연결은 무효화 키 정합성 확보 전까지 금지.

Part of #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)