### PR TITLE
fix(linker): 동명 basename 자산의 require 래퍼 이름 충돌 → 다른 자산의 URL 반환

### DIFF
--- a/.changeset/asset-require-name-deconflict.md
+++ b/.changeset/asset-require-name-deconflict.md
@@ -1,0 +1,19 @@
+---
+"@zntc/core": patch
+---
+
+동명 basename 자산의 `require_X` 래퍼 이름이 충돌해 **다른 자산의 URL 을 돌려주던** 버그 수정 (#4475).
+
+```js
+import x from "./a/logo.png";   // 내용이 서로 다른 파일
+import y from "./b/logo.png";
+console.log(x, y);
+// 전: ./logo-efdc71e4.png ./logo-efdc71e4.png   ← 둘 다 같은 URL
+// 후: ./logo-22fcfd0d.png ./logo-efdc71e4.png
+```
+
+자산 파일은 둘 다 올바른 해시로 방출되는데, 번들 JS 가 `var require_logo` 를 **두 번 선언**해서 두 번째가 첫 번째를 가렸다. 결과적으로 `a/logo.png` 는 번들에서 도달 불가능해지고 `x` 가 `b/logo.png` 의 URL 을 받았다 — 빌드는 성공하는 조용한 오컴파일.
+
+근본 원인: `registerWrapperSymbols` 가 래퍼 이름을 `uniqueName()` 으로 deconflict 하는데, 그 앞에 `if (m.semantic) |*s| s else continue` 가드가 있다. asset 모듈은 JS 파싱을 거치지 않아 `semantic` 이 null 이라 **등록을 통째로 건너뛰었고**, emit 은 basename 기반 fallback(`makeRequireVarName`)으로 떨어졌다. 그 fallback 은 충돌을 모른다.
+
+semantic 이 없어도 이름 deconflict 는 할 수 있으므로 전용 슬롯(`Module.wrapper_name_synthetic`)에 담는다. `disabled` / `optional-missing` 모듈도 같은 fallback 을 타고 있었으므로 함께 보호된다.

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -3862,3 +3862,50 @@ test "#4466 CSS url(): external 판정된 url() 이 @import 로 새어나가지 
     const css = findCssOutput(result) orelse return error.ExpectedCssOutput;
     try std.testing.expect(std.mem.indexOf(u8, css, "@import") == null);
 }
+
+test "#4475 동명 basename 자산의 require 래퍼가 deconflict 된다" {
+    // 회귀: asset 모듈은 semantic 이 없어 래퍼 이름 등록을 건너뛰었고, emit 이
+    // basename 기반 fallback(`require_logo`)을 써서 두 자산이 같은 이름을 가졌다.
+    // 두 번째 선언이 첫 번째를 가려 `import x from './a/logo.png'` 가 b 의 URL 을
+    // 돌려주는 조용한 오컴파일.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "a");
+    try tmp.dir.createDirPath(std.testing.io, "b");
+    try writeFile(tmp.dir, "entry.ts", "import x from './a/logo.png';\nimport y from './b/logo.png';\nconsole.log(x, y);");
+    // inline limit 초과 + 내용이 서로 달라야 해시가 갈린다.
+    const img_a = [_]u8{0xA1} ** 5000;
+    const img_b = [_]u8{0xB2} ** 5000;
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "a/logo.png", .data = &img_a });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "b/logo.png", .data = &img_b });
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .format = .esm });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    // 두 자산이 각각 방출됐어야 한다.
+    const outs = result.asset_outputs orelse return error.ExpectedAssetOutput;
+    var png_count: usize = 0;
+    for (outs) |o| {
+        if (std.mem.endsWith(u8, o.path, ".png")) png_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 2), png_count);
+
+    // 래퍼 이름이 충돌하면 안 된다 — `var require_logo` 가 두 번 나오면 BUG.
+    var idx: usize = 0;
+    var decl_count: usize = 0;
+    while (std.mem.indexOfPos(u8, result.output, idx, "var require_logo")) |pos| {
+        // `var require_logo$2` 도 매치되므로, 정확히 `require_logo` 로 끝나는지 본다.
+        const after = pos + "var require_logo".len;
+        if (after < result.output.len and result.output[after] == ' ') decl_count += 1;
+        idx = pos + 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), decl_count);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_logo$") != null);
+}

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -212,6 +212,9 @@ pub fn registerWrapperSymbols(self: *ModuleGraph) void {
         if (m.getInitName(null)) |n| _ = used_names.put(self.allocator, n, 1) catch {};
         if (m.getExportsName(null)) |n| _ = used_names.put(self.allocator, n, 1) catch {};
         if (m.getRequireName(null)) |n| _ = used_names.put(self.allocator, n, 1) catch {};
+        // semantic 없는 모듈(asset/disabled)의 이름도 seed — incremental rebuild 에서
+        // 새 모듈이 같은 base 를 다시 집지 않도록 (#4475).
+        if (m.wrapper_name_synthetic) |n| _ = used_names.put(self.allocator, n, 1) catch {};
     }
 
     var it = self.modules.iterator(0);
