### PR TITLE
fix(test): tsconfig_cache 테스트의 use-after-free — seed 의존 SIGSEGV

### DIFF
--- a/.changeset/tsconfig-cache-test-uaf.md
+++ b/.changeset/tsconfig-cache-test-uaf.md
@@ -1,0 +1,9 @@
+---
+"@zntc/core": patch
+---
+
+`zig build test` 가 seed 에 따라 SIGSEGV 로 죽던 flake 수정.
+
+`TsconfigCache.clear()` 는 arena 를 reset 하는데, 테스트가 그 **뒤에** clear 이전 결과 슬라이스를 그대로 읽고 있었다 (use-after-free). `retain_capacity` 라 대개는 우연히 살아 읽혀 통과했고, 메모리가 재사용/poison 되는 실행에서만 터졌다.
+
+프로덕션 코드가 아니라 **테스트 자체의 버그**였지만, `pre-push` 훅이 `zig build test` 를 돌리기 때문에 **clean main 에서도 push 가 막히는** 상태였다.

--- a/src/tsconfig_cache.zig
+++ b/src/tsconfig_cache.zig
@@ -225,13 +225,20 @@ test "TsconfigCache: clear 후 같은 dir 다시 lookup 시 정상 재캐시" {
 
     const r1 = cache.findTsconfigPath(testing.io, a);
     try testing.expect(r1 != null);
+    // `clear()` 는 arena 를 reset 한다 → 그 순간 `r1` 은 **해제된 메모리를 가리킨다**.
+    // 비교용으로 미리 복사해 둔다 (예전엔 clear 뒤에 r1 을 그대로 읽어 use-after-free —
+    // retain_capacity 라 대개는 우연히 살아 읽혀 통과했고, 메모리가 재사용/poison 되는
+    // 실행에서만 SIGSEGV 로 터졌다. seed 에 따라 갈리는 flake 의 정체다).
+    const r1_copy = try testing.allocator.dupe(u8, r1.?);
+    defer testing.allocator.free(r1_copy);
+
     cache.clear();
     try testing.expectEqual(@as(usize, 0), cache.size());
 
     const r2 = cache.findTsconfigPath(testing.io, a);
     try testing.expect(r2 != null);
     try testing.expectEqual(@as(usize, 1), cache.size());
-    try testing.expectEqualStrings(r1.?, r2.?); // 같은 결과
+    try testing.expectEqualStrings(r1_copy, r2.?); // 같은 결과
 }
 
 test "TsconfigCache: bare filename (no dirname) 안전 처리" {


### PR DESCRIPTION
## 문제

`zig build test` 가 **seed 에 따라 SIGSEGV** 로 죽습니다.

```
error: 'tsconfig_cache.test.TsconfigCache: clear 후 같은 dir 다시 lookup 시 정상 재캐시'
  terminated with signal ABRT
Segmentation fault at address 0x1090c0018
  in expectEqualStrings
```

## 원인 — 프로덕션 코드가 아니라 **테스트 자체의 use-after-free**

```zig
const r1 = cache.findTsconfigPath(...);      // arena 안의 슬라이스
cache.clear();                                // ← arena 를 reset (r1 은 이 순간 dangling)
const r2 = cache.findTsconfigPath(...);
try testing.expectEqualStrings(r1.?, r2.?);   // ← 해제된 메모리 읽기
```

`reset(.retain_capacity)` 라 대개는 옛 바이트가 그대로 남아 **우연히 통과**했고, 메모리가 재사용되거나 poison 되는 실행에서만 터졌습니다 — seed 마다 결과가 갈리던 이유입니다.

## 처방

clear 전에 복사해 두고 그 복사본과 비교합니다. **3회 연속 EXIT=0** 확인 (수정 전엔 같은 환경에서 재현).

## 왜 지금 고치나

`pre-push` 훅이 `zig build test` 를 돌립니다. 이 crash 때문에 **clean main 에서도 push 가 막혀서**, 최근 여러 작업이 `--no-verify` 로 우회하고 있었습니다 — 훅의 안전망이 사실상 무력화된 상태였습니다.

(여러 작업에서 반복적으로 "main baseline 에도 있는 기존 crash" 로 보고되던 바로 그 건입니다.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)