### PR TITLE
feat(cache): 디스크 캐시 load hit 배선 + ON==OFF (#4438 graph 통합 3 PR2)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1269,6 +1269,11 @@ pub const Bundler = struct {
             const eo = self.makeEmitOptions();
             graph.disk_options_hash = @import("compiled_cache.zig").computeDiskOptionsHash(&eo);
             graph.disk_compiler_build_id = @import("../build_id.zig").current();
+            // load hit 게이트: effective legal_comments 가 load-안전(inline/none)일 때만 load 활성.
+            // eof/linked/external 은 module.legal_comments 가 출력에 반영되나 load 는 scanner 없이
+            // 재구성 못함 → load off(store 는 계속 = 다음 안전 모드 빌드가 hit). #4438 graph 통합 3.
+            const lc = self.options.legal_comments.resolveDefault(self.options.minify_whitespace);
+            graph.disk_load_enabled = lc == .@"inline" or lc == .none;
         }
         graph.inline_dynamic_imports = self.options.inline_dynamic_imports;
         // require.context 등 parser inline scan 의 build-time 정적 평가에 사용 (#1579 Phase 2.6)

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -2278,8 +2278,7 @@ pub const emitChunkRuntimeHelpers = emitter_runtime.emitChunkRuntimeHelpers;
 
 /// default → 실제 모드로 해석. default는 minify 시 eof, 아니면 inline.
 fn resolveDefaultLegalComments(mode: types.LegalComments, minify: bool) types.LegalComments {
-    if (mode != .default) return mode;
-    return if (minify) .eof else .@"inline";
+    return mode.resolveDefault(minify);
 }
 
 /// eof/linked/external 모드에서 legal comments를 수집하여 출력 끝에 추가.

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -143,6 +143,13 @@ pub const ModuleGraph = struct {
     disk_options_hash: u64 = 0,
     /// 디스크 캐시 키의 컴파일러-버전 dimension(`build_id.current()`). bundler 주입.
     disk_compiler_build_id: u64 = 0,
+    /// #4438 load hit 활성 여부. bundler 가 legal_comments 모드가 load-안전(inline/none)일 때만
+    /// true 로 설정. eof/linked/external 은 module.legal_comments 가 출력(banner)에 반영되는데 load
+    /// 는 scanner 없이 그걸 재구성 못하므로 load 비활성(store 는 무관하게 계속 — AST 만 저장).
+    disk_load_enabled: bool = false,
+    /// #4438 디스크 캐시 load hit 카운터(계측/테스트). parseModule 이 worker 에서 병렬 increment 하므로
+    /// atomic. hit = parse 를 스킵하고 캐시에서 복원한 모듈 수.
+    disk_load_hits: std.atomic.Value(u64) = .init(0),
     /// perf/hmr-graph-topology-reuse Phase B — 위상(topology) 보존 모드.
     /// true 면 (1) `transferModulesToStore` 가 비활성(graph 가 parse_arena 단독 owner —
     /// store 로 양도하지 않음), (2) bundler external_graph 훅이 매 빌드 graph 를 전량 clear

--- a/src/bundler/graph/parse_module.zig
+++ b/src/bundler/graph/parse_module.zig
@@ -128,6 +128,13 @@ pub fn parseModule(self: *ModuleGraph, io: std.Io, idx: ModuleIndex) void {
             self.disk_options_hash,
             self.disk_compiler_build_id,
         );
+
+        // load hit: 캐시에서 AST+semantic 복원 → parse/semantic/legal_comments/store 를 스킵하고
+        // 메타를 재구성한다. miss/손상/load 비활성이면 false → 아래 기존 parse 경로로 계속.
+        if (tryDiskLoadHit(self, io, module, arena_alloc, plugin_transform_applied)) {
+            setup_scope.end();
+            return;
+        }
     }
 
     setup_scope.end();
