### PR TITLE
fix(bundler): #4533 주입된 래퍼 참조가 소비자 스코프 바인딩에 가려지는 것 — 소비자 바인딩 리네임

### DIFF
--- a/.changeset/wrapper-consumer-shadow.md
+++ b/.changeset/wrapper-consumer-shadow.md
@@ -1,0 +1,63 @@
+---
+"@zntc/core": patch
+---
+
+주입된 래퍼 참조(`require_x()`)가 **소비자의 스코프 바인딩**에 가려져 무성 TypeError 가 나던 것 수정 (#4533).
+
+```js
+function load(){
+  function require_legacy(){ return "SHADOW"; }   // 소비자의 바인딩
+  return require("./legacy.cjs").foo();            // → require_legacy().foo() → 가려짐
+}
+```
+
+`require("./legacy.cjs")` 는 emit 시 그 자리에서 `require_legacy()` 로 재작성되는데, 그 지점 스코프 체인에 동명 바인딩이 있으면 그게 래퍼를 가린다 → `require_legacy(...).foo is not a function`. 빌드 exit 0 · 파싱 통과 · **실행만** 실패.
+
+## 처방 (esbuild/rolldown 방식)
+
+**가리는 사용자 바인딩을 리네임**한다 — 래퍼 이름은 절대 안 건드린다. 래퍼 이름은 cross-chunk 전역명·preserve-modules 공개 export·mangler 등 **여러 서브시스템이 공유**하는 값이라 그걸 바꾸면 파급이 크다(래퍼를 리네임하는 접근은 cross-chunk desync / preserve-modules export 불일치 / mangler 무효화를 연쇄로 낳았다). 소비자의 지역 바인딩은 그 모듈 안에서만 참조되므로 리네임이 **로컬**하다.
+
+- `Linker.resolveWrapperConsumerShadows` — 각 소비자의 `import_records` 로 참조하는 래퍼 이름을 모아, 소비자 스코프(중첩; CJS 소비자는 클로저 안이라 scope 0 포함)에서 동명 바인딩을 찾아 `rename_table` 로 개명(`require_legacy$1`). `findAvailableCandidate` 로 owner/reserved/canonical/기존 중첩바인딩과 안 겹치는 이름 선택.
+- `buildMetadataForAst` 에 nested(scope 1+) rename 반영 추가 — module-scope self-rename 루프는 `scope_maps[0]` 만 봤다. **non-minify 전용**: minify 는 mangler(Phase B)가 nested 를 담당하고 scope-aware 라 shadow 를 자연히 피한다.
+- 단일 번들 / code-splitting(`computeRenamesForModules`) 양 경로에 배선.
+
+## 곁다리로 닫히는 것
+
+- **#4530**(래퍼 vs 사용자 **top-level** 심볼): main 의 `reserved_globals` 예약이 그대로 담당(이 PR 은 안 건드림).
+- **#4536**(asset/disabled 래퍼): 리네임 대상이 래퍼가 아니라 **소비자 바인딩**이라 래퍼에 심볼 테이블이 없어도 커버된다 — `wrapper_name_synthetic` 도 매칭 대상에 포함.
+
+정본 대조: node / esbuild / rspack / **rolldown** 전부 이 방식(소비자 바인딩 리네임). effect/zod/three `--minify` byte-identical(size 0).
+
+## code-review 반영 (2차)
+
+- 개명 후보가 CJS 소비자의 **scope-0(클로저 지역) 바인딩**과도 안 겹치게 `pickConsumerShadowName` 추가(`findAvailableCandidate` 는 scope 1+ 만 봄 → `require_legacy$1` 이 이미 있으면 거기 개명하던 재선언 결함).
+- 주입 이름 집합에 런타임 헬퍼 `__toCommonJS`/`__toESM` 포함(ESM-wrap interop `(init_x(), __toCommonJS(exports_x))`).
+- **minify 는 pass 전체 skip** — mangler 가 모든 바인딩을 유일명으로 개명해 섀도가 원천 불가(검증됨). non-minify 만 metadata nested 스캔.
+- `captureRenamesToPending` 에 nested(scope 1+) rename 의 `declaration_span` 재매칭 추가 — AST 변형(const-materialize) 후에도 소비자 shadow-rename 이 살아남게(방어적: module-scope rename 도 있는 소비자가 변형될 때만 발동).
+
+## code-review 반영 (3차) + 범위
+
+- **[3] splitting**: per-chunk 경로(`computeRenamesForModules`)의 `reserved_globals` 가 wrapper 이름·global_identifiers 를 안 예약해 형제 래퍼(`require_x$1`)와 겹치는 후보를 고르던 것 수정 — collectReservedGlobals 와 동일 예약.
+- **[2] incremental carryover**: `captureRenamesToPending` 이 scope 0/nested 동명 시 nested rename 을 scope-0 심볼에 오귀속하던 것 수정(old 심볼이 실제 module-scope 일 때만 그 경로).
+
+⚠️ **범위(#4538 epic 로 분리)**: 아래 **드문 edge** 는 이 PR 범위 밖 — cold 공통 케이스는 유지되고 main 대비 regression 아님.
+- 런타임 헬퍼(`__toESM`/`__toCommonJS`, `--minify-whitespace` 의 `$tE`/`$tC`)를 지역 변수로 shadow (사용자가 그렇게 이름 짓는 건 사실상 없음).
+- `require.context` 로 도달하는 래퍼.
+- HMR/incremental warm 재빌드에서 CJS scope-0 shadow 를 **나중에** 추가할 때 stale reuse (dev-only).
+
+## code-review 반영 (4차, 수렴)
+
+- **[0] eval/`with` 가드**: 소비자 스코프에 direct `eval`/`with` 가 있으면(=`blocksMangling()`) 개명하지 않는다 — 그 안의 동적 조회가 바인딩을 **이름 문자열**로 참조할 수 있어 리네임이 그걸 깬다. zntc mangler 도 같은 이유로 그런 모듈을 skip(#1258), esbuild 도 direct-eval 스코프를 deopt. (⚠️ eval+shadow 동시 케이스의 잔여 shadow 는 근본적으로 해결 불가한 엣지 — esbuild 도 동일하게 둔다.)
+- **[1] per-chunk 예약 축소**: 전 모듈 래퍼를 예약하던 것을 **이 청크가 실제 import 하는 래퍼**만으로 좁힘 — 무관한 다른 청크의 동명 사용자 심볼이 불필요하게 리네임돼 content-hash 파일명이 흔들리던 것 방지.
+- **[perf]** metadata nested 스캔을 `has_nonminify_nested_shadow`(scope 1+ 개명이 실제로 있을 때만 true)로 게이트 — 섀도 없는 절대다수 빌드에서 O(전 모듈 nested 바인딩) 스캔 제거.
+
+## code-review 반영 (5차, 수렴)
+
+- **[2] splitting 선언측 #4530**: per-chunk reserved 를 참조측(import 하는 래퍼)뿐 아니라 **선언측**(이 청크에 놓이는 wrapped 모듈 자신의 래퍼)까지 예약 — 래퍼 선언(`var require_X=__commonJS`)과 동명인 co-chunk 사용자 top-level 이 중복 선언되던 것(main 의 splitting #4530 갭) 수정.
+- **[perf]** metadata nested 스캔 게이트를 전역 bool → **개명된 모듈 index 집합**으로 — 스캔이 영향 모듈에만 비례.
+- **[cleanup]** 래퍼 예약을 `reserveWrapperNames(module)` 단일 헬퍼로(collectReservedGlobals + per-chunk 공유). 코드 주석의 외부 출처 표기 제거(컨벤션).
+
+⚠️ **알려진 HMR perf**(#4538): nested shadow-rename 이 있으면 HMR rename-reuse 스냅샷이 폐기돼 warm 재빌드가 full 재계산으로 떨어진다(정확성 유지, shadow 있는 프로젝트만). symbolLocalName 이 nested SymbolID 를 못 역매핑하기 때문 — reuse 를 nested rename 까지 확장하는 건 #4538.
+
+## code-review 반영 (6차, 수렴 — correctness 잔여 0)
+- **[0] --minify-whitespace 헬퍼명**: interop 헬퍼 shadow 매칭에 축약명(`$tE`/`$tC`, NAMES.TOESM_MIN/TOCOMMONJS_MIN)도 추가 — emit 은 `--minify-whitespace` 에서 축약명을 쓰는데 full 이름만 매칭해 그 조합에서만 nested 헬퍼 shadow 를 놓치던 것 수정. names 배열↔reserveWrapperNames 동기화 주석 추가.

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -267,10 +267,39 @@ fn captureRenamesToPending(
 
         if (old_sym.synthetic_kind == null) {
             const name = old_sym.nameText(source);
-            const new_idx = if (module_scope) |scope| scope.get(name) else null;
+            // ⚠️ old_sym 이 정말 **module-scope(scope 0) 심볼**일 때만 module_scope 로 재유도한다.
+            // 같은 이름이 scope 0 과 nested 양쪽에 있으면(#4533 소비자 shadow-rename 케이스),
+            // module_scope.get(name) 은 **scope 0 idx** 를 주는데 old_sym 이 nested 였다면 rename 이
+            // 엉뚱한 심볼에 붙는다 → 아래 span 폴백으로 가야 한다.
+            const old_is_module_scope = if (old_sem.scope_maps.len > 0)
+                (old_sem.scope_maps[0].get(name) orelse std.math.maxInt(usize)) == old_idx
+            else
+                false;
+            const new_idx = if (old_is_module_scope) (if (module_scope) |scope| scope.get(name) else null) else null;
             if (new_idx) |idx| {
                 if (idx < new_sem.symbols.items.len and new_sem.symbols.items[idx].synthetic_kind == null) {
                     try rebuilt.put(arena, bundler_symbol.SymbolID.make(module.index, idx), rename);
+                }
+                continue;
+            }
+            // module_scope(scope 0) 에 없으면 **nested 바인딩**이다 (#4533 소비자 shadow-rename).
+            // rename_table 에 nested entry 가 생기는 건 이번(#4533) 부터다. 이름은 nested 스코프
+            // 에서 유일하지 않으므로 `declaration_span` 으로 매칭한다 — const-materialization 은
+            // leaf 식별자만 치환하고 선언 위치는 안 옮기므로 span 안정.
+            //
+            // ⚠️ 이 폴백은 **pending 이 비지 않은(=module-scope rename 도 있는) 소비자가
+            // AST 변형(const-materialize)까지 겪을 때**만 발동한다 — 그 경우 `applyPendingRenames`
+            // 가 `removeModule` 로 nested entry 까지 지우므로 여기서 재-stash 해야 한다. nested-only
+            // 소비자는 pending 이 비어 applyPendingRenames 가 skip → rename_table 이 보존되어
+            // 이 경로가 필요 없다(그래서 cold 단순 케이스로는 재현 안 됨).
+            if (old_sym.declaration_span.end > old_sym.declaration_span.start) {
+                for (new_sem.symbols.items, 0..) |new_sym, idx| {
+                    if (new_sym.synthetic_kind != null) continue;
+                    if (new_sym.declaration_span.start != old_sym.declaration_span.start) continue;
+                    if (new_sym.declaration_span.end != old_sym.declaration_span.end) continue;
+                    if (!std.mem.eql(u8, new_sym.nameText(source), name)) continue;
+                    try rebuilt.put(arena, bundler_symbol.SymbolID.make(module.index, idx), rename);
+                    break;
                 }
             }
             continue;

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -31,6 +31,7 @@ const Span = @import("../lexer/token.zig").Span;
 const Ast = @import("../parser/ast.zig").Ast;
 const semantic_symbol = @import("../semantic/symbol.zig");
 const bundler_symbol = @import("symbol.zig");
+const rt = @import("runtime_helpers.zig");
 const unified_mangler = @import("../codegen/unified_mangler.zig");
 const profile = @import("../profile.zig");
 const debug_log = @import("../debug_log.zig");
@@ -240,6 +241,12 @@ pub const Linker = struct {
     /// (scope_maps 소유, semantic 수명 = graph > Linker). 빌드는 단일스레드 computeRenames 에서만,
     /// 조회는 const(레이스 없음). 캐시 미존재(per-chunk/빌드 전) 는 원본 스캔 fallback → byte-identical.
     nested_binding_cache: std.AutoHashMapUnmanaged(u32, std.StringHashMapUnmanaged(void)) = .empty,
+
+    /// (#4533) `resolveWrapperConsumerShadows` 가 **nested(scope 1+)** 소비자 바인딩을 개명한
+    /// **모듈 index 집합**. non-minify 에서 `buildMetadataForAst` 의 nested-scope rename_table
+    /// 스캔은 이 rename 만 반영하므로, 이 집합에 없는 모듈(절대다수)은 그 O(nested 바인딩) 스캔을
+    /// 통째로 건너뛴다. scope 0 개명은 module-scope self-rename 루프가 담당하므로 여기 무관.
+    nonminify_nested_shadow_modules: std.AutoHashMapUnmanaged(u32, void) = .empty,
 
     /// (#4120) `module_index → ChunkIndex` borrowed 슬라이스. `computeCrossChunkLinks` 직후
     /// bundler 가 `chunk_graph.module_to_chunk` 를 빌려 세팅 — emit 동안만 유효(소유권 X, free 금지).
@@ -488,6 +495,7 @@ pub const Linker = struct {
         // nested-binding 캐시: inner set 해제(computeRenames 에러 경로 안전망; 정상 경로는 defer 가 이미 clear).
         self.clearNestedBindingCache();
         self.nested_binding_cache.deinit(self.allocator);
+        self.nonminify_nested_shadow_modules.deinit(self.allocator);
         // cross-chunk 전역 이름(#4101): owned value 해제 + inner/outer 맵 deinit.
         self.clearCrossChunkGlobalNames();
         self.cross_chunk_global_names.deinit(self.allocator);
@@ -908,13 +916,18 @@ pub const Linker = struct {
         // 리네임**시키면 할당기가 하나로 모인다. 래퍼는 자연스러운 이름을 유지하므로
         // size/warm-rebuild 안정성도 낫다(`computeRenames` 는 매 빌드 실행 → watch 도 커버).
         var wit = self.graph.modulesIterator();
-        while (wit.next()) |m| {
-            if (m.wrap_kind == .none) continue;
-            if (m.getInitName(null)) |n| try self.reserved_globals.put(self.allocator, n, {});
-            if (m.getExportsName(null)) |n| try self.reserved_globals.put(self.allocator, n, {});
-            if (m.getRequireName(null)) |n| try self.reserved_globals.put(self.allocator, n, {});
-            if (m.wrapper_name_synthetic) |n| try self.reserved_globals.put(self.allocator, n, {});
-        }
+        while (wit.next()) |m| try self.reserveWrapperNames(m);
+    }
+
+    /// 한 모듈의 래퍼 심볼 이름(`require_X`/`init_X`/`exports_X` + asset `wrapper_name_synthetic`)을
+    /// `reserved_globals` 에 예약한다 — 사용자 심볼이 그 이름과 겹치면 리네임되도록(#4530/#4533).
+    /// `collectReservedGlobals`(전 모듈)와 `computeRenamesForModules`(청크)가 공유하는 단일 소스.
+    fn reserveWrapperNames(self: *Linker, m: *const Module) !void {
+        if (m.wrap_kind == .none and m.wrapper_name_synthetic == null) return;
+        if (m.getInitName(null)) |n| try self.reserved_globals.put(self.allocator, n, {});
+        if (m.getExportsName(null)) |n| try self.reserved_globals.put(self.allocator, n, {});
+        if (m.getRequireName(null)) |n| try self.reserved_globals.put(self.allocator, n, {});
+        if (m.wrapper_name_synthetic) |n| try self.reserved_globals.put(self.allocator, n, {});
     }
 
     /// 이름 충돌 감지 + 리네임 계산 (Rolldown renamer 패턴).
@@ -922,6 +935,8 @@ pub const Linker = struct {
     pub fn computeRenames(self: *Linker) !void {
         var scope = profile.begin(.link_compute_renames);
         defer scope.end();
+
+        self.nonminify_nested_shadow_modules.clearRetainingCapacity();
 
         // 0. 모든 모듈의 미해결 참조를 수집 → reserved_globals
         try self.collectReservedGlobals();
@@ -952,6 +967,148 @@ pub const Linker = struct {
         // 충돌하면 target module의 canonical name을 한 단계 더 rename.
         // 예: d3-color의 cubehelix와 d3-interpolate 내부의 function cubehelix 충돌.
         try self.resolveNestedShadowConflicts(&name_to_owners);
+
+        // 4. 주입된 래퍼 참조(require_x())가 소비자의 스코프 바인딩에 가려지는 것 방지 (#4533).
+        try self.resolveWrapperConsumerShadows(&name_to_owners, null);
+    }
+
+    /// **번들 기준** 중첩 스코프의 시작 인덱스. CJS 로 래핑된 모듈은 파일 top-level(scope 0)
+    /// 자체가 `__commonJS` 클로저 **안**이라 번들 기준으로는 중첩이다 — 그 스코프의 바인딩도
+    /// 주입된 래퍼 참조를 가릴 수 있다. 나머지(ESM/none)는 scope 1 부터.
+    ///
+    /// ⚠️ 비-CJS 소비자의 **scope 0**(top-level) 은 `require_X`/`init_X`/`exports_X` 에 대해선
+    /// #4530 예약이 담당하지만, **런타임 헬퍼 이름**(`__toESM`/`__toCommonJS`)은 예약되지
+    /// 않으므로 여기서 안 본다 = 미커버 → **#4538** epic(헬퍼명 shadow). cold 공통 케이스는
+    /// 이 gap 에 안 걸린다(사용자가 지역 변수를 `__toESM` 로 이름 짓는 건 사실상 없음).
+    fn nestedScopeStart(m: *const Module) usize {
+        return if (m.wrap_kind == .cjs) 0 else 1;
+    }
+
+    /// 소비자의 스코프 바인딩이 **주입된 래퍼 참조**를 가리는 걸 막는다 (#4533).
+    ///
+    /// `require("./x")` 는 emit 시 그 자리에서 `require_x()` 로 재작성되고, `init_x()` 호출도
+    /// 소비자 본문에 끼워진다. 그 지점의 스코프 체인에 래퍼 이름과 **동명 바인딩**이 있으면
+    /// 그게 래퍼를 가린다:
+    ///
+    ///     function load(){
+    ///       function require_legacy(){ ... }        // 소비자의 바인딩
+    ///       return require("./legacy.cjs").foo();   // → require_legacy().foo() → 가려짐
+    ///     }
+    ///     → TypeError (빌드 green · 파싱 green · 실행만 실패)
+    ///
+    /// **가리는 사용자 바인딩을 리네임**한다(래퍼 이름은 절대 안 건드림). 래퍼 이름은 cross-chunk
+    /// 전역명·preserve-modules 공개 export·mangler 등 **여러 서브시스템이 공유**하는 값이라 그걸
+    /// 바꾸면 파급이 크지만, 소비자의 지역 바인딩은 그 모듈 안에서만 참조되므로 리네임이
+    /// **로컬**하다(rename_table 한 entry + codegen 이 참조 치환 — mangler 가 nested local 을
+    /// 개명하는 것과 같은 경로).
+    ///
+    /// 소비자 자기 `import_records` 로 "무엇을 import 하는가" 를 본다(reverse 인접 불필요).
+    /// asset/disabled 래퍼(`wrapper_name_synthetic`)도 같은 방식으로 커버된다 — 리네임 대상이
+    /// 래퍼가 아니라 **소비자의 바인딩**이라 래퍼에 심볼 테이블이 없어도 무관하다(#4536).
+    ///
+    /// `only` 가 주어지면 그 모듈들만 소비자로 본다(code-splitting per-chunk — 소비자 바인딩은
+    /// 그 소비자의 청크에서 rename_table 에 반영된다). `null` 이면 전 모듈.
+    fn resolveWrapperConsumerShadows(self: *Linker, name_to_owners: *const NameToOwnersMap, only: ?[]const ModuleIndex) !void {
+        // ⚠️ minify 는 skip — mangler 가 **모든** 바인딩을 유일 단문자명으로 개명하고 주입
+        // 참조는 래퍼의 mangled 이름을 쓰므로(`a().foo()`) 섀도가 원천 불가하다. 여기서 굳이
+        // 리네임하면 metadata 반영이 minify 에서 꺼져 있어(mergeUnifiedPhaseB 가 nested 담당)
+        // 헛일이 될 뿐이다.
+        if (self.manglerActive()) return;
+
+        const count = if (only) |o| o.len else self.graph.moduleCount();
+        var i: usize = 0;
+        while (i < count) : (i += 1) {
+            const ci: u32 = if (only) |o| o[i].toU32() else @intCast(i);
+            const c = self.getModule(ci) orelse continue;
+            const csem = c.semantic orelse continue;
+            const start = nestedScopeStart(c);
+            if (csem.scope_maps.len <= start) continue;
+
+            // direct `eval`/`with` 이 있는 소비자는 개명하지 않는다 — 그 안의 동적 조회가
+            // 바인딩을 **이름 문자열**로 참조할 수 있어 리네임이 `ReferenceError` 를 낸다.
+            // mangler 도 같은 이유로 `blocksMangling()` 모듈을 통째로 skip 한다(#1258). 이
+            // 경우 shadow 는 남지만(매우 드문 eval+shadow 조합) 오컴파일보다 낫다.
+            if (csem.scopes.len > 0 and csem.scopes[0].blocksMangling()) continue;
+
+            for (c.import_records) |rec| {
+                if (rec.is_external or rec.resolved.isNone()) continue;
+                const w = self.getModule(@intFromEnum(rec.resolved)) orelse continue;
+                if (w.wrap_kind == .none and w.wrapper_name_synthetic == null) continue;
+
+                // 래퍼가 이 소비자 자리에 주입하는 이름들(현재 확정 이름 — rename_table 반영).
+                // ⚠️ 이 목록은 `reserveWrapperNames`(4개 래퍼명)와 **동기화**해야 한다 — 슬롯을
+                // 한쪽에만 추가하면 미매칭(shadow) 또는 미예약(재선언)이 샌다.
+                // ESM-wrap 소비 interop 은 `(init_x(), <toCommonJS>(exports_x))` 를 끼우므로 런타임
+                // 헬퍼 이름도 가려질 수 있다. emit 은 `--minify-whitespace` 에서 축약명(`$tE`/`$tC`,
+                // NAMES.TOESM_MIN/TOCOMMONJS_MIN)을 쓰고 그 외엔 full 이름을 쓰므로 **둘 다** 넣는다.
+                const names = [_]?[]const u8{
+                    w.getRequireName(&self.rename_table),
+                    w.getInitName(&self.rename_table),
+                    w.getExportsName(&self.rename_table),
+                    w.wrapper_name_synthetic, // asset/disabled (#4536) — semantic 없어 rt 무관
+                    if (w.wrap_kind == .esm) "__toCommonJS" else null,
+                    if (w.wrap_kind == .esm) rt.NAMES.TOCOMMONJS_MIN else null,
+                    if (w.wrap_kind != .none) "__toESM" else null,
+                    if (w.wrap_kind != .none) rt.NAMES.TOESM_MIN else null,
+                };
+                for (names) |maybe_n| {
+                    const n = maybe_n orelse continue;
+                    // 소비자의 중첩 스코프(들)에서 n 을 찾아 리네임. 같은 이름이 여러 스코프에
+                    // 바인딩될 수 있으므로(함수마다 `function require_legacy(){}`) 전부 순회한다.
+                    for (csem.scope_maps[start..], start..) |scope_map, sidx| {
+                        const sym_idx = scope_map.get(n) orelse continue;
+                        const sid = bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(ci)), sym_idx);
+                        if (self.rename_table.get(sid) != null) continue; // 이미 리네임됨(중복 import)
+                        const cand = try self.pickConsumerShadowName(n, ci, c, name_to_owners);
+                        try self.assignSymbolCanonical(sid, cand);
+                        // scope 1+ 개명만 metadata nested 스캔이 필요하다(scope 0 은 module-scope 루프).
+                        if (sidx >= 1) try self.nonminify_nested_shadow_modules.put(self.allocator, ci, {});
+                    }
+                }
+            }
+        }
+    }
+
+    /// 소비자 바인딩 개명용 안전한 이름을 고른다. `findAvailableCandidate` 는 owner/reserved/
+    /// canonical/소비자 **중첩(scope 1+)** 바인딩을 피하지만, CJS 소비자의 **scope 0**(클로저
+    /// 안이라 owner 도 nested 스캔 대상도 아님)은 못 본다 → 그 이름과 겹치면 재선언/오컴파일
+    /// (#4533 리뷰). 여기서 scope 0 까지 추가로 검사해 정말 안전한 이름을 준다.
+    fn pickConsumerShadowName(self: *Linker, base: []const u8, module_index: u32, c: *const Module, name_to_owners: *const NameToOwnersMap) ![]const u8 {
+        const csem = c.semantic;
+        var suffix: u32 = 1;
+        while (true) {
+            const cand = try self.findAvailableCandidate(base, module_index, &suffix, name_to_owners);
+            // CJS 소비자의 scope 0(클로저 지역)과 충돌하는가? (findAvailableCandidate 미검사 영역)
+            const scope0_hit = blk: {
+                if (c.wrap_kind != .cjs) break :blk false;
+                const sem = csem orelse break :blk false;
+                if (sem.scope_maps.len == 0) break :blk false;
+                break :blk sem.scope_maps[0].get(cand) != null;
+            };
+            if (!scope0_hit) return cand;
+            self.allocator.free(cand);
+            suffix += 1; // 다음 후보로
+        }
+    }
+
+    /// (#4533) nested 심볼(scope 1+)의 `rename_table` 조회. `buildMetadataForAst` 의
+    /// module-scope self-rename 루프는 `scope_maps[0]` 만 보므로, `resolveWrapperConsumerShadows`
+    /// 가 nested 바인딩에 건 shadow-rename 은 여기로 조회해 metadata 에 반영한다(non-minify).
+    /// ⚠️ minify 빌드에선 mangler(Phase B, `mergeUnifiedPhaseB`)가 nested rename 을 담당하고
+    /// 애초에 scope-aware 라 shadow 를 자연히 피하므로, `manglerActive()` 로 게이트해서만 쓴다.
+    pub fn nestedRenameFor(self: *const Linker, module_index: u32, sym_idx: u32) ?[]const u8 {
+        return self.rename_table.get(bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(module_index)), sym_idx));
+    }
+
+    /// unified mangler(Phase B nested rename)가 이번 빌드에 도는가.
+    pub fn manglerActive(self: *const Linker) bool {
+        return self.graph.minify_identifiers;
+    }
+
+    /// 이 모듈이 nested(scope 1+) 소비자 shadow-rename 을 받았는가 (#4533). `buildMetadataForAst`
+    /// 가 nested-scope rename_table 스캔을 이 모듈에만 돌리도록 게이트한다(영향 모듈에 비례).
+    pub fn moduleHasNestedShadow(self: *const Linker, module_index: u32) bool {
+        return self.nonminify_nested_shadow_modules.contains(module_index);
     }
 
     /// computeRenames 전용: owner 모듈마다 nested scope(scope 0 제외) 바인딩 이름 union set 을
@@ -3362,6 +3519,25 @@ pub const Linker = struct {
                 try self.reserved_globals.put(self.allocator, entry.key_ptr.*, {});
             }
         }
+        // (#4533) global-identifier + 래퍼 이름을 예약한다. 두 갈래를 모두 예약해야 한다:
+        //   (a) **선언측** — 이 청크에 놓이는 wrapped 모듈의 래퍼(`var require_X = __commonJS`)와
+        //       동명인 **사용자 top-level 심볼**이 이 청크에 있으면 중복 선언 SyntaxError(#4530).
+        //   (b) **참조측** — 이 청크의 소비자가 import 하는 래퍼. `pickConsumerShadowName` 후보가
+        //       형제 래퍼(`require_x$1`) 이름과 겹치면 오컴파일(#4533).
+        //
+        // ⚠️ **전 모듈 래퍼를 예약하면 안 된다**: reserved_globals 는 calculateRenames 도 쓰므로,
+        // 이 청크와 무관한 래퍼 이름까지 예약하면 그 이름과 동명인 **다른 청크의 사용자 심볼**이
+        // 불필요하게 리네임돼 content-hash 파일명이 흔들린다. (a)+(b) 로 청크 범위에 한정한다.
+        for (self.global_identifiers) |name| try self.reserved_globals.put(self.allocator, name, {});
+        for (module_indices) |mod_idx| {
+            const cm = self.graph.getModule(mod_idx) orelse continue;
+            try self.reserveWrapperNames(cm); // (a) 선언측
+            for (cm.import_records) |rec| { // (b) 참조측
+                if (rec.is_external or rec.resolved.isNone()) continue;
+                const w = self.graph.getModule(rec.resolved) orelse continue;
+                try self.reserveWrapperNames(w);
+            }
+        }
 
         // 1. 지정된 모듈의 top-level 심볼 이름 수집
         var name_to_owners: NameToOwnersMap = .empty;
@@ -3393,6 +3569,11 @@ pub const Linker = struct {
 
         // 2. 충돌하는 이름에 대해 리네임 계산 (cross-chunk 점유 마커는 skip)
         try self.calculateRenames(&name_to_owners, true);
+
+        // 2.1 주입된 래퍼 참조가 소비자 스코프 바인딩에 가려지는 것 방지 (#4533). code-splitting 은
+        // 이 per-chunk 경로만 타므로 여기서도 불러야 한다(전역 computeRenames 는 안 탄다). 소비자
+        // 바인딩을 리네임하는 방식이라 그 소비자가 이 청크에 있어야 반영된다 → module_indices 대상.
+        try self.resolveWrapperConsumerShadows(&name_to_owners, module_indices);
 
         // 2.5 #4101 cross-chunk 전역 네이밍 override — 이 청크가 export 하는 cross-chunk 심볼을
         // 전역 이름으로 고정. calculateRenames 의 per-chunk deconflict 순서(exec_index)가 전역

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -1294,6 +1294,24 @@ pub fn buildMetadataForAst(
             }
         }
 
+        // (#4533) nested(scope 1+) 바인딩의 shadow-rename 반영. `resolveWrapperConsumerShadows`
+        // 가 소비자의 가리는 바인딩을 `rename_table` 로 개명했는데, 위 self-rename 루프는
+        // scope_maps[0] 만 본다. minify 빌드에선 mangler(아래 mergeUnifiedPhaseB)가 nested 를
+        // 담당하고 scope-aware 라 shadow 를 자연히 피하므로 non-minify 에서만 스캔한다.
+        if (!self.manglerActive() and self.moduleHasNestedShadow(module_index)) {
+            var s: usize = 1;
+            while (s < sem.scope_maps.len) : (s += 1) {
+                var nit = sem.scope_maps[s].iterator();
+                while (nit.next()) |e| {
+                    const sym_idx: u32 = @intCast(e.value_ptr.*);
+                    if (renames.contains(sym_idx)) continue;
+                    if (self.nestedRenameFor(module_index, sym_idx)) |renamed| {
+                        try putOwnedRename(self, &renames, &owned_nested_renames, sym_idx, renamed);
+                    }
+                }
+            }
+        }
+
         // nested rename 을 `Linker.unified_result` 에서 조회. Phase A (module
         // scope) 은 위 self-rename 루프에서 canonical_name 경유로 이미 처리됨.
         // metadata 가 dupe 하여 소유 — unified_result 가 deinit 되어도 안전.

--- a/tests/integration/tests/wrapper-name-deconflict.test.ts
+++ b/tests/integration/tests/wrapper-name-deconflict.test.ts
@@ -187,3 +187,309 @@ describe('#4530: 래퍼 심볼 ↔ 사용자 top-level 심볼 deconflict', () =>
     }
   });
 });
+
+/**
+ * #4533 회귀 가드 — 주입된 래퍼 참조가 **소비자의 스코프 바인딩**에 가려지던 결함.
+ *
+ * `require("./x")` 는 emit 시 그 자리에서 `require_x()` 로 재작성된다. 그 지점의 스코프 체인에
+ * 래퍼 이름과 동명 바인딩이 있으면 그게 래퍼를 가린다:
+ *
+ *   function load(){
+ *     function require_legacy(){ ... }        // 소비자의 바인딩
+ *     return require("./legacy.cjs").foo();   // → require_legacy().foo() → 가려짐
+ *   }
+ *   → TypeError  (빌드 exit 0 · 파싱 통과 · **실행만** 실패)
+ *
+ * 처방(esbuild/rolldown 방식): **가리는 사용자 바인딩을 리네임**한다(래퍼 이름은 안 건드림 —
+ * 래퍼는 cross-chunk 전역명·preserve-modules export·mangler 등 여러 서브시스템의 공유 키라
+ * 건드리면 파급이 크다). 소비자 바인딩은 그 모듈 안에서만 참조되므로 리네임이 로컬하다.
+ */
+describe('#4533: 주입된 래퍼 참조 ↔ 소비자 스코프 바인딩', () => {
+  const CJS_LEGACY = 'exports.foo = function(){ return "FOO"; };';
+
+  test('(1) 중첩 스코프 바인딩', async () => {
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': CJS_LEGACY,
+      'entry.cjs':
+        'function load(){\n' +
+        '  function require_legacy(){ return "SHADOW"; }\n' +
+        '  return require("./legacy.cjs").foo() + require_legacy();\n' +
+        '}\n' +
+        'console.log(load());',
+    });
+    try {
+      const out = join(dir, 'b.mjs');
+      const res = await runZntc(['--bundle', join(dir, 'entry.cjs'), '-o', out, '--format=esm']);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(out);
+      expect(stderr).not.toContain('TypeError');
+      expect(stdout.trim()).toBe('FOOSHADOW');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('(2) 동적 import() 소비자', async () => {
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': CJS_LEGACY,
+      'entry.mjs':
+        'async function load(){\n' +
+        '  function require_legacy(){ return "SHADOW"; }\n' +
+        '  const m = await import("./legacy.cjs");\n' +
+        '  return m.default.foo() + require_legacy();\n' +
+        '}\n' +
+        'load().then(r => console.log(r));',
+    });
+    try {
+      const out = join(dir, 'b.mjs');
+      const res = await runZntc(['--bundle', join(dir, 'entry.mjs'), '-o', out, '--format=esm']);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(out);
+      expect(stderr).not.toContain('TypeError');
+      expect(stdout.trim()).toBe('FOOSHADOW');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('(3) --minify (이 경로는 mangler 가 담당 — resolveWrapperConsumerShadows 는 minify 에서 skip)', async () => {
+    // ⚠️ 이 케이스는 **resolveWrapperConsumerShadows 를 되돌려도 통과한다** — minify 는 mangler 가
+    // 모든 바인딩을 유일 단문자명으로 개명하고 주입 참조는 래퍼의 mangled 이름(`a()`)을 쓰므로
+    // 섀도가 원천 불가하기 때문이다. 이 가드의 목적은 "minify 를 mangler 에 위임하는 결정이 안전"
+    // 함을 지키는 것이지, 이 PR 의 non-minify 코드가 minify 를 고친다는 주장이 아니다.
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': CJS_LEGACY,
+      'entry.cjs':
+        'function load(){\n' +
+        '  function require_legacy(){ return "SHADOW"; }\n' +
+        '  return require("./legacy.cjs").foo() + require_legacy();\n' +
+        '}\n' +
+        'console.log(load());',
+    });
+    try {
+      const out = join(dir, 'b.mjs');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.cjs'),
+        '-o',
+        out,
+        '--format=esm',
+        '--minify',
+      ]);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(out);
+      expect(stderr).not.toContain('TypeError');
+      expect(stdout.trim()).toBe('FOOSHADOW');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('(4) preserve-modules — 래퍼 이름 불변이라 provider export 정합', async () => {
+    // 이전 "래퍼 리네임" 방식은 여기서 provider 가 require_x$1 선언 + require_x export →
+    // SyntaxError 였다. 소비자 바인딩만 리네임하므로 래퍼 export 는 그대로다.
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': CJS_LEGACY,
+      'consumer.js':
+        'import d from "./legacy.cjs";\n' +
+        'export function run(){\n' +
+        '  function require_legacy(){ return "SHADOW"; }\n' +
+        '  return d.foo() + require_legacy();\n' +
+        '}',
+      'entry.js': 'import { run } from "./consumer.js";\nconsole.log(run());',
+    });
+    try {
+      const outDir = join(dir, 'dist');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--preserve-modules',
+        '--outdir',
+        outDir,
+        '--format=esm',
+      ]);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+      const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+      expect(stderr).not.toContain('SyntaxError');
+      expect(stderr).not.toContain('TypeError');
+      expect(stdout.trim()).toBe('FOOSHADOW');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('(5) code-splitting — 래퍼 이름 불변이라 cross-chunk 정합', async () => {
+    // 이전 방식은 per-chunk rename_table clear + cross_chunk_global_names 로 desync 됐다.
+    // helper.cjs 는 실행되는 non-entry(entry 가 import) 라 런타임까지 검증된다.
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': CJS_LEGACY,
+      'other.js': 'export const val = "OTHER";',
+      'helper.cjs':
+        'function build(){\n' +
+        '  function require_legacy(){ return "SHADOW"; }\n' +
+        '  return require("./legacy.cjs").foo() + require_legacy();\n' +
+        '}\n' +
+        'module.exports = build();',
+      'entry.js':
+        'import r from "./helper.cjs";\nimport("./other.js").then(m => console.log(r + m.val));',
+    });
+    try {
+      const outdir = join(dir, 'out');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--outdir',
+        outdir,
+        '--splitting',
+        '--format=esm',
+      ]);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(join(outdir, 'entry.js'));
+      expect(stderr).not.toContain('TypeError');
+      expect(stdout.trim()).toBe('FOOSHADOWOTHER');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('(10) code-splitting — 래퍼 선언과 동명인 co-chunk 사용자 top-level (중복선언 방지)', async () => {
+    // 래퍼 var require_legacy = __commonJS 가 이 청크에 선언되는데 동명 사용자 함수가 같은
+    // 청크에 있고 legacy 는 다른 청크에서만 import → per-chunk reserved 가 **선언측** 래퍼를
+    // 예약 안 하면 둘 다 require_legacy 로 선언 → SyntaxError. 선언측 예약으로 회피.
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': 'exports.foo = function(){ return "FOO"; };',
+      'user.js': 'export function require_legacy(){ return "USER"; }',
+      'shared.js':
+        'import { require_legacy } from "./user.js";\n' +
+        'import d from "./legacy.cjs";\n' +
+        'export const combined = require_legacy() + d.foo();',
+      'entry.js': 'import("./shared.js").then(m => console.log(m.combined));',
+    });
+    try {
+      const outdir = join(dir, 'out');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--outdir',
+        outdir,
+        '--splitting',
+        '--format=esm',
+      ]);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(join(outdir, 'entry.js'));
+      expect(stderr).not.toContain('SyntaxError');
+      expect(stdout.trim()).toBe('USERFOO');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('(6) 섀도잉 없으면 사용자 바인딩 이름 그대로 (과잉 리네임 없음)', async () => {
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': CJS_LEGACY,
+      'entry.cjs': 'function load(){ return require("./legacy.cjs").foo(); }\nconsole.log(load());',
+    });
+    try {
+      const out = join(dir, 'b.mjs');
+      const res = await runZntc(['--bundle', join(dir, 'entry.cjs'), '-o', out, '--format=esm']);
+      expect(res.exitCode).toBe(0);
+      const text = readFileSync(out, 'utf-8');
+      expect(text).not.toContain('require_legacy$'); // 충돌 없음 → suffix 없음
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('(7) 개명 후보가 소비자의 다른 top-level 바인딩과도 안 겹친다', async () => {
+    // 후보 이름 선택(findAvailableCandidate)은 CJS 소비자의 scope-0(클로저 지역) 바인딩을
+    // 못 본다 → `require_legacy$1` 이 이미 있으면 거기에 개명해 재선언/오컴파일이었다.
+    // pickConsumerShadowName 이 scope-0 까지 확인해 `require_legacy$2` 로 회피한다.
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': CJS_LEGACY,
+      'entry.cjs':
+        'var require_legacy$1 = "EXISTING";\n' +
+        'function load(){\n' +
+        '  function require_legacy(){ return "SHADOW"; }\n' +
+        '  return require("./legacy.cjs").foo() + require_legacy() + require_legacy$1;\n' +
+        '}\n' +
+        'console.log(load());',
+    });
+    try {
+      const out = join(dir, 'b.mjs');
+      const res = await runZntc(['--bundle', join(dir, 'entry.cjs'), '-o', out, '--format=esm']);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(out);
+      expect(stderr).not.toContain('TypeError');
+      expect(stdout.trim()).toBe('FOOSHADOWEXISTING');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('(9) code-splitting — 형제 래퍼($N) 이름과도 안 겹친다', async () => {
+    // 두 basename `legacy` CJS → require_legacy, require_legacy$1. 소비자 섀도를 개명할 때
+    // per-chunk reserved_globals 가 래퍼 이름을 안 예약하면 require_legacy$1(2번째 래퍼)로
+    // 개명해 충돌 → require_legacy$2 로 회피해야 한다.
+    const { dir, cleanup } = await createFixture({
+      'a/legacy.cjs': 'exports.foo = function(){ return "A"; };',
+      'b/legacy.cjs': 'exports.foo = function(){ return "B"; };',
+      'consumer.cjs':
+        'function require_legacy(){ return "SHADOW"; }\n' +
+        'module.exports = require("./a/legacy.cjs").foo() + require("./b/legacy.cjs").foo() + require_legacy();',
+      'other.js': 'export const v = "V";',
+      'entry.js':
+        'import r from "./consumer.cjs";\nimport("./other.js").then(m => console.log(r + m.v));',
+    });
+    try {
+      const outdir = join(dir, 'out');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--outdir',
+        outdir,
+        '--splitting',
+        '--format=esm',
+      ]);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(join(outdir, 'entry.js'));
+      expect(stderr).not.toContain('TypeError');
+      expect(stdout.trim()).toBe('ABSHADOWV');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('(8) code-splitting — 섀도 모듈이 동적 청크(entry 와 다른 청크)에 있어도', async () => {
+    // test (5) 는 shadow 모듈이 entry 청크에 co-locate 됐다. 이건 shadow 를 **동적 import 되는
+    // 별도 청크**(chunk.cjs)에 둬 per-chunk rename(computeRenamesForModules)이 그 청크에서 도는
+    // 경로를 실제로 태운다. 소비자 바인딩은 소비자(그 청크)에서 개명되므로 청크가 갈려도 정합.
+    const { dir, cleanup } = await createFixture({
+      'legacy.cjs': CJS_LEGACY,
+      'chunk.cjs':
+        'function build(){\n' +
+        '  function require_legacy(){ return "SHADOW"; }\n' +
+        '  return require("./legacy.cjs").foo() + require_legacy();\n' +
+        '}\n' +
+        'module.exports = build();',
+      'entry.js': 'import("./chunk.cjs").then(m => console.log(m.default));',
+    });
+    try {
+      const outdir = join(dir, 'out');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--outdir',
+        outdir,
+        '--splitting',
+        '--format=esm',
+      ]);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      const { stdout, stderr } = await runNode(join(outdir, 'entry.js'));
+      expect(stderr).not.toContain('TypeError');
+      expect(stdout.trim()).toBe('FOOSHADOW');
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## 무엇을

주입된 래퍼 참조(`require_x()`)가 **소비자의 스코프 바인딩**에 가려져 무성 TypeError 가 나던 것 수정 (#4533).

```js
function load(){
  function require_legacy(){ return "SHADOW"; }   // 소비자의 바인딩
  return require("./legacy.cjs").foo();            // → require_legacy().foo() → 가려짐
}
// → TypeError: require_legacy(...).foo is not a function  (빌드 exit 0 · 파싱 통과 · 실행만 실패)
```

`require("./legacy.cjs")` 는 emit 시 그 자리에서 `require_legacy()` 로 재작성되는데, 그 지점 스코프 체인에 동명 바인딩이 있으면 그게 래퍼를 가린다.

## 처방 — rolldown/esbuild 방식 (**가리는 사용자 바인딩을 리네임**)

래퍼 이름은 절대 안 건드린다. 래퍼 이름은 **cross-chunk 전역명·preserve-modules 공개 export·mangler 등 여러 서브시스템이 공유**하는 값이라 그걸 바꾸면 파급이 크다(래퍼를 리네임하는 접근을 먼저 시도했으나 cross-chunk desync / preserve-modules export 불일치 / mangler 무효화를 연쇄로 내서 폐기). 소비자의 지역 바인딩은 그 모듈 안에서만 참조되므로 리네임이 **로컬**하다. rolldown 도 동일하다(`NestedScopeRenamer` — entry 심볼은 이름 유지, shadowing 은 nested 바인딩 리네임으로 처리).

주요 변경:
- **`Linker.resolveWrapperConsumerShadows`** — 소비자 `import_records` 로 참조 래퍼 이름(require/init/exports + asset `wrapper_name_synthetic` + interop 헬퍼 `__toESM`/`__toCommonJS` 및 `--minify-whitespace` 축약명 `$tE`/`$tC`)을 모아, 소비자 스코프(CJS 소비자는 `__commonJS` 클로저 안이라 scope 0 포함)의 동명 바인딩을 `rename_table` 로 개명. **단일 번들 + code-splitting** 양 경로. **minify 는 skip**(mangler 가 모든 바인딩을 유일명으로 개명해 섀도 원천 차단). **direct `eval`/`with` 스코프는 skip**(`blocksMangling` — 이름-문자열 동적 조회 보호, mangler 와 같은 관례).
- **`pickConsumerShadowName`** — 개명 후보가 CJS 소비자 scope-0(클로저 지역) 바인딩과도 안 겹치게.
- **per-chunk `reserveWrapperNames`** — 선언측(이 청크의 wrapped 모듈) + 참조측(import) 래퍼를 **청크 범위**로 예약(전 모듈 예약은 무관 심볼을 리네임해 content-hash 흔듦; 선언측 누락은 splitting 중복선언 SyntaxError).
- **`buildMetadataForAst`** — nested(scope 1+) rename 반영(non-minify), 개명 모듈 집합으로 게이트.
- **`captureRenamesToPending`** — nested rename 을 `declaration_span` 매칭 + module-scope 판정으로 incremental resync 에서 보존.

## 곁다리로 닫힘
- **#4530**(래퍼 vs 사용자 top-level) — main 의 `reserved_globals` 예약이 담당하며, 이 PR 이 splitting **선언측** 갭도 메움.
- **#4536**(asset/disabled 래퍼) — 리네임 대상이 래퍼가 아니라 **소비자 바인딩**이라 래퍼에 심볼 테이블이 없어도 커버.

## 범위 밖 (→ #4538 epic)
근본 원인은 **zntc 의 non-minify 리네이머가 scope-0 중심**(중첩 rename 은 mangler 전용)이라는 것. 이 PR 은 cold 공통 케이스를 닫고, 아래 **드문 edge** 는 #4538 로 분리:
- 런타임 헬퍼명을 **top-level/ESM scope-0** 에서 shadow (사용자가 지역변수를 `__toESM` 로 이름 짓는, 사실상 없는 케이스).
- `require.context` 로 도달하는 래퍼.
- HMR rename-reuse warm 재빌드: nested rename 이 있으면 스냅샷을 폐기하고 **full 재계산**(정확성 유지, warm perf 만).

## 검증
- `zig build test` **6225/6225**, integration **4246 pass / 0 fail**, effect/zod/three `--minify` **byte-identical**(size 0).
- 회귀 가드 **17종**(#4530 기존 + #4533 (1)~(10)) — 각 fix 를 되돌리면 해당 가드만 실패(비-공허 확인).
- `/code-review max` **8라운드**(2개 접근) 반영해 수렴.

Closes #4533
Closes #4536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
