### PR TITLE
fix(bundler): #4495 DCE 된 심볼이 청크 export 에 남아 모듈 로드 실패

### DIFF
--- a/.changeset/split-dangling-export-after-const-inline.md
+++ b/.changeset/split-dangling-export-after-const-inline.md
@@ -1,0 +1,20 @@
+---
+"@zntc/core": patch
+---
+
+`--splitting` 에서 **선언이 tree-shake 된 심볼이 청크의 `export {}` 에 남아** node 가 모듈 로드를 거부하던 버그 수정 (#4495).
+
+```
+SyntaxError: Export 'extra' is not defined in module
+```
+
+크로스-청크 export/import 목록(`chunk.exports_to` / `chunk.imports_from`)은 **스캐너 시점 메타데이터**(`import_bindings` / `export_bindings`)만 보고 만들어졌다. 그런데 그 뒤에 tree-shaker 가 선언을 지우는 경로가 두 가지 있다.
+
+- **크로스-모듈 const-inline**: `export const extra = 1` 은 소비자 AST 에 리터럴 `1` 로 박히므로 참조가 0 → 선언 statement 가 DCE.
+- **미사용 named import**: `import { unused } from "./barrel"` 를 실제로 안 쓰면 참조가 애초에 0 → 마찬가지로 DCE.
+
+두 경우 모두 provider 청크는 선언 없이 `export { extra };` 를 내보내고, 소비자 청크는 `import { extra } from "./chunk-X.js"` 를 그대로 유지했다. **빌드 exit 0 + 모든 청크 파싱 통과** 라 산출물 재파싱 게이트로는 잡히지 않고, node 가 모듈을 **링크**할 때 거부한다.
+
+이제 크로스-청크 심볼 등록 지점(`addCrossChunkSymbol`)이 canonical 선언의 생존 여부를 확인해, DCE 된 심볼은 provider 의 `export {}` 와 소비자의 `import {}` 양쪽에서 함께 빠진다. emitter 가 statement DCE 를 건너뛰는 모듈(래핑 모듈 / `export *` 소스 / 청크 entry + non-minify / tree-shaker 비활성)은 선언이 그대로 남으므로 보수적으로 유지한다.
+
+번들을 실제로 **실행**하는 스모크 스위트(`split-runtime-smoke`)를 함께 추가했다.

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -1256,6 +1256,72 @@ fn removeModuleFromList(list: *std.ArrayListUnmanaged(ModuleIndex), target: Modu
 // computeCrossChunkLinks — 크로스 청크 의존성 계산
 // ============================================================
 
+/// (#4495) 이 (canonical 모듈, export 이름) 심볼의 **선언이 emit 되지 않는지** 판정.
+///
+/// `exports_to`/`imports_from` 은 스캐너 시점 메타데이터(`import_bindings` /
+/// `export_bindings`)만 보고 만들어진다. 그런데 그 사이에 tree-shaker 가
+///   - 크로스-모듈 const-inline: `export const extra = 1` 이 소비자 AST 에 리터럴 `1`
+///     로 박히고 나면 참조가 0 → 선언 statement 가 DCE
+///   - 단순 미사용 named import: 참조가 애초에 0 → 선언 statement 가 DCE
+/// 로 **선언을 지운다**. 그런데도 심볼이 목록에 남으면 provider 청크가 선언 없이
+/// `export { extra };` 를 내보내고, node 는 모듈 로드 자체를 거부한다
+/// (`SyntaxError: Export 'extra' is not defined in module`). 소비자 청크 쪽
+/// `import { extra }` 도 같은 목록에서 나오므로 두 목록을 한 지점에서 함께 막는다.
+///
+/// **판정 실패 방향은 항상 "유지"(false)**. emitter 가 statement DCE 를 *건너뛰는*
+/// 모듈은 선언이 그대로 남으므로 export 를 지우면 안 된다:
+///   - tree-shaker 비활성(dev / `--no-tree-shaking`) → `tree_shaker_active == false`
+///   - 래핑 모듈(`__esm`/`__commonJS`) → emitter 의 statement-shake 게이트가 제외
+///   - `export * from` 소스 → emitter 가 `all_used` 로 DCE 자체를 끈다
+///   - 청크 entry 모듈 + `minify_syntax=false` → 같은 게이트가 statement-shake 를 끈다
+/// canonical 이 `.local` 선언이 아닐 때(re-export/star/합성 ns 변수/CJS 런타임 멤버)도
+/// 로컬 선언 유무로 판정할 수 없으므로 유지한다.
+///
+/// 순수 판정부 — Linker/ChunkGraph 조회와 분리해 유닛 테스트 대상으로 노출한다.
+/// `is_chunk_entry` / `minify_syntax` / `is_star_target` 은 emitter 의
+/// statement-shake 게이트를 그대로 옮긴 입력이다.
+pub fn crossChunkExportShakenDecision(
+    m: *const Module,
+    export_name: []const u8,
+    is_chunk_entry: bool,
+    minify_syntax: bool,
+    is_star_target: bool,
+) bool {
+    if (!m.tree_shaker_active) return false;
+    if (m.wrap_kind != .none) return false;
+    if (is_star_target) return false;
+    if (is_chunk_entry and !minify_syntax) return false;
+    const eb = m.findExportBinding(export_name) orelse return false;
+    if (eb.kind != .local) return false;
+    return !m.isLocalBindingAlive(m.exportBindingLocalName(eb.*));
+}
+
+fn crossChunkExportIsShaken(
+    chunk_graph: *const ChunkGraph,
+    lnk: *const Linker,
+    src_chunk_idx: ChunkIndex,
+    canonical_module: u32,
+    export_name: []const u8,
+) bool {
+    const m = lnk.getModule(canonical_module) orelse return false;
+    const is_star_target = if (lnk.tree_shaker) |s| s.isReExportStarTarget(canonical_module) else false;
+    const src_ci = @intFromEnum(src_chunk_idx);
+    const is_chunk_entry = blk: {
+        if (src_ci >= chunk_graph.chunks.items.len) break :blk true; // 알 수 없으면 보수적(=유지 쪽)
+        break :blk switch (chunk_graph.chunks.items[src_ci].kind) {
+            .entry_point => |info| @intFromEnum(info.module) == canonical_module,
+            .common, .manual => false,
+        };
+    };
+    return crossChunkExportShakenDecision(
+        m,
+        export_name,
+        is_chunk_entry,
+        lnk.graph.transform_options_base.minify_syntax,
+        is_star_target,
+    );
+}
+
 /// 각 청크의 크로스 청크 의존성을 계산한다.
 ///
 /// 청크 A의 모듈이 청크 B의 모듈을 정적 import하면 A.cross_chunk_imports에 B가 추가된다.
@@ -1278,6 +1344,7 @@ fn addCrossChunkSymbol(
     allocator: std.mem.Allocator,
     chunk_graph: *ChunkGraph,
     chunk: *Chunk,
+    lnk: *const Linker,
     seen_static: *std.AutoHashMapUnmanaged(u32, void),
     src_chunk_idx: ChunkIndex,
     export_name: []const u8,
@@ -1286,6 +1353,10 @@ fn addCrossChunkSymbol(
     canonical_module: u32,
 ) !void {
     const src_ci = @intFromEnum(src_chunk_idx);
+
+    // (#4495) 선언이 DCE 된 심볼은 어떤 목록에도 올리지 않는다 — provider 의
+    // `export {}` 도, 소비자의 `import {}` 도 여기 한 곳에서만 나온다.
+    if (crossChunkExportIsShaken(chunk_graph, lnk, src_chunk_idx, canonical_module, export_name)) return;
 
     // 심볼의 canonical 청크가 *직접 의존*이 아닐 수 있다(re-export 체인
     // importer→page→inner: importer 는 inner 를 직접 의존 안 함). emitter 는
@@ -1328,7 +1399,7 @@ fn linkReExportName(
     const src_chunk_idx = chunk_graph.getModuleChunk(canon.module_index);
     if (src_chunk_idx.isNone()) return;
     if (src_chunk_idx == chunk.index) return; // 같은 청크 → 스킵
-    try addCrossChunkSymbol(allocator, chunk_graph, chunk, seen_static, src_chunk_idx, canon.export_name, @intFromEnum(canon.module_index));
+    try addCrossChunkSymbol(allocator, chunk_graph, chunk, lnk, seen_static, src_chunk_idx, canon.export_name, @intFromEnum(canon.module_index));
 }
 
 /// `mod_idx` 의 `export_name` 이 namespace re-export 인지 판정하고, 맞으면
@@ -1470,7 +1541,7 @@ fn linkNamespaceCrossChunk(
     // seam — ensureSharedNsVar 가 선제 materialize. 상세는 그 doc 참조.
     const ns_var = try lnk.ensureSharedNsVar(target);
     // ns_var 는 합성 namespace 변수명(예약어 아님) → canonical_module 미사용.
-    try addCrossChunkSymbol(allocator, chunk_graph, chunk, seen_static, tgt_chunk, ns_var, @intFromEnum(target));
+    try addCrossChunkSymbol(allocator, chunk_graph, chunk, lnk, seen_static, tgt_chunk, ns_var, @intFromEnum(target));
     try fanOutModuleExports(allocator, chunk_graph, chunk, seen_static, lnk, target, module_count);
 }
 
@@ -1625,7 +1696,7 @@ pub fn computeCrossChunkLinks(
                     if (src_chunk_idx.isNone()) continue;
                     if (src_chunk_idx == chunk.index) continue; // 같은 청크 → 스킵
 
-                    try addCrossChunkSymbol(allocator, chunk_graph, chunk, &seen_static, src_chunk_idx, rb.canonical.export_name, @intFromEnum(rb.canonical.module_index));
+                    try addCrossChunkSymbol(allocator, chunk_graph, chunk, lnk, &seen_static, src_chunk_idx, rb.canonical.export_name, @intFromEnum(rb.canonical.module_index));
 
                     // canonical 이 namespace re-export 면 그 이름만 가져와선
                     // 안 된다 — 정적 멤버는 정의자 export 로 elision, 값/동적은

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -9,6 +9,7 @@ const ChunkIndex = chunk_mod.ChunkIndex;
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 const Module = @import("module.zig").Module;
+const ExportBinding = @import("module.zig").ExportBinding;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
 const resolve_cache_mod = @import("resolve_cache.zig");
 
@@ -426,6 +427,85 @@ fn makeTestModule(alloc: std.mem.Allocator, index: u32, path: []const u8) Module
     // ArrayList 필드는 .empty으로 초기화됨 — append 시 allocator를 전달
     _ = alloc;
     return m;
+}
+
+// ============================================================
+// Tests — crossChunkExportShakenDecision (#4495)
+// ============================================================
+
+/// 크로스-청크 export 목록에서 뺄지 말지의 결정표.
+///
+/// `tree_shaker_active=true` + `is_included=false` = 모듈 자체가 emit 안 됨 →
+/// `isLocalBindingAlive` 가 dead 판정하는 가장 단순한 경로. 나머지 축(래핑 /
+/// star 소스 / 청크 entry+non-minify / export kind)은 전부 **유지(false)** 쪽으로
+/// 보수 폴백해야 한다 — 잘못 빼면 소비자가 미바인딩(ReferenceError) 된다.
+fn shakenDecisionModule(dead: bool) Module {
+    var m = Module.init(@enumFromInt(0), "barrel.ts");
+    m.module_type = .js;
+    m.state = .ready;
+    m.tree_shaker_active = true;
+    m.is_included = !dead;
+    return m;
+}
+
+test "crossChunkExportShakenDecision: 선언이 DCE 된 .local export 는 목록에서 제외 (#4495)" {
+    var m = shakenDecisionModule(true);
+    var ebs = [_]ExportBinding{
+        .{ .exported_name = "extra", .local_name = "extra", .local_span = .{ .start = 0, .end = 0 }, .kind = .local },
+    };
+    m.export_bindings = &ebs;
+
+    try std.testing.expect(chunk_mod.crossChunkExportShakenDecision(&m, "extra", false, true, false));
+    // 살아있는 선언(모듈이 emit 됨) → 유지.
+    var alive = shakenDecisionModule(false);
+    alive.export_bindings = &ebs;
+    try std.testing.expect(!chunk_mod.crossChunkExportShakenDecision(&alive, "extra", false, true, false));
+}
+
+test "crossChunkExportShakenDecision: emitter 가 statement DCE 를 건너뛰는 모듈은 보수적 유지 (#4495)" {
+    var ebs = [_]ExportBinding{
+        .{ .exported_name = "extra", .local_name = "extra", .local_span = .{ .start = 0, .end = 0 }, .kind = .local },
+    };
+
+    // tree-shaker 비활성(dev / --no-tree-shaking) → 판정 불가 → 유지.
+    var no_shaker = shakenDecisionModule(true);
+    no_shaker.export_bindings = &ebs;
+    no_shaker.tree_shaker_active = false;
+    try std.testing.expect(!chunk_mod.crossChunkExportShakenDecision(&no_shaker, "extra", false, true, false));
+
+    // 래핑 모듈(__esm / __commonJS) → emitter statement-shake 게이트 제외 → 유지.
+    for ([_]types.WrapKind{ .esm, .cjs }) |wk| {
+        var wrapped = shakenDecisionModule(true);
+        wrapped.export_bindings = &ebs;
+        wrapped.wrap_kind = wk;
+        try std.testing.expect(!chunk_mod.crossChunkExportShakenDecision(&wrapped, "extra", false, true, false));
+    }
+
+    // `export * from "./this"` 소스 → emitter 가 all_used 로 DCE 자체를 끔 → 유지.
+    var star = shakenDecisionModule(true);
+    star.export_bindings = &ebs;
+    try std.testing.expect(!chunk_mod.crossChunkExportShakenDecision(&star, "extra", false, true, true));
+
+    // 청크 entry 모듈 + minify_syntax=false → statement-shake 안 돎(선언 그대로 emit) → 유지.
+    var entry = shakenDecisionModule(true);
+    entry.export_bindings = &ebs;
+    try std.testing.expect(!chunk_mod.crossChunkExportShakenDecision(&entry, "extra", true, false, false));
+    // 같은 entry 라도 minify_syntax=true 면 shake 가 돌아 선언이 사라진다 → 제외.
+    try std.testing.expect(chunk_mod.crossChunkExportShakenDecision(&entry, "extra", true, true, false));
+}
+
+test "crossChunkExportShakenDecision: .local 이 아닌 export / 미등록 이름은 유지 (#4495)" {
+    // re-export 는 canonical 선언이 이 모듈에 없다 → 로컬 선언 유무로 판정 불가.
+    var re = shakenDecisionModule(true);
+    var re_ebs = [_]ExportBinding{
+        .{ .exported_name = "extra", .local_name = "extra", .local_span = .{ .start = 0, .end = 0 }, .kind = .re_export },
+    };
+    re.export_bindings = &re_ebs;
+    try std.testing.expect(!chunk_mod.crossChunkExportShakenDecision(&re, "extra", false, true, false));
+
+    // 합성 namespace 변수(`X_ns`) 처럼 export_bindings 에 없는 이름 → 유지.
+    var ns = shakenDecisionModule(true);
+    try std.testing.expect(!chunk_mod.crossChunkExportShakenDecision(&ns, "barrel_ns", false, true, false));
 }
 
 test "generateChunks: single entry, no dynamic imports" {

--- a/tests/integration/tests/split-dangling-export.test.ts
+++ b/tests/integration/tests/split-dangling-export.test.ts
@@ -1,0 +1,189 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { createFixture, runNode, writeOutputs } from './helpers';
+import { init, close, build } from '../../../packages/core/index';
+
+// splitting 산출물의 **실행** 스모크.
+//
+// "빌드 exit 0 + 모든 청크 parse 통과 + 런타임 실패" 계열은 산출물 재파싱
+// 게이트로 잡히지 않는다. ESM 의 `export { x }` 미선언은 *문법*은 유효하고
+// 모듈 **링크** 시점에 node 가 거부한다 (`SyntaxError: Export 'x' is not
+// defined in module`). 그래서 여기서는 청크를 디스크에 쓰고 실제로 실행한다.
+//
+// #4495: 크로스-모듈 const-inline(숫자 상수) 또는 미사용 named import 로
+// 소비자 참조가 0 이 되면 tree-shaker 가 provider 의 선언을 DCE 하는데,
+// 청크의 크로스-청크 export/import 목록(chunk.exports_to / imports_from)은
+// 스캐너 시점 메타데이터로만 만들어져 그 심볼이 그대로 남아 있었다.
+
+describe('split runtime smoke (실행 검증)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  async function buildAndRun(
+    files: Record<string, string>,
+    opts: Record<string, unknown>,
+  ): Promise<{ stdout: string; outs: { path: string; text: string }[] }> {
+    const fixture = await createFixture(files);
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.ts')],
+      rootDir: fixture.dir,
+      platform: 'node',
+      splitting: true,
+      ...opts,
+    });
+    expect(result.errors ?? []).toHaveLength(0);
+    const outs = result.outputFiles!;
+    writeOutputs(fixture.dir, outs);
+    const entry = outs.find((o) => o.path.includes('entry') && o.path.endsWith('.js'))!;
+    expect(entry).toBeDefined();
+    const { stdout } = await runNode(join(fixture.dir, entry.path));
+    return { stdout, outs };
+  }
+
+  /** 모든 청크에서 `export { ... }` 로 노출된 public 이름 목록. */
+  function exportedNames(text: string): string[] {
+    const names: string[] = [];
+    for (const stmt of text.match(/export\s*\{([^}]*)\}/g) ?? []) {
+      for (const raw of stmt.replace(/export\s*\{|\}/g, '').split(',')) {
+        const s = raw.trim();
+        if (!s) continue;
+        names.push((s.includes(' as ') ? s.split(' as ')[1] : s).trim());
+      }
+    }
+    return names;
+  }
+
+  // #4495 본체: barrel 이 다른 모듈을 re-export 하면서 숫자 const 도 export.
+  // 숫자 const 는 크로스-모듈 const-inline 대상이라 a/b 에 리터럴 `1` 로 박히고
+  // barrel 의 선언은 DCE 된다. 그런데 barrel 청크는 `export { extra }` 를
+  // 그대로 내보내 node 가 모듈 로드를 거부했다.
+  const inlineFixture = {
+    'prov.ts': `export const second = { label: "second" };`,
+    'barrel.ts': `export { second } from "./prov";\nexport const extra = 1;`,
+    'a.ts': `import { second, extra } from "./barrel";\nexport const a = second.label + ":" + extra;`,
+    'b.ts': `import { second, extra } from "./barrel";\nexport const b = second.label + "/" + extra;`,
+    'entry.ts': `Promise.all([import("./a"), import("./b")]).then(([m1, m2]) => console.log("OK", m1.a, m2.b));`,
+  };
+
+  // minify 유무 모두 — 숫자 const 인라인(numeric post-pass)은 --minify 없이도 돈다.
+  for (const minify of [false, true]) {
+    test(`esm: const-inline 된 re-export 가 dangling export 를 남기지 않는다 (#4495, minify=${minify})`, async () => {
+      const { stdout, outs } = await buildAndRun(inlineFixture, { format: 'esm', minify });
+      expect(stdout.trim()).toBe('OK second:1 second/1');
+
+      // 어떤 청크도 `extra` 를 노출하면 안 된다(선언이 DCE 됐으므로).
+      for (const o of outs) {
+        if (!o.path.endsWith('.js')) continue;
+        expect(exportedNames(o.text)).not.toContain('extra');
+        // 소비자 청크의 크로스-청크 import 목록에도 남으면 안 된다.
+        expect(/import\s*\{[^}]*\bextra\b[^}]*\}\s*from/.test(o.text)).toBe(false);
+      }
+    });
+  }
+
+  // 같은 루트커즈의 일반형: 인라인이 아니라 **아예 안 쓰는** named import.
+  // 참조가 0 → provider 선언 DCE → 목록에만 남아 dangling export.
+  test('esm: 미사용 named cross-chunk import 가 dangling export 를 남기지 않는다 (#4495)', async () => {
+    const { stdout, outs } = await buildAndRun(
+      {
+        'prov.ts': `export const second = { label: "second" };`,
+        'barrel.ts': `export { second } from "./prov";\nexport const unused = { k: 1 };`,
+        'a.ts': `import { second, unused } from "./barrel";\nexport const a = second.label + ":a";`,
+        'b.ts': `import { second, unused } from "./barrel";\nexport const b = second.label + "/b";`,
+        'entry.ts': `Promise.all([import("./a"), import("./b")]).then(([m1, m2]) => console.log("OK", m1.a, m2.b));`,
+      },
+      { format: 'esm' },
+    );
+    expect(stdout.trim()).toBe('OK second:a second/b');
+    for (const o of outs) {
+      if (!o.path.endsWith('.js')) continue;
+      expect(exportedNames(o.text)).not.toContain('unused');
+    }
+  });
+
+  // 회귀 가드: 인라인되지 **않는** 심볼(string/object/function)의 크로스-청크
+  // export/import 는 그대로여야 한다. dead-export 필터가 과잉 동작하면
+  // ReferenceError 로 즉시 터진다.
+  test('esm: 인라인 안 되는 심볼의 크로스-청크 export/import 는 유지 (#4495 회귀 가드)', async () => {
+    const { stdout, outs } = await buildAndRun(
+      {
+        'prov.ts': `export const second = { label: "second" };`,
+        'barrel.ts':
+          `export { second } from "./prov";\n` +
+          `export const num = 1;\n` +
+          `export const str = "S";\n` +
+          `export const obj = { k: 2 };\n` +
+          `export function fn() { return "fn"; }`,
+        'a.ts': `import { second, num, str, obj, fn } from "./barrel";\nexport const a = [second.label, num, str, obj.k, fn()].join("|");`,
+        'b.ts': `import { second, num, str, obj, fn } from "./barrel";\nexport const b = [second.label, num, str, obj.k, fn()].join("/");`,
+        'entry.ts': `Promise.all([import("./a"), import("./b")]).then(([m1, m2]) => console.log("OK", m1.a, m2.b));`,
+      },
+      { format: 'esm' },
+    );
+    expect(stdout.trim()).toBe('OK second|1|S|2|fn second/1/S/2/fn');
+
+    const shared = outs.find(
+      (o) => o.path.endsWith('.js') && !/entry|[ab]-/.test(o.path.split('/').pop()!),
+    )!;
+    expect(shared).toBeDefined();
+    const names = exportedNames(shared.text);
+    // 인라인 대상(num)만 빠지고 나머지는 전부 크로스-청크 노출 유지.
+    for (const n of ['second', 'str', 'obj', 'fn']) expect(names).toContain(n);
+    expect(names).not.toContain('num');
+  });
+
+  // entry 모듈이 shared 청크 심볼을 dead statement 에서만 참조 — tree-shaker 는
+  // entry statement 를 살아있는 것으로 보므로 선언·export 가 유지돼야 한다
+  // (dead-export 필터가 entry 를 잘못 죽이면 ReferenceError).
+  test('esm: entry 의 dead statement 참조도 크로스-청크 export 유지 (#4495 회귀 가드)', async () => {
+    const { stdout } = await buildAndRun(
+      {
+        'shared.ts': `export const obj = { k: 1 };\nexport const other = { m: 2 };`,
+        'a.ts': `import { other } from "./shared";\nexport const a = "a" + other.m;`,
+        'b.ts': `import { other } from "./shared";\nexport const b = "b" + other.m;`,
+        'entry.ts':
+          `import { obj } from "./shared";\n` +
+          `const dead = obj.k;\n` +
+          `Promise.all([import("./a"), import("./b")]).then(([m1, m2]) => console.log("OK", m1.a, m2.b, typeof dead));`,
+      },
+      { format: 'esm' },
+    );
+    expect(stdout.trim()).toBe('OK a2 b2 number');
+  });
+
+  // cjs splitting 도 같은 목록을 쓴다 — 실행으로 미바인딩(ReferenceError) 회귀 가드.
+  test('cjs: const-inline 된 re-export 청크도 실행 정상 (#4495)', async () => {
+    const { stdout } = await buildAndRun(inlineFixture, { format: 'cjs' });
+    expect(stdout.trim()).toBe('OK second:1 second/1');
+  });
+
+  // 단일 번들(splitting 아님) 경로 불변 — computeCrossChunkLinks 자체를 안 타므로
+  // const-inline 결과가 그대로 실행돼야 한다. (dynamic import 는 단일 번들에서
+  // 인라인되는데 그 실행 순서는 이 이슈와 무관한 별건이라 정적 import 로 검증.)
+  test('esm: 단일 번들은 무변경 (#4495 회귀 가드)', async () => {
+    const fixture = await createFixture({
+      ...inlineFixture,
+      'entry.ts': `import { a } from "./a";\nimport { b } from "./b";\nconsole.log("OK", a, b);`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.ts')],
+      rootDir: fixture.dir,
+      platform: 'node',
+      format: 'esm',
+    });
+    const outs = result.outputFiles!.filter((o) => o.path.endsWith('.js'));
+    expect(outs.length).toBe(1);
+    writeOutputs(fixture.dir, result.outputFiles!);
+    const { stdout } = await runNode(join(fixture.dir, outs[0].path));
+    expect(stdout.trim()).toBe('OK second:1 second/1');
+  });
+});


