### PR TITLE
fix(compat): hashbang(#!) 을 target 무관 항상 보존 — strip 회귀 근본 수정 + #4456 rollback

### DIFF
--- a/packages/core/test/core/es2023-hashbang.ts
+++ b/packages/core/test/core/es2023-hashbang.ts
@@ -12,19 +12,21 @@ import {
 } from './helpers';
 
 describe('@zntc/core ES2023/hashbang', () => {
-  test('target es5: hashbang이 제거됨', () => {
+  test('target es5: hashbang은 보존됨 (shebang 은 다운레벨 대상 아님)', () => {
     const result = transpile("#!/usr/bin/env node\nconsole.log('hello');", {
       target: 'es5',
     });
-    expect(result.code).not.toContain('#!');
+    // hashbang(#!)은 런타임(Node)이 스크립트 실행에 쓰는 shebang 이라 어떤 target 으로
+    // 다운레벨해도 strip 하지 않는다 — 본문만 다운레벨된다.
+    expect(result.code).toContain('#!/usr/bin/env node');
     expect(result.code).toContain('hello');
   });
 
-  test('target es2022: hashbang이 제거됨 (es2022 < es2023)', () => {
+  test('target es2022: hashbang은 보존됨 (shebang 은 target 무관 유지)', () => {
     const result = transpile('#!/usr/bin/env node\nconst x = 1;', {
       target: 'es2022',
     });
-    expect(result.code).not.toContain('#!');
+    expect(result.code).toContain('#!/usr/bin/env node');
     expect(result.code).toContain('x = 1');
   });
 

--- a/packages/core/test/core/option-combinations-advanced/hashbang-targets.ts
+++ b/packages/core/test/core/option-combinations-advanced/hashbang-targets.ts
@@ -13,12 +13,13 @@ describe('@zntc/core 옵션 조합 심화 - hashbang and targets', () => {
     expect(result.code.length).toBeLessThan(80);
   });
 
-  test('hashbang + sourcemap + es2022 (hashbang 제거됨)', () => {
+  test('hashbang + sourcemap + es2022 (hashbang 보존)', () => {
     const result = transpile('#!/usr/bin/env node\nconst x = 1;', {
       sourcemap: true,
       target: 'es2022',
     });
-    expect(result.code).not.toContain('#!');
+    // hashbang 은 target 무관 항상 보존 — es2022 라도 strip 하지 않는다.
+    expect(result.code).toContain('#!/usr/bin/env node');
     expect(result.map).toBeDefined();
   });
 

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -253,10 +253,10 @@ export function buildOptionsJson(
   unsupportedOverride?: number,
 ): string {
   const payload: Record<string, unknown> = {};
-  // 미지정 target = esnext(다운레벨 없음, resolveUnsupported=0 과 동일 의도). 명시하지 않으면
-  // optionsJson 에 target 이 빠져 native 가 보수적 default 로 떨어져 esnext 기능(hashbang 등)을
-  // strip 한다 — esbuild 는 미지정=esnext(유지). 의도를 명시해 회귀 방지.
-  payload.target = opts.target ?? 'esnext';
+  // target 미지정 시 payload 에 강제하지 않는다 — native 가 tsconfig autodiscover / 기본값으로
+  // 결정하도록 위임한다 (esnext 강제는 tsconfig target 다운레벨을 덮어쓰는 회귀였음). hashbang 등
+  // 'strip 하면 안 되는' 기능은 codegen 이 target 무관 항상 보존하므로 esnext 명시가 불필요.
+  if (opts.target) payload.target = opts.target;
   if (unsupportedOverride !== undefined && unsupportedOverride !== 0)
     payload.unsupported = unsupportedOverride;
   if (opts.flow) payload.flow = true;

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -111,10 +111,11 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
             try self.writeByte(';');
         },
         .hashbang => {
-            if (!self.options.strip_hashbang) {
-                try self.addSourceMapping(node.span);
-                try self.writeNodeSpan(node);
-            }
+            // hashbang(#!)은 런타임(Node)이 스크립트 실행에 쓰는 shebang — JS 문법 기능이 아니므로
+            // 어떤 ES target 으로 다운레벨해도 strip 하지 않는다 (esbuild / RN_DOC_SUPPORTED 정합).
+            // UnsupportedFeatures.hashbang 비트는 "타겟이 hashbang 지원하는가" 쿼리 전용(regex_lookbehind 와 동일).
+            try self.addSourceMapping(node.span);
+            try self.writeNodeSpan(node);
         },
 
         // Literals

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -112,8 +112,8 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
         },
         .hashbang => {
             // hashbang(#!)은 런타임(Node)이 스크립트 실행에 쓰는 shebang — JS 문법 기능이 아니므로
-            // 어떤 ES target 으로 다운레벨해도 strip 하지 않는다 (esbuild / RN_DOC_SUPPORTED 정합).
-            // UnsupportedFeatures.hashbang 비트는 "타겟이 hashbang 지원하는가" 쿼리 전용(regex_lookbehind 와 동일).
+            // 어떤 ES target 으로 다운레벨해도 strip 하지 않는다 (RN_DOC_SUPPORTED.hashbang=true 와 동일).
+            // UnsupportedFeatures.hashbang 비트는 codegen 이 읽지 않는다 — compat 매트릭스 대칭/진단용으로만 set.
             try self.addSourceMapping(node.span);
             try self.writeNodeSpan(node);
         },

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -130,8 +130,6 @@ pub const CodegenOptions = struct {
     /// --keep-names: minify 시 함수/클래스의 .name 프로퍼티 보존.
     /// codegen이 rename 감지 후 __name() 호출을 수집, 선언 직후에 append.
     keep_names: bool = false,
-    /// ES2023 미만 타겟에서 hashbang (#!) 제거
-    strip_hashbang: bool = false,
     // JSX 옵션 제거: Transformer의 jsx_lowering이 JSX -> call_expression 변환을 담당.
     // JsxRuntime enum은 graph.zig/emitter.zig/transpile.zig에서 여전히 사용.
     /// __esm 호이스팅 모드: variable_declaration을 할당문으로 변환 (키워드 제거).

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -40,7 +40,7 @@ pub fn parse(self: *Parser) !NodeIndex {
     var stmts: std.ArrayList(NodeIndex) = .empty;
     defer stmts.deinit(self.allocator);
 
-    // hashbang (#! ...) — AST에 노드로 추가 (codegen에서 strip_hashbang 조건부 출력)
+    // hashbang (#! ...) — AST에 노드로 추가 (codegen이 target 무관 항상 출력 — shebang 은 다운레벨 대상 아님)
     if (self.current() == .hashbang_comment) {
         const hashbang_node = try self.ast.addNode(.{
             .tag = .hashbang,

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -165,6 +165,8 @@ pub const UnsupportedFeatures = packed struct(u32) {
     /// top-level 문장을 async IIFE 로 감싸 wrapping (esbuild 호환). (#1384)
     top_level_await: bool = false,
     // ES2023
+    /// hashbang(#!) "타겟이 hashbang 을 지원하는가" 쿼리 전용 비트 — codegen 은 이 비트와 무관하게
+    /// hashbang 을 항상 보존한다(shebang 은 다운레벨 대상이 아님; regex_lookbehind 와 동일 패턴).
     hashbang: bool = false,
     // ES2025
     using: bool = false,

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -165,8 +165,8 @@ pub const UnsupportedFeatures = packed struct(u32) {
     /// top-level 문장을 async IIFE 로 감싸 wrapping (esbuild 호환). (#1384)
     top_level_await: bool = false,
     // ES2023
-    /// hashbang(#!) "타겟이 hashbang 을 지원하는가" 쿼리 전용 비트 — codegen 은 이 비트와 무관하게
-    /// hashbang 을 항상 보존한다(shebang 은 다운레벨 대상이 아님; regex_lookbehind 와 동일 패턴).
+    /// hashbang(#!) "타겟이 hashbang 을 지원하는가"를 나타내는 비트. codegen 은 이 비트를 읽지 않고
+    /// hashbang 을 항상 보존한다(shebang 은 다운레벨 대상이 아님) — 비트는 compat 매트릭스 대칭/진단용.
     hashbang: bool = false,
     // ES2025
     using: bool = false,

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1529,7 +1529,6 @@ fn transpileWithCallbackInternal(
         .platform = options.platform,
         .source_root = options.source_root,
         .sources_content = options.sources_content,
-        .strip_hashbang = options.unsupported.hashbang,
         .assert_no_raw_private_syntax = options.unsupported.requiresPrivateDownlevel(),
         // JSX: Transformer가 이미 call_expression으로 lowering 완료. codegen에 JSX 옵션 불필요.
     });


### PR DESCRIPTION
## 문제

CI 의 **Integration Tests (macos/ubuntu)** 가 `TsconfigCache (#2367)` 에서 실패:
`expect(result.code).toContain('var x')` 가 깨진다. 디스크캐시 npm 표면(직전)까지 success 였으나
직전 커밋 **#4456**("target 미지정 시 hashbang strip 회귀 — optionsJson 에 esnext 명시") 머지 후 failure.

### 근본 원인

hashbang(`#!`)은 런타임(Node)이 스크립트 실행에 쓰는 shebang 이라 JS 문법 기능이 아니다 — 어떤 ES
target 으로 다운레벨해도 strip 하면 안 된다(esbuild/rolldown/rspack + 자체 `RN_DOC_SUPPORTED.hashbang=true`
와 정합). 그런데 `fromESTarget` 이 hashbang(`.es2023`)을 일반 feature 처럼 취급해 es2022 이하 target 에서
`unsupported=strip` 으로 분류했고, codegen 이 `strip_hashbang` 비트로 제거했다.

**#4456** 은 이를 JS surface 에서 target 미지정 시 esnext 강제(`opts.target ?? 'esnext'`)로 우회했으나,
그 결과 **tsconfig autodiscover target(es5)을 덮어써** 다운레벨이 사라지는 회귀를 냈다 (`var x` → `const x`).

## 수정 (근본)

증상(esnext 강제)이 아니라 분류/strip 지점을 고친다:

1. **codegen 이 hashbang 을 항상 emit** — `strip_hashbang` 비트와 무관(`node_dispatch.zig`). `strip_hashbang`
   옵션 자체 제거. `UnsupportedFeatures.hashbang` 비트는 "타겟 지원 여부" 진단/매트릭스 대칭용으로만 남긴다.
2. **#4456 의 esnext 강제 rollback** (`packages/shared/index.ts`) → target 미지정 시 native 가 tsconfig
   autodiscover / 기본값으로 결정하도록 위임. (CLI surface 는 이미 이 동작이라 NAPI 와 일관해짐.)
3. **stale 테스트 정정** — es5·es2022 에서 hashbang strip 을 기대하던 테스트를 보존 기대로 정정.

## 검증

- TsconfigCache integration: **12 pass** (`var x` 다운레벨 복원)
- rsc-directives: **53 pass** (hashbang 보존)
- es2023-hashbang / hashbang-targets: **10 pass** (es5/es2022 보존으로 정정)
- native `zig build test`: **6003 pass**
- `transpile('#!...', {target:'es5'})` → `#!/usr/bin/env node\nvar x = 1;` (보존 + 다운레벨 동시)

`/code-review max` 통과(stale 테스트 2건 + stale 주석 3곳 반영). CI 의 **Integration** 실패를 해결한다.
Debug Test(dev_server stderr → #4457) / WASM·NAPI win32(32-bit atomic → #4458) 는 독립 원인으로 별도 PR.