### PR TITLE
feat(cache): load 경로 재구성 헬퍼 materializeFromCachedAst (#4438 graph 통합 3 PR1)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -76,6 +76,7 @@ pub const ModuleGraph = struct {
     pub const runTransformerPrePass = graph_transform_prepass.run;
     pub const resyncModuleMetadataAfterConstMaterialization = graph_transform_prepass.resyncAfterConstMaterialization;
     pub const resyncModuleMetadataAfterAstMutation = graph_transform_prepass.resyncAfterAstMutation;
+    pub const materializeFromCachedAst = graph_transform_prepass.materializeFromCachedAst;
     const graph_package_info = @import("graph/package_info.zig");
     pub const lookupPkgInfo = graph_package_info.lookupPkgInfo;
     pub const applySideEffectsFromPackageJson = graph_package_info.applySideEffectsFromPackageJson;

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -16,6 +16,7 @@ const TransformOptions = @import("../../transformer/transformer.zig").TransformO
 const builtin_plugins = @import("../../transformer/plugins/builtin.zig");
 const Span = @import("../../lexer/token.zig").Span;
 const parse_helpers = @import("parse_helpers.zig");
+const injectFlowEnumRuntimeImport = @import("synthetic_imports.zig").injectFlowEnumRuntimeImport;
 
 const isFlowPath = parse_helpers.isFlowPath;
 const suppressRuntimeHelperInternalUnresolved = parse_helpers.suppressRuntimeHelperInternalUnresolved;
@@ -599,4 +600,32 @@ pub fn resyncAfterAstMutation(
     }
 
     try refreshStableBindingRefsAfterSemanticResync(self, module, arena_alloc, .graph_resync_alias);
+}
+
+/// #4438 디스크 캐시 load 경로 전용 — parser 없이 복원된 `module.ast`(+semantic)만으로
+/// `materialize`(parser_metadata.zig)의 graph 레벨 출력을 재구성한다. `materialize` 는
+/// `parser.scan_*`(parse 중 수집)에 의존하지만, `resyncAfterAstMutation` 이 같은 데이터를
+/// AST 재순회로 재생성한다(import_records / import·export_bindings / exported_names /
+/// namespace_access_index / exports_kind / wrap_kind / cjs 플래그 / semantic·prebuilt_stmt_info /
+/// alias_table). load 는 AST(+semantic)만 복원하므로 이 헬퍼로 메타를 채운 뒤 transformer
+/// pre-pass(`run`)를 재실행하면 cold parse 경로와 동일한 module 상태에 도달한다.
+///
+/// `materialize` 에만 있고 `resync` 에 없는 갭을 보완:
+///  - **flow-enum 런타임 import**: 게이트 `has_flow_enum_declaration` 는 Ast 필드라 복원된다.
+///    (resync 는 transformer 가 enum 을 이미 lower 한 post-transform AST 에서 돌기 때문에 이
+///    inject 를 skip 하지만, load 는 pre-transform AST 를 복원하므로 materialize 처럼 재현해야 함.)
+///
+/// 알려진 미보완 갭(PR② ON==OFF 코퍼스에서 검증/보완): import/export 문이 전혀 없고
+/// `import.meta` 만 있는 .js 모듈은 materialize 가 `parser.has_module_syntax` 로 `.esm` 분류하나
+/// resync 의 scan(import/export 노드 기반)은 `.none` 으로 떨어질 수 있다. 그런 단독 모듈은 극히
+/// 드물고 대부분 import/export 를 동반하므로 PR① 범위에서 제외한다.
+///
+/// 출력 영향 0: 호출자는 graph 통합 PR②(load hit 배선) — 현재 미연결(동등성 테스트 전용).
+/// `self` 는 graph(`self.defines` / `self.allocator` 사용), `arena_alloc` 는 모듈 parse_arena.
+pub fn materializeFromCachedAst(self: anytype, module: *Module, arena_alloc: std.mem.Allocator) !void {
+    try resyncAfterAstMutation(self, module, arena_alloc, null);
+    const ast = &(module.ast orelse return);
+    if (ast.has_flow_enum_declaration) {
+        module.import_records = injectFlowEnumRuntimeImport(arena_alloc, module.import_records) catch module.import_records;
+    }
 }

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -1762,3 +1762,80 @@ test "graph: 디스크 캐시 store — build 시 모듈 영속화 + load round-
     const miss = try store.load(std.testing.io, std.testing.allocator, arena.allocator(), 0xDEADBEEF);
     try std.testing.expect(miss == null);
 }
