### PR TITLE
fix(bundler): #4532 preserve-modules(ESM) import * as ns 멤버 미바인딩 수정 (증상2)

### DIFF
--- a/.changeset/preserve-modules-ns-import.md
+++ b/.changeset/preserve-modules-ns-import.md
@@ -1,0 +1,31 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules`(ESM 출력)에서 `import * as ns` (ESM-wrap dep) 의 멤버 접근이 `ReferenceError` 나던 것 수정 (#4532 증상2).
+
+```js
+// dep.js:  export const val = 42; export function greet(){ return "G"; }
+// wrap.cjs: module.exports = require("./dep.js");   // dep 를 ESM-wrap 강제
+// entry.js:
+import * as ns from "./dep.js";
+import "./wrap.cjs";
+console.log(ns.val + "|" + ns.greet());   // 버그: ReferenceError: val is not defined
+```
+
+## 근본 원인
+
+`ns.val`/`ns.greet()` 는 linker 가 bare `val`/`greet` 로 **평탄화**(namespace member rewrite)하는데, direct leaf `import * as ns` 의 멤버는 `computeCrossChunkLinks` 의 어느 경로도 소비자 청크 `imports_from` 에 등록하지 않는다(namespace binding 은 canonical 이 없어 import_bindings 루프서 skip, consumer-side 루프는 namespace **re-export**(`imported="*"`)만 잡음). 그래서 `computeCrossChunkGlobalNames` 가 그 멤버를 못 보고 → 전역명 없음 → 평탄화가 bare local 로 폴백 → provider 도 export 안 함 → 소비자 청크서 미정의.
+
+## 수정
+
+`computeCrossChunkLinks` 의 consumer-side namespace 루프에 **direct leaf namespace import 브랜치**를 추가: `nsReExportTarget`(namespace re-export)이 null 인 direct `import * as ns` 이고 dep 가 다른 청크면 `fanOutModuleExports(chunk, dep)` 로 dep 의 export 를 `imports_from`/`exports_to` 에 등록한다. 그러면 증상1이 켠 인프라가 그대로 발화 — `computeCrossChunkGlobalNames`(wrap 은 전역명, non-wrap ESM 은 자연명), provider export, 소비자 import·바인딩, 평탄화 rewrite. member-only(`ns.val`)·value-use(`Object.keys(ns)`) 둘 다 커버(후자는 소비자가 imported 멤버로 ns 객체 합성).
+
+## 범위 (code-review 반영)
+
+- 게이트 = 증상1 공유(`chunk_graph.pm_xchunk_naming` = preserve-modules + ESM + non-minify **+ non-dev**) + dep `wrap_kind != .cjs`.
+  - **non-wrap ESM(.none)도 등록**: plain ESM dep(가장 흔함)도 같은 평탄화라 wrap-only 게이트면 똑같이 깨진다. CJS dep 은 cjsNs interop 별경로라 제외.
+  - **`!dev_mode` 추가**: dev 는 namespace member rewrite 가 wrapped local 을 써 negotiated 전역명 경로를 안 탄다.
+  - `seen_ns_target` dedup 으로 같은 dep 반복 DFS 방지. splitting·CJS·minify·dev 는 pre-existing 유지.
+- 회귀 가드: `preserve-modules-cjs.test.ts` 에 실행 가드 3종 — wrap-ESM dep(`42|G`)·plain non-wrap ESM dep(`7|P`)·value-use `Object.keys(ns)`(`greet,val|42`), + fan-out 경로 pin(멤버 cross-chunk import 확인). node 로 실제 실행.
+- 잔여(#4532): 증상 3(re-export barrel) / 4(multi-entry 순환) / CJS·minify / barrel-namespace 전역명 collision(비-.esm owner).

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1925,25 +1925,28 @@ pub const Bundler = struct {
                 chunk_mod.mergeSmallChunks(&chunk_graph, graph, self.options.min_chunk_size);
             }
 
-            try chunk_mod.computeCrossChunkLinks(&chunk_graph, graph, self.allocator, if (linker) |*l| l else null);
-
-            // (#4120) metadata 가 consumer↔canonical 청크 동일성을 판정하도록 module_to_chunk 를
-            // 빌려준다(borrow — chunk_graph 소유, emit 동안 유효). defer 로 scope 이탈 시 먼저 비워
-            // chunk_graph.deinit(1674 defer, LIFO 라 나중 실행) 전에 dangling 차단.
-            // (#4532) preserve_modules(ESM 출력)도 module_to_chunk 를 대여한다 — preserve-modules 는
-            // 모든 모듈이 자기 청크라 모든 모듈 간 import 가 cross-chunk 이고, 이 대여가 없으면
-            // isCrossChunkConsumer 가 false 라 소비자 본문 rewrite 가 죽어 동명 심볼이 붕괴한다(증상1).
-            // ⚠️ **ESM 출력 한정**: CJS 출력은 소비자가 bare 전역명을 bind 못 해(require 라 `var
-            // tag$1=require_c().tag$1` materialize 필요) → ReferenceError. CJS-format 증상1 은 후속.
-            // (#4532) ⚠️ **ESM 출력 + non-minify 한정**. CJS 출력은 소비자가 bare 전역명 bind 불가
-            // (materialize 필요) → ReferenceError. minify 는 identifier mangler 가 전역명을 예약하지
-            // 않아(computeChunkMangling 은 code_splitting 게이트라 preserve-modules 서 skip) 대형
-            // 빌드서 mangled local 과 전역명 충돌 위험 → 둘 다 후속. splitting(code_splitting and
-            // !preserve_modules)은 종전대로 별개 항으로 유지 — 아래 두 게이트가 splitting 을
-            // preserve-modules 와 함께 켠 CJS 조합에서도 새 네이밍을 발화시키면 안 되기 때문.
+            // (#4532) preserve_modules(ESM·non-minify 출력)의 cross-file 심볼 네이밍 게이트. CJS
+            // 출력은 소비자가 bare 전역명 bind 불가(materialize 필요), minify 는 identifier mangler 가
+            // 전역명 미예약(computeChunkMangling 은 code_splitting 게이트라 preserve-modules 서 skip)
+            // 충돌 위험 → 둘 다 후속. splitting(code_splitting and !preserve_modules)은 별개 항 유지.
+            // ⚠️ `!dev_mode` 도 필수: dev 는 namespace member rewrite 가 wrapped local(`(init(),
+            // exp.local)`)을 쓰고 negotiated 전역명 경로를 안 타 동명 멤버가 붕괴한다(code-review).
             const pm_xchunk_naming = self.options.preserve_modules and
                 self.options.format == .esm and
