### PR TITLE
fix(ci): Debug Test 를 직접 test binary 실행으로 — zig 0.16 IPC runner 오보고 회피

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,13 @@ jobs:
         run: zig build
 
       - name: Run Tests
-        run: zig build test
+        # `zig build test`(--listen=- IPC)는 async runner 가 한 test 의 pass-path stderr 를
+        # 인접 test 실패로 오보고한다(zig 0.16). test binary 를 직접 실행하면 sequential
+        # 사람모드라 오보고가 없다. lib → exe 순차(pipefail 로 lib 실패 시 즉시 중단).
+        run: |
+          zig build test-bin
+          ./zig-out/bin/lib-unit-test
+          ./zig-out/bin/exe-unit-test
 
       - name: Run Test262 Runner Tests
         run: zig build test262

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
           zig build test-bin
           ./zig-out/bin/lib-unit-test
           ./zig-out/bin/exe-unit-test
-
-      - name: Run Test262 Runner Tests
-        run: zig build test262
+        # (Test262 runner unit test 는 lib_mod 에 포함되어 위 lib-unit-test 가 이미 커버 —
+        #  별도 `zig build test262` step 은 IPC 오보고를 다시 들이므로 제거. test262.yml 의
+        #  Test262 Conformance workflow 가 독립적으로 동일 직접-binary 실행을 수행한다.)
 
   release-build:
     name: Release Build (${{ matrix.os }}, ${{ matrix.optimize }})

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -33,7 +33,12 @@ jobs:
           cache-key: test262-unit
 
       - name: Run Test262 runner unit tests
-        run: zig build test262
+        # zig build test262 = run_lib_unit_tests (--listen=- IPC). Debug Test 와 동일하게 async
+        # runner 가 인접 test 의 pass-path stderr 를 오보고하므로, 직접 binary 실행으로 회피한다
+        # (build.zig 의 test-bin step — test262 runner unit 은 lib_mod 에 포함되어 lib-unit-test 가 커버).
+        run: |
+          zig build test-bin
+          ./zig-out/bin/lib-unit-test
 
   test262-lexer:
     name: Test262 Lexer Conformance

--- a/build.zig
+++ b/build.zig
@@ -227,6 +227,17 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_lib_unit_tests.step);
     test_step.dependOn(&run_exe_unit_tests.step);
 
+    // 직접 실행용 test binary install. `zig build test`(addRunArtifact)는 zig 0.16 의 `--listen=-`
+    // IPC 모드라, async test runner 가 한 test 의 pass-path stderr(bench 의 std.debug.print /
+    // prod 경로의 std.log.warn 등)를 인접 test 의 실패 출력으로 오보고한다 — 직접 binary 실행은
+    // sequential 사람모드라 IPC 가 없어 오보고가 없다(`./test` 는 항상 전체 pass). CI 는
+    // `zig build test-bin` 으로 빌드 후 zig-out/bin 의 binary 를 직접 실행해 이 오보고를 원천 차단한다.
+    const install_lib_test = b.addInstallArtifact(lib_unit_tests, .{ .dest_sub_path = "lib-unit-test" });
+    const install_exe_test = b.addInstallArtifact(exe_unit_tests, .{ .dest_sub_path = "exe-unit-test" });
+    const test_bin_step = b.step("test-bin", "Build test binaries for direct (non-IPC) execution");
+    test_bin_step.dependOn(&install_lib_test.step);
+    test_bin_step.dependOn(&install_exe_test.step);
+
     // ─── WASM 빌드 ───
     // `zig build wasm` — wasm32-wasi 타겟으로 트랜스파일 전용 WASM 모듈을 빌드한다.
     // packages/wasm/src/wasm_entry.zig가 진입점이며, transpile 함수만 export한다.

--- a/src/codegen/codegen_test/helpers.zig
+++ b/src/codegen/codegen_test/helpers.zig
@@ -219,7 +219,9 @@ pub fn assertNoAsyncSelfLoop(output: []const u8) !void {
             continue;
         };
         if (case_label == target_label) {
-            std.debug.print("\nself-loop detected: case {d} → return[3,{d}] in:\n{s}\n", .{ case_label, target_label, output });
+            // self-loop 발견 = error.AsyncSelfLoopDetected 로 신호. positive control 은 expectError 로,
+            // negative control 은 try 로 검증하므로 별도 print 불필요. std.debug.print(직접 stderr)는
+            // zig test 0.16 async runner 에서 무관 test 에 오귀속되므로 쓰지 않는다 (#4457 와 동일 근본).
             return error.AsyncSelfLoopDetected;
         }
         search_start = target_end;

