### PR TITLE
feat(cache): graph 디스크 캐시 키 배선·캡처 (#4438 graph 통합 1)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -79,10 +79,8 @@ pub fn build(b: *std.Build) void {
     });
 
     // #4438 디스크 캐시 무효화 키: 이 빌드의 git 식별자를 build_options 로 노출(src/build_id.zig
-    // 가 읽음). 현재 build_id 는 root.zig 의 test 블록에서만 참조 → lib_mod(테스트)만 필요.
-    // graph 통합이 build_id 를 non-test 경로(bundler)에서 쓰면 root.zig 를 root 로 하는 나머지
-    // 3개 모듈(wasm_lib_mod / wasm_bundler_lib_mod / napi_lib_mod)에도 build_options 를 추가할 것
-    // — 빠뜨리면 해당 타깃(zig build wasm/wasm-bundler/napi) 빌드만 깨져 로컬 `zig build`/test 는 통과.
+    // 가 읽음). build_id 가 bundler(non-test 경로)에서 쓰이므로 root.zig 를 root 로 하는 모든
+    // 모듈에 추가한다 — lib_mod(여기) + wasm_lib_mod / wasm_bundler_lib_mod / napi_lib_mod(아래).
     const build_opts = b.addOptions();
     build_opts.addOption([]const u8, "git_sha", gitBuildId(b));
     lib_mod.addOptions("build_options", build_opts);
@@ -243,6 +241,7 @@ pub fn build(b: *std.Build) void {
             .target = wasm_target,
             .optimize = wasm_optimize,
         });
