### PR TITLE
fix(linker): #4564 splitting namespace 멤버 canonical 전역명 재작성

### DIFF
--- a/.changeset/splitting-ns-barrel-crosschunk-global.md
+++ b/.changeset/splitting-ns-barrel-crosschunk-global.md
@@ -1,0 +1,33 @@
+---
+"@zntc/core": patch
+---
+
+`--splitting` 에서 `import * as ns` 의 멤버(`ns.max`)가 **재-export 배럴**을 통해 오고 그 멤버가 다른 lib 와 전역 충돌해 `max$1` 로 deconflict 될 때, 소비자 본문이 bare `max` 로 남아 `ReferenceError` 나던 것 수정 (#4564).
+
+```js
+// libA.js:  export const max = (arr) => ...;   // 다른 lib 의 max 와 전역 충돌 → max$1
+// barrel.js: export * from "./libA.js";         // 재-export만 (lodash-es 배럴 위상)
+// diagram.js (lazy):
+import * as _ from "./barrel.js";
+export const d = () => _.max([3, 1, 4]);         // 버그: ReferenceError: max is not defined
+```
+
+실제 mermaid: dagre 가 `import * as _ from "lodash-es"; _.max(...)` 하는데, lodash-es 는 `max` 를 재-export만 하고 `max` 는 d3 등 다른 lib 의 `max` 와 전역 충돌해 `max$1` 로 deconflict → `mermaid.render()` 가 `max is not defined` 로 크래시했다. (#4560 `channel` 을 고친 뒤 드러난 다음 블로커.)
+
+## 근본 원인
+
+`_.max` 는 linker 의 `registerNamespaceRewrites` 가 bare 멤버로 **평탄화**하며 cross-chunk 전역 공개명을 붙여야 하는데, 전역명을 **namespace 소스(`target_mod_idx` = 배럴)** 키로 조회한다. 배럴은 `max` 를 **정의하지 않고 재-export만** 하므로 `(배럴, "max")` 전역명 키가 없다 → miss → `exp.local`(`max`) fallback. 그런데 cross-chunk import 는 **canonical(libA) 기준** 전역명 `max$1` 을 노출한다 → 본문 `max` vs import `max$1` 불일치 → `ReferenceError`. 전역명은 `(canonical_module, export_name)` 키로 등록·소비되는데(import 등록은 체인 끝 canonical 사용) 본문 평탄화만 배럴(중간) 키로 조회해 발산했다.
+
+## 수정
+
+namespace 멤버 전역명 해석을 `crossChunkNsMemberName` 헬퍼로 통합:
+
+1. **canonical 기준 게이트+조회**: source(배럴) 키 조회가 miss 면 `resolveExportChain(source, member)` 으로 canonical(정의 모듈)을 해석해 **그 키**로 재조회한다(체인 끝 = import 등록과 동일 키). `isCrossChunkConsumer` 게이트도 **각 키의 정의 모듈** 기준 — 배럴이 소비자와 같은 청크여도 정의 모듈이 다른 청크로 split 되면 전역명이 필요하기 때문(import rename 경로 `metadata.zig` 와 canonical 기준으로 일치).
+2. **네 개의 형제 사이트에 모두 적용** (code-review max 반영): main 평탄화 / `allocNamespaceMemberRewriteValue`(init-식 `(init(), member)`) / `buildInlineObjectStr` getter(value-namespace) / `allocNamespaceGetterValue`. 모두 같은 canonical 해석을 쓴다.
+3. **synthetic_named_exports**: canonical 이 컨테이너 export 를 가리키고 실제 멤버는 `synthetic_member` 면 `<global>.<member>` 로 접근(전체 축약 금지).
+
+## 검증
+
+- 실제 mermaid: flowchart/sequence/gantt/class/state/pie/er/journey/git **9종 전부 headless 브라우저 렌더 성공**(`--splitting --minify --format=esm`). 산출물에 bare `max` 잔여 0.
+- 회귀 가드: `split-runtime-smoke.test.ts` 에 `#4564` 실행 가드 — 재-export 배럴 경유 namespace 멤버 + 전역 충돌을 dynamic import 로 node 실행(`5|A:d1 / 9|A:d2 / 2 / 1`) + cross-chunk 구조를 minify-robust 마커(문자열 `"A:"`)로 확인. 수정 전 bare `max` → `ReferenceError` 재현 확인.
+- zig 전체 test + 통합 스위트(4267) 무회귀.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2632,6 +2632,16 @@ pub const Linker = struct {
         return self.resolveExportChainInner(module_idx, name, depth, true);
     }
 
+    /// resolveExportChain 의 **캐시 우회** 변형 (#4564). 캐싱 wrapper 는 depth==0 에서 chain_cache
+    /// 를 락 없이 `@constCast` put/get 한다 — 병렬 emit 스레드(buildMetadataForAst)에서 **cold key**
+    /// 로 호출하면 concurrent put/get 데이터 레이스(rehash-during-read → segfault, ReleaseFast-only,
+    /// 비결정적)가 난다. `resolveExportChainInner` 는 chain_cache 를 안 건드리므로(재귀도
+    /// resolveOrCjsFallback→Inner 로 cache-free) 직접 호출해 레이스를 원천 차단. namespace 멤버
+    /// canonical 해석은 상위 ns_export_cache 가 이미 메모이즈해 캐시 손실 영향도 없다.
+    pub fn resolveExportChainUncached(self: *const Linker, module_idx: ModuleIndex, name: []const u8) ?SymbolRef {
+        return self.resolveExportChainInner(module_idx, name, 0, true);
+    }
+
     /// resolveExportChain 내부 구현 (캐시 없이).
     /// `allow_synthetic`: synthetic_named_exports fallback(#3664 P2)을 적용할지. 직접 named import·
     /// named re-export forwarding 경로는 true, `export *`(re_export_all)는 false — Rollup 은 synthetic

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -42,6 +42,53 @@ pub fn nsRewriteDisabled() bool {
 /// 강제 inline 신호. shadow 충돌은 함수 안에서 자체 감지하여 ns_inline_list 를 활성화.
 /// `force_target_init`: caller preamble 이 target namespace 모듈 init 을 보장하지 못하는
 /// named-import-of-namespace-export 경로에서 member rewrite 값에 target init 을 붙인다.
+///
+/// (#4564) namespace 멤버 `ns.<exported>` 가 cross-chunk 로 노출될 때 소비자 본문/getter/inline 이
+/// 참조해야 하는 **전역 공개명**을 해석한다. re-export 배럴(`source_mod`)은 멤버를 재-export만 하므로
+/// 전역명은 배럴이 아니라 **정의 모듈(canonical)** 키로 등록·소비된다. 그래서:
+///   1. `source_mod` 가 직접 정의·cross-chunk 면 그 키로 조회(direct namespace).
+///   2. miss 면 `resolveExportChain` 으로 canonical(정의 모듈)을 해석해 **그 키**로 조회.
+/// 게이트는 **각 키의 정의 모듈** 기준 `isCrossChunkConsumer` 다 — 배럴이 소비자와 같은 청크여도
+/// 정의 모듈이 다른 청크로 split 되면 전역명이 필요하기 때문(code-review; import rename 경로
+/// metadata.zig 와 canonical 기준으로 일치). synthetic_named_exports 는 canonical 이 컨테이너
+/// export 를 가리키고 실제 멤버는 `synthetic_member` 라 `<global>.<member>` 로 접근(축약 금지).
+/// 반환 null = cross-chunk 전역명 없음(caller 가 `exp.local` fallback). synthetic 표현식은
+/// `owned_values` 로 소유권 이전(caller 가 metadata deinit 에서 해제).
+///
+/// ⚠️ named-import rename 경로 `metadata.zig` 의 `effective_target`(+`synth_member`)이 **같은
+/// canonical→cross-chunk-global 매핑**을 한다(이미 resolved 된 `rb.canonical` 로 시작하는 점만 다름).
+/// 게이트/전역명 키/synthetic 형식을 바꾸면 **양쪽 같이** 고쳐야 namespace-멤버와 named-import 가
+/// 어긋나지 않는다(#4101/#4492/#4502 계열 드리프트). 통합 헬퍼화는 후속.
+fn crossChunkNsMemberName(
+    self: *const Linker,
+    consumer_mod: u32,
+    source_mod: u32,
+    exported: []const u8,
+    owned_values: *std.ArrayListUnmanaged([]const u8),
+) std.mem.Allocator.Error!?[]const u8 {
+    // 청크 컨텍스트 없음(단일 번들 / preserve_modules) → cross-chunk 전역명 자체가 없다. 아래
+    // resolveExportChain(대형 배럴서 export 당 chain walk)를 통째로 skip (code-review: non-splitting perf).
+    if (self.module_to_chunk == null) return null;
+    // 1. source 가 직접 이 export 를 정의·cross-chunk 로 노출 (direct namespace target).
+    if (self.isCrossChunkConsumer(consumer_mod, source_mod)) {
+        if (self.getCrossChunkGlobalName(source_mod, exported)) |g| return g;
+    }
+    // 2. canonical(정의 모듈) 해석 후 그 키로 — 배럴 재-export / renamed re-export(`as`) 커버.
+    // **Uncached**: 병렬 emit 스레드서 cold key 로 캐싱 resolveExportChain 을 부르면 chain_cache
+    // 데이터 레이스(위 wrapper 락 없음). resolveExportChainUncached 로 우회.
+    const canon = self.resolveExportChainUncached(@enumFromInt(source_mod), exported) orelse return null;
+    const canon_mod = @intFromEnum(canon.module_index);
+    if (!self.isCrossChunkConsumer(consumer_mod, canon_mod)) return null;
+    const g = self.getCrossChunkGlobalName(canon_mod, canon.export_name) orelse return null;
+    if (canon.synthetic_member) |member| {
+        const expr = try std.fmt.allocPrint(self.allocator, "{s}.{s}", .{ g, member });
+        errdefer self.allocator.free(expr);
+        try owned_values.append(self.allocator, expr);
+        return expr;
+    }
+    return g;
+}
+
 pub fn registerNamespaceRewrites(
     self: *const Linker,
     ns_rewrite_list: *std.ArrayList(LinkingMetadata.NsMemberRewrites.Entry),
@@ -246,7 +293,13 @@ pub fn registerNamespaceRewrites(
             try inner_map.put(self.allocator, exp.exported, ns_var);
             continue;
         }
-        if (try allocNamespaceMemberRewriteValue(self, target_init, target_mod_idx, exp, &source_init_cache)) |rewrite_value| {
+        // #4101 ns collision: target inner const 가 다른 ns 의 동명 const 와 deconflict(`k`/`k$1`)
+        // 되면 이 멤버 재작성(`ns.k`→local)이 잘못된 const 를 가리킨다. cross-chunk 전역명(emit 前
+        // 글로벌 패스로 확정)을 써 provider·consumer 양쪽 일치. 배럴 재-export·renamed re-export·
+        // synthetic 는 crossChunkNsMemberName 이 canonical 해석으로 커버. 없으면 exp.local (#4564).
+        const member_name = (try crossChunkNsMemberName(self, importer_mod_idx, target_mod_idx, exp.exported, owned_rewrite_values)) orelse exp.local;
+        // init 식이 필요한 경로(dev/force_target_init/ESM source)는 그 식에 member_name 을 embed.
+        if (try allocNamespaceMemberRewriteValue(self, target_init, target_mod_idx, exp, member_name, &source_init_cache)) |rewrite_value| {
             var owned_by_list = false;
             errdefer if (!owned_by_list) self.allocator.free(rewrite_value);
             // ns_member_rewrites map 은 포인터만 빌리고, 실제 소유권은
@@ -256,21 +309,6 @@ pub fn registerNamespaceRewrites(
             try inner_map.put(self.allocator, exp.exported, rewrite_value);
             continue;
         }
-        // #4101 ns collision: target 의 inner const 가 다른 ns 의 동명 const 와 deconflict
-        // 되면(`k`/`k$1`), 이 멤버 재작성(`ns.k`→local)이 잘못된 const 를 가리킨다. inner
-        // const 의 chunk-local rename 은 이 시점(buildMetadataForAst)에 rename_table 에 아직
-        // 없으나, cross-chunk 전역명(emit 前 글로벌 패스)은 이미 확정 — 게다가 그 전역명이 곧
-        // provider 청크의 local 명이자 consumer import 명이라 양쪽 일치. cross-chunk 미해당
-        // (intra-chunk/non-shared)이면 fallback=exp.local(기존).
-        // **importer 가 target 과 다른 청크일 때만** 전역 공개명을 쓴다 (#4492). 전역명은
-        // `(모듈, export)` 키라 "다른 어떤 청크가 이 심볼을 소비하는가" 만 말해주고 **누가
-        // 묻는지는 모른다** — 게이트 없이 쓰면 같은 청크 importer 도 그 청크 바깥에서만
-        // 존재하는 공개명을 받아 자유 변수가 된다 (mangle 로 local != global 이 되는 순간 폭발).
-        const use_global = self.isCrossChunkConsumer(importer_mod_idx, target_mod_idx);
-        const member_name = if (use_global)
-            (self.getCrossChunkGlobalName(target_mod_idx, exp.exported) orelse exp.local)
-        else
-            exp.local;
         try inner_map.put(self.allocator, exp.exported, member_name);
     }
     try ns_rewrite_list.append(self.allocator, .{
@@ -859,6 +897,13 @@ pub fn buildInlineObjectStr(
     // circular dep에서 init 시점에 아직 undefined인 변수도 사용 시점에 올바르게 참조.
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(self.allocator);
+    // (#4564) crossChunkNsMemberName 이 synthetic member 접근식(`<global>.<member>`)을 owned 로 낼
+    // 수 있다. getter 본문은 buf 로 복사되므로 이 함수 종료 시 일괄 해제(borrow-then-copy).
+    var owned_member_exprs: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer {
+        for (owned_member_exprs.items) |e| self.allocator.free(e);
+        owned_member_exprs.deinit(self.allocator);
+    }
     // minify_whitespace 모드 토큰 — getter 패턴의 ` ` 와 `; ` 를 제거.
     // `get foo() { return bar; }` (30c) → `get foo(){return bar}` (24c).
     // 1699 getter 가 있는 effect 번들에서 ~10KB 절감.
@@ -926,24 +971,23 @@ pub fn buildInlineObjectStr(
                 try buf.appendSlice(self.allocator, exp.exported);
             }
             try buf.appendSlice(self.allocator, get_open);
-            if (try allocNamespaceGetterValue(self, exp)) |value| {
+            // getter 본문 이름은 **이 리터럴을 담는 청크(emitter)** 기준으로 해석한다.
+            //  - 선언이 다른 청크(#4101): 그 청크가 import 해 오는 cross-chunk 전역 공개명(provider
+            //    public == consumer import 명이라 양쪽 일치). 배럴 재-export·renamed re-export·synthetic
+            //    은 crossChunkNsMemberName 이 canonical 해석으로 커버 (#4564).
+            //  - 선언이 같은 청크(#4502): 그 청크의 **확정된 chunk-local 이름**(=exp.local). 전역 공개명을
+            //    쓰면 이 청크엔 그 이름의 선언이 없어 자유 변수 → ReferenceError. exp.local 이 확정 이름
+            //    이려면 이 호출이 **per-chunk rename 이후**여야 한다(공유 ns preamble 을 emit 루프
+            //    computeRenamesForModules 뒤로 옮긴 이유).
+            // source 는 **namespace 소스(target_mod_idx = 배럴)** — decl_mod_idx(=exp.init_mod, 정의
+            // 모듈)로 뿌리내리면 renamed re-export(`max as maximum`)에서 canonical 이 outer 명(`maximum`)
+            // 을 못 따라간다(code-review). main 평탄화 경로와 동일하게 target 에서 chain 해석.
+            const gmember = (try crossChunkNsMemberName(self, emitter_mod_idx, target_mod_idx, exp.exported, &owned_member_exprs)) orelse exp.local;
+            if (try allocNamespaceGetterValue(self, exp, gmember)) |value| {
                 defer self.allocator.free(value);
                 try buf.appendSlice(self.allocator, value);
             } else {
-                // getter 본문 이름은 **이 리터럴을 담는 청크(emitter)** 기준으로 해석한다.
-                //  - 선언이 다른 청크(#4101): 그 청크가 import 해 오는 cross-chunk 전역 공개명.
-                //    전역명은 provider 청크의 public 이름이자 consumer import 명이라 양쪽 일치.
-                //  - 선언이 같은 청크(#4502): 그 청크의 **확정된 chunk-local 이름**(=exp.local).
-                //    전역 공개명을 쓰면 이 청크엔 그 이름의 선언이 없어 자유 변수 → ReferenceError.
-                // exp.local 이 확정 이름이려면 이 호출이 **해당 청크의 per-chunk rename 이후**여야
-                // 한다 (collectExportsRecursive 가 rename_table 을 읽어 local 을 해석). 그래서
-                // 공유 ns preamble 생성이 emit 루프의 computeRenamesForModules *뒤* 로 옮겨졌다.
-                const use_global = self.isCrossChunkConsumer(emitter_mod_idx, decl_mod_idx);
-                const member_name = if (use_global)
-                    (self.getCrossChunkGlobalName(decl_mod_idx, exp.exported) orelse exp.local)
-                else
-                    exp.local;
-                try buf.appendSlice(self.allocator, member_name);
+                try buf.appendSlice(self.allocator, gmember);
             }
             try buf.appendSlice(self.allocator, get_close);
         }
@@ -967,7 +1011,7 @@ pub fn buildInlineObjectStr(
     return try self.allocator.dupe(u8, result);
 }
 
-fn allocNamespaceGetterValue(self: *const Linker, exp: NsExportPair) std.mem.Allocator.Error!?[]const u8 {
+fn allocNamespaceGetterValue(self: *const Linker, exp: NsExportPair, member_name: []const u8) std.mem.Allocator.Error!?[]const u8 {
     const init_mod_idx = exp.init_mod orelse return null;
     const init_mod = self.graph.getModule(@enumFromInt(init_mod_idx)) orelse return null;
     if (init_mod.wrap_kind != .esm) return null;
@@ -975,7 +1019,8 @@ fn allocNamespaceGetterValue(self: *const Linker, exp: NsExportPair) std.mem.All
     const init_expr = try allocEsmInitExpr(self, init_mod);
     defer self.allocator.free(init_expr);
     const sep = if (self.minify_whitespace) "," else ", ";
-    return try std.fmt.allocPrint(self.allocator, "({s}{s}{s})", .{ init_expr, sep, exp.local });
+    // (#4564) member_name = caller 가 crossChunkNsMemberName 으로 해석한 cross-chunk 전역명(또는 exp.local).
+    return try std.fmt.allocPrint(self.allocator, "({s}{s}{s})", .{ init_expr, sep, member_name });
 }
 
 /// `target_init` 은 호출자가 미리 1회 계산한 target 모듈의 init 식 (예: `init_X()` 또는
@@ -989,6 +1034,9 @@ fn allocNamespaceMemberRewriteValue(
     target_init: ?[]const u8,
     target_mod_idx: u32,
     exp: NsExportPair,
+    // (#4564) 참조할 멤버명 — caller 가 crossChunkNsMemberName 으로 해석한 cross-chunk 전역명
+    // (또는 exp.local). init 식 뒤 comma-expr 의 값 자리에 embed 된다.
+    member_name: []const u8,
     source_init_cache: *std.AutoHashMapUnmanaged(u32, ?[]const u8),
 ) std.mem.Allocator.Error!?[]const u8 {
     const source_init: ?[]const u8 = if (exp.init_mod) |source_mod_idx| blk: {
@@ -1006,12 +1054,12 @@ fn allocNamespaceMemberRewriteValue(
     const sep = if (self.minify_whitespace) "," else ", ";
     if (target_init) |target_expr| {
         if (source_init) |source_expr| {
-            return try std.fmt.allocPrint(self.allocator, "({s}{s}{s}{s}{s})", .{ target_expr, sep, source_expr, sep, exp.local });
+            return try std.fmt.allocPrint(self.allocator, "({s}{s}{s}{s}{s})", .{ target_expr, sep, source_expr, sep, member_name });
         }
-        return try std.fmt.allocPrint(self.allocator, "({s}{s}{s})", .{ target_expr, sep, exp.local });
+        return try std.fmt.allocPrint(self.allocator, "({s}{s}{s})", .{ target_expr, sep, member_name });
     }
     if (source_init) |source_expr| {
-        return try std.fmt.allocPrint(self.allocator, "({s}{s}{s})", .{ source_expr, sep, exp.local });
+        return try std.fmt.allocPrint(self.allocator, "({s}{s}{s})", .{ source_expr, sep, member_name });
     }
     return null;
 }

--- a/tests/integration/tests/split-runtime-smoke.test.ts
+++ b/tests/integration/tests/split-runtime-smoke.test.ts
@@ -199,6 +199,81 @@ export const d2 = () => "d2:" + fade({ b: 3, g: 4 });
     }
   }, 120000);
 
+  test('#4564 splitting: 재-export 배럴 경유 `import * as ns` 멤버가 canonical 전역명으로 재작성된다', async () => {
+    // #4560 은 namespace 멤버가 **미등록**이었다면, #4564 는 등록은 됐는데(cross-chunk import 가
+    // canonical 전역명 `max$1` 노출) **본문 재작성이 배럴 키로 조회해 miss** → bare `max` 로 남는
+    // 케이스다. mermaid: dagre 가 `import * as _ from "lodash-es"; _.max(...)` 하는데 lodash-es 는
+    // max 를 재-export만 하고, max 는 다른 lib 의 max 와 전역 충돌해 `max$1` 로 deconflict 된다.
+    //
+    //   diagram: import * as _ from "./barrel";  _.max([..])   // 배럴은 libA.max 를 re-export
+    //   → registerNamespaceRewrites 가 `_.max`→bare 로 평탄화하며 전역명을 배럴(target) 키로 조회.
+    //     배럴은 max 를 **정의하지 않고 재-export만** 하므로 전역명 맵에 (배럴, max) 키 없음 → miss →
+    //     exp.local(`max`) fallback. 하지만 cross-chunk import 는 canonical(libA) 기준 `max$1` 노출.
+    //   수정 전: `import { max$1 } from "./chunk"; ()=>max([..])` → `ReferenceError: max is not defined`.
+    //   처방: 배럴 키 miss 시 resolveExportChain 으로 canonical(libA) 해석해 그 키로 전역명 재조회.
+    //
+    // 전역 충돌 유발: libB 도 max 를 export 하고 다른 diagram 이 소비 → (libA.max, libB.max) 가
+    // `max`/`max$1` 로 deconflict. 배럴/libA 는 두 namespace diagram 이 공유해 공통 청크로 분리.
+    const files: Record<string, string> = {
+      'libA.js': `export const pick = (x) => "A:" + x;
+export const max = (arr) => { let m = arr[0]; for (const v of arr) if (v > m) m = v; return m; };
+`,
+      'libB.js': `export const max = (arr) => { let m = arr[0]; for (const v of arr) if (v < m) m = v; return m; };\n`,
+      'barrel.js': `export * from "./libA.js";\n`, // 재-export만 (lodash-es 배럴 위상)
+      'diagram1.js': `import * as _ from "./barrel.js";
+export const d1 = () => _.max([3, 1, 4, 1, 5]) + "|" + _.pick("d1");
+`,
+      'diagram2.js': `import * as _ from "./barrel.js";
+export const d2 = () => _.max([9, 2, 7]) + "|" + _.pick("d2");
+`,
+      'diagram3.js': `import { max } from "./libB.js";\nexport const d3 = () => max([9, 2, 7]);\n`,
+      'diagram4.js': `import { max } from "./libB.js";\nexport const d4 = () => max([3, 8, 1]);\n`,
+      'entry.js': `Promise.all([import("./diagram1.js"), import("./diagram2.js"), import("./diagram3.js"), import("./diagram4.js")]).then(([a, b, c, d]) => {
+  console.log(a.d1() + " / " + b.d2() + " / " + c.d3() + " / " + d.d4());
+});
+`,
+    };
+
+    const { dir, cleanup } = await createFixture(files);
+    try {
+      const outDir = join(dir, 'out');
+      const build = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--splitting',
+        '--outdir',
+        outDir,
+        '--minify',
+        '--format=esm',
+      ]);
+      expect(build.exitCode).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+
+      // cross-chunk 경계를 **의미론적으로** 검증한다 (import 문자열/청크명/전역명 형태에 의존하지
+      // 않게 — codegen·minify 변화에 brittle 하지 않도록). libA(max·pick 정의)가 diagram1 을 담은
+      // 청크와 **다른 청크**여야 이 fix 가 실제로 발화한다(같은 청크 인라인이면 버그가 안 나 무의미).
+      // 마커 = pick 의 문자열 리터럴 `"A:"` (문자열은 mangle 안 되어 minify 에서도 안정). max·pick 은
+      // 둘 다 libA 라 libA 가 cross-chunk 면 max 도 cross-chunk.
+      const allChunks = readdirSync(outDir).filter((f) => f.endsWith('.js') && f !== 'entry.js');
+      const d1Chunk = allChunks.find((f) => /\bd1\b/.test(readFileSync(join(outDir, f), 'utf-8')));
+      const libAChunk = allChunks.find((f) =>
+        readFileSync(join(outDir, f), 'utf-8').includes('"A:"'),
+      );
+      expect(d1Chunk, 'd1 청크 없음').toBeTruthy();
+      expect(libAChunk, 'libA 정의 청크(마커 "A:") 없음').toBeTruthy();
+      expect(libAChunk, 'libA 가 diagram1 청크에 인라인됨 — cross-chunk 구조 무효').not.toBe(
+        d1Chunk,
+      );
+
+      const r = runNode(join(outDir, 'entry.js'));
+      // 수정 전: `ReferenceError: max is not defined` (본문 bare max vs import max$1)
+      expect(r.err, `모듈 평가 실패:\n${r.err}`).toBe('');
+      expect(r.out).toBe('5|A:d1 / 9|A:d2 / 2 / 1');
+    } finally {
+      await cleanup();
+    }
+  }, 120000);
+
   test('#4502 splitting: materialize 된 ns 객체 getter 가 같은 청크의 chunk-local 이름을 쓴다', async () => {
     // 네 번째 표면 — ns 를 **값으로** 쓰면(`const o = ns`) 정적 멤버 재작성이 불가능해
     // 객체가 materialize 된다: `var ns_ns = {get second(){return <name>}, ...}`.


### PR DESCRIPTION
## 문제 (#4564)

`--splitting` 에서 `import * as ns` 의 멤버(`ns.max`)가 **재-export 배럴**을 통해 오고 그 멤버가 다른 lib 와 전역 충돌해 `max$1` 로 deconflict 될 때, 소비자 본문이 bare `max` 로 남아 `ReferenceError`.

실제 mermaid: dagre 가 `import * as _ from "lodash-es"; _.max(...)` 하는데, lodash-es 는 `max` 를 재-export만 하고 `max` 는 d3 등 다른 lib 의 `max` 와 전역 충돌해 `max$1` 로 deconflict → `mermaid.render()` 가 `max is not defined` 로 크래시. (#4560 `channel` 을 고친 뒤 드러난 다음 블로커.)

```js
// libA.js:  export const max = (arr) => ...;   // 다른 lib 의 max 와 전역 충돌 → max$1
// barrel.js: export * from "./libA.js";         // 재-export만 (lodash-es 배럴 위상)
// diagram.js (lazy):
import * as _ from "./barrel.js";
export const d = () => _.max([3, 1, 4]);         // 버그: ReferenceError: max is not defined
```

## 근본 원인

`_.max` 는 `registerNamespaceRewrites` 가 bare 멤버로 **평탄화**하며 cross-chunk 전역 공개명을 붙여야 하는데, 전역명을 **namespace 소스(`target_mod_idx` = 배럴)** 키로 조회한다. 배럴은 `max` 를 **정의하지 않고 재-export만** 하므로 `(배럴, "max")` 전역명 키가 없다 → miss → `exp.local`(`max`) fallback. 그런데 cross-chunk import 는 **canonical(libA) 기준** 전역명 `max$1` 을 노출한다 → 본문 `max` vs import `max$1` 불일치. 전역명은 `(canonical_module, export_name)` 키로 등록·소비되는데(import 등록은 체인 끝 canonical 사용) 본문 평탄화만 배럴(중간) 키로 조회해 발산했다.

## 수정

namespace 멤버 전역명 해석을 `crossChunkNsMemberName` 헬퍼로 통합: source(배럴) 키 조회가 miss 면 `resolveExportChain` 으로 canonical(정의 모듈)을 해석해 **그 키**로 재조회한다(체인 끝 = import 등록과 동일 키). `isCrossChunkConsumer` 게이트도 **각 키의 정의 모듈** 기준.

## `/code-review max` 2회 반영

1. **canonical 기준 게이트**: `use_global` 을 배럴이 아닌 **정의 모듈** 기준으로 — 배럴이 소비자와 같은 청크여도 정의가 다른 청크로 split 되면 전역명 사용. 산출물 bare `max` 잔여 **0** (chunk-411917a9 등).
2. **네 형제 사이트 통합**: main 평탄화 / `allocNamespaceMemberRewriteValue`(init-식) / `buildInlineObjectStr` getter(value-namespace) / `allocNamespaceGetterValue` 모두 동일 canonical 해석. getter 는 `decl_mod_idx` 가 아닌 `target_mod_idx`(배럴)에서 chain 해석(renamed re-export 커버).
3. **synthetic_named_exports**: canonical 이 컨테이너를 가리키면 `<global>.<member>` 접근(축약 금지).
4. **thread-safety**: `resolveExportChainUncached` 신설 — 캐싱 wrapper 는 depth==0 에서 `chain_cache` 를 락 없이 `@constCast` put 한다. 병렬 emit 스레드서 **cold key**(namespace 멤버)로 부르면 concurrent put/get 데이터 레이스(ReleaseFast 간헐 segfault). `resolveExportChainInner`(cache-free) 직접 호출로 우회.
5. **non-splitting perf**: `module_to_chunk == null` 조기 반환 — 대형 배럴(lodash-es ~600 export)서 export 당 chain walk 낭비 제거.
6. named-import rename 경로(`metadata.zig`)와 **같은 매핑**이라 drift 경고 주석 추가(통합 헬퍼화는 후속).

## 검증

- 실제 mermaid: flowchart/sequence/gantt/class/state/pie/er/journey/git **9종 전부 headless 브라우저 렌더 성공**(`--splitting --minify --format=esm`), 산출물 bare `max` 0.
- 회귀 가드: `split-runtime-smoke.test.ts` `#4564` — 재-export 배럴 경유 namespace 멤버 + 전역 충돌을 dynamic import 로 node 실행(`5|A:d1 / 9|A:d2 / 2 / 1`), cross-chunk 구조를 minify-robust 마커로 확인. 수정 전 bare `max` → `ReferenceError` 재현.
- zig 전체 test + 통합 스위트(4267) 무회귀.

Closes #4564

🤖 Generated with [Claude Code](https://claude.com/claude-code)