### PR TITLE
fix(codegen): #4493 구조분해 assignment 의 shorthand+기본값 프로퍼티에서 리네임 누락

### DIFF
--- a/.changeset/destructuring-shorthand-default-rename.md
+++ b/.changeset/destructuring-shorthand-default-rename.md
@@ -1,0 +1,29 @@
+---
+"@zntc/core": patch
+---
+
+`--minify` 시 **구조분해 할당의 shorthand + 기본값** 프로퍼티에서 리네임이 누락돼 런타임에 죽던 버그 수정 (#4493).
+
+```
+ReferenceError: stackWeight is not defined
+```
+
+`({ position: pos, options: { stack, stackWeight = 1 } } = box)` 가 이렇게 방출됐다.
+
+```js
+var t,n,r;
+({position:t, options:{stack:n, stackWeight:stackWeight=1}} = box);  // ← value 가 원본 이름
+```
+
+`stack`(기본값 없는 shorthand)은 `stack:n` 으로 제대로 확장되는데, `stackWeight`(기본값 있는 shorthand)만 value 위치가 **원본 이름 그대로** 남았다. 결과적으로 미선언 전역에 대입되고(strict ESM → `ReferenceError`), 진짜 지역 변수 `r` 은 영영 대입되지 않는다.
+
+원인: `({x = 1} = o)` 는 cover grammar 로 `assignment_target_property_identifier`(left=바인딩, right=기본값)가 된다. 이걸 longhand `key:value=default` 로 펼칠 때 **value 위치를 원본 span 으로 복사**해 mangler 리네임과 namespace 치환을 통째로 건너뛰었다. key(프로퍼티 이름)는 원본을 보존하되 value(바인딩)는 치환을 따라가도록 고쳤다.
+
+선언형(`let {x = 1} = o`)이 아니라 **할당형**(`({x = 1} = o)`)이기만 하면 중첩 여부와 무관하게(최상위 포함) 샜다. `chart.js@4` 의 `buildStacks` 가 정확히 이 패턴을 써서 차트를 렌더할 때 죽었다.
+
+같은 리네임 누락이 두 곳 더 있어 함께 고쳤다.
+
+- **es5 다운레벨**: es5 에서는 codegen 이 아니라 transformer 가 구조분해를 풀어낸다. 이때 합성한 대입 타겟 노드에 symbol_id 를 물려주지 않아, 같은 버그가 다른 emit 경로로 재현됐다.
+- **TS namespace**: `namespace N { export let x; ({x = 1} = o); }` 가 `({x:x=1}=o)` 로 방출돼 `N.x` 가 아니라 자유 변수(전역)에 대입됐다 — `--minify` 와 무관하게 값이 조용히 틀리던 표면이다.
+
+**빌드 exit 0 + 산출물 파싱 통과 + 모듈 평가까지 통과**하고 해당 함수를 **호출할 때만** 터지는 계열이라, 번들을 실제로 실행해 값을 확인하는 스모크 게이트를 함께 추가했다. non-strict 포맷에서는 같은 코드가 조용히 전역을 만들고 지역 변수는 `undefined` 로 남는 **무성 오염**이 된다.

--- a/src/codegen/bindings.zig
+++ b/src/codegen/bindings.zig
@@ -53,7 +53,23 @@ pub fn emitBindingProperty(self: anytype, node: Node) !void {
         const is_shorthand_default = (node.data.binary.flags & shorthand_with_default) != 0;
         if (is_shorthand_default and node.tag == .assignment_target_property_identifier) {
             try self.writeByte(':');
-            try self.writeSpan(key_node.span);
+            // value(=대입 대상 바인딩) 위치. writeSpan 은 원본 span 을 그대로 복사해서
+            // mangler rename / ns 치환을 통째로 건너뛴다 — `({o: {s, w = 1}} = box)` 의
+            // `w` 가 리네임 대상이면 미선언 전역에 대입되고 진짜 지역 변수는 영영 대입되지
+            // 않는다 (#4493 — ReferenceError / 무성 오염).
+            //
+            // 단 치환이 있을 때만 emitNode 를 태운다. 무조건 태우면 이 노드가 대입 대상인데도
+            // tag 가 identifier_reference 라서 `undefined` peephole(`undefined` → `void 0`)이
+            // 발동한다 — `({undefined = 1} = o)` 가 `{undefined:void 0=1}` 로 방출돼 **번들
+            // 전체가 SyntaxError**. 치환이 없으면 원본 토큰을 그대로 두는 게 맞고, 이는 위
+            // shorthand(right=none) 분기가 쓰는 게이트와 동일하다.
+            //
+            // key 는 위에서 이미 원본 span 으로 출력했으므로 프로퍼티 이름은 보존된다.
+            if (expressions.identifierHasRename(self, node.data.binary.left)) {
+                try self.emitNode(node.data.binary.left);
+            } else {
+                try self.writeSpan(key_node.span);
+            }
             try self.writeByte('=');
             // default value level = .comma: 최상위 sequence(`({x=(a,b)}=o)`)가 괄호로 감싸진다
             // (default 는 AssignmentExpression 이라 `x=a,b` 는 다른 의미 — silent miscompile).

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -406,6 +406,11 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                         .span = key_node.span,
                         .data = .{ .string_ref = key_node.data.string_ref },
                     });
+                    // 새로 만든 노드는 symbol_ids 밖이라 그대로 두면 mangler rename 이
+                    // 통째로 스킵된다 — `({o: {s, w = 1}} = box)` 가 es5 로 낮아질 때
+                    // 원본 이름으로 대입돼 미선언 전역이 된다 (#4493 의 es5 표면).
+                    // 이 파일의 다른 노드 생성 지점과 동일하게 심볼을 물려준다.
+                    self.propagateSymbolId(key_idx, target_node);
 
                     // shorthand_with_default: {a = 1} → a = _ref.a === void 0 ? 1 : _ref.a
                     // flags bit 0 = shorthand_with_default, right = default value

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -2879,6 +2879,137 @@ test "#4390 refresh hook-sig: _s component ref follows mangler rename" {
     try std.testing.expect(std.mem.indexOf(u8, r.code, "_s(App,") == null);
 }
 
+test "#4493 구조분해 할당의 shorthand+기본값 프로퍼티도 rename 을 따라간다" {
+    // `({stackWeight = 1} = o)` 는 cover grammar 로
+    // assignment_target_property_identifier(left=바인딩, right=기본값, flags=shorthand_with_default)
+    // 가 된다. codegen 이 이걸 longhand `key:value=default` 로 펼칠 때 value 위치를
+    // 원본 span 으로 복사하면 mangler rename 을 건너뛴다 → 미선언 전역에 대입되고
+    // (strict ESM 에선 ReferenceError) 진짜 지역 변수는 영영 대입되지 않는다.
+    const src =
+        \\export function buildStacks(boxes) {
+        \\  let pos, stack, stackWeight;
+        \\  ({ position: pos, options: { stack, stackWeight = 1 } } = boxes);
+        \\  return pos + stack + stackWeight;
+        \\}
+    ;
+    var r = try transpile(std.testing.allocator, src, "/src/a.js", .{
+        .minify_identifiers = true,
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer r.deinit(std.testing.allocator);
+    // key(프로퍼티 이름) 는 보존되고 value(바인딩) 는 rename 되어야 한다.
+    // 버그 시: `stackWeight:stackWeight=1` (value 가 원본 이름 그대로).
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "stackWeight:stackWeight=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "stackWeight:") != null);
+    // 기본값 없는 shorthand(`stack`) 도 같은 규칙 — 이미 정상이던 대조군.
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "stack:stack") == null);
+}
+
+test "#4493 최상위(비중첩) 구조분해 할당의 shorthand+기본값도 동일" {
+    // 중첩은 트리거 조건이 아니다 — 선언(`let {x = 1} = o`)이 아니라 **할당**
+    // (`({x = 1} = o)`) 형태이기만 하면 최상위에서도 샌다.
+    const src =
+        \\export function f(o) {
+        \\  let stackWeight;
+        \\  ({ stackWeight = 1 } = o);
+        \\  return stackWeight;
+        \\}
+    ;
+    var r = try transpile(std.testing.allocator, src, "/src/a.js", .{
+        .minify_identifiers = true,
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer r.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "stackWeight:stackWeight=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "stackWeight:") != null);
+}
+
+test "#4493 TS namespace export 도 shorthand+기본값에서 ns 치환을 따라간다" {
+    // 같은 raw-span 복사가 mangler rename 뿐 아니라 **ns_prefix 치환**(`x` → `N.x`) 도
+    // 건너뛰었다. minify 와 무관하게 터지는 표면 — 수정 전에는 `({x:x=1}=o)` 로 방출돼
+    // 자유변수(전역) 에 대입되고 `N.x` 는 초기값 그대로 남았다 (무성 오염).
+    const src =
+        \\namespace N {
+        \\  export let x = 0;
+        \\  export function f(o: any) { ({ x = 1 } = o); return x; }
+        \\}
+    ;
+    var r = try transpile(std.testing.allocator, src, "/src/a.ts", .{});
+    defer r.deinit(std.testing.allocator);
+    // 대입 대상이 ns 멤버여야 한다. `x:x=1` 이면 전역에 대입 → N.x 는 영영 안 바뀐다.
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "N.x=1") != null or
+        std.mem.indexOf(u8, r.code, "N.x = 1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "x:x=1") == null);
+}
+
+test "#4493 es5 다운레벨의 중첩 구조분해 대입 타겟도 rename 을 따라간다" {
+    // es5 에서는 codegen 이 아니라 transformer 가 구조분해를 풀어낸다
+    // (`{s, w = 1}` → `s = _ref.s, w = _ref.w === void 0 ? 1 : _ref.w`).
+    // 이때 합성한 대입 타겟 노드에 symbol_id 를 물려주지 않으면 mangler rename 이
+    // 스킵돼 원본 이름으로 대입된다 — 같은 #4493 이 다른 emit 경로로 재현된다.
+    const src =
+        \\export function buildStacks(box) {
+        \\  var pos, stack, stackWeight;
+        \\  ({ position: pos, options: { stack, stackWeight = 1 } } = box);
+        \\  return pos + stack + stackWeight;
+        \\}
+    ;
+    var r = try transpile(std.testing.allocator, src, "/src/a.js", .{
+        .minify_identifiers = true,
+        .minify_whitespace = true,
+        .minify_syntax = true,
+        .es_target = .es5,
+        .unsupported = @import("transformer/compat.zig").fromESTarget(.es5),
+    });
+    defer r.deinit(std.testing.allocator);
+    // 원본 이름으로의 **대입**이 남으면 미선언 전역 대입이다. `,` 앞을 붙여 대입 타겟만
+    // 본다 — `_b.stackWeight===void 0` 같은 프로퍼티 읽기와 헷갈리지 않게.
+    try std.testing.expect(std.mem.indexOf(u8, r.code, ",stack=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.code, ",stackWeight=") == null);
+    // 프로퍼티 읽기(`.stack` / `.stackWeight`)는 그대로 남아야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.code, ".stack") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.code, ".stackWeight") != null);
+}
+
+test "#4493 `undefined` 바인딩에 void 0 peephole 이 새지 않는다" {
+    // 이 노드는 대입 대상인데도 tag 가 identifier_reference 라, value 위치를 무조건
+    // emitNode 로 태우면 `undefined` → `void 0` peephole 이 발동한다.
+    // `{undefined:void 0=1}` 은 대입 대상이 될 수 없어 **번들 전체가 SyntaxError** 다.
+    // (`({undefined = 1} = o)` 는 문법상 합법 — 런타임에 read-only 전역 대입으로 실패할 뿐.)
+    const src =
+        \\function f(o) {
+        \\  ({ undefined = 1 } = o);
+        \\}
+    ;
+    var r = try transpile(std.testing.allocator, src, "/src/a.js", .{
+        .minify_identifiers = true,
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer r.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "void 0=") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "undefined:undefined=1") != null);
+}
+
+test "#4493 rename 이 없으면 shorthand+기본값 출력은 그대로 (회귀 0)" {
+    // mangler 를 끄면 value 위치도 원본 이름이므로 emit 이 바뀌지 않아야 한다.
+    const src =
+        \\function f(o) {
+        \\  let stackWeight;
+        \\  ({ stackWeight = 1 } = o);
+        \\  return stackWeight;
+        \\}
+    ;
+    var r = try transpile(std.testing.allocator, src, "/src/a.js", .{
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer r.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.indexOf(u8, r.code, "stackWeight:stackWeight=1") != null);
+}
+
 test "#4392 refresh hook-sig: long signature (>1024B) not truncated/aborted" {
     // hook 이 많은 컴포넌트는 signature 문자열이 1024바이트를 넘는다. 과거
     // buildRefreshSigCall 의 고정 [1024]u8 버퍼는 초과 시 가짜 OOM 으로 transpile

--- a/tests/integration/tests/destructuring-rename-runtime.test.ts
+++ b/tests/integration/tests/destructuring-rename-runtime.test.ts
@@ -1,0 +1,205 @@
+import { describe, test, expect } from 'bun:test';
+import { runZntc, createFixture } from './helpers';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+/**
+ * 구조분해 리네임 산출물 **실행** 스모크 (#4493).
+ *
+ * 이 계열은 빌드 exit 0 · 산출물 재파싱 통과 · **모듈 평가까지 통과**한다. 문제의 함수를
+ * 실제로 **호출**할 때만 터진다 — 그래서 import 스모크로도 못 잡고, 여기서 직접 돌린다.
+ *
+ * 루트커즈: `({ options: { stack, stackWeight = 1 } } = box)` 는 cover grammar 로
+ * `assignment_target_property_identifier`(left=바인딩, right=기본값) 가 되는데, codegen 이
+ * 이걸 longhand `key:value=default` 로 펼칠 때 value 위치를 **원본 span 으로 복사**해
+ * mangler rename 을 건너뛰었다. 결과적으로 미선언 전역에 대입(strict ESM → ReferenceError)
+ * 되고 진짜 지역 변수는 영영 대입되지 않는다.
+ */
+
+function runNode(file: string): { out: string; err: string } {
+  const r = spawnSync('node', [file], { encoding: 'utf-8' });
+  return { out: r.stdout.trim(), err: r.stderr.trim() };
+}
+
+async function buildAndRun(
+  entry: string,
+  extraArgs: string[] = [],
+): Promise<{ out: string; err: string; code: string }> {
+  const { dir, cleanup } = await createFixture({ 'entry.js': entry });
+  try {
+    // ESM(strict) 산출물이어야 미선언 전역 대입이 ReferenceError 로 **크게** 터진다.
+    // non-strict 포맷이면 조용히 전역을 만들고 지역 변수는 undefined 로 남는다.
+    const outFile = join(dir, 'bundle.mjs');
+    const build = await runZntc([
+      '--bundle',
+      join(dir, 'entry.js'),
+      '-o',
+      outFile,
+      '--minify',
+      '--format=esm',
+      ...extraArgs,
+    ]);
+    expect(build.exitCode, `빌드 실패:\n${build.stderr}`).toBe(0);
+    const code = await Bun.file(outFile).text();
+    return { ...runNode(outFile), code };
+  } finally {
+    await cleanup();
+  }
+}
+
+describe('구조분해 rename 산출물 실행 스모크', () => {
+  test('#4493 중첩 구조분해 할당의 shorthand+기본값이 rename 을 따라간다 (chart.js buildStacks)', async () => {
+    // chart.js@4 core.layouts.js `buildStacks` 의 실제 형태. 차트를 **렌더할 때** 죽었다.
+    const entry = `
+function buildStacks(boxes) {
+  const layoutBoxes = [];
+  let box, pos, stack, stackWeight;
+  for (let i = 0; i < boxes.length; ++i) {
+    box = boxes[i];
+    ({ position: pos, options: { stack, stackWeight = 1 } } = box);
+    layoutBoxes.push(pos + ":" + stack + ":" + stackWeight);
+  }
+  return layoutBoxes.join(",");
+}
+// 모듈 평가만으로는 안 터진다 — 반드시 호출해야 드러난다.
+console.log(buildStacks([
+  { position: "top", options: { stack: "a" } },
+  { position: "left", options: { stack: "b", stackWeight: 3 } },
+]));
+`;
+    const { out, err } = await buildAndRun(entry);
+    // 수정 전: `ReferenceError: stackWeight is not defined`
+    expect(err, `실행 실패:\n${err}`).toBe('');
+    expect(out).toBe('top:a:1,left:b:3');
+  }, 120000);
+
+  test('#4493 최상위(비중첩) 구조분해 할당의 shorthand+기본값도 동일', async () => {
+    // 중첩은 트리거 조건이 아니다 — 선언(`let {x = 1} = o`)이 아니라 **할당**
+    // (`({x = 1} = o)`) 형태이기만 하면 최상위에서도 샌다.
+    const entry = `
+function pick(o) {
+  let stackWeight;
+  ({ stackWeight = 1 } = o);
+  return stackWeight;
+}
+console.log(pick({}) + "," + pick({ stackWeight: 9 }));
+`;
+    const { out, err } = await buildAndRun(entry);
+    expect(err, `실행 실패:\n${err}`).toBe('');
+    expect(out).toBe('1,9');
+  }, 120000);
+
+  test('#4493 es5 다운레벨(transformer 경로)에서도 rename 을 따라간다', async () => {
+    // es5 에서는 codegen 이 아니라 transformer 가 구조분해를 풀어낸다. 합성한 대입 타겟에
+    // symbol_id 를 물려주지 않아 같은 #4493 이 다른 emit 경로로 재현됐다.
+    const entry = `
+function buildStacks(box) {
+  var pos, stack, stackWeight;
+  ({ position: pos, options: { stack, stackWeight = 1 } } = box);
+  return pos + ":" + stack + ":" + stackWeight;
+}
+console.log(buildStacks({ position: "top", options: { stack: "a" } }));
+`;
+    const { out, err } = await buildAndRun(entry, ['--target=es5']);
+    // 수정 전: `ReferenceError: stack is not defined`
+    expect(err, `실행 실패:\n${err}`).toBe('');
+    expect(out).toBe('top:a:1');
+  }, 120000);
+
+  test('#4493 `undefined` 바인딩이 void 0 로 치환돼 SyntaxError 가 되지 않는다', async () => {
+    // 대입 대상인데 tag 가 identifier_reference 라, value 위치를 무조건 emitNode 로 태우면
+    // `undefined` → `void 0` peephole 이 발동해 `{undefined:void 0=1}` → 번들 전체가
+    // SyntaxError. (`({undefined = 1} = o)` 는 문법상 합법 — 런타임 TypeError 일 뿐이다.)
+    const entry = `
+function f(o) {
+  try { ({ undefined = 1 } = o); } catch (e) { return "TypeError"; }
+  return "assigned";
+}
+console.log(f({}));
+`;
+    const { out, err, code } = await buildAndRun(entry);
+    // 파싱 자체가 되어야 한다 — SyntaxError 면 여기서 죽는다.
+    expect(err, `실행 실패:\n${err}`).toBe('');
+    expect(code).not.toContain('void 0=');
+    expect(out).toBe('TypeError');
+  }, 120000);
+
+  test('#4493 인접 구조분해 형태 전수 회귀 0 (정상 코드가 깨지지 않는다)', async () => {
+    // 고친 분기는 assignment-target 의 shorthand+기본값 하나지만, 같은 프린터
+    // (`emitBindingProperty`) 가 선언/할당/rest/배열/computed 를 전부 태운다.
+    const entry = `
+const results = [];
+// 1. 일반 구조분해 (longhand)
+let longA;
+({ x: longA } = { x: "longhand" });
+results.push(longA);
+// 2. shorthand, 기본값 없음
+let shortNoDefault;
+({ shortNoDefault } = { shortNoDefault: "short" });
+results.push(shortNoDefault);
+// 3. 기본값 있음, shorthand 아님
+let longWithDefault;
+({ missingKey: longWithDefault = "longDefault" } = {});
+results.push(longWithDefault);
+// 4. 선언형 shorthand + 기본값
+const { declShorthand = "declDefault" } = {};
+results.push(declShorthand);
+// 5. 선언형 중첩 shorthand + 기본값
+const { nest: { deepDecl = "deepDeclDefault" } } = { nest: {} };
+results.push(deepDecl);
+// 6. 배열 + 기본값
+let arrElem;
+[arrElem = "arrDefault"] = [];
+results.push(arrElem);
+// 7. rest (객체/배열)
+let restFirst, restOfObj, restOfArr;
+({ restFirst = "restDefault", ...restOfObj } = { extraKey: "extra" });
+[, ...restOfArr] = [0, "restArr"];
+results.push(restFirst + "/" + restOfObj.extraKey + "/" + restOfArr[0]);
+// 8. 객체 리터럴의 shorthand ({a}) — 프로퍼티 이름은 보존, 값만 rename
+const literalValue = "lit";
+results.push(JSON.stringify({ literalValue }));
+// 9. computed key + 기본값 (같은 프린터의 computed_property_key 분기)
+//    주의: 키가 **식별자**인 computed key({[k]: t = d} = o)는 별개의 선재 버그가 있다 —
+//    semantic 이 assignment-target 의 computed key 를 방문하지 않아 그 심볼이
+//    DCE/const-inline 되고 키는 원본 이름으로 남는다. #4493 과 루트커즈가 다르므로
+//    여기선 리터럴 키만 고정한다.
+let computedTarget;
+({ ["ck"]: computedTarget = "computedDefault" } = {});
+results.push(computedTarget);
+// 10. 함수 파라미터 shorthand + 기본값 (중첩)
+function paramFn({ opts: { widthPx = 10 } = {} } = {}) { return widthPx; }
+results.push(paramFn() + "|" + paramFn({ opts: { widthPx: 2 } }));
+// 11. for-of 구조분해 할당 + shorthand 기본값
+let loopVar;
+const loopAcc = [];
+for ({ loopVar = 8 } of [{}, { loopVar: 3 }]) loopAcc.push(loopVar);
+results.push(loopAcc.join("-"));
+// 12. 깊은 중첩(3단) shorthand + 기본값
+let deepAssign;
+({ a: { b: { deepAssign = 42 } } } = { a: { b: {} } });
+results.push(String(deepAssign));
+console.log(results.join(" | "));
+`;
+    const { out, err, code } = await buildAndRun(entry);
+    expect(err, `실행 실패:\n${err}`).toBe('');
+    expect(out).toBe(
+      [
+        'longhand',
+        'short',
+        'longDefault',
+        'declDefault',
+        'deepDeclDefault',
+        'arrDefault',
+        'restDefault/extra/restArr',
+        '{"literalValue":"lit"}',
+        'computedDefault',
+        '10|2',
+        '8-3',
+        '42',
+      ].join(' | '),
+    );
+    // 객체 리터럴 shorthand 의 **key** 는 프로퍼티 이름이라 rename 되면 안 된다.
+    expect(code).toContain('literalValue:');
+  }, 120000);
+});


### PR DESCRIPTION
## 문제

minify 리네임이 구조분해의 **shorthand + 기본값** 프로퍼티를 건너뛰어, 선언되지 않은 전역에 할당합니다 → `ReferenceError` (chart.js).

```js
({ position: t, options: { stack: n, stackWeight = 1 } } = …)
// 방출: {position:t,options:{stack:n,stackWeight:stackWeight=1}}
//                                        ^^^^^^^^^^^ 리네임 안 됨 → ReferenceError
```

## 원인 — 또 **원문 복사가 AST 를 우회**

`({x = 1} = o)` 는 `assignment_target_property_identifier` 가 됩니다. `emitBindingProperty` 가 이걸 `key:value=default` 로 펼치면서 **value 를 `writeSpan(key_node.span)` 으로 방출**했습니다 — **원문을 그대로 복사**하는 경로라 AST 를 통째로 우회하고, 따라서 mangler 리네임과 namespace 치환이 **건너뛰어집니다**.

선언 형태(`let {x = 1} = o`)가 멀쩡했던 이유는 그쪽 `right` 가 `assignment_pattern` 이라 `emitNode` 를 타기 때문입니다.

> 이 저장소에 반복되는 계보입니다 — "원문 span 복사가 AST 변형을 우회하는 오컴파일".

**이슈의 재현 표가 틀렸습니다**: 중첩은 무관합니다. **assignment 형태면 top-level 에서도** 깨집니다 (이슈가 ✅ 로 표시한 `({x = 1} = o)` 도 깨져 있습니다).

## 검증

```
BEFORE  ({position:t,options:{stack:n,stackWeight:stackWeight=1}}=…)  → ReferenceError
AFTER   ({position:t,options:{stack:n,stackWeight:r=1}}=…)            → top|a|1
```

## code-review max 가 제 첫 수정의 회귀를 잡음

순진하게 `emitNode` 를 쓰면 lvalue 슬롯에서 `undefined`→`void 0` peephole 이 발화합니다 — `({undefined = 1} = o)`(합법 JS)가 `{undefined:void 0=1}` 이 되어 **런타임 TypeError 가 번들 전체 SyntaxError 로** 바뀝니다. 형제 shorthand 분기와 동일하게 `identifierHasRename` 으로 게이트하고 테스트로 박제했습니다.

## 함께 찾은 리네임 구멍 2건

- **es5 다운레벨**: 그쪽은 transformer 가 구조분해를 낮추는데, 합성한 타깃 노드에 `propagateSymbolId` 가 빠져 있었습니다 (같은 파일의 형제 6곳은 전부 하고 있었고 이 한 곳만 누락).
- **TS namespace**: `namespace N { export let x; ({x = 1} = o) }` 가 `{x:x=1}`(자유 전역에 할당)을 방출 — `--minify` **없이도** 값이 조용히 틀렸습니다. 이제 `{x:N.x=1}`.

## 테스트

유닛 6건 + **실행 검증 5건**(번들을 실제로 돌려 값 비교). 모든 신규 테스트가 **수정 없이는 실패**함을 확인. 통합 회귀 0.

⚠️ 검증 중 **stale 바이너리 함정**을 밟았습니다 — worktree 에 `node_modules` 가 없어 `@zntc/core` 가 **메인 저장소의 오래된 `.node`** 로 해석됐습니다. `bun install` 후 worktree 애드온이 수정을 담고 있는지 확인하고 나서야 결과를 신뢰했습니다.

## 범위 밖 (기존 버그, 별도 이슈)

`({[k]: t = d} = o)` 의 computed key 가 semantic 에 안 보여 `k` 선언이 DCE 됨, `{ undefined }` 객체 리터럴 shorthand → `{void 0}` SyntaxError, CJS 래퍼 안 `({exports = 1} = o)` 등.

Closes #4493

🤖 Generated with [Claude Code](https://claude.com/claude-code)