### PR TITLE
refactor(bundler): #4553 manualChunks 가 user entry 를 relocate 하지 않음 (relocate 버그 계열 근본 제거)

### DIFF
--- a/.changeset/no-entry-relocation.md
+++ b/.changeset/no-entry-relocation.md
@@ -1,0 +1,34 @@
+---
+"@zntc/core": patch
+---
+
+`manualChunks` 가 user entry 모듈을 manual 청크로 **relocate 하지 않도록** 변경 — user entry 는 항상 자기 entry_point 청크에 유지된다(rollup/esbuild 불변식). `--splitting` + `manualChunks` 로 entry 를 옮기면 실행이 깨지던 버그 계열(#4542/#4548/#4549/#4551)을 **근본 원인**에서 제거.
+
+## 배경 — 왜 화수분이었나
+예전엔 `manualChunks` 패턴이 entry 를 매칭하면 그 entry **모듈 자체**를 manual 청크 안에 넣었다(chunk.zig 의 "manual 우선" 정책). 그런데 emit 파이프라인의 **십수 개 site** 가 "user entry 는 자기 `.entry_point` 청크에 산다"는 불변식(`chunk_is_user_entry` / `entry_mod_idx`)에 의존한다: 표준 entry-invoke, reg_split bootstrap·보편 wrapper, `"use client"` directive 호이스팅, `run_before_main` polyfill, dev HMR runtime, dev_split 선-init… entry 를 옮기면 이 전제를 쓰는 모든 곳이 하나씩 깨졌고, 파이프라인 전역에 흩어져 있어 **고칠수록 다른 코너에서 새 버그가 나왔다**(리뷰 라운드마다 서로 다른 서브시스템). rollup/esbuild 는 애초에 entry 를 relocate 하지 않아 이 버그 클래스가 존재하지 않는다.
+
+## 수정 — entry 는 옮기지 않는다
+chunk.zig 의 manual 청크 배정에서 **user(비-dynamic) entry 를 제외**한다 — dynamic import 대상(#1848/#1849)이 이미 제외되는 것과 정확히 같은 방식:
+- **manual seed 수집**(resolver·record 경로): user entry 는 seed 로 안 넣는다. resolver 함수는 **여전히 호출**해 `getModuleInfo` 등 inspection hook 부작용은 보존하되, entry 의 배정 결과만 무시한다.
+- **Phase 2.5 BFS 전파**: user entry 에는 manual bit 를 안 세운다(vendor seed 의 transitive dep 로 도달해도 차단, entry 를 통한 dep 전파도 중단).
+- **Phase 4 강제 이동**: user entry 는 위 seed/전파에서 manual bit 를 못 받으므로 애초에 manual 청크에 배정되지 않는다 → Phase 4 에서 자기 entry_point 청크로 이동. (Phase 4 의 "manual 이면 그대로 유지" 예외는 **유지** — 이제 그건 dynamic import 대상이 manual seed 의 static dep 로 전파돼 흡수된 경우만 보호. 그걸 도로 빼내면 cross-chunk ReferenceError.)
+- **warn**: `manualChunks` 가 entry 를 매칭하면 "entry 는 relocate 되지 않고 자기 청크에 유지됩니다" 경고(rollup 관례).
+
+matched 된 **non-entry** 모듈은 종전대로 manual 청크로 간다. entry 만 매칭한 manual 청크는 비어서 생성되지 않는다.
+
+## 효과
+- `--format esm|cjs|iife|umd|amd --splitting` + `manualChunks` 가 entry 를 매칭해도 entry 는 표준 경로로 정상 실행(무출력/SyntaxError 없음).
+- #4542(esm/cjs relocate 미실행), #4548(reg_split relocate 미실행), #4549(RBM 미emit), #4551(umd export 값) 이 **전부 해소** — entry 가 안 움직이니 인프라가 흩어질 일이 없다. #4552(reg_split RBM cross-chunk ESM import)는 relocate 와 무관한 pre-existing 이라 별도.
+- #4542 가 도입했던 emit-side 일반화(`chunk_is_entry_output` +manual 스캔)는 이제 불필요 → `chunk_is_user_entry` 로 원복(both-case 처리 위한 is_entry_point 스캔만 유지).
+
+## 참조 번들러
+rollup/esbuild 모두 `manualChunks`/`splitting` 에서 entry 모듈을 relocate 하지 않는다(entry 는 항상 자기 출력 파일). 이 변경으로 zntc 도 동일 불변식을 따른다.
+
+검증: zig test(chunk_test #4553 유닛 가드 + 전체) · manual-chunks/splitting/reg_split/MF integration · esm/cjs/iife/umd/amd × (entry-only 매칭 / entry+vendor 매칭) `node` 실행 · 통합 4255 pass.
+
+(#4542 는 PR #4550 으로 이미 close — 이 변경은 그 emit-side 접근을 원복하고 근본을 chunk.zig 로 옮긴다.)
+
+Closes #4553
+Closes #4548
+Closes #4549
+Closes #4551

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -558,6 +558,20 @@ const EntryInfo = struct {
 /// shaker가 null이 아니면 tree-shaking 결과를 반영하여 미포함 모듈을 스킵한다.
 /// manual chunk 이름을 slot index 로 매핑. 이미 있으면 기존 slot 반환, 없으면 새 slot 생성.
 /// record entries + resolver 동적 결과의 dedup 통합 지점.
+/// (#4553) manualChunks 가 user entry 를 매칭했을 때 1회 경고 — entry 는 relocate 되지 않고 자기
+/// 청크에 유지된다(rollup/esbuild 동일). `warned` 로 entry 당 중복 emit 을 막는다.
+fn warnManualChunksEntry(
+    warned: *std.AutoHashMapUnmanaged(u32, void),
+    allocator: std.mem.Allocator,
+    mi: u32,
+    entry_path: []const u8,
+    chunk_name: []const u8,
+) !void {
+    const gop = try warned.getOrPut(allocator, mi);
+    if (gop.found_existing) return;
+    std.log.warn("zntc: manualChunks 가 entry '{s}' 를 청크 '{s}' 로 지정했으나, entry 는 relocate 되지 않고 자기 청크에 유지됩니다 (rollup/esbuild 동일).", .{ entry_path, chunk_name });
+}
+
 fn ensureNameSlot(
     name_to_slot: *std.StringHashMapUnmanaged(usize),
     effective_names: *std.ArrayList([]const u8),
@@ -780,6 +794,21 @@ pub fn generateChunks(
         if (e.is_dynamic) try dynamic_entry_modules.put(allocator, @intFromEnum(e.module_idx), {});
     }
 
+    // (#4553) user(비-dynamic) entry 모듈은 manual 청크에서 제외 — dynamic import 대상과 동일 정책.
+    // user entry 는 **항상 자기 entry_point 청크**에 있어야 한다(rollup/esbuild 불변식): entry 실행에
+    // 딸린 인프라(bootstrap·보편 wrapper·"use client" 호이스팅·run_before_main·HMR runtime·dev_split
+    // 선-init)가 전부 "entry 는 자기 청크에 산다"는 전제에 묶여 있어, manualChunks 로 entry 를 옮기면
+    // 그 전제를 쓰는 emit site 전부가 깨진다(#4542/#4548/#4549/#4551 계열). manualChunks 로 entry 이동
+    // 은 rollup/esbuild 도 지원하지 않는다 — entry 는 옮기지 않고 매칭 시 warn(아래).
+    var user_entry_modules: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer user_entry_modules.deinit(allocator);
+    for (entries.items) |e| {
+        if (!e.is_dynamic) try user_entry_modules.put(allocator, @intFromEnum(e.module_idx), {});
+    }
+    // 같은 entry 를 resolver·record 양쪽이 매칭해도 warn 은 entry 당 1회만 (이중 emit 방지).
+    var warned_manual_entries: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer warned_manual_entries.deinit(allocator);
+
     // Resolver 결과 미리 수집 — 모듈당 1회 호출. NAPI TSFN 경로에서도 재호출 없음.
     // resolver 없으면 배열 할당 자체 skip (빌드당 module_count × 16B 절약).
     var resolver_assignments: ?[]?usize = null;
@@ -794,6 +823,13 @@ pub fn generateChunks(
             if (m.is_external) continue;
             if (dynamic_entry_modules.contains(@intCast(mi))) continue;
             if (fn_ptr(manual_resolver_ctx, m.path, @ptrCast(graph))) |chunk_name| {
+                // (#4553) user entry 는 manual 로 안 옮긴다 — resolver 는 **호출하되**(getModuleInfo
+                // 등 hook 부작용 보존) 배정 결과만 무시하고 warn. resolver 를 아예 안 부르면 inspection
+                // hook 을 쓰는 소비자가 깨진다.
+                if (user_entry_modules.contains(@intCast(mi))) {
+                    try warnManualChunksEntry(&warned_manual_entries, allocator, @intCast(mi), m.path, chunk_name);
+                    continue;
+                }
                 ra[mi] = try ensureNameSlot(&name_to_slot, &effective_names, allocator, chunk_name);
             }
         }
@@ -916,9 +952,19 @@ pub fn generateChunks(
                     continue;
                 }
             }
-            const idx = types.ManualChunkEntry.lookup(manual_chunks, m.path) orelse continue;
-            // record name 의 slot index (effective_names 병합으로 record 가 먼저 등록됨).
-            try manual_seeds[idx].append(allocator, ModuleIndex.fromUsize(mi));
+            const rec_idx = types.ManualChunkEntry.lookup(manual_chunks, m.path) orelse continue;
+            // ⚠️ `lookup` 은 **raw record index** 를 준다. 중복 이름 record(예: 두 pattern group 을
+            // 같은 청크명으로)는 `ensureNameSlot` 이 한 slot 으로 dedupe 하므로 raw index 가
+            // manual_count 를 넘을 수 있다 → `manual_seeds[idx]`/`effective_names[idx]` OOB. name 으로
+            // deduped slot 을 되찾아 쓴다.
+            const slot = name_to_slot.get(manual_chunks[rec_idx].name) orelse continue;
+            // (#4553) user entry 는 pattern 매칭돼도 manual 로 안 옮긴다 — 배정 무시 + warn.
+            // (resolver 경로는 위에서 처리 — ra[mi] 가 null 이라 여기까지 오는 건 record pattern.)
+            if (user_entry_modules.contains(@intCast(mi))) {
+                try warnManualChunksEntry(&warned_manual_entries, allocator, @intCast(mi), m.path, effective_names.items[slot]);
+                continue;
+            }
+            try manual_seeds[slot].append(allocator, ModuleIndex.fromUsize(mi));
         }
     }
 
@@ -1008,6 +1054,10 @@ pub fn generateChunks(
                 const mi = @intFromEnum(mod_idx);
                 if (m.is_external) continue;
                 if (splitting_info[mi].hasBit(manual_bit)) continue;
+                // (#4553) user entry 는 manual bit 를 받지 않는다 — seed 로 안 걸러졌어도(vendor seed 의
+                // transitive dep 로 도달) 여기서 막아 entry 가 manual 청크로 빨려가지 않게 한다. entry 를
+                // 통해 dep 로 전파도 중단(entry 의 exclusive dep 는 entry 청크에 남음).
+                if (user_entry_modules.contains(@intCast(mi))) continue;
                 // 다른 slot 의 seed 면 skip — 그쪽에서 처리됨
                 if (module_primary_slot[mi]) |other| {
                     if (other != i) continue;
@@ -1151,7 +1201,6 @@ pub fn generateChunks(
 
     // 엔트리 모듈은 반드시 자신의 엔트리 청크에 할당되어야 함.
     // Phase 3에서 공통 청크에 배정되었을 수 있으므로, 강제로 엔트리 청크로 이동.
-    // 단, manual chunk 에 배정된 경우는 manual 우선 정책이라 그대로 유지.
     for (entries.items, 0..) |entry, ci| {
         const chunk_idx: ChunkIndex = @enumFromInt(@as(u32, @intCast(ci)));
         const current = chunk_graph.getModuleChunk(entry.module_idx);
@@ -1160,6 +1209,11 @@ pub fn generateChunks(
             chunk_graph.assignModuleToChunk(entry.module_idx, chunk_idx);
             try chunk_graph.getChunkMut(chunk_idx).addModule(allocator, entry.module_idx);
         } else if (current != chunk_idx) {
+            // manual chunk 에 있으면 그대로 유지. (#4553) **user entry** 는 위 seed/BFS 에서 이미
+            // manual 제외라 여기 걸리지 않는다 — 이 예외가 지금 보호하는 건 **dynamic import 대상**이
+            // manual seed 의 static dep 로 Phase 2.5 전파돼 manual 청크에 흡수된 경우다(seed 는 dynamic
+            // 을 빼지만 전파는 안 뺌 — 기존 동작). 그걸 자기 dynamic 청크로 도로 빼내면 manual 청크의
+            // static import 가 cross-chunk 로 바뀌며 미노출 심볼 ReferenceError.
             if (chunk_graph.getChunk(current).kind == .manual) continue;
             // 공통 청크에 잘못 배정됨 → 이전 청크에서 제거 후 엔트리 청크로 이동
             const old_chunk = chunk_graph.getChunkMut(current);

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -1294,6 +1294,71 @@ test "generateChunks: external 가 manual pattern 매칭돼도 manual chunk 안 
     try std.testing.expectEqual(@as(usize, 1), cg.chunks.items.len);
 }
 
+test "generateChunks: (#4553) manualChunks 매칭돼도 user entry 는 자기 entry_point 청크 유지" {
+    // Option A: user entry 는 manual 청크로 relocate 되지 않는다(rollup/esbuild 불변식). 패턴이
+    // entry 와 non-entry 를 모두 매칭해도, entry 는 자기 entry_point 청크에 남고 non-entry(lib)만
+    // manual 청크로 간다. (entry-in-manual 이면 entry 실행 인프라가 흩어져 깨지던 #4542/#4548 계열
+    // 화수분의 근원 제거.)
+    const alloc = std.testing.allocator;
+
+    var modules: [2]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "lib.ts"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1)); // entry → lib (static)
+
+    // 패턴이 entry 와 lib 를 **모두** 매칭.
+    const manual_entries = [_]types.ManualChunkEntry{.{ .name = "grp", .patterns = &.{ "entry", "lib" } }};
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, .{ .manual_chunks = &manual_entries });
+    defer cg.deinit();
+
+    const entry_ci = cg.getModuleChunk(@enumFromInt(0));
+    const lib_ci = cg.getModuleChunk(@enumFromInt(1));
+    try std.testing.expect(!entry_ci.isNone());
+    try std.testing.expect(!lib_ci.isNone());
+    try std.testing.expect(entry_ci != lib_ci); // 서로 다른 청크
+    // 핵심: entry 는 relocate 안 됨(자기 entry_point 청크), lib 만 manual.
+    try std.testing.expect(cg.getChunk(entry_ci).kind == .entry_point);
+    try std.testing.expect(cg.getChunk(lib_ci).kind == .manual);
+}
+
+test "generateChunks: (#4553 code-review) 중복 이름 record 는 crash 없이 한 청크로 병합" {
+    // 두 pattern group 을 같은 청크명으로 지정하는 건 합법. `ManualChunkEntry.lookup` 이 raw record
+    // index 를 반환하는데 ensureNameSlot 이 이름을 한 slot 으로 dedupe → raw index(=1)로
+    // manual_seeds/effective_names(len=1)를 인덱싱하면 OOB panic 이었다(pre-existing). name→slot
+    // 매핑으로 수정. react·lodash 둘 다 'vendor' 한 청크로.
+    const alloc = std.testing.allocator;
+
+    var modules: [3]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "react.ts"),
+        makeTestModule(alloc, 2, "lodash.ts"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1));
+    try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(2));
+
+    // 같은 이름 'vendor' 를 두 record 로 — dedupe 되어 slot 1개.
+    const manual_entries = [_]types.ManualChunkEntry{
+        .{ .name = "vendor", .patterns = &.{"react"} },
+        .{ .name = "vendor", .patterns = &.{"lodash"} },
+    };
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, .{ .manual_chunks = &manual_entries });
+    defer cg.deinit();
+
+    // crash 없이: react·lodash 는 같은 'vendor' manual 청크로 병합.
+    const react_ci = cg.getModuleChunk(@enumFromInt(1));
+    const lodash_ci = cg.getModuleChunk(@enumFromInt(2));
+    try std.testing.expect(!react_ci.isNone());
+    try std.testing.expect(react_ci == lodash_ci); // 두 record 가 한 청크로
+    try std.testing.expect(cg.getChunk(react_ci).kind == .manual);
+}
+
 // ============================================================
 // (#4494) 직접 CJS import 의 cross-chunk 심볼 등록
 // ============================================================

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -1709,35 +1709,19 @@ pub fn emitChunks(
         // reg_split=1559, preserve-modules=pm_entry_call 이 각자 담당하므로 제외(이중호출 방지).
         // (__commonJS/__esm memoize 라 설령 중복돼도 본문은 1회지만, 이중 호출문 자체를 막는다.)
         //
-        // ⚠️ (#4542) 게이트를 `chunk_is_user_entry`(chunk.kind==.entry_point)라는 **프록시**가 아니라
-        // "이 청크가 **프로그램 entry 출력**(node 가 직접 실행)인가" 라는 근본 신호로 잡는다.
-        // manualChunks 로 user entry 를 manual 청크로 relocate 하면 그 manual 청크가 곧 그 entry 의
-        // 출력인데(chunk.zig:1163 이 manualChunks 우선으로 entry 를 거기 남긴다), 프록시가 `.manual`
-        // 이라 실패해 호출이 안 나왔다. "entry 를 그것이 든 출력 청크에서 호출"은 #4537 의 의미를
-        // chunk.kind 무관하게 일반화한 것이다.
-        //   - **프로그램 entry 출력 청크** = 비-dynamic `.entry_point`(node 가 실행) 또는 `.manual`
-        //     (relocate 된 entry 출력일 수 있음). dynamic `.entry_point`(dynamic-import 대상/plugin
-        //     `emitFile` on-demand 청크)와 `.common`(user entry 는 chunk.zig:1166 에서 evict)은 제외.
-        //     ⚠️ 제외를 **모듈** 플래그(is_emitted_chunk_entry)로 하면 user entry 이면서 동시에
-        //     emitFile 된 모듈을 잘못 뺀다 — on-demand 여부는 **청크** 단위 사실이다.
-        //   - user entry 는 `is_entry_point`(build_flow 가 user/emitted entry 에만 설정, dynamic-import
-        //     대상은 false)로 식별. reg_split(bootstrap)·preserve-modules(pm_entry_call)는 각자 담당→제외.
-        // ⚠️ manualChunks 가 한 청크에 user entry 를 다른 entry 의 dep 와 **묶으면** 그 청크 로드 시
-        // entry 본문이 실행된다("자기 출력 청크에서 호출"의 일관된 결과, #4537 과 동일 성질) — 비정상
-        // config 의 예측 가능한 귀결로 수용.
-        // ⚠️ 이 esm/cjs 경로만 일반화한다. 같은 `chunk_is_user_entry` 프록시가 reg_split(iife/umd/amd)
-        // invoke+bootstrap(1644/1676)과 run_before_main polyfill(477/1021/1093)에도 쓰여 relocate 시
-        // 동일 증상이나, 각자 factory registry(reg_ids)·federation bootstrapSpan·cross-chunk RBM import
-        // 기계에 묶여 별도 수정이 필요 → #4548(reg_split)·#4549(RBM) 후속.
-        // `chunk_is_user_entry`(341: 비-dynamic `.entry_point`) 에 relocate 목적지인 `.manual` 을
-        // 더한 것이 곧 "프로그램 entry 출력 청크" — 기존 신호를 재사용(분류 규칙 단일 소스).
-        const chunk_is_entry_output = chunk_is_user_entry or chunk.kind == .manual;
-        if (!reg_split and !options.preserve_modules and chunk_is_entry_output) {
+        // 게이트는 `chunk_is_user_entry`(비-dynamic `.entry_point`). (#4553) user entry 는 항상 자기
+        // entry_point 청크에 있다(manualChunks 로도 relocate 안 됨 — chunk.zig 가 manual 청크에서 user
+        // entry 제외) → `.manual`/`.common` 은 user entry 를 담지 않으므로 여기서 볼 필요가 없다.
+        // 청크 내 `is_entry_point` 모듈을 스캔해 호출한다 — user entry 이면서 동시에 plugin `emitFile`
+        // 된 both-case(같은 non-dynamic entry_point 청크에 공존)도 정확히 1회 호출. dynamic-import
+        // 대상은 `is_entry_point=false`(build_flow)라 자동 제외. reg_split(bootstrap)·preserve-modules
+        // (pm_entry_call)는 각자 담당하므로 게이트 제외.
+        if (!reg_split and !options.preserve_modules and chunk_is_user_entry) {
             for (sorted_mods) |mod_idx| {
                 const em = graph.getModule(mod_idx) orelse continue;
                 if (!em.is_entry_point) continue; // user/emitted entry (dynamic-import 대상은 false)
                 // CJS-format 청크의 TLA(.esm+top-level await) entry 는 top-level await 가 불가하므로
-                // 제외(reg_split TLA 제외 1651 과 동일 근거). ESM-format 은 합법이라 appendModuleCall 이
+                // 제외(reg_split TLA 제외와 동일 근거). ESM-format 은 합법이라 appendModuleCall 이
                 // `await init_X()` 로 처리한다.
                 const tla_cjs = options.format == .cjs and isTlaEsmModule(em);
                 if (em.wrap_kind.isWrapped() and !tla_cjs) {

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -1105,7 +1105,12 @@ describe('manualChunks NAPI bridge', () => {
   // 미재작성된 raw specifier 로 남아 런타임 ERR_MODULE_NOT_FOUND (별도
   // 파일 없음). same-chunk 동적 import 는 inline_dynamic_imports 무관 항상
   // namespace 스냅샷으로 재작성돼야 한다.
-  test('버그픽스: manualChunks 병합된 동적 import 대상은 namespace 스냅샷으로 재작성', async () => {
+  // (#4553) entry 가 page 를 static+dynamic 둘 다 import. manualChunks 가 page+index 를 매칭해도
+  // entry(index)는 자기 청크에 남고(Option A), dynamic import 는 실제 cross-chunk 로드로 재작성된다.
+  // (예전엔 entry 가 'main' 으로 relocate 되며 dynamic 대상이 같은 청크로 병합→snapshot 이었는데,
+  //  그 병합은 entry-relocation 파생 동작이라 제거. snapshot 재작성 기능 자체는 inline-dynamic-imports
+  //  / bundle-dynamic-import 테스트가 커버.)
+  test('#4553 manualChunks 가 entry 매칭해도 entry 는 분리 + dynamic import 정상', async () => {
     const fixture = await createFixture({
       'page.ts': `export function fp(){ return "FP"; }\nexport const pv = "PV";`,
       'index.ts':
@@ -1121,21 +1126,22 @@ describe('manualChunks NAPI bridge', () => {
       manualChunks: (id: string) => (id.includes('page') || id.includes('index') ? 'main' : null),
     });
     const outs = result.outputFiles!;
-    const entry = outs.find((o) => /main|index/.test(o.path) && o.path.endsWith('.js'))!;
+    const entry = outs.find((o) => o.text.includes('main()') && o.path.endsWith('.js'))!;
     expect(entry).toBeDefined();
-    // raw `import("./page")` (확장자/파일 없는 source specifier) 가 남으면 안 됨
+    // Option A: entry 는 manual 'main' 청크로 relocate 되지 않는다.
+    expect(entry.path).not.toContain('main-');
+    // raw `import("./page")` (확장자/파일 없는 source specifier) 가 남으면 안 됨 — 실제 청크 경로로 재작성.
     expect(entry.text).not.toMatch(/import\(["']\.\/page["']\)/);
-    expect(entry.text).toContain('Promise.resolve().then(');
     writeOutputs(fixture.dir, outs);
     const { stdout } = await runNode(join(fixture.dir, entry.path));
     expect(stdout).toBe('FP PV FP');
   });
 
-  // /simplify #2c 가드: 병합된 동적 대상이 *타 청크* 심볼을 re-export 하면
-  // namespace 스냅샷에 넣을 수 없다(이 청크에 로컬 식별자 미바인딩 →
-  // ReferenceError). re-export 계열은 스냅샷에서 제외(문서화된 한계) —
-  // .local export 는 정상, 크래시 없음.
-  test('버그픽스: 병합된 동적 대상의 타-청크 re-export 는 크래시 없이 제외(.local 정상)', async () => {
+  // (#4553) entry 가 dynamic import 하는 page 가 타 청크(inner)의 심볼을 re-export 하는 경우.
+  // Option A: entry(index)는 자기 청크에 남고, dynamic import 는 실제 cross-chunk 로드라 re-export
+  // 된 rx 도 정상 해석된다(`typeof p.rx === "string"`). 예전 entry-relocation 병합 경로에선 rx 를
+  // snapshot 에서 제외해 undefined 였는데, 실제 로드가 되면서 더 정확해졌다(크래시 없음, .local 정상).
+  test('#4553 entry 매칭 + dynamic 대상의 타-청크 re-export — 실제 로드로 정상 해석', async () => {
     const fixture = await createFixture({
       'inner.ts': `export const rx = "RX";`,
       'page.ts': `export { rx } from "./inner";\nexport const pv = "PV";`,
@@ -1149,7 +1155,6 @@ describe('manualChunks NAPI bridge', () => {
       entryPoints: [join(fixture.dir, 'index.ts')],
       format: 'esm',
       splitting: true,
-      // page+index → main 병합. inner 는 별도 청크로 강제(타 청크 re-export).
       manualChunks: (id: string) =>
         id.includes('inner')
           ? 'innerchunk'
@@ -1158,20 +1163,61 @@ describe('manualChunks NAPI bridge', () => {
             : null,
     });
     const outs = result.outputFiles!;
-    const entry = outs.find((o) => /main|index/.test(o.path) && o.path.endsWith('.js'))!;
+    const entry = outs.find((o) => o.text.includes('main()') && o.path.endsWith('.js'))!;
     expect(entry).toBeDefined();
+    // Option A: entry 는 manual 'main' 로 relocate 안 됨.
+    expect(entry.path).not.toContain('main-');
     expect(entry.text).not.toMatch(/import\(["']\.\/page["']\)/);
     writeOutputs(fixture.dir, outs);
-    // ReferenceError 없이 실행, .local(pv) 정상, 타-청크 re-export(rx)는 제외
+    // ReferenceError 없이 실행, .local(pv) 정상, 타-청크 re-export(rx)도 실제 로드로 해석.
+    const { stdout } = await runNode(join(fixture.dir, entry.path));
+    expect(stdout).toBe('PV PV string');
+  });
+
+  // /simplify #2c 가드(유지): **non-entry** 모듈(mid)이 manual 청크로 그룹된 동적 대상(page, 같은
+  // manual 청크)을 dynamic import 하면 namespace **스냅샷**으로 재작성된다. 그 스냅샷은 page 가 *타
+  // 청크*(innerchunk)에서 re-export 한 심볼(rx)을 못 넣어 undefined(문서화된 한계) — 크래시 없이
+  // .local(pv) 은 정상. (entry 는 relocate 안 돼 이 병합에 안 끼므로, 병합 주체를 non-entry 로 둔다.)
+  test('#4553 non-entry 병합 동적 대상의 타-청크 re-export 는 스냅샷에서 제외(undefined, 크래시 없음)', async () => {
+    const fixture = await createFixture({
+      'inner.ts': `export const rx = "RX";`,
+      'page.ts': `export { rx } from "./inner";\nexport const pv = "PV";`,
+      // mid: non-entry. page 를 static + dynamic 둘 다 import → page 가 mid 와 같은 manual 청크로 병합.
+      'mid.ts':
+        'import { pv } from "./page";\n' +
+        'export async function run(){ const p = await import("./page"); return [p.pv, pv, typeof p.rx].join(" "); }',
+      'index.ts': 'import { run } from "./mid";\nrun().then((r) => console.log(r));',
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'esm',
+      splitting: true,
+      manualChunks: (id: string) =>
+        id.includes('inner')
+          ? 'innerchunk'
+          : id.includes('page') || id.includes('mid')
+            ? 'main'
+            : null,
+    });
+    const outs = result.outputFiles!;
+    const mainChunk = outs.find((o) => o.path.includes('main') && o.path.endsWith('.js'))!;
+    // 비-vacuity: page 가 실제로 main 으로 병합 + 동적 import 가 스냅샷으로 재작성됨.
+    expect(mainChunk.text).toContain('"PV"');
+    expect(mainChunk.text).toContain('Promise.resolve().then(');
+    writeOutputs(fixture.dir, outs);
+    const entry = outs.find((o) => o.path.includes('index') && o.path.endsWith('.js'))!;
+    // .local(pv) 정상, 타-청크 re-export(rx) 는 스냅샷에서 제외 → undefined. 크래시 없음.
     const { stdout } = await runNode(join(fixture.dir, entry.path));
     expect(stdout).toBe('PV PV undefined');
   });
 
-  // (#4542) manualChunks 로 **CJS-wrapped user entry** 를 manual 청크로 relocate 하면, 그 청크는
-  // `.manual` kind 라 `chunk_is_user_entry`=false → #4537 의 entry-invoke 게이트가 안 걸려
-  // `var require_entry = __commonJS(...)` 선언만 남고 `require_entry()` 호출이 없어 본문 미실행이었다.
-  // 이제 게이트를 "청크에 든 is_entry_point 모듈"로 잡아 relocate 된 entry 도 호출한다.
-  test('#4542 manualChunks 로 relocate 된 CJS-wrapped entry 가 --splitting 에서 실행된다', async () => {
+  // (#4553) manualChunks 가 user entry 를 매칭해도 **entry 는 자기 entry_point 청크에 남는다**
+  // (rollup/esbuild 불변식). 예전엔 entry 를 manual 청크로 relocate 했는데, 그러면 entry 실행에
+  // 딸린 인프라(bootstrap·보편 wrapper·"use client" 호이스팅·run_before_main·HMR·dev_split)가
+  // 전부 "entry 는 자기 청크에 산다"는 전제에 묶여 깨졌다(#4542/#4548/#4549/#4551 화수분). 이제
+  // entry 는 옮기지 않으므로 표준 경로로 정상 실행되고, entry 만 매칭한 manual 청크는 비어서 skip.
+  test('#4553 manualChunks 가 CJS-wrapped entry 를 매칭해도 entry 는 자기 청크에서 실행된다', async () => {
     const fixture = await createFixture({
       'entry.js':
         'function load(){ return require("./legacy.cjs").foo(); }\n' +
@@ -1190,15 +1236,18 @@ describe('manualChunks NAPI bridge', () => {
     });
     expect(result.errors ?? []).toHaveLength(0);
     const outs = result.outputFiles!;
-    // 비-vacuity: entry 모듈이 실제로 manual 청크로 relocate 됐는지(`__commonJS` 래핑 + manual 경로).
+    // 비-vacuity: entry 모듈이 실제로 wrap(__commonJS)되어 이 빌드에 존재하는지.
     const entryChunk = outs.find(
       (o) => o.text.includes('require_entry') && o.text.includes('__commonJS'),
     );
     expect(entryChunk, 'entry 모듈이 담긴 청크를 못 찾음').toBeDefined();
-    expect(entryChunk!.path).toContain('manual-entry');
-    // 핵심: require_entry() 호출이 있어야 한다(버그: 선언만 남고 미호출).
+    // 핵심(Option A): entry 는 manual 청크('manual-entry')로 relocate 되지 **않는다** — 자기 청크에.
+    expect(entryChunk!.path).not.toContain('manual-entry');
+    // 표준 entry-invoke 로 호출된다.
     expect(entryChunk!.text).toContain('require_entry()');
-    // 실제 실행 — 버그 시 무출력.
+    // entry 만 매칭한 manual 청크는 비어서 생성 안 됨.
+    expect(outs.some((o) => o.path.includes('manual-entry'))).toBe(false);
+    // 실제 실행 — 정상.
     const dist = join(fixture.dir, 'dist');
     writeOutputs(dist, outs);
     writeFileSync(join(dist, 'package.json'), JSON.stringify({ type: 'module' }));


### PR DESCRIPTION
## 요약
`manualChunks` 가 user entry 모듈을 manual 청크로 **relocate 하지 않도록** 변경한다. user entry 는 항상 자기 entry_point 청크에 유지된다(rollup/esbuild 불변식). `--splitting` + `manualChunks` 로 entry 를 옮기면 실행이 깨지던 버그 계열(#4542/#4548/#4549/#4551)을 **근본 원인**에서 제거한다.

## 배경 — 왜 화수분이었나
예전엔 `manualChunks` 패턴이 entry 를 매칭하면 entry **모듈 자체**를 manual 청크에 넣었다(chunk.zig 의 "manual 우선" 정책, #1027). 그런데 emit 파이프라인 **십수 곳**이 "user entry 는 자기 `.entry_point` 청크에 산다"는 불변식(`chunk_is_user_entry`/`entry_mod_idx`)에 의존한다: 표준 entry-invoke, reg_split bootstrap·보편 wrapper, `"use client"` directive 호이스팅, `run_before_main` polyfill, dev HMR runtime, dev_split 선-init… entry 를 옮기면 이 전제를 쓰는 모든 곳이 하나씩 깨졌고, 파이프라인 전역에 흩어져 있어 **고칠수록 다른 코너에서 새 버그가 나왔다**(리뷰 라운드마다 서로 다른 서브시스템, 심지어 수정이 새 버그를 만듦).

rollup/esbuild 는 애초에 entry 를 relocate 하지 않아 이 버그 클래스가 존재하지 않는다. #4542 가 택한 "entry 를 manual 에 넣고 인프라를 전부 따라가게 한다"는 모델이 두 갈래 중 훨씬 비싼 쪽이었다.

## 수정 — entry 는 옮기지 않는다
chunk.zig 의 manual 청크 배정에서 **user(비-dynamic) entry 를 제외**한다 — dynamic import 대상(#1848/#1849)이 이미 제외되는 것과 정확히 같은 방식:
- **manual seed 수집**(resolver·record): user entry 는 seed 로 안 넣는다. resolver 함수는 **여전히 호출**해 `getModuleInfo` 등 inspection hook 부작용은 보존하되, entry 의 배정 결과만 무시한다.
- **Phase 2.5 BFS 전파**: user entry 에는 manual bit 를 안 세운다(vendor seed 의 transitive dep 로 도달해도 차단).
- **Phase 4**: user entry 는 위에서 manual bit 를 못 받으므로 애초에 manual 청크에 없다 → 자기 entry_point 청크로. (Phase 4 의 "manual 이면 유지" 예외는 **유지** — 이제 dynamic import 대상이 manual seed 의 static dep 로 흡수된 경우만 보호.)
- **warn**: `manualChunks` 가 entry 를 매칭하면 "entry 는 relocate 되지 않고 자기 청크에 유지됩니다" 경고(rollup 관례, entry 당 1회).

matched **non-entry** 모듈은 종전대로 manual 로. entry 만 매칭한 manual 청크는 비어서 생성 안 됨.

## 효과
- esm/cjs/iife/umd/amd + splitting + `manualChunks` 가 entry 를 매칭해도 entry 는 표준 경로로 정상 실행(무출력/SyntaxError 없음).
- **#4548/#4549/#4551 전부 해소** — entry 가 안 움직이니 인프라가 흩어질 일이 없다. #4552(reg_split RBM cross-chunk ESM import)는 relocate 무관 pre-existing 이라 별도.
- #4542 도입 emit-side 일반화(`chunk_is_entry_output` +manual 스캔)는 불필요 → `chunk_is_user_entry` 로 원복(both-case 처리용 is_entry_point 스캔만 유지). on-demand plugin emitFile chunk 를 eager-invoke 하던 것도 함께 정리(on-demand 는 eager 금지가 정확).

## code-review 반영 (max, 2라운드)
- **[dynamic 대상 보호]**: Phase 4 `.manual continue` 를 **복원**. 처음엔 통째로 지웠는데, 그러면 dynamic import 대상이 manual seed 의 static dep 로 Phase 2.5 전파돼 흡수된 뒤 자기 dynamic 청크로 도로 튕겨 나가 cross-chunk ReferenceError. user entry 는 이미 상류(seed/전파)에서 제외라 이 예외에 안 걸린다.
- **[중복 이름 record OOB]**: `ManualChunkEntry.lookup` 은 raw record index 를 주는데 `ensureNameSlot` 이 이름을 한 slot 으로 dedupe → raw index 로 `manual_seeds`/`effective_names`(len=deduped) 인덱싱 시 OOB panic(pre-existing). name→slot 매핑으로 수정(유닛 가드 추가).
- **[warn 중복]**: `warnManualChunksEntry` helper + `warned` set 으로 resolver·record 양쪽 매칭 시에도 entry 당 1회.
- **[test-coverage]**: non-entry 병합 동적 대상의 타-청크 re-export snapshot 한계(undefined) 커버리지 유지(non-entry importer 버전 테스트).

## 검증
- `zig build test` (chunk_test #4553 entry-유지 + 중복-이름-OOB 유닛 가드 + 전체)
- esm/cjs/iife/umd/amd × (entry-only 매칭 / entry+vendor 매칭) `node` 실행
- manual-chunks/splitting/reg_split/MF/inline-dynamic/bundle-dynamic integration · 통합 4255 pass (known flake 2: #3099·#3104)

Zig 초보자용: `chunk.zig` 는 "어느 모듈이 어느 출력 청크(파일)로 갈지" 정하는 **청킹** 단계다. 예전엔 사용자가 manualChunks 로 "entry 를 이 청크에 넣어줘" 하면 그대로 넣었는데, entry 를 옮기면 entry 실행에 필요한 여러 코드가 "entry 는 자기 청크에 있다"고 가정해서 깨졌다. 그래서 entry 는 옮기지 않기로(rollup/esbuild 도 그렇게 한다).

Closes #4553
Closes #4548
Closes #4549
Closes #4551

🤖 Generated with [Claude Code](https://claude.com/claude-code)