### PR TITLE
fix(chunk): #4560 splitting namespace 멤버 cross-chunk 등록 누락

### DIFF
--- a/.changeset/splitting-ns-member-crosschunk.md
+++ b/.changeset/splitting-ns-member-crosschunk.md
@@ -1,0 +1,39 @@
+---
+"@zntc/core": patch
+---
+
+`--splitting` 에서 `import * as ns` 의 멤버(`ns.channel`)가 **다른 청크**에 있고 named-import 소비자가 없을 때 cross-chunk 등록이 누락돼 `ReferenceError` 나던 것 수정 (#4560).
+
+```js
+// pkg/channel.js:  export const channel = (c, ch) => ...;   // 공통 청크로 분리
+// diagram1.js (lazy):
+import * as k from "./pkg/channel.js";
+function fade(c) { return k.channel(c, "r"); }   // 각 다이어그램이 자체 정의(중복)
+export const d1 = () => fade({ r: 1 });
+// entry.js:  Promise.all([import("./diagram1.js"), import("./diagram2.js")])
+// 버그: diagram 청크서 bare `channel` → ReferenceError (mermaid.render() 크래시)
+```
+
+## 근본 원인
+
+`k.channel` 은 linker(`registerNamespaceRewrites`)가 bare `channel` 로 **평탄화**하는데, direct leaf `import * as k` 의 멤버는 `computeCrossChunkLinks` 의 어느 경로도 소비자 청크 `imports_from` 에 등록하지 않는다. `import_bindings` 루프는 namespace binding 에 canonical 이 없어 skip, consumer-side 루프는 namespace **re-export**(`imported="*"`)만 잡는다. 그리고 그 멤버(`channel`)를 **named-import 로 소비하는 청크가 하나도 없으면**(오직 namespace 멤버 접근만) 아무도 cross-chunk 등록을 트리거하지 않는다 → 소비자 청크서 bare `channel` = 선언 없는 자유 변수 → `ReferenceError`.
+
+실제 mermaid 에서 각 다이어그램(`flowDiagram-*.mjs` 등)이 `fade` 를 자체 정의하고 그 안에서 공통 청크의 `khroma.channel` 을 namespace 멤버로 부르는데, `channel` 은 오직 namespace 접근으로만 쓰여 lazy 다이어그램 청크에 bare 로 남았고 `mermaid.render()` 가 크래시했다.
+
+rolldown 은 사용된 심볼의 `canonical_ref` 기반(symbol-usage) 이라 평탄화된 namespace 멤버도 자연히 cross-chunk 에 포함된다. zntc 는 import-binding 기반이라 이 표면을 놓쳤다.
+
+## 수정
+
+`computeCrossChunkLinks` 의 consumer-side namespace 루프 — #4532 증상2 에서 preserve-modules 용으로 넣은 **direct leaf namespace fan-out 브랜치**를 splitting 에도 발화시킨다. `nsReExportTarget` 이 null 인 direct `import * as ns` 이고 dep 가 다른 청크면 `fanOutModuleExports(chunk, dep)` 로 dep 의 export 를 `imports_from`/`exports_to` 에 등록 → 뒤이은 `computeCrossChunkGlobalNames` + provider export + 소비자 import·평탄화 rewrite 가 발화한다.
+
+게이트: `const ns_fanout_ok = if (preserve_modules) pm_xchunk_naming else true;`
+- **splitting**: 항상 (이 수정).
+- **preserve-modules**: `pm_xchunk_naming`(ESM·non-minify·non-dev) 한정 — #4532 와 동일.
+- CJS dep 은 cjsNs interop 별경로라 제외, `seen_ns_target` 로 같은 dep 반복 DFS dedup.
+
+## 범위 / 한계 (code-review max 반영)
+
+- **dedup 도메인 분리**: fan-out 은 `fanOutModuleExports` 만 하는 **부분 작업**이라, 풀 작업(`markNsCrossChunk`+`ensureSharedNsVar`+ns-객체 등록)을 하는 `linkNamespaceCrossChunk` 와 dedup set(`seen_ns_target`)을 공유하면 안 된다 — 공유 시 fan-out 이 먼저 dep 를 넣어 같은 청크의 뒤이은 `export * as ns`(re-export)·값-사용용 `linkNamespaceCrossChunkOnce` 를 조기 return 시켜 ns 객체 합성이 누락된다. **별도 `seen_ns_fanout` set** 으로 격리(fanOut 은 `seen_static` 으로 멱등이라 이중 호출 안전).
+- **`!dev_mode` 게이트**: splitting 항도 dev 제외(`else !graph.dev_mode`). dev 는 namespace member rewrite 가 wrapped local 을 써 negotiated 전역명 경로를 안 타므로 preserve-modules 게이트(`pm_xchunk_naming` 이 이미 `!dev_mode`)와 동일하게 제외.
+- **과등록(correctness-neutral)**: `linkReExportName` 이 `crossChunkExportIsShaken` 으로 **전역 dead export** 는 거르지만 "이 소비자가 실제 쓰는 멤버" 까지 추리진 않아 dep 의 live export 를 통째로 등록한다 → rolldown 의 per-usage canonical-ref 보다 약간 과등록(mermaid 실측 **~0.08% dead import**, 무해). per-consumer 정밀 등록은 후속.
+- 회귀 가드: `split-runtime-smoke.test.ts` 에 `#4560` 실행 가드 — namespace 멤버가 다른 청크에 있고 named-import 소비자가 없는 구조를 dynamic import 로 node 실행(`d1:2,4 / d2:6,8`). 런타임뿐 아니라 **크로스-청크 경계**(diagram 청크가 `import{channel}from"./chunk-*"`)를 `readFileSync` 로 실제 검증 — 청킹 휴리스틱이 dep 를 복제해 fix 를 우회하면 fail.

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -1952,6 +1952,13 @@ pub fn computeCrossChunkLinks(
         // churn 을 피하려 청크 단위로 target dedup.
         var seen_ns_target: std.AutoHashMapUnmanaged(u32, void) = .empty;
         defer seen_ns_target.deinit(allocator);
+        // (#4560) direct-leaf `import * as ns` fan-out 은 **부분 작업**(fanOutModuleExports 만)이라
+        // linkNamespaceCrossChunk 의 풀 작업(markNsCrossChunk+ensureSharedNsVar+ns 객체 등록)과 dedup
+        // 도메인이 다르다. seen_ns_target 을 공유하면 이 브랜치가 먼저 dep 를 넣어 뒤이은
+        // linkNamespaceCrossChunkOnce(같은 청크의 `export * as ns`·값-사용)를 조기 return 시켜 ns 객체
+        // 합성이 누락된다(code-review). 별도 set 으로 격리 — fanOut 은 seen_static 으로 멱등이라 안전.
+        var seen_ns_fanout: std.AutoHashMapUnmanaged(u32, void) = .empty;
+        defer seen_ns_fanout.deinit(allocator);
 
         for (chunk.modules.items) |mod_idx| {
             // 청크에 포함된 모듈은 반드시 graph 범위 내에 있어야 함
@@ -2055,20 +2062,29 @@ pub fn computeCrossChunkLinks(
                         try linkNamespaceCrossChunkOnce(allocator, chunk_graph, chunk, &seen_static, &seen_ns_target, lnk, ns_target, module_count);
                         continue;
                     }
-                    // (#4532 증상2) preserve-modules(ESM): direct leaf `import * as ns from "./dep"`.
-                    // ns.val/ns.greet 는 registerNamespaceRewrites 가 bare 멤버로 평탄화하는데, nsReExportTarget
-                    // 은 namespace **re-export**(imported="*")만 잡아 이 direct leaf import 를 놓쳐 멤버가
-                    // cross-chunk 등록 안 됨 → 소비자 청크서 미정의 ReferenceError. dep 의 export 를 fan-out
-                    // 해 imports_from 에 넣으면 뒤이은 computeCrossChunkGlobalNames(wrap 은 전역명, non-wrap
-                    // ESM 은 자연명) + provider export + rewrite 가 발화한다. **ESM dep 전부**(wrap·non-wrap)
-                    // 등록해야 한다 — plain ESM dep(가장 흔함)도 같은 평탄화라 미등록이면 똑같이 깨진다. CJS
-                    // dep 은 cjsNs interop 별경로라 제외. seen_ns_target 로 같은 dep 반복 DFS 방지.
-                    if (chunk_graph.pm_xchunk_naming and ib.kind == .namespace) {
+                    // (#4532 증상2 / #4560) direct leaf `import * as ns from "./dep"` 의 멤버 접근
+                    // (`ns.channel`)은 registerNamespaceRewrites 가 bare 멤버로 평탄화하는데,
+                    // nsReExportTarget 은 namespace **re-export**(imported="*")만 잡아 이 direct leaf import
+                    // 를 놓쳐 멤버가 cross-chunk 등록 안 됨 → 소비자 청크서 미정의 ReferenceError.
+                    // dep 의 export 를 fan-out 해 imports_from 에 넣으면 computeCrossChunkGlobalNames(전역명)
+                    // + provider export + rewrite 가 발화한다. linkReExportName 이 crossChunkExportIsShaken
+                    // 으로 **전역 dead export** 는 거르지만, 소비자가 실제 쓰는 멤버만 추리진 않아 dep 의
+                    // live export 를 통째로 등록한다 — rolldown 의 per-usage canonical-ref 보다 약간
+                    // 과등록(mermaid 실측 ~0.08% dead import, correctness 무해). CJS dep 은 cjsNs interop
+                    // 별경로라 제외, seen_ns_fanout(별도 set)로 dedup — seen_ns_target 공유 시 이 부분
+                    // 작업이 뒤이은 풀 ns-object 배선을 조기 return 시킨다(위 선언부 주석).
+                    //   - **splitting**(#4560): dev 제외. mermaid `import * as khroma; khroma.channel(color,"r")`
+                    //     가 lazy 다이어그램 청크서 bare `channel` → render() ReferenceError 였다. dev 는
+                    //     member rewrite 가 wrapped local 을 써 전역명 경로를 안 타므로 preserve-modules 와
+                    //     동일하게 제외한다.
+                    //   - **preserve-modules**(#4532): pm_xchunk_naming(ESM·non-minify·non-dev) 한정.
+                    const ns_fanout_ok = if (chunk_graph.preserve_modules) chunk_graph.pm_xchunk_naming else !graph.dev_mode;
+                    if (ns_fanout_ok and ib.kind == .namespace) {
                         if (graph.getModule(src_mod)) |dep| {
                             if (dep.wrap_kind != .cjs) {
                                 const dep_chunk = chunk_graph.getModuleChunk(src_mod);
                                 if (!dep_chunk.isNone() and dep_chunk != chunk.index) {
-                                    const gop = try seen_ns_target.getOrPut(allocator, @intFromEnum(src_mod));
+                                    const gop = try seen_ns_fanout.getOrPut(allocator, @intFromEnum(src_mod));
                                     if (!gop.found_existing)
                                         try fanOutModuleExports(allocator, chunk_graph, chunk, &seen_static, lnk, src_mod, module_count);
                                 }

--- a/tests/integration/tests/split-runtime-smoke.test.ts
+++ b/tests/integration/tests/split-runtime-smoke.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { runZntc, createFixture } from './helpers';
-import { writeFileSync } from 'node:fs';
+import { writeFileSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
@@ -124,6 +124,76 @@ export const b = () => member() + "|B:" + other.label;
       // 수정 전: `ReferenceError: second is not defined`
       expect(r.err, `모듈 평가 실패:\n${r.err}`).toBe('');
       expect(r.out).toBe('second|A:second / second|B:other');
+    } finally {
+      await cleanup();
+    }
+  }, 120000);
+
+  test('#4560 splitting: `import * as ns` 멤버가 다른 청크에 있으면 크로스-청크로 등록된다', async () => {
+    // #4492 계열이 **over-registration**(같은 청크인데 전역 공개명 오염) 이라면 #4560 은
+    // 정반대 **under-registration**: `ns.member` 는 linker 가 bare `member` 로 평탄화하는데,
+    // 그 member 가 **다른 청크**(공통 청크)에 있고 named-import 로 소비하는 데가 하나도 없으면
+    // (오직 namespace 멤버 접근만) `computeCrossChunkLinks` 의 어느 경로도 소비자 청크
+    // `imports_from` 에 등록하지 않는다 → 소비자 청크서 bare `member` = 선언 없는 자유 변수
+    // → `ReferenceError`. (mermaid: 각 다이어그램 청크가 자체 `fade` 를 정의하고 그 안에서
+    // 공통 청크의 `khroma.channel` 을 namespace 멤버로 부름.)
+    //
+    // 핵심 조건: channel 을 **named-import 하는 소비자가 없어야** 한다. 있으면 import_bindings
+    // 루프가 이미 등록해버려 버그가 안 난다(#4492 는 named-import 가 있었다).
+    const files: Record<string, string> = {
+      // 함수라 minify 인라인 불가 → 공통 청크에 실제 심볼로 남는다.
+      'pkg/channel.js': `export const channel = (c, ch) => { let v = 0; for (const k in c) if (k === ch) v = c[k]; return v * 2; };\n`,
+      // 각 다이어그램이 fade 를 **자체 정의**(mermaid 처럼 중복) → k.channel 이 leaf 청크서 평탄화.
+      'diagram1.js': `import * as k from "./pkg/channel.js";
+function fade(c) { return k.channel(c, "r") + "," + k.channel(c, "g"); }
+export const d1 = () => "d1:" + fade({ r: 1, g: 2 });
+`,
+      'diagram2.js': `import * as k from "./pkg/channel.js";
+function fade(c) { return k.channel(c, "b") + "," + k.channel(c, "g"); }
+export const d2 = () => "d2:" + fade({ b: 3, g: 4 });
+`,
+      'entry.js': `Promise.all([import("./diagram1.js"), import("./diagram2.js")]).then(([m1, m2]) => {
+  console.log(m1.d1() + " / " + m2.d2());
+});
+`,
+    };
+
+    const { dir, cleanup } = await createFixture(files);
+    try {
+      const outDir = join(dir, 'out');
+      const build = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--splitting',
+        '--outdir',
+        outDir,
+        '--minify',
+        '--format=esm',
+      ]);
+      expect(build.exitCode).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+
+      // cross-chunk 경계를 **실제로** 검증한다 (런타임 출력만 보면 청킹 휴리스틱이
+      // channel.js 를 다이어그램 청크마다 복제해버려도 green 이라 fix 가 우회된다).
+      // diagram 청크가 별도 청크에서 `channel` 을 import 하는 edge 가 있어야 한다.
+      const chunkFiles = readdirSync(outDir).filter(
+        (f) => f.startsWith('diagram') && f.endsWith('.js'),
+      );
+      expect(chunkFiles.length).toBeGreaterThan(0);
+      const importsChannel = chunkFiles.some((f) =>
+        /import\{[^}]*\bchannel\b[^}]*\}from"\.\/chunk-/.test(
+          readFileSync(join(outDir, f), 'utf-8'),
+        ),
+      );
+      expect(
+        importsChannel,
+        'diagram 청크가 channel 을 cross-chunk import 하지 않음 — fix 우회',
+      ).toBe(true);
+
+      const r = runNode(join(outDir, 'entry.js'));
+      // 수정 전: `ReferenceError: channel is not defined`
+      expect(r.err, `모듈 평가 실패:\n${r.err}`).toBe('');
+      expect(r.out).toBe('d1:2,4 / d2:6,8');
     } finally {
       await cleanup();
     }


### PR DESCRIPTION
## 문제 (#4560)

`--splitting` 에서 `import * as ns` 의 멤버(`ns.channel`)가 **다른 청크**에 있고 그 멤버를 **named-import 로 소비하는 곳이 하나도 없을 때**, lazy 청크에 bare `channel` 참조가 남아 `ReferenceError` → `mermaid.render()` 크래시.

실제 mermaid: 각 다이어그램 청크(`flowDiagram-*` 등)가 `fade` 를 자체 정의하고 그 안에서 공통 청크의 `khroma.channel` 을 namespace 멤버로 부른다. `channel` 은 오직 namespace 접근으로만 쓰여(`import * as khroma`) lazy 청크에 bare 로 남았다.

```js
// pkg/channel.js:  export const channel = (c, ch) => ...;   // 공통 청크로 분리
// diagram1.js (lazy):
import * as k from "./pkg/channel.js";
function fade(c) { return k.channel(c, "r"); }
export const d1 = () => fade({ r: 1 });
// entry.js:  Promise.all([import("./diagram1.js"), import("./diagram2.js")])
```

## 근본 원인

`k.channel` 은 linker(`registerNamespaceRewrites`)가 bare `channel` 로 **평탄화**한다. 그런데 direct leaf `import * as k` 의 멤버는 `computeCrossChunkLinks` 의 어느 경로도 소비자 청크 `imports_from` 에 등록하지 않는다 — import_bindings 루프는 namespace binding 에 canonical 이 없어 skip, consumer-side 루프는 namespace **re-export**(`imported="*"`)만 잡는다. 그 멤버를 **named-import 로 소비하는 청크가 하나도 없으면** 아무도 cross-chunk 등록을 트리거하지 않아, 소비자 청크서 bare `channel` = 선언 없는 자유 변수 → `ReferenceError`.

rolldown 은 사용된 심볼의 `canonical_ref` 기반(symbol-usage)이라 평탄화된 namespace 멤버도 자연히 cross-chunk 에 포함된다. zntc 는 import-binding 기반이라 이 표면을 놓쳤다.

## 수정

#4532 증상2 에서 preserve-modules 용으로 넣은 **direct-leaf namespace fan-out 브랜치**를 splitting 에도 발화시킨다. `nsReExportTarget` 이 null 인 direct `import * as ns` 이고 dep 가 다른 청크면 `fanOutModuleExports(chunk, dep)` 로 dep 의 export 를 `imports_from`/`exports_to` 에 등록 → 뒤이은 `computeCrossChunkGlobalNames` + provider export + 소비자 import·평탄화 rewrite 가 발화한다.

```zig
const ns_fanout_ok = if (chunk_graph.preserve_modules) chunk_graph.pm_xchunk_naming else !graph.dev_mode;
```

- **splitting**: dev 제외 발화 (이 PR).
- **preserve-modules**: `pm_xchunk_naming`(ESM·non-minify·non-dev) 한정 — #4532 와 동일.
- CJS dep 은 cjsNs interop 별경로라 제외.

## `/code-review max` 반영

1. **dedup 도메인 분리** (correctness): fan-out 은 `fanOutModuleExports` 만 하는 **부분 작업**이라, 풀 작업(`markNsCrossChunk`+`ensureSharedNsVar`+ns-객체 등록)을 하는 `linkNamespaceCrossChunk` 와 dedup set 을 공유하면 안 된다. 공유(`seen_ns_target`) 시 fan-out 이 먼저 dep 를 넣어 같은 청크의 뒤이은 `export * as ns`(re-export)·값-사용용 `linkNamespaceCrossChunkOnce` 를 조기 return 시켜 ns 객체 배선이 누락될 수 있다. → **별도 `seen_ns_fanout` set** 으로 격리(fanOut 은 `seen_static` 으로 멱등이라 이중 호출 안전). 계측으로 두 경로가 같은 target 을 만지는 것 확인.
2. **`!dev_mode` 게이트** (correctness): splitting 항도 dev 제외. dev 는 namespace member rewrite 가 wrapped local 을 써 negotiated 전역명 경로를 안 타므로 preserve-modules 게이트와 동일하게 제외.
3. **테스트 경계 assertion** (test-gap): 회귀 가드가 런타임 출력만 보면 청킹 휴리스틱이 dep 를 복제해도 green 이라 fix 를 우회한다 → diagram 청크가 `import{channel}from"./chunk-*"` 로 실제 cross-chunk import 하는지 `readFileSync` 로 검증 추가.

## 한계 (correctness-neutral)

`linkReExportName` 이 `crossChunkExportIsShaken` 으로 **전역 dead export** 는 거르지만 "이 소비자가 실제 쓰는 멤버" 까지 추리진 않아 dep 의 live export 를 통째로 등록한다 → rolldown 의 per-usage canonical-ref 보다 약간 과등록(mermaid 실측 **~0.08% dead import**, 무해). per-consumer 정밀 등록은 후속 정밀화 여지.

## 검증

- 실제 mermaid: flowDiagram 청크가 `channel` 을 cross-chunk import(bare 참조 해소), `render()` 정상.
- 회귀 가드: `split-runtime-smoke.test.ts` 에 `#4560` 실행 가드(dynamic import → node 실행 `d1:2,4 / d2:6,8` + cross-chunk 경계 확인).
- zig 전체 test 통과. 통합 회귀 328건(splitting/cross-chunk/preserve-modules/smoke/output-parsable) 무회귀.

Closes #4560

🤖 Generated with [Claude Code](https://claude.com/claude-code)