### PR TITLE
fix(bundler): #4552 run_before_main 을 entry 청크에 co-locate (reg_split cross-chunk SyntaxError)

### DIFF
--- a/.changeset/regsplit-rbm-colocate.md
+++ b/.changeset/regsplit-rbm-colocate.md
@@ -1,0 +1,34 @@
+---
+"@zntc/core": patch
+---
+
+`--format iife|umd|amd --splitting` 에서 `run_before_main` 모듈이 `manualChunks` 로 다른 청크에 분리되면 entry 청크에 ESM `import` 를 방출해 SyntaxError 나던 버그 수정 (#4552). RBM 모듈을 entry 청크에 **co-locate** 한다.
+
+## 증상
+`--format iife --splitting` + `runBeforeMain: ['./setup.js']` + `manualChunks` 로 setup.js 를 별도 청크로 빼면, entry 청크에 `import { init_setup } from "./rbm-chunk.js";` 가 나온다. reg_split 청크는 `(function(g){...})` self-register IIFE 라 top-level ESM import = `SyntaxError: Unexpected token '{'`. 빌드 exit 0 · 실행만 실패.
+
+## 루트커즈
+reg_split(iife/umd/amd)은 registry 모델(`__zntc_require`)이라 다른 청크의 RBM 을 근본적으로 실행할 수 없다: 그 RBM 은 `var init_X = __esm({...})` (lazy)로 감싸지고 init 심볼이 factory 스코프 밖으로 안 나온다. 그래서 entry 청크가 (a) ESM `import`(IIFE 서 무효 문법) (b) `__zntc_require`(factory 실행하나 RBM body 미실행) (c) scope 밖 `init_X()` 호출 — 셋 다 깨진다. RBM 은 **entry 앞에서 실행돼야 하므로 애초에 split 되면 안 된다**(Metro 도 runBeforeMainModule 을 번들 최상단에 두고 split 하지 않음).
+
+## 수정 — RBM co-location (reg_split 한정)
+chunk.zig 의 manual 청크 배정에서 **run_before_main 클로저를 제외**한다 — dynamic import 대상(#1848/#1849)·user entry(#4553)가 이미 제외되는 것과 같은 방식. `GenerateOptions.run_before_main` + `reg_split` 로 받아 `rbm_modules` set 을 만들고, manual seed 수집(resolver·record)·Phase 2.5 BFS 전파에서 skip. RBM 은 entry 의 dep 로 링크돼 있어(build_flow linkExecutionRoots) 제외되면 entry 청크에 자연히 co-locate 된다. 매칭된 **non-RBM** 모듈은 종전대로 manual 로.
+- **reg_split 한정**(iife/umd/amd): esm/cjs 는 cross-chunk RBM 이 valid ESM `import` 로 동작하므로 사용자의 manualChunks 배치를 **존중**(강제 co-locate 안 함). reg_split 아닐 땐 `rbm_modules` 가 비어 exclusion no-op.
+- **최상위 RBM 만이 아니라 클로저 전체**: RBM 이 import 한 모듈(transitive static dep)이 manual 로 빠지면 entry prelude(emitter `collectRunBeforeMainClosure`)가 그걸 cross-chunk 참조해 똑같이 깨진다 → RBM 클로저 전체를 제외.
+- manual 미설정이면 스캔 자체를 skip.
+
+## 범위 / 후속
+- **단일 entry**(RN 전형, RBM 의 실사용): 완전 해결(공유 없음 → RBM 은 entry 청크에만).
+- **여러 entry 가 같은 RBM 공유**: RBM 이 `common` 청크로 가는데, zntc 는 1 모듈 = 1 청크라 각 entry 청크로 **복제(co-locate)가 불가** → registry-native(common 청크 eager-run) 필요 → **#4555 후속**. main 에서도 pre-existing(이 수정이 회귀 아님).
+- **degenerate 조합**(같은 co-location 한계, #4555 영역): (a) manual 청크의 라이브러리가 app 의 RBM 을 import(entry 스코프 init 심볼 미도달), (b) RBM 이 동시에 `import()` 대상/federation-expose 라 Phase 1b 에서 자기 dynamic 청크가 됨. 둘 다 reg_split 에서 cross-chunk 참조 → 실사용 거의 없음.
+
+참조: Metro `getModulesRunBeforeMainModule` = 번들별 최상단 co-locate(split 안 함). rollup/esbuild 는 run_before_main 개념 없음.
+
+## code-review 반영
+- **[reg_split 게이트]**: RBM co-location 은 **reg_split 한정** — esm/cjs 는 cross-chunk RBM 이 valid ESM import 로 동작(테스트가 `node` 실행으로 확인). 처음엔 무조건 제외라 esm/cjs 의 사용자 manualChunks 배치를 무성 무효화했다.
+- **[클로저]**: 최상위 RBM 만이 아니라 **transitive static 클로저** 를 제외(emitter `collectRunBeforeMainClosure` 가 prelude 로 끌어오는 것과 일치) — RBM 이 import 한 모듈이 manual 로 빠지면 여전히 cross-chunk break.
+- **[DRY]**: `reg_split = (iife|umd|amd) and !preserve_modules` 를 하드코딩하던 4곳(bundler + emitter 3)을 기존 미사용 헬퍼 `Format.isWrappedFormat()` 로 통일 — 청커 게이트와 방출부가 어긋나 초록 빌드로 버그 재발하는 드리프트 차단.
+- manual 미설정이면 rbm_modules 빌드 skip.
+
+검증: zig test(chunk_test #4552 co-locate 유닛) · esm/cjs/iife/umd/amd × manualChunks-RBM `node` 실행(`ENTRY sees DEV_SET`, ESM import·별도청크 없음) · 클로저·esm-존중 가드 · 인접 polyfill-rbm/manual-chunks/splitting 통과.
+
+Closes #4552

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1914,6 +1914,8 @@ pub const Bundler = struct {
                     .manual_resolver = self.options.manual_chunks_resolver,
                     .manual_resolver_ctx = self.options.manual_chunks_ctx,
                     .inline_dynamic_imports = self.options.inline_dynamic_imports,
+                    .run_before_main = self.options.run_before_main,
+                    .reg_split = self.options.format.isWrappedFormat() and !self.options.preserve_modules,
                 });
             defer chunk_graph.deinit();
 

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -597,6 +597,14 @@ pub const GenerateOptions = struct {
     manual_resolver_ctx: ?*anyopaque = null,
     /// Rollup `output.inlineDynamicImports` — dynamic import target 을 importer 의 chunk 로 흡수.
     inline_dynamic_imports: bool = false,
+    /// (#4552) run_before_main(Metro runBeforeMainModule) 모듈 경로. entry 앞에서 실행돼야 하므로
+    /// **entry 청크에 co-locate** — manual 청크로 relocate 안 함(reg_split 에서 cross-chunk RBM 는
+    /// lazy __esm+factory 스코프라 근본적으로 실행 불가). Metro 도 RBM 을 split 하지 않고 번들 최상단.
+    run_before_main: []const []const u8 = &.{},
+    /// (#4552) reg_split(iife/umd/amd) 출력 여부. RBM co-location 은 reg_split 에서만 적용한다 —
+    /// esm/cjs 는 cross-chunk RBM 이 valid ESM `import` 로 동작하므로 사용자의 manualChunks 배치를
+    /// 존중(강제 co-locate 하면 caching/split 전략을 무성 무효화).
+    reg_split: bool = false,
 };
 
 /// 너무 작은 `common` 청크를, 그 청크가 도달 가능한 모든 entry 가 항상 함께
@@ -805,6 +813,31 @@ pub fn generateChunks(
     for (entries.items) |e| {
         if (!e.is_dynamic) try user_entry_modules.put(allocator, @intFromEnum(e.module_idx), {});
     }
+    // (#4552) run_before_main **클로저**(RBM 모듈 + transitive static deps)를 manual 청크에서 제외 —
+    // entry 앞에서 실행돼야 하므로 entry 청크에 co-locate. reg_split(iife/umd/amd)은 cross-chunk RBM 를
+    // 근본적으로 못 실행한다(다른 청크의 RBM 은 lazy `__esm` 로 감싸지고 그 init 심볼이 factory 스코프
+    // 밖으로 안 나와, entry 청크가 ESM import(IIFE 서 SyntaxError)·미접근 init 호출로 깨짐). Metro 도
+    // RBM 을 split 하지 않는다.
+    // ⚠️ **reg_split 한정** — esm/cjs 는 cross-chunk RBM 이 valid ESM import 로 동작하므로 사용자
+    // manualChunks 배치를 존중(강제 co-locate 금지). ⚠️ **최상위 RBM 만이 아니라 클로저 전체** — RBM 이
+    // import 한 모듈이 manual 로 빠지면 entry prelude(emitter collectRunBeforeMainClosure)가 그걸
+    // cross-chunk 참조해 똑같이 깨진다. manual 미설정이면 스캔 자체를 skip(불필요 작업 회피).
+    var rbm_modules: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer rbm_modules.deinit(allocator);
+    if (options.reg_split and (manual_resolver != null or manual_chunks.len > 0)) {
+        var rbm_stack: std.ArrayList(ModuleIndex) = .empty;
+        defer rbm_stack.deinit(allocator);
+        for (options.run_before_main) |rbm_path| {
+            const m = graph.findModuleByPath(rbm_path) orelse continue;
+            try rbm_stack.append(allocator, m.index);
+        }
+        while (rbm_stack.pop()) |idx| {
+            const gop = try rbm_modules.getOrPut(allocator, @intFromEnum(idx));
+            if (gop.found_existing) continue;
+            const m = graph.getModule(idx) orelse continue;
+            for (m.dependencies.items) |dep| try rbm_stack.append(allocator, dep);
+        }
+    }
     // 같은 entry 를 resolver·record 양쪽이 매칭해도 warn 은 entry 당 1회만 (이중 emit 방지).
     var warned_manual_entries: std.AutoHashMapUnmanaged(u32, void) = .empty;
     defer warned_manual_entries.deinit(allocator);
@@ -830,6 +863,8 @@ pub fn generateChunks(
                     try warnManualChunksEntry(&warned_manual_entries, allocator, @intCast(mi), m.path, chunk_name);
                     continue;
                 }
+                // (#4552) RBM 은 entry 와 co-locate — 배정 무시(dynamic 대상처럼 silent).
+                if (rbm_modules.contains(@intCast(mi))) continue;
                 ra[mi] = try ensureNameSlot(&name_to_slot, &effective_names, allocator, chunk_name);
             }
         }
@@ -946,6 +981,7 @@ pub fn generateChunks(
             if (m.is_external) continue;
             // dynamic import target 은 정책상 manual 청크 제외 (#1848/#1849, 근본수정 #1850)
             if (dynamic_entry_modules.contains(@intCast(mi))) continue;
+            if (rbm_modules.contains(@intCast(mi))) continue; // (#4552) RBM 은 entry 와 co-locate
             if (resolver_assignments) |ra| {
                 if (ra[mi]) |slot| {
                     try manual_seeds[slot].append(allocator, ModuleIndex.fromUsize(mi));
@@ -1058,6 +1094,7 @@ pub fn generateChunks(
                 // transitive dep 로 도달) 여기서 막아 entry 가 manual 청크로 빨려가지 않게 한다. entry 를
                 // 통해 dep 로 전파도 중단(entry 의 exclusive dep 는 entry 청크에 남음).
                 if (user_entry_modules.contains(@intCast(mi))) continue;
+                if (rbm_modules.contains(@intCast(mi))) continue; // (#4552) RBM 은 manual bit 안 받음
                 // 다른 slot 의 seed 면 skip — 그쪽에서 처리됨
                 if (module_primary_slot[mi]) |other| {
                     if (other != i) continue;

--- a/src/bundler/chunk_test.zig
+++ b/src/bundler/chunk_test.zig
@@ -1325,6 +1325,40 @@ test "generateChunks: (#4553) manualChunks 매칭돼도 user entry 는 자기 en
     try std.testing.expect(cg.getChunk(lib_ci).kind == .manual);
 }
 
+test "generateChunks: (#4552) run_before_main 은 manualChunks 매칭돼도 entry 와 co-locate" {
+    // RBM 모듈은 entry 앞에서 실행돼야 하므로 entry 청크에 co-locate — manual 로 split 안 함(reg_split
+    // 에서 cross-chunk RBM 은 lazy __esm+factory 스코프라 실행 불가). 매칭된 non-RBM(lib)만 manual.
+    const alloc = std.testing.allocator;
+
+    var modules: [3]Module = .{
+        makeTestModule(alloc, 0, "entry.ts"),
+        makeTestModule(alloc, 1, "setup.ts"), // RBM
+        makeTestModule(alloc, 2, "lib.ts"),
+    };
+    var tg = try TestGraph.init(alloc, &modules);
+    defer tg.deinit(alloc);
+
+    try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(1)); // entry → setup (RBM dep)
+    try tg.graph.linkDependency(@enumFromInt(0), @enumFromInt(2)); // entry → lib
+
+    // 패턴이 setup(RBM)·lib 를 모두 매칭. run_before_main 이 setup 을 RBM 으로 지정.
+    const manual_entries = [_]types.ManualChunkEntry{.{ .name = "grp", .patterns = &.{ "setup", "lib" } }};
+    var cg = try chunk_mod.generateChunks(alloc, &tg.graph, &.{"entry.ts"}, .{
+        .manual_chunks = &manual_entries,
+        .run_before_main = &.{"setup.ts"},
+        .reg_split = true, // RBM co-location 은 reg_split(iife/umd/amd) 한정
+    });
+    defer cg.deinit();
+
+    const entry_ci = cg.getModuleChunk(@enumFromInt(0));
+    const setup_ci = cg.getModuleChunk(@enumFromInt(1));
+    const lib_ci = cg.getModuleChunk(@enumFromInt(2));
+    // 핵심: setup(RBM)은 entry 와 같은 청크(co-locate), lib 만 manual.
+    try std.testing.expect(setup_ci == entry_ci);
+    try std.testing.expect(cg.getChunk(entry_ci).kind == .entry_point);
+    try std.testing.expect(cg.getChunk(lib_ci).kind == .manual);
+}
+
 test "generateChunks: (#4553 code-review) 중복 이름 record 는 crash 없이 한 청크로 병합" {
     // 두 pattern group 을 같은 청크명으로 지정하는 건 합법. `ManualChunkEntry.lookup` 이 raw record
     // index 를 반환하는데 ensureNameSlot 이 이름을 한 slot 으로 dedupe → raw index(=1)로

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -152,7 +152,7 @@ pub fn emitChunks(
         const cjs_ok = options.format == .cjs;
         // iife/umd/amd 모두 동일 레지스트리 기계(PR3) + entry 만 보편 wrapper
         // (umd/amd, PR4). preserve-modules 와는 비호환.
-        const reg_ok = (options.format == .iife or options.format == .umd or options.format == .amd) and !options.preserve_modules;
+        const reg_ok = options.format.isWrappedFormat() and !options.preserve_modules;
         if (!cjs_ok and !reg_ok) {
             return if (options.preserve_modules)
                 error.PreserveModulesRequiresESM
@@ -239,7 +239,7 @@ pub fn emitChunks(
     // IIFE splitting(P3-B PR3): 런타임 레지스트리 활성화. 안정 모듈 ID 의
     // root = preserve_modules_root ?? 모든 entry-point 청크 모듈 절대경로의
     // 공통 조상(module_id, 결정적). 루프 1회 전 계산해 모든 청크가 공유.
-    const reg_split = (options.format == .iife or options.format == .umd or options.format == .amd) and !options.preserve_modules;
+    const reg_split = options.format.isWrappedFormat() and !options.preserve_modules;
     var iife_id_root: ?[]const u8 = null;
     defer if (iife_id_root) |r| allocator.free(r);
     if (reg_split) {
@@ -2375,7 +2375,7 @@ fn rewriteDynamicImports(
         // 청크파일은 bare(접두 ./ 없음) — 로더가 __zntc_public_path 접두.
         // 대상 청크는 dynamic entry → id = entry 모듈 안정 모듈 ID. require
         // 캐시가 상태 보존(스파이크 검증). RFC §4.3 + PR3 결정(<script>).
-        const reg_split = (emit_options.format == .iife or emit_options.format == .umd or emit_options.format == .amd) and !emit_options.preserve_modules;
+        const reg_split = emit_options.format.isWrappedFormat() and !emit_options.preserve_modules;
         if (reg_split) {
             const target_id = reg_ids[@intFromEnum(target_chunk_idx)]; // borrow
             const chunkfile = try std.fmt.allocPrint(allocator, "{s}{s}", .{ stem, out_ext });

--- a/tests/integration/tests/manual-chunks.test.ts
+++ b/tests/integration/tests/manual-chunks.test.ts
@@ -1255,4 +1255,95 @@ describe('manualChunks NAPI bridge', () => {
     const { stdout } = await runNode(join(dist, entryFile));
     expect(stdout.trim()).toBe('FOOOTHER');
   });
+
+  // (#4552) run_before_main 모듈은 entry 앞에서 실행돼야 하므로 entry 청크에 **co-locate** 된다 —
+  // manualChunks 가 매칭해도 별도 청크로 split 안 함. reg_split(iife/umd/amd)에서 RBM 이 다른 청크에
+  // 있으면 그 청크의 RBM 은 lazy `__esm`+factory 스코프라, entry 가 `import { init_X } from ...`(IIFE 서
+  // SyntaxError)로 깨졌다. 이제 RBM 은 dynamic import 대상처럼 manual 배정에서 제외돼 entry 와 co-locate.
+  test('#4552 iife: run_before_main 은 manualChunks 매칭돼도 entry 와 co-locate + 실행', async () => {
+    const fixture = await createFixture({
+      'setup.js': `globalThis.__DEV__ = "DEV_SET";`,
+      'entry.js': `console.log("ENTRY sees", globalThis.__DEV__);`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.js')],
+      platform: 'node',
+      format: 'iife',
+      splitting: true,
+      runBeforeMain: [join(fixture.dir, 'setup.js')],
+      // RBM 을 별도 청크로 빼려는 시도 — co-location 정책이 무시한다.
+      manualChunks: (id) => (id.endsWith('setup.js') ? 'rbm-chunk' : null),
+    });
+    expect(result.errors ?? []).toHaveLength(0);
+    const outs = result.outputFiles!;
+    // 핵심: RBM 이 별도 'rbm-chunk' 로 split 되지 않는다(co-locate).
+    expect(outs.some((o) => o.path.includes('rbm-chunk'))).toBe(false);
+    const entryChunk = outs.find((o) => o.text.includes('ENTRY sees'))!;
+    expect(entryChunk).toBeDefined();
+    // IIFE 에 ESM import 가 없어야(버그: cross-chunk RBM → import 방출 → SyntaxError).
+    expect(entryChunk.text).not.toMatch(/^\s*import\s*[{*]/m);
+    // 실제 실행 — RBM 이 entry 앞에 실행.
+    writeOutputs(fixture.dir, outs);
+    const { stdout } = await runNode(join(fixture.dir, entryChunk.path));
+    expect(stdout.trim()).toBe('ENTRY sees DEV_SET');
+  });
+
+  // (#4552 code-review) RBM 의 **transitive dep**(closure)도 co-locate 해야 한다 — RBM(setup)이
+  // import 한 shared 가 manualChunks 로 빠지면 entry prelude 가 shared 를 cross-chunk 참조해 여전히
+  // 깨진다. 최상위 RBM 만이 아니라 클로저 전체를 manual 에서 제외.
+  test('#4552 iife: run_before_main 의 closure(dep)도 entry 와 co-locate', async () => {
+    const fixture = await createFixture({
+      'shared.js': `export const S = "SHARED";`,
+      'setup.js': `import { S } from "./shared.js";\nglobalThis.__DEV__ = "DEV_" + S;`,
+      'entry.js': `console.log("ENTRY", globalThis.__DEV__);`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.js')],
+      platform: 'node',
+      format: 'iife',
+      splitting: true,
+      runBeforeMain: [join(fixture.dir, 'setup.js')],
+      // shared(RBM closure member)를 별도 청크로 빼려는 시도 — co-location 이 무시한다.
+      manualChunks: (id) => (id.endsWith('shared.js') ? 'vendor' : null),
+    });
+    expect(result.errors ?? []).toHaveLength(0);
+    const outs = result.outputFiles!;
+    // 핵심: RBM closure(shared 포함)가 별도 'vendor' 로 split 되지 않는다.
+    expect(outs.some((o) => o.path.includes('vendor'))).toBe(false);
+    const entryChunk = outs.find((o) => o.text.includes('ENTRY'))!;
+    expect(entryChunk.text).not.toMatch(/^\s*import\s*[{*]/m);
+    writeOutputs(fixture.dir, outs);
+    const { stdout } = await runNode(join(fixture.dir, entryChunk.path));
+    expect(stdout.trim()).toBe('ENTRY DEV_SHARED');
+  });
+
+  // (#4552 code-review) esm/cjs 는 cross-chunk RBM 이 valid ESM import 로 동작하므로, 사용자가
+  // manualChunks 로 RBM 을 별도 청크에 두면 **존중**한다(reg_split 만 co-locate 강제).
+  test('#4552 esm: run_before_main 은 manualChunks 배치 존중(별도 청크 유지)', async () => {
+    const fixture = await createFixture({
+      'setup.js': `globalThis.__DEV__ = "DEV_SET";`,
+      'entry.js': `console.log("ENTRY sees", globalThis.__DEV__);`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.js')],
+      platform: 'node',
+      format: 'esm',
+      splitting: true,
+      runBeforeMain: [join(fixture.dir, 'setup.js')],
+      manualChunks: (id) => (id.endsWith('setup.js') ? 'rbm-chunk' : null),
+    });
+    expect(result.errors ?? []).toHaveLength(0);
+    const outs = result.outputFiles!;
+    // esm 은 사용자 배치 존중 → 별도 rbm-chunk 유지.
+    expect(outs.some((o) => o.path.includes('rbm-chunk'))).toBe(true);
+    // 비-vacuity: esm cross-chunk RBM 은 valid ESM import 로 실제 동작(그래서 존중해도 안전).
+    const entryChunk = outs.find((o) => o.text.includes('ENTRY sees'))!;
+    writeOutputs(fixture.dir, outs);
+    writeFileSync(join(fixture.dir, 'package.json'), JSON.stringify({ type: 'module' }));
+    const { stdout } = await runNode(join(fixture.dir, entryChunk.path));
+    expect(stdout.trim()).toBe('ENTRY sees DEV_SET');
+  });
 });


### PR DESCRIPTION
## 요약
`--format iife|umd|amd --splitting` 에서 `run_before_main` 모듈이 `manualChunks` 로 다른 청크에 분리되면 entry 청크에 ESM `import` 를 방출해 SyntaxError 나던 버그 수정 (#4552). RBM(클로저)을 entry 청크에 **co-locate** 한다.

## 증상
`--format iife --splitting` + `runBeforeMain: ['./setup.js']` + `manualChunks` 로 setup.js 를 별도 청크로 빼면 entry 청크에 `import { init_setup } from "./rbm-chunk.js";` 가 나온다. reg_split 청크는 `(function(g){...})` self-register IIFE 라 top-level ESM import = `SyntaxError: Unexpected token '{'`. 빌드 exit 0 · 실행만 실패.

## 루트커즈
reg_split(iife/umd/amd)은 registry 모델(`__zntc_require`)이라 다른 청크의 RBM 을 근본적으로 실행할 수 없다: 그 RBM 은 `var init_X = __esm({...})` (lazy)로 감싸지고 init 심볼이 factory 스코프 밖으로 안 나온다. entry 청크가 (a) ESM `import`(IIFE 무효 문법) (b) `__zntc_require`(factory 실행하나 RBM body 미실행) (c) scope 밖 `init_X()` — 셋 다 깨진다. RBM 은 **entry 앞에서 실행돼야 하므로 애초에 split 되면 안 된다**(Metro 도 runBeforeMainModule 을 번들 최상단에 두고 split 안 함).

## 수정 — RBM co-location (reg_split 한정)
chunk.zig 의 manual 청크 배정에서 **run_before_main 클로저를 제외** — dynamic import 대상(#1848/#1849)·user entry(#4553)가 이미 제외되는 것과 같은 방식. `GenerateOptions.run_before_main`+`reg_split` 로 받아 `rbm_modules` set(클로저)을 만들고 manual seed 수집(resolver·record)·Phase 2.5 BFS 전파에서 skip. RBM 은 entry 의 dep 라 제외되면 entry 청크에 자연히 co-locate. matched **non-RBM** 은 종전대로 manual 로.

## 범위 / 후속
- **단일 entry**(RN 전형, RBM 실사용): 완전 해결.
- **여러 entry 공유 RBM**: `common` 청크로 가는데 zntc 는 1 모듈 = 1 청크라 복제(co-locate) 불가 → registry-native 필요 → **#4555 후속**(pre-existing, 회귀 아님). degenerate 조합(vendor-lib-imports-RBM, RBM-also-dynamic-target)도 #4555 영역.

## code-review 반영 (max, 2라운드)
- **[reg_split 게이트]**: co-location 은 reg_split 한정 — esm/cjs 는 cross-chunk RBM 이 valid ESM import 로 **실제 동작**(테스트가 `node` 실행 확인)하므로 사용자 manualChunks 배치 존중. (처음엔 무조건 제외라 esm/cjs 회귀였음.)
- **[클로저]**: 최상위 RBM 만이 아니라 transitive static 클로저 제외 — RBM 이 import 한 모듈이 manual 로 빠지면 여전히 cross-chunk break(emitter `collectRunBeforeMainClosure` 와 일치).
- **[DRY]**: `reg_split` 술어를 하드코딩하던 4곳을 미사용 헬퍼 `Format.isWrappedFormat()` 로 통일 — 청커 게이트↔방출부 드리프트로 초록 빌드 버그 재발 차단.

## 검증
- `zig build test`(chunk_test #4552 co-locate 유닛)
- esm/cjs/iife/umd/amd × manualChunks-RBM `node` 실행(`ENTRY sees DEV_SET`, IIFE 에 ESM import·별도청크 없음; esm 은 별도청크 유지+실행)
- 클로저(RBM dep 도 co-locate)·esm-존중 가드
- 통합 4257 pass (known flake 2: #3099·#3104)

Zig 초보자용: `run_before_main` 은 Metro 의 InitializeCore 처럼 "앱 코드 전에 먼저 실행할 모듈"이다. 이걸 별도 파일(청크)로 쪼개면 iife/umd/amd 형식에선 그 청크를 제때 실행할 방법이 없어 깨진다. 그래서 이런 모듈은 쪼개지 않고 entry 와 같은 파일에 두기로 했다(Metro 도 그렇게 한다).

Closes #4552

🤖 Generated with [Claude Code](https://claude.com/claude-code)