### PR TITLE
test(e2e): 렌더 패리티 게이트에 monaco 케이스 + 의미(semantic) 대조 축 추가

### DIFF
--- a/tests/e2e/tests/render-parity-e2e.test.ts
+++ b/tests/e2e/tests/render-parity-e2e.test.ts
@@ -38,19 +38,33 @@ import { serve, closeServer } from './serve';
  * 여기서는 **`zntc build --entry-html … --minify`** 로 짓고, **실제로 렌더**한 뒤
  * **기준 번들러(Vite) 산출물과 픽셀을 비교**한다.
  *
- * ## 픽셀 비교가 "에러 0" 보다 강한 이유
+ * ## 기준 번들러 대조가 "에러 0" 보다 강한 이유
  *
- * "에러가 없다" 는 침묵의 증거일 뿐이다. 기준 번들러와 **같은 픽셀** 이 나온다는 건
+ * "에러가 없다" 는 침묵의 증거일 뿐이다. 기준 번들러(Vite)와 **같은 결과**가 나온다는 건
  * **번들러가 의미를 바꾸지 않았다**는 증거다. 무성 오컴파일은 이 층에서만 잡힌다.
  *
- * ## 결정론 (오탐 방지)
+ * 대조 방식은 케이스마다 둘 중 하나다.
+ *   - **픽셀** — 시각적 라이브러리(react-dom · chart.js · d3 · highlight.js).
+ *   - **의미**(`semantic`) — 자체 레이아웃 엔진을 가진 무거운 컴포넌트(monaco). 토크나이저
+ *     출력 · diff 계산 결과 · 진단 메시지를 문자열로 정확 대조한다. 무성 오컴파일에는
+ *     픽셀보다 오히려 **더 예민하다** (#4503 도 결국 DOM 문자열 대조로 정체가 드러났다).
  *
- * 이 게이트가 flaky 하면 없느니만 못하다. 그래서:
- *   - **뷰포트를 앱 폭에 맞춘다.** 좁은 뷰포트로 넓은 앱을 찍으면 클리핑·리플로우로
- *     0px 이 아닌 차이가 나온다(실제로 개발 중 이 오탐을 밟았다).
- *   - 애니메이션 off · 고정 크기 · `deviceScaleFactor: 1` · 폰트는 monospace 고정.
- *   - 임계값은 `PIXEL_TOLERANCE` 하나로 모은다. 0 이 정상이며, 값을 올려야 한다면
- *     그건 결정론이 깨졌다는 신호지 임계값을 올릴 이유가 아니다.
+ * ## 결정론 (오탐 방지) — 개발 중 실제로 밟은 함정들
+ *
+ * **flaky 한 게이트는 없느니만 못하다.** 그래서 아래를 코드에 못박았다.
+ *
+ *   - **뷰포트를 앱 폭에 맞춘다.** 좁은 뷰포트로 넓은 앱을 찍으면 클리핑으로 0px 이 아닌
+ *     차이가 나온다 → 케이스마다 `width`/`height` 명시.
+ *   - **`waitForFunction(fn, arg, options)`** — 두 번째 인자는 `arg` 다. `{timeout}` 을 거기
+ *     넘기면 무제한 대기가 되어 실패 케이스가 테스트 예산을 통째로 태운다(10분을 태웠다)
+ *     → `EVAL_TIMEOUT_MS` 명시.
+ *   - **`stableScreenshot`** — 고정 sleep 은 부하에 취약하다. 연속 두 장이 바이트 동일할
+ *     때까지 기다린다. `animations: 'disabled'` · `caret: 'hide'` 도 함께.
+ *   - **픽셀이 안 맞는 컴포넌트는 픽셀로 재지 않는다.** monaco 는 CI 병렬 부하에서 픽셀이
+ *     2/8 로 흔들렸다(단독 실행은 8/8 이 0px). **임계값을 올려 덮는 대신** 의미 대조로 바꿨고,
+ *     workers=4 부하에서 8/8 안정을 확인했다.
+ *   - 임계값 `PIXEL_TOLERANCE` 는 **0 이 정상**이다. 값을 올려야 한다면 그건 결정론이 깨졌다는
+ *     신호지 임계값을 올릴 이유가 아니다.
  */
 
 const REPO_ROOT = resolve(__dirname, '../../..');
@@ -86,6 +100,23 @@ interface RenderCase {
    * 이 케이스가 과거에 잡은 결함. 회귀 시 어디를 볼지 남긴다.
    */
   guards: string;
+  /**
+   * **픽셀 대신 "계산 결과"를 대조하는 케이스.** 페이지 안에서 평가돼 문자열을 돌려주는
+   * 코드이며, zntc/vite 산출물의 반환값을 **정확히** 비교한다.
+   *
+   * 왜 필요한가: 픽셀 대조는 시각적 라이브러리엔 훌륭하지만, **자체 레이아웃 엔진을 가진
+   * 무거운 컴포넌트**(monaco 등)에는 부적합하다. 내부 렌더 경합 때문에 부하가 걸리면 안정된
+   * 상태가 두 갈래로 갈려 flaky 해진다(실제로 monaco 가 CI 병렬 부하에서 2/8 로 흔들렸다 —
+   * 단독 실행에선 8/8 이 0px 였다).
+   *
+   * **임계값을 올려 덮는 것은 금지다.** 그건 게이트가 잡아야 할 진짜 차이까지 눈감는 짓이다.
+   * 대신 그런 케이스는 **의미(계산 결과)를 본다** — 토크나이저 출력·diff 계산 결과·진단 메시지처럼
+   * 번들러가 의미를 바꿨다면 반드시 달라지는 값들이다. 무성 오컴파일에는 픽셀보다 오히려 더 예민하다
+   * (#4503 도 결국 DOM 문자열 대조로 정체가 드러났다).
+   *
+   * 이 값이 있으면 픽셀 대조는 건너뛴다.
+   */
+  semantic?: string;
   /**
    * **아직 열린 결함이라 현재는 실패가 정상**인 경우, 그 이슈 번호.
    *
@@ -218,6 +249,127 @@ new EditorView({
 setTimeout(() => { globalThis.__ready = true; }, 500);
 `,
   },
+  {
+    // Monaco 는 이 게이트의 **최대 커버리지 케이스**다 — 다른 어떤 케이스도 동시에
+    // 밟지 못하는 표면을 한 번에 지난다:
+    //   · 코드 스플리팅 (청크 100+개)
+    //   · 모듈 워커 5종 (editor/ts/json/css/html) — `new Worker(new URL(…, import.meta.url))`
+    //   · CSS `url()` 자산 (codicon 폰트)  ← #4466
+    //   · CJS interop (번들된 TypeScript 컴파일러)  ← #4472·#4481
+    // 실제로 #4466·#4472·#4481·#4483 이 전부 monaco 번들에서 처음 드러났다.
+    name: 'monaco',
+    pkg: 'monaco-editor@^0.55',
+    width: 900,
+    height: 300,
+    settleMs: 800,
+    minColors: 100,
+    guards:
+      '#4472·#4481(코드젠 괄호) · #4483(new URL 워커 지정자) · #4466(CSS url 자산=codicon) · #4503(무성 오컴파일). ' +
+      '워커·스플리팅·자산·CJS interop 을 한 케이스로 덮는다. ' +
+      '**픽셀이 아니라 의미로 본다**(아래 semantic) — monaco 는 자체 레이아웃 엔진 때문에 CI 병렬 부하에서 ' +
+      '픽셀이 흔들린다(2/8 flake, 단독 실행에선 8/8 이 0px). 임계값을 올려 덮는 대신 계산 결과를 대조한다.',
+    // 토크나이저 출력 · diff 계산 결과 · TS 진단 — 번들러가 의미를 바꿨다면 반드시 달라지는 값들.
+    semantic: `async () => {
+  const m = window.monaco;
+  const SAMPLES = {
+    javascript: 'const a = 1;\\nfunction f(x) { return "v" + x; }\\nclass K { #p = 2; get v(){ return this.#p } }\\n',
+    typescript: 'interface I<T> { x: T }\\nenum E { A = 1, B }\\n',
+    json: '{"a":1,"b":[true,null,"s"],"c":{"d":1.5e3}}',
+    css: '.a { color: #f00; } @media (min-width: 10px) { .b::after { content: "x" } }',
+    html: '<div class="a"><!-- c --><span>t</span></div>',
+    python: 'def f(a, *args, **kw):\\n    return [x for x in args if x]\\n',
+    rust: 'fn main() { let v: Vec<i32> = vec![1,2]; match v.first() { Some(&x) => {}, None => {} } }',
+    go: 'func main() { ch := make(chan int, 1); go func(){ ch <- 1 }() }',
+    java: 'public class A { private static final int X = 1; }',
+    cpp: 'template<typename T> T add(T a, T b) { return a + b; }',
+    sql: 'SELECT a.id, COUNT(*) FROM t a WHERE a.x > 1 GROUP BY a.id;',
+    yaml: 'a: 1\\nb:\\n  - x\\n',
+    markdown: '# H\\n\\n**b** _i_\\n',
+    shell: 'for f in *.txt; do echo "x"; done',
+    xml: '<?xml version="1.0"?><r a="1"><c/></r>',
+    php: '<?php function f(int $a): string { return "v"; } ?>',
+  };
+  const out = { colorize: {} };
+  // ① Monarch 토크나이저: 언어별 구문강조 결과 HTML
+  for (const [lang, src] of Object.entries(SAMPLES)) {
+    try { out.colorize[lang] = await m.editor.colorize(src, lang, {}); }
+    catch (e) { out.colorize[lang] = 'ERR:' + String(e).slice(0, 60); }
+  }
+  // ② editor.worker 의 diff 계산 결과
+  const o = m.editor.createModel('a\\nb\\nc\\nd\\ne\\n', 'plaintext');
+  const n = m.editor.createModel('a\\nX\\nc\\nd\\nY\\nZ\\n', 'plaintext');
+  const h = document.createElement('div'); h.style.cssText = 'width:600px;height:200px'; document.body.appendChild(h);
+  const de2 = m.editor.createDiffEditor(h, { automaticLayout: false });
+  de2.setModel({ original: o, modified: n });
+  for (let i = 0; i < 60; i++) { if (de2.getLineChanges()) break; await new Promise((r) => setTimeout(r, 100)); }
+  out.diff = JSON.stringify(de2.getLineChanges());
+  // ③ ts.worker 의 진단 결과
+  const bad = m.editor.createModel('const q: number = 1;\\nq.nope();\\n', 'javascript');
+  m.editor.create(document.createElement('div'), { model: bad });
+  let mk = [];
+  for (let i = 0; i < 60; i++) {
+    mk = m.editor.getModelMarkers({ resource: bad.uri });
+    if (mk.length) break;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  out.markers = JSON.stringify(mk.map((k) => [k.startLineNumber, k.startColumn, String(k.message)]).sort());
+  return JSON.stringify(out);
+}`,
+    entry: `
+import * as monaco from "monaco-editor";
+self.MonacoEnvironment = {
+  getWorker(_, label) {
+    if (label === "typescript" || label === "javascript")
+      return new Worker(new URL("monaco-editor/esm/vs/language/typescript/ts.worker.js", import.meta.url), { type: "module" });
+    if (label === "json")
+      return new Worker(new URL("monaco-editor/esm/vs/language/json/json.worker.js", import.meta.url), { type: "module" });
+    if (label === "css" || label === "scss" || label === "less")
+      return new Worker(new URL("monaco-editor/esm/vs/language/css/css.worker.js", import.meta.url), { type: "module" });
+    if (label === "html" || label === "handlebars" || label === "razor")
+      return new Worker(new URL("monaco-editor/esm/vs/language/html/html.worker.js", import.meta.url), { type: "module" });
+    return new Worker(new URL("monaco-editor/esm/vs/editor/editor.worker.js", import.meta.url), { type: "module" });
+  },
+};
+// 샘플에 백틱/템플릿리터럴을 쓰지 않는다 — 이 파일 자체가 템플릿 리터럴이라 이스케이프가 겹친다.
+const ORIG = 'function greet(name) {\\n  const msg = "hello " + name;\\n  return msg;\\n}\\n';
+const MOD  = 'function greet(name, punct = "!") {\\n  const msg = "hello " + name + punct;\\n  return msg.toUpperCase();\\n}\\n';
+
+// Monaco 는 컨테이너에 **명시적 높이**가 없으면 접힌다(공통 index.html 은 높이를 주지 않는다).
+const root = document.getElementById("root");
+root.style.width = "880px";
+root.style.height = "270px";
+
+// **비결정적 요소를 끈다.** 오버뷰 룰러는 editor.worker 의 diff 계산이 끝나야 그려지는데,
+// 그 페인트 타이밍이 스크린샷과 경합해 flaky 를 만든다(임계값을 올려 덮지 않고 원인을 없앤다).
+// 미니맵·스크롤바도 같은 이유로 끈다. 검사 대상(라인/문자 diff·구문강조·codicon)은 그대로 남는다.
+const de = monaco.editor.createDiffEditor(root, {
+  automaticLayout: false, renderSideBySide: false, fontSize: 12,
+  minimap: { enabled: false }, scrollBeyondLastLine: false, theme: "vs",
+  renderOverviewRuler: false, overviewRulerLanes: 0,
+  scrollbar: { vertical: "hidden", horizontal: "hidden", verticalScrollbarSize: 0, horizontalScrollbarSize: 0 },
+  // 커서 깜빡임은 시간에 따라 픽셀이 변한다 — 스크린샷 위상이 어긋나면 간헐 차이가 난다.
+  cursorBlinking: "solid", renderLineHighlight: "none",
+});
+de.setModel({
+  original: monaco.editor.createModel(ORIG, "javascript"),
+  modified: monaco.editor.createModel(MOD, "javascript"),
+});
+
+// semantic 프로브가 페이지 안에서 monaco API 를 부른다 — 노출해 둔다.
+window.monaco = monaco;
+
+// **고정 sleep 금지.** diff 는 editor.worker 가 비동기로 계산한다. 데코레이션이 실제로
+// DOM 에 나타난 뒤에 __ready 를 세워야 스크린샷이 결정론적이다.
+(async () => {
+  for (let i = 0; i < 150; i++) {
+    if (document.querySelectorAll(".line-insert, .line-delete, .char-insert, .char-delete").length > 0) break;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  await new Promise((r) => setTimeout(r, 500)); // 오버뷰 룰러 페인트 여유
+  globalThis.__ready = true;
+})();
+`,
+  },
 ];
 
 /** 앱 fixture 를 만들고 zntc / vite 두 벌로 빌드한다. */
@@ -270,6 +422,35 @@ async function buildBoth(caseDir: string, c: RenderCase) {
   expect(v.status, `vite build 실패(기준 번들러): ${v.stderr?.toString().slice(0, 400)}`).toBe(0);
 }
 
+/**
+ * **화면이 안정될 때까지 기다렸다가** 찍는다 — 연속 두 장이 바이트 동일해야 확정.
+ *
+ * 왜 필요한가: 고정 sleep 은 **부하에 취약하다**. CI 는 테스트를 병렬로 돌리므로 CPU 경합이
+ * 생기고, 그러면 페인트가 덜 끝난 상태로 찍혀 간헐적 픽셀 차이가 난다(개발 중 monaco 케이스가
+ * 부하 하에서만 275px 로 흔들렸다 — 단독 실행에선 8/8 이 0px 였다).
+ *
+ * 이걸 **임계값을 올려서 덮으면 안 된다.** 그건 게이트가 잡아야 할 진짜 차이까지 같이
+ * 눈감는 짓이다. 원인(페인트 미완)을 없앤다.
+ *
+ * `animations: 'disabled'` — CSS 애니메이션/트랜지션을 끝 상태로 고정.
+ * `caret: 'hide'` — 텍스트 캐럿은 깜빡여서 시간에 따라 픽셀이 변한다.
+ */
+async function stableScreenshot(page: import('@playwright/test').Page): Promise<Buffer> {
+  const opts = { type: 'png', animations: 'disabled', caret: 'hide' } as const;
+  let prev = await page.screenshot(opts);
+  for (let i = 0; i < 12; i++) {
+    await page.waitForTimeout(250);
+    const next = await page.screenshot(opts);
+    if (next.equals(prev)) return next;
+    prev = next;
+  }
+  // 3초를 기다려도 안 굳으면 페이지 자체가 비결정적이다 — 케이스를 고쳐야 한다.
+  throw new Error(
+    '렌더가 안정되지 않는다(연속 스크린샷이 계속 달라짐). 케이스에 시간 의존 요소가 남아 있다 — ' +
+      '커서 깜빡임 · 애니메이션 · 오버뷰 룰러 같은 비결정 요소를 끄거나, 완료 조건을 __ready 에 넣어라.',
+  );
+}
+
 /** 산출물을 띄워 렌더하고 스크린샷 + 진단을 돌려준다. */
 async function render(page: import('@playwright/test').Page, dir: string, c: RenderCase) {
   const { server, port } = await serve(dir);
@@ -294,9 +475,32 @@ async function render(page: import('@playwright/test').Page, dir: string, c: Ren
       })
       .then(() => true)
       .catch(() => false);
+    // 폰트가 로드되기 전에 찍으면 글리프가 폴백 폰트로 그려져 차이가 난다(codicon 등).
+    await page.evaluate(() => document.fonts.ready).catch(() => {});
     await page.waitForTimeout(c.settleMs);
-    const shot = await page.screenshot({ type: 'png' });
-    return { shot, errors: [...new Set(errors)], missing: [...new Set(missing)], evaluated };
+
+    // 의미 대조 케이스는 픽셀을 찍지 않는다(그 이유는 RenderCase.semantic 주석 참고).
+    if (c.semantic) {
+      const semantic = await page
+        .evaluate(`(${c.semantic})()`)
+        .catch((e) => 'PROBE-ERR:' + String(e).slice(0, 120));
+      return {
+        shot: null,
+        semantic,
+        errors: [...new Set(errors)],
+        missing: [...new Set(missing)],
+        evaluated,
+      };
+    }
+
+    const shot = await stableScreenshot(page);
+    return {
+      shot,
+      semantic: null,
+      errors: [...new Set(errors)],
+      missing: [...new Set(missing)],
+      evaluated,
+    };
   } finally {
     await closeServer(server);
   }
@@ -359,20 +563,37 @@ for (const c of cases) {
       `[3층] 엔트리 모듈이 끝까지 평가되지 않았다 — globalThis.__ready 미도달 (${c.guards})`,
     ).toBe(true);
 
-    // ── 4층: 실제 렌더 ───────────────────────────────────────────────
-    const zColors = colorCount(z.shot);
-    expect(zColors, `[4층] zntc 렌더가 사실상 백지다 (색 ${zColors}종)`).toBeGreaterThanOrEqual(
-      c.minColors,
-    );
-
     // 기준 번들러가 먼저 통과해야 비교가 의미 있다. 여기서 실패하면 zntc 가 아니라
     // 케이스/환경이 깨진 것이다.
     expect(v.errors, `기준(vite) 산출물이 실패했다 — 케이스 또는 환경 문제`).toEqual([]);
     expect(v.evaluated, `기준(vite) 산출물이 평가되지 않았다 — 케이스 또는 환경 문제`).toBe(true);
 
-    // ── 4층: 기준 번들러와 픽셀 대조 (무성 오컴파일 탐지) ─────────────
-    const zp = PNG.sync.read(z.shot);
-    const vp = PNG.sync.read(v.shot);
+    // ── 4층(a): 의미 대조 — 픽셀이 부적합한 케이스(monaco 등) ─────────
+    if (c.semantic) {
+      expect(
+        String(z.semantic).startsWith('PROBE-ERR:'),
+        `[4층] zntc 의미 프로브 실패: ${z.semantic}`,
+      ).toBe(false);
+      expect(
+        String(v.semantic).startsWith('PROBE-ERR:'),
+        `기준(vite) 의미 프로브 실패 — 케이스/환경 문제: ${v.semantic}`,
+      ).toBe(false);
+      expect(
+        z.semantic,
+        `[4층] 기준 번들러(vite)와 **계산 결과가 다르다**. ` +
+          `에러 없이 결과만 다르면 **무성 오컴파일**이다 — 번들러가 의미를 바꿨다. (${c.guards})`,
+      ).toEqual(v.semantic);
+      return;
+    }
+
+    // ── 4층(b): 실제 렌더 + 픽셀 대조 ────────────────────────────────
+    const zColors = colorCount(z.shot!);
+    expect(zColors, `[4층] zntc 렌더가 사실상 백지다 (색 ${zColors}종)`).toBeGreaterThanOrEqual(
+      c.minColors,
+    );
+
+    const zp = PNG.sync.read(z.shot!);
+    const vp = PNG.sync.read(v.shot!);
     expect({ w: zp.width, h: zp.height }, '스크린샷 크기가 다르다 — 뷰포트 설정 확인').toEqual({
       w: vp.width,
       h: vp.height,
@@ -385,8 +606,8 @@ for (const c of cases) {
     const diffPct = (diffPixels / (zp.width * zp.height)) * 100;
 
     if (diffPct > PIXEL_TOLERANCE) {
-      await test.info().attach(`${c.name}-zntc.png`, { body: z.shot, contentType: 'image/png' });
-      await test.info().attach(`${c.name}-vite.png`, { body: v.shot, contentType: 'image/png' });
+      await test.info().attach(`${c.name}-zntc.png`, { body: z.shot!, contentType: 'image/png' });
+      await test.info().attach(`${c.name}-vite.png`, { body: v.shot!, contentType: 'image/png' });
       await test
         .info()
         .attach(`${c.name}-diff.png`, { body: PNG.sync.write(diffPng), contentType: 'image/png' });


### PR DESCRIPTION
## Summary

렌더 패리티 게이트(#4506)에 **monaco 케이스**를 추가하고, 그 과정에서 필요해진 **의미(semantic) 대조 축**을 만들었다.

`test/render-parity-unmark`(#4516, `test.fail` 마커 제거)와 독립적이며 둘 다 머지 가능하다.

## 왜 monaco 인가 — 게이트의 최대 커버리지 케이스

monaco 는 **다른 어떤 케이스도 동시에 밟지 못하는 표면**을 한 번에 지난다:

- 코드 스플리팅 (청크 100+개)
- 모듈 워커 5종 — `new Worker(new URL(…, import.meta.url))`
- CSS `url()` 자산 (codicon 폰트)
- CJS interop (번들된 TypeScript 컴파일러)

실제로 **#4466 · #4472 · #4481 · #4483 이 전부 monaco 번들에서 처음 드러났다.** 지금 게이트의 5개 케이스는 이 조합을 못 덮는다.

## 그런데 monaco 는 픽셀로 재면 안 된다

monaco 는 자체 레이아웃 엔진을 가져서, **CI 병렬 부하가 걸리면 안정된 렌더 상태가 두 갈래로 갈린다.**

```
단독 실행(workers=1)  : 8/8 이 0px
병렬 부하(workers=4)  : 2/8 이 275px (0.102%) — 항상 정확히 같은 값
```

랜덤 노이즈가 아니라 **이분 상태**다. 오버뷰 룰러 끄기 · 커서 깜빡임 끄기 · `stableScreenshot`(연속 두 장 바이트 동일까지 대기)을 **전부 넣고도** 남았다.

**여기서 임계값을 올리는 건 자기기만이다.** 게이트가 잡아야 할 진짜 차이까지 같이 눈감는 짓이고, 이 파일 주석에 스스로 "임계값을 올려야 한다면 그건 결정론이 깨졌다는 신호"라고 써둔 것과 모순된다.

## 그래서 의미(semantic) 대조 축을 만들었다

`RenderCase.semantic` — 페이지 안에서 평가돼 문자열을 돌려주는 프로브. zntc/vite 산출물의 반환값을 **정확히** 비교한다. 있으면 픽셀 대조를 건너뛴다.

monaco 프로브가 보는 것:

| | 무엇 |
|---|---|
| ① | **Monarch 토크나이저** — 16개 언어 `colorize` 결과 HTML (js·ts·json·css·html·python·rust·go·java·cpp·sql·yaml·md·shell·xml·php) |
| ② | **`editor.worker` 의 diff 계산 결과** — `getLineChanges()` |
| ③ | **`ts.worker` 의 진단 결과** — `getModelMarkers()` |

이건 **번들러가 의미를 바꿨다면 반드시 달라지는 값들**이고, **무성 오컴파일에는 픽셀보다 오히려 더 예민하다** — #4503 도 결국 픽셀(0.415%)로 눈치채고 **DOM 문자열 대조**로 정체를 밝혔다.

## 하니스 결정론 보강 (전 케이스 적용)

개발 중 실제로 밟은 함정을 코드에 못박았다.

- **`stableScreenshot`** — 고정 sleep 은 부하에 취약하다. **연속 두 장이 바이트 동일**할 때까지 기다린다. 3초를 기다려도 안 굳으면 케이스가 비결정적이라는 뜻이므로 큰 소리로 실패시킨다(조용히 덮지 않는다).
- **`animations: 'disabled'` · `caret: 'hide'`** — Playwright 가 주는 결정론 장치인데 안 쓰고 있었다. **캐럿은 깜빡여서 시간에 따라 픽셀이 변한다.**
- **`document.fonts.ready`** — 폰트 로드 전에 찍으면 글리프가 폴백 폰트로 그려진다(codicon).

## Test Plan

- [x] `origin/main`(`b694be2d`) + **workers=4 부하**에서 **8회 연속 → monaco flake 0/8**
- [x] 의미 프로브가 실제로 동작함을 확인 (초기엔 `window.monaco` 미노출로 8/8 실패 → 노출 후 8/8 통과)
- [x] 픽셀 케이스(react-dom · chart.js · highlight.js · d3 · codemirror)는 기존대로 동작
- [ ] `zig build test` — 이 PR 은 Zig 무변경 (N/A)

> 실행 로그의 `2 failed` 는 chart.js · highlight.js 의 `test.fail` 마커 때문이다(이 브랜치는 `origin/main` 기준이라 아직 마커 보유). **#4516 이 그 마커를 제거한다.**

## Decision Impact

None
