### PR TITLE
fix(codegen): #4482 단항 토큰 병합 + prefix-단항 리터럴의 load-bearing 괄호

### DIFF
--- a/.changeset/minify-unary-merge-pow-paren.md
+++ b/.changeset/minify-unary-merge-pow-paren.md
@@ -1,0 +1,21 @@
+---
+"@zntc/core": patch
+---
+
+방출 단계에서 **단항 연산자 토큰이 병합**되거나 **`**` 좌변 괄호가 사라지던** 버그 수정 (#4482).
+
+```js
+f(-(--t))      // 버그: f(---t)        → SyntaxError
+f(-(-t))       // 버그: f(--t)         → t 를 감소시키는 silent miscompile
+(-a) ** b      // 버그: -2**2          → SyntaxError
+(-a).toString()// 버그: -2 .toString() → 문자열 "-2" 가 아니라 숫자 -2 (silent)
+true.toString()// 버그: !0.toString()  → SyntaxError
+undefined ** 2 // 버그: void 0**2      → SyntaxError
+```
+
+원인은 둘이다.
+
+1. 단항 `-`/`+` 의 **피연산자 슬롯에 토큰 병합 방지 공백 가드가 없었다**. 이항 RHS 슬롯에는 있었지만 단항에는 대응물이 없어 `-` + `--t` 가 `---t` 로 붙었다. minify 와 무관하게 발생한다.
+2. `binaryChildLevels` 가 `**` 좌변의 level 을 올려도, `exprNeedsParens` 에 `numeric_literal`/`boolean_literal` case 가 없어 그 level 이 그냥 버려졌다. 미니파이어가 `-a` 를 `numeric_literal("-2")` 로, `true` 를 `!0` 으로 바꾸는 순간 `.unary_expression` 매칭을 빠져나간다.
+
+`d3@7` (`d3-ease` 의 elastic) 이 `tpmt(-(--t))` 를 써서 `import * as d3 from "d3"` 를 `--minify` 로 번들하면 산출물이 파싱되지 않았다.

--- a/.changeset/minify-unary-merge-pow-paren.md
+++ b/.changeset/minify-unary-merge-pow-paren.md
@@ -19,3 +19,19 @@ undefined ** 2 // 버그: void 0**2      → SyntaxError
 2. `binaryChildLevels` 가 `**` 좌변의 level 을 올려도, `exprNeedsParens` 에 `numeric_literal`/`boolean_literal` case 가 없어 그 level 이 그냥 버려졌다. 미니파이어가 `-a` 를 `numeric_literal("-2")` 로, `true` 를 `!0` 으로 바꾸는 순간 `.unary_expression` 매칭을 빠져나간다.
 
 `d3@7` (`d3-ease` 의 elastic) 이 `tpmt(-(--t))` 를 써서 `import * as d3 from "d3"` 를 `--minify` 로 번들하면 산출물이 파싱되지 않았다.
+
+`/code-review max` 가 같은 계열의 구멍 3건을 더 찾아 함께 고쳤다 (셋 다 `--minify` 없이 번들만 해도 발생).
+
+```js
+// flags.js: export const U = undefined; export const ON = true;
+U ** 2                      // 버그: void 0**2      → SyntaxError
+(ON && -1) ** k             // 버그: -1 ** k        → SyntaxError
+x - (ON ? -1 : 1)           // 버그: x--1           → SyntaxError
+-(ON ? -t : t)              // 버그: --t            → t 를 감소시키는 silent miscompile
+```
+
+원인은 하나다 — 괄호/공백 판정이 **AST 태그**를 봤는데, codegen 은 emit 시점에 노드를 갈아치운다(상수 인라인, 상수 단락/조건 fold). 그래서 fold 로 사라질 분기를 보고 판단했다.
+
+처방도 하나다. 토큰 병합 방지를 **출력 바이트 기준**(esbuild `prevOp`/`prevOpEnd`)으로 바꿨다 — 어느 노드가 emit 되든 직전에 나간 바이트를 보므로 fold 와 무관하게 정확하다. AST 룩어헤드(`leadingSignChar`)는 제거했다. `**` 좌변 괄호 판정은 emit 시점의 fold/치환 결정을 그대로 따라 내려가도록 고쳤다.
+
+덤으로 과잉 공백도 사라졌다: `-(-a - b)` 는 피연산자가 이미 괄호로 감싸이므로 공백이 불필요한데 AST 룩어헤드는 그걸 몰랐다 → 이제 esbuild 와 바이트 동일(`-(-a-b)`).

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4127,3 +4127,107 @@ test "#4467 query 모듈의 watcher 경로는 디스크 경로여야 한다" {
     // 실제 파일이 감시 목록에 있어야 한다.
     try std.testing.expect(found_bare);
 }
+
+// ============================================================
+// #4482 — 번들(linking_metadata) 경로의 emit-시점 노드 교체와 load-bearing 괄호/공백
+// ============================================================
+//
+// codegen 은 emit 시점에 노드를 갈아치운다: 상수 인라인(identifier → `void 0`/`-2` 텍스트),
+// 상수 단락 fold(`ON && -1` → `-1`), 상수 조건 fold(`ON ? -1 : 2` → `-1`).
+// 그래서 **AST 태그**를 보는 괄호/공백 판정은 fold 로 사라질 분기를 보게 되어 구멍이 났다.
+// 이 경로는 linking_metadata 가 있어야만 활성화되므로 transpile/codegen 유닛으로는 재현되지
+// 않는다 — 번들 테스트로 박제한다.
+
+fn bundleMinified(tmp: *std.testing.TmpDir, comptime opts: struct { syntax: bool = true }) !@import("../bundler.zig").BundleResult {
+    const entry = try absPath(tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .node,
+        .minify_syntax = opts.syntax,
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+    return b.bundle(std.testing.io);
+}
+
+test "#4482 bundle: 상수 인라인된 undefined 가 ** 좌변이면 괄호" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "flags.ts", "export const U = undefined;");
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { U } from './flags';
+        \\globalThis.a = U ** 2;
+    );
+    var result = try bundleMinified(&tmp, .{});
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    // 유실 시 `void 0**2` — SyntaxError (단항이 ** 좌변에 직접 못 옴).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "(void 0)**2") != null);
+}
+
+test "#4482 bundle: 상수 인라인된 undefined 가 member object 면 괄호" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "flags.ts", "export const U = undefined;");
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { U } from './flags';
+        \\try { globalThis.a = U.toString(); } catch (e) { globalThis.a = "TypeError"; }
+    );
+    var result = try bundleMinified(&tmp, .{ .syntax = false });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    // 유실 시 `void 0.toString()` = `void (0..toString())` → SyntaxError.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "(void 0).toString()") != null);
+}
+
+test "#4482 bundle: 상수 인라인된 정수는 member 앞에 공백 (`2 .toString()`)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "flags.ts", "export const N = 2;");
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { N } from './flags';
+        \\globalThis.a = N.toString();
+    );
+    var result = try bundleMinified(&tmp, .{ .syntax = false });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    // 유실 시 `2.toString()` — `2.` 가 float 로 오파싱 → SyntaxError.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "2 .toString()") != null);
+}
+
+test "#4482 bundle: emit 시점 fold 로 살아남는 분기가 ** 좌변이면 괄호" {
+    // `(ON && -1) ** k` / `(ON ? -1 : 2) ** k` — codegen 이 logical/conditional 을 접고
+    // 살아남는 `-1` 을 그 자리에 emit 한다. AST 태그(logical/conditional)만 보면 단항이
+    // 아니라고 판단해 괄호를 안 붙였다 → `-1 ** k` = SyntaxError. minify 없이도 발생.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "flags.ts", "export const ON = true;");
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { ON } from './flags';
+        \\globalThis.r1 = (ON && -1) ** globalThis.k;
+        \\globalThis.r2 = (ON ? -1 : 2) ** globalThis.k;
+    );
+    var result = try bundleMinified(&tmp, .{ .syntax = false });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, result.output, "(-1)**globalThis.k"));
+}
+
+test "#4482 bundle: emit 시점 fold 로 살아남는 분기의 부호 토큰 병합 방지" {
+    // `x - (ON ? -1 : 1)` → `x--1` (SyntaxError), `-(ON ? -t : t)` → `--t` (t 를 감소시키는
+    // silent miscompile). 공백 판정이 **출력 바이트** 기준이라야 fold 를 따라간다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "flags.ts", "export const ON = true;");
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { ON } from './flags';
+        \\globalThis.b = globalThis.x - (ON ? -1 : 1);
+        \\globalThis.c = -(ON ? -globalThis.t : globalThis.t);
+    );
+    var result = try bundleMinified(&tmp, .{ .syntax = false });
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "globalThis.x- -1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=- -globalThis.t") != null);
+}

