### PR TITLE
fix(cache): #4438 디스크 캐시 견고성 후속 — LOW 4건 + 버전별 GC

### DIFF
--- a/src/build_id.zig
+++ b/src/build_id.zig
@@ -37,6 +37,14 @@ pub fn current() u64 {
     return compute(build_options.git_sha, @tagName(builtin.mode), builtin.zig_version_string);
 }
 
+/// 이 zts **바이너리가 dirty working tree 에서 컴파일됐는지**(컴파일타임 git 상태). dirty 면
+/// git_sha 가 `<sha>-dirty` 로 고정돼 변경 내용을 구분 못 하므로(같은 마커로 다른 코드가 같은
+/// build_id) disk cache 의 컴파일러-버전 가드가 무력 — caller(bundler)가 dirty 빌드는 disk cache
+/// 를 비활성화하는 데 쓴다. 릴리스(클린) 바이너리 사용자는 항상 false(영향 없음).
+pub fn isDirty() bool {
+    return std.mem.indexOf(u8, build_options.git_sha, "-dirty") != null;
+}
+
 test "build_id: 각 dimension 이 키를 바꾸고 0 이 아님" {
     const t = std.testing;
     try t.expect(current() != 0);

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1275,8 +1275,13 @@ pub const Bundler = struct {
         // 없으면 disk_module_cache(테스트 직접 주입). 둘 다 없으면 비활성.
         const disk_cache_ptr: ?*@import("disk_module_store.zig").DiskModuleStore = blk: {
             if (self.options.disk_cache_dir) |dir| {
+                // #4438: dirty 빌드(zts 바이너리가 dirty tree 에서 컴파일됨)는 build_id 가 변경
+                // 내용을 구분 못 해(<sha>-dirty 고정) stale 재사용 위험 → disk cache 비활성(정확성
+                // 우선, 캐시는 perf-only). 릴리스(클린) 바이너리 사용자는 무관(항상 false).
+                if (@import("../build_id.zig").isDirty()) break :blk null;
                 if (self.owned_disk_cache == null) {
-                    self.owned_disk_cache = @import("disk_module_store.zig").DiskModuleStore.init(self.allocator, dir) catch null;
+                    // build_id 네임스페이스(버전별 격리)+옛 버전 dir best-effort GC(디스크 bloat 방지).
+                    self.owned_disk_cache = @import("disk_module_store.zig").DiskModuleStore.initVersioned(self.allocator, io, dir, @import("../build_id.zig").current()) catch null;
                 }
                 if (self.owned_disk_cache) |*s| break :blk s;
             }

--- a/src/bundler/disk_cache.zig
+++ b/src/bundler/disk_cache.zig
@@ -8,6 +8,9 @@
 //! - **atomic write**: 유니크 tmp 파일에 쓰고 `rename` 으로 교체한다. POSIX rename 은 원자적이라
 //!   reader 가 half-written 파일을 보지 못한다. tmp 이름에 프로세스 전역 단조 카운터(seq)를
 //!   박아 같은 프로세스 내 동시 쓰기끼리 충돌하지 않는다.
+//!   (**의도적 비-fsync**: rename 전 fsync 를 하지 않는다. 전원손실 시 final 이 zero-length/부분
+//!   일 수 있으나, get 이 fail-open + codec checksum 으로 miss→재파싱하므로 정확성 안전. 매 write
+//!   fsync 는 write 비용만 늘고 정확성 이득 0이라 트레이드오프상 생략 — 손실=엔트리 1건 재파싱.)
 //! - **fail-open get**: 캐시 읽기 실패(없음/권한/손상/크기초과)는 전부 cache miss(`null`)로
 //!   degrade 해 재파싱하게 한다 — 캐시는 no-cache 보다 빌드를 더 깨뜨리면 안 된다. 시스템 자원
 //!   고갈(`OutOfMemory`)만 전파한다.
@@ -42,6 +45,20 @@ pub const DiskCache = struct {
 
     pub fn init(allocator: std.mem.Allocator, root_dir: []const u8) std.mem.Allocator.Error!DiskCache {
         return .{ .allocator = allocator, .root = try allocator.dupe(u8, root_dir) };
+    }
+
+    /// `root_dir/<build_id:016x>` 를 실제 캐시 루트로 쓴다(컴파일러 버전별 격리). 동시에 같은
+    /// `root_dir` 안의 **다른** build_id 디렉토리(16-hex 이름)를 best-effort 삭제(GC). 컴파일러
+    /// 버전이 바뀌면 옛 캐시는 키가 달라 영영 안 읽혀 누적되므로(디스크 bloat) 새 버전 init 때
+    /// 정리한다. 삭제는 16-hex 디렉토리 이름으로만 게이트(사용자 파일 오삭제 방지)+best-effort.
+    /// 동일 바이너리 재빌드는 같은 build_id → 같은 subdir → load hit 유지.
+    pub fn initVersioned(allocator: std.mem.Allocator, io: std.Io, root_dir: []const u8, build_id: u64) std.mem.Allocator.Error!DiskCache {
+        var hex: [16]u8 = undefined;
+        _ = std.fmt.bufPrint(&hex, "{x:0>16}", .{build_id}) catch unreachable; // 16자리 고정
+        pruneOtherVersions(io, root_dir, hex[0..]);
+        const versioned = try std.fs.path.join(allocator, &[_][]const u8{ root_dir, hex[0..] });
+        defer allocator.free(versioned);
+        return init(allocator, versioned);
     }
 
     pub fn deinit(self: *DiskCache) void {
@@ -89,3 +106,27 @@ pub const DiskCache = struct {
         };
     }
 };
+
+/// `root_dir` 안의 16-hex 디렉토리 중 `current_hex` 가 아닌 것을 삭제(다른 컴파일러 버전 캐시 GC).
+/// best-effort: 루트 부재/권한/삭제 실패는 전부 무시(캐시 정리가 빌드를 막으면 안 됨). 16-hex
+/// 이름 게이트로 사용자 파일/디렉토리는 건드리지 않는다.
+fn pruneOtherVersions(io: std.Io, root_dir: []const u8, current_hex: []const u8) void {
+    var dir = std.Io.Dir.cwd().openDir(io, root_dir, .{ .iterate = true }) catch return; // 루트 없음/권한 → skip
+    defer dir.close(io);
+    var it = dir.iterate();
+    while (it.next(io) catch return) |entry| {
+        if (entry.kind != .directory) continue;
+        if (!isHex16(entry.name)) continue;
+        if (std.mem.eql(u8, entry.name, current_hex)) continue;
+        dir.deleteTree(io, entry.name) catch {}; // best-effort
+    }
+}
+
+/// 정확히 16자리 소문자 hex 인지(캐시 build_id 디렉토리 이름 형식 — 삭제 게이트).
+fn isHex16(name: []const u8) bool {
+    if (name.len != 16) return false;
+    for (name) |c| {
+        if (!((c >= '0' and c <= '9') or (c >= 'a' and c <= 'f'))) return false;
+    }
+    return true;
+}

--- a/src/bundler/disk_cache_test.zig
+++ b/src/bundler/disk_cache_test.zig
@@ -139,3 +139,44 @@ test "disk_cache: 여러 key 독립 보관" {
         try testing.expectEqualStrings(want, got);
     }
 }
+
+test "disk_cache: initVersioned 가 옛 build_id dir GC + 사용자 dir 보존 (#4438)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realPathFileAlloc(testing.io, ".", testing.allocator);
+    defer testing.allocator.free(root);
+
+    const BID_OLD: u64 = 0x1111111111111111;
+    const BID_NEW: u64 = 0x2222222222222222;
+
+    // 옛 버전 캐시 채움 → <root>/1111.../<shard>/ 생성(put 이 dir lazy 생성).
+    {
+        var old = try DiskCache.initVersioned(testing.allocator, testing.io, root, BID_OLD);
+        defer old.deinit();
+        try old.put(testing.io, KEY_A, "old-version-entry");
+    }
+    // 비-hex 사용자 디렉토리(GC 가 건드리면 안 됨).
+    try tmp.dir.createDirPath(testing.io, "user-data");
+
+    // 새 버전 init → prune 이 옛 16-hex dir 삭제 후 새 dir 사용.
+    {
+        var new = try DiskCache.initVersioned(testing.allocator, testing.io, root, BID_NEW);
+        defer new.deinit();
+        try new.put(testing.io, KEY_A, "new-version-entry");
+        const got = (try new.get(testing.io, testing.allocator, KEY_A, MAX)).?;
+        defer testing.allocator.free(got);
+        try testing.expectEqualStrings("new-version-entry", got); // 새 버전은 정상 read
+    }
+
+    var old_hex: [16]u8 = undefined;
+    _ = std.fmt.bufPrint(&old_hex, "{x:0>16}", .{BID_OLD}) catch unreachable;
+    // 옛 build_id dir 은 GC 됨(access 성공하면 미삭제 = 실패).
+    if (tmp.dir.access(testing.io, &old_hex, .{})) |_| {
+        return error.OldVersionDirNotPruned;
+    } else |_| {}
+    // 사용자 dir(비-hex)·새 build_id dir 은 보존.
+    try tmp.dir.access(testing.io, "user-data", .{});
+    var new_hex: [16]u8 = undefined;
+    _ = std.fmt.bufPrint(&new_hex, "{x:0>16}", .{BID_NEW}) catch unreachable;
+    try tmp.dir.access(testing.io, &new_hex, .{});
+}

--- a/src/bundler/disk_module_store.zig
+++ b/src/bundler/disk_module_store.zig
@@ -46,6 +46,12 @@ pub const DiskModuleStore = struct {
         return .{ .disk = try DiskCache.init(allocator, root_dir) };
     }
 
+    /// build_id 로 네임스페이스(버전별 격리) + 옛 버전 dir best-effort GC. 자세한 내용은
+    /// `DiskCache.initVersioned` 참조. production(bundler)이 disk_cache_dir opt-in 에 쓴다.
+    pub fn initVersioned(allocator: std.mem.Allocator, io: std.Io, root_dir: []const u8, build_id: u64) std.mem.Allocator.Error!DiskModuleStore {
+        return .{ .disk = try DiskCache.initVersioned(allocator, io, root_dir, build_id) };
+    }
+
     pub fn deinit(self: *DiskModuleStore) void {
         self.disk.deinit();
     }

--- a/src/bundler/graph/parse_module.zig
+++ b/src/bundler/graph/parse_module.zig
@@ -120,6 +120,10 @@ pub fn parseModule(self: *ModuleGraph, io: std.Io, idx: ModuleIndex) void {
     // 일치한다(post-parse 확정 is_module/is_strict 는 source 함수라 source_hash 에 반영됨).
     // source 는 plugin transform 까지 반영된 최종값. disk_cache 비활성이면 skip(출력·비용 0).
     if (self.disk_cache != null) {
+        // compiler_build_id == 0 은 cache_key 의 컴파일러-버전 가드를 무력화한다(로직이 바뀐
+        // rebuild 후에도 같은 키 → stale). production wiring 은 build_id.current()(0→1 매핑)로
+        // 항상 비0 — 0 이면 배선 실수(테스트도 실제값 사용).
+        std.debug.assert(self.disk_compiler_build_id != 0);
         const cache_key_mod = @import("../cache_key.zig");
         const wyhash = @import("../../util/wyhash.zig");
         module.disk_cache_key = cache_key_mod.compute(

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -1929,6 +1929,7 @@ test "graph: load hit 게이트 — legal comment 모듈은 load OFF (#4438 통�
         var g1 = ModuleGraph.init(std.testing.allocator, &c1);
         defer g1.deinit();
         g1.disk_cache = &s1;
+        g1.disk_compiler_build_id = 0xABCD;
         g1.disk_load_enabled = true;
         try g1.build(std.testing.io, &.{entry});
     }
@@ -1941,6 +1942,7 @@ test "graph: load hit 게이트 — legal comment 모듈은 load OFF (#4438 통�
     var g2 = ModuleGraph.init(std.testing.allocator, &c2);
     defer g2.deinit();
     g2.disk_cache = &s2;
+    g2.disk_compiler_build_id = 0xABCD;
     g2.disk_load_enabled = true;
     try g2.build(std.testing.io, &.{entry});
 
@@ -1970,6 +1972,7 @@ test "graph: load hit 게이트 — import.meta 모듈은 load OFF (#4438 ON==OF
         var g1 = ModuleGraph.init(std.testing.allocator, &c1);
         defer g1.deinit();
         g1.disk_cache = &s1;
+        g1.disk_compiler_build_id = 0xABCD;
         g1.disk_load_enabled = true;
         try g1.build(std.testing.io, &.{entry});
     }
@@ -1981,6 +1984,7 @@ test "graph: load hit 게이트 — import.meta 모듈은 load OFF (#4438 ON==OF
     var g2 = ModuleGraph.init(std.testing.allocator, &c2);
     defer g2.deinit();
     g2.disk_cache = &s2;
+    g2.disk_compiler_build_id = 0xABCD;
     g2.disk_load_enabled = true;
     try g2.build(std.testing.io, &.{entry});
 
@@ -2013,6 +2017,7 @@ test "graph: 진단 낸 모듈은 store skip → cache ON 2nd build 도 진단 �
         var g1 = ModuleGraph.init(std.testing.allocator, &c1);
         defer g1.deinit();
         g1.disk_cache = &s1;
+        g1.disk_compiler_build_id = 0xABCD;
         g1.disk_load_enabled = true;
         try g1.build(std.testing.io, &.{entry});
         first_count = 0;
@@ -2030,6 +2035,7 @@ test "graph: 진단 낸 모듈은 store skip → cache ON 2nd build 도 진단 �
     var g2 = ModuleGraph.init(std.testing.allocator, &c2);
     defer g2.deinit();
     g2.disk_cache = &s2;
+    g2.disk_compiler_build_id = 0xABCD;
     g2.disk_load_enabled = true;
     try g2.build(std.testing.io, &.{entry});
 

--- a/src/bundler/semantic_codec.zig
+++ b/src/bundler/semantic_codec.zig
@@ -38,6 +38,14 @@ const HEADER_LEN: usize = 16;
 /// 안전한 sentinel(SymbolId.none/ScopeId.none 과 동일 패턴).
 const NULL_U32: u32 = std.math.maxInt(u32);
 
+comptime {
+    // synthetic_kind 직렬화(putSymbol/readSymbol)가 0xFF 를 ?SyntheticKind 의 null sentinel 로
+    // 쓴다. SyntheticKind(enum(u8))에 값 0xFF 변형이 생기면 null 로 오역(silent miscompile)되므로
+    // 0xFF 가 유효 변형이 아님을 못박는다(현재 4 변형이라 여유 충분 — 미래 회귀 가드).
+    if (std.enums.fromInt(symbol_mod.SyntheticKind, 0xFF) != null)
+        @compileError("SyntheticKind 0xFF 변형이 semantic_codec 의 null sentinel 과 충돌 — sentinel 폭 확장 필요.");
+}
+
 /// struct 의 `"name:typename;name:typename;…"` 시그니처를 comptime 문자열로 만든다.
 /// 필드 수뿐 아니라 **이름+타입+순서**까지 못박아 rename/retype/reorder(필드 수 불변 변경)도
 /// 컴파일 에러로 잡는다 — 이 codec 은 필드별 명시 직렬화라 그런 변경이 silent 하면 cache-hit


### PR DESCRIPTION
## 배경

`#4464`(ON==OFF 감사)에서 **보류했던 정확성-무해 robustness 항목**을 정리합니다. 모두 opt-in 디스크 캐시(`--disk-cache`) 한정.

> LOW-4(fsync)는 **fsync 추가가 잘못된 수정**이라 판단해 코드 대신 문서로 처리했습니다 — crash 시 zero-length는 이미 fail-open + checksum으로 miss→재파싱(안전)인데, 매 write fsync는 비용만 늘고 정확성 이득이 0입니다.

## 수정 5건

### LOW-1 — SyntheticKind sentinel 가드 (`semantic_codec.zig`)
`synthetic_kind` 직렬화가 `0xFF`를 null sentinel로 쓰는데, `SyntheticKind`(enum(u8)) 변형이 255에 도달하면 충돌. comptime 가드로 핀(현재 4 변형, 미래 회귀 방지).

### LOW-2 — build_id != 0 assert (`parse_module.zig`)
`compiler_build_id == 0`은 cache_key의 컴파일러-버전 가드를 무력화(rebuild 후 stale). 키 캡처 시 `assert(disk_compiler_build_id != 0)`. production은 `build_id.current()`(0→1 매핑)로 항상 비0 — `graph_test`의 disk 테스트도 실제값(0xABCD)을 쓰도록 갱신.

### LOW-3 — dirty 빌드 캐시 비활성 (`build_id.zig` + `bundler.zig`)
`build_id.isDirty()` 추가. **dirty 빌드(zts 바이너리가 dirty tree에서 컴파일됨)**는 `git_sha=<sha>-dirty`로 고정돼 변경 내용을 구분 못 하므로, bundler가 `disk_cache_dir` opt-in을 비활성화(정확성 우선). 기존엔 `build_id.zig` 주석 정책만 있고 미강제였음. **릴리스(클린) 바이너리 사용자는 무관**(항상 false).

### LOW-4 — fsync 부재 명문화 (`disk_cache.zig` 문서)
rename 전 fsync를 하지 않는 것을 "의도적 트레이드오프"로 문서화. 손실 = crash 시 엔트리 1건 재파싱.

### GC — 버전별 네임스페이스 + sweep (`disk_cache.zig` + `disk_module_store.zig` + `bundler.zig`)
`DiskCache.initVersioned`로 캐시 루트를 `<dir>/<build_id:016x>`로 네임스페이스(버전별 격리) + 같은 dir의 **다른** 16-hex build_id 디렉토리를 best-effort 삭제(GC). 컴파일러 버전이 바뀌면 옛 캐시는 키가 달라 영영 안 읽혀 누적되던 **디스크 bloat** 해소.
- 삭제는 **16-hex 이름 게이트**(사용자 파일 보존) + best-effort(에러 무시).
- 동일 바이너리 재빌드 = 같은 build_id → 같은 subdir → load hit 유지.
- 구 flat 레이아웃 엔트리(2-hex shard)는 prune 비대상 → junk 잔존하나 opt-in 실험 기능이라 무해.

## 테스트
- `disk_cache`: GC sweep 신규(옛 build_id dir 삭제 + 사용자 비-hex dir 보존) — **26/26**
- `graph`: assert(build_id 설정 후) + ON==OFF — **54/54**
- `cache_key` 24 / `semantic_codec` 24 / `module_codec` 20 / `build_id` 20 (직접 binary)

LOW-3(dirty-disable)은 컴파일타임 빌드 상태에 의존해 유닛 테스트가 어렵습니다(테스트가 Bundler.bundle+disk_cache_dir 경로를 안 탐). 로직은 `if (isDirty()) break :blk null;`로 자명.

## 영향 범위
모두 disk_cache 활성 경로 안에만 들어가 기본(비-캐시) 빌드 영향 0.

Part of #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)