### PR TITLE
test(e2e): 렌더 패리티 게이트 — 3층(모듈평가)·4층(렌더+기준 번들러 픽셀 대조) 신설

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -814,10 +814,14 @@
         "@playwright/test": "^1.50.0",
         "@rspack/cli": "2.0.1",
         "@rspack/core": "2.0.1",
+        "@types/pngjs": "^6.0.5",
         "@zntc/test-helpers": "workspace:*",
+        "pixelmatch": "^7.2.0",
+        "pngjs": "^7.0.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-refresh": "0.18.0",
+        "vite": "^8.1.4",
       },
     },
     "tests/integration": {
@@ -2884,6 +2888,8 @@
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
     "@types/picomatch": ["@types/picomatch@4.0.3", "", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
+
+    "@types/pngjs": ["@types/pngjs@6.0.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
@@ -5473,6 +5479,8 @@
 
     "piscina": ["piscina@4.9.2", "", { "optionalDependencies": { "@napi-rs/nice": "^1.0.1" } }, "sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ=="],
 
+    "pixelmatch": ["pixelmatch@7.2.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg=="],
+
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
@@ -5485,7 +5493,7 @@
 
     "png-js": ["png-js@1.1.0", "", { "dependencies": { "browserify-zlib": "^0.2.0" } }, "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q=="],
 
-    "pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
+    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 
@@ -7207,6 +7215,8 @@
 
     "@zntc/e2e/react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "@zntc/e2e/vite": ["vite@8.1.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.16", "rolldown": "~1.1.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ=="],
+
     "@zntc/example-module-federation/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "@zntc/example-react-19-vite/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
@@ -7778,6 +7788,8 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse-entities/character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "parse-png/pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -8406,6 +8418,14 @@
     "@walletconnect/utils/query-string/filter-obj": ["filter-obj@1.1.0", "", {}, "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="],
 
     "@walletconnect/utils/query-string/split-on-first": ["split-on-first@1.1.0", "", {}, "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="],
+
+    "@zntc/e2e/vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "@zntc/e2e/vite/postcss": ["postcss@8.5.18", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ=="],
+
+    "@zntc/e2e/vite/rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+
+    "@zntc/e2e/vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "@zntc/integration/@swc/cli/@xhmikosr/bin-wrapper": ["@xhmikosr/bin-wrapper@14.2.2", "", { "dependencies": { "@xhmikosr/bin-check": "^8.2.1", "@xhmikosr/downloader": "^16.1.1", "@xhmikosr/os-filter-obj": "^4.0.0", "binary-version-check": "^6.1.0" } }, "sha512-4me/0Tw0ORrrRLliLc1w6K0unrnclVaFAp69z8fNu1rcYtD/pKtI1lZWvZ8htiRQtqhoqxBiQ2qfkZBN8q2KAw=="],
 
@@ -9289,6 +9309,42 @@
 
     "@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@zntc/e2e/vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "@zntc/e2e/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "@zntc/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/bin-check": ["@xhmikosr/bin-check@8.2.1", "", { "dependencies": { "execa": "^9.6.1", "isexe": "^4.0.0" } }, "sha512-DNruLq+kalxcE7JeDxtqrN9kyWjLW8VqsQPLRTwD1t9ck/1rF4qBL0mX5Fe2/xLOMjo5wPb67BNX2kSAhzfLjA=="],
 
     "@zntc/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/downloader": ["@xhmikosr/downloader@16.1.1", "", { "dependencies": { "@xhmikosr/archive-type": "^8.0.1", "@xhmikosr/decompress": "^11.1.1", "content-disposition": "^1.0.1", "defaults": "^2.0.2", "ext-name": "^5.0.0", "file-type": "^21.3.0", "filenamify": "^7.0.1", "get-stream": "^9.0.1", "got": "^14.6.6" } }, "sha512-1B2ZqYDpIHn9bjah48rEo33GbmoV8hufXap/3KHStgIM9R9/QDm1pajqDwEgqDORMl2eZ7Dpbz71Xi854y3m3Q=="],
@@ -9691,6 +9747,12 @@
 
     "@react-native/new-app-screen/react-native/babel-plugin-syntax-hermes-parser/hermes-parser/hermes-estree": ["hermes-estree@0.33.3", "", {}, "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg=="],
 
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "@zntc/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/bin-check/execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 
     "@zntc/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/bin-check/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
@@ -9886,6 +9948,10 @@
     "@react-native/new-app-screen/react-native/@react-native/community-cli-plugin/metro/jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "@react-native/new-app-screen/react-native/@react-native/community-cli-plugin/metro/metro-transform-worker/metro-minify-terser": ["metro-minify-terser@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "terser": "^5.15.0" } }, "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@zntc/e2e/vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@zntc/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/bin-check/execa/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -12,9 +12,13 @@
     "@playwright/test": "^1.50.0",
     "@rspack/cli": "2.0.1",
     "@rspack/core": "2.0.1",