--- a/src/codegen/calls.zig
+++ b/src/codegen/calls.zig
@@ -52,9 +52,12 @@ pub fn isOptionalChainExpr(self: anytype, idx: NodeIndex) bool {
     return objectContinuesOptionalChain(self, skipWrappers(self, idx, true));
 }
 
-/// `undefined` peephole 의 callee/object/new.callee 슬롯 paren 검사.
-/// node_dispatch.zig 가 `void 0` (no paren) 으로 출력하므로, member/call/new 슬롯의
-/// caller 가 paren 으로 감싸 `void 0.x` → `void (0.x)` 오파싱 방지.
+/// 전역 `undefined` 가 `void 0` peephole 로 치환되는 식별자인지 (unbound global 만).
+///
+/// 괄호는 이제 node_dispatch 의 identifier case 가 `level` 을 보고 직접 친다(#4482) —
+/// caller 측 wrapping(emitNodeMaybeUndefParen)은 제거됐다. 이 술어의 유일한 소비자는
+/// `powLeftNeedsParen` 이며, **번들 상수 인라인된 undefined 는 여기서 false** 다
+/// (sym_id 가 잡히므로) — 그쪽은 powLeftNeedsParen 이 constInlineValue 로 따로 본다.
 pub fn isUndefinedPeephole(self: anytype, idx: NodeIndex) bool {
     if (!self.options.minify_syntax) return false;
     if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return false;

--- a/src/codegen/calls.zig
+++ b/src/codegen/calls.zig
@@ -80,15 +80,6 @@ fn calleeIsBareFunctionExpr(self: anytype, idx: NodeIndex) bool {
     };
 }
 