--- a/src/server/dev_server.zig
+++ b/src/server/dev_server.zig
@@ -387,7 +387,12 @@ pub const DevServer = struct {
         var tls_ctx: ?tls.TlsContext = null;
         if (options.cert_path != null and options.key_path != null) {
             tls_ctx = tls.TlsContext.init(options.cert_path.?, options.key_path.?) catch |err| {
-                getLog().print("zntc: TLS context init failed: {}\n", .{err}) catch {};
+                // zig test 0.16 async runner 는 병렬 실행 중 이 직접-stderr 출력을 무관 test 에
+                // 오귀속한다(비결정 CI fail — DevServer.init CertLoadFailed test 의 stderr 가
+                // cache_key_test 등에 섞여 "failed: error.CertLoadFailed" 로 보고). test 컴파일에선
+                // skip(prod 영향 0). 근본은 zig test stderr 캡처 격리(외부 이슈).
+                if (!builtin.is_test)
+                    getLog().print("zntc: TLS context init failed: {}\n", .{err}) catch {};
                 return err;
             };
         } else if (options.cert_path != null or options.key_path != null) {


### PR DESCRIPTION
## 문제 (CI Debug Test (ubuntu) spurious 실패)

`zig build test` 가 비결정적으로 실패. 로그:

```
error: 'bundler.cache_key_test.test.차등: parser flags 가 결과를 바꾸면 키도 바뀐다 (민감도)' failed:
       ============ expected this output: =============  len: 1724
```

`cache_key_test.차등` 는 `parseAndSerialize` 를 두 번 호출해 byte 동일을 검증할 뿐, 외부 출력과 무관하다.
실제로는 **인접 test 의 pass-path stderr 가 async runner 의 test 경계를 넘어 이 test 의 "expected
output" 으로 오보고**된 것. stderr 소스는 한둘이 아니다:

- `dev_server` TLS init 실패 로그 (`getLog().print`)
- prod 경로 `std.log.warn` (react-refresh 미설치 / polyfill 실패 / jsx pragma 등 다수)
- bench 의 `std.debug.print` (`link_subphase_bench` / `incremental_bench_v4` profile breakdown, ~1724B)

직접 binary 실행(`./test`)은 **sequential 사람모드**라 IPC 가 없어 오보고가 없다 — 항상 6003 all pass.
즉 코드 버그가 아니라 zig 0.16 test runner 의 `--listen=-` IPC stderr 귀속 문제다.

## 수정 (근본 — 도구 회피)

stderr 소스를 하나씩 막는 건 두더지잡기(새 test 가 stderr 를 내면 재발)다. CI 가 IPC runner 대신
**test binary 를 직접 실행**하게 해 오보고를 원천 차단한다:

- **build.zig**: test binary 를 install 하는 `test-bin` step 추가 (`lib-unit-test` / `exe-unit-test`).
- **ci.yml**: Debug Test 가 `zig build test-bin` 후 `./zig-out/bin/*-unit-test` 를 직접 실행
  (lib → exe 순차, pipefail). Debug Test matrix 는 ubuntu/macos 라 posix 직접 실행 가능.

### 함께 포함 (출력 위생 보너스 — 직접 binary 와 독립적으로 무해)

- `dev_server.zig`: TLS context init 실패 로그를 `if (!builtin.is_test)` 가드 (prod 동작 불변).
- `codegen` self-loop assertion 의 `std.debug.print` 제거 (positive control 은 `expectError` 로 검증).

## 검증

- `zig build test-bin` → `./zig-out/bin/lib-unit-test`: **All 6003 tests passed**
- `./zig-out/bin/exe-unit-test`: **All 1 tests passed**

CI 의 **Debug Test** 실패를 해결한다. Integration(hashbang → #4459) / WASM·NAPI win32(32-bit atomic
→ #4458) 는 독립 원인으로 별도 PR.