### PR TITLE
fix(bundler): #4535 증분 emit 캐시에 provider emit fingerprint (Merkle deep-fold)

### DIFF
--- a/.changeset/provider-emit-fingerprint.md
+++ b/.changeset/provider-emit-fingerprint.md
@@ -1,0 +1,29 @@
+---
+"@zntc/core": patch
+---
+
+증분 emit 캐시가 provider 의 graph-derived emit 상태 변경을 놓쳐 stale 바이트를 재사용하던 버그 수정 (#4535, emit-캐시 층).
+
+## 증상
+non-dev 증분 빌드(dev server / NAPI `rebuild()`)에서 **provider 모듈 변경이 소비자의 방출 바이트를 바꿔야 하는데** 소비자가 cache-hit 으로 **옛 바이트를 재사용** → 조용한 오컴파일. 예: 소비자가 import 한 CJS 가 다른 모듈이 `require()` 를 추가해 `wrap_kind` 가 flip 돼도, 소비자 source/mtime 은 그대로라 interop emit 이 옛 형태로 박제. re-export barrel 을 통해 origin 이 심볼을 rename 하면 소비자가 옛 이름을 참조해 `ReferenceError`.
+
+## 루트커즈
+`compiled_cache.computeInputHash` 는 소비자 자신의 상태(mtime/source/options/used_exports/import path)만 해시하고, **provider(및 그 전이 dep)의 post-link emit-영향 상태**(wrap_kind·exports_kind·canonical 이름·래퍼명·상수값·export 순서 등)는 안 본다. import record 는 "어디로 resolve 됐나(path)"만 보고 "그 대상이 어떤 wrap/export 인가"는 안 본다.
+
+## 수정 — Merkle deep-fold
+- `Linker.emitFingerprint(m)` = 모듈의 **local** emit-영향 상태 해시: Module 필드(wrap_kind·exports_kind·has_cjs_export_signal·can_skip_cjs_default_interop·uses_top_level_await·isInCycle) + 래퍼명(require_/init_/exports_/synthetic) + export 별(exported_name·자기 canonical·자기 const 값), **order-dependent**(export 순서가 소비자 inline namespace object 순서를 바꾸므로).
+- `Linker.emitDeepFingerprint(M)` = `local(M) *31 +% Σ deep(dep)` (Merkle) — `import_records` 재귀(require.context 대상은 `rec.context_resolved_paths`→`path_to_module` 로 해석). **re-export barrel 을 통한 origin 의 전이 상태(이름·wrap·star `export *`)를 자동 흡수**한다.
+- `computeInputHash` 가 각 resolved import 대상(+ 모듈 **자신**)의 **deep** fingerprint 를 키에 접어 provider 변경 시 소비자 cache miss 를 유발.
+- **자신의 fingerprint 도 접음**: 다른 모듈이 `require()` 를 추가해 이 모듈의 wrap_kind 가 flip 되면 자기 source 불변이어도 자기 emit 이 바뀌므로.
+- **non-dev 전용**: dev 는 모듈을 registry(path-id)로 래핑해 provider 변경이 소비자 바이트를 안 바꾸므로 stale 재사용이 정답(HMR 핫패스 보호 — emit_fps 빈 slice).
+- 사이클: on-stack 재방문 시 local 만 반환해 무한재귀 차단. 깊이 상한(4096)으로 매우 깊은 선형 체인의 native stack overflow 방어.
+- `is_included`(tree-shaking)는 증분 경로에서 빌드 간 비결정적이라 fingerprint 제외(provider dead/alive 는 used_export_names + path-set clear 로 커버).
+
+## 범위 / 분리 (별도 이슈)
+- **커버**: wrap_kind flip · exports_kind · canonical/래퍼 이름 · export 재정렬 · **named/star re-export barrel 통한 origin rename**. warm≡cold 회귀 가드 4종(wrap_kind flip · named barrel rename · export reorder · star barrel rename).
+- **require.context 확장 대상**: `context_resolved_paths`→`path_to_module` 로 fold(구조적 커버). ⚠️ live warm≡cold 가드는 플러그인이 context_resolved_paths 를 채워야 가능해 유닛으로는 미검증(#4538 과 동일 제약) — emitter/forEachWrapperImportTarget 와 동일 해석 경로라 구조적 정확.
+- (provider const 값도 local fp 에 접히나, 상수 인라이닝의 실제 stale 는 대개 #4544 AST-mutation 층이 지배 — 그쪽에서 종결.)
+- **#4544 (const-materialize AST-mutation)**: `export const N=42` 류 인라이닝은 tree_shaker 가 소비자 AST 를 파괴적 in-place mutation(`z`→`1`)하고 그게 `module_store` 에 남는 **두 번째 캐시 층**. Merkle 이 소비자를 정확히 miss 시켜도 재emit 이 mutated AST 를 써서 여전히 stale — emit-캐시 fp 범위 밖.
+- **잔여(비-회귀, 후속)**: 사이클 back-edge 로만 도달하는 전이 provider(완전 정확엔 SCC 축약 필요, #4545); node/babel interop mode(provider 의 importer 방향 의존)·shared-ns var 이름. 모두 **단조 안전**(fp 는 해시 입력을 추가만 → 새 false-hit 불가; 미해시분은 fp 미도입 시와 동일 stale, 회귀 아님).
+
+검증: zig build test 6231/6231 · effect/zod/three cold 빌드 byte-identical(fp 는 compiled_cache 경로 전용) · integration 4247 pass(known flake 2종 제외).

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -312,6 +312,13 @@ pub fn computeInputHash(
     options_hash: u64,
     used_export_names: ?[]const []const u8,
     graph: *const ModuleGraph,
+    /// #4535: ModuleIndex → provider 의 `Linker.emitDeepFingerprint`(local + Σ dep.deep, Merkle).
+    /// 소비자 emit 바이트가 관측하는 provider 의 post-link 상태(wrap_kind/상수값/canonical 이름 등)를
+    /// **re-export barrel 통한 전이까지** 키에 접는다. 빈 slice = folding 비활성(non-incremental /
+    /// dev / linker 없음 — 종전 동작). ⚠️ **deep** 값이라 아래 per-record fold 와 own-index fold
+    /// 둘 다 필요 — own-index fold(자신의 deep)가 consumer-induced wrap flip 을, per-record fold 가
+    /// 각 provider 변경을 잡는다(어느 쪽도 제거하면 stale-hit).
+    provider_emit_fps: []const u64,
 ) u64 {
     var h = InputHasher.init(0);
     h.addI128(module.mtime);
@@ -324,6 +331,13 @@ pub fn computeInputHash(
         h.addBool(true);
         h.addStrList(names);
     } else h.addBool(false);
+
+    // #4535: 이 모듈 **자신의** emit_fingerprint 도 접는다 — 다른 모듈이 `require()`/`import`
+    // 를 추가해 이 모듈의 wrap_kind/exports_kind 가 flip 되면(consumer-induced), 자기 source/
+    // mtime 은 그대로여도 자기 emit 바이트가 바뀐다. provider fingerprint(아래 import 루프)만으론
+    // 이 self-flip 을 못 잡는다.
+    const own_idx = module.index.toUsize();
+    if (own_idx < provider_emit_fps.len) h.addU64(provider_emit_fps[own_idx]);
 
     h.addU64(module.import_records.len);
     for (module.import_records) |rec| {
@@ -342,6 +356,10 @@ pub fn computeInputHash(
                 // 방어: 범위 밖이면 stable sentinel 로 hash (극히 이례적).
                 h.addStr("");
             }
+            // #4535: provider 의 emit fingerprint 를 접는다 — provider 내용/wrap 이 바뀌어
+            // 소비자 emit 바이트가 바뀌어야 하는데 소비자 source/path 는 그대로인 stale-hit 방지.
+            const ridx = rec.resolved.toUsize();
+            if (ridx < provider_emit_fps.len) h.addU64(provider_emit_fps[ridx]);
         }
     }
 
@@ -518,8 +536,8 @@ test "computeInputHash: transformed source participates in cache key (#2038)" {
     a.source = "console.log('plugin output A');";
     b.source = "console.log('plugin output B');";
 
-    const hash_a = computeInputHash(&a, 0xCAFE, null, &graph);
-    const hash_b = computeInputHash(&b, 0xCAFE, null, &graph);
+    const hash_a = computeInputHash(&a, 0xCAFE, null, &graph, &.{});
+    const hash_b = computeInputHash(&b, 0xCAFE, null, &graph, &.{});
     try std.testing.expect(hash_a != hash_b);
 }
 
@@ -538,8 +556,8 @@ test "computeInputHash: unchanged transformed source keeps cache key stable (#20
     a.source = "console.log('same plugin output');";
     b.source = "console.log('same plugin output');";
 
-    const hash_a = computeInputHash(&a, 0xCAFE, null, &graph);
-    const hash_b = computeInputHash(&b, 0xCAFE, null, &graph);
+    const hash_a = computeInputHash(&a, 0xCAFE, null, &graph, &.{});
+    const hash_b = computeInputHash(&b, 0xCAFE, null, &graph, &.{});
     try std.testing.expectEqual(hash_a, hash_b);
 }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -683,6 +683,26 @@ pub fn emitWithTreeShaking(
     else
         0;
 
+    // #4535: non-dev 증분 캐시 키에 접을 provider emit fingerprint 테이블 (ModuleIndex → fp).
+    // dev 는 모듈을 registry(path-id)로 래핑해 provider 변경이 소비자 emit 바이트를 안 바꾸므로
+    // stale 재사용이 정답 → folding 불필요(HMR 핫패스 보호). linker 없으면 정적 인라인 없음 → 무의미.
+    var emit_fps: []u64 = &.{};
+    defer if (emit_fps.len > 0) allocator.free(emit_fps);
+    if (options.compiled_cache != null and !options.dev_mode) {
+        if (linker) |l| {
+            const n = graph.moduleCount();
+            emit_fps = try allocator.alloc(u64, n);
+            // Merkle deep-fold: deep(M)=local(M)+Σ deep(dep). re-export barrel 통한 전이 상태까지
+            // 소비자 키에 반영. state = 방문 마킹(사이클 차단).
+            const fp_state = try allocator.alloc(u8, n);
+            defer allocator.free(fp_state);
+            @memset(fp_state, 0);
+            for (0..n) |k| {
+                _ = l.emitDeepFingerprint(@intCast(k), emit_fps, fp_state, 0);
+            }
+        }
+    }
+
     if (options.compiled_cache) |cache| {
         // PR-B: HMR 위상 보존-hit 의 unchanged 모듈은 input(source/import/mtime)이 물리 불변이라
         // 직전 Entry 의 input_hash 가 자기 자신과 일치한다. graph.changed_emit_paths(보존-hit 에서만
@@ -711,7 +731,7 @@ pub fn emitWithTreeShaking(
                 }
             }
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
-            const input_hash = cache_mod.computeInputHash(m, options_hash, used_names, graph);
+            const input_hash = cache_mod.computeInputHash(m, options_hash, used_names, graph, emit_fps);
             input_hashes[i] = input_hash;
             const hit = cache.tryHit(m.path, input_hash) orelse continue;
             results[i] = hit.dupe(allocator) catch continue;

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -3294,3 +3294,214 @@ test "lImp/lReExp partial-skip: reuse-hit named-import via re-export barrel 정�
         else => return error.TestUnexpectedResult,
     }
 }
+
+// #4535: consumer-유발 wrap_kind flip. a.js 가 lib.js 를 require 하기 시작하면 lib 이 CJS-wrap
+// 으로 flip → lib 를 import 하는 index.js 의 interop emit 이 바뀌어야 하는데 index.js source 는
+// 불변. computeInputHash 가 provider(lib)의 emit_fingerprint(wrap_kind 포함)를 접어 miss 유발.
+// ⚠️ compiled_cache ON + dev_mode OFF 필수(dev 는 registry 간접화로 은폐).
+test "reuse #4535: consumer-induced wrap_kind flip warm==cold" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.js", "export function greet(){ return \"HI\"; }");
+    try writeFile(tmp.dir, "a.js", "export function run(){ return \"A1\"; }");
+    try writeFile(tmp.dir, "index.js",
+        \\import { greet } from './lib.js';
+        \\import { run } from './a.js';
+        \\console.log(greet(), run());
+        \\
+    );
+    const entry = try absPath(&tmp, "index.js");
+    defer std.testing.allocator.free(entry);
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var cc = CompiledOutputCache.init(std.testing.allocator);
+    defer cc.deinit();
+    const base_opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = false,
+        .module_store = &store,
+        .compiled_cache = &cc,
+    });
+    for (0..2) |_| {
+        var b = Bundler.init(std.testing.allocator, base_opts);
+        var r = try b.bundle(std.testing.io);
+        try std.testing.expect(!r.hasErrors());
+        r.deinit(std.testing.allocator);
+        b.deinit();
+    }
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    // a.js 편집 → lib.js 를 require → lib.js 가 CJS-wrap 으로 flip. index.js 는 불변.
+    try writeFile(tmp.dir, "a.js", "export function run(){ return require('./lib.js').greet() + \"A2\"; }");
+    const a_abs = try absPath(&tmp, "a.js");
+    defer std.testing.allocator.free(a_abs);
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, a_abs, {});
+    var warm_opts = base_opts;
+    warm_opts.changed_files = &touched;
+    var warm = Bundler.init(std.testing.allocator, warm_opts);
+    var warm_r = try warm.bundle(std.testing.io);
+    defer warm_r.deinit(std.testing.allocator);
+    defer warm.deinit();
+    try std.testing.expect(!warm_r.hasErrors());
+    var cold = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = false });
+    var cold_r = try cold.bundle(std.testing.io);
+    defer cold_r.deinit(std.testing.allocator);
+    defer cold.deinit();
+    try std.testing.expect(!cold_r.hasErrors());
+    try std.testing.expectEqualStrings(cold_r.output, warm_r.output);
+}
+
+// #4535 [0]: transitive re-export barrel. origin(q.js)이 심볼을 rename 하면 barrel(barrel.js)의
+// emitFingerprint 가 origin canonical 을 chain-resolve 해 바뀌어야, barrel 통해 import 하는
+// main.js 가 miss 된다(안 그러면 옛 심볼명 참조 → ReferenceError). compiled_cache ON + dev OFF.
+test "reuse #4535: re-export barrel origin rename warm==cold" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "q.js", "function fmt(x){ return x + 1; }\nexport { fmt };");
+    try writeFile(tmp.dir, "barrel.js", "export { fmt } from './q.js';");
+    try writeFile(tmp.dir, "main.js",
+        \\import { fmt } from './barrel.js';
+        \\console.log(fmt(1));
+        \\
+    );
+    const entry = try absPath(&tmp, "main.js");
+    defer std.testing.allocator.free(entry);
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var cc = CompiledOutputCache.init(std.testing.allocator);
+    defer cc.deinit();
+    const base_opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = false,
+        .module_store = &store,
+        .compiled_cache = &cc,
+    });
+    for (0..2) |_| {
+        var b = Bundler.init(std.testing.allocator, base_opts);
+        var r = try b.bundle(std.testing.io);
+        try std.testing.expect(!r.hasErrors());
+        r.deinit(std.testing.allocator);
+        b.deinit();
+    }
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    // q.js 만 편집: 심볼 rename (fmt → fmtImpl as fmt). barrel/main 은 불변.
+    try writeFile(tmp.dir, "q.js", "function fmtImpl(x){ return x + 2; }\nexport { fmtImpl as fmt };");
+    const q_abs = try absPath(&tmp, "q.js");
+    defer std.testing.allocator.free(q_abs);
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, q_abs, {});
+    var warm_opts = base_opts;
+    warm_opts.changed_files = &touched;
+    var warm = Bundler.init(std.testing.allocator, warm_opts);
+    var warm_r = try warm.bundle(std.testing.io);
+    defer warm_r.deinit(std.testing.allocator);
+    defer warm.deinit();
+    try std.testing.expect(!warm_r.hasErrors());
+    var cold = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = false });
+    var cold_r = try cold.bundle(std.testing.io);
+    defer cold_r.deinit(std.testing.allocator);
+    defer cold.deinit();
+    try std.testing.expect(!cold_r.hasErrors());
+    try std.testing.expectEqualStrings(cold_r.output, warm_r.output);
+}
+
+// #4535 [2]: export 재정렬. provider(p.js) export 순서가 소비자(main.js)의 `import * as ns` inline
+// namespace object 속성 순서(`{a,b}` vs `{b,a}`)를 바꾼다. emitFingerprint 가 order-dependent 라야
+// 재정렬을 감지해 main.js 를 miss 시킨다. compiled_cache ON + dev OFF.
+test "reuse #4535: export reorder warm==cold" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "p.js", "export function a(){ return 'A'; }\nexport function b(){ return 'B'; }");
+    try writeFile(tmp.dir, "main.js",
+        \\import * as ns from './p.js';
+        \\console.log(Object.keys(ns).join(','));
+        \\
+    );
+    const entry = try absPath(&tmp, "main.js");
+    defer std.testing.allocator.free(entry);
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var cc = CompiledOutputCache.init(std.testing.allocator);
+    defer cc.deinit();
+    const base_opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = false,
+        .module_store = &store,
+        .compiled_cache = &cc,
+    });
+    for (0..2) |_| {
+        var b = Bundler.init(std.testing.allocator, base_opts);
+        var r = try b.bundle(std.testing.io);
+        try std.testing.expect(!r.hasErrors());
+        r.deinit(std.testing.allocator);
+        b.deinit();
+    }
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    // p.js 만 재정렬(같은 이름·본문, 순서만). main.js 는 불변.
+    try writeFile(tmp.dir, "p.js", "export function b(){ return 'B'; }\nexport function a(){ return 'A'; }");
+    const p_abs = try absPath(&tmp, "p.js");
+    defer std.testing.allocator.free(p_abs);
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, p_abs, {});
+    var warm_opts = base_opts;
+    warm_opts.changed_files = &touched;
+    var warm = Bundler.init(std.testing.allocator, warm_opts);
+    var warm_r = try warm.bundle(std.testing.io);
+    defer warm_r.deinit(std.testing.allocator);
+    defer warm.deinit();
+    try std.testing.expect(!warm_r.hasErrors());
+    var cold = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = false });
+    var cold_r = try cold.bundle(std.testing.io);
+    defer cold_r.deinit(std.testing.allocator);
+    defer cold.deinit();
+    try std.testing.expect(!cold_r.hasErrors());
+    try std.testing.expectEqualStrings(cold_r.output, warm_r.output);
+}
+
+// #4535 [Merkle]: star re-export barrel(`export *`). origin(x.js)이 심볼 rename 하면 deep-fold 가
+// barrel 의 deep fp 에 x 의 local fp 를 접어 barrel/main 을 miss 시킨다(single-hop 은 export*=chain
+// null 이라 못 잡아 ReferenceError 였음). compiled_cache ON + dev OFF.
+test "reuse #4535: star re-export barrel origin rename warm==cold" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "x.js", "export function foo(){ return 'F'; }");
+    try writeFile(tmp.dir, "barrel.js", "export * from './x.js';");
+    try writeFile(tmp.dir, "main.js", "import { foo } from './barrel.js';\nconsole.log(foo());\n");
+    const entry = try absPath(&tmp, "main.js");
+    defer std.testing.allocator.free(entry);
+    var store = module_store.PersistentModuleStore.init(std.testing.allocator);
+    defer store.deinit();
+    var cc = CompiledOutputCache.init(std.testing.allocator);
+    defer cc.deinit();
+    const base_opts = @as(@import("bundler.zig").BundleOptions, .{ .entry_points = &.{entry}, .dev_mode = false, .module_store = &store, .compiled_cache = &cc });
+    for (0..2) |_| {
+        var b = Bundler.init(std.testing.allocator, base_opts);
+        var r = try b.bundle(std.testing.io);
+        try std.testing.expect(!r.hasErrors());
+        r.deinit(std.testing.allocator);
+        b.deinit();
+    }
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "x.js", "function fooImpl(){ return 'F2'; }\nexport { fooImpl as foo };");
+    const x_abs = try absPath(&tmp, "x.js");
+    defer std.testing.allocator.free(x_abs);
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(std.testing.allocator);
+    try touched.put(std.testing.allocator, x_abs, {});
+    var warm_opts = base_opts;
+    warm_opts.changed_files = &touched;
+    var warm = Bundler.init(std.testing.allocator, warm_opts);
+    var warm_r = try warm.bundle(std.testing.io);
+    defer warm_r.deinit(std.testing.allocator);
+    defer warm.deinit();
+    try std.testing.expect(!warm_r.hasErrors());
+    var cold = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .dev_mode = false });
+    var cold_r = try cold.bundle(std.testing.io);
+    defer cold_r.deinit(std.testing.allocator);
+    defer cold.deinit();
+    try std.testing.expect(!cold_r.hasErrors());
+    try std.testing.expectEqualStrings(cold_r.output, warm_r.output);
+}

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2241,6 +2241,109 @@ pub const Linker = struct {
         return self.lookupSymbolCanonical(module_index, name);
     }
 
