### PR TITLE
fix(incremental): #4544 cross-module const 를 bake 한 모듈은 캐시 제외해 증분 stale 해소

### DIFF
--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -1697,6 +1697,14 @@ pub fn transferModulesToStore(self: *ModuleGraph, io: std.Io, store: *module_sto
     for (0..self.moduleCount()) |i| {
         const m = self.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         if (m.parse_arena == null) continue; // disabled 등 arena 없는 모듈 스킵
+        // (#4544) cross-module const 를 AST 에 bake 한 모듈은 캐시하지 않는다. baked 리터럴은
+        // provider const 에 의존하는 graph-derived 산출물이라, 소비자 자기 mtime 키로 캐시하면
+        // provider 변경 시 stale (#4535 2번째 층). store 에서 제외 → 다음 warm 빌드가 clean
+        // reparse 후 현재 provider 값으로 fresh 재-materialize. 과거 non-baked 시절 엔트리도 evict.
+        if (m.const_baked) {
+            store.evict(m.path);
+            continue;
+        }
         // mtime 은 buildIncremental / build 가 이미 module.mtime 에 기록.
         // 여기서 재-stat 하면 watcher-driven mtime cache 효과가 half-revert
         // 됨 (Issue #1727 §3). 0 이면 초기 경로에서 실패했던 모듈 —

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -3352,6 +3352,93 @@ test "reuse #4535: consumer-induced wrap_kind flip warm==cold" {
     try std.testing.expectEqualStrings(cold_r.output, warm_r.output);
 }
 
+// #4544 warm==cold 하네스: 초기 파일들로 warm store 를 채운 뒤(2회 빌드) provider 파일 1개를
+// 편집(changed_files)하고 warm 재빌드한 결과가 cold 빌드와 byte-identical 인지 확인한다.
+// tree_shaker const-materialize 가 소비자 AST 에 provider const 를 bake→module_store 박제하면
+// warm 이 소비자를 reparse 안 해 옛 값이 남는데(#4544), crude-b(m.const_baked evict)가 이를 막는다.
+// materialize 는 dev OFF tree-shake 에서만 → dev_mode=false + compiled_cache ON. [[project_4544]]
+const Frag4544 = struct { name: []const u8, content: []const u8 };
+fn expect4544WarmEqCold(
+    files: []const Frag4544,
+    entry_name: []const u8,
+    edit_name: []const u8,
+    edit_content: []const u8,
+) !void {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    for (files) |f| try writeFile(tmp.dir, f.name, f.content);
+    const entry = try absPath(&tmp, entry_name);
+    defer alloc.free(entry);
+    var store = module_store.PersistentModuleStore.init(alloc);
+    defer store.deinit();
+    var cc = CompiledOutputCache.init(alloc);
+    defer cc.deinit();
+    const base_opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = false,
+        .module_store = &store,
+        .compiled_cache = &cc,
+    });
+    for (0..2) |_| {
+        var b = Bundler.init(alloc, base_opts);
+        var r = try b.bundle(std.testing.io);
+        try std.testing.expect(!r.hasErrors());
+        r.deinit(alloc);
+        b.deinit();
+    }
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, edit_name, edit_content);
+    const edit_abs = try absPath(&tmp, edit_name);
+    defer alloc.free(edit_abs);
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(alloc);
+    try touched.put(alloc, edit_abs, {});
+    var warm_opts = base_opts;
+    warm_opts.changed_files = &touched;
+    var warm = Bundler.init(alloc, warm_opts);
+    var warm_r = try warm.bundle(std.testing.io);
+    defer warm_r.deinit(alloc);
+    defer warm.deinit();
+    try std.testing.expect(!warm_r.hasErrors());
+    var cold = Bundler.init(alloc, .{ .entry_points = &.{entry}, .dev_mode = false });
+    var cold_r = try cold.bundle(std.testing.io);
+    defer cold_r.deinit(alloc);
+    defer cold.deinit();
+    try std.testing.expect(!cold_r.hasErrors());
+    try std.testing.expectEqualStrings(cold_r.output, warm_r.output);
+}
+
+// value 위치(`console.log(bump(), z)`): provider z 가 1→2 로 바뀌면 소비자가 옛 `1` 을 박제하면 안 됨.
+test "reuse #4544: provider const change re-inlines in consumer warm==cold" {
+    try expect4544WarmEqCold(&.{
+        .{ .name = "shared.js", .content = "export function bump(){ return 42; }" },
+        .{ .name = "other.js", .content = "export const z = 1;" },
+        .{ .name = "index.js", .content =
+        \\import { bump } from './shared.js';
+        \\import { z } from './other.js';
+        \\console.log(bump(), z);
+        \\
+        },
+    }, "index.js", "other.js", "export const z = 2;");
+}
+
+// code-review finding 1/2 가드: minify-sensitive(`N+1` — binary 피연산자) + dead-branch
+// (`if(FLAG){import}`) 로 baked 되는 소비자. 이전 부분수정(non-sensitive 만 path-B 위임)은
+// 이 둘을 못 막았다. crude-b 는 baked 모듈을 일괄 evict 하므로 위치·minify 무관하게 커버.
+test "reuse #4544: sensitive + dead-branch consumer warm==cold" {
+    try expect4544WarmEqCold(&.{
+        .{ .name = "flags.js", .content = "export const N = 1;\nexport const FLAG = 0;\n" },
+        .{ .name = "dead.js", .content = "export const d = 99;" },
+        .{ .name = "index.js", .content =
+        \\import { N, FLAG } from './flags.js';
+        \\console.log(N + 1);
+        \\if (FLAG) { import('./dead.js').then((m) => console.log(m.d)); }
+        \\
+        },
+    }, "index.js", "flags.js", "export const N = 2;\nexport const FLAG = 1;\n");
+}
+
 // #4535 [0]: transitive re-export barrel. origin(q.js)이 심볼을 rename 하면 barrel(barrel.js)의
 // emitFingerprint 가 origin canonical 을 chain-resolve 해 바뀌어야, barrel 통해 import 하는
 // main.js 가 miss 된다(안 그러면 옛 심볼명 참조 → ReferenceError). compiled_cache ON + dev OFF.

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -285,6 +285,14 @@ pub const Module = struct {
     /// null = transform_prepass 미실행 또는 namespace import 없음 → linker 가 자체 build.
     namespace_access_index: ?@import("linker/namespace_access.zig").NamespaceAccessIndex = null,
 
+    /// (#4544) tree-shake 가 이 모듈의 AST 에 **cross-module const** 값을 리터럴로 bake 했는지.
+    /// baked 리터럴은 provider 의 `export const N` 값에 의존하는 **graph-derived** 산출물이라,
+    /// 소비자 자기 mtime 키로 module_store 에 캐시하면 provider 변경 시 stale 해진다(#4535 2번째 층).
+    /// true 인 모듈은 `transferModulesToStore` 가 캐시에서 제외(+기존 엔트리 evict) → 다음 warm 빌드가
+    /// clean reparse 후 현재 provider 값으로 fresh 재-materialize. build-scope 플래그(store round-trip
+    /// 안 함): cache-miss 재파스마다 false 로 초기화되고, cross-module bake 발생 시에만 set.
+    const_baked: bool = false,
+
     /// wrap_kind != .none 모듈의 `init_<path>` 함수 심볼 id (semantic 공간).
     /// null = 미래핑 또는 semantic 없음 (fallback: makeInitVarName 재할당).
     init_symbol: ?SemanticSymbolId = null,

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -109,6 +109,16 @@ pub const PersistentModuleStore = struct {
         return cached;
     }
 
+    /// (#4544) 경로의 캐시 엔트리를 제거(내용 free + key free). 엔트리가 없으면 no-op.
+    /// cross-module const 를 bake 한 모듈을 캐시에서 빼(그리고 과거 non-baked 엔트리도 지워)
+    /// 다음 warm 빌드가 clean reparse 하도록 강제하는 데 쓴다.
+    pub fn evict(self: *PersistentModuleStore, path: []const u8) void {
+        const entry = self.modules.fetchRemove(path) orelse return;
+        self.allocator.free(entry.key);
+        var cached = entry.value;
+        self.freeCachedModule(&cached);
+    }
+
     /// 빌드 완료 후 모듈을 캐시에 저장.
     /// Module의 parse_arena 소유권을 store로 이전 (Module.parse_arena = null 설정).
     pub fn putModule(self: *PersistentModuleStore, path: []const u8, module: *Module, mtime: i128) void {
@@ -373,6 +383,45 @@ test "PersistentModuleStore: parse_arena ownership 왕복 후 alloc 정상 (#269
 
     store.putModule("\x00zntc:runtime/extends", &mod2, 2);
     mod2.deinit(allocator);
+}
+
+// (#4544) evict: cross-module const 를 bake 한 모듈을 캐시에서 빼는 경로. store 의 가장
+// double-free/UAF 취약한 지점(엔트리 내용 free + key free)을 직접 가드한다.
+test "PersistentModuleStore: evict 완전 저장 엔트리 + parse_arena=null dangling + 없는 경로 no-op" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var store = PersistentModuleStore.init(allocator);
+    defer store.deinit();
+
+    // 없는 경로 evict = no-op (crash 없이 반환).
+    store.evict("\x00zntc:absent");
+    try testing.expect(!store.modules.contains("\x00zntc:absent"));
+
+    // case 1: 완전 저장 엔트리(arena 를 store 가 소유) evict → arena 포함 전체 free, 엔트리 제거.
+    var m1 = Module.init(@enumFromInt(0), "\x00zntc:evict/full");
+    m1.parse_arena = Module_mod.createParseArena(allocator) orelse return error.OutOfMemory;
+    _ = try m1.parse_arena.?.allocator().alloc(u8, 128);
+    store.putModule("\x00zntc:evict/full", &m1, 1);
+    m1.deinit(allocator); // graph 쪽 잔여(arena 는 이미 store 로 이전됨)
+    try testing.expect(store.modules.contains("\x00zntc:evict/full"));
+    store.evict("\x00zntc:evict/full");
+    try testing.expect(!store.modules.contains("\x00zntc:evict/full"));
+
+    // case 2: cache-hit 로 arena 를 graph 가 환수해 store 엔트리의 parse_arena=null 인 dangling
+    // 상태를 evict — freeCachedModule 이 null arena 를 이중 free 하지 않아야 한다.
+    var m2 = Module.init(@enumFromInt(0), "\x00zntc:evict/dangling");
+    m2.parse_arena = Module_mod.createParseArena(allocator) orelse return error.OutOfMemory;
+    _ = try m2.parse_arena.?.allocator().alloc(u8, 64);
+    store.putModule("\x00zntc:evict/dangling", &m2, 1);
+    m2.deinit(allocator);
+    const cached = store.getIfFresh("\x00zntc:evict/dangling", 1) orelse return error.CacheMiss;
+    // graph 가 arena 소유권 환수(cache-hit replay 시 build_flow 가 하는 것과 동일).
+    const arena = cached.module.parse_arena.?;
+    cached.module.parse_arena = null;
+    store.evict("\x00zntc:evict/dangling"); // null arena → freeCachedModule 이 arena free 안 함
+    try testing.expect(!store.modules.contains("\x00zntc:evict/dangling"));
+    Module_mod.destroyParseArena(allocator, arena); // graph 가 소유하므로 여기서 해제
 }
 
 // Regression #3755: putModule OOM rollback 시 cached_module = module.* shallow copy 의

