### PR TITLE
fix(test): 빈 소스 transpile test outdated 수정 (빈출력 의도)

### DIFF
--- a/packages/core/test/core/api/source-kind.ts
+++ b/packages/core/test/core/api/source-kind.ts
@@ -33,8 +33,9 @@ describe('@zntc/core API: source kind', () => {
     expect(jsxOnly.code).not.toContain('<div');
   });
 
-  test('빈 소스 에러', () => {
-    expect(() => transpile('')).toThrow();
+  test('빈 소스는 빈 출력 (빈 파일은 유효 입력)', () => {
+    // 7095b96d: transpile/tokenize 가 빈 소스('')를 유효 입력(빈 출력)으로 처리 — esbuild 정렬.
+    expect(transpile('').code).toBe('');
   });
 
   test('파싱 에러', () => {


### PR DESCRIPTION
## 개요
CI(NAPI Build & Test)가 오래 fail해 온 원인 중 하나를 수정합니다 — **빈소스 test가 outdated**입니다.

## 원인
커밋 `7095b96d`(*transpile/tokenize 가 빈 소스('')를 거부 — 빈 파일은 유효 입력*)가 빈 소스 동작을 **throw → 빈출력**으로 의도적으로 변경(esbuild 정렬)했으나, `source-kind.ts`의 빈소스 test는 여전히 `throw`를 기대해 fail해 왔습니다. `.node`가 gitignore라 로컬에서 가려져 admin merge로 누적됐습니다.

## 변경
```diff
- test('빈 소스 에러', () => {
-   expect(() => transpile('')).toThrow();
- });
+ test('빈 소스는 빈 출력 (빈 파일은 유효 입력)', () => {
+   expect(transpile('').code).toBe('');
+ });
```

`transpile()` 주석이 의도를 명시합니다: *"빈 문자열('')은 유효한 입력(빈 출력) — null/undefined/비-string 만 거부"*. 빈출력은 esbuild/swc 표준 동작입니다.

## 검증
- `bun test -t "빈 소스는 빈 출력"` → 1 pass

## ⚠️ 별개 CI 회귀 (개별 PR 예정)
이번 CI 조사에서 **disk cache epic(#4438)과 무관한 오래된 main 회귀**를 추가로 발견했습니다 — 각각 근본원인 확인 후 개별 PR로 진행합니다:
- **hashbang**: target 미지정에서 hashbang strip(동작 회귀, esnext 명시는 유지)
- **Debug Test (zig) / Test262 / Publish Smoke**: 미조사

이들은 `.node` 재빌드로 드러난 것으로, CI 실패가 계속 무시돼 온 결과입니다.