@@ -302,4 +309,76 @@ pub fn parseModule(self: *ModuleGraph, io: std.Io, idx: ModuleIndex) void {
     }
 
     module.state = .parsed;
+}
+
+/// #4438 디스크 캐시 load hit — parse/semantic 을 스킵하고 캐시에서 복원+재구성한다. 키 캡처
+/// 직후·parse 전에 호출. hit 처리 시 true(caller 는 parse 스킵 후 return), miss/손상/비활성이면
+/// false(기존 parse 계속). legal_comments 안전 모드(disk_load_enabled)에서만 시도한다.
+///
+/// cold 경로(parse→semantic→materialize→pre-pass)와 **동일 최종 module 상태**에 도달:
+///  - `load`: AST(pre-transform) + semantic 복원
+///  - `line_offsets`: scanner 없이 source 에서 재계산(Scanner.computeLineOffsets)
+///  - `materializeFromCachedAst`: import_records/bindings/exports_kind/semantic 재분석 등 재구성
+///  - transformer pre-pass: cold(parse_module 286-301)와 동일 분기로 transform_cache + post-transform
+///    AST 재생성(pre-pass 가 끝에 resync 재호출해 materialize 결과를 덮어쓰는 것도 cold 동일)
+///
+/// `legal_comments`/`mtime`/`uses_top_level_await` 등은: legal=안전모드만(빈 배열=inline 출력 동일),
+/// uses_tla=resync 가 재설정, mtime=source read 시 설정. (graph 통합 3 PR②)
+/// #4438 load hit 안전성 게이트 — load 가 cold parse 와 출력이 달라지는 두 패턴이 source 에 있으면
+/// 보수적으로 load OFF(cold parse 로 정확성 유지). 둘 다 load 가 scanner 산출물을 근사하지 못하는
+/// 데서 비롯한다:
+///  1) **string/template 안 U+2028/U+2029** — scanner 는 토큰 내부의 이 문자를 line break 로
+///     기록하지 않지만(content) `computeLineOffsets` 는 무조건 기록 → load 시 line_offsets 가
+///     어긋나 sourcemap line/col 이 cold 와 달라진다. 토큰 사이의 U+2028 은 일치하나 이 문자
+///     자체가 드물어 통째 게이트한다.
+///  2) **legal comment(`@license`/`@preserve`/`/*!`)** — `module.legal_comments` 가 emitter 의
+///     lazy-barrel elision 게이트(`legal_comments.len != 0`)에 쓰이는데 load 는 그 slice 를
+///     빈 채로 둔다 → banner 를 가진 barrel 이 잘못 elide 되어 누락. `isLegalComment`(scanner.zig)
+///     의 마커를 보수적으로 검출한다(false positive=load OFF 안전, false negative 없음).
+fn loadUnsafeSource(source: []const u8) bool {
+    return std.mem.indexOf(u8, source, "\xE2\x80\xA8") != null or // U+2028 (LS)
+        std.mem.indexOf(u8, source, "\xE2\x80\xA9") != null or // U+2029 (PS)
+        std.mem.indexOf(u8, source, "@license") != null or
+        std.mem.indexOf(u8, source, "@preserve") != null or
+        std.mem.indexOf(u8, source, "/*!") != null;
+}
+
+fn tryDiskLoadHit(
+    self: *ModuleGraph,
+    io: std.Io,
+    module: *module_mod.Module,
+    arena_alloc: std.mem.Allocator,
+    plugin_transform_applied: bool,
+) bool {
+    if (!self.disk_load_enabled) return false;
+    if (loadUnsafeSource(module.source)) return false;
+    const dc = self.disk_cache orelse return false;
+    const restored = (dc.load(io, self.allocator, arena_alloc, module.disk_cache_key) catch return false) orelse return false;
+
+    module.ast = restored.ast;
+    module.semantic = restored.semantic;
+    module.line_offsets = Scanner.computeLineOffsets(arena_alloc, module.source) catch {
+        // OOM — 캐시 무관 자원고갈. 부분 복원이라 parse 로 degrade 불가 → 모듈만 비우고 진행.
+        module.state = .ready;
+        return true;
+    };
+
+    self.materializeFromCachedAst(module, arena_alloc) catch {
+        module.state = .ready;
+        return true;
+    };
+
+    {
+        const run_prepass = self.shouldRunTransformerPrePass(module, plugin_transform_applied);
+        if (run_prepass) {
+            self.runTransformerPrePass(module, arena_alloc);
+        } else {
+            module.transform_cache = null;
+            suppressRuntimeHelperInternalUnresolved(module);
+        }
+    }
+
+    module.state = .parsed;
+    _ = self.disk_load_hits.fetchAdd(1, .monotonic);
+    return true;
 }

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -1839,3 +1839,110 @@ test "graph: materializeFromCachedAst — CJS 동등 재구성 (#4438 통합3 PR
 
     try expectCachedAstMaterializeEquivalent(&graph);
 }