-/// `void 0` peephole 가 적용될 자식 노드를 paren 으로 감싸 emit. 자식이 그 외엔 그대로 emit.
-/// callee/object/new.callee 슬롯 4곳에서 공유 — 정책은 [[isUndefinedPeephole]].
-pub fn emitNodeMaybeUndefParen(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) !void {
-    const need = isUndefinedPeephole(self, idx);
-    if (need) try self.writeByte('(');
-    try self.emitExpr(idx, level, flags);
-    if (need) try self.writeByte(')');
-}
-
 pub fn emitCall(self: anytype, node: Node, level: Level, flags: ExprFlags) !void {
     _ = level; // wrap(level>=.new | forbid_call | optional-chain | pure) 은 exprNeedsParens 중앙 처리.
     _ = flags; // callee 의 has_non_optional_chain_parent 는 call 자신의 optional-ness 로 계산
@@ -127,7 +118,7 @@ pub fn emitCall(self: anytype, node: Node, level: Level, flags: ExprFlags) !void
     // 보존(이중괄호 회피). arrow 는 .postfix(call-target) level 로 exprNeedsParens 가 이미 wrap.
     const iife_wrap = calleeIsBareFunctionExpr(self, callee);
     if (iife_wrap) try self.writeByte('(');
-    try emitNodeMaybeUndefParen(self, callee, Level.postfix, callee_flags);
+    try self.emitExpr(callee, Level.postfix, callee_flags);
     if (iife_wrap) try self.writeByte(')');
     if (is_optional) try self.write("?.");
     try self.writeByte('(');
@@ -516,8 +507,7 @@ pub fn emitNew(self: anytype, node: Node, level: Level, flags: ExprFlags) !void 
     // callee = .new + forbid_call + has_non_optional_chain_parent(set): `new (foo())` 보존 +
     // optional chain 끊기(`new (a?.b)()`/`new (a?.b.c)()`/`new (a?.[b])()` — new 의 첫 `()` 가
     // optional chain 안으로 들어가면 SyntaxError). new 타겟은 member object 처럼 non-optional
-    // 체인 부모다. `undefined`→`void 0` peephole 슬롯이라 emitNodeMaybeUndefParen 경유.
-    try emitNodeMaybeUndefParen(self, callee, Level.new, .{ .forbid_call = true, .has_non_optional_chain_parent = true });
+    try self.emitExpr(callee, Level.new, .{ .forbid_call = true, .has_non_optional_chain_parent = true });
     if (needs_parens) try self.writeByte(')');
     try self.writeByte('(');
     try self.emitExpressionNodeList(args_start, args_len, self.listSep());

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -18,6 +18,7 @@ const Comment = @import("../lexer/scanner.zig").Comment;
 const rt = @import("../bundler/runtime_helpers.zig");
 const options_mod = @import("options.zig");
 const writer_emit = @import("writer.zig");
+const Kind = @import("../lexer/token.zig").Kind;
 const debug_metadata = @import("debug_metadata.zig");
 
 pub const ModuleFormat = options_mod.ModuleFormat;
@@ -99,6 +100,13 @@ pub const Codegen = struct {
     /// 의 `.` emit 직전 위치가 일치하면 공백을 끼운다(`42 .toString()`). esbuild
     /// `needSpaceBeforeDot`. `maxInt` = 미마킹(절대 매치 안 됨).
     need_space_before_dot: usize = std.math.maxInt(usize),
+    /// 직전에 출력한 **연산자 토큰**과 그 끝 위치 (esbuild `prevOp`/`prevOpEnd`).
+    /// 인접 토큰이 `++`/`--`/`<!--` 로 잘못 합쳐지는 것을 막는 공백을 넣을지 판정한다
+    /// (`printSpaceBeforeOperator`). AST 태그가 아니라 **실제 출력 바이트** 기준이라,
+    /// 상수 폴딩/치환으로 emit 되는 노드가 바뀌어도(`x - (ON ? -1 : 1)` → `x- -1`)
+    /// 정확하다 (#4482). `maxInt` = 미마킹(절대 매치 안 됨).
+    prev_op: Kind = .eof,
+    prev_op_end: usize = std.math.maxInt(usize),
     pub fn init(allocator: std.mem.Allocator, ast: *const Ast) Codegen {
         return initWithOptions(allocator, ast, .{});
     }
@@ -299,6 +307,8 @@ pub const Codegen = struct {
     pub const writeNewline = writer_emit.writeNewline;
     pub const writeIndent = writer_emit.writeIndent;
     pub const writeSpace = writer_emit.writeSpace;
+    pub const printSpaceBeforeOperator = writer_emit.printSpaceBeforeOperator;
+    pub const recordOperatorToken = writer_emit.recordOperatorToken;
     pub const writeConstValue = writer_emit.writeConstValue;
     pub const writeSpan = writer_emit.writeSpan;
     pub const writeAsciiOnly = writer_emit.writeAsciiOnly;

--- a/src/codegen/codegen_test/load_bearing_paren.zig
+++ b/src/codegen/codegen_test/load_bearing_paren.zig
@@ -167,3 +167,77 @@ test "load-bearing: for-init sequence 의 in 누수 for((a in b),c;;)" {
     // sequence 는 통째로 감싼다(emitList 가 원소 flag clear 하므로 sequence 레벨 처리).
     try expectParenSurvives(r.output, "(a in b,c)");
 }
+
+// ============================================================
+// #4482 — minify 가 노드 태그를 바꾼 뒤의 load-bearing 괄호 / 토큰 병합
+// ============================================================
+//
+// 위 매트릭스는 *소스 그대로의* 노드 태그를 전제한다. minify 는 그 태그를 바꾼다:
+//   `-a` (a=2 상수)  → numeric_literal("-2")     — `.unary_expression` 아님
+//   `true`           → `!0` (boolean_literal)     — 출력만 단항으로 시작
+//   `undefined`      → `void 0` (identifier)      — 출력만 단항으로 시작
+// 그래서 `exprNeedsParens` 의 `.unary_expression` case 를 빠져나가 괄호가 유실됐다.
+// (상수 폴딩이 만드는 음수 numeric_literal 케이스는 AST 미니파이어가 transpile 레이어에서
+//  돌아 codegen 하네스로는 재현이 안 된다 → transpile.zig 의 #4482 테스트가 커버.)
+// 또 단항 `-`/`+` 피연산자 슬롯엔 토큰 병합 방지 공백 가드가 없어 `-(-t)` → `--t`
+// (t 를 감소시키는 silent miscompile) 가 나왔다.
+
+fn e2eMinifySyntax(allocator: std.mem.Allocator, source: []const u8) !helpers.TestResult {
+    return e2eWithOptions(allocator, source, .{ .minify_whitespace = true, .minify_syntax = true });
+}
+
+test "#4482 minify: !0/!1 peephole 도 ** 좌측이면 괄호" {
+    var r = try e2eMinifySyntax(std.testing.allocator, "g(true ** 2);");
+    defer r.deinit();
+    try expectParenSurvives(r.output, "(!0)**2");
+}
+
+test "#4482 minify: void 0 peephole 도 ** 좌측이면 괄호" {
+    var r = try e2eMinifySyntax(std.testing.allocator, "g(undefined ** 2);");
+    defer r.deinit();
+    try expectParenSurvives(r.output, "(void 0)**2");
+}
+
+test "#4482 minify: !0 이 member object 면 괄호" {
+    var r = try e2eMinifySyntax(std.testing.allocator, "g(true.toString());");
+    defer r.deinit();
+    // 유실 시 `!0.toString()` → SyntaxError.
+    try expectParenSurvives(r.output, "(!0).toString");
+}
+
+test "#4482: 단항 - 뒤 prefix -- 는 공백으로 끊는다 (minify 무관)" {
+    var r = try e2e(std.testing.allocator, "let t = 5; g(-(--t));");
+    defer r.deinit();
+    // 유실 시 `-(--t)` → `---t` = `--` + `-t` → SyntaxError. d3-ease elastic 이 이 패턴.
+    try expectParenSurvives(r.output, "- --t");
+}
+
+test "#4482: 단항 - 뒤 단항 - 도 공백으로 끊는다" {
+    var r = try e2e(std.testing.allocator, "g(-(-t));");
+    defer r.deinit();
+    // 유실 시 `--t` — **파싱되는** prefix 감소 연산 → t 를 바꾸는 silent miscompile.
+    try expectParenSurvives(r.output, "- -t");
+}
+
+test "#4482: 단항 + 뒤 prefix ++ 도 공백" {
+    var r = try e2e(std.testing.allocator, "let t = 5; g(+(++t));");
+    defer r.deinit();
+    try expectParenSurvives(r.output, "+ ++t");
+}
+
+test "#4482: `<` 뒤 `!--x` 는 HTML 주석(<!--) 오파싱 방지 공백" {
+    var r = try e2e(std.testing.allocator, "let b = 1; g(a < !--b);");
+    defer r.deinit();
+    // 유실 시 `a<!--b` — classic script 에서 `<!--` 는 한 줄 주석 시작(Annex B) 이라
+    // 그 뒤가 통째로 사라진다.
+    try expectParenSurvives(r.output, "<! --b");
+}
+
+test "#4482: 과잉 공백/괄호 방지 — 부호가 다르면 그대로 붙인다" {
+    var r = try e2e(std.testing.allocator, "g(-(+t)); g(+(-t)); g(1 - -2); g(2 ** 3); g(a ** -b);");
+    defer r.deinit();
+    try expectParenSurvives(r.output, "-+t");
+    try expectParenSurvives(r.output, "+-t");
+    try expectParenSurvives(r.output, "2**3");
+    try expectParenSurvives(r.output, "a**-b");
+}

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -47,18 +47,15 @@ pub fn emitUnary(self: anytype, node: Node, level: Level, flags: ExprFlags) !voi
             return;
         }
     }
-    const sym = op.symbol();
-    try self.write(sym);
-    if (op == .kw_typeof or op == .kw_void or op == .kw_delete) {
+    const is_keyword_op = op == .kw_typeof or op == .kw_void or op == .kw_delete;
+    // 직전 연산자와 붙어 `--`/`++` 로 합쳐지면 한 칸 끼운다 (`- -x`, `- --x`) (#4482).
+    if (!is_keyword_op) try self.printSpaceBeforeOperator(op);
+    try self.write(op.symbol());
+    if (is_keyword_op) {
         try self.writeByte(' ');
-    } else if ((op == .plus or op == .minus) and leadingSignChar(self, operand) == sym[0]) {
-        // 단항 `-`/`+` 뒤에 같은 부호로 시작하는 피연산자가 오면 토큰이 `--`/`++` 로
-        // 합쳐진다 (#4482). `-(--t)` → `---t` (SyntaxError), `-(-t)` → `--t` (t 를
-        // 감소시키는 **silent miscompile**). 한 칸 띄워 끊는다: `- --t`, `- -t`.
-        // 괄호가 아니라 공백인 이유 — 스펙상 단항 피연산자에 괄호는 불필요하고,
-        // 공백이 1 byte 더 작다 (esbuild printSpaceBeforeOperator 동일).
-        // minify 여부와 무관하게 필요하다: 이 슬롯은 어느 모드에서도 공백을 안 넣는다.
-        try self.writeByte(' ');
+    } else {
+        // 이 `-`/`+`/`!` 도 다음 토큰과 합쳐질 수 있다 → 기록.
+        self.recordOperatorToken(op);
     }
     // operand level = .prefix.lower() (esbuild EUnary value = LPrefix-1)
     try self.emitExpr(operand, Level.prefix.lower(), .{});
@@ -76,11 +73,10 @@ pub fn emitUpdate(self: anytype, node: Node, level: Level, flags: ExprFlags) !vo
     const is_postfix = (extra_flags & ast_mod.UnaryFlags.postfix) != 0;
     const op: Kind = @enumFromInt(@as(u8, @truncate(extra_flags)));
     if (!is_postfix) {
-        // `a < !--b` 를 tight 하게 붙이면 `a<!--b` 가 되는데, classic script 에서 `<!--` 는
-        // 한 줄 주석의 시작(Annex B) 이라 그 뒤가 통째로 사라진다 (#4482). `<!` 직후의
-        // prefix `--` 만 한 칸 끊는다. (`--` 뒤 `>` 는 줄 선두가 아니면 안전하므로 제외.)
-        if (op == .minus2 and std.mem.endsWith(u8, self.buf.items, "<!")) try self.writeByte(' ');
+        // 직전 연산자와 붙어 `---`(=`--`+`-`) 나 `<!--`(HTML 주석) 가 되면 한 칸 끊는다.
+        try self.printSpaceBeforeOperator(op);
         try self.write(op.symbol());
+        self.recordOperatorToken(op);
     }
     // operand 는 update 의 lvalue 타겟 — 미존재 ns 멤버를 `(void 0)` 으로 바꾸면
     // `(void 0)++` SyntaxError 가 되므로 emitStaticMember 가 재작성을 건너뛰게 한다.
@@ -89,7 +85,10 @@ pub fn emitUpdate(self: anytype, node: Node, level: Level, flags: ExprFlags) !vo
     const operand_level = if (is_postfix) Level.postfix.lower() else Level.prefix.lower();
     try self.emitExpr(operand, operand_level, .{});
     self.member_assign_target = false;
-    if (is_postfix) try self.write(op.symbol());
+    if (is_postfix) {
+        try self.write(op.symbol());
+        self.recordOperatorToken(op);
+    }
 }
 
 /// 이항 연산자 심볼 + 양옆 spacing 을 좌/우 피연산자 사이에 emit. 재귀·반복 경로 공용.
@@ -101,20 +100,14 @@ fn emitBinaryOperator(self: anytype, node: Node) !void {
         try self.write(op.symbol());
         try self.writeByte(' ');
     } else {
-        const sym = op.symbol();
-        // `+`/`-` 도 minify 시엔 tight (`a+b`). 단 RHS 가 unary `+`/`-` 또는 prefix
-        // `++`/`--` 로 시작하면 `++`/`--` 로 토큰이 잘못 합쳐지므로(`a+ +b` → `a++b`)
-        // 그 경우에만 한 칸 삽입. 좌측은 합쳐질 일 없음 — postfix `a++` + `+b` 는
-        // `a+++b` 로 다시 lex 해도 `(a++)+b` 라 의미 동일.
+        // RHS 가 `+`/`-` 로 시작해 토큰이 합쳐지는 경우(`a+ +b`)는 RHS 자신이 emit 직전에
+        // printSpaceBeforeOperator 로 끊는다 — 여기선 이 연산자를 기록만 한다 (#4482).
+        // 좌측은 합쳐질 일 없음: postfix `a++` + `+b` 는 `a+++b` 로 다시 lex 해도
+        // `(a++)+b` 라 의미가 같다.
         try self.writeSpace();
-        try self.write(sym);
-        if (self.options.minify_whitespace and (op == .plus or op == .minus) and
-            leadingSignChar(self, node.data.binary.right) == sym[0])
-        {
-            try self.writeByte(' ');
-        } else {
-            try self.writeSpace();
-        }
+        try self.write(op.symbol());
+        self.recordOperatorToken(op);
+        try self.writeSpace();
     }
 }
 