+        wasm_lib_mod.addOptions("build_options", build_opts); // #4438 build_id (bundler non-test 경로)
 
         const wasm_mod = b.createModule(.{
             .root_source_file = b.path("packages/wasm/src/wasm_entry.zig"),
@@ -291,6 +290,7 @@ pub fn build(b: *std.Build) void {
             .optimize = wasm_optimize,
             .single_threaded = true,
         });
+        wasm_bundler_lib_mod.addOptions("build_options", build_opts); // #4438 build_id
 
         const wasm_bundler_mod = b.createModule(.{
             .root_source_file = b.path("packages/wasm/src/wasm_bundler_entry.zig"),
@@ -336,6 +336,7 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = napi_optimize,
         });
+        napi_lib_mod.addOptions("build_options", build_opts); // #4438 build_id
 
         const napi_mod = b.createModule(.{
             .root_source_file = b.path("packages/core/src/napi_entry.zig"),

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -432,6 +432,10 @@ pub const BundleOptions = struct {
     /// Compiled output cache. HMR/watch 에서 변경 안 된 모듈의 emit 을 스킵.
     /// IncrementalBundler 가 소유.
     compiled_cache: ?*@import("compiled_cache.zig").CompiledOutputCache = null,
+    /// #4438 디스크 캐시 모듈 store(parse/semantic 영속화). null 이면 비활성(기본). caller 가
+    /// 소유. 주입되면 graph 가 parseModule 시 모듈별 무효화 키를 계산해 `module.disk_cache_key`
+    /// 에 캡처한다(디스크 store/load 호출은 후속 단계 — 현재는 키 캡처만, 출력 영향 0).
+    disk_module_cache: ?*@import("disk_module_store.zig").DiskModuleStore = null,
     /// HMR rename 재사용 활성 (perf/hmr-link-rename-reuse). true + `preserved_renames`
     /// present + 가드 통과 시 `computeRenames`(전체 모듈 top-level 이름 deconflict, ~106ms)
     /// 를 skip 하고 초기 빌드의 rename_table 을 재주입한다. IncrementalBundler 가
@@ -1256,6 +1260,16 @@ pub const Bundler = struct {
         graph.incremental_mode = self.options.module_store != null or
             self.options.changed_files != null or
             self.options.compiled_cache != null;
+        // #4438 디스크 캐시: store 주입 시 키 dimension(옵션 해시·빌드 식별자)을 graph 에 배선.
+        // parseModule 이 모듈별 키를 계산해 module.disk_cache_key 에 캡처(store/load 는 후속).
+        // 디스크 키는 source_hash 기반(mtime 무관)이라 incremental_mode(=fstat) 를 켜지 않는다.
+        // 옵션 해시는 disk 전용(plugin 포인터 대신 이름+훅 — 프로세스 간 안정) 사용.
+        if (self.options.disk_module_cache) |dc| {
+            graph.disk_cache = dc;
+            const eo = self.makeEmitOptions();
+            graph.disk_options_hash = @import("compiled_cache.zig").computeDiskOptionsHash(&eo);
+            graph.disk_compiler_build_id = @import("../build_id.zig").current();
+        }
         graph.inline_dynamic_imports = self.options.inline_dynamic_imports;
         // require.context 등 parser inline scan 의 build-time 정적 평가에 사용 (#1579 Phase 2.6)
         graph.defines = self.options.define;

--- a/src/bundler/cache_key.zig
+++ b/src/bundler/cache_key.zig
@@ -75,6 +75,21 @@ pub const ParseFlags = packed struct(u8) {
     }
 };
 
+/// 설정 완료된(**pre-parse**) parser 의 effective 상태에서 ParseFlags 를 뽑는다. store 경로(parse
+/// 후 디스크 저장)와 load 경로(parse 스킵 — pre-parse 설정값으로 키 조회)가 **반드시 동일한
+/// 매핑**을 써야 키가 일치한다(불일치 시 cache 영영 miss). 한 곳에 둬 drift 를 막는다.
+/// post-parse 확정값(unambiguous 의 is_module/is_strict)은 source 의 함수라 source_hash 에 이미
+/// 반영되므로, pre-parse 설정값(확장자/loader/jsx_in_js/--flow 반영)으로 충분하다.
+pub fn parseFlagsFromParser(parser: anytype) ParseFlags {
+    return .{
+        .is_ts = parser.source_mode == .ts,
+        .is_jsx = parser.is_jsx,
+        .is_module = parser.is_module,
+        .is_flow = parser.is_flow,
+        .is_strict = parser.is_strict_mode,
+    };
+}
+
 /// **정밀 전략**이 키에 넣는, parse/pre-pass 에 영향을 주는 옵션의 명시적 집합 —
 /// `TransformOptions` 에서 결과에 영향을 주는 필드를 **손으로 추린** 것이다.
 /// 단순 타입(bool/정수/enum)만 허용한다 — 슬라이스/포인터(define/plugins 등)는 caller 가

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -273,6 +273,31 @@ pub fn computeOptionsHash(options: *const EmitOptions) u64 {
     return h.final();
 }
 
+/// **디스크 캐시(#4438)용** options_hash. `computeOptionsHash` 와 같되 plugin 을 포인터 identity
+/// (`@intFromPtr`)가 아니라 **이름 + 훅 존재 비트**로 식별한다 — 포인터는 프로세스 재시작마다
+/// 바뀌어(ASLR) disk 키가 매 실행 달라지므로(in-memory 와 달리 disk 는 프로세스 간 안정해야 함).
+/// 같은 이름·훅 모양의 **다른 IMPL**: 빌트인 plugin 은 `build_id`(zts git SHA)로, user plugin 은
+/// `plugin_version`(향후, AST plugin epic)으로 구분 — 그 전까지는 user plugin impl 변경이
+/// disk 캐시를 무효화하지 못하는 한계(commit/재설치로 우회).
+pub fn computeDiskOptionsHash(options: *const EmitOptions) u64 {
+    var no_plugins = options.*; // 값 복사(슬라이스 헤더만) — plugins 만 비워 포인터 해시 제외
+    no_plugins.plugins = &.{};
+    var h = InputHasher.init(0);
+    h.addU64(computeOptionsHash(&no_plugins)); // plugins 외 전체 옵션(안정)
+    h.addU64(options.plugins.len);
+    for (options.plugins) |p| {
+        h.addStr(p.name);
+        var hooks: u8 = 0; // 훅 존재 비트(포인터 아님 → 안정)
+        if (p.resolveId != null) hooks |= 1;
+        if (p.load != null) hooks |= 2;
+        if (p.transform != null) hooks |= 4;
+        if (p.renderChunk != null) hooks |= 8;
+        if (p.generateBundle != null) hooks |= 16;
+        h.addU64(hooks);
+    }
+    return h.final();
+}
+
 // ===========================================================================
 // computeInputHash — 모듈별 최종 hash
 // ===========================================================================

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -133,6 +133,15 @@ pub const ModuleGraph = struct {
     /// (CLI / 첫 빌드 외부) 에서는 false — caller 자체가 없어 fstat 불필요.
     /// 5000-module 합성 벤치에서 fstat ~5000 회 절감.
     incremental_mode: bool = false,
+    /// #4438 디스크 캐시(parse/semantic 영속화). null 이면 비활성(기본). bundler 가 BundleOptions
+    /// 의 store 인스턴스를 주입. parseModule 이 이 store 가 있을 때만 모듈별 키를 계산해
+    /// `module.disk_cache_key` 에 캡처한다(store/load 호출은 후속 단계).
+    disk_cache: ?*@import("disk_module_store.zig").DiskModuleStore = null,
+    /// 디스크 캐시 키의 옵션 dimension(보수 전략 = `computeDiskOptionsHash` — plugin 을 포인터가
+    /// 아니라 이름+훅으로 해시해 프로세스 간 안정). bundler 주입.
+    disk_options_hash: u64 = 0,
+    /// 디스크 캐시 키의 컴파일러-버전 dimension(`build_id.current()`). bundler 주입.
+    disk_compiler_build_id: u64 = 0,
     /// perf/hmr-graph-topology-reuse Phase B — 위상(topology) 보존 모드.
     /// true 면 (1) `transferModulesToStore` 가 비활성(graph 가 parse_arena 단독 owner —
     /// store 로 양도하지 않음), (2) bundler external_graph 훅이 매 빌드 graph 를 전량 clear

--- a/src/bundler/graph/parse_module.zig
+++ b/src/bundler/graph/parse_module.zig
@@ -115,6 +115,21 @@ pub fn parseModule(self: *ModuleGraph, io: std.Io, idx: ModuleIndex) void {
     var parser: Parser = undefined;
     if (!self.initParserForModule(io, module, arena_alloc, &scanner, &parser)) return;
 
+    // #4438 디스크 캐시 무효화 키 캡처(configure 후·parse 전): load 경로가 parse 를 스킵하고
+    // pre-parse 설정값으로 키를 조회하므로, store 경로도 같은 시점의 effective flags 를 써야 키가
+    // 일치한다(post-parse 확정 is_module/is_strict 는 source 함수라 source_hash 에 반영됨).
+    // source 는 plugin transform 까지 반영된 최종값. disk_cache 비활성이면 skip(출력·비용 0).
+    if (self.disk_cache != null) {
+        const cache_key_mod = @import("../cache_key.zig");
+        const wyhash = @import("../../util/wyhash.zig");
+        module.disk_cache_key = cache_key_mod.compute(
+            wyhash.hashU64(module.source),
+            cache_key_mod.parseFlagsFromParser(&parser),
+            self.disk_options_hash,
+            self.disk_compiler_build_id,
+        );
+    }
+
     setup_scope.end();
     {
         var parse_scope = profile.begin(.graph_discover_pm_parse);

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -1664,3 +1664,56 @@ test "graph.invalidateModule: path 보존, ast/semantic/resolved_deps clear" {
     // resolved_deps clear
     try std.testing.expectEqual(@as(usize, 0), graph.getModule(target_idx).?.resolved_deps.items.len);
 }
+
+test "graph: 디스크 캐시 키 캡처 — 활성 시 모듈별 키 (#4438)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "import { a } from './a'; console.log(a);");
+    try writeFile(tmp.dir, "a.ts", "export const a = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry);
+    const cache_root = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "cache" });
+    defer std.testing.allocator.free(cache_root);
+
+    var store = try @import("disk_module_store.zig").DiskModuleStore.init(std.testing.allocator, cache_root);
+    defer store.deinit();
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+    graph.disk_cache = &store;
+    graph.disk_options_hash = 0x1234;
+    graph.disk_compiler_build_id = 0xABCD;
+
+    try graph.build(std.testing.io, &.{entry});
+    try std.testing.expectEqual(@as(usize, 2), graph.moduleCount());
+
+    // 두 모듈 모두 키가 캡처(0 아님)되고, source 가 다르니 키도 다르다.
+    const k0 = graph.getModule(ModuleIndex.fromUsize(0)).?.disk_cache_key;
+    const k1 = graph.getModule(ModuleIndex.fromUsize(1)).?.disk_cache_key;
+    try std.testing.expect(k0 != 0 and k1 != 0);
+    try std.testing.expect(k0 != k1);
+}
+
+test "graph: 디스크 캐시 비활성 시 키 미설정 (#4438)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+    // disk_cache = null (기본) → parseModule 이 키 계산을 skip.
+
+    try graph.build(std.testing.io, &.{entry});
+    try std.testing.expectEqual(@as(u64, 0), graph.getModule(ModuleIndex.fromUsize(0)).?.disk_cache_key);
+}

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -423,6 +423,9 @@ pub const Module = struct {
     /// 파일 mtime (나노초). graph.build / store 히트 경로에서 설정.
     /// 0 = 미확인 (가상 모듈, plugin 소스 등). compiled output cache key 구성에 사용.
     mtime: i128 = 0,
+    /// #4438 디스크 캐시 무효화 키(parse 시 계산, parser flags 가 살아있을 때 캡처). 0 = 미설정
+    /// (디스크 캐시 비활성 또는 가상 모듈). graph 의 디스크 store/load 가 이 키로 디스크를 조회.
+    disk_cache_key: u64 = 0,
     /// file/copy 로더의 asset 출력 정보. null이면 asset이 아님.
     asset_data: ?AssetData = null,
     /// RN AssetRegistry metadata (이미지 모듈만, asset_registry 활성 시). parse_arena 소유 —


### PR DESCRIPTION
## 요약

`#4438` 디스크 캐시 **graph 통합의 첫 단계**. 모듈별 무효화 키를 parse 시 계산해 `Module.disk_cache_key` 에 캡처합니다. **디스크 store/load 호출은 다음 단계**이고 opt-in off 기본이라 **출력 영향 0**(키 계산만, 디스크 미접근).

## 배선

- **`BundleOptions.disk_module_cache`**(`?*DiskModuleStore`) opt-in. null=비활성(기본). caller 소유.
- **`ModuleGraph`**: `disk_cache`/`disk_options_hash`/`disk_compiler_build_id`(bundler 주입).
- **`parseModule`**(configure 후·parse 전): `disk_cache` 활성 시 `module.disk_cache_key = cache_key.compute(wyhash(source), ParseFlags, options_hash, build_id)`.
- **`build.zig`**: `build_id` 가 bundler(non-test)에서 쓰이므로 root.zig 기반 나머지 3모듈(wasm/wasm-bundler/napi)에도 `build_options` 추가.

## `/code-review max` 반영 (정확성)

- **ParseFlags store/load 대칭**: 캡처를 **pre-parse(configure)** 시점으로. load 는 parse 를 스킵하고 pre-parse 설정값으로 키를 조회하므로, store 도 같은 시점 flags 를 써야 키가 일치합니다(post-parse 확정 `is_module`/`is_strict` 는 source 의 함수라 `source_hash` 에 이미 반영). `cache_key.parseFlagsFromParser` 헬퍼로 store/load 단일 매핑 → drift 방지.
- **disk-safe options_hash**: `computeDiskOptionsHash` 신설 — plugin 을 **포인터 identity 대신 이름+훅 비트**로 해시. 포인터는 프로세스 재시작마다(ASLR) 바뀌어 disk 키가 매 실행 달라지고(plugin 빌드=RN 핵심 타겟이 영영 cold), 포인터 재사용 시 stale match 위험. 빌트인 plugin impl 변경은 `build_id`(git SHA)로 구분.
- **불필요 fstat 회피**: `incremental_mode` 에서 `disk_module_cache` 제거 — 디스크 키는 `source_hash` 기반(mtime 무관)이라 per-module fstat 불필요.

## 테스트

graph build 시 모듈별 키 캡처 검증: 활성 → 모듈별 distinct·0 아님, 비활성 → 0(gating). Debug+ReleaseFast + **napi 빌드**(build_options 4모듈 확장 검증) 통과. 전체 5998 통과.

## 다음 단계

- **store(write)**: parse 후 `disk_store.store(key, ast, semantic)` (best-effort).
- **load+hit**: in-memory miss 뒤 디스크 load → AST+semantic 복원 → `import_scanner` 로 import_records 재구성.
- **ON==OFF byte-identical 동등성 테스트** + opt-in 표면(CLI/NAPI).

Part of #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)