### PR TITLE
fix(bundler): #4542 manualChunks 로 relocate 된 wrapped entry 미호출

### DIFF
--- a/.changeset/manualchunks-entry-invoke.md
+++ b/.changeset/manualchunks-entry-invoke.md
@@ -1,0 +1,37 @@
+---
+"@zntc/core": patch
+---
+
+manualChunks 로 relocate 된 CJS/ESM-wrapped user entry 가 `--splitting` 에서 호출되지 않아 본문이 실행되지 않던 버그 수정 (#4542, #4537 하위케이스).
+
+## 증상
+`manualChunks` 로 user entry 모듈을 manual 청크로 relocate 하면 `var require_entry = __commonJS(...)` 선언만 남고 `require_entry();` 호출이 없어 entry 본문 미실행. `node manual-entry-*.js` 무출력.
+
+## 루트커즈
+청크 배정(chunk.zig:1163)은 **manualChunks 우선 정책**상 user entry 모듈을 manual 청크에 **의도적으로 그대로 둔다** → 그 manual 청크가 곧 그 entry 의 출력(node 가 실행하는 파일)이다. 그런데 #4537 의 entry-invoke 가 "entry 출력 청크"를 `chunk_is_user_entry`(= `chunk.kind == .entry_point`)라는 **프록시**로 판정한다. relocate 되면 청크 kind 가 `.manual` 이라 이 프록시가 실패 → 호출이 안 나온다. 즉 근본은 "entry 가 어느 청크에 있든 그 청크가 그 entry 의 출력"인데 emit 이 chunk.kind 프록시만 봐 놓친 것.
+
+## 수정
+`chunk.kind == .entry_point` 라는 **프록시** 대신 "이 청크가 **프로그램 entry 출력**(node 가 직접 실행)인가" 라는 근본 신호를 쓴다. 기존 `chunk_is_user_entry`(비-dynamic `.entry_point`) 에 relocate 목적지인 `.manual` 을 더한 것이 곧 그 신호 — 분류 규칙을 단일 소스로 재사용한다:
+
+```
+const chunk_is_entry_output = chunk_is_user_entry or chunk.kind == .manual;
+```
+
+그 출력 청크 안에서 `is_entry_point` 인 모듈(build_flow 가 user/emitted entry 에만 설정, **dynamic-import 대상은 false**)을 호출한다. 이렇게 하면:
+- **relocate 된 entry**(`.manual`) → 호출 ✓ (#4542)
+- **dynamic-import 대상 / plugin `emitFile` on-demand 청크**(dynamic `.entry_point`) → 제외 ✓
+- **common 청크** → 제외 ✓ (user entry 는 애초에 안 남음)
+- **user entry ∧ emitFile'd 동시**(both-case): `addDynamicEntry` 가 "이미 non-dynamic user-entry면 skip" → 단일 비-dynamic `.entry_point` 청크로 남음 → 호출 ✓ (정확히 1회)
+
+⚠️ on-demand 여부는 **청크** 단위 사실이라, 모듈 플래그 `is_emitted_chunk_entry` 로 제외하면 both-case(user entry 이면서 emitFile 된 모듈)를 **잘못 뺀다**. 그래서 제외를 청크 kind 로 한다. "entry 를 그것이 든 출력 청크에서 호출"이라는 #4537 규칙을 chunk.kind 무관하게 일반화한 것 — 방어 게이트 없이 근본 신호만 사용. reg_split(bootstrap)·preserve-modules(pm_entry_call) 는 각자 담당하므로 게이트 제외.
+
+## 범위 / 후속
+이 PR 은 **esm/cjs 경로만** 일반화한다. `/code-review max` 에서 같은 `chunk_is_user_entry` 프록시가 다른 emit site 에도 쓰임이 드러났고, 각자 별도 기계에 묶여 별도 수정이 필요하므로 형제 이슈로 분리:
+- **#4548 (reg_split)**: iife/umd/amd 의 invoke(1644)+bootstrap(1676) 도 같은 프록시 게이트 — relocate entry 무출력. factory registry(reg_ids)·federation bootstrapSpan 강결합 동반.
+- **#4549 (run_before_main)**: RBM polyfill(477/1021/1093) 도 같은 프록시 — relocate entry 가 polyfill 없이 실행. cross-chunk RBM import·closure 이관 필요. RN/Metro 전용·극드문 조합(#4542 이전엔 entry 미실행이라 가려져 있었음).
+
+⚠️ manualChunks 가 user entry 를 다른 entry 의 dep 와 **같은 청크로 묶으면** 그 청크 로드 시 entry 본문이 실행된다("자기 출력 청크에서 호출"의 일관된 결과, #4537 과 동일 성질) — 비정상 config 의 예측 가능한 귀결.
+
+검증: zig 통과 · manual-chunks #4542 relocate 가드(require_entry() 호출 + node 실행) · 인접 splitting/manualchunks/RN 218 pass. RN fixture 재커밋 금지 준수.
+
+Closes #4542

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -1708,20 +1708,42 @@ pub fn emitChunks(
         // 없어 entry 본문이 통째로 미실행이었다(#4537). 단일번들과 대칭으로 여기서 호출한다.
         // reg_split=1559, preserve-modules=pm_entry_call 이 각자 담당하므로 제외(이중호출 방지).
         // (__commonJS/__esm memoize 라 설령 중복돼도 본문은 1회지만, 이중 호출문 자체를 막는다.)
-        if (!reg_split and !options.preserve_modules and chunk_is_user_entry) {
-            if (entry_mod_idx) |ei| {
-                if (graph.getModule(@enumFromInt(ei))) |em| {
-                    // CJS-format 청크의 TLA(.esm+top-level await) entry 는 top-level await 가
-                    // 불가하므로 제외(reg_split 1547 과 동일 근거). ESM-format 청크는 top-level
-                    // await 가 합법이라 appendModuleCall 이 `await init_X()` 로 처리한다.
-                    const tla_cjs = options.format == .cjs and isTlaEsmModule(em);
-                    if (em.is_entry_point and em.wrap_kind.isWrapped() and !tla_cjs) {
-                        // 단일번들과 동일하게 `appendGuardedModuleCall` — entry_error_guard(RN/Metro)
-                        // 활성 시 `__zntc_guarded(require_X)` 로 wrap, 아니면 appendModuleCall 과 동등.
-                        // (표준 splitting entry 는 top-level 호출이라 단일번들이 가장 가까운 대응;
-                        // reg_split/dev_split 은 factory/bootstrap 자체 error 처리라 별개.)
-                        try parent.appendGuardedModuleCall(&chunk_output, allocator, em, options, if (linker) |l| &l.rename_table else null);
-                    }
+        //
+        // ⚠️ (#4542) 게이트를 `chunk_is_user_entry`(chunk.kind==.entry_point)라는 **프록시**가 아니라
+        // "이 청크가 **프로그램 entry 출력**(node 가 직접 실행)인가" 라는 근본 신호로 잡는다.
+        // manualChunks 로 user entry 를 manual 청크로 relocate 하면 그 manual 청크가 곧 그 entry 의
+        // 출력인데(chunk.zig:1163 이 manualChunks 우선으로 entry 를 거기 남긴다), 프록시가 `.manual`
+        // 이라 실패해 호출이 안 나왔다. "entry 를 그것이 든 출력 청크에서 호출"은 #4537 의 의미를
+        // chunk.kind 무관하게 일반화한 것이다.
+        //   - **프로그램 entry 출력 청크** = 비-dynamic `.entry_point`(node 가 실행) 또는 `.manual`
+        //     (relocate 된 entry 출력일 수 있음). dynamic `.entry_point`(dynamic-import 대상/plugin
+        //     `emitFile` on-demand 청크)와 `.common`(user entry 는 chunk.zig:1166 에서 evict)은 제외.
+        //     ⚠️ 제외를 **모듈** 플래그(is_emitted_chunk_entry)로 하면 user entry 이면서 동시에
+        //     emitFile 된 모듈을 잘못 뺀다 — on-demand 여부는 **청크** 단위 사실이다.
+        //   - user entry 는 `is_entry_point`(build_flow 가 user/emitted entry 에만 설정, dynamic-import
+        //     대상은 false)로 식별. reg_split(bootstrap)·preserve-modules(pm_entry_call)는 각자 담당→제외.
+        // ⚠️ manualChunks 가 한 청크에 user entry 를 다른 entry 의 dep 와 **묶으면** 그 청크 로드 시
+        // entry 본문이 실행된다("자기 출력 청크에서 호출"의 일관된 결과, #4537 과 동일 성질) — 비정상
+        // config 의 예측 가능한 귀결로 수용.
+        // ⚠️ 이 esm/cjs 경로만 일반화한다. 같은 `chunk_is_user_entry` 프록시가 reg_split(iife/umd/amd)
+        // invoke+bootstrap(1644/1676)과 run_before_main polyfill(477/1021/1093)에도 쓰여 relocate 시
+        // 동일 증상이나, 각자 factory registry(reg_ids)·federation bootstrapSpan·cross-chunk RBM import
+        // 기계에 묶여 별도 수정이 필요 → #4548(reg_split)·#4549(RBM) 후속.
+        // `chunk_is_user_entry`(341: 비-dynamic `.entry_point`) 에 relocate 목적지인 `.manual` 을
+        // 더한 것이 곧 "프로그램 entry 출력 청크" — 기존 신호를 재사용(분류 규칙 단일 소스).
+        const chunk_is_entry_output = chunk_is_user_entry or chunk.kind == .manual;
+        if (!reg_split and !options.preserve_modules and chunk_is_entry_output) {
+            for (sorted_mods) |mod_idx| {
+                const em = graph.getModule(mod_idx) orelse continue;
+                if (!em.is_entry_point) continue; // user/emitted entry (dynamic-import 대상은 false)
+                // CJS-format 청크의 TLA(.esm+top-level await) entry 는 top-level await 가 불가하므로
+                // 제외(reg_split TLA 제외 1651 과 동일 근거). ESM-format 은 합법이라 appendModuleCall 이
+                // `await init_X()` 로 처리한다.
+                const tla_cjs = options.format == .cjs and isTlaEsmModule(em);
+                if (em.wrap_kind.isWrapped() and !tla_cjs) {
+                    // 단일번들과 동일하게 `appendGuardedModuleCall` — entry_error_guard(RN/Metro)
+                    // 활성 시 `__zntc_guarded(require_X)` 로 wrap, 아니면 appendModuleCall 과 동등.
+                    try parent.appendGuardedModuleCall(&chunk_output, allocator, em, options, if (linker) |l| &l.rename_table else null);
                 }
             }
         }

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
 import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
 import { createFixture, writeOutputs, runNode } from './helpers';
 import { init, close, build } from '../../../packages/core/index';
 import type { ManualChunksModuleInfo } from '../../../packages/core/index';
@@ -1164,5 +1165,45 @@ describe('manualChunks NAPI bridge', () => {
     // ReferenceError 없이 실행, .local(pv) 정상, 타-청크 re-export(rx)는 제외
     const { stdout } = await runNode(join(fixture.dir, entry.path));
     expect(stdout).toBe('PV PV undefined');
+  });
+
+  // (#4542) manualChunks 로 **CJS-wrapped user entry** 를 manual 청크로 relocate 하면, 그 청크는
+  // `.manual` kind 라 `chunk_is_user_entry`=false → #4537 의 entry-invoke 게이트가 안 걸려
+  // `var require_entry = __commonJS(...)` 선언만 남고 `require_entry()` 호출이 없어 본문 미실행이었다.
+  // 이제 게이트를 "청크에 든 is_entry_point 모듈"로 잡아 relocate 된 entry 도 호출한다.
+  test('#4542 manualChunks 로 relocate 된 CJS-wrapped entry 가 --splitting 에서 실행된다', async () => {
+    const fixture = await createFixture({
+      'entry.js':
+        'function load(){ return require("./legacy.cjs").foo(); }\n' +
+        'import("./other.js").then((m) => console.log(load() + m.val));',
+      'legacy.cjs': 'exports.foo = function(){ return "FOO"; };',
+      'other.js': 'export const val = "OTHER";',
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.js')],
+      rootDir: fixture.dir,
+      platform: 'node',
+      splitting: true,
+      format: 'esm',
+      manualChunks: (id) => (id.endsWith('entry.js') ? 'manual-entry' : null),
+    });
+    expect(result.errors ?? []).toHaveLength(0);
+    const outs = result.outputFiles!;
+    // 비-vacuity: entry 모듈이 실제로 manual 청크로 relocate 됐는지(`__commonJS` 래핑 + manual 경로).
+    const entryChunk = outs.find(
+      (o) => o.text.includes('require_entry') && o.text.includes('__commonJS'),
+    );
+    expect(entryChunk, 'entry 모듈이 담긴 청크를 못 찾음').toBeDefined();
+    expect(entryChunk!.path).toContain('manual-entry');
+    // 핵심: require_entry() 호출이 있어야 한다(버그: 선언만 남고 미호출).
+    expect(entryChunk!.text).toContain('require_entry()');
+    // 실제 실행 — 버그 시 무출력.
+    const dist = join(fixture.dir, 'dist');
+    writeOutputs(dist, outs);
+    writeFileSync(join(dist, 'package.json'), JSON.stringify({ type: 'module' }));
+    const entryFile = entryChunk!.path.split('/').pop()!;
+    const { stdout } = await runNode(join(dist, entryFile));
+    expect(stdout.trim()).toBe('FOOOTHER');
   });
 });


### PR DESCRIPTION
## 요약
`manualChunks` 로 relocate 된 CJS/ESM-wrapped user entry 가 `--splitting` 에서 **호출되지 않아 본문이 미실행**되던 버그를 근본 수정한다 (#4542, #4537 하위케이스).

## 증상
`manualChunks` 로 user entry 모듈을 manual 청크로 relocate 하면 `var require_entry = __commonJS(...)` **선언만** 남고 `require_entry();` 호출이 없어 entry 본문 미실행. `node manual-entry-*.js` 무출력. 빌드 exit 0 · 파싱 통과 · 실행만 실패.

## 루트커즈
청크 배정(`chunk.zig:1163`)은 **manualChunks 우선 정책**상 user entry 모듈을 manual 청크에 **의도적으로 그대로 둔다** → 그 manual 청크가 곧 그 entry 의 출력(node 가 실행하는 파일)이다. 그런데 #4537 의 entry-invoke 가 "entry 출력 청크"를 `chunk_is_user_entry`(= 비-dynamic `.entry_point`)라는 **프록시**로 판정한다. relocate 되면 청크 kind 가 `.manual` 이라 프록시가 실패 → 호출이 안 나온다. 근본은 "entry 가 어느 청크에 있든 그 청크가 그 entry 의 출력"인데 emit 이 chunk.kind 프록시만 본 것.

## 수정
프록시 대신 **"이 청크가 프로그램 entry 출력인가"** 라는 근본 신호를 쓴다. 기존 `chunk_is_user_entry`(비-dynamic `.entry_point`) 에 relocate 목적지 `.manual` 을 더한 것이 그 신호 — 분류 규칙 단일 소스 재사용:

```zig
const chunk_is_entry_output = chunk_is_user_entry or chunk.kind == .manual;
```

그 출력 청크 안에서 `is_entry_point` 모듈(build_flow 가 user/emitted entry 에만 설정, **dynamic-import 대상은 false**)을 `appendGuardedModuleCall` 로 호출한다. 케이스별:
- **relocate 된 entry**(`.manual`) → 호출 ✓ (#4542 본 수정)
- **dynamic-import 대상 / plugin `emitFile` on-demand 청크**(dynamic `.entry_point`) → 제외 ✓
- **common 청크** → 제외 ✓ (user entry 는 `chunk.zig:1166` 에서 evict)
- **user entry ∧ emitFile'd 동시**(both-case): `addDynamicEntry` 가 "이미 non-dynamic user-entry면 skip" → 단일 비-dynamic `.entry_point` 청크로 남음 → 호출 ✓ (정확히 1회)

⚠️ on-demand 여부는 **청크** 단위 사실이라, 모듈 플래그 `is_emitted_chunk_entry` 로 제외하면 both-case 를 잘못 뺀다 → 제외를 청크 kind 로 한다. 방어 게이트 없이 근본 신호만 사용.

## 범위 / 후속 (`/code-review max` 반영)
이 PR 은 **esm/cjs 경로만** 일반화한다. 리뷰에서 같은 `chunk_is_user_entry` 프록시가 다른 emit site 에도 쓰임이 드러났고, 각자 별도 기계에 묶여 별도 수정이 필요하므로 형제 이슈로 분리:
- **#4548 (reg_split)**: iife/umd/amd 의 invoke(1644)+bootstrap(1676) 도 같은 프록시 게이트 — relocate entry 무출력. factory registry(`reg_ids`)·federation `bootstrapSpan` 강결합 동반.
- **#4549 (run_before_main)**: RBM polyfill(477/1021/1093) 도 같은 프록시 — relocate entry 가 polyfill 없이 실행. cross-chunk RBM import·closure 이관 필요. RN/Metro 전용·극드문 조합(#4542 이전엔 entry 미실행이라 가려짐).

리뷰 기타:
- **both-case eager invoke 우려 → REFUTED**: 순수 emitFile'd 모듈은 `is_dynamic=true` 라 manual 청크 배정에서 제외(`chunk.zig:795`/`912`)되고 자기 dynamic 청크로 가므로, 게이트가 정확히 제외한다.
- **cleanup**: 중복 `chunk.kind` switch 를 기존 `chunk_is_user_entry` 재사용으로 제거.
- ⚠️ manualChunks 가 user entry 를 다른 entry 의 dep 와 **같은 청크로 묶으면** 그 청크 로드 시 entry 본문이 실행된다("자기 출력 청크에서 호출"의 일관된 결과) — 비정상 config 의 예측 가능한 귀결로 수용.

## 검증
- `zig build` / `zig build napi` / `zig build test` (exit 0)
- manual-chunks #4542 relocate 가드(`require_entry()` 호출 + `node` 실행) + 인접 splitting(cjs/iife/umd-amd/split-cjs-cross-chunk) 99 pass
- 통합 4255 pass (2 known flake: #3099 watch RSS·#3104 Hermes hermesc, 무관)
- `/code-review max` (finder 6 · candidate 16 · CONFIRMED correctness 3건 중 esm/cjs 본 수정 완결, reg_split·RBM 후속 분리, both-case refuted, cleanup 반영)

Zig 초보자용 설명: `chunk.kind` 는 각 출력 청크의 종류를 나타내는 union(`.entry_point`/`.common`/`.manual`). 기존 코드는 "entry 청크인가?"를 kind 가 `.entry_point` 인지로만 판단했는데, manualChunks 로 entry 가 `.manual` 청크로 옮겨지면 이 판단이 틀린다. 그래서 "이 청크가 프로그램이 실행하는 출력 파일인가"라는 실제 의미(비-dynamic entry_point **또는** manual)로 판단하도록 바꿨다.

Closes #4542