### PR TITLE
fix(core): target 미지정 시 hashbang(ES2023) strip 회귀 — optionsJson 에 esnext 명시

### DIFF
--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -253,7 +253,10 @@ export function buildOptionsJson(
   unsupportedOverride?: number,
 ): string {
   const payload: Record<string, unknown> = {};
-  if (opts.target) payload.target = opts.target;
+  // 미지정 target = esnext(다운레벨 없음, resolveUnsupported=0 과 동일 의도). 명시하지 않으면
+  // optionsJson 에 target 이 빠져 native 가 보수적 default 로 떨어져 esnext 기능(hashbang 등)을
+  // strip 한다 — esbuild 는 미지정=esnext(유지). 의도를 명시해 회귀 방지.
+  payload.target = opts.target ?? 'esnext';
   if (unsupportedOverride !== undefined && unsupportedOverride !== 0)
     payload.unsupported = unsupportedOverride;
   if (opts.flow) payload.flow = true;


### PR DESCRIPTION
## 개요
CI(NAPI Build & Test) 오래된 회귀의 두 번째 — **target 미지정에서 hashbang(`#!`)이 strip**되는 동작 회귀를 수정합니다.

## 증상
```js
transpile('#!/usr/bin/env node\nconst x=1;')              // 미지정 → hashbang 제거 ✗
transpile('#!/usr/bin/env node\nconst x=1;', {target:'esnext'})  // esnext 명시 → 유지 ✓
```
hashbang은 ES2023 spec이라 esnext(미지정 default)에서는 유지돼야 하고, esbuild도 그렇습니다.

## 근본 원인
`buildOptionsJson`(packages/shared/index.ts)가 **target 미지정 시 `payload.target`을 omit**합니다:
- 미지정 → optionsJson `{}` (target 없음)
- esnext → `{"target":"esnext"}`

native는 optionsJson에 target이 없으면 보수적 default로 떨어져 esnext 기능(hashbang)을 strip합니다. 그런데 `resolveUnsupported`상 미지정=0(esnext)이라 **의도(esnext)가 native에 전달되지 않는** 게 근본 원인입니다.

## 수정
```diff
- if (opts.target) payload.target = opts.target;
+ payload.target = opts.target ?? 'esnext';  // 미지정 의도(esnext)를 명시
```

## 검증
- 전체 `bun test`: **1056 pass**, 1 fail — hashbang fail 해소, 다른 회귀 0
- (남은 1 fail = 빈소스 test, **별개 PR #4455**에서 처리)

## 배경
이 회귀들은 `.node`가 gitignore라 로컬에서 가려져, CI(NAPI Build & Test) 실패가 무시된 채 admin merge로 누적돼 온 것입니다(disk cache epic과 무관). 점진적으로 개별 PR로 정리 중입니다:
- ✅ 빈소스 test outdated (#4455)
- ✅ hashbang strip (이 PR)
- ⏳ Debug Test (zig) / Test262 / Publish Smoke — 조사 예정