### PR TITLE
fix(linker): #4563 splitting nested-shadow self-TDZ 방지

### DIFF
--- a/.changeset/splitting-nested-shadow-conflicts.md
+++ b/.changeset/splitting-nested-shadow-conflicts.md
@@ -1,0 +1,40 @@
+---
+"@zntc/core": patch
+---
+
+`--splitting` 에서 함수-로컬 `const x` 가 import 가 해석되는 module-level `const x` 를 shadow 할 때, 초기화식이 로컬 자신을 참조하는 **self-TDZ**(`const channels = channels.set(...)`)가 되던 것 수정 (#4563).
+
+```js
+// reusable.js:  const channels = new Channels(...); export default channels;   // 싱글톤
+// rgba.js:
+import _channels from "./reusable.js";
+const rgba = (r) => {
+  const channels = _channels.set({ r });   // 로컬 channels 가 싱글톤 channels 를 shadow
+  return channels;
+};
+// 버그(splitting): const channels = channels.set(...) → ReferenceError: Cannot access 'channels' before initialization
+```
+
+실제 mermaid 를 `--format=esm`(minify 없이)로 빌드하면 khroma(rgba 등)가 이 위상으로 인라인돼 `channels` self-TDZ 로 `mermaid.render()` 가 크래시했다. (#4560/#4564 로 **minify** 경로는 이미 렌더됐고, 이건 **non-minify** 경로 블로커.)
+
+## 근본 원인
+
+zntc 가 import 참조 `_channels` 를 싱글톤 canonical `channels` 로 해석하면 함수-로컬 `channels` 와 충돌한다. **비-splitting**(글로벌 `computeRenames`)은 `resolveNestedShadowConflicts` 로 이 충돌을 감지해 싱글톤 canonical 을 `channels$1` 로 리네임하는데, **splitting** 의 per-chunk 리네이머(`computeRenamesForModules`)엔 그 패스가 빠져 있었다 → splitting 에서만 로컬이 싱글톤을 가려 self-TDZ.
+
+## 수정
+
+`computeRenamesForModules`(per-chunk)에 `resolveNestedShadowConflicts` 를 추가한다(글로벌 경로와 동일 위치). `only: ?[]const ModuleIndex` 파라미터로 청크 모듈 한정, **target(정의)이 consumer 와 같은 청크일 때만** 리네임.
+
+`/code-review max` 반영:
+- **preserve-modules(module_to_chunk==null) 제외**: null 이면 `chunkOfModule` 이 전부 `.none` → same-chunk 가드가 `.none != .none`=false 로 fail-open 해 cross-module target 을 over-rename(별도 출력 파일이 원명 export → ReferenceError). preserve-modules 는 import 를 hoisting 안 해 이 shadow 자체가 없으므로 `if (module_to_chunk != null)` 로 skip. same-chunk 가드도 `.none` 이면 skip(isCrossChunkConsumer 와 동형).
+- **nested-binding 캐시를 `calculateRenames` 전 + `defer clearNestedBindingCache()`**: 3 소비처(calculateRenames/resolveNestedShadowConflicts/resolveWrapperConsumerShadows) 공용 O(1), 에러 경로 해제.
+
+## 범위 / 후속
+
+**same-chunk splitting** 한정(mermaid khroma 는 same-chunk 인라인이라 커버). 같은 클래스의 잔여 토폴로지 — (A) cross-chunk splitting(싱글톤이 다른 청크), (B) preserve-modules(import 로컬명 shadow), (C) dev-split override revert — 는 근본이 **cross-chunk/파일경계 네이밍이 소비자 nested binding 미회피**로 별개 처방 필요. 셋 다 #4563 이전부터 있던 pre-existing gap(이 PR 이 회귀시키지 않음) → **#4566** 로 추적.
+
+## 검증
+
+- 실제 mermaid `--format=esm`(non-minify): flowchart/sequence/gantt/class/state/pie/er/journey/git **9종 전부 headless 브라우저 렌더 성공**. 산출물 self-referencing const 0. (minify 경로도 여전히 9종 렌더 — #4560/#4564.)
+- 회귀 가드: `split-runtime-smoke.test.ts` `#4563` — reusable 싱글톤 + import alias + 함수-로컬 동명 구조를 splitting 으로 node 실행(`rgba:10`), self-referencing const 부재 확인. 수정 전 self-TDZ `ReferenceError` 재현.
+- zig 전체 test + 통합 스위트(4268) 무회귀 — per-chunk 리네이머는 모든 splitting 빌드가 타는 코어 경로라 전량 검증.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1016,7 +1016,7 @@ pub const Linker = struct {
         // 3. import binding의 canonical name이 해당 모듈의 중첩 스코프와 충돌하는지 확인.
         // 충돌하면 target module의 canonical name을 한 단계 더 rename.
         // 예: d3-color의 cubehelix와 d3-interpolate 내부의 function cubehelix 충돌.
-        try self.resolveNestedShadowConflicts(&name_to_owners);
+        try self.resolveNestedShadowConflicts(&name_to_owners, null);
 
         // 4. 주입된 래퍼 참조(require_x())가 소비자의 스코프 바인딩에 가려지는 것 방지 (#4533).
         try self.resolveWrapperConsumerShadows(&name_to_owners, null);
@@ -1484,30 +1484,47 @@ pub const Linker = struct {
     /// rename 하면 매 호출이 canonical_name 을 덮어써 최종 하나만 유효, 나머지
     /// `__extends$1`, `$2` ... 호출은 ReferenceError (미선언). helper module 은 rename
     /// 대상에서 제외 — 충돌은 consumer 측 nested binding 을 mangling 단계가 처리한다.
-    fn resolveNestedShadowConflicts(self: *Linker, name_to_owners: *const NameToOwnersMap) !void {
+    /// `only` non-null(#4563 per-chunk 경로): 그 모듈들의 import binding 만 검사하고, target(정의)이
+    /// **같은 청크**일 때만 rename 한다 — 다른 청크면 cross-chunk 네이밍이 담당(여기서 그 청크의
+    /// canonical 을 건드리면 그 청크 per-chunk rename 과 충돌). null(global computeRenames, 비-splitting)
+    /// 은 전 모듈·청크 무관(기존 동작).
+    fn resolveNestedShadowConflicts(self: *Linker, name_to_owners: *const NameToOwnersMap, only: ?[]const ModuleIndex) !void {
+        if (only) |mods| {
+            for (mods) |mi| try self.resolveNestedShadowForModule(mi.toU32(), name_to_owners, true);
+        } else {
+            for (0..self.graph.moduleCount()) |mod_i| try self.resolveNestedShadowForModule(@intCast(mod_i), name_to_owners, false);
+        }
+    }
+
+    fn resolveNestedShadowForModule(self: *Linker, mod_i: u32, name_to_owners: *const NameToOwnersMap, same_chunk_only: bool) !void {
         const helper_modules = @import("../runtime_helper_modules.zig");
-        for (0..self.graph.moduleCount()) |mod_i| {
-            const m = self.getModule(@intCast(mod_i)) orelse continue;
-            for (m.import_bindings) |ib| {
-                if (ib.kind == .namespace) continue;
-                const resolved = self.getResolvedBinding(@intCast(mod_i), ib.local_span) orelse continue;
-                const target_name = self.resolveToLocalName(resolved.canonical);
+        const m = self.getModule(mod_i) orelse return;
+        for (m.import_bindings) |ib| {
+            if (ib.kind == .namespace) continue;
+            const resolved = self.getResolvedBinding(mod_i, ib.local_span) orelse continue;
+            const target_name = self.resolveToLocalName(resolved.canonical);
 
-                // target_name이 이 모듈의 중첩 스코프에 있고, local_name과 다르면 충돌
-                if (!std.mem.eql(u8, ib.local_name, target_name) and
-                    self.hasNestedBinding(@intCast(mod_i), target_name))
-                {
-                    // target module의 canonical name을 한 단계 더 rename
-                    const cmod: u32 = @intCast(@intFromEnum(resolved.canonical.module_index));
-                    const target_module = self.getModule(cmod) orelse continue;
-                    if (helper_modules.isVirtualId(target_module.path)) continue;
-                    const export_local = self.getExportLocalName(cmod, resolved.canonical.export_name) orelse resolved.canonical.export_name;
-
-                    // 새 이름: target_name$N (기존 이름 충돌 없는 것)
-                    var suffix: u32 = 1;
-                    const candidate = try self.findAvailableCandidate(target_name, cmod, &suffix, name_to_owners);
-                    try self.putCanonicalName(cmod, export_local, candidate);
+            // target_name이 이 모듈의 중첩 스코프에 있고, local_name과 다르면 충돌
+            if (!std.mem.eql(u8, ib.local_name, target_name) and
+                self.hasNestedBinding(mod_i, target_name))
+            {
+                // target module의 canonical name을 한 단계 더 rename
+                const cmod: u32 = @intCast(@intFromEnum(resolved.canonical.module_index));
+                // (#4563) per-chunk: target 이 consumer 와 다른 청크(또는 어느 쪽이든 미배정 .none)면 skip
+                // — cross-chunk/미배정은 이 청크서 canonical 을 못 건드린다. isCrossChunkConsumer 와 동형.
+                if (same_chunk_only) {
+                    const cc = self.chunkOfModule(mod_i);
+                    const pc = self.chunkOfModule(cmod);
+                    if (cc.isNone() or pc.isNone() or cc != pc) continue;
                 }
+                const target_module = self.getModule(cmod) orelse continue;
+                if (helper_modules.isVirtualId(target_module.path)) continue;
+                const export_local = self.getExportLocalName(cmod, resolved.canonical.export_name) orelse resolved.canonical.export_name;
+
+                // 새 이름: target_name$N (기존 이름 충돌 없는 것)
+                var suffix: u32 = 1;
+                const candidate = try self.findAvailableCandidate(target_name, cmod, &suffix, name_to_owners);
+                try self.putCanonicalName(cmod, export_local, candidate);
             }
         }
     }
@@ -3772,8 +3789,28 @@ pub const Linker = struct {
             try self.collectModuleNames(m.*, mod_idx.toU32(), &name_to_owners);
         }
 
+        // (#4563) nested-binding 캐시 — calculateRenames/resolveNestedShadowConflicts/
+        // resolveWrapperConsumerShadows 3 소비처 공용(글로벌 computeRenames 와 동일 위치). hasNestedBinding
+        // O(1). defer 로 에러 경로에서도 해제(code-review: non-defer clear 는 에러 시 populated 잔존).
+        try self.buildNestedBindingCache(&name_to_owners);
+        defer self.clearNestedBindingCache();
+
         // 2. 충돌하는 이름에 대해 리네임 계산 (cross-chunk 점유 마커는 skip)
         try self.calculateRenames(&name_to_owners, true);
+
+        // 2.05 (#4563) import binding 의 canonical(hoisted module-level)이 그 모듈의 nested 스코프
+        // 바인딩과 충돌하면 target canonical 을 rename. function-local `const x` 가 module-level
+        // `const x`(import 가 해석되는 대상)를 shadow 하면 초기화식이 self-TDZ 가 된다
+        // (`const channels = channels.set(...)` = khroma rgba). 전역 computeRenames(비-splitting)는
+        // resolveNestedShadowConflicts 로 하는데 이 per-chunk 경로엔 빠져 splitting 서만 깨졌다.
+        // ⚠️ **실제 splitting(module_to_chunk 세팅)만** — preserve-modules 는 module_to_chunk 가 null 이라
+        // chunkOfModule 이 전부 .none → same-chunk 가드가 `.none != .none`=false 로 **fail-open** 해
+        // cross-module target 을 over-rename(별도 출력 파일이 여전히 원명 export → ReferenceError,
+        // code-review). preserve-modules 는 import 를 hoisting 안 해(import 문 보존) shadow 자체가 없다.
+        // target 이 같은 청크일 때만 rename(cross-chunk 토폴로지는 별도 gap — 후속).
+        if (self.module_to_chunk != null) {
+            try self.resolveNestedShadowConflicts(&name_to_owners, module_indices);
+        }
 
         // 2.1 주입된 래퍼 참조가 소비자 스코프 바인딩에 가려지는 것 방지 (#4533). code-splitting 은
         // 이 per-chunk 경로만 타므로 여기서도 불러야 한다(전역 computeRenames 는 안 탄다). 소비자

--- a/tests/integration/tests/split-runtime-smoke.test.ts
+++ b/tests/integration/tests/split-runtime-smoke.test.ts
@@ -274,6 +274,63 @@ export const d2 = () => _.max([9, 2, 7]) + "|" + _.pick("d2");
     }
   }, 120000);
 
+  test('#4563 splitting: import canonical 이 nested 로컬을 shadow 하면 self-TDZ 안 나게 리네임된다', async () => {
+    // function-local `const x` 가 module-level `const x`(import 가 해석되는 정의)를 shadow 하면,
+    // 그 로컬의 **초기화식**이 로컬 자신을 참조(TDZ)한다: `const channels = channels.set(...)`.
+    // khroma rgba 실제 위상 — reusable.js 가 싱글톤 `const channels = new Channels(...)` 를 export,
+    // rgba.js 가 `_channels` 로 import 하고 로컬 `const channels = _channels.set(...)` 를 둔다. zntc 가
+    // import 참조 `_channels` 를 싱글톤 canonical `channels` 로 해석하면 로컬 `channels` 와 충돌.
+    //   수정 전(splitting): `const channels = new Channels(...)` + `const channels = channels.set(...)`
+    //     → `ReferenceError: Cannot access 'channels' before initialization`.
+    // 비-splitting(글로벌 computeRenames)은 resolveNestedShadowConflicts 로 싱글톤을 `channels$1` 로
+    // 리네임하는데, per-chunk 리네이머(splitting)엔 그 패스가 빠져 splitting 서만 깨졌다. mermaid 를
+    // `--format=esm`(minify 없이) 로 빌드할 때 khroma 가 이 위상으로 인라인돼 render() 가 크래시했다.
+    const files: Record<string, string> = {
+      'reusable.js': `class Channels { constructor(v){ this.v = v; } set(x){ this.v = x; return this; } }
+const channels = new Channels({ r: 0 });
+export default channels;
+`,
+      'rgba.js': `import _channels from "./reusable.js";
+export const rgba = (r) => {
+  const channels = _channels.set({ r: r * 2 });   // 로컬 channels 가 싱글톤 channels 를 shadow
+  return "rgba:" + channels.v.r;
+};
+`,
+      'diag.js': `import { rgba } from "./rgba.js";\nexport const run = () => rgba(5);\n`,
+      'entry.js': `import("./diag.js").then((m) => { console.log(m.run()); });\n`,
+    };
+
+    const { dir, cleanup } = await createFixture(files);
+    try {
+      const outDir = join(dir, 'out');
+      const build = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--splitting',
+        '--outdir',
+        outDir,
+        '--format=esm', // minify 없이 — non-minify 경로가 실 깨짐(#4563)
+      ]);
+      expect(build.exitCode).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+
+      // self-referencing const(`const X = X.…`) 가 산출물에 없어야 한다 (구조 검증).
+      const chunkFiles = readdirSync(outDir).filter((f) => f.endsWith('.js') && f !== 'entry.js');
+      for (const f of chunkFiles) {
+        const src = readFileSync(join(outDir, f), 'utf-8');
+        const selfRef = /const (\w+)\s*=\s*\1[.[]/.exec(src);
+        expect(selfRef, `self-referencing const in ${f}: ${selfRef?.[0]}`).toBeNull();
+      }
+
+      const r = runNode(join(outDir, 'entry.js'));
+      // 수정 전: `ReferenceError: Cannot access 'channels' before initialization`
+      expect(r.err, `모듈 평가 실패:\n${r.err}`).toBe('');
+      expect(r.out).toBe('rgba:10');
+    } finally {
+      await cleanup();
+    }
+  }, 120000);
+
   test('#4502 splitting: materialize 된 ns 객체 getter 가 같은 청크의 chunk-local 이름을 쓴다', async () => {
     // 네 번째 표면 — ns 를 **값으로** 쓰면(`const o = ns`) 정적 멤버 재작성이 불가능해
     // 객체가 materialize 된다: `var ns_ns = {get second(){return <name>}, ...}`.


### PR DESCRIPTION
## 문제 (#4563)

`--splitting` 에서 함수-로컬 `const x` 가 import 가 해석되는 module-level `const x`(hoisted 싱글톤)를 shadow 하면 초기화식이 로컬 자신을 참조하는 **self-TDZ** 가 된다.

```js
// reusable.js:  const channels = new Channels(...); export default channels;   // 싱글톤
// rgba.js:
import _channels from "./reusable.js";
const rgba = (r) => {
  const channels = _channels.set({ r });   // 로컬 channels 가 싱글톤 channels 를 shadow
  return channels;
};
// 버그(splitting): const channels = channels.set(...) → ReferenceError: Cannot access 'channels' before initialization
```

실제 mermaid 를 `--format=esm`(minify 없이)로 빌드하면 khroma(rgba 등)가 이 위상으로 인라인돼 `channels` self-TDZ 로 `mermaid.render()` 가 크래시했다. (#4560/#4564 로 **minify** 경로는 이미 렌더됐고, 이건 **non-minify** 경로 블로커.)

## 근본 원인

zntc 가 import 참조 `_channels` 를 싱글톤 canonical `channels` 로 해석하면 함수-로컬 `channels` 와 충돌한다. **비-splitting**(글로벌 `computeRenames`)은 `resolveNestedShadowConflicts` 로 싱글톤 canonical 을 `channels$1` 로 리네임하는데, **splitting** 의 per-chunk 리네이머(`computeRenamesForModules`)엔 그 패스가 빠져 splitting 에서만 로컬이 싱글톤을 가려 self-TDZ.

## 수정

`computeRenamesForModules`(per-chunk)에 `resolveNestedShadowConflicts` 추가(`only: ?[]const ModuleIndex` 로 청크 한정, target 이 consumer 와 같은 청크일 때만 rename).

### `/code-review max` 반영

- **preserve-modules(`module_to_chunk==null`) 제외**: null 이면 `chunkOfModule` 이 전부 `.none` → same-chunk 가드가 `.none != .none`=false 로 **fail-open** 해 cross-module target 을 over-rename(별도 출력 파일이 원명 export → ReferenceError). preserve-modules 는 import 를 hoisting 안 해 이 shadow 자체가 없으므로 `if (module_to_chunk != null)` 로 skip. same-chunk 가드도 `.none` 이면 skip(`isCrossChunkConsumer` 와 동형).
- **nested-binding 캐시를 `calculateRenames` 전 + `defer clearNestedBindingCache()`**: 3 소비처(calculateRenames/resolveNestedShadowConflicts/resolveWrapperConsumerShadows) 공용 O(1), 에러 경로 해제(글로벌 경로와 동일).

## 범위 / 후속 (#4566)

**same-chunk splitting** 한정(mermaid khroma 는 same-chunk 인라인이라 커버). 같은 클래스의 잔여 토폴로지 — (A) cross-chunk splitting, (B) preserve-modules, (C) dev-split override revert — 는 근본이 **cross-chunk/파일경계 네이밍이 소비자 nested binding 미회피**로 별개 처방 필요. 셋 다 #4563 이전부터 있던 pre-existing gap(이 PR 이 회귀시키지 않음) → **#4566** 로 추적.

## 검증

- 실제 mermaid `--format=esm`(non-minify): flowchart/sequence/gantt/class/state/pie/er/journey/git **9종 전부 headless 브라우저 렌더 성공**. self-referencing const 0. (minify 경로도 여전히 9종 렌더.)
- 회귀 가드: `split-runtime-smoke.test.ts` `#4563` — reusable 싱글톤 + import alias + 함수-로컬 동명 구조를 splitting node 실행(`rgba:10`), self-referencing const 부재 확인.
- zig 전체 test + 통합 스위트(4270) 무회귀 — per-chunk 리네이머는 모든 splitting 빌드가 타는 코어라 전량 검증. preserve-modules 는 byte-identical(가드로 skip).

Closes #4563

🤖 Generated with [Claude Code](https://claude.com/claude-code)