+
+test "graph: load hit — 복원 module 이 cold parse 와 동등 + parse 스킵 (#4438 통합3 PR2)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.mjs", "import { a } from './a.mjs'; export const b = a + 1; export { a };");
+    try writeFile(tmp.dir, "a.mjs", "export const a = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.mjs" });
+    defer std.testing.allocator.free(entry);
+    const cache_root = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "cache" });
+    defer std.testing.allocator.free(cache_root);
+
+    // ground truth — 1st build: 캐시 empty → miss → parse + store.
+    var gt_specs: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer {
+        for (gt_specs.items) |s| std.testing.allocator.free(s);
+        gt_specs.deinit(std.testing.allocator);
+    }
+    var gt_kind: types.ExportsKind = undefined;
+    var gt_exported: usize = 0;
+    var gt_count: usize = 0;
+    {
+        var store1 = try @import("disk_module_store.zig").DiskModuleStore.init(std.testing.allocator, cache_root);
+        defer store1.deinit();
+        var c1 = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+        defer c1.deinit();
+        var g1 = ModuleGraph.init(std.testing.allocator, &c1);
+        defer g1.deinit();
+        g1.disk_cache = &store1;
+        g1.disk_options_hash = 0x1234;
+        g1.disk_compiler_build_id = 0xABCD;
+        g1.disk_load_enabled = true;
+        try g1.build(std.testing.io, &.{entry});
+        try std.testing.expectEqual(@as(u64, 0), g1.disk_load_hits.load(.monotonic)); // empty → 전부 miss
+        const m1 = g1.modules.at(0);
+        gt_kind = m1.exports_kind;
+        gt_exported = m1.exported_names.len;
+        gt_count = g1.moduleCount();
+        for (m1.import_records) |r| try gt_specs.append(std.testing.allocator, try std.testing.allocator.dupe(u8, r.specifier));
+    }
+
+    // 2nd build: 캐시 채워짐 → load hit (parse 스킵).
+    var store2 = try @import("disk_module_store.zig").DiskModuleStore.init(std.testing.allocator, cache_root);
+    defer store2.deinit();
+    var c2 = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer c2.deinit();
+    var g2 = ModuleGraph.init(std.testing.allocator, &c2);
+    defer g2.deinit();
+    g2.disk_cache = &store2;
+    g2.disk_options_hash = 0x1234; // 1st 와 같은 키 dimension → hit
+    g2.disk_compiler_build_id = 0xABCD;
+    g2.disk_load_enabled = true;
+    try g2.build(std.testing.io, &.{entry});
+
+    // parse 스킵 증거: load hit > 0.
+    try std.testing.expect(g2.disk_load_hits.load(.monotonic) > 0);
+    // cold parse 와 동등 (모듈 수 / exports_kind / exported_names / import_records specifier).
+    try std.testing.expectEqual(gt_count, g2.moduleCount());
+    const m2 = g2.modules.at(0);
+    try std.testing.expectEqual(gt_kind, m2.exports_kind);
+    try std.testing.expectEqual(gt_exported, m2.exported_names.len);
+    try std.testing.expectEqual(gt_specs.items.len, m2.import_records.len);
+    for (gt_specs.items, m2.import_records) |g, r| try std.testing.expectEqualStrings(g, r.specifier);
+}
+
+test "graph: load hit 게이트 — legal comment 모듈은 load OFF (#4438 통합3 PR2)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // @license 마커 → loadUnsafeSource 게이트 → 캐시가 있어도 load OFF(cold parse) → hit 0.
+    // (lazy-barrel elision 이 module.legal_comments 를 읽는데 load 는 빈 배열이라 banner 누락 방지.)
+    try writeFile(tmp.dir, "index.mjs", "/*! @license MIT */\nexport const x = 1;\n");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.mjs" });
+    defer std.testing.allocator.free(entry);
+    const cache_root = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "cache" });
+    defer std.testing.allocator.free(cache_root);
+
+    // 1st build: store 진행(게이트는 load 만 막음).
+    {
+        var s1 = try @import("disk_module_store.zig").DiskModuleStore.init(std.testing.allocator, cache_root);
+        defer s1.deinit();
+        var c1 = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+        defer c1.deinit();
+        var g1 = ModuleGraph.init(std.testing.allocator, &c1);
+        defer g1.deinit();
+        g1.disk_cache = &s1;
+        g1.disk_load_enabled = true;
+        try g1.build(std.testing.io, &.{entry});
+    }
+
+    // 2nd build: 캐시 채워졌지만 legal comment 게이트로 load OFF → hit 0.
+    var s2 = try @import("disk_module_store.zig").DiskModuleStore.init(std.testing.allocator, cache_root);
+    defer s2.deinit();
+    var c2 = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer c2.deinit();
+    var g2 = ModuleGraph.init(std.testing.allocator, &c2);
+    defer g2.deinit();
+    g2.disk_cache = &s2;
+    g2.disk_load_enabled = true;
+    try g2.build(std.testing.io, &.{entry});
+
+    try std.testing.expectEqual(@as(u64, 0), g2.disk_load_hits.load(.monotonic));
+}

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -500,6 +500,12 @@ pub const LegalComments = enum {
     /// 별도 .LEGAL.txt 파일로만 추출
     external,
 
+    /// `.default` 를 minify 여부로 실제 모드(minify→eof / 아니면 inline)로 해석. 그 외는 그대로.
+    pub fn resolveDefault(self: LegalComments, minify: bool) LegalComments {
+        if (self != .default) return self;
+        return if (minify) .eof else .@"inline";
+    }
+
     pub fn fromString(s: []const u8) ?LegalComments {
         if (std.mem.eql(u8, s, "none")) return .none;
         if (std.mem.eql(u8, s, "inline")) return .@"inline";

--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -324,6 +324,44 @@ pub const Scanner = struct {
         return false;
     }
 
+    /// #4438 디스크 캐시 load 경로 전용 — scanner 없이 source 만으로 line_offsets 를 1패스 계산.
+    /// `Scanner.init`(BOM 시 [0]=3 / 그 외 [0]=0) + scan 루프의 `recordNewline`(각 줄바꿈 \n,
+    /// \r, \r\n, U+2028/2029 의 *다음* byte offset)과 **byte-identical** 해야 한다 — load 후
+    /// sourcemap·진단 위치가 cold 와 어긋나지 않도록. 동등성은 scanner test 가 박제.
+    /// `recordNewline`/`handleNewline`/`isLineSeparator` 의 로직을 그대로 미러한다(drift 시 깨짐).
+    pub fn computeLineOffsets(allocator: std.mem.Allocator, source: []const u8) std.mem.Allocator.Error![]u32 {
+        var offsets: std.ArrayList(u32) = .empty;
+        errdefer offsets.deinit(allocator);
+        offsets.ensureTotalCapacity(allocator, source.len / 20 + 1) catch {};
+        var i: u32 = 0;
+        // BOM: Scanner.init 이 current/line_start=3, line_offsets[0]=3 으로 시작.
+        if (std.mem.startsWith(u8, source, "\xEF\xBB\xBF")) {
+            try offsets.append(allocator, 3);
+            i = 3;
+        } else {
+            try offsets.append(allocator, 0);
+        }
+        while (i < source.len) {
+            const c = source[i];
+            if (c == '\n') {
+                i += 1;
+                try offsets.append(allocator, i);
+            } else if (c == '\r') {
+                i += 1;
+                if (i < source.len and source[i] == '\n') i += 1; // \r\n
+                try offsets.append(allocator, i);
+            } else if (c == 0xE2 and i + 2 < source.len and
+                source[i + 1] == 0x80 and (source[i + 2] == 0xA8 or source[i + 2] == 0xA9))
+            {
+                i += 3; // U+2028 / U+2029
+                try offsets.append(allocator, i);
+            } else {
+                i += 1;
+            }
+        }
+        return offsets.toOwnedSlice(allocator);
+    }
+
     // ====================================================================
     // 공백 스킵
     // ====================================================================

--- a/src/lexer/scanner_test.zig
+++ b/src/lexer/scanner_test.zig
@@ -1553,3 +1553,30 @@ test "peekIsNextByteSameLine: unterminated block comment → false" {
     defer scanner.deinit();
     try std.testing.expect(!scanner.peekIsNextByteSameLine('='));
 }
+
+test "computeLineOffsets: scanner line_offsets 와 byte-identical (#4438)" {
+    // 디스크 캐시 load 경로가 scanner 없이 재계산한 line_offsets 가 scanner 의 점진적
+    // recordNewline 결과와 정확히 일치해야 sourcemap·진단 위치가 cold 와 어긋나지 않는다.
+    const cases = [_][]const u8{
+        "", // 빈 → [0]
+        "abc", // newline 없음
+        "a\nb\nc", // \n
+        "a\r\nb\rc", // \r\n + 단독 \r
+        "line1\nline2\n", // trailing \n
+        "\n\n\n", // 연속 \n
+        "\xEF\xBB\xBF;\nx", // BOM → [0]=3
+        "a\xE2\x80\xA8b\xE2\x80\xA9c", // U+2028(LS) + U+2029(PS)
+        "x\r\n\r\ny", // 연속 \r\n
+    };
+    for (cases) |src| {
+        var scanner = try Scanner.init(std.testing.allocator, src);
+        defer scanner.deinit();
+        try drainTokensToEof(&scanner);
+        const expected = scanner.line_offsets.items;
+
+        const actual = try Scanner.computeLineOffsets(std.testing.allocator, src);
+        defer std.testing.allocator.free(actual);
+
+        try std.testing.expectEqualSlices(u32, expected, actual);
+    }
+}


### PR DESCRIPTION
## 개요
#4438 디스크 캐시 **graph 통합 3의 본체 — load hit 배선**입니다. epic 에서 **실제 번들 출력이 바뀌기 시작하는 첫 지점**이자 wall 절감이 나오는 핵심입니다. `parseModule` 이 캐시 hit 시 **parse + semantic 을 통째로 스킵**하고 디스크에서 AST+semantic 을 복원합니다.

> **ON==OFF**: 캐시 on/off 출력이 byte-identical — 작은 fixture + React 19 + minify + sourcemap 으로 입증.

## load hit 경로 (Zig 초보자용 설명)
캐시 무효화 키를 계산한 직후·`parser.parse()` 전에 `tryDiskLoadHit` 을 호출합니다. 캐시에 있으면(hit) parse 를 건너뛰고, 없거나(miss) 손상됐으면 그냥 기존 parse 경로로 떨어집니다(fall-through). hit 시 cold 경로(parse→semantic→materialize→pre-pass)와 **동일한 최종 module 상태**에 도달시킵니다:
- **load**: pre-transform AST + semantic 복원
- **`line_offsets`**: scanner 가 없으니 source 에서 재계산(`Scanner.computeLineOffsets`). BOM·`\n`·`\r`·`\r\n`·U+2028/2029 를 scanner 와 **byte-identical** 미러 (sourcemap 정확성 — scanner_test 가 동등성 박제)
- **`materializeFromCachedAst`**(PR①): parser 없이 import_records/bindings/exports_kind/semantic 재분석 등 재구성
- **transformer pre-pass**: cold 와 동일 분기로 `transform_cache` + post-transform AST 재생성

## 안전 게이트 (정확성 — code-review max 가 잡은 2버그 수정)
load 는 scanner 산출물을 일부 근사하므로, 어긋날 수 있는 경우를 **보수적으로 cold parse 로 떨어뜨립니다**:
1. **legal_comments 모드 게이트**(bundler): effective 모드가 `eof`/`linked`/`external` 이면 load 비활성 — `module.legal_comments` 가 banner 출력에 반영되는데 load 는 재구성 못함. `inline`/`none`(기본)만 load 활성. store 는 무관하게 계속(AST 만 저장).
2. **`loadUnsafeSource` 게이트**(parse_module): source 에 ① **U+2028/U+2029**(string/template 안이면 scanner 가 line_offsets 에 안 넣지만 computeLineOffsets 는 넣음 → 어긋남) 또는 ② **legal comment 마커**(`@license`/`@preserve`/`/*!`, emitter 의 lazy-barrel elision 이 `module.legal_comments` 를 읽음)가 있으면 load OFF. **false negative 0**(게이트 마커가 scanner 트리거의 정확한 superset), over-gating 은 cold parse=정확.

## 변경
| 파일 | 내용 |
|---|---|
| `graph/parse_module.zig` | `tryDiskLoadHit` + `loadUnsafeSource` + load 배선 |
| `lexer/scanner.zig` | `computeLineOffsets`(scanner 미러) |
| `bundler/graph.zig` | `disk_load_enabled` + `disk_load_hits`(계측/테스트, atomic) |
| `bundler/bundler.zig` | legal_comments 모드 게이트 |
| `bundler/types.zig` | `LegalComments.resolveDefault`(단일 소스) |
| `bundler/emitter.zig` | resolveDefault 위임 |
| `*_test.zig` | load hit 동등 / 게이트 load OFF / computeLineOffsets 동등 |

## 테스트 & 검증
- **유닛**: load hit → cold 동등(import_records/exports_kind/exported_names) + `disk_load_hits > 0`(**parse 스킵 명시 증거**) / legal comment 게이트 시 hit=0 / `computeLineOffsets` ↔ scanner byte-identical(BOM/CR/CRLF/LS/PS).
- **ON==OFF byte-identical**: 작은 ESM·CJS·TS, **React 19**(485KB/12모듈, jsx+node_modules), minify(eof 게이트), legal+sourcemap·U+2028+sourcemap(loadUnsafe 게이트).
- **code-review max** → correctness 가 2버그(U+2028 line_offsets / lazy-barrel legal_comments) 발견 → 게이트로 수정 → **verify COMPLETE**(게이트가 트리거 superset, false negative 0, 게이트 자체 pure·무결).
- Debug + ReleaseFast + 전체 회귀 통과(기존 TLS/self-loop 실패는 main 동일, 무관).

## 다음 단계
- **PR③**: opt-in 표면(CLI flag / NAPI / config). 현재는 실험적 env(`ZNTC_DISK_CACHE=<dir>`) 게이트 유지.

Part of #4438