### PR TITLE
feat(cache): 무효화 키 (보수/정밀 + 차등 테스트) #4438

### DIFF
--- a/src/bundler/cache_key.zig
+++ b/src/bundler/cache_key.zig
@@ -1,0 +1,156 @@
+//! parse/semantic 디스크 캐시 무효화 키 — #4438.
+//!
+//! 캐시 엔트리가 stale 인지 판정하는 u64 키를 계산한다. 키가 다르면 캐시를 버리고 재파싱
+//! (fail-safe). 핵심 원칙: **결과에 영향을 주는 입력이 키에 빠지면 "옵션 바꿨는데 옛 결과가
+//! 나오는" silent miscompile** 이므로, 입력 누락을 구조적으로 막는 것이 전부다.
+//!
+//! ## 캐시 단위 = pre-transform parse+semantic
+//! module_codec 이 직렬화하는 것은 한 모듈의 **AST + ModuleSemanticData** 다. parse+semantic
+//! 단계(`Scanner`+`Parser`+`SemanticAnalyzer`)는 입력으로 **source 바이트 + parser/analyzer
+//! 모드 플래그**(is_ts/is_jsx/is_module/is_flow/is_strict)만 읽고 **transform 옵션은 읽지
+//! 않는다**(define/jsx_transform/decorators 등은 그 다음 transform pre-pass 가 읽음). 따라서
+//! pre-transform 캐시의 키는 source + parse_flags + 버전 가드면 충분하다.
+//!
+//! ## 보수 vs 정밀 (두 전략)
+//! `compute` 는 전략 무관하게 `options_hash` 를 받아 키를 조립한다. 전략은 그 options_hash 를
+//! 무엇으로 채우느냐의 차이:
+//! - **보수(production 기본)**: 빌드 옵션 **전체**를 해시(`compiled_cache.hashEmitOptions` 같은
+//!   complete·guarded 해시를 graph 통합 PR 이 주입). 옵션 하나라도 다르면 무효화 → silent
+//!   miscompile 0. 단점은 emit-only 옵션 변경 시도 무효화(과도) — 전체-옵션 해시 전략.
+//! - **정밀(후보)**: parse/pre-pass 에 영향을 주는 옵션만(`SelectiveOptions`) 해시. emit-only
+//!   옵션 변경 시 캐시 유지(이득). pre-transform 캐시에서는 transform 옵션 전부 제외 가능
+//!   (parse+semantic 이 안 읽으므로 **구조적으로 안전**). post-transform 캐시로 확장 시엔
+//!   graph 통합의 `cache ON==OFF` byte-identical 동등성 테스트로 안전성을 실증해야 한다.
+//!
+//! ## graph 통합 시 caller 가 지켜야 할 wiring 불변식 (어기면 silent miscompile)
+//! - `source_hash` 는 **plugin transform/load 훅 적용 후** `module.source` 기준으로 계산한다
+//!   (raw 파일이 아니라 — plugin 이 바꾼 바이트가 parse 입력이므로).
+//! - `ParseFlags` 는 확장자/`module_type` 가 아니라 **설정 완료된 parser 의 effective 상태**
+//!   (`source_mode==.ts`/`is_jsx`/`is_module`/`is_flow`/`is_strict_mode`)에서 뽑는다 —
+//!   `--platform=react-native`(jsx_in_js)/`--flow`/loader override 가 이를 바꾸기 때문.
+//! - 이 캐시는 **bundler parse 설정**을 전제한다: `enable_stmt_info≡true`(false 면 serialized
+//!   `references` 가 달라짐), `source_mode` 는 `.ts`/`.js_strict`(transpile 경로의 `.js_lenient`
+//!   미사용). transpile 경로와 캐시를 공유하려면 이 둘을 키에 추가해야 한다.
+//!
+//! ## 비책임 (후속 PR)
+//! `compiler_build_id`(zts 빌드 식별자) 실제 값은 caller(graph 통합 PR)가 build.zig `addOptions`
+//! 로 주입한 git SHA 등으로 채운다. 여기선 입력 파라미터로만 받는다. graph cache-hit 연결도 후속.
+
+const std = @import("std");
+const InputHasher = @import("compiled_cache.zig").InputHasher;
+const ast_codec = @import("../parser/ast_codec.zig");
+const semantic_codec = @import("semantic_codec.zig");
+const module_codec = @import("module_codec.zig");
+
+const KEY_SEED: u64 = 0x5A4E5443_4B4559; // "ZNTC""KEY"
+const OPTS_SEED: u64 = 0x5A4E5443_4F5054; // "ZNTC""OPT"
+
+// 각 codec 포맷 버전은 16-bit 슬롯(bits 32-47 / 16-31 / 0-15)을 차지한다. 0xFFFF 초과 시
+// 인접 슬롯과 겹쳐 서로 다른 버전 조합이 충돌(→ 호환 안 되는 포맷의 stale 역직렬화)하므로 막는다.
+comptime {
+    if (ast_codec.FORMAT_VERSION > 0xFFFF or
+        semantic_codec.FORMAT_VERSION > 0xFFFF or
+        module_codec.FORMAT_VERSION > 0xFFFF)
+        @compileError("codec FORMAT_VERSION 이 16-bit 슬롯을 초과 — CODEC_FORMAT 패킹 폭을 넓힐 것.");
+}
+
+/// 3개 codec 포맷 버전 조합(16-bit 슬롯). 어느 포맷이든 bump 되면 키가 바뀌어 구버전 캐시 전량
+/// 무효화 — relocatable 바이트 레이아웃·Span 의미가 버전마다 달라 역직렬화하면 위험(포맷 버전 가드).
+pub const CODEC_FORMAT: u64 =
+    (@as(u64, ast_codec.FORMAT_VERSION) << 32) |
+    (@as(u64, semantic_codec.FORMAT_VERSION) << 16) |
+    @as(u64, module_codec.FORMAT_VERSION);
+
+/// parse+semantic 결과(AST 모양/심볼)를 직접 결정하는 파서/분석기 모드 플래그.
+pub const ParseFlags = packed struct(u8) {
+    is_ts: bool = false,
+    is_jsx: bool = false,
+    is_module: bool = false,
+    is_flow: bool = false,
+    is_strict: bool = false,
+    _pad: u3 = 0,
+
+    pub fn bits(self: ParseFlags) u32 {
+        return @as(u8, @bitCast(self));
+    }
+};
+
+/// **정밀 전략**이 키에 넣는, parse/pre-pass 에 영향을 주는 옵션의 명시적 집합 —
+/// `TransformOptions` 에서 결과에 영향을 주는 필드를 **손으로 추린** 것이다.
+/// 단순 타입(bool/정수/enum)만 허용한다 — 슬라이스/포인터(define/plugins 등)는 caller 가
+/// 미리 u64 로 해시해 넣는다(아래 `*_hash` 필드). `hashSelective` 가 comptime reflection 으로
+/// 모든 필드를 자동 해시하므로 **이 struct 내부** 필드 누락은 불가능하고, 복합 타입을 추가하면
+/// `hashSelective` 가 컴파일 에러를 낸다.
+///
+/// ⚠️ 단, reflection 은 `TransformOptions` 에 **새 parse-영향 필드가 생겨도 자동 전파하지
+/// 않는다**(정밀 전략의 근본 위험 — 누락 시 silent miscompile). 아래 comptime 가드가
+/// TransformOptions 필드 수를 못박아, 변경 시 SelectiveOptions 분류 재검토를 강제한다.
+pub const SelectiveOptions = struct {
+    // class field / decorator 다운레벨 (AST 변형)
+    experimental_decorators: bool = false,
+    emit_decorator_metadata: bool = false,
+    use_define_for_class_fields: bool = true,
+    // JSX lowering
+    jsx_transform: bool = false,
+    jsx_runtime: u8 = 0, // codegen_options.JsxRuntime 의 @intFromEnum
+    jsx_factory_hash: u64 = 0,
+    jsx_fragment_hash: u64 = 0,
+    jsx_import_source_hash: u64 = 0,
+    // dead-code / 치환 (AST 변형)
+    drop_console: bool = false,
+    drop_debugger: bool = false,
+    drop_labels_hash: u64 = 0,
+    define_hash: u64 = 0,
+    module_specifier_map_hash: u64 = 0,
+    // minify 중 AST 를 바꾸는 것 (pre-pass)
+    minify_syntax: bool = false,
+    minify_whitespace: bool = false,
+    minify_identifiers: bool = false,
+    // pre-pass 게이트 트랜스폼
+    react_refresh: bool = false,
+    styled_components: bool = false,
+    emotion: bool = false,
+    worklet_transform: bool = false,
+    // ES 다운레벨 범위 (unsupported feature set 의 사전해시)
+    unsupported_hash: u64 = 0,
+};
+
+comptime {
+    // SelectiveOptions ↔ TransformOptions 동기화 강제(정밀 전략 안전망). TransformOptions 에
+    // 필드가 추가되면 컴파일 에러 → 그 필드가 parse/semantic(pre-pass) 결과에 영향을 주는지
+    // 판정해서, 주면 SelectiveOptions 에 반영하고 이 수를 갱신할 것(누락=silent miscompile).
+    const tf_fields = @typeInfo(@import("../transformer/options.zig").TransformOptions).@"struct".fields.len;
+    if (tf_fields != 45)
+        @compileError("TransformOptions 필드 수 변경 — 새 필드의 parse-영향 여부 판정 후 SelectiveOptions 갱신 + 이 수 갱신 필요.");
+}
+
+/// `SelectiveOptions` 의 모든 필드를 reflection 으로 해시(정밀 전략 options_hash).
+pub fn hashSelective(o: *const SelectiveOptions) u64 {
+    var h = InputHasher.init(OPTS_SEED);
+    inline for (@typeInfo(SelectiveOptions).@"struct".fields) |f| {
+        const v = @field(o.*, f.name);
+        switch (@typeInfo(f.type)) {
+            .bool => h.addBool(v),
+            .int => h.addU64(@intCast(v)),
+            .@"enum" => h.addU64(@intFromEnum(v)),
+            else => @compileError("cache_key: SelectiveOptions." ++ f.name ++
+                " 타입은 reflection 해시 미지원 — caller 가 u64 로 사전해시(`*_hash` 필드)해 넣을 것."),
+        }
+    }
+    return h.final();
+}
+
+/// 무효화 키 조립. `options_hash` 는 전략에 따라 보수(전체)/정밀(`hashSelective`) 중 하나.
+/// `source_hash` = 파일 내용 wyhash(plugin transform 후 source 기준 — 위 wiring 불변식 참조).
+/// `compiler_build_id` = zts 빌드 식별자(graph PR 가 build.zig git SHA 등으로 주입).
+/// ⚠️ `compiler_build_id == 0` 은 컴파일러 버전 가드를 **무력화**한다(parser/semantic 로직이
+/// 바뀐 rebuild 후에도 같은 키 → stale miscompile). caller 는 0 이 아닌 실제 빌드 식별자를 줄 것.
+pub fn compute(source_hash: u64, flags: ParseFlags, options_hash: u64, compiler_build_id: u64) u64 {
+    var h = InputHasher.init(KEY_SEED);
+    h.addU64(source_hash);
+    h.addU32(flags.bits());
+    h.addU64(options_hash);
+    h.addU64(CODEC_FORMAT);
+    h.addU64(compiler_build_id);
+    return h.final();
+}

