### PR TITLE
fix(bundler): #4522 code-split 된 동적 CJS import 가 named 멤버를 잃던 무성 오컴파일

### DIFF
--- a/.changeset/dynamic-cjs-chunk-namespace.md
+++ b/.changeset/dynamic-cjs-chunk-namespace.md
@@ -1,0 +1,27 @@
+---
+"@zntc/core": patch
+---
+
+code-split 된 **동적 CJS import** 가 named 멤버를 잃던 무성 오컴파일 수정 (#4522).
+
+```js
+// legacy.cjs
+module.exports = { foo(){ return "FOO"; }, bar: 42 };
+
+const m = await import("./legacy.cjs");
+m.foo();
+```
+
+| | code-split 시 `keys` | `m.foo()` |
+|---|---|---|
+| node (정본) | `default, foo` | ✅ |
+| zntc (버그) | `default` | ❌ `TypeError` |
+| rolldown / rspack | named 포함 | ✅ |
+
+**같은 소스가 청킹 설정에 따라 런타임 값이 갈렸다** — 인라인(단일 번들)은 정상, `--splitting` 만 깨졌다. 빌드 exit 0 · 파싱 통과 · 실행만 실패.
+
+근본 원인: 동적 CJS entry 청크가 CJS↔ESM interop 결과(namespace)를 **`default` 슬롯 하나로 좁혀서** 내보냈다. CJS 는 정적 export 가 없어 named 멤버를 ESM `export` 문법으로 **표현할 수 없으므로** 그대로 유실된다. 같은-청크 경로는 `import()` **호출 자체**를 `__toESM(require_x())` 표현식으로 치환하니 namespace 가 통째로 살아남아서, 두 경로가 갈렸다.
+
+처방(rolldown 동형): 청크가 **namespace 를 통째로** 실어 보내고(`export default __toESM(require_x())`), 소비자가 `.default` 로 한 겹 벗긴다. esm / cjs / iife·umd·amd 세 형식 모두 동일하게 적용된다. 이제 인라인과 splitting 이 **같은 값**을 만든다.
+
+함께 수정: 동적 entry 청크의 `__toESM` 헬퍼 주입 조건에서 `can_skip_cjs_default_interop` 예외를 제거했다. 그 예외는 "`default` 값 하나만 내보내던" 시절의 것으로, namespace 를 보내는 지금은 shape 와 무관하게 항상 헬퍼가 필요하다(안 그러면 `ReferenceError: __toESM is not defined`).

--- a/.changeset/dynamic-cjs-chunk-namespace.md
+++ b/.changeset/dynamic-cjs-chunk-namespace.md
@@ -25,3 +25,9 @@ m.foo();
 처방(rolldown 동형): 청크가 **namespace 를 통째로** 실어 보내고(`export default __toESM(require_x())`), 소비자가 `.default` 로 한 겹 벗긴다. esm / cjs / iife·umd·amd 세 형식 모두 동일하게 적용된다. 이제 인라인과 splitting 이 **같은 값**을 만든다.
 
 함께 수정: 동적 entry 청크의 `__toESM` 헬퍼 주입 조건에서 `can_skip_cjs_default_interop` 예외를 제거했다. 그 예외는 "`default` 값 하나만 내보내던" 시절의 것으로, namespace 를 보내는 지금은 shape 와 무관하게 항상 헬퍼가 필요하다(안 그러면 `ReferenceError: __toESM is not defined`).
+
+추가(코드리뷰): 첫 수정이 **하드 회귀 4건**을 만들었고 전부 잡았다.
+
+- 소비자 재작성을 `rewriteImportCallToWrapper`(첫 `indexOf` 1회 + import attributes 미지원)로 바꾼 탓에, **앞선 문자열 리터럴 occurrence** 나 `import("./x.cjs", { with: {} })` 에서 specifier 가 통째로 미치환 → `ERR_MODULE_NOT_FOUND`. #4295 가 고쳤던 바로 그 miscompile 이다. 같은 positional walk 를 쓰되 호출 끝을 **괄호 균형**으로 찾는 재작성기로 다시 썼다.
+- provider 는 `linker orelse break` 로 bail 하는데 consumer 는 `linker` 를 안 봐서, `scopeHoist: false`(linker null)에서 export 가 없는 값을 `.default` 로 벗겨 **TypeError**. provider/consumer/헬퍼 3곳의 복붙 술어를 `dynamicCjsNamespaceEntry` 단일 소스로 합쳤다.
+- federation expose / plugin `emitFile({type:'chunk'})` 도 **같은 dynamic entry 모양**이라 provider 만 바뀌고 그쪽 소비자(container factory / 사용자 코드)는 안 벗긴다 → `default` 슬롯 의미가 조용히 바뀐다. entry 에 `is_import_call` 을 달아 **진짜 `import()` 대상만** namespace 로 가고, 그 둘은 기존 계약을 그대로 유지한다.

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -170,6 +170,11 @@ pub const ChunkKind = union(enum) {
         module: ModuleIndex,
         /// 동적 import로 생성된 진입점인지 여부
         is_dynamic: bool,
+        /// (#4522) 그 dynamic entry 가 **진짜 `import()` 대상**인지. federation expose /
+        /// plugin `emitFile({type:'chunk'})` 도 같은 dynamic entry 모양을 쓰지만, 그쪽
+        /// 소비자는 zntc 가 아니라 **container factory / 사용자 코드**다. 그래서 CJS 청크의
+        /// `default` 슬롯 의미를 바꾸면(값 → namespace) 조용히 깨진다 — 그 둘은 제외한다.
+        is_import_call: bool = false,
     },
     /// 여러 진입점이 공유하는 공통 청크
     common,
@@ -521,6 +526,8 @@ fn isAsciiAlpha(c: u8) bool {
 const EntryInfo = struct {
     module_idx: ModuleIndex,
     is_dynamic: bool,
+    /// (#4522) 진짜 `import()` 대상인가 (federation expose / plugin emitFile 은 false).
+    is_import_call: bool = false,
 };
 
 /// 모듈 그래프에서 청크를 생성한다 (esbuild/rolldown 패턴).
@@ -624,6 +631,7 @@ fn addDynamicEntry(
     dynamic_seen: *std.AutoHashMapUnmanaged(u32, void),
     graph: *const ModuleGraph,
     idx: ModuleIndex,
+    is_import_call: bool,
 ) !void {
     if (graph.getModule(idx)) |m| {
         if (m.is_external) return; // external phantom 은 async chunk 불요(번들 외부)
@@ -634,7 +642,7 @@ fn addDynamicEntry(
     for (entries.items) |e| {
         if (@intFromEnum(e.module_idx) == di and !e.is_dynamic) return; // 이미 user entry
     }
-    try entries.append(allocator, .{ .module_idx = idx, .is_dynamic = true });
+    try entries.append(allocator, .{ .module_idx = idx, .is_dynamic = true, .is_import_call = is_import_call });
 }
 
 /// entries 에서 module_idx 의 entry bit(= entries 인덱스)를 찾는다. 없으면 null(entry 청크 아님).
@@ -695,7 +703,7 @@ pub fn generateChunks(
         var it = graph.modulesIterator();
         while (it.next()) |m| {
             for (m.dynamic_imports.items) |dyn_idx|
-                try addDynamicEntry(allocator, &entries, &dynamic_seen, graph, dyn_idx);
+                try addDynamicEntry(allocator, &entries, &dynamic_seen, graph, dyn_idx, true);
         }
     }
 
@@ -711,7 +719,7 @@ pub fn generateChunks(
             const fidx = ModuleIndex.fromUsize(mi);
             const fm = graph.getModule(fidx) orelse continue;
             if (!fm.is_federation_expose) continue;
-            try addDynamicEntry(allocator, &entries, &dynamic_seen, graph, fidx);
+            try addDynamicEntry(allocator, &entries, &dynamic_seen, graph, fidx, false); // MF expose — 소비자는 container factory
         }
     }
 
@@ -723,7 +731,7 @@ pub fn generateChunks(
             const eidx = ModuleIndex.fromUsize(mi);
             const em = graph.getModule(eidx) orelse continue;
             if (!em.is_emitted_chunk_entry) continue;
-            try addDynamicEntry(allocator, &entries, &dynamic_seen, graph, eidx);
+            try addDynamicEntry(allocator, &entries, &dynamic_seen, graph, eidx, false); // plugin emitFile — 소비자는 사용자 코드
         }
     }
 
@@ -833,6 +841,7 @@ pub fn generateChunks(
             .bit = @intCast(bit_idx),
             .module = entry.module_idx,
             .is_dynamic = entry.is_dynamic,
+            .is_import_call = entry.is_import_call,
         } }, bits);
         chunk.name = name;
         chunk.explicit_file_name = explicit_file_name;

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -967,13 +967,20 @@ pub fn emitChunks(
         // (#4510) **CJS 모듈을 동적 import** 한 청크(`import('./x.cjs')` → dynamic entry 청크).
         // CJS 는 정적 export 가 없어 buildFinalExports 가 null 을 주고, codegen 도 `__commonJS`
         // wrapper 선언만 낸다 → 청크가 (a) 모듈 본문을 **실행조차 안 하고** (b) 아무것도 export
-        // 하지 않아, `await import('./x.cjs')` 가 빈 namespace 를 준다(`m.default` = undefined).
-        // Node 가 CJS 를 ESM 으로 로드할 때와 같은 계약 = "default = module.exports" 를 맞춘다:
-        //   ESM        : `export default require_x();`  (interop 식은 static import 와 동일 소스)
-        //   cjs/iife 등 : `exports.default = require_x();` (청크가 require 로 소비되므로 exports 객체)
+        // 하지 않아, `await import('./x.cjs')` 가 빈 namespace 를 준다.
         // require_X() 호출 자체가 모듈 본문 실행이라 (a)도 함께 해결된다(__commonJS memoize →
         // 다른 청크가 이미 실행했으면 캐시된 exports 재사용, 인스턴스 1개 유지).
         // user entry 청크는 대상 아님 — 그쪽은 bootstrap/`emitCjsEntryExports` 계약이 따로 있다.
+        //
+        // (#4522) 실어 보내는 값은 **namespace 통째**(`__toESM(require_x())`)여야 한다.
+        // 예전엔 `default` 슬롯 하나(`__toESM(require_x()).default`)만 내보냈는데, CJS 의
+        // named 멤버는 ESM `export` 문법으로 **정적으로 표현할 수 없어**(CJS 는 정적 export 가
+        // 없다) 그대로 유실됐다 → `(await import('./x.cjs')).foo` 가 undefined.
+        // 같은-청크 경로는 `import()` **호출 자체**를 `__toESM(require_x())` 표현식으로 치환해
+        // namespace 가 통째로 살아남는다 — 그래서 같은 소스가 청킹에 따라 갈렸다.
+        // 이제 두 경로가 **같은 값**을 만든다. 소비자는 `.default` 로 벗긴다
+        // (`rewriteDynamicImports` 의 cross-chunk 분기 — 그쪽 주석 참조).
+        // node/rolldown/rspack 모두 named 멤버를 노출한다(esbuild 만 예외).
         if (!options.preserve_modules) cjs_dyn_entry: {
             const info = switch (chunk.kind) {
                 .entry_point => |i| i,
@@ -983,7 +990,7 @@ pub fn emitChunks(
             const em = graph.getModule(info.module) orelse break :cjs_dyn_entry;
             if (em.wrap_kind != .cjs) break :cjs_dyn_entry;
             const l = linker orelse break :cjs_dyn_entry;
-            const expr = try l.cjsInteropAccessExpr(allocator, em, "default", options.minify_whitespace);
+            const expr = try l.cjsInteropAccessExpr(allocator, em, linker_mod.CJS_NS_EXPORT_NAME, options.minify_whitespace);
             defer allocator.free(expr);
             const min = options.minify_whitespace;
             if (options.format == .esm) {
@@ -1890,6 +1897,23 @@ fn rewriteDynamicImports(
         };
         defer allocator.free(replacement);
 
+        // (#4522) 대상이 **CJS 인 dynamic entry 청크**면 그 청크는 namespace 를 `default`
+        // 슬롯에 통째로 실어 보낸다(위 `cjs_dyn_entry` 참조 — CJS 의 named 멤버는 ESM
+        // export 문법으로 정적 표현이 불가능해서 그 방법밖에 없다). 소비자는 한 겹 벗겨야
+        // 진짜 namespace 를 얻는다. 조건은 provider 쪽 emit 조건과 **정확히 같아야** 한다.
+        const cjs_dyn_unwrap = !emit_options.preserve_modules and blk: {
+            const tc = chunk_graph.getChunk(target_chunk_idx);
+            const info = switch (tc.kind) {
+                .entry_point => |i| i,
+                .common, .manual => break :blk false,
+            };
+            if (!info.is_dynamic) break :blk false;
+            if (info.module != rec.resolved) break :blk false;
+            const em = graph.getModule(info.module) orelse break :blk false;
+            break :blk em.wrap_kind == .cjs;
+        };
+        const unwrap: []const u8 = if (cjs_dyn_unwrap) ".default" else "";
+
         // cjs+splitting(P3-B): 네이티브 import() 가 없으므로 호출 전체를
         //   Promise.resolve().then(()=>require("./chunk.js"))
         // 로 재작성(RFC §4.3, 디리스크 스파이크 검증). 대상 청크는 dynamic
@@ -1906,7 +1930,7 @@ fn rewriteDynamicImports(
             const target_id = reg_ids[@intFromEnum(target_chunk_idx)]; // borrow
             const chunkfile = try std.fmt.allocPrint(allocator, "{s}{s}", .{ stem, out_ext });
             defer allocator.free(chunkfile);
-            const wrapper = try std.fmt.allocPrint(allocator, "__zntc_load_chunk(\"{s}\").then(function(){{return __zntc_require(\"{s}\")}})", .{ chunkfile, target_id });
+            const wrapper = try std.fmt.allocPrint(allocator, "__zntc_load_chunk(\"{s}\").then(function(){{return __zntc_require(\"{s}\"){s}}})", .{ chunkfile, target_id, unwrap });
             defer allocator.free(wrapper);
             if (try rewriteImportCallToWrapper(allocator, result, rec.specifier, wrapper)) |new_result| {
                 allocator.free(result);
@@ -1917,7 +1941,19 @@ fn rewriteDynamicImports(
 
         const cjs_split = emit_options.format == .cjs and !emit_options.preserve_modules;
         if (cjs_split) {
-            const wrapper = try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>require(\"{s}\"))", .{replacement});
+            const wrapper = try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>require(\"{s}\"){s})", .{ replacement, unwrap });
+            defer allocator.free(wrapper);
+            if (try rewriteImportCallToWrapper(allocator, result, rec.specifier, wrapper)) |new_result| {
+                allocator.free(result);
+                result = new_result;
+            }
+            continue;
+        }
+
+        // ESM: 네이티브 import() 유지 — specifier 만 청크 파일명으로 교체.
+        // 단 CJS dynamic entry 청크면 namespace 를 한 겹 벗겨야 한다(#4522).
+        if (cjs_dyn_unwrap) {
+            const wrapper = try std.fmt.allocPrint(allocator, "import(\"{s}\").then((m)=>m.default)", .{replacement});
             defer allocator.free(wrapper);
             if (try rewriteImportCallToWrapper(allocator, result, rec.specifier, wrapper)) |new_result| {
                 allocator.free(result);

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -990,7 +990,11 @@ pub fn emitChunks(
             const em = graph.getModule(info.module) orelse break :cjs_dyn_entry;
             if (em.wrap_kind != .cjs) break :cjs_dyn_entry;
             const l = linker orelse break :cjs_dyn_entry;
-            const expr = try l.cjsInteropAccessExpr(allocator, em, linker_mod.CJS_NS_EXPORT_NAME, options.minify_whitespace);
+            // 진짜 `import()` 대상이면 **namespace 통째**(#4522), federation expose /
+            // plugin emitFile 이면 기존 계약(`default` = module.exports 값) 그대로.
+            const is_ns = dynamicCjsNamespaceEntry(chunk, graph, true, options.preserve_modules) != null;
+            const member = if (is_ns) linker_mod.CJS_NS_EXPORT_NAME else "default";
+            const expr = try l.cjsInteropAccessExpr(allocator, em, member, options.minify_whitespace);
             defer allocator.free(expr);
             const min = options.minify_whitespace;
             if (options.format == .esm) {
@@ -1901,16 +1905,16 @@ fn rewriteDynamicImports(
         // 슬롯에 통째로 실어 보낸다(위 `cjs_dyn_entry` 참조 — CJS 의 named 멤버는 ESM
         // export 문법으로 정적 표현이 불가능해서 그 방법밖에 없다). 소비자는 한 겹 벗겨야
         // 진짜 namespace 를 얻는다. 조건은 provider 쪽 emit 조건과 **정확히 같아야** 한다.
-        const cjs_dyn_unwrap = !emit_options.preserve_modules and blk: {
-            const tc = chunk_graph.getChunk(target_chunk_idx);
-            const info = switch (tc.kind) {
-                .entry_point => |i| i,
-                .common, .manual => break :blk false,
-            };
-            if (!info.is_dynamic) break :blk false;
-            if (info.module != rec.resolved) break :blk false;
-            const em = graph.getModule(info.module) orelse break :blk false;
-            break :blk em.wrap_kind == .cjs;
+        const cjs_dyn_unwrap = blk: {
+            const mi = dynamicCjsNamespaceEntry(
+                target_chunk,
+                graph,
+                linker != null,
+                emit_options.preserve_modules,
+            ) orelse break :blk false;
+            // 그 청크가 **이 대상 모듈**의 dynamic entry 일 때만. (CJS 가 남의 dynamic entry
+            // 청크에 병합돼 들어온 경우엔 provider 가 그 모듈용 namespace 를 안 낸다.)
+            break :blk mi == rec.resolved;
         };
         const unwrap: []const u8 = if (cjs_dyn_unwrap) ".default" else "";
 
@@ -1952,14 +1956,23 @@ fn rewriteDynamicImports(
 
         // ESM: 네이티브 import() 유지 — specifier 만 청크 파일명으로 교체.
         // 단 CJS dynamic entry 청크면 namespace 를 한 겹 벗겨야 한다(#4522).
+        // ⚠️ 여기서 `rewriteImportCallToWrapper`(첫 indexOf 1회 + attributes 미지원)를 쓰면
+        // 문자열 리터럴 선행 occurrence / import attributes 에서 **specifier 가 통째로
+        // 미치환** 되어 ERR_MODULE_NOT_FOUND 다(#4295 회귀). specifier 교체는 아래 기존
+        // positional-walk 경로와 **같은 규칙**으로 하고 suffix 만 덧붙인다.
         if (cjs_dyn_unwrap) {
-            const wrapper = try std.fmt.allocPrint(allocator, "import(\"{s}\").then((m)=>m.default)", .{replacement});
-            defer allocator.free(wrapper);
-            if (try rewriteImportCallToWrapper(allocator, result, rec.specifier, wrapper)) |new_result| {
+            if (try rewriteImportCallAppendSuffix(
+                allocator,
+                result,
+                rec.specifier,
+                replacement,
+                ".then((m)=>m.default)",
+            )) |new_result| {
                 allocator.free(result);
                 result = new_result;
+                continue;
             }
-            continue;
+            // 폴백: suffix 를 못 붙였으면 최소한 specifier 는 고친다(아래 공통 경로).
         }
 
         // 실제 `import("specifier")` 호출 안의 specifier 만 교체 (prefix 충돌/문자열 리터럴 회피).
@@ -2074,6 +2087,123 @@ pub fn rewriteDynamicImportsSingleFile(
     }
 
     return result;
+}
+
+/// (#4522) 이 청크가 **동적 CJS entry** 라서 `default` 슬롯에 namespace 를 통째로 싣는가.
+/// 그렇다면 그 모듈 인덱스를 돌려준다.
+///
+/// provider emit(`cjs_dyn_entry`) / consumer unwrap(`rewriteDynamicImports`) / `__toESM` 헬퍼
+/// 주입(runtime_helpers) — **세 곳이 반드시 같은 술어**를 봐야 한다. 어긋나면:
+///   - provider 만 켜짐 → 소비자가 안 벗겨 값이 한 겹 더 감싸진다.
+///   - consumer 만 켜짐 → export 가 없는데 `.default` 를 벗겨 **undefined** → TypeError.
+/// 실제로 `linker == null`(scopeHoist=false) 에서 provider 는 bail 하는데 consumer 는 안 봐서
+/// 후자가 났다. 그래서 복붙을 없애고 여기 한 곳으로 모은다.
+pub fn dynamicCjsNamespaceEntry(
+    chunk: *const Chunk,
+    graph: *const ModuleGraph,
+    has_linker: bool,
+    preserve_modules: bool,
+) ?ModuleIndex {
+    if (preserve_modules) return null;
+    if (!has_linker) return null; // provider 가 `linker orelse break` 로 bail 하는 조건
+    const info = switch (chunk.kind) {
+        .entry_point => |i| i,
+        .common, .manual => return null,
+    };
+    if (!info.is_dynamic) return null;
+    // (#4522) federation expose / plugin emitFile 청크도 dynamic entry 모양이지만 그 소비자는
+    // zntc 가 아니라 **container factory / 사용자 코드**다. `default` 슬롯 의미를 바꾸면
+    // (module.exports 값 → namespace) 그쪽이 조용히 깨진다 → 진짜 `import()` 대상만.
+    if (!info.is_import_call) return null;
+    const em = graph.getModule(info.module) orelse return null;
+    if (em.wrap_kind != .cjs) return null;
+    return info.module;
+}
+
+/// (#4522) `import("<spec>")` 호출의 specifier 를 바꾸고 **호출 뒤에** suffix 를 덧붙인다
+/// (`import("./c.js").then((m)=>m.default)`).
+///
+/// `rewriteImportSpecifier` 와 **같은 positional walk** 를 쓴다 — 문자열 리터럴 안의 substring
+/// 이나 prefix 충돌(`./x` vs `./xyz`)을 오재작성하지 않고 **모든 occurrence** 를 처리한다.
+/// 호출 끝은 괄호 균형으로 찾으므로 import attributes(`import("./x", { with: {…} })`)도
+/// 안전하다.
+///
+/// ⚠️ `rewriteImportCallToWrapper` 를 쓰면 안 된다 — 첫 `indexOf` 1회만 보고(문자열 리터럴이
+/// 앞에 있으면 그걸 잡고 실패) attributes 도 의도적으로 미지원이라, 둘 다 **specifier 미치환
+/// → ERR_MODULE_NOT_FOUND** 다(#4295 가 고쳤던 바로 그 miscompile).
+///
+/// 호출 끝을 못 찾으면 null — caller 는 기존 specifier-only 경로로 폴백한다.
+fn rewriteImportCallAppendSuffix(
+    allocator: std.mem.Allocator,
+    code: []const u8,
+    specifier: []const u8,
+    replacement: []const u8,
+    suffix: []const u8,
+) !?[]u8 {
+    if (specifier.len == 0) return null;
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var i: usize = 0;
+    var any = false;
+    while (i < code.len) {
+        const rel = std.mem.indexOf(u8, code[i..], specifier) orelse break;
+        const pos = i + rel;
+        const close: ?usize = blk: {
+            const c = importSpecifierCloseAt(code, pos, specifier.len) orelse break :blk null;
+            break :blk if (code[c] == ')' or code[c] == ',') c else null;
+        };
+        if (close) |c| {
+            const call_end = importCallEndFrom(code, c) orelse {
+                out.deinit(allocator);
+                return null; // 균형 파괴 — 폴백
+            };
+            try out.appendSlice(allocator, code[i..pos]);
+            try out.appendSlice(allocator, replacement);
+            try out.appendSlice(allocator, code[pos + specifier.len .. call_end + 1]);
+            try out.appendSlice(allocator, suffix);
+            i = call_end + 1;
+            any = true;
+        } else {
+            // import 호출이 아닌 occurrence — 첫 글자만 흘려보내고 다음 후보부터 재검색.
+            try out.appendSlice(allocator, code[i .. pos + 1]);
+            i = pos + 1;
+        }
+    }
+    if (!any) {
+        out.deinit(allocator);
+        return null;
+    }
+    try out.appendSlice(allocator, code[i..]);
+    return try out.toOwnedSlice(allocator);
+}
+
+/// `import(` 를 닫는 `)` 의 인덱스. `from` 은 specifier 닫는 quote **다음** 바이트(= 이미
+/// `import(` 안이므로 depth 1 에서 시작). 문자열 리터럴 안의 괄호는 건너뛴다.
+fn importCallEndFrom(code: []const u8, from: usize) ?usize {
+    var depth: usize = 1;
+    var j = from;
+    while (j < code.len) : (j += 1) {
+        switch (code[j]) {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if (depth == 0) return j;
+            },
+            '"', '\'', '`' => {
+                const q = code[j];
+                j += 1;
+                while (j < code.len) : (j += 1) {
+                    if (code[j] == '\\') {
+                        j += 1;
+                        continue;
+                    }
+                    if (code[j] == q) break;
+                }
+            },
+            else => {},
+        }
+    }
+    return null;
 }
 
 fn rewriteImportCallToWrapper(

--- a/src/bundler/emitter/runtime_helpers.zig
+++ b/src/bundler/emitter/runtime_helpers.zig
@@ -10,6 +10,7 @@ const linker_mod = @import("../linker.zig");
 const Linker = linker_mod.Linker;
 const RuntimeHelpers = @import("../../transformer/runtime_helper_bits.zig").RuntimeHelpers;
 const parent = @import("../emitter.zig");
+const chunks = @import("chunks.zig");
 const EmitOptions = parent.EmitOptions;
 
 /// 번들 레벨 런타임 헬퍼 주입 (CJS interop + decorator + async).
@@ -316,13 +317,20 @@ pub fn emitChunkRuntimeHelpers(
     // (#4510/#4522) dynamic entry 청크의 CJS entry 는 `export default __toESM(require_x())` 를
     // 깐다(chunks.zig cjs_dyn_entry) — 그 모듈을 import 하는 바인딩이 이 청크에 없어도 필요.
     //
+    // 술어는 provider/consumer 와 **같은 소스**(chunks.dynamicCjsNamespaceEntry)를 봐야 한다.
+    // 복붙해 두면 조용히 어긋난다 — 실제로 `linker == null` 을 provider 만 보고 있었다.
+    //
     // ⚠️ can_skip shape 예외를 두면 안 된다. #4510 때는 `default` **값 하나**만 실어 보내서
     // can_skip 이면 `require_x()` direct(헬퍼 불요)였지만, #4522 부터는 **namespace 통째**를
     // 보내므로 shape 와 무관하게 항상 `__toESM` 이 필요하다. 예외를 남기면 청크가
     // `ReferenceError: __toESM is not defined` 로 죽는다.
-    if (chunk.kind == .entry_point and chunk.kind.entry_point.is_dynamic) {
+    if (chunks.dynamicCjsNamespaceEntry(chunk, graph, linker != null, options.preserve_modules) != null) {
+        needs_to_esm_runtime = true;
+    } else if (!options.preserve_modules and chunk.kind == .entry_point and chunk.kind.entry_point.is_dynamic) {
+        // federation expose / plugin emitFile 청크는 기존 계약(`default` = module.exports 값)
+        // 을 유지한다 — non can_skip shape 만 `__toESM(require_x()).default` 라 헬퍼가 필요.
         if (graph.getModule(chunk.kind.entry_point.module)) |em| {
-            if (em.wrap_kind == .cjs) needs_to_esm_runtime = true;
+            if (em.wrap_kind == .cjs and !em.can_skip_cjs_default_interop) needs_to_esm_runtime = true;
         }
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {

--- a/src/bundler/emitter/runtime_helpers.zig
+++ b/src/bundler/emitter/runtime_helpers.zig
@@ -313,12 +313,16 @@ pub fn emitChunkRuntimeHelpers(
         if (m.loader == .binary) needs_to_binary = true;
         if (needs_cjs_runtime and needs_esm_wrap_runtime and needs_to_esm_runtime and needs_to_binary) break;
     }
-    // (#4510) dynamic entry 청크의 CJS entry 는 `export default __toESM(require_x()).default` 를
+    // (#4510/#4522) dynamic entry 청크의 CJS entry 는 `export default __toESM(require_x())` 를
     // 깐다(chunks.zig cjs_dyn_entry) — 그 모듈을 import 하는 바인딩이 이 청크에 없어도 필요.
-    // can_skip shape 는 `require_x()` direct 라 제외(cjsInteropAccessExpr 와 동일 조건).
+    //
+    // ⚠️ can_skip shape 예외를 두면 안 된다. #4510 때는 `default` **값 하나**만 실어 보내서
+    // can_skip 이면 `require_x()` direct(헬퍼 불요)였지만, #4522 부터는 **namespace 통째**를
+    // 보내므로 shape 와 무관하게 항상 `__toESM` 이 필요하다. 예외를 남기면 청크가
+    // `ReferenceError: __toESM is not defined` 로 죽는다.
     if (chunk.kind == .entry_point and chunk.kind.entry_point.is_dynamic) {
         if (graph.getModule(chunk.kind.entry_point.module)) |em| {
-            if (em.wrap_kind == .cjs and !em.can_skip_cjs_default_interop) needs_to_esm_runtime = true;
+            if (em.wrap_kind == .cjs) needs_to_esm_runtime = true;
         }
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {

--- a/tests/integration/tests/split-cjs-cross-chunk.test.ts
+++ b/tests/integration/tests/split-cjs-cross-chunk.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
 import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
 import { createFixture, runNode, runZntc, writeOutputs } from './helpers';
 import { init, close, build } from '../../../packages/core/index';
 
@@ -234,6 +235,57 @@ describe('code-splitting 런타임 스모크', () => {
       const { stdout } = await runNode(outFile);
       // 버그 시: `d.a = undefined`
       expect(stdout.trim()).toBe('d.a = 1');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('#4522 code-split 된 동적 CJS import 도 named 멤버를 노출한다 (인라인과 같은 값)', async () => {
+    // CJS 는 정적 export 가 없어 named 멤버를 ESM `export` 문법으로 표현할 수 없다. 그래서
+    // 동적 CJS entry 청크는 **namespace 통째**를 `default` 슬롯에 실어 보내고, 소비자가
+    // `.default` 로 한 겹 벗긴다. 예전엔 `default` **값 하나**만 내보내서 named 가 유실됐고,
+    // 그 결과 **같은 소스가 청킹에 따라 런타임 값이 갈렸다**(인라인=정상 / splitting=TypeError).
+    //
+    // 정본: node 는 `import('./x.cjs')` 에서 named 를 노출한다(cjs-module-lexer).
+    // rolldown / rspack 도 code-split 상태에서 노출한다 — esbuild 만 예외.
+    const files = {
+      'legacy.cjs': 'module.exports = { foo() { return "FOO"; }, bar: 42 };',
+      'entry.js':
+        'import("./legacy.cjs").then((m) => {\n' +
+        '  console.log("keys:" + Object.keys(m).sort().join(",") + "|foo:" + (typeof m.foo === "function" ? m.foo() : "MISSING") + "|default:" + (m.default ? m.default.bar : "MISSING"));\n' +
+        '});',
+    };
+
+    // splitting 과 인라인이 **같은 값**을 내야 한다.
+    const { dir, cleanup } = await createFixture(files);
+    try {
+      const outDir = join(dir, 'dist');
+      const split = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--splitting',
+        '--outdir',
+        outDir,
+        '--format=esm',
+      ]);
+      expect(split.exitCode, `빌드 실패:\n${split.stderr}`).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+      const splitOut = await runNode(join(outDir, 'entry.js'));
+
+      const inlineFile = join(dir, 'inline.mjs');
+      const inline = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '-o',
+        inlineFile,
+        '--format=esm',
+      ]);
+      expect(inline.exitCode, `빌드 실패:\n${inline.stderr}`).toBe(0);
+      const inlineOut = await runNode(inlineFile);
+
+      // 버그 시 splitting: `keys:default|foo:MISSING|default:42`
+      expect(splitOut.stdout.trim()).toBe('keys:bar,default,foo|foo:FOO|default:42');
+      expect(splitOut.stdout.trim()).toBe(inlineOut.stdout.trim());
     } finally {
       await cleanup();
     }

--- a/tests/integration/tests/split-cjs-cross-chunk.test.ts
+++ b/tests/integration/tests/split-cjs-cross-chunk.test.ts
@@ -290,4 +290,95 @@ describe('code-splitting 런타임 스모크', () => {
       await cleanup();
     }
   });
+  test('#4522 후속: 문자열 리터럴이 앞서 나와도 import() specifier 가 청크로 치환된다', async () => {
+    // 소비자 재작성을 `rewriteImportCallToWrapper`(첫 indexOf 1회) 로 하면 앞선 문자열
+    // 리터럴 occurrence 를 잡고 실패해 **specifier 가 통째로 미치환** → ERR_MODULE_NOT_FOUND.
+    // `rewriteImportSpecifier` 와 같은 positional walk 를 써야 한다(#4295 가 고쳤던 그 버그).
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': 'module.exports = { foo() { return "FOO"; } };',
+      'entry.js':
+        'const label = "./legacy.cjs";\n' +
+        'console.log("label:" + label);\n' +
+        'import("./legacy.cjs").then((m) => console.log("foo:" + m.foo()));',
+    });
+    try {
+      const outDir = join(dir, 'dist');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--splitting',
+        '--outdir',
+        outDir,
+        '--format=esm',
+      ]);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+      const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+      // 버그 시: ERR_MODULE_NOT_FOUND (./legacy.cjs 를 dist 에서 찾음)
+      expect(stderr).not.toContain('ERR_MODULE_NOT_FOUND');
+      expect(stdout.trim().split('\n').pop()).toBe('foo:FOO');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('#4522 후속: import attributes 가 붙어도 specifier 가 청크로 치환된다', async () => {
+    // `import("./x.cjs", { with: {} })` — 닫는 quote 뒤가 `,` 라, `)` 만 허용하는 재작성기는
+    // specifier 를 미치환으로 남긴다(#4295 회귀).
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': 'module.exports = { foo() { return "FOO"; } };',
+      'entry.js':
+        'import("./legacy.cjs", { with: {} }).then((m) => console.log("foo:" + m.foo()));',
+    });
+    try {
+      const outDir = join(dir, 'dist');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--splitting',
+        '--outdir',
+        outDir,
+        '--format=esm',
+      ]);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+      const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+      expect(stderr).not.toContain('ERR_MODULE_NOT_FOUND');
+      expect(stdout.trim()).toBe('foo:FOO');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('#4522 후속: __esModule CJS 도 default / named 가 모두 맞는다 (이중 interop 없음)', async () => {
+    // 청크가 namespace 를 싣고 소비자가 한 겹 벗기므로 `__toESM` 이 두 번 걸리면 안 된다.
+    // rolldown 과 같은 값이 나와야 한다.
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs':
+        'Object.defineProperty(exports, "__esModule", { value: true });\n' +
+        'exports.default = { kind: "REAL_DEFAULT" };\n' +
+        'exports.named = "NAMED";',
+      'entry.js':
+        'import("./legacy.cjs").then((m) => {\n' +
+        '  console.log("keys:" + Object.keys(m).sort().join(",") + "|default:" + (m.default && m.default.kind) + "|named:" + m.named);\n' +
+        '});',
+    });
+    try {
+      const outDir = join(dir, 'dist');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--splitting',
+        '--outdir',
+        outDir,
+        '--format=esm',
+      ]);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+      const { stdout } = await runNode(join(outDir, 'entry.js'));
+      expect(stdout.trim()).toBe('keys:default,named|default:REAL_DEFAULT|named:NAMED');
+    } finally {
+      await cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## 요약

**같은 소스가 청킹 설정에 따라 런타임 값이 갈리던** 무성 오컴파일을 고칩니다.

```js
// legacy.cjs
module.exports = { foo(){ return "FOO"; }, bar: 42 };

const m = await import("./legacy.cjs");
m.foo();
```

| | code-split 시 `keys` | `m.foo()` |
|---|---|---|
| **node (정본)** | `default, foo` | ✅ `FOO` |
| **zntc (버그)** | `default` | ❌ `TypeError: m.foo is not a function` |
| **zntc 인라인** | `default, foo, bar` | ✅ `FOO` |
| **rolldown / rspack** | named 포함 | ✅ `FOO` |
| esbuild | `default` | ❌ (아웃라이어) |

빌드 exit 0 · 파싱 통과 · **실행만** 실패. 개발 중엔 되다가 프로덕션 빌드에서 죽는 형태입니다.

이슈를 열 때 "esbuild 도 동일하니 생태계 공통 한계" 라고 적었는데 **틀렸습니다** — node 자신과 참조 구현 3개 중 2개는 named 를 노출합니다.

## 루트커즈

동적 CJS entry 청크가 CJS↔ESM interop 결과(namespace)를 **`default` 슬롯 하나로 좁혀서** 내보냈습니다. CJS 는 정적 export 가 없어 named 멤버를 ESM `export` 문법으로 **표현할 수 없으므로** 거기서 그대로 유실됩니다.

같은-청크 경로는 `import()` **호출 자체**를 `__toESM(require_x())` 표현식으로 치환하니 namespace 가 통째로 살아남습니다 — 그래서 두 경로가 갈렸습니다.

## 처방 (rolldown 동형)

청크가 **namespace 를 통째로** 실어 보내고(`export default __toESM(require_x())`), 소비자가 `.default` 로 한 겹 벗깁니다. esm / cjs / iife·umd·amd 세 형식 모두 같은 규칙입니다.

```js
// 청크
export default __toESM(require_legacy());
// 소비자
import("./legacy-ad225202.js").then((m)=>m.default)
```

---

## `/code-review max` 가 잡은 것 — **첫 수정이 만든 하드 회귀 4건**

리뷰가 결정적이었습니다. 전부 재현 후 `d7eeb4f7` 에서 고쳤습니다.

### (a) 견고한 재작성기를 취약한 것으로 바꿨다

소비자 unwrap 을 붙이려고 `rewriteImportSpecifier`(**모든** occurrence positional walk + import attributes 대응 — #4295 의 수정) 대신 `rewriteImportCallToWrapper`(첫 `indexOf` 1회, attributes 의도적 미지원)를 썼고, 실패해도 `continue` 해서 폴백조차 없었습니다.

```js
const label = "./legacy.cjs";        // ← 앞선 문자열 리터럴을 indexOf 가 먼저 잡음
import("./legacy.cjs").then(...)     // ← specifier 미치환 → ERR_MODULE_NOT_FOUND

import("./legacy.cjs", { with: {} }) // ← 닫는 quote 뒤가 `,` → 미치환 (#4295 회귀)
```

→ 같은 positional walk 를 쓰되 호출 끝을 **괄호 균형**으로 찾는 `rewriteImportCallAppendSuffix` 로 다시 썼습니다. 못 찾으면 기존 specifier-only 경로로 폴백합니다.

### (b) 술어를 3곳에 복붙해서 이미 어긋나 있었다

provider(emit) / consumer(unwrap) / `__toESM` 헬퍼 주입이 각자 조건을 들고 있었고, **provider 만** `linker orelse break` 를 봤습니다. `scopeHoist: false`(linker null)에서 청크는 아무것도 export 안 하는데 소비자는 `.default` 를 벗겨 **TypeError** — 조용히 틀린 값을 하드 크래시로 바꿔 놓았습니다.

→ `dynamicCjsNamespaceEntry` **단일 술어**로 합쳤습니다.

### (c) federation expose / plugin `emitFile` 청크도 같은 모양이었다

둘 다 `entry_point{is_dynamic}` 로 만들어지는데, 소비자가 zntc 가 아니라 **container factory / 사용자 코드**입니다. provider 만 바뀌니 `default` 슬롯 의미(module.exports 값 → namespace)가 조용히 바뀌어, MF 호스트의 `factory().default(...)` 가 깨집니다.

→ entry 에 `is_import_call` 을 달아 **진짜 `import()` 대상만** namespace 로 가고, 그 둘은 기존 계약을 **바이트 그대로** 유지합니다.

## 검증

- `__esModule` CJS(`exports.__esModule = true`)도 **이중 interop 없이** rolldown 과 **같은 값**: `keys:default,named|default:REAL_DEFAULT|named:NAMED`
- 정적 import 와 동적 import 혼용도 node 정본과 일치
- 유닛: `zig build test` green
- 통합: `bun test` **4201 pass / 0 fail** (+ 신규 가드 4건 — split==inline / 문자열 리터럴 선행 / import attributes / `__esModule`)

## 이 PR 이 닫지 **않는** 것 (별도 이슈)

- #4524 — `--preserve-modules` × CJS 가 통째로 깨짐(정적 import 는 `ReferenceError`, 동적은 빈 namespace). **기존 결함**이고 main 에서도 재현되며, 배선 자체가 없는 별개 문제라 분리했습니다.

Closes #4522

🤖 Generated with [Claude Code](https://claude.com/claude-code)
