### PR TITLE
ci: integration 잡별 path 필터 + draft PR skip (PR-A)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,10 @@ on:
       - '.github/actions/bun-cache/**'
   pull_request:
     branches: [main]
+    # draft PR 동안 무거운 잡 skip(아래 prepare-* 의 if). draft→ready 전환 시 다시 돌도록
+    # ready_for_review 를 트리거 타입에 추가 — 기본 types(opened/synchronize/reopened)엔
+    # 없어 누락 시 ready 후 CI 가 발화하지 않는다.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/**'
       - 'packages/**'
@@ -28,6 +32,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # 잡별 변경 영역 감지 — 파이프라인 일부만 바뀐 PR 에서 무관한 무거운 잡
+  # (hermes/e2e/compat-table/determinism)을 skip. 트랜스파일러는 파이프라인이라
+  # codegen 등 코어가 바뀌면 거의 모든 잡에 영향 → core 앵커를 보수적으로 넓게 잡아
+  # 무손실 유지(영향 가능성 있으면 무조건 포함; 과포함은 비용만 늘 뿐 커버리지 손실 없음).
+  # 추가 안전망: integration-ubuntu/macos 는 always-on 이라 cross-surface 회귀 백스톱.
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      compat: ${{ steps.filter.outputs.compat }}
+      determinism: ${{ steps.filter.outputs.determinism }}
+      e2e: ${{ steps.filter.outputs.e2e }}
+      hermes: ${{ steps.filter.outputs.hermes }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core: &core
+              - 'src/lexer/**'
+              - 'src/parser/**'
+              - 'src/semantic/**'
+              - 'src/transformer/**'
+              - 'src/codegen/**'
+              - 'src/regexp/**'
+              - 'src/transpile/**'
+              - 'src/util/**'
+              - 'src/cli/**'
+              - 'src/*.zig'
+              - 'build.zig'
+              - 'build.zig.zon'
+              - 'tests/**'
+              - '.github/workflows/integration.yml'
+              - '.github/actions/**'
+            compat:
+              - *core
+            determinism:
+              - *core
+              - 'src/bundler/**'
+            e2e:
+              - *core
+              - 'src/bundler/**'
+              - 'src/app/**'
+              - 'src/server/**'
+              - 'packages/web/**'
+              - 'packages/server/**'
+            hermes:
+              - *core
+              - 'src/bundler/**'
+              - 'packages/react-native/**'
+
   lint-format:
     name: Lint & Format
     runs-on: ubuntu-latest
@@ -54,6 +110,9 @@ jobs:
   prepare-zntc-ubuntu:
     name: Prepare ZNTC (ubuntu-latest)
     runs-on: ubuntu-latest
+    # draft PR 동안 skip — 이 prepare 가 skip 되면 의존 잡(integration-ubuntu/e2e)도
+    # cascade skip. push(main) 에선 항상 실행.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4
@@ -79,6 +138,8 @@ jobs:
   prepare-zntc-cli-ubuntu:
     name: Prepare ZNTC CLI (ubuntu-latest)
     runs-on: ubuntu-latest
+    # draft PR 동안 skip — 의존 잡(smoke/compat-table/determinism)도 cascade skip.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4
@@ -102,6 +163,8 @@ jobs:
   prepare-zntc-macos:
     name: Prepare ZNTC (macos-latest)
     runs-on: macos-latest
+    # draft PR 동안 skip — 의존 잡(integration-macos/hermes)도 cascade skip.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4
@@ -188,7 +251,10 @@ jobs:
   hermes:
     name: Hermes Validation (RN Bundle)
     runs-on: macos-latest
-    needs: prepare-zntc-macos
+    needs: [prepare-zntc-macos, changes]
+    # RN 패키지 또는 코어 transpile/bundle 경로가 바뀔 때만. web/server/dev 전용 변경엔
+    # skip(draft skip 은 prepare-zntc-macos cascade). 코어 회귀는 always-on integration 이 백스톱.
+    if: needs.changes.outputs.hermes == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -208,7 +274,10 @@ jobs:
   compat-table:
     name: compat-table ES Downlevel
     runs-on: ubuntu-latest
-    needs: prepare-zntc-cli-ubuntu
+    needs: [prepare-zntc-cli-ubuntu, changes]
+    # ES 다운레벨은 코어 transpile 경로(parser/transformer/codegen 등)만 의존 —
+    # bundler/dev-server/RN/web 전용 변경엔 skip.
+    if: needs.changes.outputs.compat == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -239,7 +308,10 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: prepare-zntc-ubuntu
+    needs: [prepare-zntc-ubuntu, changes]
+    # 브라우저 dev server 경로 — 코어 + bundler + dev server(src/app,server) + web 패키지
+    # 변경 시. RN/Flow 전용 변경엔 skip.
+    if: needs.changes.outputs.e2e == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -305,7 +377,9 @@ jobs:
   determinism:
     name: Build Determinism (N=10) (#3564)
     runs-on: ubuntu-latest
-    needs: prepare-zntc-cli-ubuntu
+    needs: [prepare-zntc-cli-ubuntu, changes]
+    # 번들 byte-identity — 코어 + bundler 변경 시. dev-server/RN/web/napi 전용 변경엔 skip.
+    if: needs.changes.outputs.determinism == 'true'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 배경

`integration.yml`(12잡)은 `src/**`·`packages/**`·`tests/**` 중 **하나라도** 바뀌면 12잡 전부 돕니다. 하지만 무거운 특화 잡(hermes/e2e/compat-table/determinism)은 실제로 관련 영역이 좁습니다. 잡별 path 필터로 무관한 PR에서 skip하고, draft PR 동안에는 전부 건너뜁니다.

**손실 없는 절감**이 원칙입니다 — 관련 영역이 바뀌면 그대로 실행하고, always-on인 `integration-ubuntu/macos`가 cross-surface 회귀 백스톱입니다.

## 변경

### ① 잡별 path 필터 (`dorny/paths-filter`)
`changes` 잡이 한 번 돌아 변경 영역을 판정하고, 4개 특화 잡이 자기 영역이 바뀔 때만 실행합니다.

| 잡 | 실행 조건 (필터) |
|---|---|
| **compat-table** | `core` (단일 파일 ES 다운레벨 — 번들/dev/RN 무관) |
| **determinism** | `core` + `src/bundler` |
| **e2e** | `core` + `bundler` + `src/app,server` + `packages/web,server` |
| **hermes** | `core` + `bundler` + `packages/react-native` |

`core` 앵커는 보수적으로 넓게 잡았습니다: `src/{lexer,parser,semantic,transformer,codegen,regexp,transpile,util,cli}`, 루트 `src/*.zig`, `build.zig*`, `tests/**`, 워크플로우/액션 파일. **코어 파이프라인이 바뀌면 4잡 모두 실행** → 무손실. `dev-server`/`RN`/`web` 같은 surface 전용 변경에서만 무관 잡이 skip됩니다.

예: 파서만 고친 PR → 4잡 다 실행(정상). `packages/web`만 고친 PR → hermes/compat/determinism skip, e2e만 실행.

### ② draft PR skip
`prepare-zntc-*` 3잡에 draft 가드를 걸어, draft PR 동안 빌드/테스트를 skip합니다. 이 prepare들이 skip되면 의존 잡(integration/smoke/compat/determinism/e2e/hermes)도 **cascade skip**됩니다. `push`(main)에선 항상 실행.

`pull_request` 트리거 `types`에 **`ready_for_review`를 추가**했습니다 — 기본 types(opened/synchronize/reopened)엔 없어서, 누락하면 draft→ready 전환 시 CI가 발화하지 않습니다.

## 안전성
- **무손실 설계**: 영향 가능성이 있으면 필터에 포함(과포함은 비용만 늘 뿐 커버리지 손실 없음). `integration-ubuntu/macos`는 always-on이라 백스톱 역할.
- main에 enforced required check가 없어, 필터로 잡이 skip돼도 머지 블로킹 없음.
- **이 PR 자기검증**: `core` 필터에 `.github/workflows/integration.yml`이 포함돼 있어, 이 PR에서 게이트 잡 4개가 전부 실행됩니다 → 필터/`if`가 잡을 깨지 않는지 직접 확인됩니다.

## 후속 (별도 PR-B 예정)
더블런 분리(PR+main 2× → main만) + 매트릭스 축소(④release-build, ⑤napi-package-smoke)는 설계 판단이 필요해 별도 PR로 분리합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)