### PR TITLE
fix(parser): #4500 중첩 new 의 member 체인 / callee tagged template 이 new 밖으로 새던 silent miscompile

### DIFF
--- a/.changeset/new-callee-member-chain.md
+++ b/.changeset/new-callee-member-chain.md
@@ -1,0 +1,22 @@
+---
+"@zntc/core": patch
+---
+
+`new` callee 파싱이 member 체인 / tagged template 을 흡수하지 못해 **진단 없이 잘못된 코드를 방출**하던 버그 3건 수정 (#4500).
+
+```js
+new new Inner().C()   // 방출: new new Inner()().C()  → TypeError: (intermediate value) is not a constructor
+new tag`x`.B()        // 방출: new tag()`x`.B()       → TypeError: (intermediate value) is not a function
+```
+
+ECMAScript 는 `MemberExpression: new MemberExpression Arguments` 이므로 중첩 `new` 뒤의 `.C`/`[k]` 와 callee 안의 `` `tpl` `` 은 **바깥 new 의 callee** 에 속한다(`new (new Inner().C)()`). 그런데 `parseNewCallee` 가 중첩 new 를 만들고 **즉시 return** 해서 뒤의 member 체인 루프에 도달하지 못했고, 그 루프엔 tagged template arm 자체가 없었다. 그 결과 체인이 바깥 new *밖*으로 새어나가고, argless 로 끝난 바깥 new 에 codegen 이 `()` 를 다시 붙여 원본과 다른 프로그램이 됐다.
+
+파이프라인 **idempotency** 도 함께 깨져 있었다 — zntc 가 `new (new A().b)()` 를 `new new A().b()` 로 방출하고, 그 출력을 zntc 가 다시 읽으면 `new new A()()` + `.b()` 로 잘못 재해석했다(2-pass/번들 시 위험).
+
+세 번째로, TS 타입 래퍼가 argless-new head 를 가려 SyntaxError 를 놓치던 accept-invalid 도 고쳤다 — `new a\`x\`!?.b` 는 타입 소거 후 `new a\`x\`?.b` 와 같은 SyntaxError 인데 `!`/`as T`/`<T>x` 래퍼를 walk 가 안 넘어가 exit 0 으로 수용했다(ZNTC0623 정상 발생). Flow 의 `(x: T)` cast 는 **괄호 자체**라 통과시키면 안 된다(유효한 `(new a: any)?.b` 오거부) — `isParenFreeTypeWrapper` 로 분리했다.
+
+"tagged template 이 new 의 callee" 라는 AST 모양이 처음 생기면서 그 모양을 못 다루던 하류 3곳도 함께 고쳤다:
+
+- **codegen**: callee 안의 call 에 괄호를 안 붙여 `` new (f())`x` `` → `` new f()`x`() `` (f 가 *생성*되고 template 결과가 *호출*됨). member 의 object 처럼 tagged template 의 tag 에도 `forbid_call` 을 전파.
+- **es5/es2015 다운레벨**: `lowerSpreadNew` 가 callee 를 identifier 로 가정해 `new a.b(...args)` 가 **컴파일러 crash** 였다(기존 버그). temp 캡처로 callee 를 1회만 평가하도록 수정 — `new ((_a = a.b).bind.apply(_a, ...))()` (tsc 동형).
+- **minify**: `` (0, o.tag)`x` `` 의 sequence 를 풀어 tag 가 `this=o` 로 호출되던 것 방지.

--- a/src/codegen/calls.zig
+++ b/src/codegen/calls.zig
@@ -419,6 +419,9 @@ fn newCalleeNeedsRenameParens(self: anytype, idx: NodeIndex) bool {
             .static_member_expression, .computed_member_expression, .private_field_expression => {
                 cur = self.ast.readExtraNode(n.data.extra, 0);
             },
+            // tagged template 도 callee 체인의 일부다(`` new tag`x`.B() `` 의 callee = `` tag`x`.B ``,
+            // #4500) — tag 가 rename→call 이면 똑같이 괄호가 필요하다. tag = extra[0].
+            .tagged_template_expression => cur = self.ast.readExtraNode(n.data.extra, 0),
             // paren 은 투명(codegen 이 괄호 미출력) — 안쪽으로 따라가 rename leaf 검사.
             .parenthesized_expression => cur = n.data.unary.operand,
             else => return false,

--- a/src/codegen/codegen_test.zig
+++ b/src/codegen/codegen_test.zig
@@ -11,6 +11,7 @@
 //   engine_jsx.zig         — 엔진 타겟 + JSX 런타임 모드
 //   private_jsx_advanced.zig — private method, JSX text/dev/auto, ES2025
 //   function_map.zig       — Metro x_facebook_sources function map E2E 테스트
+//   new_callee_chain.zig   — new callee 의 member/tagged-template 체인 방출 + idempotency (#4500)
 
 comptime {
     _ = @import("codegen_test/helpers.zig");
@@ -28,4 +29,5 @@ comptime {
     _ = @import("codegen_test/import_attributes.zig");
     _ = @import("codegen_test/class_expr_anonymize.zig");
     _ = @import("codegen_test/load_bearing_paren.zig");
+    _ = @import("codegen_test/new_callee_chain.zig");
 }

--- a/src/codegen/codegen_test/new_callee_chain.zig
+++ b/src/codegen/codegen_test/new_callee_chain.zig
@@ -1,0 +1,71 @@
+//! new callee 체인 방출 회귀 (#4500) — 중첩 new 뒤의 member/subscript 체인과
+//! tagged template 이 **바깥 new 의 callee** 로 흡수되는지(ECMAScript
+//! `MemberExpression: new MemberExpression Arguments`) 문자열 수준으로 박제한다.
+//!
+//! 예전 방출(전부 silent miscompile):
+//!   `new new Inner().C()` → `new new Inner()().C()`  (TypeError: not a constructor)
+//!   `new tag`x`.B()`      → `new tag()`x`.B()`       (TypeError: not a function)
+//!
+//! 런타임 의미(node 실행)는 tests/integration/tests/new-callee-chain.test.ts 가 본다.
+//! 여기서는 방출 문자열 + **idempotency**(방출물을 다시 파싱·방출해도 동일)를 가드한다 —
+//! 파이프라인이 2-pass/번들에서 자기 출력을 다시 읽어도 의미가 안 바뀌어야 한다.
+
+const std = @import("std");
+const helpers = @import("helpers.zig");
+const e2e = helpers.e2e;
+
+/// source 를 방출하고 기대 문자열과 비교한 뒤, **방출물을 다시 e2e** 해 같은 문자열이
+/// 나오는지(idempotent) 확인한다.
+fn expectEmitAndIdempotent(source: []const u8, expected: []const u8) !void {
+    var r1 = try e2e(std.testing.allocator, source);
+    defer r1.deinit();
+    try std.testing.expectEqualStrings(expected, std.mem.trim(u8, r1.output, " \n\t"));
+
+    var r2 = try e2e(std.testing.allocator, r1.output);
+    defer r2.deinit();
+    try std.testing.expectEqualStrings(expected, std.mem.trim(u8, r2.output, " \n\t"));
+}
+
+test "new callee: 중첩 new 뒤 member 체인 (#4500)" {
+    // callee = `new Inner().C`, Arguments = `()`.
+    try expectEmitAndIdempotent("const x = new new Inner().C();", "const x=new new Inner().C();");
+    // subscript 도 동일.
+    try expectEmitAndIdempotent("const z = new new Inner()[k]();", "const z=new new Inner()[k]();");
+    // 인자 없는 바깥 new — codegen 은 argless new 에 `()` 를 붙이지만(의미 동일),
+    // callee 는 `new A().b` 로 유지돼야 한다(`new new A()().b` 가 아니라).
+    try expectEmitAndIdempotent("const y = new new A().b;", "const y=new new A().b();");
+}
+
+test "new callee: tagged template (#4500)" {
+    // callee = `` tag`x`.B ``.
+    try expectEmitAndIdempotent("const x = new tag`x`.B();", "const x=new tag`x`.B();");
+    // callee 가 tagged template 자체인 argless new.
+    try expectEmitAndIdempotent("const t = new tag`x`;", "const t=new tag`x`();");
+}
+
+test "new callee: 기존 정상 형태 회귀 가드 (#4500)" {
+    // 인자 *있는* new 뒤의 template 은 callee 가 아니라 new 결과를 태그한다.
+    try expectEmitAndIdempotent("const a = new f()`x`;", "const a=new f()`x`;");
+    try expectEmitAndIdempotent("const b = new new a()();", "const b=new new a()();");
+    try expectEmitAndIdempotent("const c = new a.b();", "const c=new a.b();");
+    try expectEmitAndIdempotent("const d = new a();", "const d=new a();");
+}
+
+test "new callee: tag 안의 call 은 괄호 보존 (#4500)" {
+    // new 의 callee 안에 있는 call 은 괄호로 감싸야 한다 — `` new f()`x`() `` 로 방출하면
+    // `f` 가 *생성*되고 template 결과가 *호출*되는 다른 프로그램이 된다. member 의 object 처럼
+    // tagged template 의 tag 에도 forbid_call 을 전파해야 나오는 괄호다.
+    try expectEmitAndIdempotent("const x = new (f())`x`;", "const x=new (f())`x`();");
+    try expectEmitAndIdempotent("const x = new (f())`x`.B();", "const x=new (f())`x`.B();");
+    try expectEmitAndIdempotent("const x = new (f().g)`x`.B();", "const x=new (f()).g`x`.B();");
+    // new 밖(일반 tagged template)에선 tag 의 call 에 괄호가 붙으면 안 된다(회귀 가드).
+    try expectEmitAndIdempotent("const x = f()`x`;", "const x=f()`x`;");
+    try expectEmitAndIdempotent("const x = f().g`x`;", "const x=f().g`x`;");
+}
+
+test "new callee: 명시 괄호 형태의 round-trip (#4500)" {
+    // 소스가 `new (new A().b)()` 여도 방출은 `new new A().b()` — 이걸 zntc 가 다시 파싱했을 때
+    // 같은 의미(callee = `new A().b`)로 읽혀야 파이프라인이 idempotent 하다.
+    try expectEmitAndIdempotent("const x = new (new A().b)();", "const x=new new A().b();");
+    try expectEmitAndIdempotent("const y = new (tag`x`.B)();", "const y=new tag`x`.B();");
+}

--- a/src/codegen/function_class.zig
+++ b/src/codegen/function_class.zig
@@ -7,6 +7,7 @@ const NodeIndex = ast_mod.NodeIndex;
 const debug_metadata = @import("debug_metadata.zig");
 const statement_emit = @import("statements.zig");
 const call_emit = @import("calls.zig");
+const ExprFlags = @import("precedence.zig").ExprFlags;
 
 fn emitNestedExecutionBody(self: anytype, body: NodeIndex) !void {
     const saved_for_init = self.in_for_init;
@@ -64,7 +65,7 @@ pub fn emitTemplateLiteral(self: anytype, node: Node) !void {
     }
 }
 
-pub fn emitTaggedTemplate(self: anytype, node: Node) !void {
+pub fn emitTaggedTemplate(self: anytype, node: Node, flags: ExprFlags) !void {
     try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const extras = self.ast.extra_data.items;
@@ -74,8 +75,8 @@ pub fn emitTaggedTemplate(self: anytype, node: Node) !void {
     // 호출을 dead-code elimination 가능 (styled-components `pure` 옵션 등).
     if (e + 2 < extras.len) {
         const TaggedTemplateFlags = ast_mod.TaggedTemplateFlags;
-        const flags = extras[e + 2];
-        const is_pure = (flags & TaggedTemplateFlags.is_pure) != 0;
+        const tt_flags = extras[e + 2];
+        const is_pure = (tt_flags & TaggedTemplateFlags.is_pure) != 0;
         if (is_pure and !self.options.minify_whitespace) try self.write("/* @__PURE__ */ ");
     }
     // tag 는 .postfix (esbuild ETemplate tag = LPostfix). 단 tag 가 optional chain 이면
@@ -87,7 +88,11 @@ pub fn emitTaggedTemplate(self: anytype, node: Node) !void {
         try self.emitExpr(tag, .lowest, .{});
         try self.writeByte(')');
     } else {
-        try self.emitExpr(tag, .postfix, .{});
+        // forbid_call 은 tag 로 전파한다(member 의 object 와 동일 — expressions.emitStaticMember).
+        // 이 tagged template 이 new 의 callee 인데(`` new (f())`x` ``) tag 안의 call 을 괄호로
+        // 안 감싸면 `` new f()`x`() `` 로 방출돼, 재파싱 시 `f` 가 *생성*되고 template 결과가
+        // *호출*되는 다른 프로그램이 된다(#4500).
+        try self.emitExpr(tag, .postfix, .{ .forbid_call = flags.forbid_call });
     }
     try self.emitNode(@enumFromInt(extras[e + 1]));
 }

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -315,7 +315,7 @@ pub fn emitExpr(self: anytype, idx: NodeIndex, level: Level, flags: ExprFlags) E
             try self.addSourceMapping(node.span);
             try self.writeNodeSpan(node);
         },
-        .tagged_template_expression => try function_class_emit.emitTaggedTemplate(self, node),
+        .tagged_template_expression => try function_class_emit.emitTaggedTemplate(self, node, flags),
         .import_expression => try call_emit.emitImportExpr(self, node, level, flags),
         .meta_property => try call_emit.emitMetaProperty(self, node),
         // chain_expression: optional-chain wrapper — operand 가 자기 매핑 발행.

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -484,6 +484,15 @@ pub const Node = struct {
         /// noop — 타입 스트립 후 operand 만 남는다. 새 wrapper 태그 추가 시
         /// 이 함수만 갱신하면 코드베이스 전 분기가 따라온다 (#3129).
         pub fn isTransparentTypeWrapper(tag: Tag) bool {
+            return isParenFreeTypeWrapper(tag) or tag == .flow_type_cast_expression;
+        }
+
+        /// transparent type wrapper 중 **소스에 괄호가 없는** 것만 (`x as T`/`x satisfies T`/
+        /// `x!`/`<T>x`/`x<T>`/Flow `x as T`). Flow 의 `flow_type_cast_expression`(`(x: T)`)은
+        /// **괄호 자체**라 제외된다 — 괄호는 문법상 경계를 만들기 때문에(OptionalChain 의 base 를
+        /// PrimaryExpression 으로 만들어 체인을 끊는다: `(new a: any)?.b` 는 유효) 괄호를
+        /// 투명하게 통과하면 안 되는 **구문 검사**에서 이 술어를 써야 한다 (#4500).
+        pub fn isParenFreeTypeWrapper(tag: Tag) bool {
             return switch (tag) {
                 .ts_as_expression,
                 .ts_satisfies_expression,
@@ -491,7 +500,6 @@ pub const Node = struct {
                 .ts_type_assertion,
                 .ts_instantiation_expression,
                 .flow_as_expression,
-                .flow_type_cast_expression,
                 => true,
                 else => false,
             };

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1006,28 +1006,7 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                     reported_optional_template = true;
                 }
                 // tagged template: expr`text` 또는 expr`text${...}...`
-                // tagged template에서는 잘못된 이스케이프 허용 (cooked가 undefined)
-                const tmpl = if (self.current() == .template_head)
-                    try parseTemplateLiteral(self, true)
-                else blk: {
-                    const tmpl_span = self.currentSpan();
-                    try self.advance();
-                    // no-substitution template — text 는 span 에서 직접 읽으므로
-                    // 자식 리스트는 비어 있다. layout=.list 에 맞춰 빈 NodeList 저장.
-                    break :blk try self.ast.addListNode(
-                        .template_literal,
-                        tmpl_span,
-                        .{ .start = 0, .len = 0 },
-                    );
-                };
-                {
-                    const te = try self.ast.addExtras(&.{ @intFromEnum(expr), @intFromEnum(tmpl), 0 });
-                    expr = try self.ast.addNode(.{
-                        .tag = .tagged_template_expression,
-                        .span = .{ .start = expr_start, .end = self.currentSpan().start },
-                        .data = .{ .extra = te },
-                    });
-                }
+                expr = try finishTaggedTemplate(self, expr, expr_start);
             },
             .l_angle, .shift_left => {
                 // TS generic type arguments: foo<Type>() or foo<<T>() => T>()
@@ -1140,11 +1119,24 @@ fn followedByParenOnly(self: *const Parser) bool {
 /// 도 이 walk 의 첫 step 에서 잡힌다. depth 가드로 무한루프 방지(정상 AST 는 짧다).
 /// 노드를 돌려주는 이유: 호출부가 head new 의 `callee_optional_chain` 비트를 보고 "이미
 /// parseNewCallee 가 같은 new 로 623 을 보고했는지" 판단해야 하기 때문 (#4048).
+///
+/// **괄호 없는** TS/Flow 타입 래퍼(`!`/`as T`/`satisfies T`/`<T>x`/`x<T>`)는 투명하게
+/// 통과한다 — 타입 소거 후 남는 JS 형태가 같기 때문(`new a\`x\`!?.b` 는 `new a\`x\`?.b` 와
+/// 동일하게 SyntaxError). 통과하지 않으면 head 를 못 찾아 진단을 놓쳤다(#4500).
+/// 반대로 **괄호는 통과하지 않는다** — `(new a)?.b` 는 base 가 PrimaryExpression 이라 유효.
+/// Flow 의 `(x: T)` cast(`flow_type_cast_expression`)는 괄호 그 자체라 `isTransparentTypeWrapper`
+/// 가 아니라 `isParenFreeTypeWrapper` 를 써야 한다 — 안 그러면 유효한 `(new a: any)?.b` 를
+/// 오거부한다.
 fn optionalChainArglessNewHead(self: *const Parser, base: NodeIndex) NodeIndex {
     var cur = base;
     var guard: u32 = 0;
     while (guard < 100_000) : (guard += 1) {
+        if (cur.isNone() or @intFromEnum(cur) >= self.ast.nodes.items.len) return .none;
         const node = self.ast.getNode(cur);
+        if (ast_mod.Node.Tag.isParenFreeTypeWrapper(node.tag)) {
+            cur = node.data.unary.operand;
+            continue;
+        }
         switch (node.tag) {
             .static_member_expression,
             .computed_member_expression,
@@ -1152,9 +1144,8 @@ fn optionalChainArglessNewHead(self: *const Parser, base: NodeIndex) NodeIndex {
             .tagged_template_expression,
             => {
                 // member 의 object / tagged template 의 tag = extra[0].
-                const next = self.ast.readExtraNode(node.data.extra, 0);
-                if (next.isNone()) return .none;
-                cur = next;
+                // `.none`/범위 밖은 루프 선두 가드가 잡는다(#4500).
+                cur = self.ast.readExtraNode(node.data.extra, 0);
             },
             .new_expression => {
                 const had_args = (self.ast.readExtra(node.data.extra, 3) & ast_mod.CallFlags.had_arguments) != 0;
@@ -1192,8 +1183,12 @@ fn finishNewExpressionWithArgs(self: *Parser, start: u32, callee: NodeIndex, arg
     return new_expr;
 }
 
-/// 인자 없는 `new` 노드 생성 — extras 레이아웃을 `finishNewExpressionWithArgs` 와 **단일 소스**로
-/// 유지한다. 예전엔 두 곳에 복붙돼 있어, 새 플래그를 한쪽에만 넣으면 조용히 유실됐다 (#4048).
+/// 인자 절(괄호)이 없는 new (`new a`, `new new a()` 의 바깥 new = NewExpression).
+/// had_arguments unset → `optionalChainArglessNewHead` 가 이 비트로 trailing
+/// `?.`(`new new a()?.b`)를 거부한다.
+///
+/// extras 레이아웃을 `finishNewExpressionWithArgs` 와 **단일 소스**로 유지한다. 예전엔 두 곳에
+/// 복붙돼 있어, 새 플래그를 한쪽에만 넣으면 조용히 유실됐다 (#4048).
 fn finishNewExpressionNoArgs(
     self: *Parser,
     start: u32,
@@ -1210,14 +1205,46 @@ fn finishNewExpressionNoArgs(
     });
 }
 
+/// `tag_expr` 뒤의 template literal 을 소비해 tagged template 노드를 만든다
+/// (ECMAScript `MemberExpression: MemberExpression TemplateLiteral`).
+/// postfix 루프와 new callee 루프(parseNewCallee)의 공용 구현 — 두 곳의 tagged template
+/// 생성이 갈라지면 `new tag\`x\`.B()` 같은 형태가 한쪽에서만 붙는다(#4500).
+fn finishTaggedTemplate(self: *Parser, tag_expr: NodeIndex, start: u32) !NodeIndex {
+    // tagged template 에서는 잘못된 이스케이프 허용 (cooked 가 undefined)
+    const tmpl = if (self.current() == .template_head)
+        try parseTemplateLiteral(self, true)
+    else blk: {
+        const tmpl_span = self.currentSpan();
+        try self.advance();
+        // no-substitution template — text 는 span 에서 직접 읽으므로
+        // 자식 리스트는 비어 있다. layout=.list 에 맞춰 빈 NodeList 저장.
+        break :blk try self.ast.addListNode(
+            .template_literal,
+            tmpl_span,
+            .{ .start = 0, .len = 0 },
+        );
+    };
+    const te = try self.ast.addExtras(&.{ @intFromEnum(tag_expr), @intFromEnum(tmpl), 0 });
+    return try self.ast.addNode(.{
+        .tag = .tagged_template_expression,
+        .span = .{ .start = start, .end = self.currentSpan().start },
+        .data = .{ .extra = te },
+    });
+}
+
 /// new 표현식의 callee를 파싱한다.
-/// new는 중첩 가능하므로 new를 만나면 재귀한다.
-/// member access (.prop, [expr])만 허용하고 호출 ()은 상위에서 처리.
+/// member access (.prop, [expr], `tpl`)만 허용하고 호출 ()은 상위에서 처리.
 ///
-/// `out_callee_optional`: callee 에서 `?.` 를 만나 ZNTC0623 을 보고했으면 true 로 set 한다
-/// (false 로 초기화된 채 넘어온다고 가정하지 않고, set 만 한다 = OR 누적). 중첩 new 재귀에는
-/// **같은 포인터**를 넘겨 `new new a?.b\`x\`?.c` 처럼 안쪽 callee 에서 난 보고가 바깥 new 까지
-/// 전파되게 한다 — trailing `?.` 검사는 체인 head(= 가장 바깥 new)의 flag 만 보기 때문 (#4048).
+/// 중첩 new(`new new a()`)는 **여기서 재귀하지 않는다** — 아래 `parsePrimaryExpression` 의
+/// `kw_new` 분기가 만들고, 그 결과를 member 루프로 흘린다 (#4500).
+///
+/// `out_callee_optional`: **이 callee** 에서 `?.` 를 만나 ZNTC0623 을 보고했으면 true 로 set
+/// 한다(set 만 한다 = OR 누적). 호출부는 이 값을 new 노드의 `callee_optional_chain` 비트로
+/// 남겨, postfix 루프가 *같은 new* 를 trailing `?.` 로 재보고하지 않게 한다 (#4048).
+///
+/// 중첩 new 는 각자의 플래그를 갖는다 — 안쪽 new 는 `parsePrimaryExpression` 이 자기 지역
+/// 변수로 받아 자기 노드에 찍는다. 즉 안쪽 보고가 바깥 new 로 전파되지 않아, 바깥 new 의
+/// 별개 위반이 조용히 사라지는 일이 없다(#4048 리뷰 요구사항이 구조적으로 성립).
 fn parseNewCallee(self: *Parser, out_callee_optional: *bool) ParseError2!NodeIndex {
     // ECMAScript: new import(...) / new import.source(...) / new import.defer(...) は금지
     // 단, new import.meta 는 허용 (import.meta는 MemberExpression)
@@ -1236,26 +1263,18 @@ fn parseNewCallee(self: *Parser, out_callee_optional: *bool) ParseError2!NodeInd
         // import. → parsePrimaryExpression에서 처리
         // 결과를 확인하여 import.source/defer면 에러
     }
-    if (self.current() == .kw_new) {
-        const span = self.currentSpan();
-        try self.advance(); // skip 'new'
-        // **안쪽 new 전용 플래그**로 받는다 (#4048). 바깥의 `out_callee_optional` 을 그대로
-        // 넘기면 "안쪽 new 의 callee 에 `?.` 가 있었다" 는 사실이 **바깥 new** 에 찍혀,
-        // 바깥 new 자신의 별개 위반(argless new 뒤 trailing `?.`)이 조용히 사라진다.
-        // 두 new 는 서로 다른 위반이므로 각각 보고돼야 한다 — 괄호 형태
-        // (`new (new a?.b)\`x\`?.c`)가 실제로 2건을 내는 것과 일관되게.
-        var inner_callee_optional = false;
-        const callee = try parseNewCallee(self, &inner_callee_optional);
-        _ = trySkipTypeArgsSpeculative(self, true, type_args.canFollowTypeArgumentsInExpression);
-        if (self.current() == .l_paren) {
-            try self.advance();
-            const arg_list = try parseArgumentList(self);
-            return try finishNewExpressionWithArgs(self, span.start, callee, arg_list, inner_callee_optional);
-        }
-        return try finishNewExpressionNoArgs(self, span.start, callee, inner_callee_optional);
-    }
-
-    // primary expression + member chain (호출 제외)
+    // primary expression + member chain (호출 제외).
+    // 중첩 new(`new new Inner().C()`)도 parsePrimaryExpression 의 `kw_new` 분기가 그대로
+    // 처리한다(new.target 포함) — 여기서 따로 재귀하지 않고 **아래 member 루프로 흘린다**.
+    // 안쪽 new 뒤의 `.C`/`[k]`/`` `tpl` `` 는 ECMAScript 상 **바깥 new 의 callee** 에 속하기
+    // 때문(`MemberExpression: new MemberExpression Arguments` → `new (new Inner().C)()`).
+    // 예전엔 이 자리에서 중첩 new 를 만들고 즉시 return 해 `.C` 가 바깥 new *밖*으로
+    // 새어나갔고, argless 로 끝난 바깥 new 에 codegen 이 `()` 를 붙여
+    // `new new Inner()().C()` 라는 잘못된 코드를 진단 없이 방출했다(#4500).
+    //
+    // 이 위임 덕에 안쪽 new 의 callee 보고는 안쪽 `parsePrimaryExpression` 의 지역 플래그로
+    // 끝나고, 바깥 `out_callee_optional` 에는 **이 루프가 직접 본 `?.`** 만 기록된다 — #4048 이
+    // 별도 `inner_callee_optional` 지역변수로 막던 "안쪽→바깥 전파" 가 구조적으로 불가능해진다.
     var expr = try parsePrimaryExpression(self);
     // import.source(...) / import.defer(...)는 ImportCall (CallExpression)이므로 new 불가
     // parsePrimaryExpression이 전체 호출을 소비하므로 결과 tag를 확인
@@ -1354,6 +1373,14 @@ fn parseNewCallee(self: *Parser, out_callee_optional: *bool) ParseError2!NodeInd
                     // 종료한다. 단일 623 진단 유지(2차 에러·dangling `.invalid` prop 없음).
                     break;
                 }
+            },
+            .no_substitution_template, .template_head => {
+                // `new tag\`x\`.B()` — tagged template 도 callee(MemberExpression)의 일부다
+                // (`MemberExpression: MemberExpression TemplateLiteral`). 즉 callee 는
+                // `` tag`x`.B `` 이고, 뒤의 `()` 만 바깥 new 의 Arguments 다. 이 arm 이 없어
+                // `else => break` 로 빠지면 tag 가 new 밖에 남아 `` new tag()`x`.B() `` 로
+                // 오파싱됐다(#4500).
+                expr = try finishTaggedTemplate(self, expr, expr_start);
             },
             else => break,
         }

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2329,6 +2329,95 @@ fn expectSingleParseError(source: []const u8, message: []const u8) !void {
     try std.testing.expectEqualStrings(message, parser.errors.items[0].message);
 }
 
+/// 소스를 `ext` 확장자 설정(TS/Flow)으로 파싱하고 에러가 *정확히 1개*이며 메시지가 일치하는지 검증.
+fn expectSingleParseErrorWithExt(source: []const u8, ext: []const u8, message: []const u8) !void {
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    parser.configureFromExtension(ext);
+
+    _ = try parser.parse();
+    try std.testing.expectEqual(@as(usize, 1), parser.errors.items.len);
+    try std.testing.expectEqualStrings(message, parser.errors.items[0].message);
+}
+
+/// 단일 new 표현식 소스의 **바깥** new_expression 을 찾아 callee 의 tag 와 인자 절 유무를 검증.
+/// AST 노드는 post-order(자식 먼저)로 추가되므로 **마지막** new_expression 이 바깥 new 다.
+/// `new new Inner().C()` 처럼 중첩 new 뒤의 member 체인이 바깥 callee 로 흡수됐는지 박제한다.
+fn expectOuterNewCallee(source: []const u8, callee_tag: Tag, had_arguments: bool) !void {
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
+
+    var outer: ?ast_mod.Node = null;
+    for (parser.ast.nodes.items) |node| {
+        if (node.tag == .new_expression) outer = node;
+    }
+    try std.testing.expect(outer != null);
+    const callee = parser.ast.readExtraNode(outer.?.data.extra, 0);
+    try std.testing.expectEqual(callee_tag, parser.ast.getNode(callee).tag);
+    const flags = parser.ast.readExtra(outer.?.data.extra, 3);
+    try std.testing.expectEqual(had_arguments, (flags & ast_mod.CallFlags.had_arguments) != 0);
+}
+
+test "new callee: 중첩 new 뒤 member/subscript 체인은 바깥 new 의 callee (#4500)" {
+    // ECMAScript `MemberExpression: new MemberExpression Arguments` — `new new Inner().C()` 의
+    // `.C` 는 **바깥 new 의 callee** 다(`new (new Inner().C)()`). 예전엔 parseNewCallee 가 중첩
+    // new 직후 즉시 return 해 `.C` 가 바깥 new *밖*으로 새어나갔고, argless 로 끝난 바깥 new 에
+    // codegen 이 `()` 를 붙여 `new new Inner()().C()` (TypeError)를 진단 없이 방출했다.
+    try expectOuterNewCallee("new new Inner().C()", .static_member_expression, true);
+    try expectOuterNewCallee("new new A().b", .static_member_expression, false);
+    try expectOuterNewCallee("new new A()[k]()", .computed_member_expression, true);
+    try expectOuterNewCallee("new new A().b.c()", .static_member_expression, true);
+    // 인자 없는 중첩 new(`new new a()()`)·일반 callee 는 기존 그대로 (회귀 가드).
+    try expectOuterNewCallee("new new a()()", .new_expression, true);
+    try expectOuterNewCallee("new new a", .new_expression, false);
+    try expectOuterNewCallee("new a.b()", .static_member_expression, true);
+    try expectOuterNewCallee("new a()", .identifier_reference, true);
+    try expectOuterNewCallee("new a", .identifier_reference, false);
+}
+
+test "new callee: tagged template 도 callee 의 일부 (#4500)" {
+    // `MemberExpression: MemberExpression TemplateLiteral` — `new tag`x`.B()` 의 callee 는
+    // `` tag`x`.B `` 이고 뒤의 `()` 만 new 의 Arguments 다. callee 루프에 template arm 이
+    // 없어 `` new tag()`x`.B() `` 로 오파싱되던 것을 박제.
+    try expectOuterNewCallee("new tag`x`.B()", .static_member_expression, true);
+    try expectOuterNewCallee("new tag`x`", .tagged_template_expression, false);
+    try expectOuterNewCallee("new tag`x${y}z`.B()", .static_member_expression, true);
+    // 인자 *있는* new 뒤의 template 은 callee 가 아니라 new 결과를 태그한다(`(new a())`x``).
+    // callee 루프는 `(` 에서 break 하므로 이 형태는 영향 없음.
+    try expectOuterNewCallee("new a()`x`", .identifier_reference, true);
+}
+
+test "new + optional chain: TS 타입 래퍼(!/as/<T>)가 argless-new head 를 가리지 못한다 (#4500)" {
+    // 타입 소거 후 남는 JS 형태가 `new a\`x\`?.b`(SyntaxError)와 같으므로 `!` 가 끼어도 거부해야
+    // 한다. optionalChainBaseIsArglessNew 의 walk 가 타입 래퍼를 안 넘어가 head(argless new)를
+    // 못 찾고 조용히 수용하던 accept-invalid 버그.
+    try expectSingleParseErrorWithExt("declare const a: any;\nnew a`x`!?.b;", ".ts", "Invalid optional chain in 'new' expression");
+    try expectSingleParseErrorWithExt("declare const a: any;\nnew a`x`!.b?.c;", ".ts", "Invalid optional chain in 'new' expression");
+    try expectSingleParseErrorWithExt("declare const a: any;\nnew new a().b!?.c;", ".ts", "Invalid optional chain in 'new' expression");
+    // 인자 *있는* new 는 MemberExpression → 래퍼가 끼어도 유효(오거부 가드).
+    try expectNoParseErrorWithExt("declare const a: any;\nnew a()!?.b;", ".ts");
+    try expectNoParseErrorWithExt("declare const a: any;\nnew a()`x`!?.b;", ".ts");
+    // paren 은 체인을 끊는다 — `(new a)!?.b` 의 base 는 PrimaryExpression → 유효.
+    try expectNoParseErrorWithExt("declare const a: any;\n(new a)!?.b;", ".ts");
+}
+
+test "new + optional chain: Flow `(x: T)` cast 는 괄호 자체 → 체인을 끊는다 (#4500)" {
+    // `flow_type_cast_expression` 은 다른 타입 래퍼(`as`/`!`)와 달리 **괄호가 노드 그 자체**다.
+    // walk 가 이걸 투명하게 통과하면 유효한 `(new a: any)?.b`(= `(new a)?.b`)를 오거부한다.
+    // → `isParenFreeTypeWrapper` 로 걸러 통과 금지. (`isTransparentTypeWrapper` 를 쓰면 회귀)
+    try expectFlowParseResult("(new a: any)?.b;", .{});
+    try expectFlowParseResult("(new a: any).b?.c;", .{});
+    // 괄호 없는 Flow 래퍼(`as`)는 통과해야 한다 — argless new head 도달 → SyntaxError 유지.
+    try expectFlowParseResult("new a`x` as any;\nnew (a: any)`x`?.b;", .{ .expect_error = true });
+}
+
 test "new + optional chain: callee 의 optional chain 은 SyntaxError" {
     // ECMAScript: new 의 MemberExpression callee 는 OptionalExpression 일 수 없다.
     // V8/esbuild 와 동일하게 거부. (이전엔 수용하고 `(new obj)?.fn()` 로 오파싱했다.)
@@ -2406,11 +2495,26 @@ test "new + optional chain: callee 보고 + trailing `?.` 가 겹쳐도 623 은 
     // new 노드의 callee_optional_chain 비트로 "이미 보고함" 을 전파해 1개로 수렴.
     try expectSingleParseError("new a?.b`x`?.c", msg);
     try expectSingleParseError("new a?.b.c`x`?.d", msg);
-    // 중첩 new 는 **서로 다른 new 의 서로 다른 위반**이다 — 각각 1건씩 나야 한다.
-    // (안쪽 callee 의 `?.` / 바깥 argless new 뒤 trailing `?.`)
-    // 안쪽 보고를 바깥까지 전파하면 바깥의 별개 위반이 조용히 사라진다. 괄호 형태
-    // `new (new a?.b)`x`?.c` 가 2건을 내는 것과도 어긋난다.
-    try expectParseErrorCount("new new a?.b`x`?.c", msg, 2, 2);
+
+    // 중첩 new 의 623 개수 = **위반 callee 의 개수**. 그리고 tagged template 이 안쪽 new 의
+    // callee 에 속하는지 바깥 new 의 callee 에 속하는지는 *안쪽 new 가 닫혔는지*로 갈린다
+    // (#4500 이 바로잡은 지점 — `MemberExpression: MemberExpression TemplateLiteral` 은
+    // callee 안으로 greedy 하게 흡수된다). node 로 확인한 세 형태:
+    //
+    //   new new a.b`x`.c    안쪽 new 가 안 닫힘 → `` `x` ``+`.c` 는 **안쪽 callee**  (a.b 가 tag 로 호출됨)
+    //   new (new a.b)`x`.c  괄호가 안쪽 new 를 닫음 → `` `x` `` 는 **바깥 callee**   (a.b 가 construct 됨)
+    //   new new a.b()`x`.c  인자절이 안쪽 new 를 닫음 → `` `x` `` 는 **바깥 callee**  (a.b 가 construct 됨)
+    //
+    // 따라서 `?.` 판본의 위반 callee 수도 1 / 2 / 2 로 갈린다.
+    //
+    // ① bare: `?.` 가 **전부 안쪽 callee 하나**에 들어간다 — 바깥 new 의 callee 는 `new (…)`
+    //    (= 유효한 NewExpression) 이고 뒤따르는 체인 자체가 없다. 위반 callee 1개 → 623 1건.
+    //    (#4048 은 `` `x` `` 가 두 new 를 다 빠져나가던 옛 오파싱을 전제로 2건을 기대했다.)
+    try expectParseErrorCount("new new a?.b`x`?.c", msg, 1, 1);
+    // ②③ 안쪽 new 가 인자절/괄호로 닫히면 `` `x`?.c `` 는 **바깥 callee** 로 간다 →
+    //    안쪽·바깥 각각 `?.` 를 품은 별개 위반 → 2건. (안쪽 보고가 바깥으로 전파되면 이 2건이
+    //    1건으로 뭉개진다 — #4048 리뷰가 막으려던 회귀. 지금은 안쪽 new 를
+    //    parsePrimaryExpression 이 자기 지역 플래그로 처리해 구조적으로 전파가 불가능하다.)
     try expectParseErrorCount("new new a?.b()`x`?.c", msg, 2, 2);
     try expectParseErrorCount("new (new a?.b)`x`?.c", msg, 2, 2);
     // 회귀 가드: 원래도 1개였던 인접 형태들이 그대로 1개인지.
@@ -2425,15 +2529,24 @@ test "new + optional chain: 623 dedup 이 다른 진단/다른 new 를 삼키지
     const msg607 = "Tagged template cannot be used in optional chain";
     // dedup 은 623 을 *같은 new* 안에서만 접는다. 서로 다른 new 두 개면 각자 위반이므로 2개:
     //   ① 안쪽 `new a?.b` = callee optional chain,
-    //   ② 바깥 argless new = trailing `?.c` 의 invalid base.
+    //   ② 바깥 new = 괄호로 안쪽이 닫힌 뒤 이어지는 `` `x`?.c `` (= 바깥 callee)의 `?.`.
     try expectParseErrorCount("new (new a?.b)`x`?.c", msg623, 2, 2);
-    // 623 을 접어도 *다른 코드*의 진단(607)은 그대로 살아 있어야 한다.
-    // `?.c` 뒤의 `` `y` `` 는 optional chain 위 tagged template → 607.
-    try expectParseErrorCount("new a?.b`x`?.c`y`?.d", msg623, 1, 2);
-    try expectParseErrorCount("new a?.b`x`?.c`y`?.d", msg607, 1, 2);
-    // new 없는 순수 optional chain 은 623 과 무관 — 607 만 단독으로.
+
+    // `new a?.b`x`?.c`y`?.d` — #4500 이후 이 체인은 **통째로 new 의 callee** 다
+    //  (`` `x` ``/`` `y` `` 가 callee 로 흡수되므로). 즉 optional chain *식* 자체가 없고,
+    // `?.` 들은 callee 복구 과정에서 일반 멤버로 소비된다 → 위반 callee 1개 = 623 1건이 전부.
+    // 607("optional chain 위 tagged template")은 여기서 **성립하지 않는다** — 예전엔
+    // `` `x` `` 가 callee 밖으로 새어 postfix 루프가 optional chain 으로 오인해 붙던 진단이다.
+    // "한 broken callee = SyntaxError 1개(2차 cascade 노이즈 없음)" 라는 이 파일의 계약과도 일치.
+    try expectParseErrorCount("new a?.b`x`?.c`y`?.d", msg623, 1, 1);
+    try expectParseErrorCount("new a?.b`x`?.c`y`?.d", msg607, 0, 1);
+    // 607 자체는 멀쩡하다 — new 가 없어 진짜 optional chain 인 형태에선 그대로 발행된다.
+    // (dedup 이 *다른 코드*의 진단을 삼키지 않는다는 원래 가드는 이 케이스가 지킨다.)
     try expectSingleParseError("a?.b`x`?.c", msg607);
     try expectParseErrorCount("a?.b`x`?.c", msg623, 0, 1);
+    // 인자 있는 new 는 MemberExpression → 뒤는 진짜 optional chain → 607 살아 있음.
+    try expectParseErrorCount("new a()`x`?.c`y`?.d", msg607, 1, 1);
+    try expectParseErrorCount("new a()`x`?.c`y`?.d", msg623, 0, 1);
 }
 
 test "new + optional chain: 유효 형태는 통과" {

--- a/src/transformer/es2015_spread.zig
+++ b/src/transformer/es2015_spread.zig
@@ -119,6 +119,22 @@ pub fn ES2015Spread(comptime Transformer: type) type {
 
             const new_callee = try self.visitNode(callee_idx);
 
+            // callee 는 **두 번** 필요하다 — `X.bind` 의 수신자, 그리고 `apply` 의 첫 인자.
+            // 단순 식별자면 부작용이 없어 복제로 충분하지만(`Foo.bind.apply(Foo, ...)`),
+            // member(`a.b`)·tagged template(`` tag`x` ``)·중첩 new 같은 callee 는 두 번
+            // 평가하면 안 되므로 temp 에 담는다 — `(_a = a.b).bind.apply(_a, ...)` (TS 동형).
+            // 예전엔 callee 를 identifier 로 가정하고 `string_ref` 를 그대로 읽어 재구성해서,
+            // 그 외 callee 는 `extra` 인덱스를 span 으로 오독해 컴파일러가 죽었다
+            // (`new a.b(...args)` --target=es5 crash). #4500 의 파서 수정으로
+            // `` new tag`x`(...args) `` / `new new A().b(...args)` 도 이 경로로 들어온다.
+            const bind_target: NodeIndex, const this_arg: NodeIndex =
+                if (es_helpers.isSimpleIdentifier(self, new_callee))
+                    .{ new_callee, try es_helpers.cloneNode(self, new_callee) }
+                else blk: {
+                    const cap = try es_helpers.captureToTemp(self, new_callee, span);
+                    break :blk .{ cap.paren_assign, try es_helpers.makeTempVarRef(self, cap.span, span) };
+                };
+
             // [null].concat(args) — null을 첫 인자로 추가 (bind의 this)
             const null_span = try self.ast.addString("null");
             const null_node = try self.ast.addNode(.{
@@ -169,7 +185,7 @@ pub fn ES2015Spread(comptime Transformer: type) type {
                 .data = .{ .string_ref = bind_span },
             });
             const bind_me = try self.ast.addExtras(&.{
-                @intFromEnum(new_callee), @intFromEnum(bind_prop), 0,
+                @intFromEnum(bind_target), @intFromEnum(bind_prop), 0,
             });
             const bind_member = try self.ast.addNode(.{
                 .tag = .static_member_expression,
@@ -194,14 +210,7 @@ pub fn ES2015Spread(comptime Transformer: type) type {
             });
 
             // Foo.bind.apply(Foo, [null].concat(args))
-            // new_callee를 재사용하지 않고 새 identifier 생성 (AST 노드는 1곳에서만 참조)
-            const new_callee_node = self.ast.getNode(new_callee);
-            const callee_ref2 = try self.ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = new_callee_node.span,
-                .data = .{ .string_ref = new_callee_node.data.string_ref },
-            });
-            const apply_args = try self.ast.addNodeList(&.{ callee_ref2, null_concat });
+            const apply_args = try self.ast.addNodeList(&.{ this_arg, null_concat });
             const apply_extra = try self.ast.addExtras(&.{
                 @intFromEnum(apply_member), apply_args.start, apply_args.len, 0,
             });

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -374,7 +374,11 @@ fn isLiveMinifyNode(live_nodes: ?*const std.DynamicBitSet, node_idx: u32) bool {
 
 fn markCallCalleeSequences(ast: *const Ast, protected_sequences: *std.DynamicBitSet) void {
     for (ast.nodes.items) |node| {
-        if (node.tag != .call_expression and node.tag != .new_expression) continue;
+        // tagged template 의 tag 도 callee 자리다(extra[0]) — `` (0, o.tag)`x` `` 의 sequence 를
+        // 풀면 tag 가 this=o 로 호출된다(`` o.tag`x` ``). #4500 의 파서 수정으로 tagged template 이
+        // new 의 callee 로도 들어오면서(`` new (0, o.tag)`x`() ``) 같은 경로가 새로 열렸다.
+        if (node.tag != .call_expression and node.tag != .new_expression and
+            node.tag != .tagged_template_expression) continue;
         markSequenceInCallee(ast, @enumFromInt(ast.readExtra(node.data.extra, 0)), protected_sequences);
     }
 }

--- a/tests/integration/tests/new-callee-chain.test.ts
+++ b/tests/integration/tests/new-callee-chain.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runNode, runZntc, transpileAndRun } from './helpers';
+
+// #4500 — new callee 체인 silent miscompile 런타임 가드.
+//
+// 방출 문자열(빠른 1차)은 src/codegen/codegen_test/new_callee_chain.zig 가 본다.
+// 여기서는 transpile → 실제 실행으로 "TypeError 없이 원본과 같은 값이 나오는지"를 박제한다.
+//
+// 수정 전 방출:
+//   `new new Inner().C()` → `new new Inner()().C()` → TypeError: not a constructor
+//   `new tag`x`.B()`      → `new tag()`x`.B()`      → TypeError: not a function
+describe('new callee 체인 (#4500)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test('중첩 new 뒤 member 체인: new new Inner().C()', async () => {
+    const r = await transpileAndRun(
+      `
+      class Inner { C: any; constructor(){ this.C = class { ok = 42; }; } }
+      const x = new new Inner().C();
+      console.log(x.ok);
+    `,
+      [],
+      { ext: 'ts' },
+    );
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    // 오파싱 시 `new new Inner()().C()` 가 방출돼 실행이 TypeError 로 죽는다(runOutput 빈 문자열).
+    expect(r.runOutput.trim()).toBe('42');
+  });
+
+  test('중첩 new 뒤 subscript 체인: new new Inner()[k]()', async () => {
+    const r = await transpileAndRun(
+      `
+      class Inner { constructor(){ this.C = class { constructor(){ this.ok = 7; } }; } }
+      const k = 'C';
+      const z = new new Inner()[k]();
+      console.log(z.ok);
+    `,
+      [],
+      { ext: 'js' },
+    );
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    expect(r.runOutput.trim()).toBe('7');
+  });
+
+  test('new callee 안의 tagged template: new tag`x`.B()', async () => {
+    const r = await transpileAndRun(
+      `
+      function tag(strings){ return { B: class { constructor(){ this.ok = 9; } } }; }
+      const x = new tag\`x\`.B();
+      console.log(x.ok);
+    `,
+      [],
+      { ext: 'js' },
+    );
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    expect(r.runOutput.trim()).toBe('9');
+  });
+
+  test('TS 타입 래퍼가 argless-new head 를 가려도 SyntaxError: new a`x`!?.b', async () => {
+    const r = await transpileAndRun(
+      `
+      declare const a: any;
+      new a\`x\`!?.b;
+    `,
+      [],
+      { ext: 'ts' },
+    );
+    cleanup = r.cleanup;
+    // 예전엔 exit 0 으로 수용하고 ``new a()`x`?.b`` (의미까지 다름)를 방출했다.
+    expect(r.transpileExitCode).not.toBe(0);
+    expect(r.transpileStderr).toContain('ZNTC0623');
+  });
+
+  test('new callee 안의 call 은 괄호 보존: new (f())`x`.B()', async () => {
+    // 실행은 **node(V8)** 로 한다 — bun 1.3.11 의 파서가 이 형태를 잘못 읽어(undefined)
+    // `bun run` 기반 transpileAndRun 으로는 의미 검증이 안 된다. zntc 는 V8/tsc 를 따른다.
+    const dir = await mkdtemp(join(tmpdir(), 'zntc-4500-paren-'));
+    cleanup = async () => rm(dir, { recursive: true, force: true });
+    const src = join(dir, 'in.js');
+    const out = join(dir, 'out.js');
+    await writeFile(
+      src,
+      `function f(){ return function tag(s){ return { B: class { constructor(){ this.ok = 4; } } }; }; }\n` +
+        `const x = new (f())\`x\`.B();\nconsole.log(x.ok);\n`,
+    );
+    const t = await runZntc([src, '-o', out]);
+    expect(t.exitCode).toBe(0);
+    // 괄호 유실 시 `new f()`x`.B()` → f 가 *생성*되고 template 결과가 *호출*된다 → TypeError.
+    const run = await runNode(out);
+    expect(run.stdout.trim()).toBe('4');
+  });
+
+  test('es5 spread + new: member/tagged callee 가 컴파일러를 죽이지 않고 1회만 평가된다', async () => {
+    // 예전엔 lowerSpreadNew 가 callee 를 identifier 로 가정해 `new a.b(...args)` 가 컴파일러
+    // panic 이었다. #4500 파서 수정으로 `` new tag`x`(...args) `` 도 이 경로로 들어온다.
+    const r = await transpileAndRun(
+      `
+      const args = [7];
+      let evals = 0;
+      const a = { get b(){ evals++; return class { constructor(v){ this.ok = v; } }; } };
+      const v = new a.b(...args);
+      console.log(v.ok, evals);
+    `,
+      ['--target=es5'],
+      { ext: 'js' },
+    );
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    // callee 는 정확히 1회 평가돼야 한다(temp 캡처) — 복제로 두 번 평가하면 `2`.
+    expect(r.runOutput.trim()).toBe('7 1');
+  });
+
+  test('minify: tagged template tag 의 sequence 는 보존된다 (this 바인딩)', async () => {
+    const r = await transpileAndRun(
+      `
+      const o = { tag(s){ return function(){ this.self = (o === undefined); }; }, self: true };
+      const v = new (0, o.tag)\`x\`();
+      console.log(typeof v);
+    `,
+      ['--minify'],
+      { ext: 'js' },
+    );
+    cleanup = r.cleanup;
+    expect(r.transpileExitCode).toBe(0);
+    // sequence 가 풀리면 `o.tag`x`` → tag 가 this=o 로 호출된다(의미 변화).
+    expect(r.runOutput.trim()).toBe('object');
+  });
+
+  test('idempotency: 방출물을 다시 transpile 해도 의미가 같다', async () => {
+    // 파이프라인이 자기 출력을 다시 읽는 경우(2-pass/번들) 가드. `new (new A().b)()` 는
+    // `new new A().b()` 로 방출되는데, 그걸 다시 파싱했을 때 callee 가 `new A().b` 로
+    // 유지돼야 한다(예전엔 `new new A()()` + `.b()` 로 재해석 → TypeError).
+    const dir = await mkdtemp(join(tmpdir(), 'zntc-4500-'));
+    cleanup = async () => rm(dir, { recursive: true, force: true });
+
+    const src = join(dir, 'in.js');
+    const out1 = join(dir, 'out1.js');
+    const out2 = join(dir, 'out2.js');
+    await writeFile(
+      src,
+      `class A { constructor(){ this.b = class { constructor(){ this.ok = 5; } }; } }\n` +
+        `const x = new (new A().b)();\nconsole.log(x.ok);\n`,
+    );
+
+    const t1 = await runZntc([src, '-o', out1]);
+    expect(t1.exitCode).toBe(0);
+    const t2 = await runZntc([out1, '-o', out2]);
+    expect(t2.exitCode).toBe(0);
+
+    // runNode 는 exit != 0 이면 throw — 오파싱 시 TypeError 로 여기서 잡힌다.
+    const run1 = await runNode(out1);
+    const run2 = await runNode(out2);
+    expect(run1.stdout.trim()).toBe('5');
+    expect(run2.stdout.trim()).toBe('5');
+  });
+});

--- a/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-templates.test.ts.snap
@@ -229,14 +229,14 @@ f.thisIsNotATag(\`abc\${1}def\${2}ghi\`);
 exports[`TSC: es6/templates taggedTemplateStringsWithManyCallAndMemberExpressions 1`] = `
 "// @target: es2015
 var f;
-var x = new new new f()()()\`abc\${0}def\`.member("hello")(42) === true;
+var x = new new new f\`abc\${0}def\`.member("hello")(42)() === true;
 "
 `;
 
 exports[`TSC: es6/templates taggedTemplateStringsWithManyCallAndMemberExpressionsES6 1`] = `
 "// @target: ES6
 var f;
-var x = new new new f()()()\`abc\${0}def\`.member("hello")(42) === true;
+var x = new new new f\`abc\${0}def\`.member("hello")(42)() === true;
 "
 `;
 
@@ -597,7 +597,7 @@ c.returnedObjProp.z;
 `;
 
 exports[`TSC: es6/templates taggedTemplatesWithTypeArguments2 1`] = `
-"const a = new tag()\`\${100} \${200}\`("hello", "world");
+"const a = new tag\`\${100} \${200}\`("hello", "world");
 const b = new tag()\`\${"hello"} \${"world"}\`(100, 200);
 const c = new tag()\`\${100} \${200}\`("hello", "world");
 const d = new tag()\`\${"hello"} \${"world"}\`(100, 200);


### PR DESCRIPTION
## 문제 — 진단 없이 **다른 프로그램**을 방출

ECMAScript `MemberExpression: new MemberExpression Arguments` 상, 중첩 `new` 뒤의 `.C`/`[k]` 와 callee 안의 tagged template 은 **바깥 new 의 callee** 에 속합니다. 그런데 `parseNewCallee` 가 중첩 new 를 만들고 **즉시 return** 했고, callee member 루프엔 template arm 이 없어서, 체인이 new **밖으로 새고** codegen 이 argless new 에 `()` 를 다시 붙였습니다.

| 입력 | 수정 전 방출 → 실행 | 수정 후 |
|---|---|---|
| `new new Inner().C()` | `new new Inner()().C()` → **TypeError: not a constructor** | `new new Inner().C()` → `42` ✅ |
| ``new tag`x`.B()`` | ``new tag()`x`.B()`` → **TypeError: not a function** | ``new tag`x`.B()`` → `7` ✅ |
| ``new a`x`!?.b`` (TS) | **exit 0 으로 수용** (accept-invalid) | **ZNTC0623** exit 1 ✅ |

**파이프라인이 idempotent 하지 않았습니다** — zntc 가 `new (new A().b)()` 를 `new new A().b()` 로 방출하고, 그걸 zntc 가 다시 파싱하면 잘못 읽습니다 (2-pass/번들 시 위험).

## 참조 파서 근거

TypeScript API AST: `new new Inner().C()` → `NewExpression(callee = PropertyAccess(NewExpression, C))`, ``new tag`x`.B()`` → `NewExpression(callee = PropertyAccess(TaggedTemplate, B))`, ``new a`x`!?.b`` → `"Invalid optional chain from new expression"`. node 실행 결과도 동일합니다.

(참고: bun 1.3.11 은 ``new (f())`x`.B()`` 를 오파싱합니다 — V8/tsc 를 따랐고 해당 테스트는 node 로 실행합니다.)

## 처방

중첩 new 분기를 `parsePrimaryExpression` 위임으로 교체해 **공용 member 루프로 흘리고**(중복 제거), callee 루프에 tagged-template arm 을 추가하고, argless-new head walk 가 TS 타입 래퍼(`!`/`as T`/`<T>x`)를 통과하게 했습니다.

## code-review max 가 잡은 것 (전부 반영)

새 AST 모양("tagged template 이 new 의 callee")을 하류가 못 다뤄 **이 수정이 만든 회귀 2건 + 기존 crash 1건**이 드러났습니다.

1. **codegen 괄호 유실** — ``new (f())`x` `` → ``new f()`x`() `` (`f` 가 *생성*됨). member object 처럼 tag 에 `forbid_call` 전파로 수정.
2. **Flow 오거부** — `(new a: any)?.b` 가 ZNTC0623 로 거부됨. Flow 의 `(x: T)` cast 는 괄호 자체라 통과시키면 안 되므로 `isParenFreeTypeWrapper` 로 분리.
3. **컴파일러 crash (기존 버그)** — `lowerSpreadNew` 가 callee 를 identifier 로 가정해서 `new a.b(...args) --target=es5` 가 **main 에서도 panic**. temp 캡처로 수정 (`new ((_a = a.b).bind.apply(_a, …))()`, tsc 동형, callee 1회 평가).

덤: minify 의 `` (0, o.tag)`x` `` sequence 보호, `new new.target()` 이 main 에서 ZNTC0600 오류나던 것도 해소.

## 회귀 0 실증

- **typescript.js(8.7MB) 방출이 main baseline 과 byte-identical**
- downlevel / load-bearing-paren / bundle-smoke / determinism / es5-call-super 등 **648 pass, 0 fail**
- `zig build test` 통과

## 남은 것 (별도 이슈)

TS 전용 2건이 같은 뿌리로 남습니다 — `new a!.b()` → `new a().b()`, ``new a<T>`x`.B()`` → ``new a()`x`.B()``. callee 루프에 `!`/`<T>` arm 이 없어 접미사가 callee 밖으로 새는 것인데, 고치려면 type-args speculation 을 루프 안으로 옮겨야 해서 분리했습니다.

Closes #4500

🤖 Generated with [Claude Code](https://claude.com/claude-code)