@@ -170,18 +163,56 @@ fn binaryChildIsLogical(self: anytype, idx: NodeIndex) bool {
     return cop == .pipe2 or cop == .amp2;
 }
 
-/// `**` 좌측이 출력 시 prefix 단항으로 시작해 직접 올 수 없는 형태인지 (transparent
-/// wrapper 너머). esbuild BinOpPow: unary(비-update)/await/undefined(`void 0`)/number(음수)/
-/// (minify)boolean.
+/// `**` 좌측이 **출력 시** prefix 단항으로 시작하는지 — 그러면 `-a ** b` 가 SyntaxError 라
+/// 괄호가 필수다 (esbuild BinOpPow).
+///
+/// 중요 — AST 태그만 봐서는 안 된다 (#4482). codegen 은 emit 시점에 노드를 갈아치운다:
+///   - 상수 단락 fold: `(ON && -1) ** k` → emitBinary 가 살아남는 분기(`-1`)를 그 자리에 emit
+///   - 상수 조건 fold: `(ON ? -1 : 2) ** k` → emitConditional 이 동일
+///   - 상수 인라인:   `U ** 2` (U=undefined) → identifier 자리에 `void 0` 텍스트
+/// 그래서 **실제로 먼저 나올 토큰**을 따라 내려간다. 여기서 true 면 `binaryChildLevels` 가
+/// 좌측 level 을 올리고, 실제 괄호는 그 자리에 emit 되는 노드의 wrap 이 만든다.
 fn powLeftNeedsParen(self: anytype, idx: NodeIndex) bool {
-    const real = skipTransparent(self, idx);
-    if (real.isNone() or @intFromEnum(real) >= self.ast.nodes.items.len) return false;
-    const n = self.ast.getNode(real);
-    return switch (n.tag) {
-        .unary_expression, .await_expression, .numeric_literal => true,
-        .boolean_literal => self.options.minify_syntax, // !0/!1 peephole
-        else => calls.isUndefinedPeephole(self, real), // undefined → void 0
-    };
+    var cur = skipTransparent(self, idx);
+    var depth: u8 = 0;
+    while (depth < 32) : (depth += 1) {
+        if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return false;
+        const n = self.ast.getNode(cur);
+        switch (n.tag) {
+            // `-x` / `!x` / `void x` / `await x` — 단항으로 시작.
+            .unary_expression, .await_expression => return true,
+            // 상수 폴딩이 만든 음수 리터럴(`-2`). 양수면 exprNeedsParens 가 괄호를 안 친다.
+            .numeric_literal, .bigint_literal => return true,
+            .boolean_literal => return self.options.minify_syntax, // `!0`/`!1` peephole
+            .identifier_reference => {
+                if (constInlineValue(self, cur)) |cv| {
+                    return switch (cv.kind) {
+                        .undefined_ => true, // `void 0`
+                        .number => cv.number_text.len > 0 and cv.number_text[0] == '-',
+                        else => false, // true/false/null → 키워드로 시작
+                    };
+                }
+                return calls.isUndefinedPeephole(self, cur); // 전역 `undefined` → `void 0`
+            },
+            // 상수 단락 fold — emitBinary 와 **같은 판정**을 해야 한다.
+            .logical_expression => {
+                if (self.options.linking_metadata == null) return false;
+                const left_val = self.evalBooleanCondition(n.data.binary.left) orelse return false;
+                const op: Kind = @enumFromInt(n.data.binary.flags);
+                // 단락 확정 → `true`/`false` 텍스트로 접힘 (키워드로 시작).
+                if ((op == .amp2 and !left_val) or (op == .pipe2 and left_val)) return false;
+                cur = skipTransparent(self, n.data.binary.right); // 우변이 그 자리에 온다
+            },
+            // 상수 조건 fold — emitConditional 과 같은 판정.
+            .conditional_expression => {
+                if (self.options.linking_metadata == null) return false;
+                const cond = self.evalBooleanCondition(n.data.ternary.a) orelse return false;
+                cur = skipTransparent(self, if (cond) n.data.ternary.b else n.data.ternary.c);
+            },
+            else => return false,
+        }
+    }
+    return false;
 }
 
 /// 이항 노드 emit. 좌결합 체인(a+b+c+…)은 좌 스파인이 N-deep 라 순수 재귀면 스택 오버플로우
@@ -262,65 +293,6 @@ pub fn constInlineValue(self: anytype, idx: NodeIndex) ?ConstValue {
     const meta = self.options.linking_metadata orelse return null;
     const sid = self.resolveSymbolId(idx, meta) orelse return null;
     return meta.const_values.get(sid);
-}
-
-/// 노드가 출력 시 `+` 또는 `-` 로 시작하는지 — 시작하면 그 문자, 아니면 null.
-/// 앞에 같은 부호가 있으면 `++`/`--` 로 토큰이 합쳐지므로 공백을 끼워야 한다.
-/// binary `+`/`-` 의 RHS 슬롯(emitBinaryOperator)과 단항 `+`/`-` 의 피연산자 슬롯
-/// (emitUnary) 이 공유한다 (#4482).
-///
-/// 해당 케이스: unary `+`/`-`, prefix `++`/`--`, (상수 폴딩으로 생긴) 음수 numeric/
-/// bigint literal, 음수로 const-인라인되는 식별자. 더 높은 우선순위 이항식은 codegen 이
-/// 괄호 없이 출력하므로 leftmost leaf 로 내려가 검사한다.
-fn leadingSignChar(self: anytype, idx: NodeIndex) ?u8 {
-    var cur = idx;
-    var depth: u8 = 0;
-    while (depth < 32) : (depth += 1) {
-        // transparent wrapper(paren 등)는 `(` 미출력 → 안쪽 토큰이 시작 (#4042).
-        cur = skipTransparent(self, cur);
-        if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return null;
-        const n = self.ast.getNode(cur);
-        switch (n.tag) {
-            .unary_expression => return switch (unaryOpKind(self, n.data.extra) orelse return null) {
-                .plus => '+',
-                .minus => '-',
-                else => null, // !x, ~x, typeof/void/delete x → 다른 글자로 시작
-            },
-            .update_expression => {
-                const extras = self.ast.extra_data.items;
-                const e = n.data.extra;
-                if (e + 1 >= extras.len) return null;
-                if ((extras[e + 1] & ast_mod.UnaryFlags.postfix) != 0) {
-                    cur = @enumFromInt(extras[e]); // `x++` → operand 의 첫 글자로 시작 → 내려감
-                    continue;
-                }
-                return switch (@as(Kind, @enumFromInt(@as(u8, @truncate(extras[e + 1]))))) {
-                    .plus2 => '+',
-                    .minus2 => '-',
-                    else => null,
-                };
-            },
-            .numeric_literal, .bigint_literal => {
-                const text = self.ast.getText(n.span);
-                return if (text.len > 0 and text[0] == '-') '-' else null;
-            },
-            // 번들 상수 인라인이 이 자리에 리터럴 텍스트를 직접 쓴다 (`const NEG = -2` → `-2`).
-            // `void 0`/`true`/`null` 은 부호로 시작하지 않아 해당 없음.
-            .identifier_reference => {
-                const cv = constInlineValue(self, cur) orelse return null;
-                if (cv.kind != .number) return null;
-                return if (cv.number_text.len > 0 and cv.number_text[0] == '-') '-' else null;
-            },
-            // 같은/낮은 우선순위 RHS 는 paren 으로 감싸져 `(` 로 시작 → 안전(null).
-            // 더 높은 우선순위(`a + b*c` 의 `b*c`)면 leftmost leaf 로 내려가 검사.
-            .binary_expression, .logical_expression => {
-                cur = n.data.binary.left;
-                continue;
-            },
-            else => return null,
-        }
-    }
-    return null;
 }
 
 pub fn emitAssignment(self: anytype, node: Node, level: Level, flags: ExprFlags) !void {

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -10,6 +10,7 @@ const calls = @import("calls.zig");
 const precedence = @import("precedence.zig");
 const Level = precedence.Level;
 const ExprFlags = precedence.ExprFlags;
+const ConstValue = @import("../semantic/symbol.zig").ConstValue;
 
 /// minify_syntax 시 string_literal 객체 키를 따옴표 없이 emit 가능한지.
 /// `raw` 는 따옴표 포함 리터럴 텍스트. escape 없는 단순 리터럴이고 valid ES
@@ -46,8 +47,19 @@ pub fn emitUnary(self: anytype, node: Node, level: Level, flags: ExprFlags) !voi
             return;
         }
     }
