### PR TITLE
fix(bundler): #4537 --splitting 에서 CJS-wrapped entry 미실행

### DIFF
--- a/.changeset/split-cjs-entry-invoke.md
+++ b/.changeset/split-cjs-entry-invoke.md
@@ -1,0 +1,40 @@
+---
+"@zntc/core": patch
+---
+
+`--splitting` 에서 CJS/ESM-wrapped **user entry** 모듈이 호출되지 않아 본문이 실행되지 않던 버그 수정 (#4537).
+
+## 증상
+entry 가 `require()` 를 써서 `__commonJS` 로 래핑되면(`var require_entry = __commonJS({...})`), `--splitting` 빌드에서 **아무도 `require_entry()` 를 부르지 않아** entry 본문이 통째로 미실행이었다. 빌드 exit 0 · 파싱 통과 · **실행만** 무동작(`node out/entry.js` 가 아무것도 출력 안 함).
+
+## 루트커즈
+wrapped entry 호출 emit 이 세 경로의 게이트에 전부 걸려 표준 splitting 에서 어디서도 안 나왔다:
+- `dev_split_chunk` — `reg_split`(iife/umd/amd) 한정 + entry 자신은 skip
+- `preserveModulesWrapperChunk` — `preserve_modules` 한정
+- `reg_split` bootstrap(`__zntc_require`) — iife/umd/amd 한정
+
+단일번들은 맨 끝에서 `require_X()`/`init_X()` 로 entry 를 실행하고(`emitter.zig`), preserve-modules·reg_split 도 각자 호출하는데, **표준 `--splitting`(esm/cjs, 비-preserve-modules)만** 그 호출을 빠뜨렸다.
+
+## 수정
+`chunks.zig` 청크 조립부에 단일번들과 대칭인 호출을 추가 — `!reg_split and !preserve_modules and chunk_is_user_entry` 이고 entry 모듈이 wrapped 이면 body 끝에서 `appendModuleCall` 로 호출. reg_split·preserve-modules 는 각자 담당하므로 게이트로 제외(이중호출 방지, `__commonJS`/`__esm` memoize 라 설령 중복돼도 본문은 1회). CJS-format 청크의 TLA(.esm+top-level await) entry 만 제외(top-level await 불가).
+
+esbuild/rolldown 은 entry 를 아예 wrap 하지 않고 scope-hoist 인라인 실행하지만, zntc 는 "entry wrap + 호출" 모델(단일번들·preserve-modules·reg_split 전부)이라 그 모델과 일관되게 splitting 도 호출하도록 맞춘 것 — wrap_kind 분류를 바꾸는 광범위 변경(#4522-4538 campaign 전체)을 피한 저위험 root-cause 수정.
+
+검증: zig 6227/6227 · split-cjs-cross-chunk 19 pass(esm/cjs 가드 2종 추가, 빈 dist 실행 non-vacuous) · 인접 splitting/wrap 145 pass · effect/zod/three --minify byte-identical.
+
+## code-review 반영
+- **[3] --minify 변형 추가**: 회귀 가드에 esm/cjs × plain/minify 4종. 호출은 `appendModuleCall` 이 rename_table 로 이름을 풀어 선언측과 일치(minify 래퍼명 `require_entry`→`$c` 축약도 실측 정상). 파일 규약(minify-only 회귀 방지).
+- **[4] TLA 가드 통합**: `wrap_kind==.esm and uses_top_level_await` 술어가 세 entry-invoke 지점(dev_split·reg_split·표준 splitting)에 복붙돼 있던 것을 `isTlaEsmModule` helper 로 단일화(각 지점의 컨텍스트별 await-합법성 게이트는 유지).
+- **[0] known limitation (범위 밖·무회귀)**: wrapped-CJS entry 를 외부에서 `require()` 로 소비하면 exports 가 청크 module.exports 에 노출되지 않는다(호출 반환값 discard). **단일번들 `--format=cjs` 도 동일**(실측 `result=undefined`) — zntc "wrap entry+호출" 모델의 선재 한계이지 이 수정의 회귀가 아니다. `module.exports=require_X()` 확장은 pm 블록이 경고한 손상 위험이 있어 별도 이슈 #4542.
+- **[2] known limitation (범위 밖·무회귀)**: CJS-format + ESM-wrap + top-level await entry 는 top-level await 불가로 침묵 미실행(additive 라 pre-fix 대비 무회귀). esbuild식 async-IIFE 래핑은 별도 기능.
+
+## code-review 반영 (2차)
+- **[3] non-vacuity 가드 강화**: `toMatch(/__commonJS|\$c/)` 는 helper 정의·형제 `require_legacy` 래퍼와도 매칭돼 scope-hoist entry 를 진공 통과시켰다. plain 변형에서 entry **자기** 래퍼 `var require_entry =` **선언 + `require_entry();` 호출**을 직접 확인(회귀 시 실패)으로 교체.
+- **[4] multi-chunk 가드**: `.js` 파일 >1 assert 추가(청킹 붕괴 시 진공 방지).
+- **[1] 별도 선재 버그 발견(범위 밖)**: entry(또는 임의 청크)가 raw `require("./x.cjs")` 하고 그 CJS 가 common chunk 에 안착하면, 소비자 청크가 common chunk 를 side-effect import 만 하고 `require_X` 를 **import 도 export 도 안 해** `ReferenceError: require_X is not defined`. **entry 를 미-wrap 시켜 이 수정을 끈 상태에서도 동적 import 된 비-entry 청크가 동일 크래시** → 내 수정과 독립인 #4494/#4522 계열 raw-require 변종. 별도 이슈 #4541.
+- **[2] manualChunks 로 relocate 된 entry(범위 밖)**: entry 모듈을 manual 청크로 옮기면 `chunk_is_user_entry`=false 라 미호출(선재 #4537 하위케이스, 회귀 아님). 리뷰의 "선언/호출 분리 → ReferenceError"는 재현 안 됨(entry 청크 자체가 없어짐). 별도 이슈.
+
+## code-review 반영 (3차, 최종)
+- **entry_error_guard parity**: 표준 splitting entry 호출을 `appendModuleCall`→`appendGuardedModuleCall` 로 교체 — 단일번들과 동일하게 `entry_error_guard`(RN/Metro) 활성 시 `__zntc_guarded(require_X)` 로 wrap. guard 비활성(기본)엔 `shouldGuard`=false 라 `appendModuleCall` 로 fallback → **출력 byte-identical**(repro 확인). reg_split/dev_split 은 factory/bootstrap 자체 error 처리라 그대로.
+- **테스트 주석 정정**: minify rename 회귀는 `runNode` 가 non-zero exit 시 throw 하므로 "빈 stdout"이 아니라 thrown error 로 드러남.
+검증: zig 6227/6227 · split/iife/umd/pm/dev/RN(es5-rn) 인접 127 pass · guard-off byte-identical.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -103,6 +103,14 @@ fn resolveOwnerLocal(l: *Linker, graph: *const ModuleGraph, mod_idx: ModuleIndex
     return null;
 }
 
+/// 모듈이 ESM-wrap + top-level await 인가. 그 `init_X()` 호출은 `await` 를 요구하므로 비-async
+/// 컨텍스트에선 낼 수 없다: reg_split factory·dev_split factory 는 함수라 top-level await 불가,
+/// CJS-format 청크도 top-level await 불가. 세 entry-invoke 지점이 공유해 드리프트를 막는다
+/// (각 지점의 컨텍스트별 await-합법성 게이트는 호출부에 남는다 — ESM-format 청크만 허용).
+fn isTlaEsmModule(m: anytype) bool {
+    return m.wrap_kind == .esm and m.uses_top_level_await;
+}
+
 /// (#4120) owner 모듈이 CJS-wrapped 면 cross-chunk export `name` 은 런타임 interop 멤버라 진짜
 /// 로컬 바인딩이 없다. provider 청크에 `var <global> = <interop>;` 을 materialize 해 cross-chunk
 /// 소비자가 일반 식별자로 import 하게 한다(metadata 의 per-importer preamble 은 #4120 가드로 억제).
@@ -1137,7 +1145,7 @@ pub fn emitChunks(
                     }
                 }
                 const m = graph.getModule(mod_idx) orelse continue;
-                const tla = m.wrap_kind == .esm and m.uses_top_level_await;
+                const tla = isTlaEsmModule(m);
                 if (m.wrap_kind.isWrapped() and !tla) {
                     try parent.appendModuleCall(&chunk_output, allocator, m, if (linker) |l| &l.rename_table else null);
                 }
@@ -1544,7 +1552,7 @@ pub fn emitChunks(
                     // 를 내는데, reg_split 청크 factory 는 비-async `function(...)` 이라 top-level
                     // await = SyntaxError. TLA+reg_split entry 는 이 PR 이전에도 미실행이었으므로
                     // 여기서 제외(회귀 없음 — 무효 JS 생성 방지). 비-TLA wrapped entry 만 호출.
-                    const tla_entry = em.wrap_kind == .esm and em.uses_top_level_await;
+                    const tla_entry = isTlaEsmModule(em);
                     if (em.wrap_kind.isWrapped() and !tla_entry) {
                         try parent.appendModuleCall(&chunk_output, allocator, em, if (linker) |l| &l.rename_table else null);
                     }
@@ -1592,6 +1600,33 @@ pub fn emitChunks(
                 }
                 try chunk_output.appendSlice(allocator, reg_ids[ci]);
                 try chunk_output.appendSlice(allocator, if (min) "\");" else "\");\n");
+            }
+        }
+
+        // (#4537) 표준 splitting(비-reg_split·비-preserve-modules)의 wrapped **user entry**
+        // 는 본문을 실행할 호출이 없다. 단일번들은 맨 끝에서 require_X()/init_X() 로 entry 를
+        // 실행하는데(emitter.zig:1093, appendGuardedModuleCall), splitting 은 그 호출이 세
+        // 경로의 게이트에 전부 걸려 어디서도 안 나온다: dev_split_chunk(reg_split 한정, 게다가
+        // entry 자신은 skip)·preserveModulesWrapperChunk(preserve-modules 한정)·reg_split(1559,
+        // iife/umd/amd 의 bootstrap). 그래서 `var require_X=__commonJS(...)` 선언만 남고 호출이
+        // 없어 entry 본문이 통째로 미실행이었다(#4537). 단일번들과 대칭으로 여기서 호출한다.
+        // reg_split=1559, preserve-modules=pm_entry_call 이 각자 담당하므로 제외(이중호출 방지).
+        // (__commonJS/__esm memoize 라 설령 중복돼도 본문은 1회지만, 이중 호출문 자체를 막는다.)
+        if (!reg_split and !options.preserve_modules and chunk_is_user_entry) {
+            if (entry_mod_idx) |ei| {
+                if (graph.getModule(@enumFromInt(ei))) |em| {
+                    // CJS-format 청크의 TLA(.esm+top-level await) entry 는 top-level await 가
+                    // 불가하므로 제외(reg_split 1547 과 동일 근거). ESM-format 청크는 top-level
+                    // await 가 합법이라 appendModuleCall 이 `await init_X()` 로 처리한다.
+                    const tla_cjs = options.format == .cjs and isTlaEsmModule(em);
+                    if (em.is_entry_point and em.wrap_kind.isWrapped() and !tla_cjs) {
+                        // 단일번들과 동일하게 `appendGuardedModuleCall` — entry_error_guard(RN/Metro)
+                        // 활성 시 `__zntc_guarded(require_X)` 로 wrap, 아니면 appendModuleCall 과 동등.
+                        // (표준 splitting entry 는 top-level 호출이라 단일번들이 가장 가까운 대응;
+                        // reg_split/dev_split 은 factory/bootstrap 자체 error 처리라 별개.)
+                        try parent.appendGuardedModuleCall(&chunk_output, allocator, em, options, if (linker) |l| &l.rename_table else null);
+                    }
+                }
             }
         }
 

--- a/tests/integration/tests/split-cjs-cross-chunk.test.ts
+++ b/tests/integration/tests/split-cjs-cross-chunk.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
 import { join } from 'node:path';
-import { writeFileSync } from 'node:fs';
+import { writeFileSync, readFileSync, readdirSync } from 'node:fs';
 import { createFixture, runNode, runZntc, writeOutputs } from './helpers';
 import { init, close, build } from '../../../packages/core/index';
 
@@ -381,4 +381,66 @@ describe('code-splitting 런타임 스모크', () => {
       await cleanup();
     }
   });