+
+/// #4438 통합3 PR1: build 직후 module(=정상 materialize 결과, ground truth)을 캡처하고,
+/// parser 없이 `materializeFromCachedAst`(헬퍼)로 같은 module.ast 를 재구성한 뒤 graph 레벨
+/// 출력이 동등한지 검증한다. caller 는 pre-pass 미실행 fixture(.mjs/.cjs, minify off)를 써서
+/// module.* 가 materialize 결과 그대로 남도록 한다(헬퍼=resync 기반과 진짜 비교).
+fn expectCachedAstMaterializeEquivalent(graph: *ModuleGraph) !void {
+    const m = graph.modules.at(0);
+    const arena_alloc = m.parse_arena.?.allocator();
+
+    // ground truth (materialize 결과) 캡처.
+    const gt_kind = m.exports_kind;
+    const gt_wrap = m.wrap_kind;
+    const gt_exported = m.exported_names.len;
+    const gt_specs = try std.testing.allocator.alloc([]const u8, m.import_records.len);
+    defer {
+        for (gt_specs) |s| std.testing.allocator.free(s);
+        std.testing.allocator.free(gt_specs);
+    }
+    for (m.import_records, 0..) |r, i| gt_specs[i] = try std.testing.allocator.dupe(u8, r.specifier);
+
+    // 실제 load(fresh module)는 graph-level 필드가 비어있다 — import_records 를 비워
+    // resync 의 mergeImportRecords(previous=empty)가 load 와 동일 경로를 타게 한다.
+    m.import_records = &.{};
+
+    // parser 없이 module.ast 만으로 재구성.
+    try graph.materializeFromCachedAst(m, arena_alloc);
+
+    // materialize 와 동등해야 한다.
+    try std.testing.expectEqual(gt_kind, m.exports_kind);
+    try std.testing.expectEqual(gt_wrap, m.wrap_kind);
+    try std.testing.expectEqual(gt_exported, m.exported_names.len);
+    try std.testing.expectEqual(gt_specs.len, m.import_records.len);
+    for (gt_specs, m.import_records) |g, r| try std.testing.expectEqualStrings(g, r.specifier);
+}
+
+test "graph: materializeFromCachedAst — ESM 동등 재구성 (#4438 통합3 PR1)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // .mjs: TS strip 없음 + ESM + minify off → transformer pre-pass 미실행 → module.* =
+    // materialize 결과 그대로(ground truth). import + named export + re-export 커버.
+    try writeFile(tmp.dir, "index.mjs", "import { a } from './a.mjs'; export const b = a + 1; export { a };");
+    try writeFile(tmp.dir, "a.mjs", "export const a = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.mjs" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+    try graph.build(std.testing.io, &.{entry});
+
+    try expectCachedAstMaterializeEquivalent(&graph);
+}
+
+test "graph: materializeFromCachedAst — CJS 동등 재구성 (#4438 통합3 PR1)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // .cjs: require + module.exports → exports_kind=.commonjs / wrap_kind=.cjs 경로 커버.
+    try writeFile(tmp.dir, "index.cjs", "const a = require('./a.cjs'); module.exports = a.x + 1;");
+    try writeFile(tmp.dir, "a.cjs", "module.exports = { x: 1 };");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.cjs" });
+    defer std.testing.allocator.free(entry);
+
+    var cache = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(std.testing.allocator, &cache);
+    defer graph.deinit();
+    try graph.build(std.testing.io, &.{entry});
+
+    try expectCachedAstMaterializeEquivalent(&graph);
+}