-    try self.write(op.symbol());
-    if (op == .kw_typeof or op == .kw_void or op == .kw_delete) try self.writeByte(' ');
+    const sym = op.symbol();
+    try self.write(sym);
+    if (op == .kw_typeof or op == .kw_void or op == .kw_delete) {
+        try self.writeByte(' ');
+    } else if ((op == .plus or op == .minus) and leadingSignChar(self, operand) == sym[0]) {
+        // 단항 `-`/`+` 뒤에 같은 부호로 시작하는 피연산자가 오면 토큰이 `--`/`++` 로
+        // 합쳐진다 (#4482). `-(--t)` → `---t` (SyntaxError), `-(-t)` → `--t` (t 를
+        // 감소시키는 **silent miscompile**). 한 칸 띄워 끊는다: `- --t`, `- -t`.
+        // 괄호가 아니라 공백인 이유 — 스펙상 단항 피연산자에 괄호는 불필요하고,
+        // 공백이 1 byte 더 작다 (esbuild printSpaceBeforeOperator 동일).
+        // minify 여부와 무관하게 필요하다: 이 슬롯은 어느 모드에서도 공백을 안 넣는다.
+        try self.writeByte(' ');
+    }
     // operand level = .prefix.lower() (esbuild EUnary value = LPrefix-1)
     try self.emitExpr(operand, Level.prefix.lower(), .{});
 }
@@ -63,7 +75,13 @@ pub fn emitUpdate(self: anytype, node: Node, level: Level, flags: ExprFlags) !vo
     const extra_flags = extras[e + 1];
     const is_postfix = (extra_flags & ast_mod.UnaryFlags.postfix) != 0;
     const op: Kind = @enumFromInt(@as(u8, @truncate(extra_flags)));
-    if (!is_postfix) try self.write(op.symbol());
+    if (!is_postfix) {
+        // `a < !--b` 를 tight 하게 붙이면 `a<!--b` 가 되는데, classic script 에서 `<!--` 는
+        // 한 줄 주석의 시작(Annex B) 이라 그 뒤가 통째로 사라진다 (#4482). `<!` 직후의
+        // prefix `--` 만 한 칸 끊는다. (`--` 뒤 `>` 는 줄 선두가 아니면 안전하므로 제외.)
+        if (op == .minus2 and std.mem.endsWith(u8, self.buf.items, "<!")) try self.writeByte(' ');
+        try self.write(op.symbol());
+    }
     // operand 는 update 의 lvalue 타겟 — 미존재 ns 멤버를 `(void 0)` 으로 바꾸면
     // `(void 0)++` SyntaxError 가 되므로 emitStaticMember 가 재작성을 건너뛰게 한다.
     self.member_assign_target = true;
