### PR TITLE
fix(codegen): minify comma-sequence 접기 시 statement-start 괄호 소실 (런타임 SyntaxError)

### DIFF
--- a/.changeset/minify-seq-stmt-start-paren.md
+++ b/.changeset/minify-seq-stmt-start-paren.md
@@ -1,0 +1,23 @@
+---
+"@zntc/core": patch
+---
+
+minify 시 `if (c) { ({a} = o); g(); }` 를 콤마 시퀀스로 접을 때 **필수 괄호가 사라지던** 버그 수정 (#4472).
+
+`--minify`(= `minify_whitespace` + `minify_syntax`)는 블록 안의 expression statement 들을 `if(c) a,b;` 처럼 콤마 시퀀스로 접는다. 이 경로가 statement-start 를 표시하지 않아, 시퀀스 **첫 원소**가 object destructuring 할당이면 괄호가 빠졌다:
+
+```js
+// 입력
+if (href) { ({ href, dimensions } = cleanUrl(href)); out.push(href); }
+
+// 잘못된 출력
+if(n){href:n,dimensions:r}=t(n),i.push(n);
+//    ^ 브라우저는 `{` 를 블록으로, `href:` 를 라벨로 읽는다 → SyntaxError
+
+// 고쳐진 출력
+if(n)({href:n,dimensions:r}=t(n)),i.push(n);
+```
+
+**빌드는 exit 0 으로 성공하는데 산출물이 런타임에 죽는** silent miscompile 이었다 — `monaco-editor`(marked 의 image 렌더러)를 번들하면 `SyntaxError: Unexpected token ':'` 로 페이지 전체가 실행되지 않았다.
+
+단일 문장 본문(`if (c) ({a} = o);`)은 `emitExpressionStatement` 를 타서 정상이었고, 여러 문장을 접는 경로만 그 마킹을 건너뛰고 있었다. object literal 선두(`({}).toString()`)도 같은 원인으로 깨졌고 함께 고쳐진다. 배열 구조분해(`[a,b] = arr`)는 `[` 가 블록으로 오파싱되지 않으므로 괄호가 붙지 않는다.

--- a/src/codegen/codegen_test/minify_sourcemap.zig
+++ b/src/codegen/codegen_test/minify_sourcemap.zig
@@ -286,3 +286,53 @@ test "SourceMap: enum members map to their source line" {
 }
 
 // ================================================================
+
+/// #4472 가드용 — multi-expr block 을 comma sequence 로 접는 경로는
+/// `minify_whitespace` + `minify_syntax` 가 **둘 다** 켜져야 활성화된다.
+fn e2eMinify(allocator: std.mem.Allocator, source: []const u8) !helpers.TestResult {
+    return e2eWithOptions(allocator, source, .{ .minify_whitespace = true, .minify_syntax = true });
+}
+
+// ============================================================
+// #4472 — multi-expr block → comma sequence 접기 시 statement-start 괄호 소실
+// ============================================================
+//
+// `if (c) { ({a} = o); g(); }` 를 `if(c) a,b;` 로 접는 경로가 statement_start 를
+// 찍지 않아, 선두 object destructuring 할당의 **필수 괄호**가 빠졌다:
+//   `if(c){a:x}=f(),g();`  ← `{` 를 블록으로, `a:` 를 라벨로 파싱 → SyntaxError
+// 빌드는 green 인데 산출물이 런타임에 죽는 silent miscompile (monaco-editor 번들).
+
+test "#4472 minify: if body sequence 선두 object destructuring 할당에 괄호 유지" {
+    var r = try e2eMinify(std.testing.allocator,
+        \\function f(c, o, g) { let a, b; if (c) { ({ a, b } = o); g(a); } return [a, b]; }
+    );
+    defer r.deinit();
+    // `if(c)({a,b}=o),g(a);` — 괄호가 빠지면 `if(c){a,b}=o` 로 파싱 불가.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "if(c)({a,b}=o)") != null);
+}
+
+test "#4472 minify: if body sequence 선두 object literal 에 괄호 유지" {
+    var r = try e2eMinify(std.testing.allocator,
+        \\function f(c, g) { if (c) { ({}).toString(); g(1); } }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "if(c)({}).toString()") != null);
+}
+
+test "#4472 minify: 배열 구조분해는 괄호가 필요없다 (과잉 괄호 방지)" {
+    var r = try e2eMinify(std.testing.allocator,
+        \\function f(c, arr, g) { let a, b; if (c) { [a, b] = arr; g(2); } return [a, b]; }
+    );
+    defer r.deinit();
+    // `[` 는 statement 선두여도 블록으로 오파싱되지 않는다 → 괄호 없이 그대로.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "if(c)[a,b]=") != null);
+}
+
+test "#4472 minify: while / for body 도 동일하게 보호된다" {
+    var r = try e2eMinify(std.testing.allocator,
+        \\function f(c, o, g) { let a; while (c) { ({ a } = o); g(3); } for (;c;) { ({ a } = o); g(4); } return a; }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "while(c)({a}=o)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ")({a}=o),g(4)") != null);
+}

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -205,6 +205,23 @@ pub fn canEmitMultiExprBlockAsSequence(self: anytype, body_idx: NodeIndex) bool 
 /// declaration 또는 control flow statement 가 끼면 false (block 그대로 emit).
 fn emitMultiExprBlockAsSequence(self: anytype, body_idx: NodeIndex) !bool {
     if (!canEmitMultiExprBlockAsSequence(self, body_idx)) return false;
+    // statement-start 마킹 (#4472). 이 경로는 `if (c) { a; b; }` 의 body block 을
+    // `if(c) a,b;` 로 접는다 — 즉 sequence 의 **첫 원소가 statement 선두**에 놓인다.
+    //
+    // emitExpressionStatement 는 operand 를 emit 하기 전에 stmt_start 를 찍어,
+    // object destructuring 할당(`({a} = b)`)과 object literal(`({})`)이 선두에 올 때
+    // 괄호가 붙도록 한다. 그런데 아래 inner 는 expression_statement 를 건너뛰고
+    // operand 를 직접 emit 하므로 그 마킹이 없었다 → `if(c){a:x}=f(),g();` 처럼
+    // 괄호가 빠진 코드가 나왔다. 브라우저는 선두 `{` 를 블록으로, `a:` 를 라벨로
+    // 읽어 `SyntaxError: Unexpected token ':'` — 빌드는 green 인데 런타임에 죽는다.
+    //
+    // 두 번째 원소부터는 `,` 뒤라 expression 위치이므로 `{` 가 object literal 로
+    // 명확히 파싱된다 — 마킹은 첫 원소에만 필요하고, 여기서 찍으면 inner 가 그
+    // 사이에 아무것도 쓰지 않으므로 정확히 첫 원소에 걸린다.
+    //
+    // inner 를 공유하는 ternary branch 경로(`c ? a,b : d`)는 statement 선두가
+    // 아니라서 이 마킹을 하면 안 된다 — 그래서 inner 가 아니라 여기서 찍는다.
+    self.stmt_start = self.buf.items.len;
     try emitMultiExprBlockSeqInner(self, body_idx);
     try self.writeByte(';');
     return true;


### PR DESCRIPTION
Closes #4472

## 문제 — build green, runtime dead

`--minify`(= `minify_whitespace` + `minify_syntax`)는 블록 안의 expression statement 들을 콤마 시퀀스로 접는다:

```js
if (c) { a(); b(); }   →   if(c) a(),b();
```

이 경로가 **statement-start 를 표시하지 않아서**, 시퀀스의 **첫 원소**가 object destructuring 할당일 때 문법상 **필수인 괄호**가 빠졌다.

```js
// 입력 (marked 의 image 렌더러)
if (href) { ({ href, dimensions } = cleanUrl(href)); out.push(href); }

// 잘못된 출력
if(n){href:n,dimensions:r}=t(n),i.push(n);
//    ^ 브라우저는 `{` 를 블록으로, `href:` 를 라벨로 읽는다
//    → SyntaxError: Unexpected token ':'

// 고쳐진 출력
if(n)({href:n,dimensions:r}=t(n)),i.push(n);
```

**`zntc build` 는 exit 0 으로 성공하는데 산출물이 런타임에 죽는다.** `monaco-editor` 를 번들하면 해당 청크가 통째로 실행되지 않아 페이지가 뜨지 않았다.

## 근본 원인

`src/codegen/statements.zig` 의 `emitMultiExprBlockSeqInner` 가 `expression_statement` 를 건너뛰고 operand 를 **직접** emit 한다:

```zig
try self.emitNode(n.data.unary.operand);   // ← emitExpressionStatement 우회
```

괄호 판정은 `stmt_start` 마크에 의존한다:

```zig
.assignment_expression => level.gte(.assign) or
    (self.atStmtOrArrowStart() and assignTargetIsObject(...)),
```

그런데 그 마크를 찍는 건 `emitExpressionStatement` 뿐이다:

```zig
self.stmt_start = self.buf.items.len;   // ← 우회 경로엔 없다
try self.emitNode(node.data.unary.operand);
```

단일 문장 본문(`if (c) ({a} = o);`)은 `emitExpressionStatement` 를 타서 **정상이었고**, 여러 문장을 접는 경로만 구멍이었다. 그래서 문맥 의존적으로 보였다.

## 해결

`emitMultiExprBlockAsSequence`(statement 위치 래퍼)에서 첫 원소 직전에 `stmt_start` 를 찍는다. 두 번째 원소부터는 `,` 뒤라 expression 위치이므로 `{` 가 object literal 로 명확히 파싱된다 — 마킹은 첫 원소에만 필요하다.

inner 를 공유하는 **ternary branch 경로**(`c ? a,b : d`)는 statement 선두가 아니므로 마킹하면 안 된다 → inner 가 아니라 래퍼에서 찍는다.

## 함께 고쳐지는 것

| 케이스 | 전 | 후 |
|---|---|---|
| object destructuring | `if(c){a,b}=o,g()` ❌ | `if(c)({a,b}=o),g()` ✅ |
| object literal 선두 | `if(c){}.toString(),g(1)` ❌ | `if(c)({}).toString(),g(1)` ✅ |
| 배열 구조분해 | `if(c)[a,b]=t,g(2)` ✅ | 그대로 (괄호 불필요) |
| while / for body | 동일 버그 | 동일 수정 |

## 검증

- 유닛 6019 pass / 통합 4108 pass
- 회귀 가드 4개 추가 (구조분해 / object literal / 배열은 과잉괄호 없음 / while·for)
- `node --check` + 실제 실행으로 산출물 유효성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)