### PR TITLE
feat(cache): graph 디스크 캐시 store 호출 배선 (#4438 graph 통합 2)

### DIFF
--- a/src/bundler/graph/parse_module.zig
+++ b/src/bundler/graph/parse_module.zig
@@ -257,6 +257,22 @@ pub fn parseModule(self: *ModuleGraph, io: std.Io, idx: ModuleIndex) void {
     module.ast = parser.ast;
     module.line_offsets = scanner.line_offsets.items;
 
+    // #4438 디스크 캐시 store: parse+semantic 산출물을 디스크에 영속화한다. 아래 transformer
+    // pre-pass 가 module.ast 를 mutate 하므로 **pre-pass 전** AST 를 저장해야 한다 — load(후속
+    // PR)는 이 산출물을 복원한 뒤 materialize/pre-pass 를 재실행하므로, store/load 가 같은 시점
+    // (parse 직후) AST 여야 정합한다. best-effort: 쓰기 실패는 catch 로 흘려 캐시가 no-cache 보다
+    // 빌드를 더 깨뜨리지 않게 한다(disk full 등). semantic 이 OOM 으로 null 이면 skip(부분 데이터
+    // 저장 방지). 키는 parse 직전 동일 게이트(self.disk_cache != null)에서 이미 캡처됐다.
+    // 지금은 store 만 — load(parse 스킵)는 graph 통합 3 → 출력 영향 0(항상 parse 실행).
+    // self.allocator 는 worker 동시 호출에 안전(release=mimalloc / debug=DebugAllocator).
+    if (self.disk_cache) |dc| {
+        if (module.ast) |*ast| {
+            if (module.semantic) |*sem| {
+                dc.store(io, self.allocator, module.disk_cache_key, ast, sem) catch {};
+            }
+        }
+    }
+
     if (!self.materializeParserMetadata(module, &parser, arena_alloc)) return;
 
     // #1961/#1913: transformer pre-pass. helper module 을 graph 의 1급 모듈로

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -1717,3 +1717,48 @@ test "graph: 디스크 캐시 비활성 시 키 미설정 (#4438)" {
     try graph.build(std.testing.io, &.{entry});
     try std.testing.expectEqual(@as(u64, 0), graph.getModule(ModuleIndex.fromUsize(0)).?.disk_cache_key);
 }
+
+test "graph: 디스크 캐시 store — build 시 모듈 영속화 + load round-trip (#4438)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "import { a } from './a'; console.log(a);");
+    try writeFile(tmp.dir, "a.ts", "export const a = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry);
+    const cache_root = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "cache" });
+    defer std.testing.allocator.free(cache_root);
+
+    var store = try @import("disk_module_store.zig").DiskModuleStore.init(std.testing.allocator, cache_root);
+    defer store.deinit();
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+    graph.disk_cache = &store;
+    graph.disk_options_hash = 0x1234;
+    graph.disk_compiler_build_id = 0xABCD;
+
+    try graph.build(std.testing.io, &.{entry});
+    try std.testing.expectEqual(@as(usize, 2), graph.moduleCount());
+
+    // store 가 build 중 두 모듈을 디스크에 썼으면, 같은 키로 load 가 복원한다 — 실제 모듈
+    // AST+semantic codec round-trip self-check (load 는 테스트 전용, 파이프라인 미연결).
+    const k0 = graph.getModule(ModuleIndex.fromUsize(0)).?.disk_cache_key;
+    const k1 = graph.getModule(ModuleIndex.fromUsize(1)).?.disk_cache_key;
+    try std.testing.expect(k0 != 0 and k1 != 0);
+
+    // 복원본(ast.source 포함)은 arena 소유 — arena.deinit 가 일괄 회수(개별 deinit 금지).
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const r0 = try store.load(std.testing.io, std.testing.allocator, arena.allocator(), k0);
+    try std.testing.expect(r0 != null);
+    const r1 = try store.load(std.testing.io, std.testing.allocator, arena.allocator(), k1);
+    try std.testing.expect(r1 != null);
+
+    // 미저장 키는 miss(null)로 degrade — fail-safe.
+    const miss = try store.load(std.testing.io, std.testing.allocator, arena.allocator(), 0xDEADBEEF);
+    try std.testing.expect(miss == null);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -830,6 +830,19 @@ pub fn main(init: std.process.Init) !void {
         // watch + dev: 초기 빌드에서도 module_codes 수집 (HMR 캐시 초기화용)
         var initial_opts = bundle_opts;
         if (opts.watch and opts.dev) initial_opts.collect_module_codes = true;
+
+        // #4438 디스크 모듈 캐시 (실험적, env-gated): `ZNTC_DISK_CACHE=<dir>` 설정 시 활성.
+        // 현재는 store 단계 — parse+semantic 산출물을 <dir> 에 영속화만 한다(load=후속 PR).
+        // 미설정/빈 값/init 실패면 비활성(null) → 디스크 미접근, 출력·비용 0.
+        var disk_module_store: ?lib.bundler.disk_module_store.DiskModuleStore = null;
+        defer if (disk_module_store) |*s| s.deinit();
+        if (env_flag.get("ZNTC_DISK_CACHE")) |dir| {
+            if (dir.len > 0) {
+                disk_module_store = lib.bundler.disk_module_store.DiskModuleStore.init(allocator, dir) catch null;
+                if (disk_module_store) |*s| initial_opts.disk_module_cache = s;
+            }
+        }
+
         var bundler = Bundler.init(allocator, initial_opts);
         defer bundler.deinit();
 


### PR DESCRIPTION
## 개요
#4438 디스크 캐시 graph 통합의 **두 번째 단계 — `store` 호출 배선**입니다. 통합 1(#4449)이 parse 직전 무효화 키를 **캡처만** 했다면, 이번엔 그 키로 parse+semantic 산출물을 **실제 디스크에 영속화**합니다.

`load`(parse 스킵 + 복원)는 다음 단계(graph 통합 3)로 분리했습니다. load 가 정합성 위험(import_records / line_offsets / legal_comments / pre-pass 재구성)을 지므로, store 를 먼저 머지해 **캐시 파일 생성·codec round-trip·write 비용**을 독립 검증하고 load 로 넘어갑니다.

> 캐시를 켜도(`ZNTC_DISK_CACHE`) load 가 없으니 **항상 parse 를 실행** → 출력은 캐시 on/off 무관 **byte-identical**. 즉 이 PR 자체의 빌드 출력 영향은 0이고, 디스크에 캐시만 쌓습니다.

## 변경
- **`parse_module.zig`**: semantic 직후·transformer pre-pass **전**에 `disk_cache.store(key, ast, sem)` 호출.
  - pre-pass 가 `module.ast` 를 mutate 하므로 **pre-pass 전** AST 를 저장합니다 — load 는 복원 후 materialize/pre-pass 를 재실행하므로, store/load 가 **같은 시점(parse 직후) AST** 여야 정합합니다.
  - best-effort: 쓰기 실패는 `catch {}` 로 흘립니다(캐시는 no-cache 보다 빌드를 더 깨뜨리지 않는다 — disk full 등). `semantic` 이 OOM 으로 `null` 이면 skip(부분 데이터 저장 방지).
- **`main.zig`**: env-gated 주입. `ZNTC_DISK_CACHE=<dir>` 설정 시에만 `DiskModuleStore` 를 만들어 `initial_opts.disk_module_cache` 에 주입. 미설정/빈 값/init 실패면 비활성(null) → 디스크 미접근. 첫(cold) 빌드 경로만 — watch rebuild 는 메모리 캐시(incremental)라 미연결(통합 1에서 결정).

## 동시성 (Zig 초보자용 설명)
`store` 는 **worker thread** 에서 호출됩니다(`parseModule` 이 병렬 실행). 직렬화 임시 버퍼와 `DiskCache.put` 의 tmp/final 경로 문자열이 모두 `self.allocator` 로 할당되는데, 이 allocator 는 release=mimalloc / debug=`DebugAllocator(thread_safe=true)` 라 **여러 worker 가 동시에 호출해도 안전**합니다. tmp 파일 이름은 프로세스 전역 atomic 카운터로 유일성을 보장하고, 최종 파일은 atomic `rename` 으로 교체되어 reader 가 half-written 파일을 보지 못합니다.

## 테스트 & 검증
- **유닛**(`graph_test.zig`): graph build 시 두 모듈을 store → 같은 키로 `load` 가 복원(실제 모듈 AST+semantic **codec round-trip self-check**, load 는 테스트 전용·파이프라인 미연결) + 미저장 키는 miss(null) **fail-safe**. Debug + ReleaseFast 통과.
- **end-to-end**: `ZNTC_DISK_CACHE` on/off 출력 **byte-identical** 확인.
  - 작은 fixture(119B, 2모듈) → 캐시 2파일, 샤딩 경로 정상.
  - React 19 앱(485KB, 12모듈, node_modules dep 포함) → 출력 동일, 캐시 12파일/3.6M (압축 PoC 입력 데이터).
- **code-review max** 후속(correctness/cleanup/conventions, fresh-eyes 서브에이전트 2종) — clean.

## 다음 단계
- graph 통합 3: `load`(parse 스킵 + 복원, import_records/line_offsets/legal_comments/pre-pass 재구성) → 실제 wall 절감.
- 압축 PoC(캐시 3.6M/12모듈 → 308MB/빌드 규모 IO·공간 절감).

Part of #4438