### PR DESCRIPTION
## 문제

`--splitting` 산출물이 **모듈 로드 자체를 거부**당합니다.

```
SyntaxError: Export 'extra' is not defined in module
```

빌드 exit 0, **모든 청크가 파싱은 통과**합니다 (문법은 유효 — ESM 링크 시점에 거부).

```js
// barrel 청크
import { second } from "./chunk-X.js";
export { extra };          // ← `extra` 는 리터럴 1 로 인라인되고 선언은 DCE 됐다
// a.js
import { extra, second } from "./chunk-X.js";   // ← 쓰지도 않는 extra 를 여전히 import
```

## 조사 중 확인 — **버그 범위가 이슈보다 넓다**

const-inline 은 트리거 **중 하나**일 뿐이고, 근본은 "소비자 참조가 0이 되는 모든 경로" 입니다.

- 크로스-모듈 const-inline (`export const extra = 1` → 리터럴로 박힘) — **`--minify` 없이도 재현** (numeric post-pass 는 무조건 실행)
- **단순 미사용 named import** (`import { unused }` 를 안 씀) → 동일하게 dangling export. 이슈에 없던 케이스

## 원인

`chunk.exports_to` / `imports_from` 를 만드는 `computeCrossChunkLinks` 는 **스캐너 시점 메타데이터**(`import_bindings` / `export_bindings`)만 봅니다. 그 뒤 tree-shaker 가 선언을 지우는데 **목록은 갱신되지 않습니다.**

