### PR TITLE
feat(cache): 디스크 모듈 store — codec+IO 결합 레이어 #4438

### DIFF
--- a/src/bundler/disk_module_store.zig
+++ b/src/bundler/disk_module_store.zig
@@ -1,0 +1,83 @@
+//! 디스크 모듈 store — #4438. `disk_cache`(영속화) + `module_codec`(직렬화)를 묶어
+//! "캐시 키(u64) → 한 모듈의 AST+semantic" 을 디스크에 저장/복원한다.
+//!
+//! 캐시 키 계산은 `cache_key.compute` 의 몫이고, 여기선 그 키를 받아 바이트를 읽고 쓴다.
+//! graph 통합 PR 이 buildIncremental 의 cache-hit 경로에 연결할 때까지는 **단위 테스트 전용**
+//! (파이프라인 미연결 → HMR/RN/빌드 출력 영향 0).
+//!
+//! ## 범위: AST+semantic 만 (graph 통합 시 필독)
+//! `load` 는 한 모듈의 **AST+semantic 만** 복원한다 — `import_records`/`resolved_deps`/
+//! `alias_table` 등 graph 레벨 Module 상태는 **포함하지 않는다**(module_codec 범위와 동일).
+//! 이는 in-memory `module_store.PersistentModuleStore.getIfFresh`(전체 Module 을 struct-assign)
+//! 와 **다르다** — 이름이 비슷하니 혼동 주의. graph cache-hit 경로가 load() 결과를 full Module 로
+//! 착각해 import_records 를 재구성하지 않으면 import 미링크로 번들이 깨진다.
+//!
+//! `load` 가 `null`(miss/손상)을 돌려줄 때 주입한 `arena` 에 **부분 복원분이 남을 수 있다**
+//! (codec 이 ast 블록까지 alloc 한 뒤 sem 블록에서 실패하는 경우). caller 는 miss 시 그 arena 를
+//! 재사용하지 말고 **모듈별 새 parse_arena** 에 load 를 시도할 것(arena.deinit 가 일괄 회수).
+//!
+//! 동시성: `DiskCache` 와 동일 — 한 인스턴스를 여러 스레드가 공유하면 thread-safe allocator 가
+//! 필요하다(경로 문자열 할당). graph 통합이 worker 에서 호출할 때 주의.
+//!
+//! ## fail-safe (캐시는 no-cache 보다 빌드를 더 깨뜨리지 않는다)
+//! - `store` 는 best-effort: caller 가 `store(...) catch {}` 로 감싸 쓰기 실패가 빌드를 막지
+//!   않게 한다(디스크 풀 등). 여기선 propagate 하고 정책은 caller 가 정한다.
+//! - `load` 는 miss(파일 없음, `disk_cache.get`→null)뿐 아니라 **손상**(magic/checksum/truncated)
+//!   도 `null` 로 degrade → 재파싱. codec 의 fail-safe 검증이 잘못된 캐시를 조용히 쓰는 것을
+//!   막는다. `OutOfMemory` 만 전파.
+
+const std = @import("std");
+const DiskCache = @import("disk_cache.zig").DiskCache;
+const module_codec = @import("module_codec.zig");
+const Ast = @import("../parser/ast.zig").Ast;
+const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
+
+/// 한 캐시 엔트리(한 모듈) 크기 상한 — 손상/거대 파일 방어. 초과 시 load 는 miss 로 degrade.
+/// 512MB 는 정상 모듈(typescript.js ~9MB src → 직렬화 수십 MB)에 넉넉한 손상 방어 천장이지
+/// 실제 quota 가 아니다 — 정상 모듈은 근접하지 않는다.
+pub const MAX_ENTRY_BYTES: usize = 512 * 1024 * 1024;
+
+pub const DiskModuleStore = struct {
+    disk: DiskCache,
+
+    pub fn init(allocator: std.mem.Allocator, root_dir: []const u8) std.mem.Allocator.Error!DiskModuleStore {
+        return .{ .disk = try DiskCache.init(allocator, root_dir) };
+    }
+
+    pub fn deinit(self: *DiskModuleStore) void {
+        self.disk.deinit();
+    }
+
+    /// 한 모듈의 AST+semantic 을 직렬화해 key 에 atomic 저장. best-effort(caller 가 catch).
+    /// `alloc` 은 직렬화 임시 버퍼용(반환 없음 — 디스크에만 남는다).
+    pub fn store(
+        self: *const DiskModuleStore,
+        io: std.Io,
+        alloc: std.mem.Allocator,
+        key: u64,
+        ast: *const Ast,
+        sem: *const ModuleSemanticData,
+    ) !void {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(alloc);
+        try module_codec.serialize(ast, sem, &buf, alloc);
+        try self.disk.put(io, key, buf.items);
+    }
+
+    /// key 의 캐시를 `arena` 에 복원. **miss/손상은 모두 `null`**(재파싱) — `OutOfMemory` 만 전파.
+    /// `alloc` 은 디스크 바이트 읽기용 임시(복원 후 free), 복원본은 `arena` 소유.
+    pub fn load(
+        self: *const DiskModuleStore,
+        io: std.Io,
+        alloc: std.mem.Allocator,
+        arena: std.mem.Allocator,
+        key: u64,
+    ) !?module_codec.DeserializedModule {
+        const bytes = (try self.disk.get(io, alloc, key, MAX_ENTRY_BYTES)) orelse return null;
+        defer alloc.free(bytes);
+        return module_codec.deserialize(bytes, arena) catch |err| switch (err) {
+            error.OutOfMemory => err, // 자원 고갈은 캐시 문제 아님 → 전파
+            else => null, // magic/checksum/truncated 손상 = miss → 재파싱(fail-safe)
+        };
+    }
+};

