### PR TITLE
feat(cache): 디스크 캐시 CLI opt-in (--disk-cache/--cache-dir) (#4438 graph 통합 3 PR3-1)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -432,10 +432,14 @@ pub const BundleOptions = struct {
     /// Compiled output cache. HMR/watch 에서 변경 안 된 모듈의 emit 을 스킵.
     /// IncrementalBundler 가 소유.
     compiled_cache: ?*@import("compiled_cache.zig").CompiledOutputCache = null,
-    /// #4438 디스크 캐시 모듈 store(parse/semantic 영속화). null 이면 비활성(기본). caller 가
-    /// 소유. 주입되면 graph 가 parseModule 시 모듈별 무효화 키를 계산해 `module.disk_cache_key`
-    /// 에 캡처한다(디스크 store/load 호출은 후속 단계 — 현재는 키 캡처만, 출력 영향 0).
+    /// #4438 디스크 캐시 모듈 store(parse/semantic 영속화) — 테스트/직접 주입용 포인터(caller 소유).
+    /// 일반 경로는 아래 `disk_cache_dir` 로 bundler 가 내부 store(`owned_disk_cache`)를 생성/소유한다.
     disk_module_cache: ?*@import("disk_module_store.zig").DiskModuleStore = null,
+    /// #4438 디스크 캐시 디렉토리(opt-in, 정식 표면). non-null 이면 bundler 가 그 경로에
+    /// DiskModuleStore 를 생성해 parse/semantic 을 영속화 → 다음 cold build 가 parse 스킵(hit).
+    /// CLI `--disk-cache`(기본 node_modules/.cache/zntc) / `--cache-dir <path>`, config·NAPI `cache`.
+    /// `disk_module_cache`(직접 주입)보다 우선.
+    disk_cache_dir: ?[]const u8 = null,
     /// HMR rename 재사용 활성 (perf/hmr-link-rename-reuse). true + `preserved_renames`
     /// present + 가드 통과 시 `computeRenames`(전체 모듈 top-level 이름 deconflict, ~106ms)
     /// 를 skip 하고 초기 빌드의 rename_table 을 재주입한다. IncrementalBundler 가
@@ -787,6 +791,9 @@ pub const Bundler = struct {
     /// 포인터를 parking 하지 않음(mf→non-mf 전환·조기 resolve 안전).
     mf_eff_external: ?[]const []const u8 = null,
     mf_eff_globals: ?[]const types.GlobalEntry = null,
+    /// #4438 `disk_cache_dir` 가 주어지면 bundler 가 생성/소유하는 DiskModuleStore. graph 에
+    /// 포인터로 주입되고 deinit 가 유일 free 지점. `disk_module_cache`(직접 주입)보다 우선.
+    owned_disk_cache: ?@import("disk_module_store.zig").DiskModuleStore = null,
 
     /// platform=react-native → Hermes unsupported matrix로 덮어쓰기.
     /// 사용자가 --target으로 지정한 값은 무시된다 (Hermes는 ES 버전으로 표현 불가능한
@@ -872,6 +879,7 @@ pub const Bundler = struct {
         // #3318 ④ combined seam 버퍼(컨테이너만; 원소 borrow).
         if (self.mf_eff_external) |x| self.allocator.free(x);
         if (self.mf_eff_globals) |x| self.allocator.free(x);
+        if (self.owned_disk_cache) |*s| s.deinit();
     }
 
     /// BundleOptions → TransformOptions base 변환 (#1961 PR 1f). graph 와 emitter
@@ -1261,10 +1269,20 @@ pub const Bundler = struct {
             self.options.changed_files != null or
             self.options.compiled_cache != null;
         // #4438 디스크 캐시: store 주입 시 키 dimension(옵션 해시·빌드 식별자)을 graph 에 배선.
-        // parseModule 이 모듈별 키를 계산해 module.disk_cache_key 에 캡처(store/load 는 후속).
         // 디스크 키는 source_hash 기반(mtime 무관)이라 incremental_mode(=fstat) 를 켜지 않는다.
         // 옵션 해시는 disk 전용(plugin 포인터 대신 이름+훅 — 프로세스 간 안정) 사용.
-        if (self.options.disk_module_cache) |dc| {
+        // disk_cache_dir(문자열, 정식 opt-in) 우선 — bundler 가 store 를 생성/소유(owned_disk_cache).
+        // 없으면 disk_module_cache(테스트 직접 주입). 둘 다 없으면 비활성.
+        const disk_cache_ptr: ?*@import("disk_module_store.zig").DiskModuleStore = blk: {
+            if (self.options.disk_cache_dir) |dir| {
+                if (self.owned_disk_cache == null) {
+                    self.owned_disk_cache = @import("disk_module_store.zig").DiskModuleStore.init(self.allocator, dir) catch null;
+                }
+                if (self.owned_disk_cache) |*s| break :blk s;
+            }
+            break :blk self.options.disk_module_cache;
+        };
+        if (disk_cache_ptr) |dc| {
             graph.disk_cache = dc;
             const eo = self.makeEmitOptions();
             graph.disk_options_hash = @import("compiled_cache.zig").computeDiskOptionsHash(&eo);

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -177,6 +177,10 @@ pub const CliOptions = struct {
     /// (blunt fromHermesPreset 대신, 진실 소스 = RN javascript-environment 문서).
     /// raw 스펙 보관 — 유효성 검증은 파싱 시점에 완료.
     rn_version: ?[]const u8 = null,
+    /// #4438 디스크 캐시 디렉토리(opt-in). `--disk-cache`(기본 node_modules/.cache/zntc) /
+    /// `--cache-dir <path>`. null=비활성. bundler 가 이 경로에 parse/semantic 을 영속화 →
+    /// 다음 cold build 가 parse 스킵. env `ZNTC_DISK_CACHE` 하위호환(main.zig).
+    disk_cache_dir: ?[]const u8 = null,
     /// --outbase: 엔트리 포인트 공통 기준 경로 (출력 디렉토리 구조 결정)
     outbase: ?[]const u8 = null,
     /// --packages=external: 모든 bare import를 external 처리
@@ -787,6 +791,19 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator,
                 std.process.exit(1);
             }
             opts.rn_version = val;
+        } else if (std.mem.eql(u8, arg, "--disk-cache")) {
+            // #4438 디스크 캐시 활성(기본 경로). --cache-dir 가 있으면 그쪽이 우선(순서 무관).
+            if (opts.disk_cache_dir == null) opts.disk_cache_dir = "node_modules/.cache/zntc";
+        } else if (std.mem.startsWith(u8, arg, "--cache-dir=") or std.mem.eql(u8, arg, "--cache-dir")) {
+            // `--cache-dir=<path>` / `--cache-dir <path>`. 경로 지정 = 디스크 캐시 활성(+override).
+            opts.disk_cache_dir = if (std.mem.startsWith(u8, arg, "--cache-dir=")) arg["--cache-dir=".len..] else blk: {
+                i += 1;
+                if (i >= args.len) {
+                    try stderr.print("zntc: --cache-dir requires a value (a directory path)\n", .{});
+                    std.process.exit(1);
+                }
+                break :blk args[i];
+            };
         } else if (std.mem.eql(u8, arg, "--format=iife")) {
             opts.bundle_format = .iife;
             opts.bundle_format_explicit = true;
@@ -1170,4 +1187,29 @@ test "parseArgs: cert/key 미지정 시 둘 다 null (plain HTTP 기본)" {
     defer opts.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(?[]const u8, null), opts.serve_cert_path);
     try std.testing.expectEqual(@as(?[]const u8, null), opts.serve_key_path);
+}
+
+test "parseArgs: --cache-dir <path> → disk_cache_dir (#4438)" {
+    const args = [_][]const u8{ "zntc", "--bundle", "--cache-dir", "/tmp/zc", "a.ts" };
+    var opts = (parseCliArguments(&args, std.testing.allocator) catch return error.TestUnexpectedResult) orelse return error.TestUnexpectedResult;
+    defer opts.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("/tmp/zc", opts.disk_cache_dir.?);
+}
+
+test "parseArgs: --disk-cache → 기본 경로 node_modules/.cache/zntc (#4438)" {
+    const args = [_][]const u8{ "zntc", "--bundle", "--disk-cache", "a.ts" };
+    var opts = (parseCliArguments(&args, std.testing.allocator) catch return error.TestUnexpectedResult) orelse return error.TestUnexpectedResult;
+    defer opts.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("node_modules/.cache/zntc", opts.disk_cache_dir.?);
+}
+
+test "parseArgs: --cache-dir 가 --disk-cache 보다 우선 (순서 무관) (#4438)" {
+    const a1 = [_][]const u8{ "zntc", "--bundle", "--disk-cache", "--cache-dir", "/x", "a.ts" };
+    var o1 = (parseCliArguments(&a1, std.testing.allocator) catch return error.TestUnexpectedResult) orelse return error.TestUnexpectedResult;
+    defer o1.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("/x", o1.disk_cache_dir.?);
+    const a2 = [_][]const u8{ "zntc", "--bundle", "--cache-dir", "/y", "--disk-cache", "a.ts" };
+    var o2 = (parseCliArguments(&a2, std.testing.allocator) catch return error.TestUnexpectedResult) orelse return error.TestUnexpectedResult;
+    defer o2.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("/y", o2.disk_cache_dir.?);
 }

--- a/src/cli/usage.zig
+++ b/src/cli/usage.zig
@@ -90,6 +90,8 @@ pub fn printUsage(writer: anytype) !void {
         \\  --metafile=<path>                Emit build metadata to file (esbuild compat)
         \\  --analyze                        Print bundle analyzer summary
         \\  --shim-missing-exports           Stub-export missing named imports (rolldown compat)
+        \\  --disk-cache                     Persist parse/semantic to node_modules/.cache/zntc (faster cold rebuilds)
+        \\  --cache-dir <path>               Disk cache directory (implies --disk-cache)
         \\  --conditions=<cond,...>          Custom export conditions (e.g. production)
         \\  --platform=browser|node|neutral  Target platform (default: browser)
         \\  --rn-platform=ios|android        RN sub-platform (.ios.*/.android.* extensions)

--- a/src/main.zig
+++ b/src/main.zig
@@ -831,16 +831,13 @@ pub fn main(init: std.process.Init) !void {
         var initial_opts = bundle_opts;
         if (opts.watch and opts.dev) initial_opts.collect_module_codes = true;
 
-        // #4438 디스크 모듈 캐시 (실험적, env-gated): `ZNTC_DISK_CACHE=<dir>` 설정 시 활성.
-        // 현재는 store 단계 — parse+semantic 산출물을 <dir> 에 영속화만 한다(load=후속 PR).
-        // 미설정/빈 값/init 실패면 비활성(null) → 디스크 미접근, 출력·비용 0.
-        var disk_module_store: ?lib.bundler.disk_module_store.DiskModuleStore = null;
-        defer if (disk_module_store) |*s| s.deinit();
-        if (env_flag.get("ZNTC_DISK_CACHE")) |dir| {
-            if (dir.len > 0) {
-                disk_module_store = lib.bundler.disk_module_store.DiskModuleStore.init(allocator, dir) catch null;
-                if (disk_module_store) |*s| initial_opts.disk_module_cache = s;
-            }
+        // #4438 디스크 캐시 opt-in: CLI(--disk-cache / --cache-dir <path>) 우선, env
+        // (ZNTC_DISK_CACHE) 하위호환. bundler 가 disk_cache_dir 로 내부 store 를 생성/소유하므로
+        // 여기선 경로 문자열만 전달한다(미설정이면 비활성 → 디스크 미접근).
+        if (opts.disk_cache_dir) |dir| {
+            initial_opts.disk_cache_dir = dir;
+        } else if (env_flag.get("ZNTC_DISK_CACHE")) |dir| {
+            if (dir.len > 0) initial_opts.disk_cache_dir = dir;
         }
 
         var bundler = Bundler.init(allocator, initial_opts);


### PR DESCRIPTION
## 개요
#4438 디스크 캐시 **opt-in 표면(PR③)의 네이티브 CLI 부분**입니다. 지금까지 실험적 env(`ZNTC_DISK_CACHE`)로만 켜던 디스크 캐시를 정식 CLI 플래그로 노출합니다.

> 4표면 중 **네이티브 CLI 먼저**, npm 표면(NAPI / JS API / config)은 **PR③-2**로 분리합니다.

## rspack 패턴 채택
다른 번들러 조사 결과(webpack/rspack/vite/parcel) 공통 관례를 따랐습니다:
- **opt-in** — zntc 디스크 캐시는 실험적(압축·CI 보존 미완)이라 vite/parcel식 자동 on이 아니라 명시 활성
- **기본 경로 `node_modules/.cache/zntc`** — webpack(`node_modules/.cache/webpack`)·rspack(`node_modules/.cache/rspack`) 관례
- **directory override** — webpack `cacheDirectory` / vite `cacheDir`에 해당

rspack의 `cache.storage` 2단계 nesting은 zntc가 디스크 캐시 전용(rspack은 memory+filesystem 겸용)이라 한 단계 평탄화했습니다.

## CLI
| flag | 동작 |
|---|---|
| `--disk-cache` | 활성화 + 기본 경로 `node_modules/.cache/zntc` |
| `--cache-dir <path>` | 경로 지정(활성 함의, 순서 무관 우선) |

env `ZNTC_DISK_CACHE`는 하위호환으로 유지됩니다(CLI 우선).

## 설계 (Zig 초보자용)
이전엔 main.zig가 `DiskModuleStore`를 직접 만들어 포인터로 주입했습니다. 이번엔 **bundler가 경로 문자열(`disk_cache_dir`)을 받아 내부에서 store를 생성/소유**하도록 옮겼습니다(`owned_disk_cache`, `deinit`가 유일 해제 지점). 덕분에 각 표면(CLI/NAPI/...)은 store 인스턴스의 생명주기를 신경 쓸 필요 없이 **경로 문자열만 전달**하면 됩니다 — PR③-2의 NAPI 배선이 훨씬 간단해집니다. 테스트용 직접 주입(`disk_module_cache` 포인터)도 그대로 두되 `disk_cache_dir`이 우선합니다.

## 변경
| 파일 | 내용 |
|---|---|
| `bundler.zig` | `BundleOptions.disk_cache_dir` + `Bundler.owned_disk_cache`(내부 store 생성/소유) + 주입(dir 우선) + deinit |
| `cli/options.zig` | `--disk-cache`/`--cache-dir` 파싱 + 필드 + 파싱 테스트 3종 |
| `cli/usage.zig` | help |
| `main.zig` | CLI 우선 + env 하위호환 (store 생성을 bundler로 이전) |

## 테스트 & 검증
- **파싱 유닛**: `--cache-dir <path>` → `disk_cache_dir` / `--disk-cache` → 기본 경로 / `--cache-dir`가 순서 무관 우선
- **스모크**: `--cache-dir <path>`·`--disk-cache`(기본 경로 자동 생성) 모두 **off == load hit byte-identical**
- **code-review max** (correctness 7포인트): owned_disk_cache lifetime·포인터 안정성 / watch 비활성(cold-path만) / `DiskCache.init`의 root dupe(borrowed 안전) / precedence / `catch null` fail-safe / double-deinit 없음 — **clean**
- Debug + ReleaseFast + 전체 회귀(기존 TLS/self-loop 외 0)

`watch` 증분 빌드는 `disk_cache_dir`을 상속하지 않아(`initial_opts`에만 설정) 디스크 캐시는 cold-build 경로 전용으로 유지됩니다.

## 다음 단계
- **PR③-2**: npm 표면 — NAPI(`napi/options.zig`) / JS API(`index.ts`) / config DTO / `bin/cli-flags.mjs`. `cache?: boolean | { dir?: string }`. (참고: config에 기존 `experimentalCodeCache` 필드가 있어 관계 정리 필요)

Part of #4438