provider 의 `export {}` 와 소비자의 `import {}` 는 **둘 다 같은 등록 지점**(`addCrossChunkSymbol`)에서 나오므로, 거기서 한 번에 막았습니다.

## 처방

`addCrossChunkSymbol` 진입부에서 canonical 선언의 **생존**을 확인해 조기 return 합니다.

판정이 불확실하면 **항상 "유지"** 쪽으로 폴백합니다 — emitter 가 statement DCE 를 건너뛰는 모듈은 선언이 남으므로, export 를 잘못 지우면 SyntaxError 가 ReferenceError 로 바뀔 뿐입니다. emitter 의 statement-shake 게이트를 그대로 미러링했습니다 (tree-shaker 비활성(dev) / 래핑 모듈 / `export *` 소스 / 청크 entry + `minify_syntax=false` / `.local` 아닌 export).

**#4492 의 함정 회피**: 판정에 export 명과 소스 local 명만 쓰므로 **chunk-local rename 확정 시점에 의존하지 않습니다.**

## 검증

```
[before] node out/entry.js → SyntaxError: Export 'extra' is not defined in module
         chunk: let t={label:"second"};export{extra,t as second};   ← extra 선언 없음
         a.js : import{extra,second}from"./chunk-X.js";             ← 쓰지도 않는 extra

[after]  node out/entry.js → OK
         chunk: let t={label:"second"};export{t as second};
         a.js : import{second}from"./chunk-X.js";
```

## 테스트

- 결정표 유닛 3건 + **실행 스모크 6건** (번들을 실제로 실행 — 이 계열은 파싱을 통과하므로 재파싱 게이트로는 못 잡습니다). 인라인 안 되는 심볼의 크로스-청크 export/import 가 **유지**되는지도 회귀 가드로 박제.
- `zig build test` 통과, 통합 4129 pass / 0 fail
- lock 테스트(`cross-chunk-*`, cjs/iife/umd-amd, css-code-splitting, const-value-inline, export-star-emit, determinism, bundle-smoke) 전부 통과

## 부수 발견 (별건, 미수정)

**단일 번들 + 인라인된 dynamic import 의 모듈 순서 버그** — main 에도 존재합니다. `entry → a → b → barrel → prov` 순으로 emit 되어 `const a = second.label…` 이 `const second` 보다 먼저 나옵니다 → `ReferenceError: Cannot access 'second' before initialization`. #4495 와 무관한 exec-order 문제라 손대지 않았고, 스모크의 단일 번들 가드는 정적 import 로 우회했습니다. 별도 이슈 등록 예정.

Closes #4495

🤖 Generated with [Claude Code](https://claude.com/claude-code)