### PR TITLE
ci: CI 잡 수 축소 (test262 lexer 중복 제거, benchmark ubuntu-only, 문서 PR skip)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # ubuntu-latest 만 — 회귀 게이트(check-regression.ts)가 ubuntu JSON 만 읽고,
+        # macOS/Windows 공유 runner 는 run 마다 2~3배 출렁여 추세 신뢰 불가(노이즈).
+        # 전체 OS wall-time 비교가 필요하면 workflow_dispatch 로 수동 실행.
+        os: [ubuntu-latest]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,23 @@ name: CI
 on:
   push:
     branches: [main]
+    # 순수 문서 변경은 build/test 에 영향 없음 — 24-job 매트릭스 skip. documents/
+    # 사이트는 docs.yml 이 별도 배포. tests/**/*.md fixture 영향을 피하려 docs 위치/
+    # 루트 *.md 로 한정(전역 **.md 미사용).
+    paths-ignore:
+      - 'documents/**'
+      - 'docs/**'
+      - '*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'documents/**'
+      - 'docs/**'
+      - '*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -40,72 +40,8 @@ jobs:
           zig build test-bin
           ./zig-out/bin/lib-unit-test
 
-  test262-lexer:
-    name: Test262 Lexer Conformance
-    runs-on: ubuntu-latest
-    needs: test262-unit
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Setup Zig
-        uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
-          # lexer/parser job 이 동일 ReleaseFast 빌드를 의도적으로 공유 (cross-job
-          # 캐시 재사용). 분리하지 말 것 — save race 는 동일 산출물이라 무해.
-          cache-key: test262-run
-
-      - name: Build (ReleaseFast)
-        run: zig build -Doptimize=ReleaseFast
-
-      - name: Test262 — literals/numeric
-        run: zig build run -- --test262 tests/test262/test/language/literals/numeric/
-
-      - name: Test262 — literals/string
-        run: zig build run -- --test262 tests/test262/test/language/literals/string/
-
-      - name: Test262 — literals/bigint
-        run: zig build run -- --test262 tests/test262/test/language/literals/bigint/
-
-      - name: Test262 — literals/regexp
-        run: zig build run -- --test262 tests/test262/test/language/literals/regexp/
-
-      - name: Test262 — literals/boolean
-        run: zig build run -- --test262 tests/test262/test/language/literals/boolean/
-
-      - name: Test262 — literals/null
-        run: zig build run -- --test262 tests/test262/test/language/literals/null/
-
-      - name: Test262 — comments
-        run: zig build run -- --test262 tests/test262/test/language/comments/
-
-      - name: Test262 — white-space
-        run: zig build run -- --test262 tests/test262/test/language/white-space/
-
-      - name: Test262 — line-terminators
-        run: zig build run -- --test262 tests/test262/test/language/line-terminators/
-
-      - name: Test262 — template-literal
-        run: zig build run -- --test262 tests/test262/test/language/expressions/template-literal/
-
-      - name: Test262 — identifiers
-        run: zig build run -- --test262 tests/test262/test/language/identifiers/
-
-      - name: Test262 — keywords
-        run: zig build run -- --test262 tests/test262/test/language/keywords/
-
-      - name: Test262 — future-reserved-words
-        run: zig build run -- --test262 tests/test262/test/language/future-reserved-words/
-
-      - name: Test262 — asi
-        run: zig build run -- --test262 tests/test262/test/language/asi/
-
   test262-parser:
-    name: Test262 Parser Conformance
+    name: Test262 Language Conformance
     runs-on: ubuntu-latest
     needs: test262-unit
 
@@ -119,12 +55,14 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.16.0
-          # test262-lexer 와 동일 ReleaseFast 빌드 — 키 공유로 cross-job 재사용.
           cache-key: test262-run
 
       - name: Build (ReleaseFast)
         run: zig build -Doptimize=ReleaseFast
 
+      # 전체 language/ 한 번에 — literals/comments/asi 등 (이전 별도 lexer job 의 모든
+      # 카테고리) 이 이 디렉토리의 부분집합이라 단일 run 으로 동일 커버리지. 실패 시
+      # 위반 파일 경로가 출력되므로 카테고리별 step 분리 없이도 회귀 위치 식별 가능.
       - name: Test262 — full language/
         run: zig build run -- --test262 tests/test262/test/language/
 


### PR DESCRIPTION
## 배경

PR당 CI 잡이 너무 많아(`src/**` 건드리는 일반 PR 기준 ≈43잡) 커버리지 손실 없이 줄일 수 있는 항목을 정리합니다. **Tier 1**(중복/노이즈 제거)만 적용했습니다.

## 변경

| # | 파일 | 변경 | 효과 |
|---|---|---|---|
| ① | `test262.yml` | `test262-lexer` 잡 제거 | −1 잡 −1 ReleaseFast 빌드 / PR |
| ② | `benchmark.yml` | matrix `[ubuntu, macos, windows]` → `[ubuntu]` | −2 잡 / src PR |
| ③ | `ci.yml` | `paths-ignore` 추가 (문서/마크다운) | 문서 PR에서 −24 잡 |

### ① test262-lexer 제거
`test262-parser` 잡이 `--test262 tests/test262/test/language/`(전체)를 실행합니다. 기존 lexer 잡이 돌던 `literals/numeric`, `literals/string`, `comments`, `asi` 등은 모두 `language/`의 **하위 디렉토리**라 같은 바이너리·같은 모드에서 이미 커버됩니다. 카테고리별 step 리포팅 granularity만 사라질 뿐, 실패 시 위반 파일 경로가 출력되므로 회귀 위치 식별에는 지장 없습니다.

### ② benchmark ubuntu-only
회귀 게이트(`check-regression.ts`)가 ubuntu JSON만 읽고, 워크플로우 주석에도 명시돼 있듯 macOS/Windows 공유 runner는 run마다 2~3배 출렁여 추세를 신뢰할 수 없습니다(노이즈). 전체 OS wall-time 비교가 필요하면 `workflow_dispatch`로 수동 실행 가능합니다.

### ③ ci.yml paths-ignore
순수 문서 변경(`documents/**`, `docs/**`, 루트 `*.md`, 이슈/PR 템플릿)은 build/test에 영향이 없는데도 24-job 매트릭스(release-build 9 + napi-package-smoke 8 포함)를 전부 기동하고 있었습니다. `tests/**/*.md` fixture 변경을 실수로 skip하지 않도록 전역 `**.md` 대신 docs 위치/루트 `*.md`로 한정했습니다. `documents/` 사이트는 `docs.yml`이 별도로 배포합니다.

## 안전성
- `main`에 enforced required status check / ruleset가 없어, `paths-ignore`로 잡이 skip돼도 머지가 블로킹되지 않습니다.
- ②는 `benchmark.yml`이 자신의 트리거 paths에 포함돼 이 PR에서 self-검증됩니다. ③은 `ci.yml`이 workflow 파일을 ignore하지 않아 역시 self-검증됩니다.
- ①(`test262.yml`)은 트리거 paths가 `src/**`뿐이라 이 PR에선 실행되지 않고, 머지 후 다음 `src` 변경 PR에서 검증됩니다(단순 잡 제거라 저위험).

🤖 Generated with [Claude Code](https://claude.com/claude-code)