### PR TITLE
fix(bundler): #4502 ns 객체 getter 가 같은 청크 소비자에게도 크로스-청크 공개명을 쓰던 문제

### DIFF
--- a/.changeset/ns-getter-chunk-local-name.md
+++ b/.changeset/ns-getter-chunk-local-name.md
@@ -1,0 +1,26 @@
+---
+"@zntc/core": patch
+---
+
+코드 스플리팅 + `--minify` 에서 **materialize 된 namespace 객체의 getter** 가 같은 청크 소비자에게도 크로스-청크 전역 공개명을 써서 런타임에 죽던 버그 수정 (#4502, #4492 의 네 번째 표면).
+
+```
+ReferenceError: second is not defined
+```
+
+`import * as ns` 를 **값으로** 쓰면(`const o = ns`) 정적 멤버 재작성이 불가능해 객체가 materialize 된다. 그 리터럴은 **정의자 청크** preamble 로 들어가는데, getter 본문이 크로스-청크 전역 공개명을 쓰고 있었다:
+
+```js
+// 공유 청크 — 선언은 여기 있다
+let n = { label: "second" }, r = { label: "other" };
+var ns_ns = { get second(){ return second }, get other(){ return r } };
+//                          ^^^^^^ 이 청크엔 `second` 선언이 없다 → ReferenceError
+```
+
+`other` 는 크로스-청크로 안 나가서 chunk-local `r` 을 올바르게 쓰는데, `second` 는 **다른 청크가 소비해서 전역 공개명이 등록됐다는 이유만으로** 그 이름을 썼다.
+
+**왜 순진한 게이트로는 못 고치는가.** getter 생성 지점(`buildInlineObjectStr`)을 "같은 청크면 로컬 이름" 으로 게이트하면 #4101 이 회귀한다. 그 시점엔 **per-chunk rename 이 아직 안 돌아서** 로컬 이름이 미-deconflict 원본 이름이기 때문이다 — 서로 다른 모듈의 동명 `const k` 두 개가 한 청크에서 `k` / `k$1` 로 갈려야 하는데 둘 다 `k` 로 collapse 된다(`e1 XK YK XK YK` → `e1 XK YK XK XK`). 코드가 전역 공개명을 쓰고 있던 건 그것이 **"확정된 이름의 대리물"** 이었기 때문이다.
+
+**처방은 게이트가 아니라 타이밍.** 공유 ns preamble 생성을 청크 emit 루프의 `computeRenamesForModules` **뒤** 로 옮겨(출력 위치는 `insertSlice` 로 종전과 동일하게 유지) chunk-local 이름이 확정된 뒤에 리터럴을 만든다. 그러면 getter 가 (같은 청크 선언 → 확정된 chunk-local 이름 / 다른 청크 선언 → 크로스-청크 전역 공개명) 을 정확히 고른다. `ns_inline_cache` 도 소비자 청크마다 문자열이 달라지므로 `(emitter 청크, target)` 복합 키로 re-key 했다.
+
+빌드 exit 0 + 산출물 파싱 통과 + **실행만 실패**하는 계열이라, 번들을 실제로 실행하는 스모크 테스트를 함께 추가했다.

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -1490,7 +1490,6 @@ pub fn computeCrossChunkGlobalNames(
     lnk: *Linker,
 ) !void {
     lnk.clearCrossChunkGlobalNames();
-    lnk.ns_collision_present = false;
 
     // 1. cross-chunk 심볼 enumerate + (mod, name) dedup.
     const Sym = struct { mod: u32, name: []const u8 };
@@ -1531,9 +1530,6 @@ pub fn computeCrossChunkGlobalNames(
     defer used.deinit(allocator);
     for (syms.items) |s| {
         const preferred = lnk.getExportLocalName(s.mod, s.name) orelse s.name;
-        // #4101: preferred 가 이미 다른 cross-chunk 심볼이 점유 = *실제 동명 충돌*(예약어 회피
-        // 와 구분). ns 객체 finalize 재빌드 게이트(ns_collision_present)를 켠다.
-        if (used.contains(preferred)) lnk.ns_collision_present = true;
         const candidate = try deconflictGlobalName(allocator, &used, preferred);
         // candidate 소유권을 맵으로 이전. used 는 맵의 저장본을 borrow(used.deinit 가 키 미해제).
         try lnk.putCrossChunkGlobalName(s.mod, s.name, candidate);

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -447,15 +447,17 @@ pub fn emitChunks(
         // 이 청크의 정의자 모듈에 속한 namespace object literal 만 inline.
         // referrer 청크가 자기 self-preamble 에 inline 하던 동작 (entry 에 vendor
         // 코드 누출) 을 정의자 청크 preamble 로 옮긴다.
-        if (linker) |l| if (l.use_shared_ns_preamble) {
-            var chunk_targets: std.AutoHashMapUnmanaged(u32, void) = .empty;
-            defer chunk_targets.deinit(allocator);
-            try chunk_targets.ensureTotalCapacity(allocator, @intCast(chunk.modules.items.len));
-            for (chunk.modules.items) |mod_idx| {
-                chunk_targets.putAssumeCapacity(@intFromEnum(mod_idx), {});
-            }
-            try l.appendSharedNamespacePreambleFiltered(&chunk_output, &chunk_targets);
-        };
+        //
+        // (#4502) **생성은 아래 `computeRenamesForModules` 뒤로 미룬다.** ns 객체 getter 본문은
+        // 이 청크에 선언이 있는 심볼이면 그 청크의 *확정된* chunk-local 이름을 써야 하는데,
+        // 여기(rename 전)선 아직 미확정이다 — 이전엔 그 대리물로 cross-chunk 전역 공개명을
+        // 썼고, 그 이름은 정작 이 청크 안엔 선언이 없어 ReferenceError 였다. 텍스트가 들어갈
+        // **위치만** 기억해 두고 나중에 `insertSlice` 로 꽂는다 (출력 순서는 종전과 동일 —
+        // sourcemap base 인 `module_line` 은 이 insert 이후에 계산되므로 영향 없음).
+        const ns_preamble_pos: ?usize = if (linker) |l|
+            (if (l.use_shared_ns_preamble) chunk_output.items.len else null)
+        else
+            null;
 
         var rbm_cross_imports: std.ArrayList(RunBeforeMainCrossImport) = .empty;
         defer {
@@ -725,6 +727,26 @@ pub fn emitChunks(
         if (linker) |l| {
             try l.computeRenamesForModules(sorted_mods, occupied.items);
         }
+
+        // (#4502) 이제 이 청크의 chunk-local 이름이 확정됐다 — 공유 namespace preamble 을
+        // 생성해 위에서 잡아 둔 자리에 삽입. getter 본문이 (같은 청크 선언 → 확정 local 명 /
+        // 다른 청크 선언 → cross-chunk 전역 공개명) 으로 정확히 해석된다.
+        if (ns_preamble_pos) |pos| if (linker) |l| {
+            var chunk_targets: std.AutoHashMapUnmanaged(u32, void) = .empty;
+            defer chunk_targets.deinit(allocator);
+            try chunk_targets.ensureTotalCapacity(allocator, @intCast(chunk.modules.items.len));
+            for (chunk.modules.items) |mod_idx| {
+                chunk_targets.putAssumeCapacity(@intFromEnum(mod_idx), {});
+            }
+            // appendSharedNamespacePreambleFiltered 는 linker 의 allocator 로 append 하므로
+            // deinit 도 같은 allocator 로 (기존엔 chunk_output 에 직접 append 했었다).
+            var ns_preamble: std.ArrayList(u8) = .empty;
+            defer ns_preamble.deinit(l.allocator);
+            try l.appendSharedNamespacePreambleFiltered(&ns_preamble, &chunk_targets);
+            if (ns_preamble.items.len > 0) {
+                try chunk_output.insertSlice(allocator, pos, ns_preamble.items);
+            }
+        };
 
         // 엔트리 모듈 인덱스 (final exports용). manual/common 은 엔트리 모듈 없음.
         const entry_mod_idx: ?u32 = switch (chunk.kind) {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -219,11 +219,6 @@ pub const Linker = struct {
     /// 값(전역 이름)은 이 맵이 소유(owned dupe) — borrowed-ptr UAF(#3933) 회피.
     /// **Inc-1: 채우기만(비활성 read)** — 동작 변경 0, 후속 increment 가 wire.
     cross_chunk_global_names: std.AutoHashMapUnmanaged(u32, std.StringHashMapUnmanaged([]const u8)) = .empty,
-    /// #4101 ns collision: cross-chunk 전역명 deconflict 에서 *실제 동명 충돌*(예약어 회피
-    /// 아님)이 1건이라도 발생했는지. true 일 때만 ns 객체 literal 을 finalize 에서 canonical
-    /// 재빌드(getter 가 deconflict 된 inner const 참조) — 비충돌(대부분)은 frozen 유지해
-    /// 재빌드 비용 0(#perf: RN/large 번들 finalize 회귀 방지).
-    ns_collision_present: bool = false,
 
     /// computeRenames 동안만 사는 메모이즈: `module_index → 그 모듈의 nested scope(scope 0 제외)
     /// 바인딩 이름 union set`. `hasNestedBinding` 이 후보(`name$N`)마다 모듈의 모든 scope_maps 를
@@ -335,8 +330,13 @@ pub const Linker = struct {
     /// 슬라이스는 `allocator.dupe` 한 독립 할당이라 다른 키의 put 으로도 무효화되지 않음 —
     /// lock 해제 후에도 안전하게 읽기 가능.
     ns_export_cache: std.AutoHashMapUnmanaged(u32, []NsExportPair) = .empty,
-    /// buildInlineObjectStr 결과 캐시. 키: target_mod_idx. 값 문자열 linker 소유.
-    ns_inline_cache: std.AutoHashMapUnmanaged(u32, []const u8) = .empty,
+    /// buildInlineObjectStr 결과 캐시. 값 문자열 linker 소유.
+    /// 키: `(emitter 청크 << 32) | target_mod_idx` (#4502). 같은 target 이라도 리터럴을
+    /// **담는 청크가 다르면 getter 본문 이름이 달라진다** — 선언이 그 청크 안이면
+    /// chunk-local rename, 밖이면 cross-chunk 전역 공개명. target 단독 키로 캐싱하면
+    /// 먼저 만든 청크의 문자열이 다른 청크로 새어 나가 ReferenceError.
+    /// 청크 컨텍스트가 없으면(단일 번들 / preserve_modules) sentinel 청크로 단일 슬롯.
+    ns_inline_cache: std.AutoHashMapUnmanaged(u64, []const u8) = .empty,
     /// target module 별 공유 namespace object var. namespace 를 값으로 쓰는 여러 importer 가
     /// 같은 객체 선언을 중복 emit 하지 않도록 bundle/chunk preamble 에서 한 번만 쓴다.
     ns_shared_inline_cache: std.AutoHashMapUnmanaged(u32, SharedNsInline) = .empty,
@@ -1767,6 +1767,14 @@ pub const Linker = struct {
         const pc = m2c[canonical_mod];
         if (cc.isNone() or pc.isNone()) return false;
         return cc != pc;
+    }
+
+    /// (#4502) `module_index → ChunkIndex` raw 조회. 청크 컨텍스트가 없거나(단일 번들 /
+    /// preserve_modules) 미배정이면 `.none`. `ns_inline_cache` 의 emitter-청크 키 계산에 쓴다.
+    pub fn chunkOfModule(self: *const Linker, mod_idx: u32) types.ChunkIndex {
+        const m2c = self.module_to_chunk orelse return .none;
+        if (mod_idx >= m2c.len) return .none;
+        return m2c[mod_idx];
     }
 
     /// 전역 이름 맵 비우기 — owned value 해제 + inner 맵 deinit.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -947,7 +947,8 @@ pub fn buildMetadataForAst(
                 {
                     const preamble_name = importBindingName(self, module_index, ib, local_name);
                     // ESM-local getter 객체 (CJS plain-star 멤버는 부재, inner-CJS 는 __toESM).
-                    const obj = try self.buildNamespaceInlineObject(@intCast(canonical_mod), 0);
+                    // emitter = 이 모듈(자기 self-preamble 로 들어감) → getter 이름이 이 청크 기준.
+                    const obj = try self.buildNamespaceInlineObject(module_index, @intCast(canonical_mod), 0);
                     defer self.allocator.free(obj);
                     try preamble.writeNamespaceObject(preamble_name, obj);
                     // 각 `export * from <CJS>` 의 동적 멤버를 런타임 복사.

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -231,7 +231,8 @@ pub fn registerNamespaceRewrites(
                 }
                 const fresh = try makeUniqueNsVarName(self, exp.exported, &seen_exports);
                 try ns_target_to_var.put(self.allocator, target, fresh);
-                const obj_str = try buildInlineObjectStr(self, target, 0);
+                // 비-shared 경로 — 리터럴은 importer 의 self-preamble(= importer 청크) 로 들어간다.
+                const obj_str = try buildInlineObjectStr(self, importer_mod_idx, target, 0);
                 try ns_inline_list.append(self.allocator, .{
                     .symbol_id = null,
                     .object_literal = obj_str,
@@ -284,7 +285,8 @@ pub fn registerNamespaceRewrites(
         if (self.useSharedNsInline(target_mod_idx)) {
             _ = try appendSharedNsInlineEntry(self, ns_inline_list, symbol_id, target_mod_idx, &seen_exports);
         } else {
-            const obj_str = try buildInlineObjectStr(self, target_mod_idx, 0);
+            // 비-shared 경로 — importer self-preamble(= importer 청크) 이 emitter.
+            const obj_str = try buildInlineObjectStr(self, importer_mod_idx, target_mod_idx, 0);
             const ns_var_name = try makeUniqueNsVarName(self, var_name, &seen_exports);
             try ns_inline_list.append(self.allocator, .{
                 .symbol_id = symbol_id,
@@ -369,7 +371,11 @@ fn getOrCreateSharedNamespaceVar(
     }
     mutable_self.ns_cache_mutex.unlock();
 
-    const object_literal = try buildInlineObjectStr(self, target_mod_idx, 0);
+    // shared 경로 — 리터럴은 **정의자 청크**(=target 이 속한 청크) preamble 로 들어간다.
+    // 이 시점(computeCrossChunkLinks/metadata)엔 청크 컨텍스트가 없을 수도 있어 sentinel 키로
+    // 캐시된다. splitting emit 은 appendSharedNamespacePreambleFiltered 가 청크-확정 이름으로
+    // 재빌드하므로 여기 값은 단일 번들 / 증분 persist 용 스냅샷이다 (#4502).
+    const object_literal = try buildInlineObjectStr(self, target_mod_idx, target_mod_idx, 0);
     errdefer self.allocator.free(object_literal);
     const base_name = try makeSharedNamespaceBaseName(self, target_mod_idx);
     defer self.allocator.free(base_name);
@@ -435,20 +441,21 @@ pub fn appendSharedNamespacePreambleFiltered(
             if (!f.contains(target_mod_idx)) continue;
         }
         const entry = self.ns_shared_inline_cache.get(target_mod_idx) orelse continue;
-        // #4101 ns collision: entry.object_literal 은 cross-chunk 전역명 확정 전(computeCrossChunk
-        // Links)에 frozen 됐다 — getter 가 미-deconflict inner const 참조(`{get k(){return k}}`).
-        // *실제 동명 충돌이 있을 때만*(ns_collision_present) 전역명 확정된 이 시점에 ns_inline_cache
-        // 무효화 후 재빌드 → getter(buildInlineObjectStr)가 getCrossChunkGlobalName 으로 올바른
-        // const(=provider 청크 local)를 가리킨다. 비충돌(대부분)은 frozen 유지(재빌드 비용 0 —
-        // RN/large 번들 finalize 회귀 방지). OOM 시 frozen fallback(.ptr 비교로 free 분기).
-        const obj_literal = if (self.ns_collision_present) blk: {
-            const ms = @constCast(self);
-            // 옛 캐시 값은 fetchRemove 로 소유권 회수 후 free — 단순 remove 는 orphan 누수
-            // (deinit 은 맵에 남은 값만 해제). 재빌드가 새 값을 다시 캐시한다.
-            if (ms.ns_inline_cache.fetchRemove(target_mod_idx)) |kv| self.allocator.free(kv.value);
-            break :blk buildInlineObjectStr(self, target_mod_idx, 0) catch entry.object_literal;
-        } else entry.object_literal;
-        defer if (obj_literal.ptr != entry.object_literal.ptr) self.allocator.free(obj_literal);
+        // (#4101 / #4502) `entry.object_literal` 은 청크·rename 확정 *전*(computeCrossChunkLinks 의
+        // ensureSharedNsVar)에 frozen 됐다 — getter 본문이 미-deconflict 원본 이름이다.
+        // splitting emit(=`module_to_chunk` 세팅)에서는 이 리터럴이 **정의자 청크**(target 의 청크)
+        // preamble 로 들어가고, 호출 시점은 그 청크의 `computeRenamesForModules` *이후* 다(emit
+        // 루프가 그렇게 배치, chunks.zig 의 ns preamble insert 참조). 따라서 여기서 emitter=target
+        // 으로 재빌드하면 getter 가 (같은 청크 선언 → 확정된 chunk-local 이름 / 다른 청크 선언 →
+        // cross-chunk 전역 공개명) 을 정확히 고른다. 결과는 `(청크, target)` 키로 캐시되므로 청크당
+        // 1회. 단일 번들/preserve_modules(청크 컨텍스트 없음)는 frozen 유지 → byte-identical.
+        // OOM 시 frozen fallback (`rebuilt == null`).
+        const rebuilt: ?[]const u8 = if (self.module_to_chunk != null)
+            buildInlineObjectStr(self, target_mod_idx, target_mod_idx, 0) catch null
+        else
+            null;
+        defer if (rebuilt) |r| self.allocator.free(r);
+        const obj_literal = rebuilt orelse entry.object_literal;
         if (self.minify_whitespace) {
             if (try tryRewriteGetterObjToArrowExport(self.allocator, obj_literal)) |arrow_map| {
                 defer self.allocator.free(arrow_map);
@@ -483,7 +490,7 @@ pub fn appendSharedNamespacePreambleFiltered(
         // (~9 exports 부터 helper 패턴이 더 짧음). 어느 라이브러리에서 격차가 큰지
         // 식별용 — export count 는 `get ` prefix 개수로 근사.
         if (debug_log.enabled(.ns_inline_audit)) {
-            const literal = entry.object_literal;
+            const literal = obj_literal;
             const export_count = std.mem.count(u8, literal, "get ");
             debug_log.print(.ns_inline_audit, "  - {s}: exports={d} bytes={d}\n", .{
                 entry.var_name,
@@ -778,11 +785,27 @@ fn makeUniqueNsVarName(self: *const Linker, base: []const u8, exports: *const st
     }
 }
 
+/// (#4502) `ns_inline_cache` 키 = `(emitter 청크 << 32) | target`.
+/// 같은 target 이라도 리터럴을 **담는 청크(emitter)** 가 다르면 getter 본문 이름이 달라진다
+/// (선언이 그 청크 안 → chunk-local rename / 밖 → cross-chunk 전역 공개명). target 단독 키면
+/// 먼저 만든 청크의 문자열이 다른 청크로 새어 나간다. 청크 컨텍스트 부재(단일 번들 /
+/// preserve_modules / emit 前)면 `.none`(=maxInt(u32)) 이 sentinel 슬롯이 된다.
+fn nsInlineCacheKey(self: *const Linker, emitter_mod_idx: u32, target_mod_idx: u32) u64 {
+    const chunk_bits: u64 = @intFromEnum(self.chunkOfModule(emitter_mod_idx));
+    return (chunk_bits << 32) | @as(u64, target_mod_idx);
+}
+
 /// 모듈의 모든 export를 인라인 객체 문자열로 생성 (재귀적).
 /// `export * as ns` export는 소스 모듈의 인라인 객체로 중첩.
-/// 결과는 `self.ns_inline_cache` 에 target_mod_idx 별로 캐싱 — linker 전역 공유.
+/// 결과는 `self.ns_inline_cache` 에 `(emitter 청크, target)` 별로 캐싱 — linker 전역 공유.
+///
+/// `emitter_mod_idx`: 이 리터럴이 **어느 청크의 텍스트로 들어가는가**를 대표하는 모듈.
+/// - shared 경로(정의자 청크 preamble) → target 자신
+/// - 비-shared 경로(importer self-preamble) → importer 모듈
+/// getter 본문 이름 해석이 이 청크 기준으로 갈린다 (#4502).
 pub fn buildInlineObjectStr(
     self: *const Linker,
+    emitter_mod_idx: u32,
     target_mod_idx: u32,
     depth: u32,
 ) std.mem.Allocator.Error![]const u8 {
@@ -791,10 +814,11 @@ pub fn buildInlineObjectStr(
         return try self.allocator.dupe(u8, "{}");
 
     const mutable_self = @constCast(self);
+    const cache_key = nsInlineCacheKey(self, emitter_mod_idx, target_mod_idx);
 
     // 캐시 히트: 복사본 반환 (호출자가 소유권을 가짐)
     mutable_self.ns_cache_mutex.lock();
-    const cache_hit = self.ns_inline_cache.get(target_mod_idx);
+    const cache_hit = self.ns_inline_cache.get(cache_key);
     mutable_self.ns_cache_mutex.unlock();
     if (cache_hit) |cached_str| {
         return try self.allocator.dupe(u8, cached_str);
@@ -887,7 +911,8 @@ pub fn buildInlineObjectStr(
                     continue;
                 }
             }
-            const nested = try buildInlineObjectStr(self, src_mod, depth + 1);
+            // 중첩 객체도 같은 emitter 청크의 텍스트 — emitter 를 그대로 물려준다.
+            const nested = try buildInlineObjectStr(self, emitter_mod_idx, src_mod, depth + 1);
             defer self.allocator.free(nested);
             try buf.appendSlice(self.allocator, nested);
         } else {
@@ -905,10 +930,20 @@ pub fn buildInlineObjectStr(
                 defer self.allocator.free(value);
                 try buf.appendSlice(self.allocator, value);
             } else {
-                // #4101 ns collision: materialize 된 ns 객체의 getter 가 참조하는 inner const 도
-                // 동명 deconflict 시 cross-chunk 전역명을 써야 한다(그게 곧 provider 청크 local
-                // 명). chunk-local rename 은 이 시점 미확정이라 getCrossChunkGlobalName 사용.
-                try buf.appendSlice(self.allocator, self.getCrossChunkGlobalName(decl_mod_idx, exp.exported) orelse exp.local);
+                // getter 본문 이름은 **이 리터럴을 담는 청크(emitter)** 기준으로 해석한다.
+                //  - 선언이 다른 청크(#4101): 그 청크가 import 해 오는 cross-chunk 전역 공개명.
+                //    전역명은 provider 청크의 public 이름이자 consumer import 명이라 양쪽 일치.
+                //  - 선언이 같은 청크(#4502): 그 청크의 **확정된 chunk-local 이름**(=exp.local).
+                //    전역 공개명을 쓰면 이 청크엔 그 이름의 선언이 없어 자유 변수 → ReferenceError.
+                // exp.local 이 확정 이름이려면 이 호출이 **해당 청크의 per-chunk rename 이후**여야
+                // 한다 (collectExportsRecursive 가 rename_table 을 읽어 local 을 해석). 그래서
+                // 공유 ns preamble 생성이 emit 루프의 computeRenamesForModules *뒤* 로 옮겨졌다.
+                const use_global = self.isCrossChunkConsumer(emitter_mod_idx, decl_mod_idx);
+                const member_name = if (use_global)
+                    (self.getCrossChunkGlobalName(decl_mod_idx, exp.exported) orelse exp.local)
+                else
+                    exp.local;
+                try buf.appendSlice(self.allocator, member_name);
             }
             try buf.appendSlice(self.allocator, get_close);
         }
@@ -919,11 +954,16 @@ pub fn buildInlineObjectStr(
     // double-check 후 put. race 로 다른 스레드가 이미 put 했으면 내 result 폐기.
     mutable_self.ns_cache_mutex.lock();
     defer mutable_self.ns_cache_mutex.unlock();
-    if (self.ns_inline_cache.get(target_mod_idx)) |raced| {
+    if (self.ns_inline_cache.get(cache_key)) |raced| {
         self.allocator.free(result);
         return try self.allocator.dupe(u8, raced);
     }
-    try mutable_self.ns_inline_cache.put(self.allocator, target_mod_idx, result);
+    // put 실패 시에만 result 해제 (성공하면 맵이 소유 — errdefer 로 걸면 뒤의 dupe OOM 에서
+    // 맵이 소유한 메모리를 또 해제해 double-free).
+    mutable_self.ns_inline_cache.put(self.allocator, cache_key, result) catch |e| {
+        self.allocator.free(result);
+        return e;
+    };
     return try self.allocator.dupe(u8, result);
 }
 

--- a/tests/integration/tests/split-runtime-smoke.test.ts
+++ b/tests/integration/tests/split-runtime-smoke.test.ts
@@ -84,11 +84,8 @@ export const b = () => ticker() + "|B:" + minute.label;
 
   test('#4492 splitting: `import * as ns` 의 멤버 접근도 같은 청크 참조가 오염되지 않는다', async () => {
     // 같은 루트커즈의 **다른 표면** — ns 멤버 재작성(`ns.second` → 식별자)도 게이트 없이
-    // 전역 공개명을 썼다.
-    //
-    // ⚠️ materialize 된 ns **객체 getter**(`{get second(){return second}}`) 는 아직 미해결이다
-    // (#4502) — 그 경로는 `exp.local` 이 미-deconflict 이름이라 순진하게 게이트하면 #4101 이
-    // 회귀한다. 여기선 멤버 경로만 고정한다.
+    // 전역 공개명을 썼다. materialize 된 ns **객체 getter** 는 #4502 에서 별도로 고쳤다
+    // (아래 테스트).
     const files: Record<string, string> = {
       'shared/p.js': `export const second = { label: "second" };\nexport const other = { label: "other" };\n`,
       'shared/consumer.js': `import * as ns from "./p.js";
@@ -127,6 +124,67 @@ export const b = () => member() + "|B:" + other.label;
       // 수정 전: `ReferenceError: second is not defined`
       expect(r.err, `모듈 평가 실패:\n${r.err}`).toBe('');
       expect(r.out).toBe('second|A:second / second|B:other');
+    } finally {
+      await cleanup();
+    }
+  }, 120000);
+
+  test('#4502 splitting: materialize 된 ns 객체 getter 가 같은 청크의 chunk-local 이름을 쓴다', async () => {
+    // 네 번째 표면 — ns 를 **값으로** 쓰면(`const o = ns`) 정적 멤버 재작성이 불가능해
+    // 객체가 materialize 된다: `var ns_ns = {get second(){return <name>}, ...}`.
+    // 이 객체 리터럴은 **정의자 청크**(p.js 가 있는 공유 청크) preamble 로 들어가는데,
+    // getter 본문이 cross-chunk 전역 공개명(`second`)을 쓰면 그 청크엔 그 이름의 선언이
+    // 없다(로컬은 `--minify` 로 `n`) → `ReferenceError: second is not defined`.
+    //
+    //   let n={label:"second"}, r={label:"other"};
+    //   var ns_ns = {get second(){return second}, get other(){return r}};
+    //                             ^^^^^^ 선언 없음      ^ 얘는 맞음(비-cross-chunk)
+    //
+    // 순진하게 "같은 청크면 exp.local" 로 게이트하면 #4101 이 회귀한다 — 리터럴 생성
+    // 시점에 chunk-local rename 이 미확정이라 exp.local 이 미-deconflict 원본 이름이기
+    // 때문. 처방은 리터럴 생성을 per-chunk rename **이후**로 미루는 것.
+    // (#4101 lock 은 cross-chunk-reexport.test.ts 의 'namespace re-export collision' 테스트.)
+    const files: Record<string, string> = {
+      'shared/p.js': `export const second = { label: "second" };\nexport const other = { label: "other" };\n`,
+      'shared/consumer.js': `import * as ns from "./p.js";
+export function useNs() {
+  const o = ns;                      // ns 를 값으로 → 객체 materialize 강제
+  return o.second.label + "+" + o.other.label + "+" + Object.keys(o).length;
+}
+`,
+      'a.js': `import { useNs } from "./shared/consumer.js";
+import { second } from "./shared/p.js";               // 다른 청크가 second 를 소비 → 전역 공개명 생성
+export const a = () => useNs() + "|A:" + second.label;
+`,
+      'b.js': `import { useNs } from "./shared/consumer.js";
+import { other } from "./shared/p.js";
+export const b = () => useNs() + "|B:" + other.label;
+`,
+      'entry.js': `Promise.all([import("./a.js"), import("./b.js")]).then(([m1, m2]) => {
+  console.log(m1.a() + " / " + m2.b());
+});
+`,
+    };
+
+    const { dir, cleanup } = await createFixture(files);
+    try {
+      const outDir = join(dir, 'out');
+      const build = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--splitting',
+        '--outdir',
+        outDir,
+        '--minify',
+        '--format=esm',
+      ]);
+      expect(build.exitCode).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+
+      const r = runNode(join(outDir, 'entry.js'));
+      // 수정 전: `ReferenceError: second is not defined`
+      expect(r.err, `모듈 평가 실패:\n${r.err}`).toBe('');
+      expect(r.out).toBe('second+other+2|A:second / second+other+2|B:other');
     } finally {
       await cleanup();
     }


### PR DESCRIPTION
## 문제

`--splitting --minify` 에서, materialize 된 namespace 객체의 getter 가 **같은 청크 소비자에게도** 크로스-청크 전역 공개명을 씁니다.

```js
// 공유 청크 — 선언이 바로 여기 있다
let n = { label: "second" }, r = { label: "other" };
var ns_ns = { get second(){ return second }, get other(){ return r } };
//                          ^^^^^^ 이 청크엔 `second` 선언이 없다 → ReferenceError
```

`other` getter 는 청크-local `r` 을 올바르게 쓰는데, `second` 는 **다른 청크가 소비해서 전역 공개명이 등록됐다는 이유만으로** 그 공개명을 씁니다. 빌드 exit 0, 파싱 통과, **실행만 실패**.

## 왜 #4492 에서 같이 못 고쳤나 — 게이트가 아니라 **타이밍** 문제였다

`isCrossChunkConsumer` 로 순진하게 게이트하면 **#4101 이 회귀합니다** (실측):

```
x.ts: export const k='XK'   y.ts: export const k='YK'   (한 청크에서 k / k$1 로 deconflict)
기대           : e1 XK YK XK YK
순진한 게이트  : e1 XK YK XK XK      ← 동적 접근(getter)이 둘 다 XK 로 collapse
```

원인을 코드로 확인했습니다. `emitChunks` 에서 **shared-ns preamble 은 `chunks.zig:457` 에서 방출**되는데, 그 청크의 `computeRenamesForModules` 는 **269줄 뒤인 `:726`** 에서야 돕니다. 즉 리터럴을 만드는 시점엔 `exp.local` 이 **아직 deconflict 되지 않은 이름**입니다. 그래서 코드가 크로스-청크 전역명을 **"확정된 이름의 대리물"** 로 쓰고 있었던 겁니다 — 게이트로 그 대리물만 뺏으면 대체제가 없어 `k`/`k$1` 이 `k` 로 collapse 됩니다.

## 처방 — 타이밍을 고친다

1. **preamble 생성을 rename 이후로** — `chunks.zig` 가 preamble 의 바이트 위치를 기억해 두고, `computeRenamesForModules` **뒤에** 생성해 그 위치에 `insertSlice` 합니다. 출력 바이트 순서는 그대로이고, 소스맵 base(`module_line`)도 insert 이후에 계산해 정확합니다.
2. **getter 이름을 export 별로 해석** — decl 이 **다른 청크** 면 전역 공개명(#4101 경로), **같은 청크** 면 `exp.local` (이제 **확정된** chunk-local 이름, #4502).
3. **캐시 re-key** — `ns_inline_cache` 를 `(emitter 청크 << 32) | target` 으로 키잉. 청크 컨텍스트가 없으면(단일 번들 / preserve_modules) sentinel 슬롯 → 그 경로는 **byte-identical**. 키가 청크별이라 stale 이 새지 않아 `ns_collision_present` 조건부 재빌드 훅(그리고 orphan 을 흘리던 `fetchRemove`)을 **통째로 제거**했습니다.
4. 도입할 뻔한 double-free 도 함께 정리 (`put` 실패 시 free 와 후속 `dupe` OOM 의 errdefer 충돌).

## 검증 — 둘 다 통과해야 의미가 있다

| | 수정 전 | 수정 후 |
|---|---|---|
| **#4502 재현** | `{get second(){return second}}` → **ReferenceError** | `{get second(){return n}}` → 정상 |
| **#4101 lock** | `e1 XK YK XK YK` | `e1 XK YK XK YK` (**byte-identical**) |

추가 확인: `--minify` 하의 #4101, getter 의 선언이 *다른* 청크에 있는 경우(전역명이 정답) 정상, 연속 2회 빌드 byte-identical(결정성).

## 테스트

- `zig build test` 통과
- 통합: base 대비 **신규 실패 0** (실패 셋이 동일). 스냅샷 1765건 통과 → 비-splitting 출력 byte-identical
- 실행 스모크 추가 (번들을 **실제로 실행**해 검증)

Closes #4502

🤖 Generated with [Claude Code](https://claude.com/claude-code)