### PR TITLE
fix(cache): #4438 디스크 캐시 ON==OFF 감사 후속 3건 (진단 누락 / .d.ts 키 / import.meta)

### DIFF
--- a/src/bundler/cache_key.zig
+++ b/src/bundler/cache_key.zig
@@ -68,7 +68,11 @@ pub const ParseFlags = packed struct(u8) {
     is_module: bool = false,
     is_flow: bool = false,
     is_strict: bool = false,
-    _pad: u3 = 0,
+    // #4438: `.d.ts`/`.d.mts`/`.d.cts` ambient 컨텍스트는 파싱을 바꾼다(initializer 없는
+    // const 허용, rest-param trailing comma 등). 경로 파생이라 source_hash/다른 플래그에
+    // 안 잡혀, 키에 명시 포함하지 않으면 byte-identical `.d.ts`↔`.ts` 가 키 충돌 → stale 재사용.
+    is_ambient: bool = false,
+    _pad: u2 = 0,
 
     pub fn bits(self: ParseFlags) u32 {
         return @as(u8, @bitCast(self));
@@ -87,6 +91,10 @@ pub fn parseFlagsFromParser(parser: anytype) ParseFlags {
         .is_module = parser.is_module,
         .is_flow = parser.is_flow,
         .is_strict = parser.is_strict_mode,
+        // configureAmbientFromPath(.d.ts 등)가 pre-parse 에 설정한 ambient 상태. 키 캡처가
+        // parse 전이라 path 파생값만 반영(parse 중 declare 블록의 transient 설정과 무관 — 그건
+        // source 의 함수라 source_hash 에 잡힘). store/load 가 같은 시점이라 키 일치 보장.
+        .is_ambient = parser.ctx.in_ambient,
     };
 }
 

--- a/src/bundler/cache_key_test.zig
+++ b/src/bundler/cache_key_test.zig
@@ -86,6 +86,37 @@ test "cache_key: compute 결정성 + 입력별 민감도" {
     try testing.expect(base != cache_key.compute(sh, flags, 0x1111, BUILD_ID +% 1)); // build id
 }
 
+test "cache_key: is_ambient 가 키에 반영 (#4438 .d.ts↔.ts 충돌 가드)" {
+    const sh = wyhash.hashU64(SRC);
+    // byte-identical source + 동일 나머지 플래그라도 ambient 여부가 다르면 키가 달라야
+    // 한다(.d.ts ambient AST 가 byte-identical .ts non-ambient 에 stale 재사용되는 것 방지).
+    const non_ambient = cache_key.ParseFlags{ .is_ts = true, .is_module = true };
+    const ambient = cache_key.ParseFlags{ .is_ts = true, .is_module = true, .is_ambient = true };
+    try testing.expect(cache_key.compute(sh, non_ambient, 0x1111, BUILD_ID) !=
+        cache_key.compute(sh, ambient, 0x1111, BUILD_ID));
+}
+
+test "cache_key: parseFlagsFromParser 가 ambient 상태를 캡처 (#4438 wiring)" {
+    const alloc = testing.allocator;
+    // .d.ts → configureAmbientFromPath 가 ctx.in_ambient=true → ParseFlags.is_ambient=true.
+    var scanner = try Scanner.init(alloc, SRC);
+    defer scanner.deinit();
+    var parser = Parser.init(alloc, &scanner);
+    defer parser.deinit();
+    parser.configureForBundler(".ts");
+    parser.configureAmbientFromPath("foo.d.ts");
+    try testing.expect(cache_key.parseFlagsFromParser(&parser).is_ambient);
+
+    // .ts → ambient 아님.
+    var scanner2 = try Scanner.init(alloc, SRC);
+    defer scanner2.deinit();
+    var parser2 = Parser.init(alloc, &scanner2);
+    defer parser2.deinit();
+    parser2.configureForBundler(".ts");
+    parser2.configureAmbientFromPath("foo.ts");
+    try testing.expect(!cache_key.parseFlagsFromParser(&parser2).is_ambient);
+}
+
 test "cache_key: hashSelective 가 모든 필드를 반영 (reflection 완전성)" {
     const base = cache_key.SelectiveOptions{};
     const base_h = cache_key.hashSelective(&base);

--- a/src/bundler/graph/parse_module.zig
+++ b/src/bundler/graph/parse_module.zig
@@ -148,9 +148,16 @@ pub fn parseModule(self: *ModuleGraph, io: std.Io, idx: ModuleIndex) void {
         };
     }
 
+    // #4438 ON==OFF: load hit 은 parse 전에 return 하므로 parse/semantic 단계의 진단
+    // (use_strict_non_simple / assign_to_import 등)을 재발행하지 못한다. 진단을 낸 모듈을
+    // store 하면 다음 빌드 load hit 이 cold 와 달리 에러를 삼킨다 → 그런 모듈은 store skip 해
+    // 항상 cold parse(=진단 재발행)되게 한다(가장 보수적).
+    var emitted_error_diag = false;
+
     if (parser.errors.items.len > 0) {
         // 파싱 에러 기록. recoverable validation 에러(use_strict_non_simple 등)는
         // AST가 정상이고 런타임도 실행하므로 모듈을 스킵하지 않는다 (#1291).
+        emitted_error_diag = true;
         var has_fatal = false;
         for (parser.errors.items) |err| {
             const msg = if (err.message.len > 0) err.message else "Parse error";
@@ -215,6 +222,7 @@ pub fn parseModule(self: *ModuleGraph, io: std.Io, idx: ModuleIndex) void {
             if (sem_err.code == .assign_to_import) {
                 const m = if (sem_err.message.len > 0) sem_err.message else "Cannot assign to or delete an imported binding";
                 self.addDiag(.assign_to_import, .@"error", module.path, sem_err.span, .link, m, null);
+                emitted_error_diag = true; // #4438 ON==OFF: 진단 발행 → store skip
             }
         }
 
@@ -273,9 +281,13 @@ pub fn parseModule(self: *ModuleGraph, io: std.Io, idx: ModuleIndex) void {
     // 지금은 store 만 — load(parse 스킵)는 graph 통합 3 → 출력 영향 0(항상 parse 실행).
     // self.allocator 는 worker 동시 호출에 안전(release=mimalloc / debug=DebugAllocator).
     if (self.disk_cache) |dc| {
-        if (module.ast) |*ast| {
-            if (module.semantic) |*sem| {
-                dc.store(io, self.allocator, module.disk_cache_key, ast, sem) catch {};
+        // #4438 ON==OFF: 진단을 낸 모듈은 store skip — load hit 이 parse 를 스킵해 그 진단을
+        // 재발행 못 하므로, 캐시되면 다음 빌드에서 에러가 사라진다(cold≠load).
+        if (!emitted_error_diag) {
+            if (module.ast) |*ast| {
+                if (module.semantic) |*sem| {
+                    dc.store(io, self.allocator, module.disk_cache_key, ast, sem) catch {};
+                }
             }
         }
     }
@@ -335,12 +347,17 @@ pub fn parseModule(self: *ModuleGraph, io: std.Io, idx: ModuleIndex) void {
 ///     lazy-barrel elision 게이트(`legal_comments.len != 0`)에 쓰이는데 load 는 그 slice 를
 ///     빈 채로 둔다 → banner 를 가진 barrel 이 잘못 elide 되어 누락. `isLegalComment`(scanner.zig)
 ///     의 마커를 보수적으로 검출한다(false positive=load OFF 안전, false negative 없음).
+///  3) **`import.meta`** — cold 은 import.meta 가 has_module_syntax 를 켜 exports_kind=.esm
+///     로 만들지만, load 의 import_scanner 는 import/export 선언만 보고 meta_property 를 무시해
+///     .none 으로 떨어진다(require-target/entry/RN-wrap 에서 wrap_kind·출력 발산). import.meta
+///     substring 을 보수적으로 검출한다(과검출=load OFF 안전).
 fn loadUnsafeSource(source: []const u8) bool {
     return std.mem.indexOf(u8, source, "\xE2\x80\xA8") != null or // U+2028 (LS)
         std.mem.indexOf(u8, source, "\xE2\x80\xA9") != null or // U+2029 (PS)
         std.mem.indexOf(u8, source, "@license") != null or
         std.mem.indexOf(u8, source, "@preserve") != null or
-        std.mem.indexOf(u8, source, "/*!") != null;
+        std.mem.indexOf(u8, source, "/*!") != null or
+        std.mem.indexOf(u8, source, "import.meta") != null; // #4438 exports_kind 발산 방지
 }
 
 fn tryDiskLoadHit(

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -1946,3 +1946,98 @@ test "graph: load hit 게이트 — legal comment 모듈은 load OFF (#4438 통�
 
     try std.testing.expectEqual(@as(usize, 0), g2.disk_load_hits.load(.monotonic));
 }
+
+test "graph: load hit 게이트 — import.meta 모듈은 load OFF (#4438 ON==OFF)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // import.meta 는 cold 에서 has_module_syntax→exports_kind=.esm 로 만들지만, load 의
+    // import_scanner 는 meta_property 를 안 봐 .none 으로 발산(require-target/entry/RN-wrap 에서
+    // wrap_kind 차이). loadUnsafeSource 게이트로 cold parse 유지 → 캐시 있어도 load OFF(hit 0).
+    try writeFile(tmp.dir, "index.mjs", "const u = import.meta.url; console.log(u);");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.mjs" });
+    defer std.testing.allocator.free(entry);
+    const cache_root = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "cache" });
+    defer std.testing.allocator.free(cache_root);
+
+    {
+        var s1 = try @import("disk_module_store.zig").DiskModuleStore.init(std.testing.allocator, cache_root);
+        defer s1.deinit();
+        var c1 = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+        defer c1.deinit();
+        var g1 = ModuleGraph.init(std.testing.allocator, &c1);
+        defer g1.deinit();
+        g1.disk_cache = &s1;
+        g1.disk_load_enabled = true;
+        try g1.build(std.testing.io, &.{entry});
+    }
+
+    var s2 = try @import("disk_module_store.zig").DiskModuleStore.init(std.testing.allocator, cache_root);
+    defer s2.deinit();
+    var c2 = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer c2.deinit();
+    var g2 = ModuleGraph.init(std.testing.allocator, &c2);
+    defer g2.deinit();
+    g2.disk_cache = &s2;
+    g2.disk_load_enabled = true;
+    try g2.build(std.testing.io, &.{entry});
+
+    try std.testing.expectEqual(@as(usize, 0), g2.disk_load_hits.load(.monotonic));
+}
+
+test "graph: 진단 낸 모듈은 store skip → cache ON 2nd build 도 진단 재발행 (#4438 ON==OFF)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // import 바인딩 변형 → assign_to_import(ZNTC0805) error. AST/semantic 은 산출되어 store
+    // 까지 도달하지만, 캐시하면 2nd build load hit 이 parse 를 스킵해 진단을 삼킨다(#4020 의도적
+    // fatal 이 cache 로 사라짐). store skip 으로 위반 모듈은 항상 cold parse 되게 한 것을 가드.
+    try writeFile(tmp.dir, "index.mjs", "import { a } from './a.mjs'; a = 1;");
+    try writeFile(tmp.dir, "a.mjs", "export const a = 1;");
+
+    const dp = try dirPath(&tmp);
+    defer std.testing.allocator.free(dp);
+    const entry = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.mjs" });
+    defer std.testing.allocator.free(entry);
+    const cache_root = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "cache" });
+    defer std.testing.allocator.free(cache_root);
+
+    // 1st build: cold → 진단 emit + 위반 모듈 store skip(a.mjs 는 store 됨).
+    var first_count: usize = undefined;
+    {
+        var s1 = try @import("disk_module_store.zig").DiskModuleStore.init(std.testing.allocator, cache_root);
+        defer s1.deinit();
+        var c1 = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+        defer c1.deinit();
+        var g1 = ModuleGraph.init(std.testing.allocator, &c1);
+        defer g1.deinit();
+        g1.disk_cache = &s1;
+        g1.disk_load_enabled = true;
+        try g1.build(std.testing.io, &.{entry});
+        first_count = 0;
+        for (g1.diagnostics.items) |d| {
+            if (d.code == .assign_to_import and d.severity == .@"error") first_count += 1;
+        }
+        try std.testing.expect(first_count > 0); // 진단 존재 전제(소스가 실제로 트리거)
+    }
+
+    // 2nd build: a.mjs 는 load hit 되지만(캐시 동작 증명), 위반 모듈은 store 안 돼 cold parse → 진단 재발행.
+    var s2 = try @import("disk_module_store.zig").DiskModuleStore.init(std.testing.allocator, cache_root);
+    defer s2.deinit();
+    var c2 = resolve_cache_mod.ResolveCache.init(std.testing.allocator, .{});
+    defer c2.deinit();
+    var g2 = ModuleGraph.init(std.testing.allocator, &c2);
+    defer g2.deinit();
+    g2.disk_cache = &s2;
+    g2.disk_load_enabled = true;
+    try g2.build(std.testing.io, &.{entry});
+
+    try std.testing.expect(g2.disk_load_hits.load(.monotonic) > 0); // a.mjs load hit = 캐시 동작 증명
+    var second_count: usize = 0;
+    for (g2.diagnostics.items) |d| {
+        if (d.code == .assign_to_import and d.severity == .@"error") second_count += 1;
+    }
+    // 핵심: cache ON 2nd build 도 1st 와 같은 진단 수(ON==OFF). store skip 없으면 0 으로 떨어진다.
+    try std.testing.expectEqual(first_count, second_count);
+}


### PR DESCRIPTION
## 배경

`#4438` 디스크 캐시(opt-in `--disk-cache`, 기본 OFF)를 **전수 감사**한 결과, 직렬화/IO 코어(결정성·round-trip·fail-safe·32-bit·소유권)는 견고하나, **load hit이 cold build와 다른 결과를 내는** 경계 버그 3건을 발견해 수정합니다. 모두 이 기능의 핵심 불변식 **ON==OFF byte-identical**을 위반합니다.

> 코어는 깨끗합니다(CRITICAL 0). 이미 수정된 함정(#4460 직렬화 결정성, #4458 32-bit atomic)도 present & complete 확인.

## 수정 3건

### 🔴 HIGH-1 — load hit이 진단(diagnostics)을 누락 (`parse_module.zig`)
cold 경로는 `use_strict_non_simple`(recoverable)·`assign_to_import`(ZNTC0805, #4020에서 의도적 fatal) 진단을 `.@"error"`로 emit하고도 AST/semantic을 산출해 **store까지 도달**합니다. load hit은 parse 전에 `return`하므로 이 진단을 **재발행하지 못해**, 캐시되면 2nd build에서 에러가 사라집니다(빌드 실패→성공으로 뒤집힘).
- **수정**: 진단을 낸 모듈은 **store skip** → 항상 cold parse(진단 재발행)되게 함(가장 보수적).

### 🔴 HIGH-2 — `.d.ts` ambient 파싱 모드가 키에 없음 (`cache_key.zig`)
`configureAmbientFromPath(.d.ts)`가 `in_ambient` 파싱을 켜(initializer 없는 `const` 허용 등) AST가 달라지는데, `ParseFlags`에 ambient가 없고 키에 경로도 없어 byte-identical `.d.ts`↔`.ts`가 **키 충돌** → ambient AST가 non-ambient에 stale 재사용.
- **수정**: `ParseFlags`에 `is_ambient` 추가(`_pad` u3→u2) + `parseFlagsFromParser`가 `ctx.in_ambient` 캡처. (트리거 확률은 낮으나 "경로 파생 parse 모드 키 누락" = silent miscompile 버그 클래스)

### 🟡 MED — `import.meta`-only 모듈의 exports_kind 발산 (`parse_module.zig`)
cold은 `import.meta`가 `has_module_syntax`→`exports_kind=.esm`로 만들지만, load의 `import_scanner`는 import/export 선언만 보고 `meta_property`를 무시해 `.none`으로 발산(require-target/entry/RN-wrap에서 wrap_kind·출력 차이).
- **수정**: `loadUnsafeSource` 게이트에 `import.meta` 추가 — legal_comment/U+2028과 동일한 **보수적 source 게이트** 패턴(과검출=load OFF 안전).

## 테스트 (4건, 로컬 직접 binary 통과)
- `cache_key`: `is_ambient` 키 반영 + `parseFlagsFromParser` wiring → **24/24**
- `graph`: 진단 낸 모듈 store skip으로 진단 보존(+ a.mjs는 load hit되어 캐시 동작 증명) + import.meta load OFF → **54/54**

HIGH-1 테스트는 `import { a } from './a.mjs'; a = 1;`가 실제로 assign_to_import을 트리거하고(전제 assert), 수정 없이는 2nd build 진단이 0으로 떨어졌을 것을 검증합니다.

## 영향 범위
세 수정 모두 **`if (disk_cache)` / `tryDiskLoadHit` / `cache_key.compute` 안에만** 들어가 기본(비-캐시) 빌드 경로엔 영향 0입니다.

Part of #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)