### PR TITLE
fix(bundler): #4494 크로스-청크 CJS import 가 provider 청크의 require 썽크를 참조

### DIFF
--- a/.changeset/cross-chunk-cjs-require-thunk.md
+++ b/.changeset/cross-chunk-cjs-require-thunk.md
@@ -1,0 +1,25 @@
+---
+"@zntc/core": patch
+---
+
+`--splitting` 에서 **다른 청크의 CJS 모듈을 직접 import** 하면 실행이 `ReferenceError` 로 죽던 버그 수정 (#4494).
+
+```
+shared/single.cjs : module.exports = { tag: "singleton" };
+shared/same.js    : import single from "./single.cjs";   // 공통 청크에 안착
+a.js              : import single from "./single.cjs";   // 별도 동적 청크
+```
+
+→ `ReferenceError: require_single is not defined`. 빌드는 exit 0, 산출물도 전부 파싱을 통과하고 **실행만** 실패했다 (named import 도 동일).
+
+소비자 청크가 per-importer interop preamble(`var single = require_single();`)을 냈는데, `require_X` 썽크는 provider 청크에만 있고 export 되지도 않는다(minify 후엔 이름도 다름).
+
+**원인** — 직접 CJS import 가 cross-chunk 심볼로 등록되지 않았다. CJS 는 정적 export 가 없어 `resolveExportChain` 이 null → resolved binding 이 없고, `computeCrossChunkLinks` 가 그 바인딩을 통째로 skip 했다. 그래서 provider 는 interop 값을 export 하지 않았고 #4120 의 "cross-chunk CJS-interop 소비 억제" 게이트도 전역 공개명을 못 찾아 발화하지 않았다(re-export 경유 `export {default} from './a.cjs'` 만 등록돼 정상 동작). 이제 직접 import 도 canonical(CJS)+export 명으로 등록해, provider 청크가 interop 값을 materialize/export 하고 소비자는 일반 cross-chunk import 로 받는다.
+
+같이 고친 것 (멤버명이 cross-chunk 공개명이 되면서 드러난 인접 결함들):
+
+- **CJS 공개명을 합성명으로** (`default$single` / `named$second`). 예전엔 멤버명을 그대로 청크 top-level 식별자로 썼는데, 그러면 `exports.Buffer` 같은 멤버가 청크 안의 진짜 전역 `Buffer` 를 가리고(`Buffer.from is not a function`), 동명 청크 로컬(`const named`)과 `var`↔`const` 재선언 SyntaxError 를 냈다.
+- **CJS owner 는 항상 materialize**. 예전엔 "동명 로컬이 있으면 interop 불요" 로 판단했는데, 그 로컬은 `__commonJS` 클로저 *안* 심볼이었다 — minify 시 `export { o as tag }` 로 클로저 스코프 이름을 노출해 `SyntaxError: Export 'o' is not defined`. (#4120 re-export 경로에도 있던 선재 버그.)
+- dev/lazy 의 cross-chunk 전역명 override 가 CJS 클로저 내부 심볼을 개명하던 문제.
+
+provider 가 실제로 materialize 하지 못하는 구성(preserve-modules, 비-ESM 포맷 + provider 가 entry 청크)에서는 **등록하지 않는다** — 소비자만 preamble 을 억제하면 값이 조용히 `undefined` 가 되어, 기존의 시끄러운 ReferenceError 보다 나빠지기 때문이다.

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -24,6 +24,8 @@ const Module = @import("module.zig").Module;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
 const TreeShaker = @import("tree_shaker.zig").TreeShaker;
 const Linker = @import("linker.zig").Linker;
+const SymbolRef = @import("linker.zig").SymbolRef;
+const metadata_mod = @import("linker/metadata.zig");
 
 // ============================================================
 // BitSet — 진입점 비트 마스크
@@ -315,6 +317,12 @@ pub const ChunkGraph = struct {
     chunks: std.ArrayListUnmanaged(Chunk),
     /// 모듈 인덱스 → 청크 인덱스 매핑 (고정 크기 배열)
     module_to_chunk: []ChunkIndex,
+    /// preserve-modules 로 생성된 청크 그래프인가 (`generatePreserveModulesChunks`).
+    /// (#4494) cross-chunk **CJS-interop** 배선은 preserve-modules 에서 금지 — bundler 가
+    /// 이 모드에선 `cross_chunk_global_names` 를 채우지 않고(전역명 없음) emit 의 xchunk
+    /// export 블록도 `!preserve_modules` 게이트라, 등록만 하면 provider 가 노출하지 않는
+    /// 이름을 소비자가 `import { default as … }` 로 가져와 링크 에러가 난다.
+    preserve_modules: bool = false,
 
     /// module_count 크기의 빈 ChunkGraph를 생성한다.
     pub fn init(allocator: std.mem.Allocator, module_count: usize) !ChunkGraph {
@@ -1149,6 +1157,8 @@ pub fn generatePreserveModulesChunks(
     const module_count = graph.moduleCount();
     var chunk_graph = try ChunkGraph.init(allocator, module_count);
     errdefer chunk_graph.deinit();
+    // (#4494) cross-chunk CJS-interop 배선 금지 표식 — 이 모드는 전역명/xchunk export 를 안 쓴다.
+    chunk_graph.preserve_modules = true;
 
     // 엔트리 모듈 인덱스를 미리 수집 (entry_point 청크 판별용)
     var entry_set: std.AutoHashMapUnmanaged(u32, void) = .empty;
@@ -1600,7 +1610,37 @@ pub fn computeCrossChunkGlobalNames(
     var used: std.StringHashMapUnmanaged(void) = .empty;
     defer used.deinit(allocator);
     for (syms.items) |s| {
-        const preferred = lnk.getExportLocalName(s.mod, s.name) orelse s.name;
+        // (#4494) **CJS owner 의 공개명은 원문 멤버명을 쓰면 안 된다.** CJS 멤버는 provider 청크
+        // top-level 에 `var <공개명> = require_X().<멤버>;` 로 *새 식별자를 만들어* 노출된다
+        // (#4120 materialize). 멤버명을 그대로 쓰면:
+        //   - `exports.Buffer` 같은 멤버가 청크 안의 진짜 전역(`Buffer`)을 가려 다른 모듈이 깨지고,
+        //   - entry 모듈의 동명 export 와 충돌하며(중복 export / 잘못된 바인딩),
+        //   - 동명 청크 로컬(`const named`)과 `var`↔`const` 재선언 SyntaxError 가 난다.
+        // 공개명은 provider/consumer 가 합의만 하면 되는 **내부 이름**이라 자유롭게 지어도 된다 →
+        // `<멤버>$<모듈 태그>`(`default$cjslib` / `named$second`) 합성명으로 충돌 가능성을 원천 차단.
+        // 모듈 태그는 래퍼 이름(`require_x`, #4475 가 basename 충돌까지 deconflict)에서 `require_`
+        // 접두사를 뗀 것 — 결정론적이고 모듈마다 유니크하다. deconflict 는 안전망으로만 동작.
+        //  - 멤버명을 **앞**에 두는 건 #4096 계약("예약어를 bare 로 쓰지 않는다" — `default` 뒤에 `$…`
+        //    가 붙어 유효 식별자가 된다) 유지를 위함.
+        //  - `require_` 접두사를 **떼는** 건 dev/lazy 계약(정의자 청크에 갇힌 `require_x` 를 lazy 청크가
+        //    렉시컬 참조하면 안 된다) 과 텍스트로도 헷갈리지 않게 하기 위함.
+        // (ESM owner 는 진짜 로컬을 `local as 공개명` 으로 브리지하므로 기존대로 로컬명 우선 — 바이트 동일.)
+        var synth: ?[]u8 = null;
+        defer if (synth) |b| allocator.free(b);
+        const preferred = blk: {
+            const om = lnk.getModule(s.mod) orelse break :blk (lnk.getExportLocalName(s.mod, s.name) orelse s.name);
+            if (om.wrap_kind != .cjs) break :blk (lnk.getExportLocalName(s.mod, s.name) orelse s.name);
+            const req = try om.allocRequireName(allocator, null);
+            defer allocator.free(req);
+            const req_prefix = "require_";
+            const tag = if (std.mem.startsWith(u8, req, req_prefix) and req.len > req_prefix.len)
+                req[req_prefix.len..]
+            else
+                req;
+            const b = try std.fmt.allocPrint(allocator, "{s}${s}", .{ s.name, tag });
+            synth = b;
+            break :blk b;
+        };
         const candidate = try deconflictGlobalName(allocator, &used, preferred);
         // candidate 소유권을 맵으로 이전. used 는 맵의 저장본을 borrow(used.deinit 가 키 미해제).
         try lnk.putCrossChunkGlobalName(s.mod, s.name, candidate);
@@ -1624,6 +1664,52 @@ pub fn deconflictGlobalName(
         candidate = try std.fmt.allocPrint(allocator, "{s}${d}", .{ preferred, suffix });
     }
     return candidate;
+}
+
+/// 이름이 `require_X().<name>` 멤버 접근 + `var <name>` 선언에 그대로 쓸 수 있는 평범한
+/// 식별자인지. `import { 'a-b' as x }`(ES2022 arbitrary module namespace name) 같은 이름은
+/// interop 식/선언을 만들 수 없으므로 cross-chunk 배선 대상에서 제외한다. 예약어(`default`)는
+/// 멤버 접근에 유효하고 공개명은 별도 합성명이라 허용.
+fn isPlainMemberName(name: []const u8) bool {
+    if (name.len == 0) return false;
+    for (name, 0..) |c, i| {
+        const ok = std.ascii.isAlphabetic(c) or c == '_' or c == '$' or (i > 0 and std.ascii.isDigit(c));
+        if (!ok) return false;
+    }
+    return true;
+}
+
+/// (#4494) **직접 CJS import** 바인딩이 cross-chunk 배선 대상이면 그 canonical 을 반환.
+///
+/// `import x from './a.cjs'` 는 CJS 에 정적 export 가 없어 resolved binding 이 없다(=호출부의
+/// `getResolvedBinding` 이 null). 그대로 두면 소비자 청크가 provider 청크에만 있는 `require_X()`
+/// 썽크를 참조해 ReferenceError 가 난다(#4494). 등록하면 #4120 경로(provider 가 interop 값을
+/// 전역명으로 materialize + export, 소비자는 preamble 억제 후 일반 import)가 발화한다.
+///
+/// **provider 가 실제로 materialize 하는 구성에서만** 등록해야 한다 — 안 그러면 소비자만 preamble
+/// 을 억제해 값이 조용히 `undefined` 가 된다(기존의 시끄러운 ReferenceError 보다 나쁘다):
+///  - preserve-modules: 전역명 자체를 안 만들고 emit 의 xchunk export 블록도 통째로 skip.
+///  - 비-ESM(cjs/iife/umd/amd) + provider 가 **entry 청크**: emit 이 `emitCjsEntryExports` 에
+///    일임하며 xchunk 블록을 early-break → materialize 가 방출되지 않는다.
+/// 그 외 제외: namespace(ns 합성 경로) · helper(esm_wrap 경로) · type-only(런타임에 존재하지 않음)
+/// · 비-식별자 멤버명(interop 식 생성 불가).
+fn cjsDirectCrossChunkCanonical(
+    lnk: *const Linker,
+    chunk_graph: *const ChunkGraph,
+    m: *const Module,
+    ib: anytype,
+) ?SymbolRef {
+    if (chunk_graph.preserve_modules) return null;
+    if (ib.kind == .namespace or ib.is_helper) return null;
+    if (!isPlainMemberName(ib.imported_name)) return null;
+    if (m.semantic) |*sem| {
+        if (metadata_mod.isImportBindingTypeOnly(sem, ib)) return null;
+    }
+    const canon = lnk.cjsDirectCanonical(m, ib) orelse return null;
+    const cjs_chunk = chunk_graph.getModuleChunk(canon.module_index);
+    if (cjs_chunk.isNone()) return null;
+    if (lnk.format != .esm and chunk_graph.getChunk(cjs_chunk).kind == .entry_point) return null;
+    return canon;
 }
 
 pub fn computeCrossChunkLinks(
@@ -1683,21 +1769,38 @@ pub fn computeCrossChunkLinks(
             // 심볼 수준 크로스 청크 바인딩 추적 (linker가 있을 때만)
             if (linker) |lnk| {
                 for (m.import_bindings) |ib| {
-                    // resolved binding으로 canonical 모듈을 찾는다
-                    const rb = lnk.getResolvedBinding(@intCast(mi), ib.local_span) orelse continue;
-                    const canonical_mi = @intFromEnum(rb.canonical.module_index);
+                    // canonical 모듈: resolved binding 이 있으면 그것, 없으면 **직접 CJS import** fallback.
+                    //
+                    // (#4494) CJS 는 정적 export 가 없어 resolveExportChain 이 null → `import x from
+                    // './a.cjs'` 는 resolved binding 이 **아예 없다**(re-export 포워딩만 resolveOrCjsFallback
+                    // 로 등록됨). 예전엔 여기서 그대로 skip 해 cross-chunk 심볼이 등록되지 않았고, 그 결과
+                    // (a) provider 가 interop 값을 export 하지 않고 (b) metadata 의 #4120 억제 게이트도
+                    // 전역명을 못 찾아 발화하지 않아 → 소비자 청크가 provider 청크에만 있는 `require_X()`
+                    // 썽크를 참조 = ReferenceError. import_record 로 canonical(CJS)+export 명(`default`/
+                    // 멤버명)을 만들어 등록하면 기존 #4120 경로(provider materialize + 소비자 preamble
+                    // 억제)가 그대로 발화한다. namespace 는 ns 합성 경로(linkNamespaceCrossChunkOnce),
+                    // helper 는 esm_wrap 경로가 담당하므로 제외 — metadata 게이트의 제외 조건과 동일.
+                    const canonical: SymbolRef = if (lnk.getResolvedBinding(@intCast(mi), ib.local_span)) |rb|
+                        rb.canonical
+                    else if (cjsDirectCrossChunkCanonical(lnk, chunk_graph, m, ib)) |c|
+                        c
+                    else
+                        continue;
+
+                    const canonical_mi = @intFromEnum(canonical.module_index);
                     if (canonical_mi >= module_count) continue;
 
-                    const src_chunk_idx = chunk_graph.getModuleChunk(rb.canonical.module_index);
+                    const src_chunk_idx = chunk_graph.getModuleChunk(canonical.module_index);
                     if (src_chunk_idx.isNone()) continue;
                     if (src_chunk_idx == chunk.index) continue; // 같은 청크 → 스킵
 
-                    try addCrossChunkSymbol(allocator, chunk_graph, chunk, lnk, &seen_static, src_chunk_idx, rb.canonical.export_name, @intFromEnum(rb.canonical.module_index));
+                    try addCrossChunkSymbol(allocator, chunk_graph, chunk, lnk, &seen_static, src_chunk_idx, canonical.export_name, canonical_mi);
 
                     // canonical 이 namespace re-export 면 그 이름만 가져와선
                     // 안 된다 — 정적 멤버는 정의자 export 로 elision, 값/동적은
                     // 합성 ns 객체 필요. 대상 모듈을 cross-chunk fan-out.
-                    if (nsReExportTarget(graph, rb.canonical.module_index, rb.canonical.export_name)) |ns_target|
+                    // (CJS canonical 은 export_bindings 가 없어 항상 null → no-op.)
+                    if (nsReExportTarget(graph, canonical.module_index, canonical.export_name)) |ns_target|
                         try linkNamespaceCrossChunkOnce(allocator, chunk_graph, chunk, &seen_static, &seen_ns_target, lnk, ns_target, module_count);
                 }
 

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -1255,3 +1255,78 @@ test "generateChunks: external 가 manual pattern 매칭돼도 manual chunk 안 
     // entry chunk 만. vendor manual chunk 는 매칭 모듈 0 이라 생성 안 됨.
     try std.testing.expectEqual(@as(usize, 1), cg.chunks.items.len);
 }
+
+// ============================================================
+// (#4494) 직접 CJS import 의 cross-chunk 심볼 등록
+// ============================================================
+
+const linker_mod = @import("linker.zig");
+const Linker = linker_mod.Linker;
+const test_helpers = @import("test_helpers.zig");
+
+// 다른 청크의 CJS 모듈을 **직접** import(`import d from './lib.cjs'`)하면 cross-chunk
+// 심볼로 등록돼야 한다. CJS 는 정적 export 가 없어 `resolveExportChain` 이 null →
+// resolved binding 이 없고, 예전엔 그대로 skip 돼 심볼이 등록되지 않았다. 그 결과
+// 소비자 청크가 provider 청크에만 있는 `require_X()` 썽크를 참조 = ReferenceError (#4494).
+test "computeCrossChunkLinks: 직접 CJS import 도 cross-chunk 심볼로 등록 (#4494)" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // lib.cjs 는 a/b 양쪽에서 도달 → common 청크. a 는 그 CJS 를 직접 import(cross-chunk).
+    try test_helpers.writeFile(tmp.dir, "lib.cjs", "module.exports = { tag: 1 };");
+    try test_helpers.writeFile(tmp.dir, "shared.ts", "import d from './lib.cjs';\nexport const s = d.tag;");
+    try test_helpers.writeFile(tmp.dir, "a.ts", "import d from './lib.cjs';\nimport { s } from './shared';\nconsole.log(d.tag, s);");
+    try test_helpers.writeFile(tmp.dir, "b.ts", "import { s } from './shared';\nconsole.log(s);");
+
+    const ep_a = try test_helpers.absPath(&tmp, "a.ts");
+    defer alloc.free(ep_a);
+    const ep_b = try test_helpers.absPath(&tmp, "b.ts");
+    defer alloc.free(ep_b);
+
+    var cache = resolve_cache_mod.ResolveCache.init(alloc, .{});
+    defer cache.deinit();
+    const graph = try alloc.create(ModuleGraph);
+    defer alloc.destroy(graph);
+    graph.* = ModuleGraph.init(alloc, &cache);
+    defer graph.deinit();
+    try graph.build(std.testing.io, &.{ ep_a, ep_b });
+
+    var linker = Linker.init(alloc, graph, .esm);
+    defer linker.deinit();
+    try linker.link();
+
+    var cg = try chunk_mod.generateChunks(alloc, graph, &.{ ep_a, ep_b }, .{});
+    defer cg.deinit();
+    try chunk_mod.computeCrossChunkLinks(&cg, graph, alloc, &linker);
+
+    // lib.cjs / a.ts 의 모듈 인덱스를 path 로 찾는다.
+    var cjs_mi: ?u32 = null;
+    var a_mi: ?u32 = null;
+    for (0..graph.moduleCount()) |i| {
+        const m = graph.getModule(ModuleIndex.fromUsize(@intCast(i))) orelse continue;
+        if (std.mem.endsWith(u8, m.path, "lib.cjs")) cjs_mi = @intCast(i);
+        if (std.mem.endsWith(u8, m.path, "a.ts")) a_mi = @intCast(i);
+    }
+    try std.testing.expect(cjs_mi != null);
+    try std.testing.expect(a_mi != null);
+    // CJS 로 래핑됐는지 (전제 확인)
+    try std.testing.expect(graph.getModule(ModuleIndex.fromUsize(cjs_mi.?)).?.wrap_kind == .cjs);
+
+    const a_chunk = cg.getModuleChunk(ModuleIndex.fromUsize(a_mi.?));
+    const cjs_chunk = cg.getModuleChunk(ModuleIndex.fromUsize(cjs_mi.?));
+    try std.testing.expect(!a_chunk.isNone() and !cjs_chunk.isNone());
+    // lib.cjs 가 a 와 같은 청크면 이 테스트의 전제(cross-chunk)가 성립하지 않는다.
+    try std.testing.expect(a_chunk != cjs_chunk);
+
+    // a 청크가 lib.cjs 청크에서 "default" 를 가져온다 (canonical = lib.cjs).
+    const syms = cg.getChunk(a_chunk).imports_from.get(@intFromEnum(cjs_chunk));
+    try std.testing.expect(syms != null);
+    var found = false;
+    for (syms.?.items) |sym| {
+        if (std.mem.eql(u8, sym.name, "default") and sym.canonical_module == cjs_mi.?) found = true;
+    }
+    try std.testing.expect(found);
+    // provider 청크는 그 이름을 노출한다.
+    try std.testing.expect(cg.getChunk(cjs_chunk).exports_to.contains("default"));
+}

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -720,6 +720,29 @@ pub fn emitChunks(
             for (rbm_cross_imports.items) |imp| {
                 try occupied.append(allocator, imp.name);
             }
+            // (#4494) **provider 측** CJS-interop materialize 전역명도 점유. 이 청크가 CJS 모듈의
+            // 멤버를 cross-chunk 로 노출하면 아래 xchunk_exports 블록이 `var <global> = <interop>;`
+            // 를 청크 top-level 에 *새로* 깐다. 이 이름은 어떤 모듈의 심볼도 아니라 rename 입력에
+            // 안 잡혀, 같은 이름의 청크 로컬(`const named = …`)이 있으면 `var`↔`const` 재선언
+            // SyntaxError 가 난다. 점유로 등록해 로컬을 밀어낸다(`named` → `named$1`).
+            //
+            // 조건은 materialize 발화 조건의 **보수적 상위집합**(owner=CJS + 전역명 보유). materialize
+            // 는 여기에 더해 `resolveOwnerLocal == null`(진짜 로컬 없음)·entry 청크 분기 등을 본다.
+            // 과잉 예약은 안전하다 — 동명 로컬을 한 번 더 rename 할 뿐(미스는 SyntaxError, 과잉은
+            // 이름만 바뀜). CJS owner 는 대개 소수라 wrap_kind 로 먼저 걸러 스캔을 줄인다.
+            if (linker) |l| {
+                for (sorted_mods) |mod_idx| {
+                    const mi = @intFromEnum(mod_idx);
+                    if (mi >= module_count) continue;
+                    const owner = graph.getModule(mod_idx) orelse continue;
+                    if (owner.wrap_kind != .cjs) continue;
+                    var eit = chunk.exports_to.iterator();
+                    while (eit.next()) |e| {
+                        const global = l.getCrossChunkGlobalName(@intCast(mi), e.key_ptr.*) orelse continue;
+                        try occupied.append(allocator, global);
+                    }
+                }
+            }
         }
 
         // per-chunk 리네임 계산: 각 청크는 독립된 네임스페이스이므로
@@ -1048,8 +1071,15 @@ pub fn emitChunks(
                         const global = l.getCrossChunkGlobalName(@intCast(mi), name) orelse continue;
                         const owner = graph.getModule(mod_idx) orelse continue;
                         if (owner.wrap_kind != .cjs) continue;
-                        // 진짜 로컬이 있으면(resolveOwnerLocal!=null) interop 아님 — materialize 불요.
-                        if (resolveOwnerLocal(l, graph, mod_idx, @intCast(mi), name) != null) continue;
+                        // (#4494) 예전엔 `resolveOwnerLocal != null` 이면 "진짜 로컬이 있으니 interop
+                        // 불요" 로 skip 했다. 하지만 **CJS-wrapped 모듈은 청크 top-level 로컬이 하나도
+                        // 없다** — 본문 전체가 `__commonJS(...)` 클로저 안이다. resolveOwnerLocal 은
+                        // getCanonicalName 으로 *클로저 안* 심볼까지 찾아내므로(예: `function tag(){}` +
+                        // `module.exports={tag}` 를 `import {tag}` — minify 시 rename_table 에 (mod,"tag")
+                        // 엔트리가 생긴다), materialize 를 건너뛰고 클로저-스코프 이름을 그대로
+                        // `export { o as tag }` 로 노출 → ReferenceError. export 명이 `default`(예약어라
+                        // 로컬일 수 없음)뿐이던 시절엔 안 드러났고, #4494 로 멤버명이 cross-chunk 키가
+                        // 되면서 재현됐다. owner=CJS 면 **항상** materialize 한다.
                         if (cjs_interop_globals.contains(global)) continue; // 이미 materialize
                         try writeCjsInteropMaterialize(allocator, &chunk_output, l, owner, name, global, options.minify_whitespace);
                         try cjs_interop_globals.put(allocator, global, {});

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -3093,6 +3093,46 @@ pub const Linker = struct {
         return self.resolved_bindings.get(bk);
     }
 
+    /// (#4494) **직접** import(`import x from './a.cjs'`)의 CJS canonical. CJS 가 아니면 null.
+    ///
+    /// CJS 는 정적 export 가 없어 `resolveExportChain` 이 null → `resolveImports` 가 resolved
+    /// binding 을 **등록하지 못한다**(re-export 포워딩만 `resolveOrCjsFallback` 로 등록됨).
+    /// 그래서 직접 import 는 import_record 의 target 이 곧 canonical 이고 export 이름은
+    /// `ib.imported_name`("default" 또는 멤버명)이다.
+    ///
+    /// 판정은 `wrap_kind == .cjs` 하나 — `resolveOrCjsFallback` 의 `has_cjs_export_signal` 는
+    /// 붙이지 않는다. 여기서 묻는 건 "이 import 가 `require_X()` 썽크를 거치는가"이고, 그 답은
+    /// 래핑 여부(=wrap_kind)로 결정된다. metadata 의 preamble 조건(`canonical.wrap_kind == .cjs`)
+    /// 과 정확히 같은 집합이어야 억제/등록이 lockstep 을 유지한다.
+    pub fn cjsDirectCanonical(self: *const Linker, m: *const Module, ib: ImportBinding) ?SymbolRef {
+        if (ib.import_record_index >= m.import_records.len) return null;
+        const target = m.import_records[ib.import_record_index].resolved;
+        if (target.isNone()) return null;
+        const tm = self.graph.getModule(target) orelse return null;
+        if (tm.wrap_kind != .cjs) return null;
+        return .{ .module_index = target, .export_name = ib.imported_name };
+    }
+
+    /// (#4494) import 바인딩이 최종적으로 가리키는 **CJS canonical**(re-export 포워딩 + 직접
+    /// import 통합). CJS 가 아니면 null.
+    ///
+    /// chunk.zig 의 cross-chunk 심볼 등록과 metadata.zig 의 #4120 interop 억제 게이트가 *같은
+    /// 판정*을 써야 한다 — 어긋나면 한쪽만 발화해 `require_X is not defined` / 중복선언이 된다.
+    /// namespace(별도 ns 합성 경로)·helper 바인딩은 호출부에서 제외한다.
+    pub fn cjsCanonicalForBinding(
+        self: *const Linker,
+        module_index: u32,
+        m: *const Module,
+        ib: ImportBinding,
+    ) ?SymbolRef {
+        if (self.getResolvedBinding(module_index, ib.local_span)) |rb| {
+            const cm = self.graph.getModule(rb.canonical.module_index) orelse return null;
+            if (cm.wrap_kind != .cjs) return null;
+            return rb.canonical;
+        }
+        return self.cjsDirectCanonical(m, ib);
+    }
+
     fn addDiag(
         self: *Linker,
         code: BundlerDiagnostic.ErrorCode,
@@ -3298,6 +3338,14 @@ pub const Linker = struct {
         if (self.graph.lazy_compilation) {
             for (module_indices) |mod_idx| {
                 const inner = self.cross_chunk_global_names.get(mod_idx.toU32()) orelse continue;
+                // (#4494) CJS-wrapped owner 는 제외. CJS 는 export local 이 없어 `local` 이 export 명
+                // 으로 fallback 하는데, `putCanonicalName` 은 그 이름으로 **CJS 클로저 *안*의 사적
+                // 심볼**을 찾아(findSymbolIdx) 전역명으로 rename 해버린다(엉뚱한 바인딩 개명 + emit
+                // 의 resolveOwnerLocal 이 그 rename 을 보고 materialize 를 skip → 클로저 스코프 이름을
+                // export → ReferenceError). CJS 전역명은 모듈 심볼이 아니라 emit 이 materialize 한다.
+                if (self.graph.getModule(mod_idx)) |om| {
+                    if (om.wrap_kind == .cjs) continue;
+                }
                 var git = inner.iterator();
                 while (git.next()) |e| {
                     const local = self.getExportLocalName(mod_idx.toU32(), e.key_ptr.*) orelse e.key_ptr.*;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -759,22 +759,22 @@ pub fn buildMetadataForAst(
             // preamble(`var x = __toESM(require_X())…`) 대신 일반 cross-chunk import 로 받는다.
             // require_X 는 provider 청크에만 있어 여기서 preamble 을 내면 (a) require_X 미정의
             // (b) cross-chunk import 와 동명 중복선언이 된다. local 심볼만 전역명으로 rename(cross-
-            // chunk import 바인딩명과 일치)하고 skip. canonical_mod 직접-CJS 와 re-export 포워딩
-            // (canonical_mod=.none re-exporter, rb.canonical=CJS) 양 경로 공통 — rb.canonical 로 판정.
+            // chunk import 바인딩명과 일치)하고 skip.
+            // (#4494) canonical 해석은 `cjsCanonicalForBinding` 으로 통합 — re-export 포워딩(resolved
+            // binding 존재)뿐 아니라 **직접 CJS import**(resolved binding 없음, import_record 가 곧
+            // canonical)까지 커버한다. 예전엔 rb 만 봐서 직접 import 는 게이트가 발화하지 않았고,
+            // 소비자가 preamble 을 그대로 내 provider 청크의 require 썽크를 참조했다(#4494).
+            // chunk.zig 의 cross-chunk 심볼 등록과 **같은 판정 함수**를 써야 lockstep 이 유지된다.
             // default/named 한정 — namespace 는 별도 ns 합성 경로(linkNamespaceCrossChunkOnce)가 처리.
             if (!is_helper_binding and ib.kind != .namespace) {
-                if (self.getResolvedBinding(module_index, ib.local_span)) |rb| {
-                    const canon_mi = @intFromEnum(rb.canonical.module_index);
-                    if (self.graph.getModule(rb.canonical.module_index)) |canon_mod| {
-                        if (canon_mod.wrap_kind == .cjs and
-                            self.isCrossChunkConsumer(module_index, canon_mi))
-                        {
-                            if (self.getCrossChunkGlobalName(canon_mi, rb.canonical.export_name)) |g| {
-                                if (ib.local_symbol.semanticIndex()) |sym_idx| {
-                                    try putOwnedRename(self, &renames, &owned_nested_renames, sym_idx, g);
-                                }
-                                continue;
+                if (self.cjsCanonicalForBinding(module_index, &m, ib)) |canon| {
+                    const canon_mi = @intFromEnum(canon.module_index);
+                    if (self.isCrossChunkConsumer(module_index, canon_mi)) {
+                        if (self.getCrossChunkGlobalName(canon_mi, canon.export_name)) |g| {
+                            if (ib.local_symbol.semanticIndex()) |sym_idx| {
+                                try putOwnedRename(self, &renames, &owned_nested_renames, sym_idx, g);
                             }
+                            continue;
                         }
                     }
                 }

--- a/tests/integration/tests/split-cjs-cross-chunk.test.ts
+++ b/tests/integration/tests/split-cjs-cross-chunk.test.ts
@@ -1,0 +1,218 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { createFixture, runNode, writeOutputs } from './helpers';
+import { init, close, build } from '../../../packages/core/index';
+
+// code-splitting 산출물을 **실제로 실행**해 값을 검증하는 스모크.
+//
+// 이 계열의 버그(#4494)는 빌드 exit 0 + 산출물 전부 파싱 통과인데 **실행만** 실패한다
+// (미정의 식별자 참조). 즉 재파싱/텍스트 검사만으로는 못 잡는다 — 반드시 node 로 돌려
+// stdout 을 비교해야 한다.
+//
+// ⚠️ 산출물은 반드시 **빈 `dist/`** 로 내보내고 거기서 실행한다. fixture 루트에 덮어쓰면
+// 원본 소스(a.js/b.js…)가 그대로 남아, entry 청크가 안 써져도 node 가 *원본* 을 실행해
+// 같은 stdout 을 내는 진공(vacuous) 통과가 가능하다.
+//
+// minify 는 이름을 한 번 더 바꾸므로 항상 on/off 양쪽을 돈다 — 이 계열은 minify 에서만
+// 깨지는 변종이 실재한다(CJS 내부 심볼 rename).
+
+const MATRIX = [
+  { name: 'plain', minify: false },
+  { name: 'minify', minify: true },
+] as const;
+
+type Files = Record<string, string>;
+
+describe('code-splitting 런타임 스모크', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  /// fixture 를 splitting 번들로 빌드해 `dist/` 에 쓰고 `dist/entry.js` 를 실행한 stdout 반환.
+  async function buildAndRun(
+    files: Files,
+    opts: { minify: boolean; format?: 'esm' | 'cjs' },
+  ): Promise<string> {
+    const fixture = await createFixture(files);
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.js')],
+      rootDir: fixture.dir,
+      platform: 'node',
+      splitting: true,
+      format: opts.format ?? 'esm',
+      minify: opts.minify,
+    });
+    expect(result.errors ?? []).toHaveLength(0);
+
+    const outs = result.outputFiles!;
+    // 전제: 실제로 청크가 쪼개졌다(= cross-chunk 경계가 존재). 청킹 휴리스틱이 바뀌어
+    // 모든 게 한 청크로 합쳐지면 이 가드들은 아무것도 검증하지 못한다.
+    expect(outs.filter((o) => o.path.endsWith('.js')).length).toBeGreaterThan(2);
+
+    const dist = join(fixture.dir, 'dist');
+    writeOutputs(dist, outs);
+    const { stdout } = await runNode(join(dist, 'entry.js'));
+    return stdout.trim();
+  }
+
+  // (#4494) 크로스-청크 CJS import.
+  //
+  // `single.cjs` 는 공통 청크(same.js + a.js 양쪽에서 도달)에 안착하고, `a.js` 는 그 CJS 를
+  // **직접** import 한다 → 소비자 청크(a)가 provider 청크의 `require_single()` 썽크를 참조했다.
+  // 썽크는 export 되지도 않고 minify 후엔 이름도 다르다 → `ReferenceError: require_single is
+  // not defined`. 이제 provider 가 interop 값을 합성 전역명으로 materialize/export 하고 소비자는
+  // 일반 cross-chunk import 로 받는다.
+  const CROSS_CHUNK_CJS: Files = {
+    'shared/single.cjs': 'module.exports = { tag: "singleton" };',
+    'shared/second.cjs': 'exports.named = "named-value";',
+    // 공통 청크: 같은 CJS 들을 같은 청크에서 소비(= provider 측 preamble 경로).
+    'shared/same.js':
+      'import single from "./single.cjs";\n' +
+      'import { named } from "./second.cjs";\n' +
+      'export const fromSameChunk = single.tag + "/" + named;',
+    // 소비자 청크: 같은 CJS 를 **다른 청크에서** 직접 import(cross-chunk).
+    'a.js':
+      'import single from "./shared/single.cjs";\n' +
+      'import { named } from "./shared/second.cjs";\n' +
+      'import { fromSameChunk } from "./shared/same.js";\n' +
+      'export const a = [single.tag, named, fromSameChunk].join("|");',
+    'b.js':
+      'import { fromSameChunk } from "./shared/same.js";\nexport const b = "b:" + fromSameChunk;',
+    'entry.js':
+      'Promise.all([import("./a.js"), import("./b.js")]).then(([m1, m2]) => {\n' +
+      '  console.log("RESULT", m1.a, m2.b);\n' +
+      '});',
+  };
+  const CROSS_CHUNK_CJS_EXPECT =
+    'RESULT singleton|named-value|singleton/named-value b:singleton/named-value';
+
+  for (const { name, minify } of MATRIX) {
+    for (const format of ['esm', 'cjs'] as const) {
+      test(`${format}/${name}: 크로스-청크 CJS default/named import 가 실행된다 (#4494)`, async () => {
+        expect(await buildAndRun(CROSS_CHUNK_CJS, { minify, format })).toBe(CROSS_CHUNK_CJS_EXPECT);
+      });
+    }
+  }
+
+  // (#4494) CJS 모듈이 export 멤버와 **같은 이름의 내부 심볼**을 가진 경우.
+  // provider 는 `var <전역명> = require_lib().tag;` 를 청크 top-level 에 깔아야 하는데,
+  // 예전엔 "이 이름의 로컬이 이미 있다"고 오판(그 로컬은 `__commonJS` 클로저 *안*의 `tag` 다)해
+  // materialize 를 건너뛰고 클로저 스코프 이름을 그대로 `export { o as tag }` 로 노출했다
+  // → minify 에서만 터지는 `SyntaxError: Export 'o' is not defined in module`.
+  for (const { name, minify } of MATRIX) {
+    test(`${name}: CJS 내부 심볼과 export 멤버명이 같아도 실행된다 (#4494)`, async () => {
+      const out = await buildAndRun(
+        {
+          'shared/lib.cjs': 'function tag() { return "TAG"; }\nmodule.exports = { tag: tag };',
+          'shared/same.js':
+            'import { tag } from "./lib.cjs";\nexport const fromSameChunk = "same:" + tag();',
+          'a.js':
+            'import { tag } from "./shared/lib.cjs";\n' +
+            'import { fromSameChunk } from "./shared/same.js";\n' +
+            'export const a = tag() + "|" + fromSameChunk;',
+          'b.js':
+            'import { fromSameChunk } from "./shared/same.js";\nexport const b = "b:" + fromSameChunk;',
+          'entry.js':
+            'Promise.all([import("./a.js"), import("./b.js")]).then(([m1, m2]) =>\n' +
+            '  console.log("RESULT", m1.a, m2.b));',
+        },
+        { minify },
+      );
+      expect(out).toBe('RESULT TAG|same:TAG b:same:TAG');
+    });
+  }
+
+  // (#4494) CJS export 멤버명이 **진짜 전역**(Buffer)과 같은 경우. provider 청크 top-level 에
+  // `var Buffer = require_lib().Buffer;` 를 깔면 같은 청크의 다른 모듈이 쓰는 Node 전역 Buffer 를
+  // 가려버린다(`Buffer.from is not a function`). 공개명을 합성명(`Buffer$lib`)으로 만들어 회피한다.
+  for (const { name, minify } of MATRIX) {
+    test(`${name}: CJS export 멤버명이 전역(Buffer)과 같아도 전역을 가리지 않는다 (#4494)`, async () => {
+      const out = await buildAndRun(
+        {
+          'shared/lib.cjs': 'exports.Buffer = { fake: true };\nexports.other = "OTHER";',
+          'shared/same.js':
+            'import d from "./lib.cjs";\n' +
+            'export const s = d.other;\n' +
+            'export function realBuf() { return Buffer.from("hi").toString(); }',
+          'a.js':
+            'import { Buffer as FakeBuf } from "./shared/lib.cjs";\n' +
+            'import { s, realBuf } from "./shared/same.js";\n' +
+            'export const a = FakeBuf.fake + "|" + s + "|" + realBuf();',
+          'b.js':
+            'import { s, realBuf } from "./shared/same.js";\n' +
+            'export const b = "b:" + s + ":" + realBuf();',
+          'entry.js':
+            'Promise.all([import("./a.js"), import("./b.js")]).then(([m1, m2]) =>\n' +
+            '  console.log("RESULT", m1.a, m2.b));',
+        },
+        { minify },
+      );
+      expect(out).toBe('RESULT true|OTHER|hi b:OTHER:hi');
+    });
+  }
+
+  // (#4494) 합성 공개명이 provider 청크의 동명 로컬(`const named = …`)과 부딪히지 않는지.
+  // (예전 설계는 멤버명을 그대로 공개명으로 써서 `var named` ↔ `const named` 재선언 SyntaxError.)
+  for (const { name, minify } of MATRIX) {
+    test(`${name}: CJS export 멤버명이 provider 청크 로컬과 같아도 실행된다 (#4494)`, async () => {
+      const out = await buildAndRun(
+        {
+          'shared/second.cjs': 'exports.named = "from-cjs";',
+          'shared/other.js': 'export const named = "LOCAL-CONST";',
+          'shared/same.js':
+            'import { named as cjsNamed } from "./second.cjs";\n' +
+            'import { named } from "./other.js";\n' +
+            'export const fromSameChunk = "same:" + named + "/" + cjsNamed;',
+          'a.js':
+            'import { named } from "./shared/second.cjs";\n' +
+            'import { fromSameChunk } from "./shared/same.js";\n' +
+            'export const a = named + "|" + fromSameChunk;',
+          'b.js':
+            'import { fromSameChunk } from "./shared/same.js";\nexport const b = "b:" + fromSameChunk;',
+          'entry.js':
+            'Promise.all([import("./a.js"), import("./b.js")]).then(([m1, m2]) =>\n' +
+            '  console.log("RESULT", m1.a, m2.b));',
+        },
+        { minify },
+      );
+      expect(out).toBe('RESULT from-cjs|same:LOCAL-CONST/from-cjs b:same:LOCAL-CONST/from-cjs');
+    });
+  }
+
+  // (#4494) `__esModule` 마커가 있는 CJS(= __toESM interop 필요) + 크로스-청크 default/named,
+  // 그리고 그 import 를 소비자 청크가 그대로 재-export 하는 형태.
+  for (const { name, minify } of MATRIX) {
+    test(`${name}: __esModule CJS 크로스-청크 + import 재-export 가 실행된다 (#4494)`, async () => {
+      const out = await buildAndRun(
+        {
+          'shared/esm_cjs.cjs':
+            'Object.defineProperty(exports, "__esModule", { value: true });\n' +
+            'exports.default = "ESM-DEFAULT";\n' +
+            'exports.other = "OTHER";',
+          'shared/same.js':
+            'import d from "./esm_cjs.cjs";\nexport const fromSameChunk = "same:" + d;',
+          'a.js':
+            'import esmD, { other } from "./shared/esm_cjs.cjs";\n' +
+            'import { fromSameChunk } from "./shared/same.js";\n' +
+            'export { esmD };\n' +
+            'export const a = [esmD, other, fromSameChunk].join("|");',
+          'b.js':
+            'import { fromSameChunk } from "./shared/same.js";\nexport const b = "b:" + fromSameChunk;',
+          'entry.js':
+            'Promise.all([import("./a.js"), import("./b.js")]).then(([m1, m2]) =>\n' +
+            '  console.log("RESULT", m1.a, m2.b, m1.esmD));',
+        },
+        { minify },
+      );
+      expect(out).toBe('RESULT ESM-DEFAULT|OTHER|same:ESM-DEFAULT b:same:ESM-DEFAULT ESM-DEFAULT');
+    });
+  }
+});


### PR DESCRIPTION
## 문제

`--splitting` 산출물이 런타임에 죽습니다.

```
ReferenceError: require_single is not defined
```

빌드 exit 0, 모든 청크 파싱 통과. **`--minify` 없이도 재현됩니다** (이슈 서술이 조금 좁았습니다).

```js
// a-*.js (소비자 청크)
import { fromSameChunk } from "./chunk-*.js";
var single = require_single();     // ← 이 이름은 이 청크에 없다
// chunk-*.js (provider 청크)
var i = $c(...);                   // 썽크는 minify 로 `i` 가 됐고
export { fromSameChunk };          // 애초에 export 되지도 않는다
```

## 원인

CJS 는 **정적 export 가 없어서** `resolveExportChain` 이 null 을 반환합니다 → `resolveImports` 가 **직접 CJS import** 에 대해 resolved binding 을 등록하지 않습니다. `computeCrossChunkLinks` 의 import-binding 루프는 `getResolvedBinding(...) orelse continue` 로 그 바인딩을 **조용히 버립니다.**

결과: provider 청크가 interop 값을 export 하지 않고, metadata 의 #4120 억제 게이트도 크로스-청크 전역명을 못 찾아 발화하지 않습니다 → 소비자가 자기 preamble 을 만들어 provider 전용 `require_X` 썽크를 참조합니다.

**re-export 경로**(`export {default} from './a.cjs'`)만 동작했던 이유는 그쪽이 `resolveOrCjsFallback` 을 타기 때문입니다.

## 처방

- `linker.zig` — `cjsCanonicalForBinding` / `cjsDirectCanonical`: chunk.zig(등록)와 metadata.zig(억제)가 **하나의 술어를 공유**해 서로 어긋나지 않게 합니다.
- `chunk.zig` — 직접 CJS import 를 크로스-청크 심볼로 등록 → 기존 #4120 기계가 그때부터 발화합니다.
- `metadata.zig` — #4120 게이트가 공유 술어를 씁니다 (re-export forwarding 뿐 아니라 직접 import 도 커버).

**provider 가 정말 materialize 할 수 없는 경우엔 등록하지 않습니다** — 등록해 버리면 소비자가 preamble 을 억제하고 값이 조용히 `undefined` 가 되는데, 그건 시끄러운 ReferenceError 보다 나쁩니다. 제외: preserve-modules, 비-ESM 포맷 + entry-chunk provider, type-only 바인딩, 비-식별자 멤버명.

## code-review max 가 잡은 인접 결함 3건 (좁은 패치 대신 함께 수정)

멤버 이름이 **청크 레벨 식별자**가 되면서 도달 가능해진 것들입니다.

1. **CJS 공개명을 합성** (`default$single`, `named$second`). 원시 멤버명을 쓰면 `exports.Buffer` 가 **진짜 전역 `Buffer` 를 가려** `Buffer.from is not a function`, 동명 청크 로컬과 충돌해 `var`/`const` 재선언 SyntaxError, entry 모듈 export 와도 충돌합니다. member-first 순서로 #4096 계약을, `require_` 접두 제거로 dev/lazy 계약을 보존합니다 (둘 다 기존 lock 테스트가 검증).
2. **CJS owner 를 항상 materialize.** 옛 `resolveOwnerLocal != null` skip 은 `__commonJS` 클로저 **안쪽** 심볼에 속아 `--minify` 에서 `export { o as tag }`(클로저 스코프 이름)를 방출했습니다 — **#4120 re-export 경로에도 있던 기존 버그**입니다.
3. dev/lazy 전역명 override 가 CJS 클로저 내부 심볼을 리네임하지 않도록.

## 테스트

- **실행 스모크 12건** — 깨끗한 `dist/` 로 방출한 뒤 번들을 **실제로 실행**합니다. 픽스처 루트에 방출하면 node 가 원본 소스로 폴백해 **무의미하게 통과**합니다 (함정).
  **baseline 12/12 실패 → 수정 후 12/12 통과.**
- `chunk_test.zig` 등록 유닛 테스트 (chunk.zig 변경 없으면 실패)
- `zig build test` 통과, 통합 4134 pass / 0 fail

## 남은 것 (기존 버그, 별도 이슈 예정)

1. `import * as ns from './x.cjs'` 크로스-청크 — namespace 합성 경로라 별도 설계 필요
2. `import { 'foo-bar' as x } from './x.cjs'` → `require_x()."foo-bar"` — **splitting 없이도** 동일하게 실패하는 독립 preamble-writer 버그
3. `import('./x.cjs')` 의 `.default` 가 undefined — splitting 무관

Closes #4494

🤖 Generated with [Claude Code](https://claude.com/claude-code)