### PR TITLE
test(codegen): 산출물 재파싱 게이트 + #4488 for-await 다운레벨 수정

### DIFF
--- a/.changeset/for-await-generator-await.md
+++ b/.changeset/for-await-generator-await.md
@@ -1,0 +1,12 @@
+---
+"@zntc/core": patch
+---
+
+`--target=es2015` / `es2016` 에서 `for await` 를 쓰면 방출된 코드가 **파싱조차 되지 않던** 버그 수정 (#4488).
+
+```js
+async function f(xs) { for await (const x of xs) use(x); }
+```
+→ `function f(xs){ return __async(function*(){ ... await _a.next() ... }); }` — generator 안에 `await` 가 남아 `'await' is not allowed in non-async function`.
+
+`for await` 다운레벨이 만드는 `await` 노드는 body 를 **방문하는 도중에** 생겨서, 이미 지나간 async lowering 의 방문(`await` → `yield`)을 받지 못했다. `async function` / `async function*` / `async` 화살표 세 경로 모두 해당. async lowering 이 body 를 visit 한 뒤 남은 await 를 정리하는 post-pass 를 추가했다.

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -3437,3 +3437,61 @@ test "#4468 static block: TS 타입 어노테이션이 블록 안에서도 strip
 // 주석 배치(빈 블록 안의 주석이 밖으로 새지 않는지)는 codegen 유닛에서 검증할 수
 // 없다 — 이 harness 는 `comments` 배열을 배선하지 않아 codegen 이 주석을 못 본다.
 // 통합 스냅샷(tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap)이 담당.
+
+// ============================================================
+// #4488 — for-await 다운레벨이 generator 안에 raw `await` 를 남김
+// ============================================================
+//
+// `for await` 다운레벨은 iterator 프로토콜 + **`await` 표현식**을 만든다. 그 await 는 바깥
+// async lowering 이 `yield` 로 바꿔 줘야 하는데, visitor 는 자기가 *방문한* await 만 낮춘다.
+// for-await 는 body 를 visit 하는 **도중에** 새 await 노드를 만들므로 이미 지나간 방문을
+// 받지 못했다 → generator 안에 raw `await` 가 남아 산출물이 파싱조차 안 됐다
+// (`'await' is not allowed in non-async function`, es2015/es2016).
+//
+// 파싱 가능성 자체는 helpers 의 **산출물 재파싱 게이트**가 잡는다 (이 버그를 그렇게 찾았다).
+// 여기서는 세 async 형태가 모두 `yield` 로 낮아졌는지를 명시적으로 박제한다.
+
+fn expectNoRawAwait(output: []const u8) !void {
+    // `__await(` 헬퍼 호출(async generator 의 `yield __await(v)`)은 정상 — 그 외의 `await ` 만 본다.
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, output, i, "await")) |pos| {
+        i = pos + 5;
+        if (pos >= 2 and std.mem.eql(u8, output[pos - 2 .. pos], "__")) continue; // __await / __asyncValues 등
+        if (pos + 5 < output.len and (output[pos + 5] == '(' or output[pos + 5] == '=')) continue; // __await(v) / 헬퍼 정의
+        if (pos > 0 and (std.ascii.isAlphanumeric(output[pos - 1]) or output[pos - 1] == '_' or output[pos - 1] == '$')) continue;
+        std.debug.print("\ngenerator 안에 raw await 잔존:\n{s}\n", .{output});
+        return error.RawAwaitInGenerator;
+    }
+}
+
+test "#4488 ES2015: async function 의 for-await 가 generator 안에 await 를 남기지 않는다" {
+    var r = try e2eTarget(
+        std.testing.allocator,
+        "async function f(xs){ for await (const x of xs) { use(x); } }",
+        .es2015,
+    );
+    defer r.deinit();
+    try expectNoRawAwait(r.output);
+}
+
+test "#4488 ES2015: async generator 의 for-await 도 yield __await 로 낮아진다" {
+    var r = try e2eTarget(
+        std.testing.allocator,
+        "async function* g(xs){ for await (const x of xs) { yield x; } }",
+        .es2015,
+    );
+    defer r.deinit();
+    try expectNoRawAwait(r.output);
+    // async generator 는 사용자 yield 와 구분하기 위해 `yield __await(v)` 형태여야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__await(") != null);
+}
+
+test "#4488 ES2015: async arrow 의 for-await 도 동일" {
+    var r = try e2eTarget(
+        std.testing.allocator,
+        "const f = async (xs) => { for await (const x of xs) { use(x); } };",
+        .es2015,
+    );
+    defer r.deinit();
+    try expectNoRawAwait(r.output);
+}

