### PR TITLE
fix(bundler): #4532 preserve-modules(ESM) 동명 심볼 붕괴 수정 — cross-file 네이밍 인프라 켜기

### DIFF
--- a/.changeset/preserve-modules-cross-file-naming.md
+++ b/.changeset/preserve-modules-cross-file-naming.md
@@ -1,0 +1,37 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules`(ESM 출력)에서 서로 다른 wrap 된 파일의 **동명 심볼이 소비자 본문에서 붕괴**하던 조용한 오컴파일 수정 (#4532 증상1).
+
+`--splitting` 에는 있는 파일 간 심볼 네이밍 인프라(`computeCrossChunkGlobalNames` + 소비자 본문 참조 rewrite)가 preserve-modules 에선 `code_splitting and !preserve_modules` 로 꺼져 있었다. 그래서 두 wrap 된 dep 이 각각 `tag` 를 export 하고 소비자가 둘 다 참조하면:
+
+```js
+// b.js (a.cjs 가 require 해 ESM-wrap): export function tag(){ return "B"; }
+// c.js (동일):                          export function tag(){ return "C"; }
+// entry.js:
+import { tag } from "./b.js";
+import { tag as tag2 } from "./c.js";
+console.log(tag() + tag2());
+```
+
+| | 결과 |
+|---|---|
+| node 정본 · `--splitting` | `BC` |
+| `--preserve-modules` (수정 전) | **`BB`** ❌ (두 참조가 한 이름으로 붕괴) |
+| `--preserve-modules` (수정 후) | `BC` ✅ |
+
+## 수정
+
+두 게이트를 preserve-modules(ESM 출력)에도 연다:
+- **`module_to_chunk` 대여**(`isCrossChunkConsumer` 의 숨은 스위치) — 없으면 소비자 본문 rewrite 가 죽는다.
+- **`computeCrossChunkGlobalNames`** — 단 **ESM-wrap owner 로 한정**. non-wrap ESM 은 자연명 export, CJS owner 는 re-export barrel 배선(증상3)이 아직 없어, 전역명을 붙이면 provider/consumer 가 어긋난다. ESM-wrap owner 만 provider emit(`pm_wrapped_esm_provider`, #4528)이 전역명을 노출해 양측이 합의된다.
+
+## 범위
+
+- **ESM 출력 + non-minify 한정**:
+  - CJS 출력은 소비자가 bare 전역명을 bind 못 해(`require` 라 `var tag$1 = require_c().tag$1` materialize 필요) → 후속.
+  - minify 는 identifier mangler 가 전역명을 예약하지 않아(`computeChunkMangling` 은 `code_splitting` 게이트라 preserve-modules 서 skip) 대형 빌드서 mangled local 과 충돌 위험 → 후속.
+  - 게이트(`(code_splitting and !preserve_modules) or (preserve_modules and format==.esm and !minify_identifiers)`)로 splitting·CJS-format·minify 는 모두 pre-existing 동작 유지(회귀 없음).
+- 증상 2(`import * as ns` 미바인딩) / 증상 3(re-export barrel 스냅샷) / 증상 4(multi-entry 순환)는 네이밍이 자리잡은 뒤 후속 (#4532 잔여).
+- 회귀 가드: `preserve-modules-cjs.test.ts` 에 동명 심볼 실행 가드(`BC`) + 네이밍 경로 pin(`tag$1` 방출) 추가 — node 로 실제 실행.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1930,8 +1930,22 @@ pub const Bundler = struct {
             // (#4120) metadata 가 consumer↔canonical 청크 동일성을 판정하도록 module_to_chunk 를
             // 빌려준다(borrow — chunk_graph 소유, emit 동안 유효). defer 로 scope 이탈 시 먼저 비워
             // chunk_graph.deinit(1674 defer, LIFO 라 나중 실행) 전에 dangling 차단.
+            // (#4532) preserve_modules(ESM 출력)도 module_to_chunk 를 대여한다 — preserve-modules 는
+            // 모든 모듈이 자기 청크라 모든 모듈 간 import 가 cross-chunk 이고, 이 대여가 없으면
+            // isCrossChunkConsumer 가 false 라 소비자 본문 rewrite 가 죽어 동명 심볼이 붕괴한다(증상1).
+            // ⚠️ **ESM 출력 한정**: CJS 출력은 소비자가 bare 전역명을 bind 못 해(require 라 `var
+            // tag$1=require_c().tag$1` materialize 필요) → ReferenceError. CJS-format 증상1 은 후속.
+            // (#4532) ⚠️ **ESM 출력 + non-minify 한정**. CJS 출력은 소비자가 bare 전역명 bind 불가
+            // (materialize 필요) → ReferenceError. minify 는 identifier mangler 가 전역명을 예약하지
+            // 않아(computeChunkMangling 은 code_splitting 게이트라 preserve-modules 서 skip) 대형
+            // 빌드서 mangled local 과 전역명 충돌 위험 → 둘 다 후속. splitting(code_splitting and
+            // !preserve_modules)은 종전대로 별개 항으로 유지 — 아래 두 게이트가 splitting 을
+            // preserve-modules 와 함께 켠 CJS 조합에서도 새 네이밍을 발화시키면 안 되기 때문.
+            const pm_xchunk_naming = self.options.preserve_modules and
+                self.options.format == .esm and
+                !self.options.minify_identifiers;
             if (linker) |*l| {
-                if (self.options.code_splitting and !self.options.preserve_modules)
+                if ((self.options.code_splitting and !self.options.preserve_modules) or pm_xchunk_naming)
                     l.module_to_chunk = chunk_graph.module_to_chunk;
             }
             defer if (linker) |*l| {
@@ -1943,10 +1957,12 @@ pub const Bundler = struct {
             // override(lazy 전용)로, production 은 provider 가 전역명을 public 으로 노출(`export
             // { local as global }`) + 소비자 import key=global 로 일치(emit 측 분기). 단순 export
             // (local==export명)는 global==export명이라 byte-identical, 동명 충돌(global=`v$1`)·공유
-            // default·renamed export 만 달라진다. ⚠️ preserve_modules 는 제외 — emit 측 xchunk
-            // 블록이 `!preserve_modules` 게이트라, 켜면 consumer 만 전역명으로 바뀌어 mismatch.
+            // default·renamed export 만 달라진다. (#4532) preserve_modules 도 포함한다 — provider
+            // emit 측이 #4528 의 `pm_wrapped_esm_provider` 로 이미 전역명을 노출하므로 consumer 만
+            // 바뀌는 mismatch 는 없다. 단 computeCrossChunkGlobalNames 안에서 **wrap 된 owner 로 한정**
+            // 한다(non-wrap ESM provider 는 자연명 export → 전역명 붙이면 provider/consumer 어긋남).
             if (linker) |*l| {
-                if (self.options.code_splitting and !self.options.preserve_modules)
+                if ((self.options.code_splitting and !self.options.preserve_modules) or pm_xchunk_naming)
                     try chunk_mod.computeCrossChunkGlobalNames(self.allocator, &chunk_graph, l);
             }
 

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -1728,6 +1728,19 @@ pub fn computeCrossChunkGlobalNames(
     var used: std.StringHashMapUnmanaged(void) = .empty;
     defer used.deinit(allocator);
     for (syms.items) |s| {
+        // (#4532 증상1) preserve-modules 는 전역명을 **ESM-wrap owner 로 한정**한다.
+        // preserve-modules 는 모든 모듈이 자기 청크라 모든 import 가 cross-chunk 로 잡히는데:
+        //  - non-wrap ESM provider(.none): codegen 이 소스 `export { tag }` 를 자연명 재방출 →
+        //    전역명 붙이면 consumer 만 `import { tag$1 }`, provider 는 `export { tag }` 로 어긋남.
+        //  - CJS owner(.cjs): re-export barrel 등 소비 경로의 전역명 배선(`foo$legacy`)이 아직
+        //    없어(증상3 영역, 후속) 켜면 barrel 이 미정의 이름을 export → SyntaxError.
+        // ESM-wrap owner(.esm)만 provider emit 이 `pm_wrapped_esm_provider` 로 전역명(`local as
+        // global`)을 노출하므로 consumer/​provider 가 합의된다 → 동명 심볼 붕괴(증상1)를 여기서 해소.
+        // (splitting 은 non-wrap ESM·CJS 도 emit 측이 브리지하므로 전부 네이밍 → preserve 한정 skip.)
+        if (chunk_graph.preserve_modules) {
+            const owner = lnk.getModule(s.mod);
+            if (owner == null or owner.?.wrap_kind != .esm) continue;
+        }
         // (#4494) **CJS owner 의 공개명은 원문 멤버명을 쓰면 안 된다.** CJS 멤버는 provider 청크
         // top-level 에 `var <공개명> = require_X().<멤버>;` 로 *새 식별자를 만들어* 노출된다
         // (#4120 materialize). 멤버명을 그대로 쓰면:

--- a/tests/integration/tests/preserve-modules-cjs.test.ts
+++ b/tests/integration/tests/preserve-modules-cjs.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { join } from 'node:path';
-import { writeFileSync } from 'node:fs';
+import { writeFileSync, readFileSync } from 'node:fs';
 import { createFixture, runNode, runZntc } from './helpers';
 
 /**
@@ -596,4 +596,38 @@ describe('#4524: --preserve-modules × CJS', () => {
       }
     });
   }
+
+  // 증상1(조용한 오컴파일): 서로 다른 wrap 된 dep(b/c, a.cjs 가 require 해 ESM-wrap)의 동명 심볼
+  // `tag` 를 소비자 본문이 **둘 다** 호출하면 cross-chunk 전역명(`tag`/`tag$1`)으로 구분돼야 한다.
+  // 네이밍 인프라가 꺼져 있으면 두 참조가 한 이름으로 붕괴 → node 정본 `BC`, 버그 시 `BB`.
+  // ⚠️ ESM 출력 + non-minify 한정 — CJS-format 은 bare 전역명 bind 불가, minify 는 mangler 미예약
+  //    충돌 위험이라 둘 다 후속.
+  test('#4532 esm: 동명 wrap dep 두 심볼을 소비자 본문이 둘 다 참조해도 붕괴 안 함', async () => {
+    const { outDir, cleanup } = await buildPm(
+      {
+        'b.js': 'export function tag(){ return "B"; }',
+        'c.js': 'export function tag(){ return "C"; }',
+        'a.cjs':
+          'const b = require("./b.js");\nconst c = require("./c.js");\nmodule.exports = { x: 1 };',
+        'entry.js':
+          'import { tag } from "./b.js";\n' +
+          'import { tag as tag2 } from "./c.js";\n' +
+          'import "./a.cjs";\n' +
+          'console.log(tag() + tag2());',
+      },
+      'entry.js',
+    );
+    try {
+      const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+      expect(stderr).not.toContain('SyntaxError');
+      expect(stdout.trim()).toBe('BC');
+      // 네이밍 경로가 실제로 발화했는지 핀(natural-ESM fallback 이면 `BC` 는 나와도 이 fix 코드가
+      // 안 탄다 — b/c 가 ESM-wrap 이라 deconflict 전역명 `tag$1` 이 방출돼야 한다).
+      const bundled =
+        readFileSync(join(outDir, 'entry.js'), 'utf8') + readFileSync(join(outDir, 'c.js'), 'utf8');
+      expect(bundled).toContain('tag$1');
+    } finally {
+      await cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## 문제 (증상1 — 조용한 오컴파일)

`--preserve-modules` 에서 서로 다른 wrap 된 파일의 **동명 심볼이 소비자 본문에서 한 이름으로 붕괴**해, node 정본은 `BC` 인데 preserve-modules 는 에러 없이 `BB` 를 냈다.

```js
// b.js (a.cjs 가 require 해 ESM-wrap): export function tag(){ return "B"; }
// c.js (동일):                          export function tag(){ return "C"; }
// entry.js:
import { tag } from "./b.js";
import { tag as tag2 } from "./c.js";
import "./a.cjs";
console.log(tag() + tag2());
```

| | 결과 |
|---|---|
| node 정본 · `--splitting` | `BC` |
| `--preserve-modules` (수정 전) | **`BB`** ❌ |
| `--preserve-modules` (수정 후) | `BC` ✅ |

## 근본 원인

`--splitting` 이 쓰는 **파일 간 심볼 네이밍 인프라**(`computeCrossChunkGlobalNames` + 소비자 본문 참조 rewrite)가 preserve-modules 에선 `code_splitting and !preserve_modules` 로 꺼져 있었다. 특히 **`module_to_chunk` 대여가 숨은 스위치** — 없으면 `isCrossChunkConsumer` 가 false 라 본문 rewrite 가 죽어 두 `tag` 참조가 같은 이름으로 붕괴한다.

## 수정

두 게이트를 preserve-modules(ESM·non-minify 출력)에 연다:
- **`module_to_chunk` 대여**(bundler.zig): 본문 rewrite 를 살리는 숨은 스위치.
- **`computeCrossChunkGlobalNames`**(bundler.zig): 켜되 chunk.zig 안에서 **ESM-wrap owner 로 한정** — non-wrap ESM 은 자연명 export, CJS owner 는 re-export barrel 배선(증상3)이 없어 켜면 provider/consumer 가 어긋난다. ESM-wrap owner 만 provider emit(`pm_wrapped_esm_provider`, #4528)이 전역명(`local as global`)을 노출해 양측이 합의 → `tag`/`tag$1` 로 구분.

게이트 = `(code_splitting and !preserve_modules) or (preserve_modules and format==.esm and !minify_identifiers)`. splitting 항의 `!preserve_modules` 를 유지해 `--splitting --preserve-modules --format=cjs` 조합에서 새 네이밍이 발화하는 회귀를 막는다(code-review finding 1).

## 범위 (무회귀)

- **ESM 출력 + non-minify 한정**:
  - CJS 출력 → 소비자가 bare 전역명 bind 불가(`var tag$1=require_c().tag$1` materialize 필요) → 후속.
  - minify → identifier mangler 가 전역명 미예약(`computeChunkMangling` 은 `code_splitting` 게이트라 preserve-modules 서 skip) 대형 빌드 충돌 위험(code-review finding 2) → 후속.
  - 게이트로 splitting·CJS-format·minify 는 모두 pre-existing 유지(회귀 없음).
- provider emit(chunks.zig)은 #4528 로 이미 열려 있어 무변경.
- **잔여**: 증상 2(`import * as ns` 미바인딩) / 3(re-export barrel 스냅샷) / 4(multi-entry 순환) / CJS-format·minify 증상1 → 네이밍이 자리잡은 뒤 후속 (#4532).

## 테스트

- `preserve-modules-cjs.test.ts`: 동명 심볼 실행 가드(`console.log(tag()+tag2())` → node `BC`) + **네이밍 경로 pin**(`tag$1` 방출 확인 — natural-ESM fallback 이면 통과 못 하게, code-review finding 3).
- 검증: preserve-modules 40 / splitting·cross-chunk 104 / 스모크 174 / zig 전체 무회귀. `--splitting --preserve --format=cjs` 는 `tag()+tag()`(pre-existing) 유지.

Refs #4532

🤖 Generated with [Claude Code](https://claude.com/claude-code)