### PR TITLE
feat(cache): 디스크 캐시 npm 표면 (NAPI/JS/config) + experimentalCodeCache 정리 (#4438 graph 통합 3 PR3-2)

### DIFF
--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -136,6 +136,9 @@ export const FLAG_REGISTRY = [
   { kind: 'string', flag: '--rn-version', target: 'rnVersion', forms: ['equal', 'pair'] },
   // #2540 PR #7 — RN preset 의 projectRoot. 기본 cwd, 사용자 monorepo root 지정 시 사용.
   { kind: 'string', flag: '--rn-project-root', target: 'rnProjectRoot', forms: ['equal', 'pair'] },
+  // #4438 디스크 캐시 opt-in: --disk-cache(활성, 기본 node_modules/.cache/zntc) / --cache-dir <path>.
+  { kind: 'bool', flag: '--disk-cache', target: 'diskCache' },
+  { kind: 'string', flag: '--cache-dir', target: 'cacheDir', forms: ['equal', 'pair'] },
   // ─── RN CLI 호환 flag 매트릭스 (#2605 audit P0) ───
   // `react-native bundle` / Metro CLI 의 standard flag 들 — `zntc bundle --platform=react-native`
   // 가 dropin 으로 동작하기 위한 호환 layer. zntc 내부 옵션 (outfile 등) 과 별개로 받아 매핑.

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -349,6 +349,8 @@ function parseArgs(argv) {
     mainFields: [],
     rnPlatform: undefined,
     rnVersion: undefined,
+    diskCache: false, // #4438 디스크 캐시 활성 (--disk-cache)
+    cacheDir: undefined, // #4438 디스크 캐시 경로 (--cache-dir)
     jsxInJs: false,
     outExtensionJs: undefined,
     sourceRoot: undefined,
@@ -1326,6 +1328,7 @@ function mergeConfigIntoOpts(opts, config) {
     'platform',
     'target',
     'rnVersion',
+    'cacheDir', // #4438 디스크 캐시 경로 (NAPI 가 disk_cache_dir 로 해석)
     'banner',
     'footer',
     'globalName',
@@ -1406,6 +1409,7 @@ function mergeConfigIntoOpts(opts, config) {
     // 머지 안 되던 실 BuildOption bool.
     'analyze',
     'devMode',
+    'diskCache', // #4438 디스크 캐시 활성 (NAPI 가 disk_cache_dir 로 해석)
   ];
   for (const key of BOOL_KEYS) {
     if ((opts[key] === false || opts[key] === undefined) && config[key] === true) {
@@ -1546,6 +1550,9 @@ async function buildBundleOptions(opts, config, { filterCallerPreWarmCss = false
     target: opts.target,
     // --rn-version: platform=react-native 함의 + RN 문서 기준 버전별 다운레벨 (NAPI 가 해석).
     rnVersion: opts.rnVersion,
+    // #4438 디스크 캐시 opt-in: --disk-cache(활성) / --cache-dir <path>. NAPI 가 disk_cache_dir 로 해석.
+    diskCache: opts.diskCache,
+    cacheDir: opts.cacheDir,
     browserslist: opts.browserslist,
     external: opts.external,
     packagesExternal: opts.packagesExternal,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -867,6 +867,14 @@ interface BuildOptionsCommon {
    * Conflicts with `platform: 'node' | 'neutral'`.
    */
   rnVersion?: string;
+  /**
+   * #4438 Disk cache: persist parse/semantic across builds for faster cold rebuilds.
+   * `true` enables it at the default dir `node_modules/.cache/zntc`; pass `cacheDir`
+   * for a custom path. Opt-in (off by default). Mirrors CLI `--disk-cache`.
+   */
+  diskCache?: boolean;
+  /** #4438 Disk cache directory (implies `diskCache`). Mirrors CLI `--cache-dir`. */
+  cacheDir?: string;
   minify?: boolean;
   minifyWhitespace?: boolean;
   minifyIdentifiers?: boolean;

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -324,6 +324,16 @@ pub fn parseBuildOptions(
     else
         .browser;
 
+    // #4438 디스크 캐시 (opt-in): cacheDir(경로) 우선, diskCache(bool)면 기본 node_modules/.cache/zntc.
+    // bundler 가 이 경로로 내부 DiskModuleStore 를 생성/소유(disk_cache.init 이 root dupe — borrowed 안전).
+    const cache_dir_str = getObjectString(env, opts_obj, "cacheDir", native_alloc);
+    if (cache_dir_str) |s| if (!trackStr(owned_strings, s)) return null;
+    const disk_cache_dir: ?[]const u8 = blk: {
+        // 빈 cacheDir("")은 비활성으로 취급(main.zig env 가드 `dir.len > 0` 과 일관). cacheDir 우선.
+        if (cache_dir_str) |s| if (s.len > 0) break :blk s;
+        break :blk if (getObjectBoolOptional(env, opts_obj, "diskCache") orelse false) "node_modules/.cache/zntc" else null;
+    };
+
     // external
     const external = getObjectStringArray(env, opts_obj, "external", native_alloc);
     if (external) |exts| {
@@ -783,6 +793,7 @@ pub fn parseBuildOptions(
         .format = format,
         .platform = platform,
         .rn_version_matrix = rn_version_matrix,
+        .disk_cache_dir = disk_cache_dir,
         .external = external orelse &.{},
         .mf = mf_cfg,
         .debug = debug_categories orelse &.{},

--- a/packages/core/src/schema-allowlists.ts
+++ b/packages/core/src/schema-allowlists.ts
@@ -23,7 +23,6 @@ export const NAPI_INTERNAL_ONLY_KEYS = [
   'devMode',
   'emitDiskSourcemap',
   'entryErrorGuard',
-  'experimentalCodeCache',
   'fallback',
   'globalIdentifiers',
   'onReady',

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -111,6 +111,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'platform',
   'target',
   'rnVersion',
+  'diskCache',
+  'cacheDir',
   'browserslist',
   'runtimePolyfills',
   'coreJs',

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -225,6 +225,8 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "target",
     "browserslist",
     "rnVersion", // RN 버전 타겟 — NAPI 가 내부 rn_version_matrix 로 해석 (1:1 DTO 필드 아님)
+    "diskCache", // #4438 disk cache 활성 — NAPI 가 disk_cache_dir 로 변환 (1:1 DTO 아님)
+    "cacheDir", // #4438 disk cache 경로 — NAPI 가 disk_cache_dir 로 변환
     "runtimePolyfills", // JS wrapper가 core-js compat 후보를 native graph plan 으로 전달
     "coreJs", // runtimePolyfills 전용 core-js 버전 힌트
     "plugins",
@@ -238,7 +240,6 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "codegenTransform", // RN view config codegen (#2348)
     "moduleSpecifierMap", // cherry-pick import 분해 (#2393)
     "strictExecutionOrder", // 모듈 실행 순서 보장
-    "experimentalCodeCache", // persistent cache 실험
     "watch", // CLI flag, BuildOptions 노출 안 함이 정석이지만 일부 wrapper 가 노출
     "extends", // config-only
     "server", // config-only dev server defaults


### PR DESCRIPTION
## 개요
#4438 디스크 캐시 **opt-in 표면(PR③)의 npm 부분** — PR③-1(네이티브 CLI)에 이어 NAPI / JS `build()` API / npm CLI(`zntc.mjs`) / config-merge / schema sync를 배선해 **4표면을 완성**합니다.

## rspack 패턴 (flat 키)
PR③-1과 동일하게 rspack의 정신(opt-in + 기본 경로 + directory override)을 따르되, NAPI가 nested object 파서가 없고 네이티브 CLI(`--disk-cache`/`--cache-dir`)가 flat이라 **flat 키 `diskCache`/`cacheDir`로 1:1 통일**했습니다.

## 4표면 배선
| 표면 | 키 | 흐름 |
|---|---|---|
| **NAPI** (`napi/options.zig`) | `cacheDir`/`diskCache` | → `disk_cache_dir` (cacheDir 우선, diskCache면 기본 경로) |
| **JS `build()`** (`index.ts`) | `diskCache?`/`cacheDir?` | BuildOptionsCommon → `prepareNapiOptions` spread → NAPI |
| **npm CLI** (`cli-flags.mjs`/`zntc.mjs`) | `--disk-cache`/`--cache-dir` | flag → buildOpts → build() → NAPI |
| **config 파일** (`zntc.mjs` mergeConfigIntoOpts) | `diskCache`/`cacheDir` | SCALAR/BOOL 그룹 머지 |

bundler가 `disk_cache_dir`로 내부 store를 생성/소유(PR③-1)하므로 각 표면은 **경로 문자열만 전달**합니다.

## experimentalCodeCache 정리
조사 결과 `experimentalCodeCache`는 **완전히 dead**였습니다 — TS interface(BuildOptionsCommon/TranspileOptions) 어디에도 없고, NAPI/JS 구현/사용처가 0이며, `schema-allowlists`(NAPI_INTERNAL_ONLY_KEYS)와 config_dto allowlist에만 잔존한 placeholder입니다. 주석("persistent cache 실험")이 가리키던 의도의 **실제 구현이 바로 #4438 disk cache**이므로, dead 항목을 제거하고 정식 `diskCache`/`cacheDir`로 대체했습니다(노출 0 → 안전).

## schema sync
- `config_dto` `ts_buildoptions_only_allowlist` + `typo-suggest` `KNOWN_CONFIG_KEYS`에 diskCache/cacheDir 추가 (rnVersion 패턴 — NAPI가 `disk_cache_dir`로 변환하므로 1:1 DTO 필드 아님)
- `mergeConfigIntoOpts` SCALAR_KEYS(cacheDir) / BOOL_KEYS(diskCache) + opts default — config 파일에서도 설정 가능

## 테스트 & 검증
- **4표면 end-to-end ON==OFF**: JS `build()` API(캐시 2파일 생성) + npm CLI `--cache-dir`(off==load hit) + `--disk-cache`(기본 경로 자동 생성)
- **schema sync**: config_dto `schema diff`(21 pass) + typo-suggest(23 pass) + cli-schema-sync(SCALAR/BOOL/default 일관)
- **bun 1055 pass** (자세한 검증은 아래 ⚠️)
- **code-review max** (correctness 7포인트): NAPI 메모리(double-free/UAF 없음 — trackStr/literal static/freeOptionsTypedSlices 무관) · precedence(cacheDir > diskCache 모든 표면 일관) · build() spread 생존 · experimentalCodeCache orphan 0 — **clean**
- napi 빌드 통과

## ⚠️ 무관한 기존 회귀 발견 (별도 조사 필요)
bun test에 2개 fail(`source kind > 빈 소스 에러`, `ES2023/hashbang > target 미지정`)이 있는데, **본 PR과 무관한 main HEAD의 기존 회귀**임을 확인했습니다:
- 내 변경을 `git stash`한 main 소스 + 내 cacheDir 없는 main HEAD napi 재빌드로도 동일 재현
- 빈소스/hashbang은 cacheDir과 완전히 무관한 영역
- 이전 머지(PR①②③-1) 때 `.node`를 재빌드하지 않아 가려져 있던 것으로 보입니다 (`.node`는 gitignore)

→ 이건 별도 이슈로 조사가 필요합니다(본 PR 머지와 독립).

Part of #4438