+
+  // (#4537) **CJS-wrapped entry** + `--splitting`. entry 가 `require()` 를 써서 `__commonJS`
+  // 로 래핑되면 `var require_entry = __commonJS(...)` **선언만** 나오고 아무도 `require_entry()`
+  // 를 안 불러 entry 본문이 통째로 미실행이었다(splitting 만; 단일번들은 끝에서 호출). 빌드
+  // exit 0 · 파싱 통과 · 실행만 무동작(stdout 빈 문자열)이라 node 로 돌려야만 잡힌다.
+  //
+  // ⚠️ minify 변형 필수(이 파일 규약, l.17): 호출은 `appendModuleCall` 이 rename_table 로
+  // 이름을 푸는데, minify 는 래퍼명(`require_entry`→`o`)을 한 번 더 바꾼다. 선언과 호출이
+  // 다른 이름으로 풀리면 `ReferenceError: <name> is not defined` — minify 에서만 터진다.
+  for (const format of ['esm', 'cjs'] as const) {
+    for (const { name, minify } of MATRIX) {
+      test(`#4537 ${format}/${name}: --splitting 에서 CJS-wrapped entry 본문이 실행된다`, async () => {
+        const { dir, cleanup } = await createFixture({
+          'legacy.cjs': 'exports.foo = function(){ return "FOO"; };',
+          'other.js': 'export const val = "OTHER";',
+          'entry.js':
+            'function load(){ return require("./legacy.cjs").foo(); }\n' +
+            'import("./other.js").then((m) => console.log(load() + m.val));',
+        });
+        try {
+          const outDir = join(dir, 'dist');
+          const args = [
+            '--bundle',
+            join(dir, 'entry.js'),
+            '--splitting',
+            '--outdir',
+            outDir,
+            `--format=${format}`,
+          ];
+          if (minify) args.push('--minify');
+          const res = await runZntc(args);
+          expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+          if (format === 'esm')
+            writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+
+          // 실제로 청크가 쪼개졌는지(cross-chunk 경계 존재) — 청킹 휴리스틱이 바뀌어 단일
+          // 청크로 합쳐지면 splitting entry 경로를 안 밟아 이 가드가 진공이 된다.
+          const jsFiles = readdirSync(outDir).filter((f) => f.endsWith('.js'));
+          expect(jsFiles.length).toBeGreaterThan(1);
+
+          // non-vacuity: entry 가 **자기 자신의** `__commonJS` 래퍼(`require_entry`)로 래핑되고
+          // **그 래퍼가 호출**되는지 — plain 에서 구조로 직접 확인한다(minify 는 이름을 mangle
+          // 하므로 `$c`/`__commonJS` 만 보면 helper 정의·`require_legacy` 형제 래퍼와도 매칭돼
+          // scope-hoist entry 를 진공 통과시킨다). #4537 회귀 시(선언만·호출없음, 또는 scope-hoist
+          // 로 래퍼 소멸) plain 변형이 이 두 assert 로 잡는다. minify 변형은 stdout 으로 rename
+          // 일치까지 검증(불일치면 ReferenceError → 빈 stdout).
+          const entryCode = readFileSync(join(outDir, 'entry.js'), 'utf8');
+          if (!minify) {
+            expect(entryCode).toContain('var require_entry =');
+            expect(entryCode).toContain('require_entry();');
+          }
+
+          const { stdout } = await runNode(join(outDir, 'entry.js'));
+          // 버그 시: 빈 문자열(본문 미실행 — exit 0). minify rename 불일치 회귀 시: node 가
+          // `ReferenceError` 로 non-zero exit → `runNode` 가 throw(빈 stdout 아님).
+          expect(stdout.trim()).toBe('FOOOTHER');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
 });


### PR DESCRIPTION
## 증상

`require()` 를 써서 `__commonJS` 로 래핑된 **user entry** 가 `--splitting` 빌드에서 **호출되지 않아** 본문이 실행되지 않았다. 방출된 `entry.js` 는 `var require_entry = __commonJS({...})` **선언만** 있고 `require_entry();` 호출이 없어, `node out/entry.js` 가 아무것도 출력하지 않는다(정본 `FOOOTHER`). 빌드 exit 0 · 파싱 통과 · **실행만** 무동작.

```js
// entry.js  (require → CJS 래핑됨)
function load(){ return require("./legacy.cjs").foo(); }
import("./other.js").then(m => console.log(load() + m.val));   // 동적 import → splitting
```

## 루트커즈

wrapped entry 호출 emit 이 세 경로의 게이트에 전부 걸려 표준 splitting 에서 어디서도 안 나왔다:
- `dev_split_chunk` — `reg_split`(iife/umd/amd) 한정 + entry 자신은 skip
- `preserveModulesWrapperChunk` — `preserve_modules` 한정
- `reg_split` bootstrap(`__zntc_require`) — iife/umd/amd 한정

단일번들은 맨 끝에서 `require_X()`/`init_X()` 로 entry 를 실행하고(emitter.zig), preserve-modules·reg_split 도 각자 호출하는데 **표준 `--splitting`(esm/cjs, 비-preserve-modules)만** 그 호출을 빠뜨렸다.

## 수정

`chunks.zig` 청크 body 끝(단일번들과 대칭 위치)에 호출 추가:
```zig
if (!reg_split and !options.preserve_modules and chunk_is_user_entry) {
    if (entry_mod_idx) |ei| if (graph.getModule(...)) |em| {
        const tla_cjs = options.format == .cjs and isTlaEsmModule(em);
        if (em.is_entry_point and em.wrap_kind.isWrapped() and !tla_cjs)
            try parent.appendGuardedModuleCall(&chunk_output, allocator, em, options, rename_table);
    };
}
```
- 기존 3경로는 게이트로 제외(이중호출 방지, `__commonJS`/`__esm` memoize 라 설령 중복돼도 본문 1회).
- **CJS-format 청크의 TLA(.esm+top-level await) entry** 만 제외(top-level await 불가). ESM-format 은 합법이라 `appendModuleCall` 이 `await init_X()` 처리.
- `appendGuardedModuleCall` 로 단일번들과 동일하게 `entry_error_guard`(RN/Metro) parity(비활성 시 bare 호출로 fallback → 출력 byte-identical).
- TLA 술어(`wrap_kind==.esm and uses_top_level_await`)가 세 지점에 복붙돼 있던 것을 `isTlaEsmModule` helper 로 통합(드리프트 방지).

**설계 참고**: esbuild/rolldown 은 entry 를 아예 wrap 하지 않고 scope-hoist 인라인 실행하지만, zntc 는 "entry wrap + 호출" 모델(단일번들·preserve-modules·reg_split 전부)이라 그 모델과 일관되게 splitting 도 호출하도록 맞춘 저위험 root-cause 수정 — wrap_kind 분류를 바꾸는 광범위 변경(#4522-4538 campaign 전체)을 피함.

## 검증
- `zig build test` **6227/6227**
- integration **4249 pass**(known flake #3099 watch-RSS / #3104 hermesc 2종 제외)
- `split-cjs-cross-chunk.test.ts`: **#4537 회귀 가드 esm/cjs × plain/minify 4종** 추가(빈 dist 실행 non-vacuous, entry **자기** 래퍼 `var require_entry =`+`require_entry();` 직접 확인, multi-chunk assert)
- 인접 splitting/RN/dev 127 pass · effect/zod/three `--minify` byte-identical · guard-off byte-identical

## code-review max 3라운드
correctness 를 라운드마다 좁혀 전부 반영(minify 변형·non-vacuity 강화·TLA helper·guard parity). 리뷰 중 **발견한 선재·독립 버그 2건은 별도 이슈**로 분리:
- **#4541** — raw `require("./x.cjs")` 한 common-chunk CJS 래퍼가 cross-chunk 미노출(ReferenceError). **entry 미-wrap 상태에서도 비-entry 동적청크가 동일 크래시**로 실증 → #4537 과 독립인 #4494/#4522 계열 선재 버그.
- **#4542** — manualChunks 로 relocate 된 entry 미호출(선재 #4537 하위케이스).

Closes #4537