--- a/src/bundler/cache_key_test.zig
+++ b/src/bundler/cache_key_test.zig
@@ -1,0 +1,170 @@
+// cache_key_test.zig — #4438 무효화 키 결정성/민감도 + 보수↔정밀 차등 테스트.
+//
+// 실제 parse+semantic 을 옵션/모드 매트릭스로 돌려 키가 결과를 올바르게 추적하는지,
+// 그리고 보수(전체 옵션)와 정밀(선별) 두 전략의 trade-off 를 구체적으로 검증한다.
+
+const std = @import("std");
+const testing = std.testing;
+const cache_key = @import("cache_key.zig");
+const module_codec = @import("module_codec.zig");
+const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
+const wyhash = @import("../util/wyhash.zig");
+const Scanner = @import("../lexer/scanner.zig").Scanner;
+const Parser = @import("../parser/parser.zig").Parser;
+const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
+
+const BUILD_ID: u64 = 0xABCD_1234; // 테스트 고정 compiler_build_id
+
+// import/export 가 없어 .mjs/.ts/.tsx/.cjs 모두에서 유효하게 파싱되는 source.
+const SRC = "const a = 1; function f(x) { let y = x + a; return y; } const b = f(2);";
+
+const Parsed = struct {
+    bytes: []u8, // module_codec 직렬화 결과 (caller free)
+    flags: cache_key.ParseFlags,
+};
+
+/// 주어진 확장자로 parse+semantic 을 돌려 module_codec 직렬화 바이트 + ParseFlags 반환.
+/// 실제 graph 파이프라인(parse_module.zig)과 동일하게 모드 플래그를 전파한다.
+fn parseAndSerialize(alloc: std.mem.Allocator, ext: []const u8, source: []const u8) !Parsed {
+    var scanner = try Scanner.init(alloc, source);
+    defer scanner.deinit();
+    var parser = Parser.init(alloc, &scanner);
+    defer parser.deinit();
+    parser.configureForBundler(ext);
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(alloc, &parser.ast);
+    defer ana.deinit();
+    ana.is_strict_mode = parser.is_strict_mode;
+    ana.is_module = parser.is_module;
+    ana.is_ts = parser.source_mode == .ts;
+    ana.is_flow = parser.is_flow;
+    ana.enable_stmt_info = true;
+    try ana.analyze();
+
+    const sem = ModuleSemanticData{
+        .symbols = ana.symbols,
+        .scopes = ana.scopes.items,
+        .scope_maps = ana.scope_maps.items,
+        .exported_names = ana.exported_names,
+        .symbol_ids = ana.symbol_ids.items,
+        .unresolved_references = ana.unresolved_references,
+        .references = ana.references.items,
+        .numeric_const_texts = ana.numeric_const_texts,
+        .helper_scope_map = ana.helper_scope_map,
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(alloc);
+    try module_codec.serialize(&parser.ast, &sem, &buf, alloc);
+
+    return .{
+        .bytes = try buf.toOwnedSlice(alloc),
+        .flags = .{
+            .is_ts = parser.source_mode == .ts,
+            .is_jsx = parser.is_jsx,
+            .is_module = parser.is_module,
+            .is_flow = parser.is_flow,
+            .is_strict = parser.is_strict_mode,
+        },
+    };
+}
+
+fn keyFor(flags: cache_key.ParseFlags, opts: *const cache_key.SelectiveOptions) u64 {
+    return cache_key.compute(wyhash.hashU64(SRC), flags, cache_key.hashSelective(opts), BUILD_ID);
+}
+
+test "cache_key: compute 결정성 + 입력별 민감도" {
+    const sh = wyhash.hashU64(SRC);
+    const flags = cache_key.ParseFlags{ .is_ts = true, .is_module = true };
+    const base = cache_key.compute(sh, flags, 0x1111, BUILD_ID);
+
+    try testing.expectEqual(base, cache_key.compute(sh, flags, 0x1111, BUILD_ID)); // 결정적
+    try testing.expect(base != cache_key.compute(sh +% 1, flags, 0x1111, BUILD_ID)); // source
+    try testing.expect(base != cache_key.compute(sh, .{ .is_jsx = true, .is_ts = true, .is_module = true }, 0x1111, BUILD_ID)); // flags
+    try testing.expect(base != cache_key.compute(sh, flags, 0x2222, BUILD_ID)); // options
+    try testing.expect(base != cache_key.compute(sh, flags, 0x1111, BUILD_ID +% 1)); // build id
+}
+
+test "cache_key: hashSelective 가 모든 필드를 반영 (reflection 완전성)" {
+    const base = cache_key.SelectiveOptions{};
+    const base_h = cache_key.hashSelective(&base);
+    // 모든 필드를 하나씩 변형 → 해시가 바뀌어야(어떤 필드도 무시되지 않음).
+    inline for (@typeInfo(cache_key.SelectiveOptions).@"struct".fields) |f| {
+        var o = base;
+        switch (@typeInfo(f.type)) {
+            .bool => @field(o, f.name) = !@field(base, f.name),
+            .int => @field(o, f.name) = @field(base, f.name) +% 1,
+            else => unreachable, // SelectiveOptions 는 단순 타입만(컴파일 가드)
+        }
+        try testing.expect(cache_key.hashSelective(&o) != base_h);
+    }
+}
+
+test "차등: parser flags 가 결과를 바꾸면 키도 바뀐다 (민감도)" {
+    const alloc = testing.allocator;
+    const opts = cache_key.SelectiveOptions{};
+
+    // 결정성: 같은 (ext, source) 두 번 → byte 동일 + 키 동일.
+    const m1 = try parseAndSerialize(alloc, ".mjs", SRC);
+    defer alloc.free(m1.bytes);
+    const m2 = try parseAndSerialize(alloc, ".mjs", SRC);
+    defer alloc.free(m2.bytes);
+    try testing.expectEqualSlices(u8, m1.bytes, m2.bytes);
+    try testing.expectEqual(keyFor(m1.flags, &opts), keyFor(m2.flags, &opts));
+
+    // 모드별 ParseFlags 가 달라 키가 pairwise 구분되는지.
+    const ts = try parseAndSerialize(alloc, ".ts", SRC);
+    defer alloc.free(ts.bytes);
+    const tsx = try parseAndSerialize(alloc, ".tsx", SRC);
+    defer alloc.free(tsx.bytes);
+    const cjs = try parseAndSerialize(alloc, ".cjs", SRC);
+    defer alloc.free(cjs.bytes);
+
+    const keys = [_]u64{
+        keyFor(m1.flags, &opts), // .mjs : module, !ts, !jsx
+        keyFor(ts.flags, &opts), // .ts  : module, ts, !jsx
+        keyFor(tsx.flags, &opts), // .tsx : module, ts, jsx
+        keyFor(cjs.flags, &opts), // .cjs : !module
+    };
+    for (keys, 0..) |ka, i| {
+        for (keys[i + 1 ..]) |kb| try testing.expect(ka != kb); // 모든 모드 키 구별
+    }
+
+    // 모드 플래그가 실제로 다른지(테스트 전제 보장).
+    try testing.expect(ts.flags.is_ts and !m1.flags.is_ts);
+    try testing.expect(tsx.flags.is_jsx and !ts.flags.is_jsx);
+    try testing.expect(!cjs.flags.is_module and m1.flags.is_module);
+}
+
+test "차등: 보수↔정밀 trade-off — compute 의 options_hash 메커니즘" {
+    const alloc = testing.allocator;
+
+    // 주의(범위 정직화): 이 테스트는 키 조립 **메커니즘**만 검증한다 — `parseAndSerialize` 는
+    // 옵션을 입력으로 받지 않으므로, emit-only 옵션이 실제 parse 출력을 바꾸는지/안 바꾸는지는
+    // 여기서 입증하지 못한다(pre-transform 에서는 parse 가 옵션을 안 읽어 구조상 자명, post-
+    // transform 안전성은 graph 통합의 ON==OFF byte-identical 동등성 테스트의 몫). 아래 byte
+    // 동등성은 "옵션 무관"이 아니라 동일 입력의 **결정성**이다.
+    const m = try parseAndSerialize(alloc, ".mjs", SRC);
+    defer alloc.free(m.bytes);
+    const m_again = try parseAndSerialize(alloc, ".mjs", SRC);
+    defer alloc.free(m_again.bytes);
+    try testing.expectEqualSlices(u8, m.bytes, m_again.bytes); // 결정성
+
+    const sh = wyhash.hashU64(SRC);
+
+    // 정밀: 같은 SelectiveOptions → 같은 options_hash → 같은 키(emit-only 차이는 키에 안 들어옴).
+    const sel = cache_key.SelectiveOptions{ .jsx_transform = true, .define_hash = 0xDEF };
+    const sel_a = cache_key.compute(sh, m.flags, cache_key.hashSelective(&sel), BUILD_ID);
+    const sel_b = cache_key.compute(sh, m.flags, cache_key.hashSelective(&sel), BUILD_ID);
+    try testing.expectEqual(sel_a, sel_b);
+
+    // 보수: options_hash 가 달라지면 키도 달라짐(compute 의 options_hash 민감도). 실제 보수 해시
+    // (hashEmitOptions)는 graph PR 이 주입하며, 여기선 stand-in 상수로 민감도만 검증한다.
+    try testing.expect(cache_key.compute(sh, m.flags, 0xE1770_0A, BUILD_ID) !=
+        cache_key.compute(sh, m.flags, 0xE1770_0B, BUILD_ID));
+
+    // 정밀: parse-영향 옵션이 실제로 다르면 키도 달라야(SelectiveOptions 필드가 키에 반영됨).
+    const sel2 = cache_key.SelectiveOptions{ .jsx_transform = true, .define_hash = 0xFED };
+    try testing.expect(sel_a != cache_key.compute(sh, m.flags, cache_key.hashSelective(&sel2), BUILD_ID));
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -41,6 +41,7 @@ pub const module_store = @import("module_store.zig");
 pub const semantic_codec = @import("semantic_codec.zig");
 pub const module_codec = @import("module_codec.zig");
 pub const disk_cache = @import("disk_cache.zig");
+pub const cache_key = @import("cache_key.zig");
 pub const css_scanner = @import("css_scanner.zig");
 pub const css_emitter = @import("css_emitter.zig");
 pub const symbol = @import("symbol.zig");
@@ -132,6 +133,7 @@ test {
     _ = @import("semantic_codec_test.zig");
     _ = @import("module_codec_test.zig");
     _ = @import("disk_cache_test.zig");
+    _ = @import("cache_key_test.zig");
     _ = @import("tree_shaker_test.zig");
     _ = @import("linker_test.zig");
     _ = @import("emitter_test.zig");


### PR DESCRIPTION
## 요약

`#4438` 디스크 캐시의 **무효화 키** 단계. parse/semantic 캐시 엔트리가 stale 인지 판정하는 u64 키를 계산합니다. 핵심 위험은 **결과에 영향을 주는 입력이 키에서 빠지면 "옵션 바꿨는데 옛 결과가 나오는" silent miscompile** — 입력 누락을 구조적으로 막는 것이 전부입니다.

## 두 전략 (사용자 결정: 둘 다 구현 후 차등 비교)

다른 번들러 조사 결과 per-file 캐시는 **보수(전체 옵션 해시)** 가 주류(babel-loader)이고, 정밀(선별)은 누락 시 silent miscompile 위험이 큽니다. 사용자 제안대로 **둘 다 구현하고 차등 테스트로 정밀의 안전성을 사냥**합니다.

- **보수(production 기본)**: 빌드 옵션 **전체**를 해시(graph PR 이 `compiled_cache.hashEmitOptions` 주입) → 옵션 하나라도 다르면 무효화 → silent miscompile 0. 단점은 emit-only 옵션 변경 시도 무효화(과도).
- **정밀(후보)**: `SelectiveOptions`(parse/pre-pass 영향 필드)만 reflection 해시 → emit-only 변경 시 캐시 유지(이득). pre-transform 캐시에선 transform 옵션 제외가 구조적으로 안전.

## 차등 테스트 하니스

parser flags 매트릭스(`.mjs`/`.ts`/`.tsx`/`.cjs`)로 **실제 parse+semantic 을 돌려** module_codec 바이트를 비교:
- flags 가 결과를 바꾸면 키도 바뀐다(민감도) + pairwise 구별.
- 동일 입력은 byte/키 동일(결정성).
- `hashSelective` reflection 완전성(필드 토글 → 해시 변화).

pipeline-level(post-pre-pass) 옵션 영향 실증은 **graph 통합의 `ON==OFF` byte-identical 동등성 테스트의 몫**(여기선 키 메커니즘 검증).

## `/code-review max` 반영 (정확성 핵심)

- **CODEC_FORMAT 비트 겹침 수정(CONFIRMED 버그)**: `ast<<32 | sem<<16 | module` 에서 u32 버전이 16-bit 슬롯 초과 시 인접 슬롯과 겹쳐 **다른 포맷 조합이 같은 키** → 호환 안 되는 포맷의 stale 역직렬화. comptime 가드로 각 버전 ≤ 0xFFFF 강제.
- **SelectiveOptions↔TransformOptions 동기화 가드**: reflection 은 SelectiveOptions 내부 누락만 막을 뿐, `TransformOptions` 에 parse-영향 필드가 추가되면 자동 전파 안 됨(정밀 전략의 근본 위험). 필드 수(45) comptime 가드로 변경 시 분류 재검토 강제.
- **`compiler_build_id==0` 무력화 경고** + graph 통합 **wiring 불변식 문서화**: source_hash 는 plugin transform 후, ParseFlags 는 effective parser state(확장자 아님), `enable_stmt_info≡true` 전제(false 면 serialized `references` 달라짐).
- 차등 테스트 주석 정직화(보수는 stand-in 상수로 메커니즘만 검증 — overclaim 제거). 외부 도구명(babel-loader/rustc) 주석 제거(no-reference 규칙).

## 테스트

`zig build test -Dtest-filter=cache_key` (Debug + ReleaseFast): compute 결정성·민감도 / hashSelective reflection 완전성 / 차등(parser flags 매트릭스) / 보수↔정밀 메커니즘. 전체 5992 통과.

## 다음 단계

**graph 통합**(`buildIncremental` 디스크 hit 분기 + opt-in + `ON==OFF` byte-identical 동등성) — **이때 비로소 실제 동작**하며, 그 전까지 출력 영향 0(codec/cache는 파이프라인 미연결).

Part of #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)