--- a/src/codegen/codegen_test/helpers.zig
+++ b/src/codegen/codegen_test/helpers.zig
@@ -155,7 +155,35 @@ pub fn e2eFull(backing_allocator: std.mem.Allocator, source: []const u8, t_optio
         } else break :blk raw_output;
     } else raw_output;
 
+    // 산출물 재파싱 게이트 (#4472/#4481/#4482 계열). 이 계열의 버그는 전부 "빌드 green +
+    // 산출물이 파싱 불가" 였다 — codegen 이 필수 괄호를 빠뜨리거나(`c&&{x:a}=o`) 인접 토큰을
+    // 합쳐(`f(---t)`) 놓아도, 문자열 비교 테스트는 그 needle 만 맞으면 통과했다.
+    // 위 입력 파서 진단 검사(#1906)의 **대칭** — 방출한 것을 다시 파싱해 본다.
+    try expectReparses(allocator, output, ext, source);
+
     return .{ .output = output, .arena = arena };
+}
+
+/// codegen 산출물을 zntc 자체 파서로 다시 파싱해 진단이 없는지 확인.
+/// (JSX preserve 처럼 확장자 의존 문법이 남을 수 있어 원본과 같은 ext 로 파싱한다.)
+fn expectReparses(allocator: std.mem.Allocator, output: []const u8, ext: []const u8, source: []const u8) !void {
+    var scanner = Scanner.init(allocator, output) catch return; // scanner 실패는 아래 파서가 잡는다
+    var parser = Parser.init(allocator, &scanner);
+    parser.configureFromExtension(ext);
+    _ = parser.parse() catch |err| {
+        std.debug.print(
+            "\n산출물 재파싱 실패 ({s}) — codegen 이 파싱 불가한 코드를 방출했다\n  입력: {s}\n  출력: {s}\n",
+            .{ @errorName(err), source, output },
+        );
+        return error.OutputNotParsable;
+    };
+    if (parser.hasErrors()) {
+        std.debug.print(
+            "\n산출물 재파싱 실패 — codegen 이 파싱 불가한 코드를 방출했다\n  진단: {s}\n  입력: {s}\n  출력: {s}\n",
+            .{ parser.errors.items[0].message, source, output },
+        );
+        return error.OutputNotParsable;
+    }
 }
 
 pub fn e2eWithOptions(allocator: std.mem.Allocator, source: []const u8, cg_options: CodegenOptions) !TestResult {

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -28,6 +28,24 @@ pub fn ES2017(comptime Transformer: type) type {
         /// 변환. nested function/arrow scope 는 traversal 안 함 (own this/await context 가짐).
         /// (#1911)
         fn rewriteAwaitToYieldAwait(self: *Transformer, node_idx: NodeIndex) Transformer.Error!void {
+            return rewriteRemainingAwait(self, node_idx, true);
+        }
+
+        /// async function body 안에 **남아 있는** await 표현을 `yield value` 로 변환 (#4488).
+        ///
+        /// 왜 필요한가 — visitor 는 자기가 *방문한* `await_expression` 만 yield 로 낮춘다
+        /// (`lowerAwaitExpression`). 그런데 `for await` 다운레벨(es2018_for_await)은 body 를
+        /// visit 하는 **도중에 새 await 노드를 만든다**. 그 노드는 이미 지나간 방문을 받지 못해
+        /// generator 안에 raw `await` 로 남았다 → `'await' is not allowed in non-async function`.
+        /// (es2015/es2016 타겟에서 산출물이 파싱조차 안 됐다.)
+        /// body visit 이 **끝난 뒤** 한 번 훑어 남은 것을 정리한다.
+        fn rewriteRemainingAwaitToYield(self: *Transformer, node_idx: NodeIndex) Transformer.Error!void {
+            return rewriteRemainingAwait(self, node_idx, false);
+        }
+
+        /// `wrap_await_helper` = true → `yield __await(v)` (async generator: 사용자 yield 와 구분),
+        /// false → `yield v` (plain async: __async 헬퍼의 generator 프로토콜).
+        fn rewriteRemainingAwait(self: *Transformer, node_idx: NodeIndex, comptime wrap_await_helper: bool) Transformer.Error!void {
             // 반복 post-order worklist(#4123): 원본은 generic else 에서 자식을, await_expression
             // 에서 operand 를 재귀해, async-generator body 안 깊은 식(`await (a+b+c+…)`, 깊은
             // statement 중첩, `await await …`)에서 스택오버플로우였다. await_expression 만 operand
@@ -44,16 +62,18 @@ pub fn ES2017(comptime Transformer: type) type {
             try stack.append(self.allocator, .{ .idx = node_idx, .post = false });
             while (stack.pop()) |frame| {
                 if (frame.post) {
-                    // operand 는 이미 변환 완료. 이제 이 await 를 `yield __await(operand)` 로 replace.
+                    // operand 는 이미 변환 완료. 이제 이 await 를 yield 로 replace.
                     const node = self.ast.getNode(frame.idx);
-                    self.runtime_helpers.await_helper = true;
-                    const await_ref = try es_helpers.makeRuntimeHelperRef(self, "__await");
-                    const await_call = try es_helpers.makeCallExpr(self, await_ref, &.{node.data.unary.operand}, node.span);
-                    // span 보존하면서 await_expression → yield __await(value).
+                    const yielded = if (wrap_await_helper) blk: {
+                        self.runtime_helpers.await_helper = true;
+                        const await_ref = try es_helpers.makeRuntimeHelperRef(self, "__await");
+                        break :blk try es_helpers.makeCallExpr(self, await_ref, &.{node.data.unary.operand}, node.span);
+                    } else node.data.unary.operand;
+                    // span 보존하면서 await_expression → yield <value>.
                     self.ast.replaceNode(frame.idx, .{
                         .tag = .yield_expression,
                         .span = node.span,
-                        .data = .{ .unary = .{ .operand = await_call, .flags = 0 } },
+                        .data = .{ .unary = .{ .operand = yielded, .flags = 0 } },
                     });
                     continue;
                 }
@@ -128,6 +148,20 @@ pub fn ES2017(comptime Transformer: type) type {
             });
             // inner function 자체도 visitNode 거쳐 generator/await downlevel 적용.
             const lowered_inner = try self.visitNode(inner_func);
+            // 위 rewriteAwaitToYieldAwait 는 inner visit **전** 이라, 그 visit 중 for-await
+            // 다운레벨이 새로 만든 await 를 놓친다 → 한 번 더 훑는다 (#4488).
+            // 주의 — visit 은 body 를 **새 노드로 교체**하므로 원래 `body_idx` 가 아니라
+            // 낮아진 결과의 body 를 봐야 한다. generator 가 state machine 으로 접힌 타겟
+            // (es5)에선 함수 형태가 아니거나 남은 await 가 없어 no-op.
+            if (!lowered_inner.isNone() and @intFromEnum(lowered_inner) < self.ast.nodes.items.len) {
+                const li = self.ast.getNode(lowered_inner);
+                switch (li.tag) {
+                    .function_expression, .function, .function_declaration => {
+                        try rewriteAwaitToYieldAwait(self, self.readNodeIdx(li.data.extra, 2));
+                    },
+                    else => {},
+                }
+            }
 
             // __asyncGenerator(this, arguments, function*() {...})
             self.runtime_helpers.async_generator = true;
@@ -184,6 +218,9 @@ pub fn ES2017(comptime Transformer: type) type {
 
             const new_name = try self.visitNode(name_idx);
             const new_body = try self.visitBodyWorkletAware(body_idx);
+            // body 를 visit 하는 도중 for-await 다운레벨이 **새로 만든** await 노드는 visitor 의
+            // await→yield 변환을 못 받는다 → 여기서 정리 (#4488).
+            try rewriteRemainingAwaitToYield(self, new_body);
 
             const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 
@@ -229,6 +266,8 @@ pub fn ES2017(comptime Transformer: type) type {
 
             const new_params = try self.visitNode(params_idx);
             const new_body = try self.visitBodyWorkletAware(body_idx);
+            // body visit 중 for-await 다운레벨이 새로 만든 await 정리 (#4488, lowerAsyncFunction 동일).
+            try rewriteRemainingAwaitToYield(self, new_body);
 
             // expression body → { return expr; }
             const body_node = self.ast.getNode(new_body);

--- a/tests/integration/tests/output-parsable.test.ts
+++ b/tests/integration/tests/output-parsable.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect } from 'bun:test';
+import { runZntc, createFixture } from './helpers';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+/**
+ * 산출물 재파싱 게이트 (#4472 / #4481 / #4482 / #4483 계열).
+ *
+ * 이 계열의 버그는 전부 **빌드 exit 0 + 산출물이 파싱 불가** 였다. codegen 이 필수 괄호를
+ * 빠뜨리거나(`c&&{x:a}=o`) 인접 토큰을 합쳐(`f(---t)`) 놓아도 빌드는 성공하고, 문자열 비교
+ * 테스트는 needle 만 맞으면 통과했다. 실제 라이브러리(d3 · monaco · codemirror)가
+ * 프로덕션에서 통째로 죽고 나서야 발견됐다.
+ *
+ * 여기서는 방출물을 **다시 파싱**하고(`node --check`), 나아가 **실행해서 값까지** 원본과
+ * 비교한다 — `f(-(-t))` → `f(--t)` 처럼 파싱은 되면서 의미만 바뀌는 silent miscompile 은
+ * 재파싱만으로는 못 잡기 때문이다.
+ *
+ * (codegen 유닛 레이어의 대칭 게이트는 `src/codegen/codegen_test/helpers.zig` 의
+ *  `expectReparses` — 자체 파서로 모든 e2e 테스트 산출물을 재파싱한다.)
+ */
+
+/** 위험 패턴 코퍼스. 각 항목은 `globalThis.out` 에 결과를 문자열로 남긴다. */
+const HAZARD_CORPUS = `
+// --- #4481: if → &&/?: 폴딩 시 필수 괄호 ---
+let a, b, m;
+const obj = { x: 1, y: 2 };
+const cond = globalThis.__c !== 0;
+if (cond) ({ x: a, y: b } = obj);                 // c && ({x:a,y:b} = obj)
+const results = [a + "," + b];
+
+const f = () => 7;
+if ((m = f())) results.push("cond-assign:" + m);  // (m=f()) && ...  (괄호 없으면 의미가 바뀜)
+
+function chain(g, h) { let n; if ((n = g())) { return h(n); } else { return 0; } }
+results.push("chain:" + chain(() => 3, (v) => v * 2));
+
+function fall(g) { let n; if ((n = g())) return 1; return 2; }
+results.push("fall:" + fall(() => 0));
+
+const q = (x, y) => { if ((x ?? y)) return "nullish"; return "no"; };  // (a??b) && — 혼용 금지
+results.push("nullish:" + q(null, 1));
+
+// --- #4482: 단항 토큰 병합 + prefix-단항 리터럴 괄호 ---
+let t = 5;
+const id = (x) => x;
+results.push("unary:" + id(-(--t)) + ":" + t);    // f(- --t) — f(---t) 는 SyntaxError
+let u = 5;
+results.push("dbl-neg:" + id(-(-u)) + ":" + u);   // f(- -u) — f(--u) 는 u 를 감소시킴
+const two = 2;
+results.push("pow:" + String((-two) ** 2));       // (-2)**2 — -2**2 는 SyntaxError
+results.push("neg-member:" + (-two).toString());  // (-2).toString() — 문자열 "-2"
+results.push("bool-member:" + true.toString());   // (!0).toString()
+results.push("void-pow:" + String(undefined ** 2));
+
+// --- #4472: comma-sequence 접기 시 statement-start 괄호 ---
+let c1, c2;
+if (cond) { ({ x: c1, y: c2 } = obj); results.push("seq:" + c1 + c2); }
+
+globalThis.out = results.join("|");
+console.log(globalThis.out);
+`;
+
+/** emit 시점 상수 fold 를 타는 경로 (#4482 리뷰 — 번들 linking_metadata 전용). */
+const FOLD_FLAGS = `export const ON = true;
+export const U = undefined;
+export const NEG_SRC = 2;
+`;
+
+const FOLD_ENTRY = `import { ON, U, NEG_SRC } from "./flags.js";
+const out = [];
+out.push("pow-fold:" + String((ON && -1) ** 2));      // (-1)**2 — fold 로 살아남는 분기
+out.push("pow-cond:" + String((ON ? -1 : 2) ** 2));
+out.push("sub-fold:" + String(10 - (ON ? -1 : 1)));   // 10- -1 — 10--1 은 SyntaxError
+const t = { v: 3 };
+out.push("neg-fold:" + String(-(ON ? -t.v : t.v)));   // - -3 — --t.v 는 silent miscompile
+out.push("undef-pow:" + String(U ** 2));              // (void 0)**2
+out.push("undef-member:" + String(U ?? "dflt"));
+out.push("const-member:" + NEG_SRC.toString());       // 2 .toString()
+globalThis.out = out.join("|");
+console.log(globalThis.out);
+`;
+
+/** 번들 후 `node --check` 로 재파싱. 실패하면 산출물 전문과 함께 터진다. */
+function expectParsable(outFile: string, label: string) {
+  const r = spawnSync('node', ['--check', outFile], { encoding: 'utf-8' });
+  if (r.status !== 0) {
+    const code = readFileSync(outFile, 'utf-8');
+    throw new Error(
+      `[${label}] 산출물이 파싱되지 않는다 — 빌드는 green 인데 런타임에 죽는다\n` +
+        `${r.stderr}\n--- 산출물 ---\n${code}`,
+    );
+  }
+}
+
+function runNode(outFile: string): string {
+  const r = spawnSync('node', [outFile], { encoding: 'utf-8' });
+  if (r.status !== 0) throw new Error(`실행 실패:\n${r.stderr}`);
+  return r.stdout.trim();
+}
+
+/** minify 유무에 따라 산출물이 달라져도 **의미는 같아야** 한다. */
+const OPTION_MATRIX: { label: string; args: string[] }[] = [
+  { label: 'plain', args: [] },
+  { label: 'minify-syntax', args: ['--minify-syntax'] },
+  { label: 'minify-whitespace', args: ['--minify-whitespace'] },
+  { label: 'minify', args: ['--minify'] },
+  { label: 'minify + es2015', args: ['--minify', '--target=es2015'] },
+  { label: 'minify + es5', args: ['--minify', '--target=es5'] },
+];
+
+describe('산출물 재파싱 게이트', () => {
+  test('위험 패턴 코퍼스가 모든 옵션 조합에서 파싱되고 의미가 보존된다', async () => {
+    const { dir, cleanup } = await createFixture({ 'entry.js': HAZARD_CORPUS });
+    try {
+      // 기준값: node 가 원본 소스를 직접 실행한 결과.
+      const expected = runNode(join(dir, 'entry.js'));
+      expect(expected.length).toBeGreaterThan(0);
+
+      for (const { label, args } of OPTION_MATRIX) {
+        const outFile = join(dir, `out-${label.replace(/[^a-z0-9]/gi, '_')}.js`);
+        const bundle = await runZntc(['--bundle', join(dir, 'entry.js'), '-o', outFile, ...args]);
+        expect(bundle.exitCode).toBe(0);
+
+        expectParsable(outFile, label);
+        expect(runNode(outFile), `[${label}] 의미가 바뀌었다`).toBe(expected);
+      }
+    } finally {
+      await cleanup();
+    }
+  }, 60000);
+
+  test('emit 시점 상수 fold 경로도 파싱되고 의미가 보존된다', async () => {
+    const { dir, cleanup } = await createFixture({
+      'flags.js': FOLD_FLAGS,
+      'entry.js': FOLD_ENTRY,
+    });
+    try {
+      // 기준값은 fold 가 없는 esm 실행 결과 (node 가 직접 실행).
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ type: 'module' }));
+      const expected = runNode(join(dir, 'entry.js'));
+
+      for (const { label, args } of OPTION_MATRIX) {
+        const outFile = join(dir, `fold-${label.replace(/[^a-z0-9]/gi, '_')}.js`);
+        const bundle = await runZntc(['--bundle', join(dir, 'entry.js'), '-o', outFile, ...args]);
+        expect(bundle.exitCode).toBe(0);
+
+        expectParsable(outFile, label);
+        expect(runNode(outFile), `[${label}] 의미가 바뀌었다`).toBe(expected);
+      }
+    } finally {
+      await cleanup();
+    }
+  }, 60000);
+
+  test('for-await 다운레벨 산출물이 모든 타겟에서 파싱된다 (#4488)', async () => {
+    const src = `
+async function collect(xs) { const out = []; for await (const x of xs) out.push(x); return out; }
+const arrow = async (xs) => { const out = []; for await (const x of xs) out.push(x); return out; };
+collect([Promise.resolve(1), 2]).then((r) => arrow([3, 4]).then((s) => console.log(r.join(",") + "|" + s.join(","))));
+`;
+    const { dir, cleanup } = await createFixture({ 'entry.js': src });
+    try {
+      const expected = runNode(join(dir, 'entry.js'));
+      for (const target of ['es5', 'es2015', 'es2016', 'es2017', 'esnext']) {
+        const outFile = join(dir, `fa-${target}.js`);
+        const bundle = await runZntc([
+          '--bundle',
+          join(dir, 'entry.js'),
+          '-o',
+          outFile,
+          `--target=${target}`,
+        ]);
+        expect(bundle.exitCode).toBe(0);
+        // generator 안에 raw await 가 남으면 파싱 불가:
+        // "'await' is not allowed in non-async function"
+        expectParsable(outFile, target);
+        expect(runNode(outFile), `[${target}] 의미가 바뀌었다`).toBe(expected);
+      }
+    } finally {
+      await cleanup();
+    }
+  }, 60000);
+});


### PR DESCRIPTION
## 왜

#4472 · #4481 · #4482 · #4483 은 **전부 같은 실패 양식**이었습니다.

> 빌드는 exit 0 인데, 방출된 JS 가 **파싱조차 되지 않는다.**

codegen 이 필수 괄호를 빠뜨리거나(`c&&{x:a}=o`) 인접 토큰을 합쳐(`f(---t)`) 놓아도 빌드는 성공하고, 문자열 비교 테스트는 needle 만 맞으면 통과합니다. 그래서 **d3 · monaco-editor · codemirror 가 프로덕션에서 통째로 죽고 나서야** 발견됐습니다. 세 이슈가 모두 같은 요청을 했습니다 — *"번들 산출물 전체를 파서로 재파싱하는 스모크 게이트. 이번 건들 전부 이것만으로 잡혔을 것"*.

## 게이트 (두 레이어)

**유닛** — `codegen_test/helpers.zig` 의 `e2eFull` 이 방출물을 **zntc 자체 파서로 다시 파싱**하고 진단이 있으면 실패합니다. 이미 있던 *입력* 파서 진단 검사(#1906)의 **대칭**이라 자연스럽게 붙고, **모든 codegen e2e 테스트가 소급 보호**됩니다.

**통합** — `tests/integration/tests/output-parsable.test.ts` 가 위험 패턴 코퍼스를 옵션 매트릭스(plain / minify-syntax / minify-whitespace / minify / es2015 / es5)로 번들해 `node --check` 로 재파싱하고, 나아가 **실행해서 값까지 원본과 비교**합니다.

값 비교가 필요한 이유 — 재파싱만으로는 **파싱은 되면서 의미만 바뀌는** silent miscompile 을 못 잡습니다:

| 입력 | 잘못된 방출 | 파싱 | 결과 |
|---|---|---|---|
| `f(-(-t))` | `f(--t)` | ✅ | `t` 를 감소시킴 |
| `if ((m=f())) g(m)` | `m=f()&&g(m)` | ✅ | `m = (f() && g(m))` 로 의미가 바뀜 |
| `(-a).toString()` | `-2 .toString()` | ✅ | 문자열 `"-2"` 가 아니라 숫자 `-2` |

코퍼스는 지금까지 나온 계열을 전부 담습니다 — if→`&&`/`?:` 폴딩 괄호, cond-assign, `??` 혼용, 단항 토큰 병합, `**` 좌변, 음수 리터럴 member, comma-sequence statement-start, for-await 다운레벨. **emit 시점 상수 fold 경로**(번들 linking_metadata 전용 — #4482 의 구멍이 정확히 여기로 새어나갔습니다)도 별도 케이스로 덮습니다.

## 게이트가 켜지자마자 잡은 것 — #4488

`--target=es2015` / `es2016` 에서 `for await` 를 쓰면 **산출물이 파싱조차 안 됐습니다**.

```js
async function f(xs) { for await (const x of xs) use(x); }
```
→ `function f(xs){ return __async(function*(){ … await _a.next() … }); }`
→ `SyntaxError: 'await' is not allowed in non-async function`

`for await` 다운레벨은 iterator 프로토콜 + **`await` 표현식**을 만듭니다. 그 await 를 `yield` 로 바꾸는 건 visitor 인데, visitor 는 자기가 **방문한** await 만 낮춥니다. for-await 는 body 를 visit 하는 *도중에* 새 await 노드를 만들어 반환하므로 **이미 지나간 방문**을 받지 못합니다. `async function` / `async function*` / `async` 화살표 **세 경로 전부** 깨져 있었습니다.

기존 테스트(`"ES2018: for-await destructuring body lowered at es2015 target (#1382)"`)는 문자열 일치만 검사해 파싱 불가한 산출물을 통과시키고 있었습니다.

**처방**: async lowering 이 body 를 visit 한 **뒤** 남은 await 를 정리하는 post-pass. async generator 는 `yield __await(v)` 여야 사용자 yield 와 구분됩니다. (주의 — visit 은 body 를 새 노드로 교체하므로 원래 인덱스가 아니라 낮아진 결과의 body 를 봐야 합니다.)

es2015/es2016/es2017/es5 전 타겟에서 `node --check` 통과 + 런타임 값이 원본과 일치함을 확인했습니다.

## 남은 것

es5 + `async function*` + `for await` 는 런타임 의미가 여전히 틀립니다 (state machine 이 raw await 를 평범한 yield op 로 소비). **main 에서도 동일한 기존 버그**이고 산출물 파싱은 통과하므로 이 PR 범위 밖 — #4488 에 남겨 뒀습니다.

## 검증

- `zig build test` 통과 (게이트 ON)
- 통합 4115 pass / 0 fail
- 게이트 브랜치를 **머지 전 main** 에 올려보면 #4482 의 버그들(`-1 ** 2`, `--t.v`, `void 0 ** 2`)을 그대로 검출합니다 — 게이트가 실제로 작동한다는 증거입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)