### PR TITLE
feat(cache): compiler_build_id 주입 (build.zig git SHA) #4438

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,25 @@
 const std = @import("std");
 const boringssl_build = @import("build/boringssl.zig");
 
+/// 이 빌드의 commit 식별자(#4438 디스크 캐시 무효화 키 — src/build_id.zig 참조).
+/// `git rev-parse HEAD`(clone depth 무관 — `describe` 와 달리 shallow clone 에서도 같은 commit =
+/// 같은 값) + working tree dirty 여부. git 이 없거나 실패하면 "unknown"(tarball 빌드 등).
+fn gitBuildId(b: *std.Build) []const u8 {
+    const sha = gitRun(b, &.{ "git", "rev-parse", "HEAD" }) orelse return "unknown";
+    // dirty 면 "-dirty" 부착(변경 내용 자체는 구분 못 함 — build_id.zig 의 dirty 주의 참조).
+    const dirty = gitRun(b, &.{ "git", "status", "--porcelain", "--untracked-files=no" });
+    return if (dirty != null) b.fmt("{s}-dirty", .{sha}) else sha;
+}
+
+/// argv 를 실행해 trim 된 stdout 반환. 실패/비-제로 exit/빈 출력은 null. out_code 는
+/// runAllowFail 이 error 경로에서만 쓰므로(성공 시 미기록) 읽지 않는다.
+fn gitRun(b: *std.Build, argv: []const []const u8) ?[]const u8 {
+    var code: u8 = 0;
+    const out = b.runAllowFail(argv, &code, .ignore) catch return null;
+    const t = std.mem.trim(u8, out, " \t\r\n");
+    return if (t.len > 0) t else null;
+}
+
 // Although this function looks imperative, note that its job is to
 // declaratively construct a build graph that will be executed by an external
 // runner.
@@ -58,6 +77,15 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .strip = strip_setting,
     });
