### PR TITLE
fix(bundler): #4530 래퍼 심볼이 사용자 top-level 심볼과 deconflict 되지 않아 파싱 불가

### DIFF
--- a/.changeset/wrapper-name-deconflict.md
+++ b/.changeset/wrapper-name-deconflict.md
@@ -5,8 +5,6 @@
 생성된 **래퍼 심볼**이 사용자 top-level 심볼과 deconflict 되지 않아 **파싱 불가** 산출물이 나오던 것 수정 (#4530).
 
 ```js
-// legacy.cjs
-module.exports = { foo(){ return "FOO"; } };
 // entry.js
 function require_legacy(){ return "USER"; }   // ← 사용자 심볼
 import d from "./legacy.cjs";
@@ -22,8 +20,11 @@ function require_legacy(){ return "USER"; }   // ← 사용자 코드
 
 **단일 번들에서도** 재현된다 — 번들 스코프에 모든 모듈의 top-level 이 호이스팅되기 때문이다.
 
-근본 원인: `registerWrapperSymbols` 의 deconflict 풀이 **래퍼 이름끼리만** 봤다. #4475 는 basename 충돌(`a/logo.png` vs `b/logo.png` 가 둘 다 `require_logo`)만 다뤘고, **사용자 코드의 top-level 심볼과는 대조하지 않았다.** CJS 의 `require_X` 뿐 아니라 ESM-wrap 의 `init_X` / `exports_X` 도 같은 위험이 있었다.
+근본 원인: 래퍼 심볼(`extendSymbol`)은 `scope_id = .none` 으로 만들어져 **`scope_maps` 에 들어가지 않는다** → linker 의 rename 풀(`name_to_owners`)이 **못 본다**. 그래서 사용자 심볼과 이름이 겹쳐도 아무도 못 막았다. CJS 의 `require_X` 뿐 아니라 ESM-wrap 의 `init_X` / `exports_X` 도 같았다.
 
-처방: 래퍼 이름을 짓기 전에 **모든 모듈의 top-level 심볼 이름을 같은 풀에 seed** 한다 → 충돌 시 `require_legacy$2` 로 갈린다.
+처방: 래퍼 이름을 linker 의 **`reserved_globals` 에 예약**한다 → 충돌하는 **사용자 심볼**이 리네임된다.
 
-size 영향 0 — effect/zod/three `--minify` 산출물이 **byte-identical**(충돌이 없으면 이름이 그대로).
+⚠️ **래퍼 쪽 이름을 바꾸는 방식으로 풀면 안 된다.** graph finalize 의 `used_names` 와 linker 의 `$N` 할당기는 **서로를 못 보는 두 개의 독립 풀**이라, 한 단계 위에서 다시 충돌한다(양쪽이 각각 `require_legacy$2` 를 발급). 예약해서 사용자 심볼을 리네임시키면 할당기가 **하나로 모인다**. 부수 효과로:
+
+- 래퍼가 자연스러운 이름을 유지 → size 회귀 0 (effect/zod/three `--minify` byte-identical).
+- `computeRenames` 는 **매 빌드 실행**되므로 **watch/incremental 재빌드**도 커버된다 (래퍼 이름은 한 번 정해지면 캐시되므로, finalize 쪽 seed 는 warm 에서 아예 발동하지 않았다).

--- a/.changeset/wrapper-name-deconflict.md
+++ b/.changeset/wrapper-name-deconflict.md
@@ -1,0 +1,29 @@
+---
+"@zntc/core": patch
+---
+
+생성된 **래퍼 심볼**이 사용자 top-level 심볼과 deconflict 되지 않아 **파싱 불가** 산출물이 나오던 것 수정 (#4530).
+
+```js
+// legacy.cjs
+module.exports = { foo(){ return "FOO"; } };
+// entry.js
+function require_legacy(){ return "USER"; }   // ← 사용자 심볼
+import d from "./legacy.cjs";
+```
+
+방출:
+
+```js
+var require_legacy = __commonJS({ ... });     // ← emitter 가 찍은 래퍼
+function require_legacy(){ return "USER"; }   // ← 사용자 코드
+// → SyntaxError: Identifier 'require_legacy' has already been declared
+```
+
+**단일 번들에서도** 재현된다 — 번들 스코프에 모든 모듈의 top-level 이 호이스팅되기 때문이다.
+
+근본 원인: `registerWrapperSymbols` 의 deconflict 풀이 **래퍼 이름끼리만** 봤다. #4475 는 basename 충돌(`a/logo.png` vs `b/logo.png` 가 둘 다 `require_logo`)만 다뤘고, **사용자 코드의 top-level 심볼과는 대조하지 않았다.** CJS 의 `require_X` 뿐 아니라 ESM-wrap 의 `init_X` / `exports_X` 도 같은 위험이 있었다.
+
+처방: 래퍼 이름을 짓기 전에 **모든 모듈의 top-level 심볼 이름을 같은 풀에 seed** 한다 → 충돌 시 `require_legacy$2` 로 갈린다.
+
+size 영향 0 — effect/zod/three `--minify` 산출물이 **byte-identical**(충돌이 없으면 이름이 그대로).

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -221,6 +221,25 @@ pub fn registerWrapperSymbols(self: *ModuleGraph) void {
         if (m.wrapper_name_synthetic) |n| _ = used_names.put(self.allocator, n, 1) catch {};
     }
 
+    // (#4530) **사용자 top-level 심볼도 같은 풀에 seed 한다.** 예전엔 래퍼 이름끼리만
+    // deconflict 해서, 사용자 코드에 `function require_legacy(){}` 같은 top-level 심볼이
+    // 있으면 CJS 래퍼(`var require_legacy = __commonJS(...)`)와 **중복 선언**됐다
+    // → `SyntaxError: Identifier 'require_legacy' has already been declared`.
+    // **단일 번들에서도** 재현되는 결함이다(번들 스코프에 모든 모듈의 top-level 이 호이스팅됨).
+    //
+    // preserve-modules 는 파일마다 스코프가 따로라 전역 deconflict 가 과하지만, 이름이
+    // 파일 경계를 넘는 **공개 키**이기도 해서 전역으로 유일하면 provider/consumer 가 항상
+    // 같은 값을 본다 — 안전한 방향의 과잉이다.
+    var user_seed_it = self.modules.iterator(0);
+    while (user_seed_it.next()) |m| {
+        const sem_ptr = if (m.semantic) |*s| s else continue;
+        if (sem_ptr.scope_maps.len == 0) continue;
+        var name_it = sem_ptr.scope_maps[0].keyIterator();
+        while (name_it.next()) |name_ptr| {
+            _ = used_names.put(self.allocator, name_ptr.*, 1) catch {};
+        }
+    }
+
     var it = self.modules.iterator(0);
     while (it.next()) |m| {
         if (m.wrap_kind == .none) continue;

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -221,25 +221,6 @@ pub fn registerWrapperSymbols(self: *ModuleGraph) void {
         if (m.wrapper_name_synthetic) |n| _ = used_names.put(self.allocator, n, 1) catch {};
     }
 
-    // (#4530) **사용자 top-level 심볼도 같은 풀에 seed 한다.** 예전엔 래퍼 이름끼리만
-    // deconflict 해서, 사용자 코드에 `function require_legacy(){}` 같은 top-level 심볼이
-    // 있으면 CJS 래퍼(`var require_legacy = __commonJS(...)`)와 **중복 선언**됐다
-    // → `SyntaxError: Identifier 'require_legacy' has already been declared`.
-    // **단일 번들에서도** 재현되는 결함이다(번들 스코프에 모든 모듈의 top-level 이 호이스팅됨).
-    //
-    // preserve-modules 는 파일마다 스코프가 따로라 전역 deconflict 가 과하지만, 이름이
-    // 파일 경계를 넘는 **공개 키**이기도 해서 전역으로 유일하면 provider/consumer 가 항상
-    // 같은 값을 본다 — 안전한 방향의 과잉이다.
-    var user_seed_it = self.modules.iterator(0);
-    while (user_seed_it.next()) |m| {
-        const sem_ptr = if (m.semantic) |*s| s else continue;
-        if (sem_ptr.scope_maps.len == 0) continue;
-        var name_it = sem_ptr.scope_maps[0].keyIterator();
-        while (name_it.next()) |name_ptr| {
-            _ = used_names.put(self.allocator, name_ptr.*, 1) catch {};
-        }
-    }
-
     var it = self.modules.iterator(0);
     while (it.next()) |m| {
         if (m.wrap_kind == .none) continue;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -893,6 +893,28 @@ pub const Linker = struct {
         for (self.global_identifiers) |name| {
             try self.reserved_globals.put(self.allocator, name, {});
         }
+
+        // (#4530) **생성된 래퍼 심볼 이름도 예약**한다 — CJS `require_X`, ESM-wrap
+        // `init_X`/`exports_X`. 이들은 emitter 가 직접 찍는 top-level 선언인데
+        // `extendSymbol` 이 `scope_id = .none` 으로 만들어 **scope_maps 에 안 들어간다**
+        // → linker 의 rename 풀(`name_to_owners`)이 못 본다. 그래서 사용자 코드에
+        // `function require_legacy(){}` 가 있으면 **중복 선언**됐다
+        // (`SyntaxError: Identifier 'require_legacy' has already been declared`).
+        // **단일 번들에서도** 재현된다(번들 스코프에 모든 모듈의 top-level 이 호이스팅됨).
+        //
+        // ⚠️ 래퍼 쪽 이름을 바꾸는 걸로 풀면 안 된다 — graph finalize 의 `used_names` 와
+        // 여기 `$N` 할당기가 **서로를 못 보는 두 개의 독립 풀**이라 한 단계 위에서 다시
+        // 충돌한다(`require_legacy$2` 를 양쪽이 각각 발급). 예약해서 **사용자 심볼을
+        // 리네임**시키면 할당기가 하나로 모인다. 래퍼는 자연스러운 이름을 유지하므로
+        // size/warm-rebuild 안정성도 낫다(`computeRenames` 는 매 빌드 실행 → watch 도 커버).
+        var wit = self.graph.modulesIterator();
+        while (wit.next()) |m| {
+            if (m.wrap_kind == .none) continue;
+            if (m.getInitName(null)) |n| try self.reserved_globals.put(self.allocator, n, {});
+            if (m.getExportsName(null)) |n| try self.reserved_globals.put(self.allocator, n, {});
+            if (m.getRequireName(null)) |n| try self.reserved_globals.put(self.allocator, n, {});
+            if (m.wrapper_name_synthetic) |n| try self.reserved_globals.put(self.allocator, n, {});
+        }
     }
 
     /// 이름 충돌 감지 + 리네임 계산 (Rolldown renamer 패턴).

--- a/tests/integration/tests/wrapper-name-deconflict.test.ts
+++ b/tests/integration/tests/wrapper-name-deconflict.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { createFixture, runNode, runZntc } from './helpers';
+
+/**
+ * #4530 회귀 가드 — 생성된 **래퍼 심볼**이 사용자 top-level 심볼과 deconflict 되지 않던 결함.
+ *
+ * wrap 된 모듈은 emitter 가 래퍼 심볼을 직접 찍는다:
+ *   - CJS      : `var require_<basename> = __commonJS({...})`
+ *   - ESM-wrap : `var init_<basename> = __esm({...})`, `var exports_<basename> = {}`
+ *
+ * 그런데 `registerWrapperSymbols` 의 deconflict 풀이 **래퍼 이름끼리만** 봤다(#4475 는
+ * basename 충돌 — `a/logo.png` vs `b/logo.png` — 만 다뤘다). 사용자 코드에 같은 이름의
+ * top-level 심볼이 있으면 **중복 선언**이다:
+ *
+ *   var require_legacy = __commonJS({...});   // emitter
+ *   function require_legacy(){ ... }          // 사용자 코드
+ *   → SyntaxError: Identifier 'require_legacy' has already been declared
+ *
+ * **단일 번들에서도** 재현된다(번들 스코프에 모든 모듈의 top-level 이 호이스팅되므로).
+ * → 사용자 top-level 심볼도 같은 풀에 seed 한다.
+ */
+
+const LEGACY = 'module.exports = { foo(){ return "FOO"; } };';
+
+describe('#4530: 래퍼 심볼 ↔ 사용자 top-level 심볼 deconflict', () => {
+  test('단일 번들: CJS 래퍼(require_X)가 동명 사용자 심볼과 충돌하지 않는다', async () => {
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': LEGACY,
+      // 소비자 2개 — 래퍼가 인라인되지 않고 named 로 남게 한다.
+      'u1.js': 'import d from "./legacy.cjs";\nexport const x = () => d.foo();',
+      'entry.js':
+        'function require_legacy(){ return "USER"; }\n' +
+        'import d from "./legacy.cjs";\n' +
+        'import { x } from "./u1.js";\n' +
+        'console.log(require_legacy() + "|" + d.foo() + "|" + x());',
+    });
+    try {
+      const out = join(dir, 'b.mjs');
+      const res = await runZntc(['--bundle', join(dir, 'entry.js'), '-o', out, '--format=esm']);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(out);
+      // 버그 시: SyntaxError: Identifier 'require_legacy' has already been declared
+      expect(stderr).not.toContain('SyntaxError');
+      expect(stdout.trim()).toBe('USER|FOO|FOO');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('단일 번들: ESM-wrap 래퍼(init_X / exports_X)도 충돌하지 않는다', async () => {
+    const { dir, cleanup } = await createFixture({
+      'b.js': 'export function tag(){ return "T"; }',
+      // b.js 를 CJS 가 require → ESM-wrap 됨
+      'a.cjs': 'const b = require("./b.js");\nmodule.exports = { run: () => b.tag() };',
+      'entry.js':
+        'function init_b(){ return "USER-INIT"; }\n' +
+        'var exports_b = "USER-EXP";\n' +
+        'import a from "./a.cjs";\n' +
+        'console.log(init_b() + "|" + exports_b + "|" + a.run());',
+    });
+    try {
+      const out = join(dir, 'b.mjs');
+      const res = await runZntc(['--bundle', join(dir, 'entry.js'), '-o', out, '--format=esm']);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(out);
+      expect(stderr).not.toContain('SyntaxError');
+      expect(stdout.trim()).toBe('USER-INIT|USER-EXP|T');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  for (const format of ['esm', 'cjs'] as const) {
+    test(`--preserve-modules ${format}: 래퍼 이름이 사용자 심볼과 충돌하지 않는다`, async () => {
+      // preserve-modules 는 래퍼 이름이 **파일 경계를 넘는 공개 키**이기도 하다 —
+      // deconflict 결과가 provider/consumer 양쪽에서 같은 값이어야 한다.
+      const { dir, cleanup } = await createFixture({
+        'b.js': 'export function tag(){ return "T"; }',
+        'a.cjs': 'const b = require("./b.js");\nmodule.exports = { run: () => b.tag() };',
+        'entry.js':
+          'function init_b(){ return "USER-INIT"; }\n' +
+          'var exports_b = "USER-EXP";\n' +
+          'import a from "./a.cjs";\n' +
+          'console.log(init_b() + "|" + exports_b + "|" + a.run());',
+      });
+      try {
+        const outDir = join(dir, 'dist');
+        const res = await runZntc([
+          '--bundle',
+          join(dir, 'entry.js'),
+          '--preserve-modules',
+          '--outdir',
+          outDir,
+          `--format=${format}`,
+        ]);
+        expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+        if (format === 'esm') {
+          writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+        }
+        const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+        expect(stderr).not.toContain('SyntaxError');
+        expect(stdout.trim()).toBe('USER-INIT|USER-EXP|T');
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+});

--- a/tests/integration/tests/wrapper-name-deconflict.test.ts
+++ b/tests/integration/tests/wrapper-name-deconflict.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { join } from 'node:path';
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { createFixture, runNode, runZntc } from './helpers';
 
 /**
@@ -107,4 +107,83 @@ describe('#4530: 래퍼 심볼 ↔ 사용자 top-level 심볼 deconflict', () =>
       }
     });
   }
+  test('동명 사용자 심볼이 여러 모듈에 있어도 $N 레벨에서 재충돌하지 않는다', async () => {
+    // ⚠️ 래퍼 **이름을 바꾸는** 방식으로 풀면 안 된다 — graph finalize 의 `used_names` 와
+    // linker 의 `$N` 할당기가 **서로를 못 보는 두 개의 독립 풀**이라, 한 단계 위에서 다시
+    // 충돌한다(양쪽이 각각 `require_legacy$2` 를 발급 → SyntaxError).
+    // 래퍼를 **예약**해서 사용자 심볼을 리네임시키면 할당기가 하나로 모인다.
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': LEGACY,
+      'u1.js': 'import d from "./legacy.cjs";\nexport const x = () => d.foo();',
+      'm1.js': 'function require_legacy(){ return "A"; }\nexport const a = require_legacy();',
+      'm2.js': 'function require_legacy(){ return "B"; }\nexport const b = require_legacy();',
+      'entry.js':
+        'function require_legacy(){ return "C"; }\n' +
+        'import d from "./legacy.cjs";\n' +
+        'import { x } from "./u1.js";\n' +
+        'import { a } from "./m1.js";\n' +
+        'import { b } from "./m2.js";\n' +
+        'console.log(require_legacy() + a + b + d.foo() + x());',
+    });
+    try {
+      const out = join(dir, 'b.mjs');
+      const res = await runZntc(['--bundle', join(dir, 'entry.js'), '-o', out, '--format=esm']);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(out);
+      expect(stderr).not.toContain('SyntaxError');
+      expect(stdout.trim()).toBe('CABFOOFOO');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('--minify 에서도 충돌하지 않는다', async () => {
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': LEGACY,
+      'u1.js': 'import d from "./legacy.cjs";\nexport const x = () => d.foo();',
+      'entry.js':
+        'function require_legacy(){ return "USER"; }\n' +
+        'import d from "./legacy.cjs";\n' +
+        'import { x } from "./u1.js";\n' +
+        'console.log(require_legacy() + "|" + d.foo() + "|" + x());',
+    });
+    try {
+      const out = join(dir, 'b.mjs');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '-o',
+        out,
+        '--format=esm',
+        '--minify',
+      ]);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(out);
+      expect(stderr).not.toContain('SyntaxError');
+      expect(stdout.trim()).toBe('USER|FOO|FOO');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('충돌이 없으면 래퍼 이름이 그대로다 (과잉 deconflict 없음)', async () => {
+    // 래퍼를 **예약**하는 방식이라 래퍼는 자연스러운 이름을 유지하고, 충돌하는 **사용자
+    // 심볼**만 리네임된다 — size/warm-rebuild 안정성이 낫다.
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': LEGACY,
+      'u1.js': 'import d from "./legacy.cjs";\nexport const x = () => d.foo();',
+      'entry.js':
+        'import d from "./legacy.cjs";\nimport { x } from "./u1.js";\nconsole.log(d.foo() + x());',
+    });
+    try {
+      const out = join(dir, 'b.mjs');
+      const res = await runZntc(['--bundle', join(dir, 'entry.js'), '-o', out, '--format=esm']);
+      expect(res.exitCode).toBe(0);
+      const text = readFileSync(out, 'utf-8');
+      expect(text).toContain('var require_legacy = __commonJS');
+      expect(text).not.toContain('require_legacy$');
+    } finally {
+      await cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## 요약

생성된 **래퍼 심볼**이 사용자 top-level 심볼과 deconflict 되지 않아 **파싱 불가** 산출물이 나오던 것을 고칩니다.

```js
// entry.js
function require_legacy(){ return "USER"; }   // ← 사용자 심볼
import d from "./legacy.cjs";
```

방출:

```js
var require_legacy = __commonJS({ ... });     // ← emitter 가 찍은 래퍼
function require_legacy(){ return "USER"; }   // ← 사용자 코드
// → SyntaxError: Identifier 'require_legacy' has already been declared
```

**단일 번들에서도** 재현됩니다 — 번들 스코프에 모든 모듈의 top-level 이 호이스팅되기 때문입니다. CJS 의 `require_X` 뿐 아니라 ESM-wrap 의 `init_X` / `exports_X` 도 같았습니다.

## 루트커즈

**래퍼 심볼은 linker 의 rename 풀이 볼 수 없습니다.** `extendSymbol` 이 `scope_id = .none` 으로 만들어 **`scope_maps` 에 넣지 않기** 때문에, `name_to_owners` 에 잡히지 않고 아무도 충돌을 막지 못합니다.

`registerWrapperSymbols` 의 deconflict 풀은 **래퍼 이름끼리만** 봤습니다 — #4475 가 다룬 basename 충돌(`a/logo.png` vs `b/logo.png` 가 둘 다 `require_logo`)만요.

## 처방 — 래퍼 이름을 **예약**한다 (풀을 하나로)

래퍼 이름을 linker 의 **`reserved_globals`** 에 넣습니다 → 충돌하는 **사용자 심볼**이 리네임됩니다.

### ⚠️ 래퍼 쪽 이름을 바꾸는 방식으로 풀면 안 됩니다

첫 시도는 finalize 의 `used_names` 에 사용자 심볼을 seed 했는데, 리뷰가 **두 번째 `$N` 할당기를 만들 뿐**임을 짚었습니다:

- finalize 의 `uniqueName`(래퍼용, `$2`부터)과 linker 의 `findAvailableCandidate`(사용자용, `$1`부터)가 **서로를 못 보는 독립 풀**입니다 → 동명 사용자 심볼이 3개면 양쪽이 각각 `require_legacy$2` 를 발급해 **한 단계 위에서 다시 충돌**합니다.
- 래퍼 이름은 한 번 정해지면 Module 에 캐시됩니다(`needs_require = require_symbol == null`) → **warm/watch 재빌드에서 seed 가 아예 발동하지 않아** 같은 SyntaxError 가 그대로 나갑니다.

**예약** 방식은 할당기를 하나로 모읍니다. 부수 효과:

- 래퍼가 자연스러운 이름을 유지 → **size 회귀 0** (effect/zod/three `--minify` **byte-identical**).
- `computeRenames` 는 **매 빌드 실행** → **watch 재빌드도 커버**.

## 검증 (전부 node 정본 일치)

| 케이스 | |
|---|---|
| 단일 번들: CJS 래퍼(`require_X`) ↔ 동명 사용자 심볼 | ✅ |
| 단일 번들: ESM-wrap 래퍼(`init_X` / `exports_X`) | ✅ |
| `--preserve-modules` esm / cjs | ✅ |
| 동명 사용자 심볼 **3개** (`$N` 레벨 재충돌) | ✅ |
| `--minify` | ✅ |
| 충돌 없으면 래퍼 이름 그대로 (과잉 deconflict 없음) | ✅ |
| warm 재빌드 (충돌이 나중에 생김) | ✅ |
| 결정성 (같은 입력 5회 byte-identical) | ✅ |

- 유닛: `zig build test` green
- 통합: `bun test` **4235 pass / 0 fail** (신규 `wrapper-name-deconflict.test.ts` 7건)

## 남긴 것 — #4533

**중첩 스코프**의 동명 바인딩이 호이스팅된 래퍼를 섀도잉하는 케이스는 기존 결함으로 남습니다:

```js
function load(){
  function require_legacy(){ return "SHADOW"; }
  return require("./legacy.cjs").foo();   // → require_legacy() 로 재작성 → 섀도잉됨
}
// → TypeError: require_legacy(...).foo is not a function
```

linker 는 자기 rename 후보에 대해선 이미 `hasNestedBinding` 으로 막지만, 래퍼 심볼은 `scope_maps` 에 없어 그 기계를 타지 않습니다. 예약으로는 안 풀리고(중첩 바인딩은 리네임 대상이 아님), **래퍼 심볼을 rename 기계에 정식 참여**시켜야 합니다.

Closes #4530

🤖 Generated with [Claude Code](https://claude.com/claude-code)