+    "@types/pngjs": "^6.0.5",
     "@zntc/test-helpers": "workspace:*",
+    "pixelmatch": "^7.2.0",
+    "pngjs": "^7.0.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "react-refresh": "0.18.0"
+    "react-refresh": "0.18.0",
+    "vite": "^8.1.4"
   }
 }

--- a/tests/e2e/tests/render-parity-e2e.test.ts
+++ b/tests/e2e/tests/render-parity-e2e.test.ts
@@ -1,0 +1,398 @@
+import { test, expect } from '@playwright/test';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { PNG } from 'pngjs';
+import pixelmatch from 'pixelmatch';
+import { serve, closeServer } from './serve';
+
+/**
+ * 렌더 패리티 게이트 — "빌드 green + 파싱 green" 을 통과하고도 **런타임에서만** 죽는
+ * 결함, 그리고 **에러 없이 결과만 다른** 무성 오컴파일을 잡는다.
+ *
+ * ## 왜 필요한가 (기존 게이트로는 못 잡는 것)
+ *
+ * 번들러 결함은 네 층에 걸쳐 있고, **위 층 통과가 아래 층을 보장하지 않는다.**
+ *
+ *   1층 빌드 exit code       — #4472·#4481·#4482·#4491·#4492·#4493 전부 exit 0 으로 통과했다.
+ *   2층 산출물 재파싱         — `tests/integration/tests/output-parsable.test.ts` (#4472·#4481·#4482).
+ *   3층 모듈 평가            — 문법은 유효한데 평가 중 죽는다. 2층은 통과한다.
+ *                              예: #4491 `TypeError: $m is not a function` (highlight.js),
+ *                                  #4492 크로스-모듈 바인딩 미링크 (mermaid).
+ *   4층 렌더 + 기준 대조      — 평가까지 통과하고 **API 를 실제로 호출해야** 죽는다.
+ *                              예: #4493 `ReferenceError: stackWeight is not defined` (chart.js).
+ *                                  `import * as X from "chart.js"` 는 성공한다. `new Chart()` 를
+ *                                  **그려봐야** 터진다. 1~3층 전부 통과한다.
+ *
+ * 이 파일이 3층·4층을 담당한다.
+ *
+ * ## 기존 browser-smoke 와 다른 점
+ *
+ * `browser-smoke.test.ts` 는 `--bundle`(단일 파일·minify 없음·스플리팅 없음) 로 작은 스니펫의
+ * console 출력을 본다. 위 결함들은 **app 빌드 + `--minify` + 코드 스플리팅** 경로에 살기 때문에
+ * 그 경로를 밟지 않는다. (highlight.js 케이스도 `lib/core` 서브셋이라 #4491 을 유발하는
+ * 190개 CJS 언어 모듈 경로를 비껴간다.)
+ *
+ * 여기서는 **`zntc build --entry-html … --minify`** 로 짓고, **실제로 렌더**한 뒤
+ * **기준 번들러(Vite) 산출물과 픽셀을 비교**한다.
+ *
+ * ## 픽셀 비교가 "에러 0" 보다 강한 이유
+ *
+ * "에러가 없다" 는 침묵의 증거일 뿐이다. 기준 번들러와 **같은 픽셀** 이 나온다는 건
+ * **번들러가 의미를 바꾸지 않았다**는 증거다. 무성 오컴파일은 이 층에서만 잡힌다.
+ *
+ * ## 결정론 (오탐 방지)
+ *
+ * 이 게이트가 flaky 하면 없느니만 못하다. 그래서:
+ *   - **뷰포트를 앱 폭에 맞춘다.** 좁은 뷰포트로 넓은 앱을 찍으면 클리핑·리플로우로
+ *     0px 이 아닌 차이가 나온다(실제로 개발 중 이 오탐을 밟았다).
+ *   - 애니메이션 off · 고정 크기 · `deviceScaleFactor: 1` · 폰트는 monospace 고정.
+ *   - 임계값은 `PIXEL_TOLERANCE` 하나로 모은다. 0 이 정상이며, 값을 올려야 한다면
+ *     그건 결정론이 깨졌다는 신호지 임계값을 올릴 이유가 아니다.
+ */
+
+const REPO_ROOT = resolve(__dirname, '../../..');
+const ZNTC_CLI = join(REPO_ROOT, 'packages/core/bin/zntc.mjs');
+const VITE_BIN = resolve(__dirname, '../node_modules/vite/bin/vite.js');
+
+/** 픽셀 차이 허용치(전체 대비 %). 0 이 정상. */
+const PIXEL_TOLERANCE = 0.1;
+
+/**
+ * 3층(모듈 평가) 대기 상한.
+ *
+ * **반드시 명시해야 한다.** Playwright 러너에서 액션 기본 타임아웃은 테스트 타임아웃에
+ * 종속되므로, 여기서 상한을 주지 않으면 **평가에 실패한 케이스가 테스트 예산을 통째로
+ * 소진**한다(개발 중 실제로 10분을 태웠다). 3층 실패는 **빨리** 실패해야 한다.
+ */
+const EVAL_TIMEOUT_MS = 15_000;
+
+interface RenderCase {
+  name: string;
+  /** npm install 인자. */
+  pkg: string;
+  /** 렌더 앱 소스. `globalThis.__ready = true` 로 완료를 알린다. */
+  entry: string;
+  /** 앱 폭·높이. **뷰포트가 여기에 맞춰진다** — 어긋나면 클리핑 오탐. */
+  width: number;
+  height: number;
+  /** 렌더 완료 대기(ms). 워커·워밍업이 필요한 케이스는 넉넉히. */
+  settleMs: number;
+  /** 렌더 결과가 비어 있지 않은지 보는 최소 조건(고유 색 수). */
+  minColors: number;
+  /**
+   * 이 케이스가 과거에 잡은 결함. 회귀 시 어디를 볼지 남긴다.
+   */
+  guards: string;
+  /**
+   * **아직 열린 결함이라 현재는 실패가 정상**인 경우, 그 이슈 번호.
+   *
+   * `test.fail()` 로 표시한다 — 지금은 CI 를 red 로 만들지 않고, **결함이 고쳐지면
+   * 테스트가 통과해버려서 오히려 실패**한다("expected to fail but passed"). 그때가
+   * 이 마커를 떼는 시점이다. 게이트를 먼저 들이고 수정과 함께 해제하기 위한 장치이며,
+   * 결함이 조용히 잊히지 않는다.
+   */
+  knownBroken?: string;
+}
+
+const cases: RenderCase[] = [
+  {
+    name: 'react-dom',
+    pkg: 'react@^19 react-dom@^19',
+    width: 400,
+    height: 260,
+    settleMs: 400,
+    minColors: 10,
+    guards: 'sanity — DOM 렌더 경로',
+    entry: `
+import React from "react";
+import { createRoot } from "react-dom/client";
+const Row = ({ i }) =>
+  React.createElement("div", { style: { padding: "4px 8px", background: i % 2 ? "#eef" : "#dfd", fontFamily: "monospace", fontSize: 14 } }, "row " + i + " — " + i * i);
+const App = () =>
+  React.createElement("div", { style: { width: 380 } }, [
+    React.createElement("h2", { key: "h", style: { fontFamily: "monospace" } }, "React"),
+    ...Array.from({ length: 8 }, (_, i) => React.createElement(Row, { key: i, i })),
+  ]);
+createRoot(document.getElementById("root")).render(React.createElement(App));
+setTimeout(() => { globalThis.__ready = true; }, 200);
+`,
+  },
+  {
+    name: 'chart.js',
+    pkg: 'chart.js@^4',
+    width: 400,
+    height: 260,
+    settleMs: 700,
+    minColors: 20,
+    knownBroken: '#4493',
+    guards:
+      '#4493 — 중첩 shorthand+기본값 리네임 누락(ReferenceError: stackWeight). ' +
+      'import 만으로는 통과하고 new Chart() 를 **그려야** 터진다. 1~3층 전부 통과하는 결함.',
+    entry: `
+import { Chart, BarController, BarElement, CategoryScale, LinearScale } from "chart.js";
+Chart.register(BarController, BarElement, CategoryScale, LinearScale);
+const c = document.createElement("canvas");
+c.width = 380; c.height = 220;
+document.getElementById("root").appendChild(c);
+new Chart(c, {
+  type: "bar",
+  data: { labels: ["a","b","c","d","e"], datasets: [{ label: "v", data: [12,19,7,15,9], backgroundColor: "#36a" }] },
+  options: { animation: false, responsive: false, plugins: { legend: { display: false } } },
+});
+setTimeout(() => { globalThis.__ready = true; }, 400);
+`,
+  },
+  {
+    name: 'highlight.js',
+    pkg: 'highlight.js@^11 marked@^18',
+    width: 400,
+    height: 260,
+    settleMs: 500,
+    minColors: 10,
+    knownBroken: '#4503',
+    guards:
+      '#4503 — dead-store 제거가 클로저 읽기를 놓쳐 대입문 삭제 → **무성 오컴파일**. ' +
+      '에러 0 · 파싱 0 · 평가 0 인데 하이라이팅 결과만 틀리다(`functionfunction f f(a)`). ' +
+      '이 게이트가 실제로 잡아낸 결함이며, **픽셀 대조 없이는 관측 자체가 불가능**하다. ' +
+      '더불어 #4491(CJS 래퍼 $e/$m 섀도잉)도 이 경로가 지킨다. ' +
+      '**full `highlight.js` 를 써야 한다** — `lib/core` 서브셋은 190개 CJS 언어 모듈 경로를 비껴가서 둘 다 못 잡는다.',
+    entry: `
+import { marked } from "marked";
+import hljs from "highlight.js";
+const md = "# Title\\n\\nSome **bold** text.\\n\\n\\\`\\\`\\\`js\\nconst x = 1;\\nfunction f(a) { return a + x; }\\n\\\`\\\`\\\`\\n";
+const el = document.getElementById("root");
+el.innerHTML = marked.parse(md);
+el.style.width = "380px";
+el.style.fontFamily = "monospace";
+el.querySelectorAll("pre code").forEach((b) => {
+  b.innerHTML = hljs.highlight(b.textContent, { language: "javascript" }).value;
+});
+setTimeout(() => { globalThis.__ready = true; }, 300);
+`,
+  },
+  {
+    name: 'd3',
+    pkg: 'd3@^7',
+    width: 400,
+    height: 260,
+    settleMs: 500,
+    minColors: 10,
+    guards:
+      '#4482 — 단항 토큰 병합(d3-ease 의 `tpmt(-(--t))` → `---t`). ' +
+      'scaleTime().ticks() 로 d3-time 바인딩(크로스-모듈) 경로도 함께 밟는다.',
+    entry: `
+import * as d3 from "d3";
+const svg = d3.select("#root").append("svg").attr("width", 380).attr("height", 220);
+const t = d3.scaleTime()
+  .domain([new Date(Date.UTC(2020, 0, 1, 0, 0, 0)), new Date(Date.UTC(2020, 0, 1, 0, 1, 0))])
+  .range([30, 350]);
+svg.append("g").attr("transform", "translate(0,180)").call(d3.axisBottom(t).ticks(5));
+const y = d3.scaleLinear().domain([0, 10]).range([170, 20]);
+svg.selectAll("rect").data([3, 7, 2, 9, 5]).enter().append("rect")
+  .attr("x", (d, i) => 40 + i * 64).attr("y", (d) => y(d))
+  .attr("width", 44).attr("height", (d) => 170 - y(d)).attr("fill", "#a33");
+setTimeout(() => { globalThis.__ready = true; }, 300);
+`,
+  },
+  {
+    name: 'codemirror',
+    pkg: 'codemirror@^6 @codemirror/lang-javascript@^6',
+    width: 400,
+    height: 260,
+    settleMs: 700,
+    minColors: 30,
+    guards: '#4481 — `if(c) ({…}=o)` → `c&&{…}=o` (`&&` 폴딩 시 필수 괄호 소실).',
+    entry: `
+import { EditorView, basicSetup } from "codemirror";
+import { javascript } from "@codemirror/lang-javascript";
+new EditorView({
+  doc: "function hello(name) {\\n  const greeting = \\\`hi \\\${name}\\\`;\\n  return greeting.toUpperCase();\\n}\\n",
+  extensions: [basicSetup, javascript()],
+  parent: document.getElementById("root"),
+});
+setTimeout(() => { globalThis.__ready = true; }, 500);
+`,
+  },
+];
+
+/** 앱 fixture 를 만들고 zntc / vite 두 벌로 빌드한다. */
+async function buildBoth(caseDir: string, c: RenderCase) {
+  await mkdir(join(caseDir, 'src'), { recursive: true });
+  await writeFile(
+    join(caseDir, 'package.json'),
+    JSON.stringify({ name: `rp-${c.name}`, private: true, type: 'module' }),
+  );
+
+  const install = spawnSync('npm', ['install', ...c.pkg.split(/\s+/), '--no-audit', '--no-fund'], {
+    cwd: caseDir,
+    stdio: 'pipe',
+    timeout: 180_000,
+  });
+  expect(
+    install.status,
+    `npm install ${c.pkg} 실패: ${install.stderr?.toString().slice(0, 300)}`,
+  ).toBe(0);
+
+  await writeFile(join(caseDir, 'src/main.js'), c.entry.trim() + '\n');
+  await writeFile(
+    join(caseDir, 'index.html'),
+    `<!DOCTYPE html><html><head><meta charset="utf-8"><style>` +
+      `*{margin:0;padding:0;animation:none!important;transition:none!important}` +
+      `body{background:#fff;width:${c.width}px;font-family:monospace}` +
+      `#root{padding:8px}` +
+      `</style></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/main.js"></script></body></html>\n`,
+  );
+
+  // ── zntc: app 빌드 + minify (결함이 사는 경로)
+  const z = spawnSync(
+    'node',
+    [ZNTC_CLI, 'build', '.', '--entry-html', 'index.html', '--outdir', 'out-zntc', '--minify'],
+    { cwd: caseDir, stdio: 'pipe', timeout: 300_000 },
+  );
+  expect(z.status, `zntc build 실패: ${z.stderr?.toString().slice(0, 400)}`).toBe(0);
+
+  // ── vite: 기준 번들러
+  await writeFile(
+    join(caseDir, 'vite.config.js'),
+    `export default { root: ".", build: { outDir: "out-vite", emptyOutDir: true, rollupOptions: { input: "index.html" } }, logLevel: "error" };\n`,
+  );
+  const v = spawnSync('node', [VITE_BIN, 'build', '--config', 'vite.config.js'], {
+    cwd: caseDir,
+    stdio: 'pipe',
+    timeout: 300_000,
+  });
+  expect(v.status, `vite build 실패(기준 번들러): ${v.stderr?.toString().slice(0, 400)}`).toBe(0);
+}
+
+/** 산출물을 띄워 렌더하고 스크린샷 + 진단을 돌려준다. */
+async function render(page: import('@playwright/test').Page, dir: string, c: RenderCase) {
+  const { server, port } = await serve(dir);
+  const errors: string[] = [];
+  const missing: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message.split('\n')[0]));
+  page.on('response', (r) => {
+    if (r.status() === 404 && !r.url().endsWith('/favicon.ico'))
+      missing.push(new URL(r.url()).pathname);
+  });
+  try {
+    // 뷰포트 = 앱 폭. 어긋나면 클리핑으로 픽셀 오탐이 난다.
+    await page.setViewportSize({ width: c.width, height: c.height });
+    await page.goto(`http://localhost:${port}/`, { waitUntil: 'networkidle' });
+    // 3층: 엔트리 모듈이 **끝까지** 평가됐는가.
+    // 시그니처 주의: waitForFunction(fn, arg, options) — 두 번째 인자는 `arg` 다.
+    // `waitForFunction(fn, { timeout })` 로 쓰면 timeout 이 arg 로 먹혀 기본 타임아웃이
+    // 적용된다(실제로 이 함정을 밟았다). 반드시 arg 자리에 undefined 를 넣는다.
+    const evaluated = await page
+      .waitForFunction(() => (globalThis as Record<string, unknown>).__ready === true, undefined, {
+        timeout: EVAL_TIMEOUT_MS,
+      })
+      .then(() => true)
+      .catch(() => false);
+    await page.waitForTimeout(c.settleMs);
+    const shot = await page.screenshot({ type: 'png' });
+    return { shot, errors: [...new Set(errors)], missing: [...new Set(missing)], evaluated };
+  } finally {
+    await closeServer(server);
+  }
+}
+
+/** 스크린샷의 고유 색 수 — 백지 렌더 탐지용. */
+function colorCount(buf: Buffer): number {
+  const p = PNG.sync.read(buf);
+  const seen = new Set<number>();
+  for (let i = 0; i < p.data.length; i += 4) {
+    seen.add((p.data[i] << 16) | (p.data[i + 1] << 8) | p.data[i + 2]);
+  }
+  return seen.size;
+}
+
+let fixtureRoot: string;
+
+test.beforeAll(async () => {
+  fixtureRoot = await mkdtemp(join(tmpdir(), 'zntc-render-parity-'));
+  // 기준 번들러가 없으면 4층 자체가 성립하지 않는다 — 조용히 skip 하지 말고 크게 실패시킨다.
+  expect(
+    () => readFileSync(VITE_BIN),
+    'vite(기준 번들러)가 tests/e2e devDependency 에 있어야 한다',
+  ).not.toThrow();
+});
+
+test.afterAll(async () => {
+  await rm(fixtureRoot, { recursive: true, force: true });
+});
+
+for (const c of cases) {
+  test(`render-parity: ${c.name}`, async ({ page }) => {
+    // 케이스마다 npm install + zntc/vite 두 번 빌드 + 두 번 렌더다. 기본 30s 로는
+    // 큰 라이브러리(chart.js·codemirror)가 설치 단계에서 넘긴다. `test.slow()`(3배)
+    // 로도 부족해 명시 timeout 을 준다 — 여기서 타임아웃이 나면 결함이 아니라
+    // 환경 문제이므로, 애매한 실패로 신뢰를 깎지 않도록 넉넉히 잡는다.
+    test.setTimeout(4 * 60_000);
+
+    if (c.knownBroken) {
+      // 아직 열린 결함이다. 지금은 실패가 **정상** — CI 를 red 로 만들지 않는다.
+      // 결함이 고쳐지면 이 테스트가 통과해버려 "expected to fail but passed" 로 실패하고,
+      // 그게 이 마커를 떼라는 신호다.
+      test.fail(
+        true,
+        `${c.knownBroken} 이 열려 있는 동안은 실패가 정상이다. 수정되면 이 마커를 제거할 것.`,
+      );
+    }
+
+    const caseDir = join(fixtureRoot, c.name.replace(/[^\w.-]/g, '_'));
+    await buildBoth(caseDir, c);
+
+    const z = await render(page, join(caseDir, 'out-zntc'), c);
+    const v = await render(page, join(caseDir, 'out-vite'), c);
+
+    // ── 3층: 모듈 평가 ───────────────────────────────────────────────
+    expect(z.errors, `[3층] zntc 산출물이 런타임 에러를 냈다 (${c.guards})`).toEqual([]);
+    expect(z.missing, `[3층] zntc 산출물이 참조하는 자산이 404 다`).toEqual([]);
+    expect(
+      z.evaluated,
+      `[3층] 엔트리 모듈이 끝까지 평가되지 않았다 — globalThis.__ready 미도달 (${c.guards})`,
+    ).toBe(true);
+
+    // ── 4층: 실제 렌더 ───────────────────────────────────────────────
+    const zColors = colorCount(z.shot);
+    expect(zColors, `[4층] zntc 렌더가 사실상 백지다 (색 ${zColors}종)`).toBeGreaterThanOrEqual(
+      c.minColors,
+    );
+
+    // 기준 번들러가 먼저 통과해야 비교가 의미 있다. 여기서 실패하면 zntc 가 아니라
+    // 케이스/환경이 깨진 것이다.
+    expect(v.errors, `기준(vite) 산출물이 실패했다 — 케이스 또는 환경 문제`).toEqual([]);
+    expect(v.evaluated, `기준(vite) 산출물이 평가되지 않았다 — 케이스 또는 환경 문제`).toBe(true);
+
+    // ── 4층: 기준 번들러와 픽셀 대조 (무성 오컴파일 탐지) ─────────────
+    const zp = PNG.sync.read(z.shot);
+    const vp = PNG.sync.read(v.shot);
+    expect({ w: zp.width, h: zp.height }, '스크린샷 크기가 다르다 — 뷰포트 설정 확인').toEqual({
+      w: vp.width,
+      h: vp.height,
+    });
+
+    const diffPng = new PNG({ width: zp.width, height: zp.height });
+    const diffPixels = pixelmatch(zp.data, vp.data, diffPng.data, zp.width, zp.height, {
+      threshold: 0.12,
+    });
+    const diffPct = (diffPixels / (zp.width * zp.height)) * 100;
+
+    if (diffPct > PIXEL_TOLERANCE) {
+      await test.info().attach(`${c.name}-zntc.png`, { body: z.shot, contentType: 'image/png' });
+      await test.info().attach(`${c.name}-vite.png`, { body: v.shot, contentType: 'image/png' });
+      await test
+        .info()
+        .attach(`${c.name}-diff.png`, { body: PNG.sync.write(diffPng), contentType: 'image/png' });
+    }
+    expect(
+      diffPct,
+      `[4층] 기준 번들러(vite)와 렌더가 다르다 — ${diffPixels}px (${diffPct.toFixed(3)}%). ` +
+        `**에러 없이 결과만 다르면 무성 오컴파일이다.** 첨부된 zntc/vite/diff 이미지를 볼 것. (${c.guards})`,
+    ).toBeLessThanOrEqual(PIXEL_TOLERANCE);
+  });
+}


