### PR TITLE
fix(bundler): #4541 --splitting raw require() common-chunk CJS 썽크 cross-chunk 노출

### DIFF
--- a/.changeset/crosschunk-raw-require.md
+++ b/.changeset/crosschunk-raw-require.md
@@ -1,0 +1,30 @@
+---
+"@zntc/core": patch
+---
+
+`--splitting` 에서 raw `require("./x.cjs")` 한 CJS 가 common chunk 에 안착하면 그 `require_X` 썽크가 cross-chunk 미노출돼 `ReferenceError` 나던 버그 수정 (#4541).
+
+## 증상
+raw `require("./x.cjs")` 로 다른 청크의 CJS 를 참조하면, 소비자 청크는 `import "./chunk"`(side-effect)만 하고 `require_X()` 를 **import 없이** 참조 → provider 청크에만 있는 `require_X` = free variable → `ReferenceError: require_X is not defined`. 빌드 exit 0 · 파싱 통과 · 실행만 실패.
+
+## 루트커즈
+`computeCrossChunkLinks`(chunk.zig)는 cross-chunk 심볼을 **`import_bindings` 순회**로만 등록한다. raw `require()` 는 ImportBinding 이 없어(`kind=.require`) `require_X` 가 `exports_to`/`imports_from` 에 안 들어간다(chunk-level 의존 edge=side-effect import 만 생성). `import` 경로(#4494/#4522)는 provider 가 interop 값을 materialize+export 하지만, raw-require 는 그 경로를 안 탄다. wrapper 심볼(`require_X`, scope_id=.none)은 rename 풀에도 없어 심볼 기계가 구조적으로 못 본다.
+
+## 수정
+esbuild/rolldown 동형 — provider 가 썽크를 **export**, 소비자가 **import** 후 `require_X()`. raw `require` 는 **lazy**(호출 시점 평가)라 import-path 의 eager materialize(`default$X=require_X()`)를 재사용하지 않고 썽크 자체를 넘긴다.
+- `Chunk.wrapper_cross_exports`/`wrapper_cross_imports` 필드 추가 — import-path 의 exports_to/imports_from(export명 키) 기계와 분리(래퍼는 export명이 없음).
+- `computeCrossChunkLinks` 에 raw-require 루프: `kind==.require` + CJS 타겟 + 다른 청크면 provider 에 export 표시·소비자에 import 표시.
+- provider emit: `export { <로컬> as require_X }`(esm) / `exports.require_X = <로컬>`(cjs). ⚠️ `--minify` 는 provider 본문 선언을 mangle(`r`)하나 소비자는 canonical `require_X` 로 import·호출 → **로컬(mangled)→공개(canonical) aliasing** 으로 3자 일치.
+- 소비자 emit: `import { require_X }`(esm, live binding) / cjs 는 **lazy forwarding**(`require("...");` side-effect + `const require_X = function(){ return require("...").require_X.apply(this,arguments); }`) — `const{require_X}=require(...)` 구조분해는 CJS↔CJS cross-chunk 순환에서 로드 시점 스냅샷(undefined 박제) 위험이라 호출 시점 조회로 지연 복원(#4526 계열).
+- `buildRequireRewrites` 는 `require_X()` 그대로(변경 불요).
+
+## 범위
+esm·cjs 포맷. **preserve-modules 는 #4524 가 자체 wrapper 기계로 담당**하므로 제외(게이트). **iife/umd/amd(reg_split)는 registry 모델이라 후속.**
+
+검증: zig 6227/6227 · split-cjs-cross-chunk #4541 가드 esm/cjs × plain/minify 4종(node 실행) · 인접 splitting/preserve-modules 152 pass · effect/zod/three byte-identical.
+
+Closes #4541
+
+## code-review 반영
+- **[r0] cjs 순환 lazy forwarding**: cjs 소비자가 `const{require_X}=require(...)` 로 로드 시점 구조분해하면 CJS↔CJS cross-chunk 순환에서 provider 의 `exports.require_X` 미할당 시점을 스냅샷 → TypeError(#4526 계열). require_X 는 함수라 `const require_X = function(){ return require("...").require_X.apply(this,arguments); }` **호출 시점 조회**로 지연 복원. esm 은 live binding 이라 named import 유지. 순환 가드 추가.
+- **[r1] reset 멱등**: `computeCrossChunkLinks` reset 루프에 새 `wrapper_cross_exports`/`wrapper_cross_imports` clear 추가(재실행/HMR re-link 시 stale export 방지).

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -265,6 +265,16 @@ pub const Chunk = struct {
     /// 공통 청크에서 export 문을 생성할 때 사용.
     exports_to: std.StringHashMapUnmanaged(void),
 
+    /// (#4541) raw `require("./x.cjs")` 로 **다른 청크**의 CJS 모듈을 참조하면 그 `require_X` 썽크를
+    /// cross-chunk export/import 해야 한다(esbuild/rolldown 동형: provider `export{require_X}`,
+    /// 소비자 `import{require_X}` 후 `require_X()`). import binding 이 없는 raw require 라 기존
+    /// exports_to/imports_from(심볼 export명 키) 기계가 못 봐 별도 트랙으로 둔다(래퍼는 scope_id
+    /// =.none 이라 rename 풀에도 없음, canonical 이름은 reserveWrapperNames 로 전역 유일).
+    /// wrapper_cross_exports = 이 청크가 썽크로 export 해야 할 (CJS wrap) 모듈 index 집합.
+    wrapper_cross_exports: std.AutoHashMapUnmanaged(u32, void),
+    /// src_chunk_index → 이 청크가 그 청크에서 import 해야 할 wrapper(CJS) 모듈 index 목록.
+    wrapper_cross_imports: std.AutoHashMapUnmanaged(u32, std.ArrayListUnmanaged(u32)),
+
     /// 기본값으로 Chunk를 생성한다.
     pub fn init(index: ChunkIndex, kind: ChunkKind, bits: BitSet) Chunk {
         return .{
@@ -279,6 +289,8 @@ pub const Chunk = struct {
             .cross_chunk_dynamic_imports = .empty,
             .imports_from = .empty,
             .exports_to = .empty,
+            .wrapper_cross_exports = .empty,
+            .wrapper_cross_imports = .empty,
         };
     }
 
@@ -295,6 +307,10 @@ pub const Chunk = struct {
         }
         self.imports_from.deinit(allocator);
         self.exports_to.deinit(allocator);
+        self.wrapper_cross_exports.deinit(allocator);
+        var wit = self.wrapper_cross_imports.iterator();
+        while (wit.next()) |entry| entry.value_ptr.deinit(allocator);
+        self.wrapper_cross_imports.deinit(allocator);
         // PR B-1: name_dir 은 sanitizeNameDir 의 결과 — chunk 가 owning.
         // doc 의 "빌림" 표현은 부정확 — 실제로는 chunk lifetime 와 일치하므로
         // 여기서 free 한다(chunk.rel_dir 와 달리 항상 alloc 된 메모리).
@@ -1806,6 +1822,13 @@ pub fn computeCrossChunkLinks(
             chunk.imports_from.clearAndFree(allocator);
         }
         chunk.exports_to.clearAndFree(allocator);
+        // (#4541) 재실행(HMR re-link) 멱등 — 새 wrapper 맵도 초기화(안 하면 stale export/import).
+        chunk.wrapper_cross_exports.clearAndFree(allocator);
+        {
+            var wit = chunk.wrapper_cross_imports.iterator();
+            while (wit.next()) |entry| entry.value_ptr.deinit(allocator);
+            chunk.wrapper_cross_imports.clearAndFree(allocator);
+        }
     }
 
     for (chunk_graph.chunks.items) |*chunk| {
@@ -1940,6 +1963,34 @@ pub fn computeCrossChunkLinks(
                 }
                 if (has_star)
                     try fanOutModuleExports(allocator, chunk_graph, chunk, &seen_static, lnk, mod_idx, module_count);
+
+                // (#4541) raw `require("./x.cjs")` 로 **다른 청크**의 CJS 를 참조: import binding 이
+                // 없어 위 심볼 루프가 못 보고 chunk-level 의존 edge(side-effect import)만 생긴다.
+                // 그 결과 소비자가 provider 청크에만 있는 `require_X()` 썽크를 미-import 참조 →
+                // ReferenceError(#4541). 여기서 provider 는 썽크를 export, 소비자는 import 하도록
+                // 표시한다(esbuild/rolldown 동형). ⚠️ require_X 는 **lazy**(호출 시점 평가)라 provider
+                // 에서 eager materialize(default$X=require_X())하지 않고 썽크 자체를 넘긴다.
+                for (m.import_records) |rec| {
+                    if (rec.kind != .require) continue;
+                    if (rec.resolved.isNone()) continue;
+                    const tmod = graph.getModule(rec.resolved) orelse continue;
+                    if (tmod.wrap_kind != .cjs) continue; // require_X 썽크(CJS)만 — ESM-wrap 은 후속
+                    const target_chunk = chunk_graph.getModuleChunk(rec.resolved);
+                    if (target_chunk.isNone() or target_chunk == chunk.index) continue;
+                    const ti = @intFromEnum(rec.resolved);
+                    const tci = @intFromEnum(target_chunk);
+                    try chunk_graph.chunks.items[tci].wrapper_cross_exports.put(allocator, ti, {});
+                    const wgop = try chunk.wrapper_cross_imports.getOrPut(allocator, tci);
+                    if (!wgop.found_existing) wgop.value_ptr.* = .empty;
+                    for (wgop.value_ptr.items) |e| {
+                        if (e == ti) break;
+                    } else try wgop.value_ptr.append(allocator, ti);
+                    // cross_chunk_imports 보장: 위 정적-의존 루프(m.dependencies)가 보통 이미 이
+                    // provider 를 추가하지만(raw require = 의존 edge), 그 edge 가 없는 경우를 대비해
+                    // seen_static dedup 으로 방어적 append(중복 없음 — 소비자 import emit 이 이 목록 순회).
+                    const sgop = try seen_static.getOrPut(allocator, tci);
+                    if (!sgop.found_existing) try chunk.cross_chunk_imports.append(allocator, target_chunk);
+                }
             }
 
             // 동적 의존성 → cross_chunk_dynamic_imports

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -761,6 +761,58 @@ pub fn emitChunks(
                 }
             }
 
+            // (#4541) 이 dep 청크에서 raw-require 한 CJS 썽크(require_X)를 named import 로 가져온다.
+            // esm: `import { require_X } from "…"` / cjs·iife: `const { require_X } = require/__zntc_require`.
+            // require_X 는 canonical(reserveWrapperNames 로 전역 유일)이라 rename_table 불요 — provider
+            // export·소비자 import·본문 `require_X()` 3자가 같은 이름을 쓴다(#4524 계약과 동일).
+            // ⚠️ esm/cjs 포맷만 — reg_split(iife/umd/amd)은 registry 모델이라 별도(후속).
+            // ⚠️ preserve-modules 는 #4524 가 자체 wrapper thunk export/import 를 담당하므로 제외.
+            var wrapper_import_emitted = false;
+            if (!reg_split and !options.preserve_modules) {
+                if (chunk.wrapper_cross_imports.get(dep_ci)) |wlist| {
+                    if (wlist.items.len > 0) {
+                        const min = options.minify_whitespace;
+                        std.mem.sort(u32, wlist.items, {}, comptime std.sort.asc(u32));
+                        if (cjs_require) {
+                            // (#4526) ⚠️ cjs 는 **구조분해 금지**(`const{require_X}=require(...)`는 로드
+                            // 시점 값 스냅샷 → CJS↔CJS cross-chunk 순환에서 provider 의 `exports.require_X`
+                            // 가 아직 미할당이라 undefined 박제 → TypeError). require_X 는 함수라 **호출
+                            // 시점 조회(lazy forwarding)**로 지연을 복원한다(require 는 node memoize).
+                            try chunk_output.appendSlice(allocator, "require(\"");
+                            try chunk_output.appendSlice(allocator, bind_arg);
+                            try chunk_output.appendSlice(allocator, if (min) "\");" else "\");\n");
+                            for (wlist.items) |wm| {
+                                const tmod = graph.getModule(@enumFromInt(wm)) orelse continue;
+                                const wn = try wrapperNamesFor(allocator, tmod, null);
+                                defer wn.deinit(allocator);
+                                try chunk_output.appendSlice(allocator, "const ");
+                                try chunk_output.appendSlice(allocator, wn.a);
+                                try chunk_output.appendSlice(allocator, if (min) "=function(){return require(\"" else " = function() { return require(\"");
+                                try chunk_output.appendSlice(allocator, bind_arg);
+                                try chunk_output.appendSlice(allocator, "\").");
+                                try chunk_output.appendSlice(allocator, wn.a);
+                                try chunk_output.appendSlice(allocator, if (min) ".apply(this,arguments)};" else ".apply(this, arguments); };\n");
+                            }
+                        } else {
+                            // esm: live binding 이라 named import 로 충분(순환도 안전).
+                            try chunk_output.appendSlice(allocator, if (min) "import{" else "import { ");
+                            for (wlist.items, 0..) |wm, wi| {
+                                const tmod = graph.getModule(@enumFromInt(wm)) orelse continue;
+                                const wn = try wrapperNamesFor(allocator, tmod, null);
+                                defer wn.deinit(allocator);
+                                try chunk_output.appendSlice(allocator, wn.a);
+                                if (wi + 1 < wlist.items.len)
+                                    try chunk_output.appendSlice(allocator, if (min) "," else ", ");
+                            }
+                            try chunk_output.appendSlice(allocator, if (min) "}from\"" else " } from \"");
+                            try chunk_output.appendSlice(allocator, bind_arg);
+                            try chunk_output.appendSlice(allocator, if (min) "\";" else "\";\n");
+                        }
+                        wrapper_import_emitted = true;
+                    }
+                }
+            }
+
             if (!pm_cjs_dep and pm_esm_wrap_dep_syms == null and symbols != null and symbols.?.items.len > 0) {
                 // 심볼 수준 import: import { a, b } from './chunk-xxx.js';
                 if (!options.minify_whitespace) {
@@ -844,9 +896,10 @@ pub fn emitChunks(
                 try chunk_output.appendSlice(allocator, sym_open);
                 try chunk_output.appendSlice(allocator, bind_arg);
                 try chunk_output.appendSlice(allocator, sym_close);
-            } else if (pm_wrapper_dep == null) {
+            } else if (pm_wrapper_dep == null and !wrapper_import_emitted) {
                 // 심볼 정보 없음 → side-effect (실행/등록 순서 보장용)
-                // ⚠️ 래퍼 분기가 이미 결합을 냈으면(preserve-modules) 여기서 또 내면 중복이다.
+                // ⚠️ 래퍼 분기(preserve-modules) 또는 #4541 wrapper named import 가 이미 결합을
+                // 냈으면 여기서 또 내면 중복이다.
                 const se_open = if (reg_split)
                     "__zntc_require(\""
                 else if (cjs_require)
@@ -1535,6 +1588,49 @@ pub fn emitChunks(
                     try chunk_output.appendSlice(allocator, " };\n");
                 } else {
                     try chunk_output.appendSlice(allocator, "};");
+                }
+            }
+        }
+
+        // (#4541) 다른 청크가 raw-require 한 이 청크의 CJS 썽크(require_X)를 export 한다.
+        // esm: `export { require_X };` / cjs: `exports.require_X = require_X;`. require_X 는 이 청크
+        // 본문에 `var require_X = __commonJS(...)` 로 이미 선언(모듈 region) → 여기선 참조만.
+        // canonical 이름(reserveWrapperNames 전역 유일)이라 소비자 import·본문 `require_X()` 와 일치.
+        // ⚠️ esm/cjs 만(reg_split 은 registry 모델, 후속). preserve-modules 는 #4524 담당 → 제외.
+        if (!reg_split and !options.preserve_modules and chunk.wrapper_cross_exports.count() > 0) {
+            const min = options.minify_whitespace;
+            const cjs_out = options.format == .cjs;
+            var wids: std.ArrayListUnmanaged(u32) = .empty;
+            defer wids.deinit(allocator);
+            var wit = chunk.wrapper_cross_exports.keyIterator();
+            while (wit.next()) |k| try wids.append(allocator, k.*);
+            std.mem.sort(u32, wids.items, {}, comptime std.sort.asc(u32));
+            for (wids.items) |wm| {
+                const tmod = graph.getModule(@enumFromInt(wm)) orelse continue;
+                // ⚠️ 공개명(canonical, 소비자 import 키)과 provider 청크의 **실제 로컬명**을 분리한다.
+                // --minify 는 provider 본문의 `var require_X = __commonJS(...)` 선언을 mangle(`r`)하는데
+                // (rename_table 은 청크별), 소비자는 canonical `require_X` 로 import·호출한다. 따라서
+                // provider 는 `export { <로컬 r> as require_X }`(esm) / `exports.require_X = r`(cjs)로
+                // 로컬→공개 aliasing 해야 3자(export·import·본문)가 일치한다.
+                const wn_local = try wrapperNamesFor(allocator, tmod, linker);
+                defer wn_local.deinit(allocator);
+                const wn_pub = try wrapperNamesFor(allocator, tmod, null);
+                defer wn_pub.deinit(allocator);
+                const same = std.mem.eql(u8, wn_local.a, wn_pub.a);
+                if (cjs_out) {
+                    try chunk_output.appendSlice(allocator, "exports.");
+                    try chunk_output.appendSlice(allocator, wn_pub.a);
+                    try chunk_output.appendSlice(allocator, if (min) "=" else " = ");
+                    try chunk_output.appendSlice(allocator, wn_local.a);
+                    try chunk_output.appendSlice(allocator, if (min) ";" else ";\n");
+                } else {
+                    try chunk_output.appendSlice(allocator, if (min) "export{" else "export { ");
+                    try chunk_output.appendSlice(allocator, wn_local.a);
+                    if (!same) {
+                        try chunk_output.appendSlice(allocator, " as ");
+                        try chunk_output.appendSlice(allocator, wn_pub.a);
+                    }
+                    try chunk_output.appendSlice(allocator, if (min) "};" else " };\n");
                 }
             }
         }

--- a/tests/integration/tests/split-cjs-cross-chunk.test.ts
+++ b/tests/integration/tests/split-cjs-cross-chunk.test.ts
@@ -103,6 +103,67 @@ describe('code-splitting 런타임 스모크', () => {
     }
   }
 
+  // (#4541) **raw `require("./x.cjs")`** 한 CJS 가 common chunk 에 안착하면, 소비자 청크가 그
+  // `require_x()` 썽크를 import 없이 참조했다(provider 는 export 안 함, 소비자는 side-effect import
+  // 만) → `ReferenceError: require_x is not defined`. import binding 이 없는 raw require 라 기존
+  // cross-chunk 심볼 기계가 못 봤다. 이제 provider 가 썽크를 export, 소비자가 import 한다
+  // (esbuild/rolldown 동형). 빌드 green·파싱 통과·실행만 실패라 node 로 돌려야만 잡힌다.
+  const RAW_REQUIRE_COMMON: Files = {
+    'shared.cjs': 'exports.s = function(){ return "SHARED"; };',
+    'a.js': 'const sh = require("./shared.cjs");\nexport const a = "A:" + sh.s();',
+    'b.js': 'const sh = require("./shared.cjs");\nexport const b = "B:" + sh.s();',
+    'entry.js':
+      'Promise.all([import("./a.js"), import("./b.js")]).then(([m1, m2]) =>\n' +
+      '  console.log("RESULT", m1.a, m2.b));',
+  };
+  for (const { name, minify } of MATRIX) {
+    for (const format of ['esm', 'cjs'] as const) {
+      test(`#4541 ${format}/${name}: raw require() 한 common-chunk CJS 썽크가 cross-chunk 노출된다`, async () => {
+        // 버그 시: ReferenceError: require_shared is not defined
+        expect(await buildAndRun(RAW_REQUIRE_COMMON, { minify, format })).toBe(
+          'RESULT A:SHARED B:SHARED',
+        );
+      });
+    }
+  }
+
+  // (#4541 후속, #4526 계열) cjs 소비자는 cross-chunk 썽크를 **구조분해하면 안 된다**
+  // (`const{require_X}=require(...)`는 로드 시점 스냅샷 → CJS↔CJS cross-chunk 순환에서 provider 의
+  // `exports.require_X` 미할당 시점을 박제 → TypeError). require_X 는 함수라 **호출 시점 조회
+  // (lazy forwarding)**로 지연 복원한다. ⚠️ 구조적 가드 — 순환은 청커가 상호의존 모듈을 같은
+  // 청크로 합쳐 재현이 불안정하므로, 방출된 소비자 청크가 forwarding(`.apply(this, arguments)`)을
+  // 쓰고 eager 구조분해(`const { require_`)를 안 쓰는지 직접 확인해 r0 revert 를 잡는다.
+  test('#4541 cjs: cross-chunk 썽크 소비자가 eager 구조분해 대신 lazy forwarding 을 쓴다', async () => {
+    const { dir, cleanup } = await createFixture(RAW_REQUIRE_COMMON);
+    try {
+      const outDir = join(dir, 'dist');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--splitting',
+        '--outdir',
+        outDir,
+        '--format=cjs',
+      ]);
+      expect(res.exitCode, `빌드 실패:\n${res.stderr}`).toBe(0);
+      // 소비자 청크(shared.cjs 를 raw-require 한 a/b) 를 찾는다.
+      const jsFiles = readdirSync(outDir).filter((f) => f.endsWith('.js'));
+      const consumer = jsFiles
+        .map((f) => readFileSync(join(outDir, f), 'utf8'))
+        .find((c) => c.includes('require_shared') && !c.includes('exports.require_shared'));
+      expect(consumer, '소비자 청크(require_shared 참조)를 못 찾음').toBeDefined();
+      // lazy forwarding: 호출 시점 조회 `require("...").require_shared.apply(...)`.
+      expect(consumer!).toContain('.apply(this, arguments)');
+      // eager 구조분해(로드 시점 스냅샷)를 쓰면 안 된다.
+      expect(consumer!).not.toContain('const { require_shared }');
+      // 그리고 실제로 실행돼야 한다.
+      const { stdout } = await runNode(join(outDir, 'entry.js'));
+      expect(stdout.trim()).toBe('RESULT A:SHARED B:SHARED');
+    } finally {
+      await cleanup();
+    }
+  });
+
   // (#4494) CJS 모듈이 export 멤버와 **같은 이름의 내부 심볼**을 가진 경우.
   // provider 는 `var <전역명> = require_lib().tag;` 를 청크 top-level 에 깔아야 하는데,
   // 예전엔 "이 이름의 로컬이 이미 있다"고 오판(그 로컬은 `__commonJS` 클로저 *안*의 `tag` 다)해


### PR DESCRIPTION
## 증상
`--splitting` 에서 raw `require("./x.cjs")` 로 **다른 청크**의 CJS 를 참조하면, 소비자 청크가 그 `require_X()` 썽크를 **import 없이** 참조 → provider 청크에만 있는 `require_X` = free variable → `ReferenceError: require_X is not defined`. 빌드 exit 0 · 파싱 통과 · **실행만** 실패.

```js
// a.js / b.js — 둘 다 raw require → shared.cjs 가 common chunk 로 분리
const sh = require("./shared.cjs");
export const a = "A:" + sh.s();
// entry.js: Promise.all([import("./a.js"), import("./b.js")]).then(...)
```

## 루트커즈
`computeCrossChunkLinks`(chunk.zig)는 cross-chunk 심볼을 **`import_bindings` 순회**로만 등록한다. raw `require()` 는 ImportBinding 이 없어(`kind=.require`) `require_X` 가 `exports_to`/`imports_from` 에 안 들어간다(chunk-level 의존 edge = side-effect import 만). `import` 경로(#4494/#4522)는 provider 가 interop 값을 materialize+export 하지만 raw-require 는 그 경로를 안 탄다. wrapper 심볼(`require_X`, scope_id=.none)은 rename 풀에도 없어 심볼 기계가 구조적으로 못 본다.

## 수정 — esbuild/rolldown 동형(썽크 export/import)
raw `require` 는 **lazy**(호출 시점 평가)라 import-path 의 eager materialize(`default$X=require_X()`)를 재사용하지 않고 썽크 자체를 넘긴다.
- `Chunk.wrapper_cross_exports`/`wrapper_cross_imports` 필드 추가 — export명 키인 기존 기계와 분리.
- `computeCrossChunkLinks` raw-require 루프: `kind==.require` + CJS 타겟 + 다른 청크면 provider 에 export 표시·소비자에 import 표시. (reset 루프에 clear 추가 — HMR re-link 멱등.)
- **provider emit**: `export { <로컬> as require_X }`(esm) / `exports.require_X = <로컬>`(cjs). ⚠️ `--minify` 는 provider 본문 선언을 mangle(`r`)하나 소비자는 canonical `require_X` 로 import·호출 → **로컬(mangled)→공개(canonical) aliasing** 으로 3자 일치.
- **소비자 emit**: esm 은 `import { require_X }`(live binding). cjs 는 **lazy forwarding**(`require("...");` + `const require_X = function(){ return require("...").require_X.apply(this,arguments); }`) — `const{require_X}=require(...)` 구조분해는 CJS↔CJS cross-chunk 순환에서 로드 시점 스냅샷(undefined 박제→TypeError) 위험이라 호출 시점 조회로 지연 복원(#4526 계열).
- `buildRequireRewrites` 는 `require_X()` 그대로(변경 불요).

## 범위
esm·cjs 포맷. **preserve-modules 는 #4524 가 자체 wrapper 기계 담당** → 게이트로 제외. **iife/umd/amd(reg_split)는 registry 모델이라 후속. ESM-wrap(.esm) raw require cross-chunk 도 후속**(이 PR 은 CJS require_X 만).

## 검증
- zig 6227/6227 · integration 4255 pass(known flake #3099/#3104 제외)
- split-cjs-cross-chunk 가드: #4541 esm/cjs × plain/minify 4종(node 실행) + cjs lazy-forwarding **구조적 가드**(`.apply(this,arguments)` 사용·eager 구조분해 부재 확인 → r0 revert 감지)
- 인접 splitting/preserve-modules 152 pass · effect/zod/three byte-identical
- code-review max 2라운드(cjs 순환 lazy forwarding·reset 멱등·구조적 가드 반영)

Closes #4541