@@ -91,7 +109,7 @@ fn emitBinaryOperator(self: anytype, node: Node) !void {
         try self.writeSpace();
         try self.write(sym);
         if (self.options.minify_whitespace and (op == .plus or op == .minus) and
-            rhsLeadingSignChar(self, node.data.binary.right) == sym[0])
+            leadingSignChar(self, node.data.binary.right) == sym[0])
         {
             try self.writeByte(' ');
         } else {
@@ -237,11 +255,24 @@ pub fn unaryOpKind(self: anytype, extra_base: u32) ?Kind {
     return @enumFromInt(@as(u8, @truncate(extras[extra_base + 1])));
 }
 
-/// binary `+`/`-` 의 RHS 가 출력 시 `+` 또는 `-` 로 시작하는지 — 시작하면 그 문자 반환,
-/// 아니면 null. minify 시 `++`/`--` 토큰 오결합 방지용. unary `+`/`-`, prefix `++`/`--`,
-/// 그리고 (상수 폴딩으로 생긴) 음수 numeric/bigint literal 만 해당. 더 높은 우선순위
-/// 이항식은 codegen 이 paren 없이 출력하므로 leftmost leaf 로 내려가 검사한다.
-fn rhsLeadingSignChar(self: anytype, idx: NodeIndex) ?u8 {
+/// 식별자가 번들 상수 인라인 대상이면 그 상수값, 아니면 null. codegen 의 identifier
+/// 경로가 리터럴 텍스트를 **직접** 쓰므로(노드 태그는 그대로 identifier_reference),
+/// 출력 시작 토큰을 보는 검사들은 이 값을 봐야 실제 출력과 일치한다.
+pub fn constInlineValue(self: anytype, idx: NodeIndex) ?ConstValue {
+    const meta = self.options.linking_metadata orelse return null;
+    const sid = self.resolveSymbolId(idx, meta) orelse return null;
+    return meta.const_values.get(sid);
+}
+
+/// 노드가 출력 시 `+` 또는 `-` 로 시작하는지 — 시작하면 그 문자, 아니면 null.
+/// 앞에 같은 부호가 있으면 `++`/`--` 로 토큰이 합쳐지므로 공백을 끼워야 한다.
+/// binary `+`/`-` 의 RHS 슬롯(emitBinaryOperator)과 단항 `+`/`-` 의 피연산자 슬롯
+/// (emitUnary) 이 공유한다 (#4482).
+///
+/// 해당 케이스: unary `+`/`-`, prefix `++`/`--`, (상수 폴딩으로 생긴) 음수 numeric/
+/// bigint literal, 음수로 const-인라인되는 식별자. 더 높은 우선순위 이항식은 codegen 이
+/// 괄호 없이 출력하므로 leftmost leaf 로 내려가 검사한다.
+fn leadingSignChar(self: anytype, idx: NodeIndex) ?u8 {
     var cur = idx;
     var depth: u8 = 0;
     while (depth < 32) : (depth += 1) {
@@ -272,6 +303,13 @@ fn rhsLeadingSignChar(self: anytype, idx: NodeIndex) ?u8 {
             .numeric_literal, .bigint_literal => {
                 const text = self.ast.getText(n.span);
                 return if (text.len > 0 and text[0] == '-') '-' else null;
+            },
+            // 번들 상수 인라인이 이 자리에 리터럴 텍스트를 직접 쓴다 (`const NEG = -2` → `-2`).
+            // `void 0`/`true`/`null` 은 부호로 시작하지 않아 해당 없음.
+            .identifier_reference => {
+                const cv = constInlineValue(self, cur) orelse return null;
+                if (cv.kind != .number) return null;
+                return if (cv.number_text.len > 0 and cv.number_text[0] == '-') '-' else null;
             },
             // 같은/낮은 우선순위 RHS 는 paren 으로 감싸져 `(` 로 시작 → 안전(null).
             // 더 높은 우선순위(`a + b*c` 의 `b*c`)면 leftmost leaf 로 내려가 검사.
@@ -635,7 +673,7 @@ pub fn emitStaticMember(self: anytype, node: Node, level: Level, flags: ExprFlag
         .forbid_call = flags.forbid_call,
         .has_non_optional_chain_parent = !self_in_chain,
     };
-    try calls.emitNodeMaybeUndefParen(self, object, Level.postfix, obj_flags);
+    try self.emitExpr(object, Level.postfix, obj_flags);
     if (member_flags & MemberFlags.optional_chain != 0) {
         try self.write("?.");
     } else {
@@ -668,7 +706,7 @@ pub fn emitComputedMember(self: anytype, node: Node, level: Level, flags: ExprFl
         .forbid_call = flags.forbid_call,
         .has_non_optional_chain_parent = !self_in_chain,
     };
-    try calls.emitNodeMaybeUndefParen(self, object, Level.postfix, obj_flags);
+    try self.emitExpr(object, Level.postfix, obj_flags);
     if (member_flags & MemberFlags.optional_chain != 0) {
         try self.write("?.");
     }

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -17,6 +17,7 @@ const precedence = @import("precedence.zig");
 const Level = precedence.Level;
 const ExprFlags = precedence.ExprFlags;
 const Kind = @import("../lexer/token.zig").Kind;
+const ConstValue = @import("../semantic/symbol.zig").ConstValue;
 
 const Error = std.mem.Allocator.Error;
 
@@ -183,25 +184,29 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
 
             // Peephole: global `undefined` → `void 0` (minify_syntax 활성화 시).
             // 9 bytes → 6 bytes, 3 bytes 절감 (esbuild/rolldown/rspack 동일).
-            // call.callee / member.object / new.callee 슬롯에서는 caller 가 paren 추가
-            // (`void 0.x` 가 `void (0.x)` 로 오파싱 되는 위험 회피) — 그 외는 paren 불필요.
+            // `void 0` 는 prefix 단항이라 `.prefix` 이상 슬롯(member/call/new 타겟,
+            // `**` 좌변)에선 괄호 필수 — `void 0.x` 는 `void (0.x)` 로 오파싱된다.
+            // 중앙 wrap(exprNeedsParens)은 이 case 의 early-return 들 때문에 쓸 수 없어
+            // (닫는 `)` 유실) 여기서 level 을 보고 직접 감싼다.
             // global binding 일 때만 치환 (shadow rebind 드물지만 보호).
             if (self.options.minify_syntax and node.tag == .identifier_reference and sym_id == null) {
                 const text = self.ast.identifierNameText(node);
                 if (std.mem.eql(u8, text, "undefined")) {
                     try self.addSourceMapping(node.span);
-                    try self.write("void 0");
+                    try emitPrefixStartText(self, "void 0", level);
                     return;
                 }
             }
 
             if (self.options.linking_metadata) |meta| {
                 if (sym_id) |sid| {
-                    // 상수 인라인: import symbol이 상수이면 리터럴로 대체
+                    // 상수 인라인: import symbol이 상수이면 리터럴로 대체.
+                    // 값이 음수(`-2`) 또는 `void 0` 면 출력이 prefix 단항으로 시작하므로
+                    // 위 `void 0` 과 같은 이유로 level 기반 괄호가 필요하다 (#4482).
                     if (node.tag == .identifier_reference) {
                         if (meta.const_values.get(sid)) |cv| {
                             try self.addSourceMapping(node.span);
-                            try self.writeConstValue(cv);
+                            try emitConstValueAtLevel(self, cv, level);
                             return;
                         }
                     }
@@ -421,6 +426,16 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
 pub fn exprNeedsParens(self: anytype, node: ast_mod.Node, level: Level, flags: ExprFlags) bool {
     return switch (node.tag) {
         .unary_expression, .await_expression => level.gte(.prefix),
+        // 출력이 **prefix 단항으로 시작하는 리터럴** — precedence 상 unary 와 동급으로
+        // 다뤄야 한다 (#4482). minify 가 `-a` 를 numeric_literal("-2") 로 접고
+        // `true` 를 `!0` 으로 바꾸면서 태그가 바뀌어, 위 `.unary_expression` 매칭을
+        // 빠져나가 괄호가 유실됐다:
+        //   `(-a) ** b`      → `-2**2`         (SyntaxError — `**` 좌변에 단항 불가)
+        //   `(-a).toString()`→ `-2 .toString()`(값이 문자열 "-2" 가 아닌 숫자 -2 — silent)
+        //   `true.toString()`→ `!0.toString()` (SyntaxError)
+        .numeric_literal, .bigint_literal => level.gte(.prefix) and
+            startsWithMinus(self.ast.getText(node.span)),
+        .boolean_literal => self.options.minify_syntax and level.gte(.prefix),
         .update_expression => blk: {
             const e = node.data.extra;
             const extras = self.ast.extra_data.items;
@@ -507,6 +522,39 @@ pub fn exprNeedsParens(self: anytype, node: ast_mod.Node, level: Level, flags: E
         //  early-return 들과 충돌하므로 중앙 wrap 으로 처리하지 않는다.)
         else => false,
     };
+}
+
+/// 리터럴 텍스트가 `-` 로 시작하는지 (상수 폴딩이 만든 음수 리터럴). 출력이 prefix
+/// 단항 `-` 로 시작한다는 뜻이라 `.prefix` 이상 슬롯에선 괄호가 필요하다.
+fn startsWithMinus(text: []const u8) bool {
+    return text.len > 0 and text[0] == '-';
+}
+
+/// prefix 단항으로 시작하는 텍스트(`void 0`, `-2`)를 identifier case 안에서 emit —
+/// `.prefix` 이상 슬롯이면 괄호로 감싼다 (#4482). identifier dispatch 는 early-return
+/// 이 많아 중앙 wrap(emitExpr 진입부)을 쓸 수 없다(닫는 `)` 유실).
+fn emitPrefixStartText(self: anytype, text: []const u8, level: Level) Error!void {
+    const wrap = level.gte(.prefix);
+    if (wrap) try self.writeByte('(');
+    try self.write(text);
+    if (wrap) try self.writeByte(')');
+}
+
+/// 상수 인라인 값 emit + 출력 형태에 따른 후처리 (#4482).
+/// - `void 0` / 음수 숫자 → prefix 단항으로 시작 → `.prefix` 이상 슬롯에서 괄호.
+/// - 십진 정수(`2`) → 바로 뒤 `.` 가 소수점으로 오파싱 → `need_space_before_dot` 마킹
+///   (numeric_literal 노드 경로와 동일. 상수 인라인은 리터럴 노드를 거치지 않아 이
+///   마킹이 없었다).
+fn emitConstValueAtLevel(self: anytype, cv: ConstValue, level: Level) Error!void {
+    switch (cv.kind) {
+        .undefined_ => return emitPrefixStartText(self, "void 0", level),
+        .number => {
+            if (startsWithMinus(cv.number_text)) return emitPrefixStartText(self, cv.number_text, level);
+            try self.write(cv.number_text);
+            if (numericIsPlainInteger(cv.number_text)) self.need_space_before_dot = self.buf.items.len;
+        },
+        else => try self.writeConstValue(cv),
+    }
 }
 
 /// numeric literal 텍스트가 (소수점/지수/radix prefix/bigint 없는) 십진 정수 형태인지

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -135,6 +135,9 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
         },
         .numeric_literal => {
             try self.addSourceMapping(node.span);
+            // 상수 폴딩이 만든 음수 리터럴(`-2`)은 출력이 `-` 로 시작 → 직전 연산자와
+            // `--` 로 합쳐질 수 있다 (`a- -2`, `- -2`). wrap 된 경우엔 앞이 `(` 라 무발동 (#4482).
+            if (startsWithMinus(self.ast.getText(node.span))) try self.printSpaceBeforeOperator(.minus);
             try self.writeNodeSpan(node);
             // 정수 형태(`42`)면 바로 뒤 `.` 가 소수점으로 오파싱됨 → member 의 `.` 가
             // 공백을 끼우도록 위치 마킹 (`42 .toString()`). `.`/`e`/`x`/`b`/`o` 가 있는
@@ -144,8 +147,12 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
                 self.need_space_before_dot = self.buf.items.len;
             }
         },
+        .bigint_literal => {
+            try self.addSourceMapping(node.span);
+            if (startsWithMinus(self.ast.getText(node.span))) try self.printSpaceBeforeOperator(.minus);
+            try self.writeNodeSpan(node);
+        },
         .null_literal,
-        .bigint_literal,
         .regexp_literal,
         => {
             try self.addSourceMapping(node.span);
@@ -540,20 +547,26 @@ fn emitPrefixStartText(self: anytype, text: []const u8, level: Level) Error!void
     if (wrap) try self.writeByte(')');
 }
 
-/// 상수 인라인 값 emit + 출력 형태에 따른 후처리 (#4482).
-/// - `void 0` / 음수 숫자 → prefix 단항으로 시작 → `.prefix` 이상 슬롯에서 괄호.
+/// 상수 인라인 값 emit + 출력 형태에 따른 후처리 (#4482). 값 자체의 텍스트는
+/// `writeConstValue` 단일 구현이 쓰고, 여기서는 **출력 형태**만 본다.
+/// - `void 0` / 음수 숫자 → prefix 단항으로 시작 → `.prefix` 이상 슬롯에서 괄호,
+///   괄호가 없으면 직전 연산자와의 토큰 병합 방지 공백.
 /// - 십진 정수(`2`) → 바로 뒤 `.` 가 소수점으로 오파싱 → `need_space_before_dot` 마킹
-///   (numeric_literal 노드 경로와 동일. 상수 인라인은 리터럴 노드를 거치지 않아 이
-///   마킹이 없었다).
+///   (numeric_literal 노드 경로와 동일. 상수 인라인은 리터럴 노드를 거치지 않아 이 마킹이 없었다).
 fn emitConstValueAtLevel(self: anytype, cv: ConstValue, level: Level) Error!void {
-    switch (cv.kind) {
-        .undefined_ => return emitPrefixStartText(self, "void 0", level),
-        .number => {
-            if (startsWithMinus(cv.number_text)) return emitPrefixStartText(self, cv.number_text, level);
-            try self.write(cv.number_text);
-            if (numericIsPlainInteger(cv.number_text)) self.need_space_before_dot = self.buf.items.len;
-        },
-        else => try self.writeConstValue(cv),
+    const is_negative_number = cv.kind == .number and startsWithMinus(cv.number_text);
+    const starts_with_prefix_op = cv.kind == .undefined_ or is_negative_number;
+    const wrap = starts_with_prefix_op and level.gte(.prefix);
+    if (wrap) {
+        try self.writeByte('(');
+    } else if (is_negative_number) {
+        try self.printSpaceBeforeOperator(.minus);
+    }
+    try self.writeConstValue(cv);
+    if (wrap) {
+        try self.writeByte(')');
+    } else if (cv.kind == .number and numericIsPlainInteger(cv.number_text)) {
+        self.need_space_before_dot = self.buf.items.len;
     }
 }
 

--- a/src/codegen/writer.zig
+++ b/src/codegen/writer.zig
@@ -5,6 +5,7 @@ const ast_mod = @import("../parser/ast.zig");
 const Span = @import("../lexer/token.zig").Span;
 const Ast = ast_mod.Ast;
 const ConstValue = @import("../semantic/symbol.zig").ConstValue;
+const Kind = @import("../lexer/token.zig").Kind;
 
 pub fn write(self: anytype, s: []const u8) !void {
     try self.buf.appendSlice(self.allocator, s);
@@ -26,6 +27,48 @@ pub fn writeByte(self: anytype, b: u8) !void {
     } else {
         self.gen_col += 1;
     }
+}
+
+/// 방금 출력한 연산자 토큰을 기록 (esbuild `prevOp`/`prevOpEnd`). 다음 토큰이
+/// 이것과 붙어 `++`/`--`/`<!--` 로 합쳐질 수 있는지 `printSpaceBeforeOperator` 가 판정한다.
+/// **연산자 심볼을 write 한 직후**에 부른다 — 그 사이에 다른 바이트가 나가면
+/// `prev_op_end != buf.len` 이 되어 자동으로 무효화된다(공백/괄호가 이미 끊어준 경우).
+pub fn recordOperatorToken(self: anytype, op: Kind) void {
+    self.prev_op = op;
+    self.prev_op_end = self.buf.items.len;
+}
+
+/// 연산자(또는 연산자로 *시작하는* 토큰: 음수 리터럴 `-2`)를 출력하기 **직전**에 불러,
+/// 직전 연산자와 붙으면 다른 토큰으로 합쳐지는 경우 공백 한 칸을 끼운다 (#4482,
+/// esbuild `printSpaceBeforeOperator`).
+///
+///   `- -x`   : `--x` 로 합쳐지면 prefix 감소 — **파싱되는** silent miscompile
+///   `- --x`  : `---x` → `--` + `-x` → SyntaxError
+///   `+ ++x`  : 동일
+///   `<! --x` : `<!--` 는 classic script 에서 한 줄 주석(Annex B) → 뒤가 통째로 사라짐
+///
+/// postfix `x++` 뒤의 `+`(`x+++y`)는 다시 lex 해도 `(x++)+y` 라 의미가 같아 끊지 않는다.
+/// 판정이 **출력 바이트** 기준이라, AST 상 어느 노드가 emit 될지(상수 폴딩·치환)와 무관하게
+/// 정확하다 — 태그 룩어헤드는 fold 로 사라질 분기를 봐서 구멍이 났다.
+pub fn printSpaceBeforeOperator(self: anytype, op: Kind) !void {
+    if (self.prev_op_end != self.buf.items.len) return;
+    const merges = switch (op) {
+        // `+ +x` / `+ ++x`
+        .plus, .plus2 => self.prev_op == .plus,
+        // `- -x` / `- --x`
+        .minus, .minus2 => self.prev_op == .minus,
+        else => false,
+    };
+    const html_open_comment = op == .minus2 and self.prev_op == .bang and endsWithLtBang(self.buf.items);
+    if (merges or html_open_comment) try self.writeByte(' ');
+}
+
+/// buf 가 `<` + `!` 로 끝나는지 — 뒤에 `--` 가 붙으면 `<!--` (HTML open comment).
+/// `<<!` 는 제외한다: lexer 가 `<<` 를 maximal-munch 로 먼저 떼므로 `<!--` 토큰이 생기지 않는다.
+fn endsWithLtBang(buf: []const u8) bool {
+    if (buf.len < 2) return false;
+    if (buf[buf.len - 1] != '!' or buf[buf.len - 2] != '<') return false;
+    return buf.len < 3 or buf[buf.len - 3] != '<';
 }
 
 pub fn trimTrailingSemicolonBeforeMinifyBoundary(self: anytype) void {

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -2931,3 +2931,56 @@ test "#4481 return/throw 직후 괄호 안 주석은 inline (ASI 방지)" {
     try std.testing.expect(std.mem.indexOf(u8, result.code, "return /* inner */\n") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.code, "throw /* inner */\n") == null);
 }
+
+// ============================================================
+// #4482 — AST 미니파이어가 노드 태그를 바꾼 뒤의 load-bearing 괄호
+// ============================================================
+//
+// `minify_syntax` 는 상수를 인라인하고 `-a` 를 **numeric_literal("-2")** 로 접는다.
+// 그 순간 codegen 의 `exprNeedsParens` 가 보던 `.unary_expression` 태그가 사라져
+// `.prefix` 이상 슬롯의 필수 괄호가 유실됐다 (`-2**2` = SyntaxError,
+// `-2 .toString()` = 값이 문자열이 아닌 숫자 — silent). 폴딩은 transpile 레이어에서
+// 일어나 codegen 유닛 하네스로는 재현되지 않으므로 여기서 가드한다.
+// (`!0`/`void 0` peephole 은 codegen 레벨이라 load_bearing_paren.zig 가 커버.)
+
+fn expectMinifiedCodeContains(source: []const u8, needle: []const u8) !void {
+    var result = try transpileWithCallbackInternal(
+        std.testing.allocator,
+        source,
+        "input.js",
+        .{ .minify_syntax = true, .minify_whitespace = true },
+        null,
+        true,
+    );
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+    if (std.mem.indexOf(u8, result.code, needle) == null) {
+        std.debug.print("\n#4482: \"{s}\" 가 출력에 없음:\n{s}\n", .{ needle, result.code });
+        return error.LoadBearingParenLost;
+    }
+}
+
+test "#4482 minify: 폴딩된 음수 리터럴이 ** 좌측이면 괄호" {
+    // `-2**2` 는 SyntaxError — `**` 좌변에 단항이 직접 올 수 없다.
+    try expectMinifiedCodeContains("const a = 2; g((-a) ** 2);", "(-2)**2");
+}
+
+test "#4482 minify: 폴딩된 음수 리터럴이 member object 면 괄호" {
+    // `-2 .toString()` 은 `-(2 .toString())` 로 파싱된다 — 문자열 "-2" 가 아니라 숫자 -2.
+    // 빌드는 통과하고 런타임 값만 틀리는 silent miscompile.
+    try expectMinifiedCodeContains("const a = 2; g((-a).toString());", "(-2).toString");
+}
+
+test "#4482 minify: 음수 리터럴이 call callee / new callee 면 괄호" {
+    try expectMinifiedCodeContains("const a = 2; g((-a)());", "(-2)()");
+}
+
+test "#4482 minify: 폴딩된 음수 리터럴 앞 단항 부호는 공백으로 끊는다" {
+    // `--2` 는 prefix 감소 연산으로 오파싱 → SyntaxError (리터럴은 lvalue 가 아님).
+    try expectMinifiedCodeContains("const a = 2; g(-(-a));", "- -2");
+}
+
+test "#4482 minify: 과잉 괄호 방지 — 양수 리터럴은 그대로" {
+    try expectMinifiedCodeContains("const a = 2; g(a ** 2);", "4");
+    try expectMinifiedCodeContains("g(2 ** 3);", "8");
+}

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -2981,6 +2981,14 @@ test "#4482 minify: 폴딩된 음수 리터럴 앞 단항 부호는 공백으로
 }
 
 test "#4482 minify: 과잉 괄호 방지 — 양수 리터럴은 그대로" {
-    try expectMinifiedCodeContains("const a = 2; g(a ** 2);", "4");
-    try expectMinifiedCodeContains("g(2 ** 3);", "8");
+    // needle 이 `4`/`8` 이면 `(4)`/`(8)` 에도 매치해 과잉 괄호를 못 잡는다 → 호출 형태로 고정.
+    try expectMinifiedCodeContains("const a = 2; g(a ** 2);", "g(4)");
+    try expectMinifiedCodeContains("g(2 ** 3);", "g(8)");
+    try expectMinifiedCodeContains("g(-(+t));", "g(-+t)");
+    try expectMinifiedCodeContains("g(a ** -b);", "g(a**-b)");
+    // 괄호로 감싸이는 피연산자 앞에는 공백을 넣지 않는다 (`- (-a-b)` 가 아니라 `-(-a-b)`).
+    try expectMinifiedCodeContains("g(-(-a - b));", "g(-(-a-b))");
+    try expectMinifiedCodeContains("g(a - (-b - a));", "g(a-(-b-a))");
+    // `<<` 는 maximal-munch 로 먼저 떨어져 `<!--` 가 생기지 않는다 → 공백 불필요.
+    try expectMinifiedCodeContains("g(x << !--b);", "g(x<<!--b)");
 }


### PR DESCRIPTION
## 문제

`--minify` 산출물이 파싱조차 안 되거나(또는 **값이 조용히 틀리거나**) 하던 계열입니다. 뿌리는 둘입니다.

### 1. 단항 피연산자 슬롯의 토큰 병합 (minify 무관)

이항 `+`/`-` 의 RHS 슬롯에는 병합 방지 가드가 있었지만 **단항 슬롯에는 대응물이 없었습니다**. paren 이 투명해진(#4042) 뒤로 소스의 괄호도 방어막이 아니라 그대로 붙어 나옵니다.

| 입력 | 방출 | 결과 |
|---|---|---|
| `f(-(--t))` | `f(---t)` | SyntaxError (`--` + `-t`) |
| `f(-(-t))` | `f(--t)` | **파싱되는** prefix 감소 → `t` 를 바꾸는 silent miscompile |
| `a < !--b` | `a<!--b` | classic script 에서 `<!--` 는 한 줄 주석(Annex B) → 뒤가 통째로 사라짐 |

`d3-ease` 의 elastic 이 `tpmt(-(--t))` 를 써서 d3 번들이 통째로 죽었습니다.

### 2. prefix-단항으로 시작하는 리터럴의 괄호 유실

`binaryChildLevels` 는 "괄호 필요"를 자식 level 을 올리는 것으로 표현하는데, **`exprNeedsParens` 에 그 태그의 case 가 없으면 level 이 그냥 버려집니다.** 미니파이어가 노드 태그를 바꾸는 순간 `.unary_expression` 매칭을 빠져나가는 게 근본 원인입니다.

| 입력 | 방출 | 결과 |
|---|---|---|
| `(-a) ** b` | `-2**2` | SyntaxError |
| `(-a).toString()` | `-2 .toString()` | **빌드 green + 런타임 오답** — `-(2 .toString())` 이라 문자열 `"-2"` 가 아니라 숫자 `-2` |
| `true.toString()` | `!0.toString()` | SyntaxError |
| `undefined ** 2` | `void 0**2` | SyntaxError |

## code-review max 반영 (2번째 커밋) — 여기가 진짜 루트커즈

리뷰가 **같은 계열의 구멍 3건을 더** 찾았고, 셋 다 `--minify` 없이 번들만 해도 발생했습니다.

```js
// flags.js: export const U = undefined; export const ON = true;
U ** 2              // → void 0**2   SyntaxError
(ON && -1) ** k     // → -1 ** k     SyntaxError
x - (ON ? -1 : 1)   // → x--1        SyntaxError
-(ON ? -t : t)      // → --t         t 를 감소시키는 silent miscompile
```

**원인은 하나입니다.** 제 첫 커밋의 가드들이 **AST 태그**를 봤는데, codegen 은 emit 시점에 노드를 갈아치웁니다 — 상수 인라인(identifier → `void 0` 텍스트), 상수 단락 fold(`ON && -1` → 살아남는 `-1`), 상수 조건 fold. 그래서 **fold 로 사라질 분기**를 보고 판단했습니다. 태그 기반 가드를 추가한 게 애초에 잘못된 층위였습니다.

**처방**: 토큰 병합 방지를 **출력 바이트 기준**으로 전환했습니다 (esbuild `prevOp`/`prevOpEnd`). `printSpaceBeforeOperator` 는 직전에 *실제로 나간 연산자 바이트*만 보므로, 어느 노드가 emit 되든 fold 를 자동으로 따라갑니다. AST 룩어헤드(`leadingSignChar`, ~55줄 + 해시맵 조회)는 통째로 제거했고, 이항 RHS 가드도 이 공통 경로로 흡수돼 **슬롯별 대응이 사라졌습니다**. `**` 좌변 괄호 판정은 emit 시점의 fold/치환 결정을 그대로 따라 내려가도록 고쳤습니다.

### 덤 — 과잉 공백/괄호도 사라짐

- `-(-a - b)` 는 피연산자가 이미 괄호로 감싸여 공백이 불필요한데 AST 룩어헤드는 몰라서 `- (-a-b)` 를 냈습니다. 바이트 기준 전환으로 자동 해소 → **esbuild 와 바이트 동일**(`-(-a-b)`).
- `x << !--b` 의 `<!` 검사가 `<<!` 에도 걸렸습니다. lexer maximal-munch 로 `<<` 가 먼저 떨어져 `<!--` 가 생기지 않으므로 제외했습니다 (esbuild 는 여기서 공백을 낭비합니다).

## 테스트

- **번들(linking_metadata) 경로는 테스트가 0건이었습니다** — 그래서 `**` 구멍이 새어나갔습니다. `bundler_test` 에 5건 추가.
- "과잉 괄호 방지" 테스트가 needle 이 `"4"` 라 `"(4)"` 에도 매치돼 무의미했던 것도 호출 형태(`g(4)`)로 고정.
- 유닛 17건 추가. 수정을 롤백하면 실패하는 것을 확인했습니다.
- `zig build test` 통과, 통합 4112 pass / 0 fail.

Closes #4482

🤖 Generated with [Claude Code](https://claude.com/claude-code)