--- a/src/bundler/tree_shaker/const_materialize.zig
+++ b/src/bundler/tree_shaker/const_materialize.zig
@@ -378,6 +378,10 @@ fn materializeCrossModuleConstFactsForIndex(
     const_values.deinit(self.allocator);
     if (!materialized.changed) return false;
 
+    // (#4544) 이 모듈 AST 에 cross-module const 를 bake 함 → module_store 캐시에서 제외되도록 표시.
+    // baked 값은 provider const 에 의존하므로 소비자 mtime 캐시로 재사용하면 stale (transferModulesToStore 가 evict).
+    m.const_baked = true;
+
     const skip_minify = const_profile.policy.skipMinifyIfSafe() and !materialized.needs_minify;
     minifyAndResyncModule(self, m, sem, ast, const_profile, skip_minify);
     return true;


### PR DESCRIPTION
## 문제 (#4544 — #4535 의 2번째 층)

tree-shake 의 const-materialize 가 소비자 AST 에 provider 의 `export const N` 값을 **리터럴로
in-place bake** 하는데, 그 AST 가 `module_store` 에 **소비자 자기 mtime** 키로 캐시된다. baked 리터럴은
**provider const 에 의존하는 graph-derived** 산출물이라, provider 만 바뀌고 소비자 소스는 그대로면
warm 재빌드가 소비자를 reparse 하지 않아 **옛 상수값이 박제**된다(cold 와 불일치).

- 재현: `other.js: export const z = 1` → `index.js: import {z}; console.log(bump(), z)`.
  z 를 2 로 바꾸고 `other.js` 만 changed → warm 은 `console.log(...,1)` (stale), cold 는 `...,2`.
- #4535 는 emit fingerprint 로 소비자를 **재emit** 하게 했지만, 재emit 이 **박제된 AST** 를 읽어
  여전히 옛 값 → 이것이 "2번째 층".

## 근본 원인

캐시가 **graph-derived AST 를 source-derived 인 양(자기 mtime 키로)** 저장한 것. baked 값의 참
의존성은 "소비자 소스 + 구워넣은 provider const" 인데 소비자 mtime 만 봤다.

## 수정

그 의존성을 정확히 모델링한다 — cross-module const 를 bake 한 모듈(`m.const_baked`)을 `module_store`
캐시에서 **제외**(`transferModulesToStore` 에서 기존 엔트리도 `evict`). 다음 warm 빌드가 clean reparse
후 현재 provider 값으로 **fresh 재-materialize** → warm==cold.

- **baking 은 그대로 유지** → 전이 const 인라인 / 산술 folding / dead-branch dynamic·require import
  pruning 등 최적화 **전부 보존** (zod `--minify` 출력 main 과 **byte-identical**).
- **dev HMR 무영향**: tree-shake 는 `!dev_mode` 에서만 → dev 는 `const_baked` 발생 안 함.

## 대안 검토 (왜 이 방식인가)

- **clone (clean AST 캐싱)**: AST 뿐 아니라 semantic/symbol_ids/namespace/alias/export 메타데이터
  6종까지 스냅샷해야 함 (tree-shake 가 in-place 재구성) → `module_store` 의 UAF-prone 코드 재배선 =
  고위험. 폐기.
- **no-bake (순수 clean-cache)**: baking 이 전이 const/folding/dead-branch pruning 의 구현체라,
  제거하면 이 최적화들을 비파괴로 재구현해야 함(큰 재작성 + size 회귀). 폐기.
- **캐시 제외(본 PR)**: baking 보존 + arena 무접촉(안전) + 의존성 정확 모델링. 채택.

## 알려진 trade-off → 후속 #4557

`const_baked` eviction 이 **무조건적**이라, provider 가 안 바뀌어도 const-소비자가 매 warm(프로덕션
증분) 빌드마다 reparse 된다. 실측: zod/three 0, effect 2/361, date-fns 38/304. dev HMR 무영향.
provider-변경 시에만 무효화하는 **B-precise 최적화는 #4557 후속** (re-export 체인 설계가 있어 별도 PR).

## 테스트

- `reuse #4544: provider const change re-inlines in consumer warm==cold` (value 위치)
- `reuse #4544: sensitive + dead-branch consumer warm==cold` (code-review finding 1/2 가드:
  `N+1` binary 피연산자 + `if(FLAG){import}` dead-branch)
- `PersistentModuleStore: evict ...` (evict 완전엔트리 + parse_arena=null dangling + 없는경로 no-op)
- zod `--minify` main 과 byte-identical (baking 무손실) · zig test 전체 · 통합 const-value-inline/
  tree-shake/bundle-smoke/inline-dynamic 212 pass.

Closes #4544
Refs #4557

🤖 Generated with [Claude Code](https://claude.com/claude-code)