--- a/src/bundler/disk_module_store_test.zig
+++ b/src/bundler/disk_module_store_test.zig
@@ -1,0 +1,131 @@
+// disk_module_store_test.zig — #4438 디스크 모듈 store/load round-trip + miss + 손상 fail-safe.
+//
+// 실제 parse+semantic 을 만들어 디스크에 저장하고, 새 arena 로 복원해 동등성을 검증한다.
+
+const std = @import("std");
+const testing = std.testing;
+const DiskModuleStore = @import("disk_module_store.zig").DiskModuleStore;
+const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
+const Scope = @import("../semantic/scope.zig").Scope;
+const Reference = @import("../semantic/symbol.zig").Reference;
+const Scanner = @import("../lexer/scanner.zig").Scanner;
+const Parser = @import("../parser/parser.zig").Parser;
+const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
+
+const KEY: u64 = 0xC0FFEE_1234_5678;
+const SRC = "const a = 1; export function f(x) { let y = x + a; return y; } const b = f(2);";
+
+const Fixture = struct {
+    scanner: Scanner,
+    parser: Parser,
+    analyzer: SemanticAnalyzer,
+    sem: ModuleSemanticData,
+
+    fn deinit(self: *Fixture) void {
+        self.analyzer.deinit();
+        self.parser.deinit();
+        self.scanner.deinit();
+    }
+};
+
+fn analyze(alloc: std.mem.Allocator, fx: *Fixture, source: []const u8) !void {
+    fx.scanner = try Scanner.init(alloc, source);
+    fx.parser = Parser.init(alloc, &fx.scanner);
+    fx.parser.configureForBundler(".mjs");
+    _ = try fx.parser.parse();
+    fx.analyzer = SemanticAnalyzer.init(alloc, &fx.parser.ast);
+    fx.analyzer.is_strict_mode = fx.parser.is_strict_mode;
+    fx.analyzer.is_module = fx.parser.is_module;
+    fx.analyzer.is_ts = fx.parser.source_mode == .ts;
+    fx.analyzer.is_flow = fx.parser.is_flow;
+    fx.analyzer.enable_stmt_info = true;
+    try fx.analyzer.analyze();
+    fx.sem = .{
+        .symbols = fx.analyzer.symbols,
+        .scopes = fx.analyzer.scopes.items,
+        .scope_maps = fx.analyzer.scope_maps.items,
+        .exported_names = fx.analyzer.exported_names,
+        .symbol_ids = fx.analyzer.symbol_ids.items,
+        .unresolved_references = fx.analyzer.unresolved_references,
+        .references = fx.analyzer.references.items,
+        .numeric_const_texts = fx.analyzer.numeric_const_texts,
+        .helper_scope_map = fx.analyzer.helper_scope_map,
+    };
+}
+
+fn openStore(tmp: *std.testing.TmpDir) !DiskModuleStore {
+    const root = try tmp.dir.realPathFileAlloc(testing.io, ".", testing.allocator);
+    defer testing.allocator.free(root);
+    return DiskModuleStore.init(testing.allocator, root);
+}
+
+test "disk_module_store: store→load round-trip (새 arena 복원)" {
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try openStore(&tmp);
+    defer store.deinit();
+
+    var fx: Fixture = undefined;
+    try analyze(alloc, &fx, SRC);
+    defer fx.deinit();
+
+    try store.store(testing.io, alloc, KEY, &fx.parser.ast, &fx.sem);
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const m = (try store.load(testing.io, alloc, arena.allocator(), KEY)).?;
+
+    // source + AST + semantic 동등성.
+    try testing.expectEqualStrings(SRC, m.ast.source);
+    try testing.expectEqual(fx.parser.ast.nodes.items.len, m.ast.nodes.items.len);
+    try testing.expectEqual(fx.sem.symbols.items.len, m.semantic.symbols.items.len);
+    try testing.expectEqualSlices(Scope, fx.sem.scopes, m.semantic.scopes);
+    try testing.expectEqualSlices(Reference, fx.sem.references, m.semantic.references);
+    try testing.expect(m.semantic.exported_names.contains("f"));
+
+    // symbol name(Span)이 복원된 source 기준으로 resolve 되는지.
+    for (fx.sem.symbols.items, m.semantic.symbols.items) |s1, s2| {
+        try testing.expectEqualStrings(s1.nameText(fx.parser.ast.source), s2.nameText(m.ast.source));
+    }
+}
+
+test "disk_module_store: miss 는 null" {
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var store = try openStore(&tmp);
+    defer store.deinit();
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    try testing.expect((try store.load(testing.io, alloc, arena.allocator(), KEY)) == null);
+}
+
+test "disk_module_store: 손상 캐시는 miss 로 degrade (fail-safe)" {
+    const alloc = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realPathFileAlloc(testing.io, ".", alloc);
+    defer alloc.free(root);
+    var store = try DiskModuleStore.init(alloc, root);
+    defer store.deinit();
+
+    var fx: Fixture = undefined;
+    try analyze(alloc, &fx, SRC);
+    defer fx.deinit();
+    try store.store(testing.io, alloc, KEY, &fx.parser.ast, &fx.sem);
+
+    // 캐시 파일(root/<ab>/<cdef…>)을 짧은 garbage 로 덮어써 손상 → load 는 hard error 가 아니라
+    // null(재파싱). codec 의 magic/checksum/truncated 검증이 잘못된 캐시를 거른다.
+    var hex: [16]u8 = undefined;
+    _ = std.fmt.bufPrint(&hex, "{x:0>16}", .{KEY}) catch unreachable;
+    const path = try std.fs.path.join(alloc, &.{ root, hex[0..2], hex[2..16] });
+    defer alloc.free(path);
+    try std.Io.Dir.cwd().writeFile(testing.io, .{ .sub_path = path, .data = "xx" }); // < HEADER_LEN
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    try testing.expect((try store.load(testing.io, alloc, arena.allocator(), KEY)) == null);
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -42,6 +42,7 @@ pub const semantic_codec = @import("semantic_codec.zig");
 pub const module_codec = @import("module_codec.zig");
 pub const disk_cache = @import("disk_cache.zig");
 pub const cache_key = @import("cache_key.zig");
+pub const disk_module_store = @import("disk_module_store.zig");
 pub const css_scanner = @import("css_scanner.zig");
 pub const css_emitter = @import("css_emitter.zig");
 pub const symbol = @import("symbol.zig");
@@ -134,6 +135,7 @@ test {
     _ = @import("module_codec_test.zig");
     _ = @import("disk_cache_test.zig");
     _ = @import("cache_key_test.zig");
+    _ = @import("disk_module_store_test.zig");
     _ = @import("tree_shaker_test.zig");
     _ = @import("linker_test.zig");
     _ = @import("emitter_test.zig");


### PR DESCRIPTION
## 요약

`#4438` graph 통합 **직전** 레이어. `disk_cache`(영속화) + `module_codec`(직렬화)를 묶어 **"캐시 키(u64) → 한 모듈의 AST+semantic"** 을 디스크에 저장/복원하는 `DiskModuleStore` 를 추가합니다.

## API

```zig
pub const DiskModuleStore = struct {
    pub fn init(allocator, root_dir) !DiskModuleStore
    pub fn deinit(self) void
    pub fn store(self, io, alloc, key: u64, ast, sem) !void   // serialize → disk.put(atomic)
    pub fn load(self, io, alloc, arena, key: u64) !?DeserializedModule  // disk.get → deserialize
};
```

- **store**: best-effort — caller 가 `store(...) catch {}` 로 감싸 쓰기 실패가 빌드를 막지 않게.
- **load**: **miss(파일 없음)와 손상(magic/checksum/truncated) 모두 `null`** 로 degrade → 재파싱. codec 의 fail-safe 검증이 잘못된 캐시를 조용히 쓰는 것을 막음. `OutOfMemory` 만 전파.

## 범위 (graph 통합 시 필독 — doc에 명시)

`load` 는 **AST+semantic 만** 복원합니다 — `import_records`/`resolved_deps`/`alias_table` 등 graph 레벨 Module 상태는 미포함(module_codec 범위와 동일). 이는 in-memory `PersistentModuleStore.getIfFresh`(전체 Module struct-assign)와 **다릅니다** — graph cache-hit 경로가 이를 full Module 로 착각해 import_records 를 재구성 안 하면 import 미링크로 깨집니다.

## 테스트

`zig build test -Dtest-filter=disk_module_store` (Debug + ReleaseFast):
- **store → 새 arena 로 load → round-trip**: source/AST/semantic 동등성 + `exported_names` 포함 + symbol name(Span)이 복원 source 기준 resolve.
- miss → null.
- 손상(캐시 파일을 짧은 garbage 로 덮어씀) → null **fail-safe**(hard error 아님).

전체 5995 통과.

## `/code-review max` 반영

정확성 버그 0(테스트 앵글 포함 클린). 다음 graph PR 을 de-risk 하는 doc 보강:
- `load` 가 AST+semantic 만 복원함 + `PersistentModuleStore` 와 혼동 주의.
- miss/null 시 arena 부분 복원분 잔존 가능 → caller 는 모듈별 새 parse_arena 사용.
- MAX_ENTRY_BYTES 512MB 근거 + 동시성(thread-safe allocator) 주의.

## 다음 단계

**graph 통합**(`buildIncremental` 의 in-memory warm-hit 경로 옆에 디스크 hit/miss 분기 + opt-in + `ON==OFF` byte-identical 동등성) — **이때 비로소 실제 동작**. 이 PR 까지는 파이프라인 미연결로 출력 영향 0.

Part of #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)