+    /// #4535: 한 모듈의 **local** emit-영향 상태를 해시한다(자기 자신만; 전이성은 아래 deep-fold 가
+    /// 담당). `emitDeepFingerprint` 가 `local + Σ dep.deep` (Merkle) 로 합성하고, 그 deep 값을
+    /// `compiled_cache.computeInputHash` 가 각 resolved import 대상마다 접어, provider 의 wrap_kind
+    /// flip / 인라인 상수값 변경 / canonical 이름 변경이 **re-export barrel 을 통해서도** 소비자
+    /// 캐시 키에 반영되게 한다(증분 emit 캐시 stale 방지).
+    ///
+    /// ⚠️ **non-dev 전용** — dev 는 모듈을 registry(path-id)로 래핑해 provider 변경이 소비자
+    /// 바이트를 안 바꾸므로 stale 재사용이 정답이다. folding 은 emitter 가 `!dev_mode` 에서만 건넨다.
+    pub fn emitFingerprint(self: *const Linker, m: *const Module) u64 {
+        var h: u64 = 0x4535;
+        // 1. Module-level emit-영향 사실 (interop/wrap/reachability/TLA).
+        h = h *% 31 +% @as(u64, @intFromEnum(m.wrap_kind));
+        h = h *% 31 +% @as(u64, @intFromEnum(m.exports_kind));
+        h = h *% 31 +% @as(u64, @intFromBool(m.has_cjs_export_signal));
+        h = h *% 31 +% @as(u64, @intFromBool(m.can_skip_cjs_default_interop));
+        // ⚠️ is_included(tree-shaking)는 증분 경로에서 빌드 간 비결정적(store 재사용 시 stale)이라
+        // fingerprint 에서 제외 — provider dead/alive 는 소비자의 used_export_names(computeInputHash
+        // 가 이미 해시) + path-set clear(incremental.zig)로 커버된다.
+        h = h *% 31 +% @as(u64, @intFromBool(m.uses_top_level_await));
+        h = h *% 31 +% @as(u64, @intFromBool(m.isInCycle()));
+        // 2. 래퍼명(cross-chunk deconflict 결과 — 소비자 preamble 이 이 이름을 호출/참조).
+        if (m.getRequireName(&self.rename_table)) |n| h ^= std.hash.Wyhash.hash(0x11, n);
+        if (m.getInitName(&self.rename_table)) |n| h ^= std.hash.Wyhash.hash(0x12, n);
+        if (m.getExportsName(&self.rename_table)) |n| h ^= std.hash.Wyhash.hash(0x13, n);
+        if (m.wrapper_name_synthetic) |n| h ^= std.hash.Wyhash.hash(0x14, n);
+        // 3. export 별: exported_name + 자기 canonical local + 자기 인라인 const 값.
+        //    ⚠️ **order-dependent 누산**(`h*31 +% eh`) — export 순서가 소비자의 inline namespace
+        //    object 속성 순서(`{a,b}` vs `{b,a}`)를 바꾸므로 재정렬도 감지해야 한다. export_bindings
+        //    는 파싱(binding_scanner) 소스 순서라 빌드 간 결정적. (re-export 의 origin 상태는 여기서
+        //    chain-resolve 하지 않는다 — deep-fold 가 origin.deep 을 접어 전이성을 담당.)
+        const mi: u32 = m.index.toU32();
+        for (m.export_bindings) |eb| {
+            var eh: u64 = std.hash.Wyhash.hash(0x21, eb.exported_name);
+            eh ^= std.hash.Wyhash.hash(0x22, self.getCanonicalForExport(eb, mi));
+            // 소비자가 인라인하는 const 값 — buildCrossModuleConstValues 의 provider-side read 와 동일.
+            if (m.semantic) |sem| {
+                if (sem.scope_maps.len > 0) {
+                    const local = m.exportBindingLocalName(eb);
+                    if (sem.scope_maps[0].get(local)) |sidx| {
+                        if (sidx < sem.symbols.items.len) {
+                            const sym = sem.symbols.items[sidx];
+                            eh ^= (@as(u64, @intFromEnum(sym.const_kind)) +% 1) *% 0x9e3779b1;
+                            eh ^= @as(u64, sym.write_count) *% 0x100000001b3;
+                            if (sym.const_kind == .number) {
+                                eh ^= std.hash.Wyhash.hash(0x24, sem.numericConstText(@intCast(sidx)));
+                            }
+                        }
+                    }
+                }
+            }
+            h = h *% 31 +% eh;
+        }
+        return h;
+    }
+
+    /// #4535 Merkle deep-fold: `deep(M) = local(M) *31 +% Σ deep(dep)`. 소비자 emit 바이트가
+    /// **re-export barrel 을 통해** 관측하는 origin 의 전이 상태(이름·상수값·wrap_kind·star)를
+    /// 자동 흡수한다 — single-hop `emitFingerprint` 만으론 barrel 의 local fp 가 origin 을 안 담아
+    /// stale-hit(ReferenceError/잘못된 값)이 났다.
+    ///
+    /// `out`(ModuleIndex→deep fp)/`state`(0=미방문·1=on-stack·2=완료)는 emitter 가 소유. 사이클은
+    /// on-stack 재방문 시 local 만 반환해 무한재귀를 끊는다(사이클 멤버의 deep 은 서로의 local 을
+    /// 포함 — 대부분의 사이클 내 변경을 감지). 방문 순서는 결정적 acyclic 부분엔 무영향; 사이클
+    /// 부분은 진입순(ModuleIndex)에 의존한다. ⚠️ 사이클 back-edge 로만 도달하는 전이 provider 를
+    /// 놓치는 좁은 topology 잔여가 있으나(완전 정확엔 SCC 축약 필요, 후속) **비-회귀**(fp 미도입
+    /// 시보다 항상 더 많이 감지). `depth` 는 매우 깊은 선형 체인의 native stack overflow 방어 —
+    /// 상한 초과 시 local 만(그 지점 이하 전이 미반영, 크래시보다 안전).
+    pub fn emitDeepFingerprint(self: *const Linker, idx: u32, out: []u64, state: []u8, depth: u32) u64 {
+        if (idx >= out.len) return 0;
+        if (state[idx] == 2) return out[idx];
+        const m = self.graph.getModule(@enumFromInt(idx)) orelse {
+            state[idx] = 2;
+            out[idx] = 0;
+            return 0;
+        };
+        if (state[idx] == 1) return self.emitFingerprint(m); // 사이클 차단: local 만.
+        if (depth >= 4096) return self.emitFingerprint(m); // stack overflow 방어(비-memoize).
+        state[idx] = 1;
+        var h = self.emitFingerprint(m);
+        for (m.import_records) |rec| {
+            if (rec.is_external) continue;
+            // #4535: require.context 대상은 `rec.resolved`(=.none)가 아니라 `context_resolved_paths`
+            // →`path_to_module` 로 해석해야 접힌다. 안 접으면 context 대상의 wrap flip/이름 변경이
+            // 소비자 키에 반영 안 돼 stale-hit(초기 구현이 context_expansion_deps 를 봐 dead 였던 버그).
+            // ⚠️ `forEachWrapperImportTarget`(위)와 **동일 해석 경로**지만 그건 wrapped-only 로 필터해
+            // 여기선 재사용 불가(fingerprint 는 전 대상 필요) — require.context resolution 변경 시 양쪽
+            // 동반 수정(이 walk 가 4번째 사본 — 드리프트 주의).
+            if (rec.kind == .require_context) {
+                for (rec.context_resolved_paths) |abs_opt| {
+                    const abs = abs_opt orelse continue;
+                    const wi = self.graph.path_to_module.get(abs) orelse continue;
+                    h = h *% 31 +% self.emitDeepFingerprint(wi.toU32(), out, state, depth + 1);
+                }
+                continue;
+            }
+            if (rec.resolved.isNone()) continue;
+            h = h *% 31 +% self.emitDeepFingerprint(rec.resolved.toU32(), out, state, depth + 1);
+        }
+        state[idx] = 2;
+        out[idx] = h;
+        return h;
+    }
+
     fn lookupSymbolCanonical(self: *const Linker, module_index: u32, name: []const u8) ?[]const u8 {
         const idx = self.findSymbolIdx(module_index, name) orelse return null;
         // emit 경로는 build-scope `rename_table` 을 읽는다 — `Symbol.canonical_name` field 는


### PR DESCRIPTION
## 증상

non-dev 증분 빌드(dev server / NAPI `rebuild()`)에서 **provider 모듈 변경이 소비자의 방출 바이트를 바꿔야 하는데** 소비자가 cache-hit 으로 **옛 바이트를 재사용** → 조용한 오컴파일. 예: 다른 모듈이 `require()` 를 추가해 import 대상 CJS 의 `wrap_kind` 가 flip 돼도 소비자 source/mtime 은 그대로라 interop emit 이 옛 형태로 박제. re-export barrel 을 통해 origin 이 심볼을 rename 하면 소비자가 옛 이름을 참조해 `ReferenceError`.

## 루트커즈

`compiled_cache.computeInputHash` 는 소비자 자신의 상태(mtime/source/options/used_exports/import path)만 해시하고, **provider(및 그 전이 dep)의 post-link emit-영향 상태**(wrap_kind·exports_kind·canonical 이름·래퍼명·export 순서 등)는 안 본다. import record 는 "어디로 resolve 됐나(path)"만 보고 "그 대상이 어떤 wrap/export 인가"는 안 본다. `incremental.zig` 의 무효화는 **모듈 path set 변경 시에만** cache clear 라, provider 파일 *내용* 편집은 방어선을 통과한다.

## 수정 — Merkle deep-fold

- `Linker.emitFingerprint(m)` = 모듈의 **local** emit-영향 상태 해시(Module 필드·래퍼명·export 이름/canonical/const, **order-dependent**).
- `Linker.emitDeepFingerprint(M)` = `local(M) *31 +% Σ deep(dep)` (Merkle) — `import_records` 재귀(require.context 대상은 `context_resolved_paths`→`path_to_module`). **re-export barrel 을 통한 origin 의 전이 상태(이름·wrap·star `export *`)를 자동 흡수**.
- `computeInputHash` 가 각 resolved import(+ 모듈 **자신**)의 **deep** fingerprint 를 키에 접어 provider 변경 시 소비자 cache miss 유발. 자신의 fold 는 consumer-induced wrap flip 감지.
- **non-dev 전용**: dev 는 모듈을 registry(path-id)로 래핑해 provider 변경이 소비자 바이트를 안 바꾸므로 stale 재사용이 정답(HMR 핫패스 보호 — emit_fps 빈 slice).
- 사이클 on-stack 차단 + 깊이 상한(4096)으로 무한재귀·stack overflow 방어. `is_included`(tree-shaking 비결정)는 제외.

## 왜 Merkle 인가 (설계 경위)

code-review 를 통해 접근이 **single-hop → chain-resolution → Merkle** 로 수렴했다. single-hop non-recursive fingerprint 는 **re-export barrel 을 통한 transitive 상태**(star `export *`·const·wrap)를 구조적으로 못 잡아 barrel 소비자가 false-hit(ReferenceError)했다. Merkle deep-fold 는 barrel 의 deep fp 가 origin 의 deep fp 를 포함해 그 계열을 근본 해소한다.

## 검증

- `zig build test` **6231/6231**
- integration **4249 pass**(known flake #3099 watch-RSS / #3104 hermesc 2종 제외)
- warm≡cold 회귀 가드 **4종**(compiled_cache ON + dev_mode OFF): wrap_kind flip · named re-export barrel rename · export reorder · star re-export barrel rename
- effect/zod/three cold 빌드 byte-identical(fp 는 compiled_cache 경로 전용) · napi clean

## 범위 / 분리 (별도 이슈)

이 PR = **emit-캐시 층**. code-review 로 발견한 인접 층·잔여는 분리:
- **#4544** — `export const N=42` 류 **상수 인라이닝**은 tree_shaker 의 const-materialize 가 소비자 AST 를 파괴적 in-place mutation 하고 `module_store` 에 남는 **두 번째 캐시 층**. Merkle 이 소비자를 정확히 miss 시켜도 재emit 이 mutated AST 를 써서 stale(실증).
- **#4545** — 사이클 back-edge 로만 도달하는 전이 provider(완전 정확엔 SCC 축약) · node/babel interop-mode(provider 의 importer 방향 의존) · shared-ns var 이름. 전부 **단조 안전**(fp 는 해시 입력 추가만 → 새 false-hit 불가; 미해시분은 fp 미도입 시와 동일 stale, 회귀 아님).

require.context 확장 대상은 구조적으로 fold 하나 live warm≡cold 가드는 플러그인이 `context_resolved_paths` 를 채워야 가능(#4538 과 동일 제약).

Refs #4535