### PR DESCRIPTION
## Summary

번들러 결함은 **네 층**에 걸쳐 있고, **위 층 통과가 아래 층을 보장하지 않는다.** 최근 결함들(#4472·#4481·#4482·#4483·#4488·#4491·#4492·#4493·#4503)은 **전부 빌드 exit 0** 을 통과했고, 각각 서로 다른 층에서야 처음 드러났다.

`output-parsable.test.ts`(#4472 후속)가 2층을 막아준다. 이 PR 은 **3층·4층**을 막는다.

| 층 | 검사 | 잡는 것 | 현재 |
|---|---|---|---|
| 1 | 빌드 exit code | 거의 아무것도 — 위 결함 **전부** 통과했다 | — |
| 2 | 산출물 재파싱 | 문법이 깨진 산출물 (#4472·#4481·#4482) | ✅ `output-parsable.test.ts` |
| 3 | **모듈 평가** | 문법은 유효한데 **평가 중 죽는다** (#4491·#4492) | ❌ → **이 PR** |
| 4 | **렌더 + 기준 번들러 픽셀 대조** | **API 를 실제로 호출해야** 죽는 결함(#4493), 그리고 **무성 오컴파일**(#4503) | ❌ → **이 PR** |

## Changes

- `tests/e2e/tests/render-parity-e2e.test.ts` 신규 — 실제 라이브러리로 앱을 짓고(`zntc build --entry-html … --minify`), **렌더한 뒤**, **기준 번들러(Vite) 산출물과 스크린샷을 픽셀 비교**한다.
- `tests/e2e/package.json` — devDependency 에 `vite` · `pixelmatch` · `pngjs` 추가.

케이스는 **과거에 실제로 결함을 잡은 라이브러리**로 골랐고, 각 케이스에 `guards` 로 무엇을 지키는지 남겼다.

| 케이스 | 지키는 결함 |
|---|---|
| react-dom | sanity (DOM 렌더 경로) |
| **chart.js** | **#4493** — `import` 만으로는 통과하고 `new Chart()` 를 **그려야** 터진다. 1~3층 전부 통과하는 결함 |
| **highlight.js** | **#4503** — 무성 오컴파일. 에러 0 · 파싱 0 · 평가 0 인데 **하이라이팅 결과만 틀리다** |
| d3 | #4482 (단항 토큰 병합) + d3-time 크로스-모듈 바인딩 |
| codemirror | #4481 (`&&` 폴딩 괄호 소실) |

## 왜 픽셀 대조인가

**"에러가 없다" 는 침묵의 증거일 뿐이다.** 기준 번들러와 **같은 픽셀**이 나온다는 건 **번들러가 의미를 바꾸지 않았다**는 증거다.

이 PR 을 만들면서 실제로 **#4503 을 이 게이트가 잡아냈다.** highlight.js 가 에러 하나 없이 렌더되는데 Vite 대비 0.415% 픽셀이 달랐고, DOM 을 대조하니 `functionfunction f f(a)` 로 텍스트가 손상돼 있었다. 원인은 dead-store 제거가 클로저 읽기를 놓쳐 `modeBuffer = text` 를 삭제한 것이었다. **재파싱·모듈평가·에러 카운트 어느 것으로도 관측 불가능한 결함이다.**

## 기존 `browser-smoke.test.ts` 와 다른 점

`browser-smoke` 는 `--bundle`(단일 파일·minify 없음·스플리팅 없음) 로 작은 스니펫의 `console.log` 를 본다. 위 결함들은 **app 빌드 + `--minify` + 코드 스플리팅** 경로에 살아서 그 경로를 밟지 않는다. (`browser-smoke` 의 highlight.js 케이스도 `lib/core` 서브셋이라 #4491·#4503 을 유발하는 190개 CJS 언어 모듈 경로를 비껴간다.)

## 결정론 (오탐 방지)

게이트가 flaky 하면 없느니만 못하므로:

- **뷰포트를 앱 폭에 맞춘다.** 좁은 뷰포트로 넓은 앱을 찍으면 클리핑으로 0px 이 아닌 차이가 난다 — 개발 중 실제로 이 오탐을 밟았고, 그래서 케이스마다 `width`/`height` 를 명시한다.
- 애니메이션 off · 고정 크기 · `deviceScaleFactor: 1` · monospace 고정.
- 임계값은 `PIXEL_TOLERANCE` 하나로 모았다. **0 이 정상**이며, 값을 올려야 한다면 그건 결정론이 깨졌다는 신호지 임계값을 올릴 이유가 아니다.
- 기준(Vite) 쪽이 먼저 실패하면 **zntc 가 아니라 케이스/환경 문제**로 구분해 보고한다.
- 실패 시 zntc/vite/diff 이미지를 Playwright artifact 로 첨부한다.

## Test Plan

- [x] `origin/main`(`d5f026b2`) 기준으로 실행 — react-dom · d3 · codemirror **통과**, chart.js(#4493) · highlight.js(#4503) **정확히 실패**로 검출
- [x] 두 결함을 고치면 통과할 것 (현재는 열린 이슈라 red 가 정상)
- [ ] `zig build test` — 이 PR 은 Zig 코드를 건드리지 않음 (N/A)
- [ ] `zig fmt --check src/` — N/A

**주의**: #4493 · #4503 이 열려 있는 동안 이 게이트는 red 다. 그게 의도다 — 게이트가 결함을 정확히 가리킨다는 증거다. 머지 시점은 두 이슈 수정 뒤로 잡거나, 두 케이스를 `test.fixme` 로 표시해 먼저 들이고 수정과 함께 해제하는 방법도 있다.

## Decision Impact

None