+
+    // #4438 디스크 캐시 무효화 키: 이 빌드의 git 식별자를 build_options 로 노출(src/build_id.zig
+    // 가 읽음). 현재 build_id 는 root.zig 의 test 블록에서만 참조 → lib_mod(테스트)만 필요.
+    // graph 통합이 build_id 를 non-test 경로(bundler)에서 쓰면 root.zig 를 root 로 하는 나머지
+    // 3개 모듈(wasm_lib_mod / wasm_bundler_lib_mod / napi_lib_mod)에도 build_options 를 추가할 것
+    // — 빠뜨리면 해당 타깃(zig build wasm/wasm-bundler/napi) 빌드만 깨져 로컬 `zig build`/test 는 통과.
+    const build_opts = b.addOptions();
+    build_opts.addOption([]const u8, "git_sha", gitBuildId(b));
+    lib_mod.addOptions("build_options", build_opts);
 
     // We will also create a module for our other entry point, 'main.zig'.
     const exe_mod = b.createModule(.{

--- a/src/build_id.zig
+++ b/src/build_id.zig
@@ -1,0 +1,49 @@
+//! 이 zts 바이너리의 빌드 식별자 — 디스크 캐시(#4438) 무효화 키의 컴파일러-버전 dimension.
+//!
+//! parser/semantic/transformer 로직이 바뀐 rebuild 후 같은 source 여도 결과가 달라질 수 있다.
+//! in-memory 캐시는 프로세스 재시작으로 자연 무효화되지만 disk cache 는 그렇지 않으므로,
+//! 바이너리를 식별하는 값을 캐시 키에 넣어야 한다(증분 컴파일러가 빌드 해시를 박는 것과 동일 발상).
+//!
+//! 식별자 = hash(git_sha + optimize mode + zig 버전). git 이 없으면 git 부분이 "unknown"
+//! (tarball 빌드 등) — 같은 tarball 은 한 버전이라 무방. optimize mode 포함은 release-only 회귀
+//! (debug 통과해도 ReleaseFast 에서만 깨지는 차이)를 다른 빌드로 분리하기 위함. git_sha 는
+//! `git rev-parse HEAD`(clone depth 무관)라 full/shallow clone 이 같은 commit 에 같은 값.
+//!
+//! ⚠️ working tree 가 dirty 면 git_sha 가 `<sha>-dirty` 로 **고정**되어 dirty 변경 내용을
+//! 구분하지 못한다. disk cache 를 켤 때(graph 통합) dirty 빌드는 캐시를 신뢰하지 않거나
+//! (opt-in off) commit 후 사용해야 stale 을 피한다.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const build_options = @import("build_options");
+
+/// 세 dimension 을 NUL 구분자로 해시(고정 필드라 충돌 안전). pure 헬퍼라 테스트가 각 dimension
+/// 의 민감도를 rebuild 없이 검증할 수 있다. 0 은 1 로 매핑 — `cache_key` 에서 0 은 가드 무력화
+/// 신호라 build_id 가 (천문학적 확률로) 0 을 내면 안 된다.
+fn compute(git_sha: []const u8, mode_tag: []const u8, zig_ver: []const u8) u64 {
+    var h = std.hash.Wyhash.init(0);
+    h.update(git_sha);
+    h.update(&[_]u8{0});
+    h.update(mode_tag);
+    h.update(&[_]u8{0});
+    h.update(zig_ver);
+    const v = h.final();
+    return if (v == 0) 1 else v;
+}
+
+/// 이 바이너리의 빌드 식별자(u64). graph 통합이 `cache_key.compute` 의 `compiler_build_id` 로
+/// 넘긴다(항상 0 이 아님).
+pub fn current() u64 {
+    return compute(build_options.git_sha, @tagName(builtin.mode), builtin.zig_version_string);
+}
+
+test "build_id: 각 dimension 이 키를 바꾸고 0 이 아님" {
+    const t = std.testing;
+    try t.expect(current() != 0);
+    // 결정성.
+    try t.expectEqual(compute("abc", "Debug", "0.16.0"), compute("abc", "Debug", "0.16.0"));
+    // 각 dimension 변경 → 키 변경(하나라도 해시에서 빠지면 cross-build cache poisoning).
+    try t.expect(compute("abc", "Debug", "0.16.0") != compute("abd", "Debug", "0.16.0")); // git_sha
+    try t.expect(compute("abc", "Debug", "0.16.0") != compute("abc", "ReleaseFast", "0.16.0")); // mode
+    try t.expect(compute("abc", "Debug", "0.16.0") != compute("abc", "Debug", "0.16.1")); // zig ver
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -49,6 +49,7 @@ test {
     _ = @import("transformer/cooked_name.zig");
     _ = @import("test_arena.zig");
     _ = @import("env_flag.zig");
+    _ = @import("build_id.zig");
     _ = util.wyhash;
     _ = util.codec_io;
 


### PR DESCRIPTION
## 요약

`#4438` 디스크 캐시 **graph 통합의 선행 인프라**. parser/semantic/transformer 로직이 바뀐 rebuild 후 disk cache 가 같은 source 에 stale 결과를 재사용하는 것을 막는 **"컴파일러-버전" dimension** 을 만듭니다. in-memory 캐시는 프로세스 재시작으로 자연 무효화되지만 disk cache 는 그렇지 않아 필수입니다(증분 컴파일러가 빌드 해시를 박는 발상).

## 변경

- **build.zig**: `gitBuildId` = `git rev-parse HEAD` + dirty 여부를 `build_options.git_sha` 로 노출. git 없으면 `"unknown"`(tarball). `lib_mod`(test 경로)에만 추가 — 현재 build_id 는 `root.zig` test 블록에서만 참조하므로 non-test 빌드(exe/wasm/napi)는 영향 0.
- **src/build_id.zig**: `current() u64` = `hash(git_sha + optimize mode + zig 버전)`. graph 통합이 `cache_key.compute` 의 `compiler_build_id` 로 넘깁니다. optimize mode 포함은 **release-only 회귀**(debug 통과해도 ReleaseFast 에서만 깨지는 차이)를 다른 빌드로 분리하기 위함.

## `/code-review max` 반영

- **UB 제거(CONFIRMED)**: `git describe` 의 `out_code` 미초기화 read(`runAllowFail` 은 성공 exit-0 시 out_code 를 안 씀) → `git rev-parse HEAD` + dirty 체크로 교체. 덤으로 **shallow clone depth-무관성** 확보(`describe` 는 full/shallow clone 이 같은 commit 에 다른 값 → cross-env 캐시 미스, `rev-parse` 는 동일).
- **0→1 가드**: `cache_key` 에서 `compiler_build_id==0` 은 가드 무력화 신호라, build_id 가 (1/2^64 확률로) 0 을 내면 안 됨.
- **pure `compute` 헬퍼 + 강한 테스트**: 각 dimension(git/mode/zig) 변경 → 키 변경 검증 → 하나라도 해시에서 빠지는 cross-build poisoning 을 회귀 가드. (기존 테스트는 `current()==current()` near-tautology 였음.)
- 와ent 주석을 root.zig 기반 모듈 3개(wasm/wasm-bundler/napi)로 정정 — graph 통합이 build_id 를 non-test 경로에서 쓸 때 build_options 를 누락하면 해당 타깃 빌드만 깨지는 함정 명시.

## ⚠️ dirty 한계 (graph 통합 시 처리)

`git ... -dirty` 는 working tree 가 dirty 면 `<sha>-dirty` 로 고정되어 dirty 변경 내용을 구분하지 못합니다. disk cache 를 켤 때(graph 통합) dirty 빌드는 캐시를 신뢰하지 않거나(opt-in off) commit 후 사용해야 stale 을 피합니다 — build_id.zig 주석에 명시.

## 테스트

`zig build test -Dtest-filter=build_id` (Debug + ReleaseFast): 0 아님 + 결정성 + 각 dimension 민감도. 전체 5996 통과.

## 다음 단계

graph 통합 본체: `buildIncremental` 디스크 hit/miss 분기 + opt-in + `ON==OFF` byte-identical 동등성. 이때 build_id 를 BundleOptions 통해 cache_key 로 배선.

Part of #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)