@@ -221,8 +224,23 @@ pub fn registerWrapperSymbols(self: *ModuleGraph) void {
         const needs_exports = m.exports_symbol == null;
         const needs_require = m.wrap_kind == .cjs and m.require_symbol == null;
         if (!needs_init and !needs_exports and !needs_require) continue;
-        const sem_ptr = if (m.semantic) |*s| s else continue;
         const arena = if (m.parse_arena) |a| a.allocator() else continue;
+
+        // semantic 이 없는 모듈 (asset / disabled / optional-missing) — JS 파싱을 거치지
+        // 않아 심볼 테이블이 없다. 예전엔 여기서 `continue` 해 등록을 통째로 건너뛰었고,
+        // emit 은 basename 기반 fallback 이름을 써서 `a/logo.png` 와 `b/logo.png` 가 둘 다
+        // `require_logo` 가 됐다 → 두 번째 선언이 첫 번째를 가려 한쪽 자산이 다른 쪽의
+        // URL 을 돌려주는 조용한 오컴파일 (#4475).
+        //
+        // 심볼 테이블은 못 만들지만 이름 deconflict 는 할 수 있다 — 전용 슬롯에 담는다.
+        if (m.semantic == null) {
+            if (needs_require and m.wrapper_name_synthetic == null) {
+                const base = types.makeRequireVarName(arena, m.path) catch continue;
+                m.wrapper_name_synthetic = uniqueName(arena, base, &used_names, self.allocator) catch continue;
+            }
+            continue;
+        }
+        const sem_ptr = if (m.semantic) |*s| s else continue;
 
         if (needs_init) {
             const init_base = types.makeInitVarName(arena, m.path) catch continue;

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -194,6 +194,15 @@ pub const Module = struct {
     /// 정적으로 export 안 된 named import 를 이 export 의 member 로 해석(CJS fallback 과 동형이되
     /// 대상이 namespace 가 아니라 default/named export value). parse_arena 가 backing 소유.
     synthetic_named_exports: ?[]const u8 = null,
+    /// semantic 이 없는 모듈(asset / disabled / optional-missing)의 deconflict 된 CJS
+    /// 래퍼 이름 (#4475). graph 의 registerWrapperSymbols 가 채운다. parse_arena 소유.
+    ///
+    /// 이런 모듈은 JS 파싱을 거치지 않아 `semantic` 이 null 이고, 그래서 예전엔 래퍼
+    /// 이름 등록을 통째로 건너뛴 뒤 emit 시 `makeRequireVarName(path)` 로 폴백했다.
+    /// 그 폴백은 basename 기반이라 `a/logo.png` 와 `b/logo.png` 가 **둘 다**
+    /// `require_logo` 가 됐고, 두 번째 선언이 첫 번째를 가려 한쪽 자산이 다른 쪽의
+    /// URL 을 돌려주는 조용한 오컴파일이 났다.
+    wrapper_name_synthetic: ?[]const u8 = null,
     /// 파싱된 AST. nodes/extra_data/string_table 의 backing 은 `parse_arena` 가 소유.
     ///
     /// ### Ownership 규약 (D1 디버그 인프라 — RFC #1672)
@@ -594,6 +603,9 @@ pub const Module = struct {
 
     pub fn allocRequireName(self: *const Module, allocator: std.mem.Allocator, rt: ?*const RenameTable) ![]const u8 {
         if (self.getRequireName(rt)) |n| return allocator.dupe(u8, n);
+        // semantic 없는 모듈(asset/disabled)은 registerWrapperSymbols 가 deconflict 해
+        // 둔 이름을 쓴다 (#4475). 이게 없으면 basename 충돌로 래퍼가 서로를 가린다.
+        if (self.wrapper_name_synthetic) |n| return allocator.dupe(u8, n);
         return types.makeRequireVarName(allocator, self.path);
     }
 


### PR DESCRIPTION
Closes #4475

## 문제 — build green, 잘못된 자산

```js
import x from "./a/logo.png";   // 내용이 서로 다른 파일
import y from "./b/logo.png";
console.log(x, y);
```

```
$ node out/d.js
./logo-efdc71e4.png ./logo-efdc71e4.png     ← 둘 다 같은 URL!
```

자산 파일은 **둘 다 올바른 해시로 방출된다** (`logo-22fcfd0d.png`, `logo-efdc71e4.png`). 그런데 번들 JS 가 `var require_logo` 를 **두 번 선언**해 두 번째가 첫 번째를 가린다:

```js
//#region logo.png
var require_logo = __commonJS({ ... module.exports="./logo-22fcfd0d.png"; });
//#region logo.png
var require_logo = __commonJS({ ... module.exports="./logo-efdc71e4.png"; });  // ← 같은 이름
```

결과: `a/logo.png` 는 번들에서 **도달 불가능**해지고, `x` 가 `b/logo.png` 의 URL 을 받는다. 빌드는 exit 0 — 조용한 오컴파일이다.

## 근본 원인

`graph/finalize.zig` 의 `registerWrapperSymbols` 가 래퍼 이름을 `uniqueName()` 으로 deconflict 해서 심볼로 등록한다. 그런데 그 앞에:

```zig
const sem_ptr = if (m.semantic) |*s| s else continue;   // ← asset 모듈이 여기서 탈락
```

asset 모듈은 JS 파싱을 거치지 않아 `semantic` 이 null 이라 **등록을 통째로 건너뛴다.** 그러면 emit 이 fallback 으로 떨어지는데, 그 fallback 은 충돌을 모른다:

```zig
// emitter/cjs_wrap.zig
// RFC #3940 L.5b: disabled/asset 모듈은 semantic 없어 syntheticName 이 즉시 fallback (rt 무관).
const var_name = try module.allocRequireName(allocator, null);

// module.zig
return types.makeRequireVarName(allocator, self.path);   // ← basename 기반
```

`makeRequireVarName` 은 basename 에서 확장자를 떼므로 `a/logo.png` 와 `b/logo.png` 가 똑같이 `require_logo` 가 된다.

## 해결

심볼 테이블은 못 만들어도 **이름 deconflict 는 할 수 있다.** semantic 없는 모듈용 전용 슬롯(`Module.wrapper_name_synthetic`)에 `uniqueName()` 결과를 담고, emit fallback 이 그걸 우선 쓴다.

```js
// 후
var require_logo = ...      // a/logo.png
var require_logo$2 = ...    // b/logo.png
→ ./logo-22fcfd0d.png ./logo-efdc71e4.png   ✅
```

`disabled` / `optional-missing` 모듈도 같은 fallback 을 타고 있었으므로 함께 보호된다. incremental rebuild 를 위해 seed 루프에도 이 이름을 등록한다.

## 검증

- 유닛 6059 pass / 통합 4112 pass
- 회귀 가드 추가 (자산 2개 방출 + `var require_logo` 선언이 정확히 1회 + `require_logo$` 존재)

> #4467(Vite query-suffix) 구현 중 발견 — `./x.png?url` 과 `./x.png?inline` 도 basename 이 같아 이 버그에 걸린다. 그쪽 PR 의 선행 조건이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)