### PR TITLE
fix(parser): #4048 argless new 의 optional callee + trailing `?.` 에서 ZNTC0623 중복 발행

### DIFF
--- a/.changeset/new-optional-chain-duplicate-diagnostic.md
+++ b/.changeset/new-optional-chain-duplicate-diagnostic.md
@@ -1,0 +1,14 @@
+---
+"@zntc/core": patch
+---
+
+argless `new` 의 optional callee 뒤에 tagged template + trailing `?.` 가 붙으면 `ZNTC0623 (Invalid optional chain in 'new' expression)` 진단이 **2번** 나오던 문제 수정 (#4048).
+
+```js
+new a?.b`x`?.c    // ZNTC0623 × 2 → × 1
+new a?.b.c`x`?.d  // ZNTC0623 × 2 → × 1
+```
+
+파서에 623 을 내는 지점이 둘이다 — callee 의 `?.` 를 잡는 `parseNewCallee` 와, argless new 를 base 로 하는 trailing `?.` 를 잡는 postfix 루프. 각자 자기 함수의 로컬 플래그로만 중복을 막고 있어서, 두 지점이 *같은 new* 를 보고하는 위 조합에서 서로를 모른 채 2번 발행했다. `parseNewCallee` 가 복구를 위해 `?.` 를 비-optional 멤버로 소비해버려 AST 구조만으로는 "callee 에 optional 이 있었다" 를 알 수 없는 것이 근본 원인.
+
+new 노드에 `CallFlags.callee_optional_chain` 비트를 남겨 그 잃어버린 사실을 전파하고, postfix 루프가 이미 보고된 new 면 재보고하지 않게 했다. 진단 개수만 줄어들 뿐 수용/거부 동작은 그대로이며(입력은 여전히 SyntaxError), 서로 다른 new 두 개(`new (new a?.b)\`x\`?.c`)나 다른 코드의 진단(ZNTC0607)은 그대로 보고된다.

--- a/.changeset/new-optional-chain-duplicate-diagnostic.md
+++ b/.changeset/new-optional-chain-duplicate-diagnostic.md
@@ -2,13 +2,8 @@
 "@zntc/core": patch
 ---
 
-argless `new` 의 optional callee 뒤에 tagged template + trailing `?.` 가 붙으면 `ZNTC0623 (Invalid optional chain in 'new' expression)` 진단이 **2번** 나오던 문제 수정 (#4048).
+`new a?.b\`x\`?.c` 처럼 argless `new` 의 optional callee 와 trailing `?.` 가 겹칠 때 진단 ZNTC0623 이 **2번** 발행되던 문제 수정 (#4048).
 
-```js
-new a?.b`x`?.c    // ZNTC0623 × 2 → × 1
-new a?.b.c`x`?.d  // ZNTC0623 × 2 → × 1
-```
+두 검사 지점이 **같은 `new`** 를 각각 보고하고 있었다. 복구 경로가 callee 의 `?.` 를 비-optional 멤버로 소비해 버려서, AST 에 "이 new 의 callee 는 optional 이었다" 는 사실이 남지 않았던 게 원인이다. dedup 필터로 뭉개는 대신 그 사실을 `new` 노드에 비트로 복원해, 뒤따르는 검사가 같은 new 를 다시 보고하지 않게 했다.
 
-파서에 623 을 내는 지점이 둘이다 — callee 의 `?.` 를 잡는 `parseNewCallee` 와, argless new 를 base 로 하는 trailing `?.` 를 잡는 postfix 루프. 각자 자기 함수의 로컬 플래그로만 중복을 막고 있어서, 두 지점이 *같은 new* 를 보고하는 위 조합에서 서로를 모른 채 2번 발행했다. `parseNewCallee` 가 복구를 위해 `?.` 를 비-optional 멤버로 소비해버려 AST 구조만으로는 "callee 에 optional 이 있었다" 를 알 수 없는 것이 근본 원인.
-
-new 노드에 `CallFlags.callee_optional_chain` 비트를 남겨 그 잃어버린 사실을 전파하고, postfix 루프가 이미 보고된 new 면 재보고하지 않게 했다. 진단 개수만 줄어들 뿐 수용/거부 동작은 그대로이며(입력은 여전히 SyntaxError), 서로 다른 new 두 개(`new (new a?.b)\`x\`?.c`)나 다른 코드의 진단(ZNTC0607)은 그대로 보고된다.
+**같은 new 안에서만** 접는다 — 서로 다른 `new` 두 개는 각자의 위반이므로 그대로 2건이 나온다 (`new new a?.b\`x\`?.c`, `new (new a?.b)\`x\`?.c`). 다른 진단(ZNTC0607 tagged template on optional chain)도 억제되지 않는다.

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1951,9 +1951,16 @@ pub const CallFlags = struct {
     /// Arguments`, MemberExpression) 면 set, `new a`/`new new a()` 의 바깥 new (= NewExpression)
     /// 면 unset. trailing optional chain(`new ...?.x`)의 base 체인 head 가 인자 없는 new 면
     /// SyntaxError — ECMAScript 상 OptionalChain base 는 MemberExpression/CallExpression 만 가능.
-    /// parse-time 전용(finishNewExpressionWithArgs set, optionalChainBaseIsArglessNew read);
+    /// parse-time 전용(finishNewExpressionWithArgs set, optionalChainArglessNewHead read);
     /// codegen/transformer 는 미사용.
     pub const had_arguments: u32 = 0x04;
+    /// new_expression 전용: callee 에 optional chain(`?.`)이 있었는가 (`new a?.b`). 이건
+    /// SyntaxError 라서 parseNewCallee 가 그 자리에서 ZNTC0623 을 보고하고, 복구를 위해 `?.` 를
+    /// **비-optional 멤버로 소비**한다 — 그래서 callee 서브트리에는 optional 흔적이 남지 않는다.
+    /// 이 비트가 그 잃어버린 구조 정보를 new 노드에 보존한다. trailing `?.`(`new a?.b\`x\`?.c`)를
+    /// 검사하는 postfix 루프가 같은 new 에 대해 623 을 또 보고하지 않도록 하는 데 쓴다 (#4048).
+    /// parse-time 전용; codegen/transformer 는 미사용.
+    pub const callee_optional_chain: u32 = 0x08;
 };
 
 /// static_member_expression / computed_member_expression / private_field_expression의 flags (D082).

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1192,6 +1192,24 @@ fn finishNewExpressionWithArgs(self: *Parser, start: u32, callee: NodeIndex, arg
     return new_expr;
 }
 
+/// 인자 없는 `new` 노드 생성 — extras 레이아웃을 `finishNewExpressionWithArgs` 와 **단일 소스**로
+/// 유지한다. 예전엔 두 곳에 복붙돼 있어, 새 플래그를 한쪽에만 넣으면 조용히 유실됐다 (#4048).
+fn finishNewExpressionNoArgs(
+    self: *Parser,
+    start: u32,
+    callee: NodeIndex,
+    callee_optional: bool,
+) !NodeIndex {
+    const extra = try self.ast.addExtras(&.{
+        @intFromEnum(callee), 0, 0, newCalleeOptionalFlag(callee_optional),
+    });
+    return try self.ast.addNode(.{
+        .tag = .new_expression,
+        .span = .{ .start = start, .end = self.currentSpan().start },
+        .data = .{ .extra = extra },
+    });
+}
+
 /// new 표현식의 callee를 파싱한다.
 /// new는 중첩 가능하므로 new를 만나면 재귀한다.
 /// member access (.prop, [expr])만 허용하고 호출 ()은 상위에서 처리.
@@ -1221,22 +1239,20 @@ fn parseNewCallee(self: *Parser, out_callee_optional: *bool) ParseError2!NodeInd
     if (self.current() == .kw_new) {
         const span = self.currentSpan();
         try self.advance(); // skip 'new'
-        // 같은 out 포인터를 넘겨 안쪽 new 의 callee 보고를 바깥까지 전파 (#4048).
-        const callee = try parseNewCallee(self, out_callee_optional);
+        // **안쪽 new 전용 플래그**로 받는다 (#4048). 바깥의 `out_callee_optional` 을 그대로
+        // 넘기면 "안쪽 new 의 callee 에 `?.` 가 있었다" 는 사실이 **바깥 new** 에 찍혀,
+        // 바깥 new 자신의 별개 위반(argless new 뒤 trailing `?.`)이 조용히 사라진다.
+        // 두 new 는 서로 다른 위반이므로 각각 보고돼야 한다 — 괄호 형태
+        // (`new (new a?.b)\`x\`?.c`)가 실제로 2건을 내는 것과 일관되게.
+        var inner_callee_optional = false;
+        const callee = try parseNewCallee(self, &inner_callee_optional);
         _ = trySkipTypeArgsSpeculative(self, true, type_args.canFollowTypeArgumentsInExpression);
         if (self.current() == .l_paren) {
             try self.advance();
             const arg_list = try parseArgumentList(self);
-            return try finishNewExpressionWithArgs(self, span.start, callee, arg_list, out_callee_optional.*);
+            return try finishNewExpressionWithArgs(self, span.start, callee, arg_list, inner_callee_optional);
         }
-        const ne_no_args = try self.ast.addExtras(&.{
-            @intFromEnum(callee), 0, 0, newCalleeOptionalFlag(out_callee_optional.*),
-        });
-        return try self.ast.addNode(.{
-            .tag = .new_expression,
-            .span = .{ .start = span.start, .end = self.currentSpan().start },
-            .data = .{ .extra = ne_no_args },
-        });
+        return try finishNewExpressionNoArgs(self, span.start, callee, inner_callee_optional);
     }
 
     // primary expression + member chain (호출 제외)
@@ -1502,14 +1518,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             }
 
             // 인자 없는 new: new Foo
-            const ne2_no = try self.ast.addExtras(&.{
-                @intFromEnum(callee), 0, 0, newCalleeOptionalFlag(callee_optional),
-            });
-            return try self.ast.addNode(.{
-                .tag = .new_expression,
-                .span = .{ .start = span.start, .end = self.currentSpan().start },
-                .data = .{ .extra = ne2_no },
-            });
+            return try finishNewExpressionNoArgs(self, span.start, callee, callee_optional);
         },
         .kw_super => {
             // super expression: super() 또는 super.prop 또는 super[expr]

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -906,9 +906,22 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                 // ECMAScript: OptionalChain 의 base 는 MemberExpression/CallExpression 만 가능.
                 // base 체인 head 가 인자 없는 new(NewExpression)면 SyntaxError(`new new a()?.b`,
                 // `new new a().b?.c`, `new a\`tpl\`?.b`). 인자 있는 new·call·기타 head 는 유효.
-                if (!reported_new_optional and optionalChainBaseIsArglessNew(self, expr)) {
-                    try self.addErrorCode(self.ast.getNode(expr).span, "Invalid optional chain in 'new' expression", .optional_chain_new);
-                    reported_new_optional = true;
+                if (!reported_new_optional) {
+                    const head_new = optionalChainArglessNewHead(self, expr);
+                    if (!head_new.isNone()) {
+                        // 단, 그 new 의 callee 에 이미 `?.` 가 있었다면(`new a?.b\`x\`?.c`)
+                        // parseNewCallee 가 *같은 new* 로 623 을 이미 보고했다. 여기서 또 내면
+                        // 한 new 에 623 이 2번 (#4048). callee_optional_chain 비트로 판별한다 —
+                        // callee 의 `?.` 는 복구 과정에서 비-optional 멤버로 소비돼 AST 구조만
+                        // 봐서는 알 수 없기 때문.
+                        const head_flags = self.ast.readExtra(self.ast.getNode(head_new).data.extra, 3);
+                        if ((head_flags & ast_mod.CallFlags.callee_optional_chain) == 0) {
+                            try self.addErrorCode(self.ast.getNode(expr).span, "Invalid optional chain in 'new' expression", .optional_chain_new);
+                        }
+                        // 보고했든 (callee 보고로) 생략했든 이 체인의 argless-new head 는 처리 완료.
+                        // 뒤따르는 `?.` 마다 같은 head 를 재발견하므로 여기서 닫는다.
+                        reported_new_optional = true;
+                    }
                 }
                 try self.advance(); // skip ?.
                 if (self.current() == .l_bracket) {
@@ -1118,13 +1131,16 @@ fn followedByParenOnly(self: *const Parser) bool {
     return self.current() == .l_paren;
 }
 
-/// `?.`(OptionalChain)의 base 체인 head 가 *인자 없는* new(NewExpression)인지 판정.
+/// `?.`(OptionalChain)의 base 체인 head 가 *인자 없는* new(NewExpression)면 그 new 노드를,
+/// 아니면 `.none` 을 반환한다.
 /// ECMAScript: OptionalChain 의 base 는 MemberExpression/CallExpression 만 가능하므로,
 /// 비-optional 멤버 접근(`.x`/`[k]`/`#p`)·tagged template 만 거쳐 인자 없는 new 에 도달하면
 /// SyntaxError(`new new a().b?.c`, `new a\`tpl\`?.b` 등). 인자 있는 new(MemberExpression)·
 /// call_expression·그 외 head 에서 멈춘다(유효). 즉시 base 가 argless new 인 `new new a()?.b`
 /// 도 이 walk 의 첫 step 에서 잡힌다. depth 가드로 무한루프 방지(정상 AST 는 짧다).
-fn optionalChainBaseIsArglessNew(self: *const Parser, base: NodeIndex) bool {
+/// 노드를 돌려주는 이유: 호출부가 head new 의 `callee_optional_chain` 비트를 보고 "이미
+/// parseNewCallee 가 같은 new 로 623 을 보고했는지" 판단해야 하기 때문 (#4048).
+fn optionalChainArglessNewHead(self: *const Parser, base: NodeIndex) NodeIndex {
     var cur = base;
     var guard: u32 = 0;
     while (guard < 100_000) : (guard += 1) {
@@ -1136,22 +1152,34 @@ fn optionalChainBaseIsArglessNew(self: *const Parser, base: NodeIndex) bool {
             .tagged_template_expression,
             => {
                 // member 의 object / tagged template 의 tag = extra[0].
-                cur = self.ast.readExtraNode(node.data.extra, 0);
-                if (cur.isNone()) return false;
+                const next = self.ast.readExtraNode(node.data.extra, 0);
+                if (next.isNone()) return .none;
+                cur = next;
             },
-            .new_expression => return (self.ast.readExtra(node.data.extra, 3) & ast_mod.CallFlags.had_arguments) == 0,
-            else => return false,
+            .new_expression => {
+                const had_args = (self.ast.readExtra(node.data.extra, 3) & ast_mod.CallFlags.had_arguments) != 0;
+                return if (had_args) .none else cur;
+            },
+            else => return .none,
         }
     }
-    return false;
+    return .none;
 }
 
-fn finishNewExpressionWithArgs(self: *Parser, start: u32, callee: NodeIndex, arg_list: NodeList) !NodeIndex {
+/// new callee 에서 optional chain(`?.`)을 봤으면 new 노드에 남길 flag 비트.
+fn newCalleeOptionalFlag(callee_optional: bool) u32 {
+    return if (callee_optional) ast_mod.CallFlags.callee_optional_chain else 0;
+}
+
+fn finishNewExpressionWithArgs(self: *Parser, start: u32, callee: NodeIndex, arg_list: NodeList, callee_optional: bool) !NodeIndex {
     // had_arguments: 인자 절(괄호)이 있는 new = MemberExpression → trailing optional chain
-    // (`new a()?.b`)의 valid base. 무인자 new 경로는 flags=0 으로 두어 `new new a()?.b`/
-    // `new new a().b?.c` 등을 optionalChainBaseIsArglessNew 가 거부.
+    // (`new a()?.b`)의 valid base. 무인자 new 경로는 had_arguments 를 빼두어 `new new a()?.b`/
+    // `new new a().b?.c` 등을 optionalChainArglessNewHead 가 잡아낸다.
     const ne = try self.ast.addExtras(&.{
-        @intFromEnum(callee), arg_list.start, arg_list.len, ast_mod.CallFlags.had_arguments,
+        @intFromEnum(callee),
+        arg_list.start,
+        arg_list.len,
+        ast_mod.CallFlags.had_arguments | newCalleeOptionalFlag(callee_optional),
     });
     const new_expr = try self.ast.addNode(.{
         .tag = .new_expression,
@@ -1167,7 +1195,12 @@ fn finishNewExpressionWithArgs(self: *Parser, start: u32, callee: NodeIndex, arg
 /// new 표현식의 callee를 파싱한다.
 /// new는 중첩 가능하므로 new를 만나면 재귀한다.
 /// member access (.prop, [expr])만 허용하고 호출 ()은 상위에서 처리.
-fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
+///
+/// `out_callee_optional`: callee 에서 `?.` 를 만나 ZNTC0623 을 보고했으면 true 로 set 한다
+/// (false 로 초기화된 채 넘어온다고 가정하지 않고, set 만 한다 = OR 누적). 중첩 new 재귀에는
+/// **같은 포인터**를 넘겨 `new new a?.b\`x\`?.c` 처럼 안쪽 callee 에서 난 보고가 바깥 new 까지
+/// 전파되게 한다 — trailing `?.` 검사는 체인 head(= 가장 바깥 new)의 flag 만 보기 때문 (#4048).
+fn parseNewCallee(self: *Parser, out_callee_optional: *bool) ParseError2!NodeIndex {
     // ECMAScript: new import(...) / new import.source(...) / new import.defer(...) は금지
     // 단, new import.meta 는 허용 (import.meta는 MemberExpression)
     if (self.current() == .kw_import) {
@@ -1188,15 +1221,16 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .kw_new) {
         const span = self.currentSpan();
         try self.advance(); // skip 'new'
-        const callee = try parseNewCallee(self);
+        // 같은 out 포인터를 넘겨 안쪽 new 의 callee 보고를 바깥까지 전파 (#4048).
+        const callee = try parseNewCallee(self, out_callee_optional);
         _ = trySkipTypeArgsSpeculative(self, true, type_args.canFollowTypeArgumentsInExpression);
         if (self.current() == .l_paren) {
             try self.advance();
             const arg_list = try parseArgumentList(self);
-            return try finishNewExpressionWithArgs(self, span.start, callee, arg_list);
+            return try finishNewExpressionWithArgs(self, span.start, callee, arg_list, out_callee_optional.*);
         }
         const ne_no_args = try self.ast.addExtras(&.{
-            @intFromEnum(callee), 0, 0, 0,
+            @intFromEnum(callee), 0, 0, newCalleeOptionalFlag(out_callee_optional.*),
         });
         return try self.ast.addNode(.{
             .tag = .new_expression,
@@ -1216,7 +1250,8 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
         }
     }
     // new callee 에 optional chain(`a?.b`)이 있으면 SyntaxError — 진단은 callee 당 1회만.
-    var reported_optional_new = false;
+    // 보고 여부는 out 파라미터로 new 노드까지 올려보낸다(로컬 플래그로 끝내면 postfix 루프가
+    // 같은 new 를 모른 채 623 을 또 낸다 — #4048).
     while (true) {
         const expr_start = self.ast.getNode(expr).span.start;
         switch (self.current()) {
@@ -1259,12 +1294,12 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
             .question_dot => {
                 // ECMAScript: new 의 callee(MemberExpression)는 OptionalExpression 일 수 없다
                 // (`new a?.b()` / `new a.b?.c()` = SyntaxError). 진단은 callee 당 1회만 내고
-                // (`reported_optional_new`), `?.`와 뒤따르는 멤버를 일반 멤버처럼 소비해 postfix
+                // (`out_callee_optional`), `?.`와 뒤따르는 멤버를 일반 멤버처럼 소비해 postfix
                 // 루프가 `(new ...)?.x` 로 잘못 재해석하는 것을 막는다. paren 으로 감싼
                 // `new (a?.b)()` 는 `?.`가 paren 내부라 이 루프에 도달하지 않아 유효 통과.
-                if (!reported_optional_new) {
+                if (!out_callee_optional.*) {
                     try self.addErrorCode(self.currentSpan(), "Invalid optional chain in 'new' expression", .optional_chain_new);
-                    reported_optional_new = true;
+                    out_callee_optional.* = true;
                 }
                 try self.advance(); // consume `?.`
                 if (self.current() == .l_bracket) {
@@ -1452,7 +1487,9 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             }
 
             // callee: 재귀적으로 new 또는 primary + member chain
-            const callee = try parseNewCallee(self);
+            // callee 에 `?.` 가 있어 623 을 보고했으면 그 사실을 new 노드 flag 로 보존한다 (#4048).
+            var callee_optional = false;
+            const callee = try parseNewCallee(self, &callee_optional);
 
             // TS/Flow: new X<T>() — type argument를 speculatively 파싱하여 skip
             _ = trySkipTypeArgsSpeculative(self, true, type_args.canFollowTypeArgumentsInExpression);
@@ -1461,12 +1498,12 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             if (self.current() == .l_paren) {
                 try self.advance(); // skip (
                 const arg_list = try parseArgumentList(self);
-                return try finishNewExpressionWithArgs(self, span.start, callee, arg_list);
+                return try finishNewExpressionWithArgs(self, span.start, callee, arg_list, callee_optional);
             }
 
             // 인자 없는 new: new Foo
             const ne2_no = try self.ast.addExtras(&.{
-                @intFromEnum(callee), 0, 0, 0,
+                @intFromEnum(callee), 0, 0, newCalleeOptionalFlag(callee_optional),
             });
             return try self.ast.addNode(.{
                 .tag = .new_expression,

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2199,10 +2199,13 @@ test "new + optional chain: 진단은 callee 당 정확히 1개 (중복/cascade 
     try expectSingleParseError("new new a().b?.c", "Invalid optional chain in 'new' expression");
 }
 
-/// 소스를 파싱하고 `message` 와 일치하는 에러가 정확히 `expected` 개인지 검증한다.
-/// 다른 진단이 함께 나야 하는 케이스(#4048: 623 + 607)에서 특정 진단의 중복만 가드할 때 사용 —
-/// 전체 개수를 세는 expectSingleParseError 로는 표현할 수 없다.
-fn expectParseErrorCount(source: []const u8, message: []const u8, expected: usize) !void {
+/// 소스를 파싱하고 `message` 와 일치하는 에러가 정확히 `expected` 개, **그리고 전체 진단이
+/// `total` 개**인지 검증한다. 다른 진단이 함께 나야 하는 케이스(#4048: 623 + 607)에서 특정
+/// 진단의 중복만 가드할 때 사용 — 전체 개수를 세는 expectSingleParseError 로는 표현할 수 없다.
+///
+/// `total` 도 함께 못 박는 이유: 메시지별 개수만 보면 2차 cascade 노이즈("Identifier expected"
+/// 류)가 새로 붙어도 테스트가 green 이라, "한 SyntaxError 로 끝난다" 는 규약이 조용히 깨진다.
+fn expectParseErrorCount(source: []const u8, message: []const u8, expected: usize, total: usize) !void {
     var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
     var parser = Parser.init(std.testing.allocator, &scanner);
@@ -2213,7 +2216,12 @@ fn expectParseErrorCount(source: []const u8, message: []const u8, expected: usiz
     for (parser.errors.items) |err| {
         if (std.mem.eql(u8, err.message, message)) count += 1;
     }
+    if (expected != count or total != parser.errors.items.len) {
+        std.debug.print("\n[{s}] 진단:\n", .{source});
+        for (parser.errors.items) |err| std.debug.print("  - {s}\n", .{err.message});
+    }
     try std.testing.expectEqual(expected, count);
+    try std.testing.expectEqual(total, parser.errors.items.len);
 }
 
 test "new + optional chain: callee 보고 + trailing `?.` 가 겹쳐도 623 은 1개 (#4048)" {
@@ -2223,10 +2231,13 @@ test "new + optional chain: callee 보고 + trailing `?.` 가 겹쳐도 623 은 
     // new 노드의 callee_optional_chain 비트로 "이미 보고함" 을 전파해 1개로 수렴.
     try expectSingleParseError("new a?.b`x`?.c", msg);
     try expectSingleParseError("new a?.b.c`x`?.d", msg);
-    // 중첩 new: 안쪽 callee 에서 난 보고가 바깥 new(체인 head)까지 전파돼야 한다.
-    try expectSingleParseError("new new a?.b`x`?.c", msg);
-    // 인자 있는 안쪽 new 를 거쳐도 전파(바깥 argless new 가 head).
-    try expectSingleParseError("new new a?.b()`x`?.c", msg);
+    // 중첩 new 는 **서로 다른 new 의 서로 다른 위반**이다 — 각각 1건씩 나야 한다.
+    // (안쪽 callee 의 `?.` / 바깥 argless new 뒤 trailing `?.`)
+    // 안쪽 보고를 바깥까지 전파하면 바깥의 별개 위반이 조용히 사라진다. 괄호 형태
+    // `new (new a?.b)`x`?.c` 가 2건을 내는 것과도 어긋난다.
+    try expectParseErrorCount("new new a?.b`x`?.c", msg, 2, 2);
+    try expectParseErrorCount("new new a?.b()`x`?.c", msg, 2, 2);
+    try expectParseErrorCount("new (new a?.b)`x`?.c", msg, 2, 2);
     // 회귀 가드: 원래도 1개였던 인접 형태들이 그대로 1개인지.
     try expectSingleParseError("new a?.b()", msg);
     try expectSingleParseError("new a?.b`x`", msg);
@@ -2240,15 +2251,14 @@ test "new + optional chain: 623 dedup 이 다른 진단/다른 new 를 삼키지
     // dedup 은 623 을 *같은 new* 안에서만 접는다. 서로 다른 new 두 개면 각자 위반이므로 2개:
     //   ① 안쪽 `new a?.b` = callee optional chain,
     //   ② 바깥 argless new = trailing `?.c` 의 invalid base.
-    // (paren 이 체인을 끊어 안쪽 보고가 바깥으로 전파되지 않는다.)
-    try expectParseErrorCount("new (new a?.b)`x`?.c", msg623, 2);
+    try expectParseErrorCount("new (new a?.b)`x`?.c", msg623, 2, 2);
     // 623 을 접어도 *다른 코드*의 진단(607)은 그대로 살아 있어야 한다.
     // `?.c` 뒤의 `` `y` `` 는 optional chain 위 tagged template → 607.
-    try expectParseErrorCount("new a?.b`x`?.c`y`?.d", msg623, 1);
-    try expectParseErrorCount("new a?.b`x`?.c`y`?.d", msg607, 1);
+    try expectParseErrorCount("new a?.b`x`?.c`y`?.d", msg623, 1, 2);
+    try expectParseErrorCount("new a?.b`x`?.c`y`?.d", msg607, 1, 2);
     // new 없는 순수 optional chain 은 623 과 무관 — 607 만 단독으로.
     try expectSingleParseError("a?.b`x`?.c", msg607);
-    try expectParseErrorCount("a?.b`x`?.c", msg623, 0);
+    try expectParseErrorCount("a?.b`x`?.c", msg623, 0, 1);
 }
 
 test "new + optional chain: 유효 형태는 통과" {

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2199,6 +2199,58 @@ test "new + optional chain: 진단은 callee 당 정확히 1개 (중복/cascade 
     try expectSingleParseError("new new a().b?.c", "Invalid optional chain in 'new' expression");
 }
 
+/// 소스를 파싱하고 `message` 와 일치하는 에러가 정확히 `expected` 개인지 검증한다.
+/// 다른 진단이 함께 나야 하는 케이스(#4048: 623 + 607)에서 특정 진단의 중복만 가드할 때 사용 —
+/// 전체 개수를 세는 expectSingleParseError 로는 표현할 수 없다.
+fn expectParseErrorCount(source: []const u8, message: []const u8, expected: usize) !void {
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    var count: usize = 0;
+    for (parser.errors.items) |err| {
+        if (std.mem.eql(u8, err.message, message)) count += 1;
+    }
+    try std.testing.expectEqual(expected, count);
+}
+
+test "new + optional chain: callee 보고 + trailing `?.` 가 겹쳐도 623 은 1개 (#4048)" {
+    const msg = "Invalid optional chain in 'new' expression";
+    // #4048 재현 케이스. callee 의 `?.`(parseNewCallee 보고)와 tagged template 뒤 trailing
+    // `?.`(postfix 루프의 argless-new head 검사)가 *같은 new* 를 각각 보고해 623 이 2번 나왔다.
+    // new 노드의 callee_optional_chain 비트로 "이미 보고함" 을 전파해 1개로 수렴.
+    try expectSingleParseError("new a?.b`x`?.c", msg);
+    try expectSingleParseError("new a?.b.c`x`?.d", msg);
+    // 중첩 new: 안쪽 callee 에서 난 보고가 바깥 new(체인 head)까지 전파돼야 한다.
+    try expectSingleParseError("new new a?.b`x`?.c", msg);
+    // 인자 있는 안쪽 new 를 거쳐도 전파(바깥 argless new 가 head).
+    try expectSingleParseError("new new a?.b()`x`?.c", msg);
+    // 회귀 가드: 원래도 1개였던 인접 형태들이 그대로 1개인지.
+    try expectSingleParseError("new a?.b()", msg);
+    try expectSingleParseError("new a?.b`x`", msg);
+    try expectSingleParseError("new a`x`?.b", msg);
+    try expectSingleParseError("new a?.b?.c", msg);
+}
+
+test "new + optional chain: 623 dedup 이 다른 진단/다른 new 를 삼키지 않는다 (#4048)" {
+    const msg623 = "Invalid optional chain in 'new' expression";
+    const msg607 = "Tagged template cannot be used in optional chain";
+    // dedup 은 623 을 *같은 new* 안에서만 접는다. 서로 다른 new 두 개면 각자 위반이므로 2개:
+    //   ① 안쪽 `new a?.b` = callee optional chain,
+    //   ② 바깥 argless new = trailing `?.c` 의 invalid base.
+    // (paren 이 체인을 끊어 안쪽 보고가 바깥으로 전파되지 않는다.)
+    try expectParseErrorCount("new (new a?.b)`x`?.c", msg623, 2);
+    // 623 을 접어도 *다른 코드*의 진단(607)은 그대로 살아 있어야 한다.
+    // `?.c` 뒤의 `` `y` `` 는 optional chain 위 tagged template → 607.
+    try expectParseErrorCount("new a?.b`x`?.c`y`?.d", msg623, 1);
+    try expectParseErrorCount("new a?.b`x`?.c`y`?.d", msg607, 1);
+    // new 없는 순수 optional chain 은 623 과 무관 — 607 만 단독으로.
+    try expectSingleParseError("a?.b`x`?.c", msg607);
+    try expectParseErrorCount("a?.b`x`?.c", msg623, 0);
+}
+
 test "new + optional chain: 유효 형태는 통과" {
     // paren 으로 감싼 optional chain 은 new 의 피연산자로 유효.
     try expectNoParseError("new (a?.b)()");


### PR DESCRIPTION
## 문제

```js
new a?.b`x`?.c    // ZNTC0623 × 2  (기대: × 1)
```

동작은 정상(입력은 여전히 SyntaxError)이고 **진단만 중복**됩니다.

## 원인 — 복구 경로가 사실을 지워버림

파서에 623 을 내는 지점이 둘입니다.
1. `parseNewCallee` — callee 의 `?.` 를 잡음
2. postfix 루프 — argless new 를 base 로 하는 trailing `?.` 를 잡음

각자 **자기 함수의 로컬 플래그**로만 중복을 막고 있어서, 두 지점이 *같은 new* 를 보고하는 위 조합에서 서로를 모른 채 2번 발행했습니다.

근본 원인은 **복구 경로가 사실을 지운 것**입니다 — `parseNewCallee` 는 복구를 위해 callee 의 `?.` 를 **비-optional 멤버로 소비**해버려, AST 구조만 봐서는 "이 new 의 callee 에 optional 이 있었다" 를 알 수 없습니다.

## 처방 — dedup 필터가 아니라 사실 복원

`CallFlags.callee_optional_chain` 비트로 그 잃어버린 사실을 `new` 노드에 남기고, postfix 루프가 **이미 보고된 같은 new** 면 재보고하지 않게 했습니다.

## code-review max 가 잡은 회귀 (2번째 커밋)

첫 구현이 중첩 new 재귀에 플래그 포인터를 **공유**해서, 안쪽 new 의 보고가 **바깥 new** 를 "이미 보고됨" 으로 표시 → 바깥 new 자신의 **별개 위반**이 조용히 사라졌습니다.

```
new new a?.b()?.c     main: 623 × 2  →  첫 구현: × 1   (하나 유실)
new (new a?.b)`x`?.c  괄호가 체인을 끊어 그대로 × 2    (같은 위반인데 철자에 따라 갈림)
```

두 new 는 **서로 다른 위반**입니다. 안쪽 전용 플래그로 받아 각자 보고하게 고쳤고, 잘못된 동작을 박제하던 테스트도 정정했습니다.

함께 반영: `expectParseErrorCount` 가 메시지별 개수만 세어 2차 cascade 노이즈가 붙어도 green 이던 것 → **전체 진단 수**도 고정. argless `new` 노드 생성 복붙 2곳 → `finishNewExpressionNoArgs` 단일화 (새 플래그를 한쪽에만 넣으면 조용히 유실되는 구조였음). changeset 의 백틱 escape 가 CommonMark 에서 안 먹혀 CHANGELOG 가 깨지던 것도 수정.

## 억제되지 않는 것 (테스트로 고정)

- 서로 다른 new 두 개 → 각자 623 (`new (new a?.b)`x`?.c` = 2건)
- 다른 진단 → 그대로 (`ZNTC0607` tagged template on optional chain)
- `new` 없는 순수 optional chain → 623 은 0건

## 범위 밖 (별도 이슈 #4500)

리뷰가 실증한 **기존 silent miscompile 3건** — 중첩 new 뒤의 member 체인/tagged template 이 바깥 callee 로 흡수되지 않아 `new new Inner().C()` 가 `new new Inner()().C()` 로 방출되는 것 등. 이 diff 와 무관한 pre-existing 결함입니다.

Closes #4048

🤖 Generated with [Claude Code](https://claude.com/claude-code)