### PR DESCRIPTION
## 개요
#4438 디스크 캐시 **graph 통합 3(load+hit)의 첫 단계 — load 경로 재구성 헬퍼**입니다. 통합 2(#4450)가 `store`(쓰기)를 배선했다면, 통합 3는 `load`(parse 스킵 + 복원)로 실제 wall 절감을 만드는 본체입니다. 가장 위험한 부분은 "**재구성 정확성**"(복원한 AST만으로 parser 없이 메타데이터를 byte-identical 재현)이라, 이걸 **출력 영향 0**으로 먼저 박제합니다.

> load hit 배선은 PR②, opt-in 표면(CLI/NAPI)은 PR③. 이 PR의 헬퍼는 **테스트만 호출**(파이프라인 미연결) → 빌드 출력 영향 0.

## 핵심 난관과 해법
`materialize`(parser_metadata.zig)는 `parser.scan_*`(parse 중 수집한 스캔 결과)에 강하게 의존합니다. 그런데 load 경로엔 **Parser가 없습니다**(parse를 스킵하니까). 복원되는 건 AST + semantic 뿐입니다.

해법: 이미 존재하는 `resyncAfterAstMutation`(transformer pre-pass가 AST를 바꾼 뒤 호출하는 재동기화 함수)이 **parser 없이 `module.ast`만으로** 같은 메타데이터를 AST 재순회로 재생성합니다 — `import_records` / `import·export_bindings` / `exported_names` / `namespace_access_index` / `exports_kind` / `wrap_kind` / cjs 플래그 / semantic·prebuilt_stmt_info / alias_table. 이걸 재사용합니다.

`materialize`에만 있고 `resync`에 없는 갭은 단 하나:
- **flow-enum 런타임 import** — 게이트 `has_flow_enum_declaration`가 Ast 구조체 필드라 복원됩니다(codec 직렬화·clone 보존). 헬퍼가 materialize처럼 재현합니다.

## 변경
- **`transform_prepass.zig`**: `materializeFromCachedAst(self, module, arena)` 추가 = `resyncAfterAstMutation(...)` + flow-enum 갭 보완.
- **`graph.zig`**: 별칭 1줄.
- **`graph_test.zig`**: 동등성 검증 헬퍼 `expectCachedAstMaterializeEquivalent` + ESM(.mjs)/CJS(.cjs) 테스트.

## 알려진 갭 (PR②에서 검증)
import/export 문이 전혀 없고 `import.meta`만 있는 `.js` 모듈은 materialize가 `.esm`, resync가 `.none`으로 분류할 수 있습니다. 그런 단독 모듈은 극히 드물고 대부분 import/export를 동반하므로 PR① 범위에서 제외하고, PR② ON==OFF 코퍼스 검증에서 실제 노출 시 보완합니다(헬퍼 doc에 명시).

## 테스트 & 검증
- **동등성**(graph_test.zig): build 직후 module(=정상 materialize 결과, ground truth) 캡처 → `import_records`를 비워 **실제 load(fresh module) 경로**와 동일하게 만든 뒤 헬퍼 재구성 → `exports_kind`/`wrap_kind`/`exported_names`/`import_records` specifier 동등 검증. ESM + CJS 분류 경로 커버(pre-pass 미실행 fixture라 `module.*` = materialize 결과 그대로).
- **code-review max** 후속(correctness/cleanup/conventions, fresh-eyes 서브에이전트 2종) — clean. 핵심: flow-enum inject **순서 차이**(헬퍼는 resync 후, materialize는 exports_kind 계산 전)가 안전함을 확인 — synthetic record의 `span=EMPTY`라 `exports_kind`/binding/namespace 등 **파생 필드에 전혀 참여하지 않음**.
- Debug + ReleaseFast + graph 테스트 통과.

## 다음 단계
- **PR②**: load hit 배선(parse_module.zig 키 계산 후 load 시도 → hit → 복원 + 이 헬퍼 + line_offsets/legal_comments 재구성 + pre-pass) + **ON==OFF byte-identical 동등성**(실제 코퍼스).
- **PR③**: opt-in 표면(CLI/NAPI flag).

Part of #4438