-                !self.options.minify_identifiers;
+                !self.options.minify_identifiers and
+                !self.options.dev_mode;
+            // (#4532 증상2) computeCrossChunkLinks 의 direct `import * as ns`(leaf ESM-wrap dep) fan-out
+            // 을 이 게이트로 한정 — dep export 를 소비자 imports_from 에 등록해 아래 네이밍/provider
+            // emit 이 발화한다(안 하면 평탄화된 bare 멤버 val/greet 가 미정의 → ReferenceError).
+            chunk_graph.pm_xchunk_naming = pm_xchunk_naming;
+
+            try chunk_mod.computeCrossChunkLinks(&chunk_graph, graph, self.allocator, if (linker) |*l| l else null);
+
+            // (#4120/#4532) metadata 가 consumer↔canonical 청크 동일성을 판정하도록 module_to_chunk 를
+            // 빌려준다(borrow, emit 동안 유효). preserve-modules(ESM)도 대여 — 없으면 isCrossChunkConsumer
+            // 가 false 라 소비자 본문 rewrite 가 죽어 동명 심볼 붕괴(증상1). splitting 항의 `!preserve_modules`
+            // 는 splitting+preserve+cjs 조합에서 새 네이밍 발화(ReferenceError) 회귀를 막으려 유지.
+            // defer 로 scope 이탈 시 chunk_graph.deinit 전에 dangling 차단.
             if (linker) |*l| {
                 if ((self.options.code_splitting and !self.options.preserve_modules) or pm_xchunk_naming)
                     l.module_to_chunk = chunk_graph.module_to_chunk;

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -347,6 +347,11 @@ pub const ChunkGraph = struct {
     /// 이름을 소비자가 `import { default as … }` 로 가져와 링크 에러가 난다.
     preserve_modules: bool = false,
 
+    /// (#4532) preserve-modules(ESM·non-minify) cross-file 심볼 네이밍이 켜졌는지. bundler.zig 가
+    /// computeCrossChunkLinks 전에 세팅. direct `import * as ns`(ESM-wrap dep) fan-out(증상2)을
+    /// 이 게이트 + dep `wrap_kind==.esm` 로 한정해, 네이밍이 켜진 경우에만 imports_from 에 등록한다.
+    pm_xchunk_naming: bool = false,
+
     /// module_count 크기의 빈 ChunkGraph를 생성한다.
     pub fn init(allocator: std.mem.Allocator, module_count: usize) !ChunkGraph {
         const module_to_chunk = try allocator.alloc(ChunkIndex, module_count);
@@ -2046,8 +2051,30 @@ pub fn computeCrossChunkLinks(
                     if (ib.import_record_index >= m.import_records.len) continue;
                     const src_mod = m.import_records[ib.import_record_index].resolved;
                     if (src_mod.isNone()) continue;
-                    const ns_target = nsReExportTarget(graph, src_mod, ib.imported_name) orelse continue;
-                    try linkNamespaceCrossChunkOnce(allocator, chunk_graph, chunk, &seen_static, &seen_ns_target, lnk, ns_target, module_count);
+                    if (nsReExportTarget(graph, src_mod, ib.imported_name)) |ns_target| {
+                        try linkNamespaceCrossChunkOnce(allocator, chunk_graph, chunk, &seen_static, &seen_ns_target, lnk, ns_target, module_count);
+                        continue;
+                    }
+                    // (#4532 증상2) preserve-modules(ESM): direct leaf `import * as ns from "./dep"`.
+                    // ns.val/ns.greet 는 registerNamespaceRewrites 가 bare 멤버로 평탄화하는데, nsReExportTarget
+                    // 은 namespace **re-export**(imported="*")만 잡아 이 direct leaf import 를 놓쳐 멤버가
+                    // cross-chunk 등록 안 됨 → 소비자 청크서 미정의 ReferenceError. dep 의 export 를 fan-out
+                    // 해 imports_from 에 넣으면 뒤이은 computeCrossChunkGlobalNames(wrap 은 전역명, non-wrap
+                    // ESM 은 자연명) + provider export + rewrite 가 발화한다. **ESM dep 전부**(wrap·non-wrap)
+                    // 등록해야 한다 — plain ESM dep(가장 흔함)도 같은 평탄화라 미등록이면 똑같이 깨진다. CJS
+                    // dep 은 cjsNs interop 별경로라 제외. seen_ns_target 로 같은 dep 반복 DFS 방지.
+                    if (chunk_graph.pm_xchunk_naming and ib.kind == .namespace) {
+                        if (graph.getModule(src_mod)) |dep| {
+                            if (dep.wrap_kind != .cjs) {
+                                const dep_chunk = chunk_graph.getModuleChunk(src_mod);
+                                if (!dep_chunk.isNone() and dep_chunk != chunk.index) {
+                                    const gop = try seen_ns_target.getOrPut(allocator, @intFromEnum(src_mod));
+                                    if (!gop.found_existing)
+                                        try fanOutModuleExports(allocator, chunk_graph, chunk, &seen_static, lnk, src_mod, module_count);
+                                }
+                            }
+                        }
+                    }
                 }
 
                 // `export * from "./y"` (re_export_star, y 별도 청크): 위 named

--- a/tests/integration/tests/preserve-modules-cjs.test.ts
+++ b/tests/integration/tests/preserve-modules-cjs.test.ts
@@ -630,4 +630,77 @@ describe('#4524: --preserve-modules × CJS', () => {
       await cleanup();
     }
   });
+
+  // 증상2: `import * as ns from "./dep.js"` (dep 는 wrap.cjs 가 require 해 ESM-wrap) 의 `ns.val`/
+  // `ns.greet()` 멤버 접근이 bare `val`/`greet` 로 평탄화되는데, 그 멤버가 cross-chunk 로 등록 안 돼
+  // 소비자 청크서 미정의 → ReferenceError. dep export 를 fan-out 해 소비자가 import·바인딩하게 한다.
+  // ⚠️ ESM 출력 + non-minify 한정(증상1 게이트 공유).
+  test('#4532 esm: import * as ns (ESM-wrap dep) 의 멤버 접근이 cross-chunk 바인딩된다', async () => {
+    const { outDir, cleanup } = await buildPm(
+      {
+        'dep.js': 'export const val = 42;\nexport function greet(){ return "G"; }',
+        'wrap.cjs': 'module.exports = require("./dep.js");',
+        'entry.js':
+          'import * as ns from "./dep.js";\n' +
+          'import "./wrap.cjs";\n' +
+          'console.log(ns.val + "|" + ns.greet());',
+      },
+      'entry.js',
+    );
+    try {
+      const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+      // 버그 시: ReferenceError: val is not defined (평탄화된 bare 멤버 미바인딩)
+      expect(stderr).not.toContain('ReferenceError');
+      expect(stdout.trim()).toBe('42|G');
+      // fix 경로 pin: 평탄화된 멤버가 dep 청크에서 cross-chunk import 돼야 한다(fan-out 발화).
+      const entryJs = readFileSync(join(outDir, 'entry.js'), 'utf8');
+      expect(entryJs).toMatch(/import\s*\{[^}]*\bval\b[^}]*\}\s*from\s*["']\.\/dep\.js["']/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // (code-review) plain ESM dep(non-wrap, 가장 흔함) 도 같은 평탄화라 fan-out 게이트가 wrap-only 면
+  // 미등록으로 남아 똑같이 ReferenceError. dep wrap_kind != .cjs 로 non-wrap ESM 도 등록해야 한다.
+  test('#4532 esm: import * as ns (plain non-wrap ESM dep) 도 cross-chunk 바인딩된다', async () => {
+    const { outDir, cleanup } = await buildPm(
+      {
+        'dep.js': 'export const val = 7;\nexport function greet(){ return "P"; }',
+        'entry.js': 'import * as ns from "./dep.js";\nconsole.log(ns.val + "|" + ns.greet());',
+      },
+      'entry.js',
+    );
+    try {
+      const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+      expect(stderr).not.toContain('ReferenceError');
+      expect(stdout.trim()).toBe('7|P');
+      const entryJs = readFileSync(join(outDir, 'entry.js'), 'utf8');
+      expect(entryJs).toMatch(/import\s*\{[^}]*\bval\b[^}]*\}\s*from\s*["']\.\/dep\.js["']/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // (code-review) value-use 경로: ns 를 값으로도 쓰면(Object.keys(ns)) 소비자가 imported 멤버로 ns
+  // 객체를 합성해야 한다 — 멤버-접근만 검증하면 이 경로 회귀가 green CI 로 샌다.
+  test('#4532 esm: import * as ns value-use (Object.keys) 가 동작한다', async () => {
+    const { outDir, cleanup } = await buildPm(
+      {
+        'dep.js': 'export const val = 42;\nexport function greet(){ return "G"; }',
+        'wrap.cjs': 'module.exports = require("./dep.js");',
+        'entry.js':
+          'import * as ns from "./dep.js";\n' +
+          'import "./wrap.cjs";\n' +
+          'console.log(Object.keys(ns).sort().join(",") + "|" + ns.val);',
+      },
+      'entry.js',
+    );
+    try {
+      const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+      expect(stderr).not.toContain('ReferenceError');
+      expect(stdout.trim()).toBe('greet,val|42');
+    } finally {
+      await cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## 문제 (증상2)

`--preserve-modules`(ESM 출력)에서 `import * as ns` 의 멤버 접근이 `ReferenceError`.

```js
// dep.js:  export const val = 42; export function greet(){ return "G"; }
// entry.js:
import * as ns from "./dep.js";
console.log(ns.val + "|" + ns.greet());   // 버그: ReferenceError: val is not defined
```

## 근본 원인

`ns.val`/`ns.greet()` 는 linker 가 bare `val`/`greet` 로 **평탄화**(namespace member rewrite)하는데, direct leaf `import * as ns` 의 멤버는 `computeCrossChunkLinks` 의 어느 경로도 소비자 청크 `imports_from` 에 등록하지 않는다(namespace binding 은 canonical 없어 import_bindings 루프 skip, consumer-side 루프는 namespace **re-export**(`imported="*"`)만 잡음). → `computeCrossChunkGlobalNames` 가 멤버를 못 봄 → 전역명 없음 → 평탄화가 bare local 폴백 → provider 도 미-export.

## 수정

consumer-side namespace 루프에서 `nsReExportTarget` 이 null 인 **direct leaf `import * as ns`** 이고 dep 가 다른 청크면 `fanOutModuleExports(chunk, dep)` 로 dep export 를 `imports_from`/`exports_to` 에 등록. 이후 증상1이 켠 인프라 발화 — `computeCrossChunkGlobalNames`(wrap=전역명, non-wrap ESM=자연명) → provider export → 소비자 import·바인딩 → 평탄화 rewrite. member-only(`ns.val`)·value-use(`Object.keys(ns)`) 둘 다 커버.

## 범위 (code-review max 반영)

- 게이트 = 증상1 공유 `chunk_graph.pm_xchunk_naming`(preserve-modules + ESM + non-minify **+ non-dev**) + dep **`wrap_kind != .cjs`**:
  - **non-wrap ESM(.none)도 등록** — plain ESM dep(가장 흔함)도 같은 평탄화라 wrap-only 게이트면 똑같이 깨진다(finding [4]). CJS dep 은 cjsNs interop 별경로라 제외.
  - **`!dev_mode`** — dev 는 ns member rewrite 가 wrapped local 을 써 negotiated 전역명 경로를 안 탄다(finding [0]).
  - `seen_ns_target` dedup — 같은 dep 반복 DFS 방지(finding [3]).
- splitting·CJS-format·minify·dev 는 pre-existing 유지(회귀 없음).

## 테스트

- `preserve-modules-cjs.test.ts`: `import * as ns` 실행 가드 3종 — wrap-ESM dep(`42|G`)·plain non-wrap ESM dep(`7|P`)·value-use `Object.keys(ns)`(`greet,val|42`, finding [2]) + fan-out 경로 pin(멤버 cross-chunk import). node 실제 실행.
- 검증: preserve-modules/splitting/cross-chunk/smoke 276 pass, zig 전체 무회귀.

## 잔여 (#4532)

증상 3(re-export barrel) / 4(multi-entry 순환) / CJS·minify / barrel-namespace 전역명 collision(비-.esm owner, finding [1] — single-val 은 동작, name-collision 변형만 latent).

Refs #4532

🤖 Generated with [Claude Code](https://claude.com/claude-code)