### PR TITLE
fix(linker): #4566 nested-shadow self-TDZ — cross-chunk/preserve-modules/dev-split

### DIFF
--- a/.changeset/nested-shadow-crosschunk-preserve-modules.md
+++ b/.changeset/nested-shadow-crosschunk-preserve-modules.md
@@ -1,0 +1,34 @@
+---
+"@zntc/core": patch
+---
+
+함수-로컬 `const x` 가 import 참조를 shadow 해 self-TDZ(`const c = c.set(...)`) 나던 것을 **cross-chunk splitting** / **preserve-modules** / **dev-split** 세 토폴로지에서 모두 수정 (#4566, #4563 후속).
+
+```js
+// s.js:  const c = new C(); export default c;   // 싱글톤
+// u.js:
+import _c from "./s.js";
+export const f = (r) => { const c = _c.set(r); return c; };   // 함수-로컬 c 가 import c 를 shadow
+// 버그: const c = c.set(r) → ReferenceError: Cannot access 'c' before initialization
+```
+
+#4563 은 싱글톤과 소비자가 **같은 청크**(target canonical 을 `c$1` 로 rename)인 경우만 고쳤다. 잔여 토폴로지 — (A) cross-chunk splitting(싱글톤이 다른 청크로 hoist), (B) preserve-modules(import 를 문으로 보존, 로컬명이 export 명으로 rename 돼 함수-로컬과 충돌), (C) dev-split(same-chunk 인데 cross-chunk-export 도 돼 lazy override 가 target-rename 을 revert) — 은 target 의 canonical 을 이 청크서 못 건드려 self-TDZ 가 남았다.
+
+## 수정
+
+`resolveNestedShadowForModule` 을 분기: target 이 소비자와 **같은 청크 & cross-chunk-export 아님**이면 target canonical 을 rename(#4563), 아니면(다른 청크 / 파일경계 / cross-chunk-export) target 을 못/안 건드리므로 **소비자의 nested(scope 1+) 바인딩**을 rename. 소비자 로컬은 토폴로지 무관하게 항상 rename 가능하므로 세 케이스를 통합 해소한다.
+
+### `/code-review max` 반영
+
+- **참조 이름은 same-chunk 면 canonical local, cross-chunk 면 전역 공개명**: same-chunk 소비자는 로컬명으로 참조하므로 전역명으로 shadow 를 찾으면(local!=global) 놓쳐 #4563 이 회귀. `target_same_chunk` 판정 후 ref_name 결정.
+- **eval/`with` 가드**: consumer-rename 는 `resolveWrapperConsumerShadows` 와 동일하게 `blocksMangling()` 모듈 skip(동적 이름 참조 → 리네임 시 ReferenceError). minify 도 skip(mangler 담당).
+- **공유 헬퍼 `renameConsumerScopeBindings`**: consumer-nested-rename 루프를 `deconflictConsumerShadows`(#4533)와 공유 — 드리프트 제거(가드/scope 처리 단일 출처).
+- 회귀 가드 cross-chunk 구조 검증에 `fChunk` 정의 확인 추가(undefined 시 vacuous 통과 방지).
+
+## 검증
+
+- (A) cross-chunk splitting: `import { c }` + `const c$1 = c.set(...)`, 실행 `f:6 / 6`.
+- (B) preserve-modules: `import { default as c }` + `const c$1 = c.set(...)`, 실행 `f:6`.
+- (#4563) same-chunk(non-cross-export): `channels$1`(target rename) 유지, `rgba:10`.
+- 실제 mermaid: minify·non-minify **양쪽 9종 다이어그램 브라우저 렌더 성공**.
+- 회귀 가드: `split-runtime-smoke.test.ts` `#4566(A)`/`#4566(B)`. zig 전체 + 통합(4272) 무회귀 — per-chunk 리네이머는 모든 splitting/preserve-modules 빌드 코어라 전량 검증.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1119,16 +1119,26 @@ pub const Linker = struct {
             //     하지만 **런타임 헬퍼 이름**(`__toESM` 등)은 예약 대상이 아니라 여기서 처리해야
             //     scope-0 헬퍼 shadow 가 잡힌다.
             // 같은 이름이 여러 스코프에 바인딩될 수 있으므로(함수마다 `function require_legacy(){}`)
-            // 전부 순회한다.
-            for (csem.scope_maps, 0..) |scope_map, sidx| {
-                const sym_idx = scope_map.get(n) orelse continue;
-                const sid = bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(ci)), sym_idx);
-                if (self.rename_table.get(sid) != null) continue; // 이미 리네임됨(#4530/중복 import)
-                const cand = try self.pickConsumerShadowName(n, ci, c, name_to_owners);
-                try self.assignSymbolCanonical(sid, cand);
-                // scope 1+ 개명만 metadata nested 스캔이 필요하다(scope 0 은 module-scope 루프).
-                if (sidx >= 1) try self.nonminify_nested_shadow_modules.put(self.allocator, ci, {});
-            }
+            // 전 스코프(0 포함) 순회 — renameConsumerScopeBindings 공용(#4566 self-TDZ 와 동일 기계).
+            try self.renameConsumerScopeBindings(ci, c, csem, n, name_to_owners, 0);
+        }
+    }
+
+    /// consumer `ci` 의 스코프(인덱스 `min_scope` 이상)에서 `name` 바인딩을 안전한 이름으로 리네임.
+    /// wrapper shadow(#4533, min_scope=0: CJS scope-0 클로저 포함)와 self-TDZ shadow(#4566,
+    /// min_scope=1: nested 만) 공용. 같은 이름이 여러 스코프에 있을 수 있어 전부 순회. 이미 리네임된
+    /// 심볼(#4530/중복 import)은 skip. scope 1+ 개명만 metadata nested 스캔 필요(scope 0 은 module-scope
+    /// 루프)라 `nonminify_nested_shadow_modules` 로 표시. ⚠️ eval/`with` 소비자는 caller 가 미리 걸러야
+    /// 한다(동적 이름 참조 → 리네임 시 ReferenceError).
+    fn renameConsumerScopeBindings(self: *Linker, ci: u32, c: *const Module, csem: *const ModuleSemanticData, name: []const u8, name_to_owners: *const NameToOwnersMap, min_scope: usize) !void {
+        for (csem.scope_maps, 0..) |scope_map, sidx| {
+            if (sidx < min_scope) continue;
+            const sym_idx = scope_map.get(name) orelse continue;
+            const sid = bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(ci)), sym_idx);
+            if (self.rename_table.get(sid) != null) continue;
+            const cand = try self.pickConsumerShadowName(name, ci, c, name_to_owners);
+            try self.assignSymbolCanonical(sid, cand);
+            if (sidx >= 1) try self.nonminify_nested_shadow_modules.put(self.allocator, ci, {});
         }
     }
 
@@ -1496,35 +1506,65 @@ pub const Linker = struct {
         }
     }
 
-    fn resolveNestedShadowForModule(self: *Linker, mod_i: u32, name_to_owners: *const NameToOwnersMap, same_chunk_only: bool) !void {
+    /// `per_chunk`(#4563/#4566 splitting·preserve-modules per-chunk 경로): target 이 consumer 와
+    /// **같은 청크**면 target canonical 을 리네임(같은 청크라 안전, #4563), **다른 청크/파일경계**
+    /// (cross-chunk splitting·preserve-modules·미배정)면 target 을 못 건드리므로 대신 **consumer 의
+    /// nested(scope 1+) 바인딩**을 리네임(#4566). false(글로벌 computeRenames, 비-splitting)는 단일
+    /// 번들이라 항상 target-rename(기존 동작).
+    fn resolveNestedShadowForModule(self: *Linker, mod_i: u32, name_to_owners: *const NameToOwnersMap, per_chunk: bool) !void {
         const helper_modules = @import("../runtime_helper_modules.zig");
         const m = self.getModule(mod_i) orelse return;
         for (m.import_bindings) |ib| {
             if (ib.kind == .namespace) continue;
             const resolved = self.getResolvedBinding(mod_i, ib.local_span) orelse continue;
-            const target_name = self.resolveToLocalName(resolved.canonical);
+            const cmod: u32 = @intCast(@intFromEnum(resolved.canonical.module_index));
 
-            // target_name이 이 모듈의 중첩 스코프에 있고, local_name과 다르면 충돌
-            if (!std.mem.eql(u8, ib.local_name, target_name) and
-                self.hasNestedBinding(mod_i, target_name))
-            {
-                // target module의 canonical name을 한 단계 더 rename
-                const cmod: u32 = @intCast(@intFromEnum(resolved.canonical.module_index));
-                // (#4563) per-chunk: target 이 consumer 와 다른 청크(또는 어느 쪽이든 미배정 .none)면 skip
-                // — cross-chunk/미배정은 이 청크서 canonical 을 못 건드린다. isCrossChunkConsumer 와 동형.
-                if (same_chunk_only) {
-                    const cc = self.chunkOfModule(mod_i);
-                    const pc = self.chunkOfModule(cmod);
-                    if (cc.isNone() or pc.isNone() or cc != pc) continue;
-                }
+            // target 이 이 청크(리네임 가능)인가. (module_to_chunk==null 이면 chunkOfModule 이 .none 이라
+            // 아래 isNone 가드가 false → per_chunk 여도 same-chunk 아님.)
+            const target_same_chunk = per_chunk and blk: {
+                const cc = self.chunkOfModule(mod_i);
+                const pc = self.chunkOfModule(cmod);
+                break :blk !cc.isNone() and !pc.isNone() and cc == pc;
+            };
+            // 소비자 본문이 이 import 를 참조하는 **이름**: cross-chunk(다른 청크)면 전역 공개명(import 로
+            // 그 이름을 들여옴), same-chunk/글로벌이면 canonical **local**(같은 청크 참조는 로컬명). 이
+            // 이름과 동명인 nested 바인딩이 self-TDZ 를 낸다. ⚠️ same-chunk 에 전역명을 쓰면(local!=global)
+            // 로컬명 shadow 를 놓쳐 #4563 이 회귀(code-review).
+            const ref_name = if (per_chunk and !target_same_chunk)
+                (self.getCrossChunkGlobalName(cmod, resolved.canonical.export_name) orelse self.resolveToLocalName(resolved.canonical))
+            else
+                self.resolveToLocalName(resolved.canonical);
+
+            // ref_name 이 이 모듈의 중첩 스코프에 있고, import local_name 과 다르면(참조가 재작성됨) 충돌
+            if (std.mem.eql(u8, ib.local_name, ref_name)) continue;
+            if (!self.hasNestedBinding(mod_i, ref_name)) continue;
+
+            // (#4566 C) same-chunk 라도 target 이 **cross-chunk-export** 되면, dev-split 의 lazy override
+            // (computeRenamesForModules 2.5)가 target canonical 을 전역 공개명으로 되돌려 target-rename 이
+            // 무효화(shadow 부활 → self-TDZ)된다. 그 경우 target 대신 **consumer** 를 리네임(2.5 는 target
+            // 만 건드리므로 consumer-rename 은 안전). cross-chunk-export 여부 = 전역명 맵에 있는가.
+            const target_cross_exported = per_chunk and
+                self.getCrossChunkGlobalName(cmod, resolved.canonical.export_name) != null;
+            const use_target_rename = !per_chunk or (target_same_chunk and !target_cross_exported);
+
+            if (use_target_rename) {
+                // target canonical 을 한 단계 더 rename (글로벌 경로 / same-chunk splitting, #4563).
                 const target_module = self.getModule(cmod) orelse continue;
                 if (helper_modules.isVirtualId(target_module.path)) continue;
                 const export_local = self.getExportLocalName(cmod, resolved.canonical.export_name) orelse resolved.canonical.export_name;
-
-                // 새 이름: target_name$N (기존 이름 충돌 없는 것)
                 var suffix: u32 = 1;
-                const candidate = try self.findAvailableCandidate(target_name, cmod, &suffix, name_to_owners);
+                const candidate = try self.findAvailableCandidate(ref_name, cmod, &suffix, name_to_owners);
                 try self.putCanonicalName(cmod, export_local, candidate);
+            } else {
+                // (#4566) cross-chunk / preserve-modules: target(다른 청크·별도 출력 파일)의 canonical 을
+                // 못 건드린다 → 대신 **consumer 의 nested 바인딩**을 리네임(renameConsumerScopeBindings,
+                // resolveWrapperConsumerShadows 와 공유 기계). minify 는 mangler 가 유일명 부여해 shadow
+                // 원천 불가 → skip. direct eval/`with` 소비자는 동적 이름 참조라 리네임 시 ReferenceError
+                // → skip(resolveWrapperConsumerShadows 와 동일 가드, #1258).
+                if (self.manglerActive()) continue;
+                const csem = if (m.semantic) |*s| s else continue;
+                if (csem.scopes.len > 0 and csem.scopes[0].blocksMangling()) continue;
+                try self.renameConsumerScopeBindings(mod_i, m, csem, ref_name, name_to_owners, 1);
             }
         }
     }
@@ -3798,19 +3838,13 @@ pub const Linker = struct {
         // 2. 충돌하는 이름에 대해 리네임 계산 (cross-chunk 점유 마커는 skip)
         try self.calculateRenames(&name_to_owners, true);
 
-        // 2.05 (#4563) import binding 의 canonical(hoisted module-level)이 그 모듈의 nested 스코프
-        // 바인딩과 충돌하면 target canonical 을 rename. function-local `const x` 가 module-level
-        // `const x`(import 가 해석되는 대상)를 shadow 하면 초기화식이 self-TDZ 가 된다
-        // (`const channels = channels.set(...)` = khroma rgba). 전역 computeRenames(비-splitting)는
-        // resolveNestedShadowConflicts 로 하는데 이 per-chunk 경로엔 빠져 splitting 서만 깨졌다.
-        // ⚠️ **실제 splitting(module_to_chunk 세팅)만** — preserve-modules 는 module_to_chunk 가 null 이라
-        // chunkOfModule 이 전부 .none → same-chunk 가드가 `.none != .none`=false 로 **fail-open** 해
-        // cross-module target 을 over-rename(별도 출력 파일이 여전히 원명 export → ReferenceError,
-        // code-review). preserve-modules 는 import 를 hoisting 안 해(import 문 보존) shadow 자체가 없다.
-        // target 이 같은 청크일 때만 rename(cross-chunk 토폴로지는 별도 gap — 후속).
-        if (self.module_to_chunk != null) {
-            try self.resolveNestedShadowConflicts(&name_to_owners, module_indices);
-        }
+        // 2.05 (#4563/#4566) import binding 의 canonical(hoisted module-level)이 그 모듈의 nested 스코프
+        // 바인딩과 충돌하면(`const channels = channels.set(...)` self-TDZ = khroma rgba) 해소한다. 전역
+        // computeRenames(비-splitting)는 resolveNestedShadowConflicts 로 하는데 이 per-chunk 경로엔 빠져
+        // splitting/preserve-modules 서만 깨졌다. target 이 **같은 청크**면 target canonical 을 rename
+        // (#4563), **다른 청크/파일경계**(cross-chunk splitting·preserve-modules)면 target 을 못 건드리므로
+        // **consumer 의 nested 바인딩**을 rename(#4566) — resolveNestedShadowForModule 이 분기.
+        try self.resolveNestedShadowConflicts(&name_to_owners, module_indices);
 
         // 2.1 주입된 래퍼 참조가 소비자 스코프 바인딩에 가려지는 것 방지 (#4533). code-splitting 은
         // 이 per-chunk 경로만 타므로 여기서도 불러야 한다(전역 computeRenames 는 안 탄다). 소비자

--- a/tests/integration/tests/split-runtime-smoke.test.ts
+++ b/tests/integration/tests/split-runtime-smoke.test.ts
@@ -331,6 +331,98 @@ export const rgba = (r) => {
     }
   }, 120000);
 
+  test('#4566(A) splitting: 싱글톤이 다른 청크여도 소비자 함수-로컬 shadow 를 해소한다', async () => {
+    // #4563 은 싱글톤과 소비자가 **같은 청크**(target-rename)였다면, #4566(A) 는 싱글톤이 공유돼
+    // **다른 청크**로 hoist 된 cross-chunk 케이스다. target(싱글톤)의 canonical 은 이 청크서 못
+    // 건드리므로(cross-chunk 전역명 공유) 대신 **소비자의 함수-로컬**을 리네임해야 self-TDZ 를 피한다.
+    //   수정 전: `import { c } from './shared'` + `const c = c.set(...)` → ReferenceError.
+    const files: Record<string, string> = {
+      's.js': `class C { constructor(v){ this.v = v; } set(x){ this.v = x; return this; } }
+const c = new C({ r: 0 });
+export default c;
+`,
+      'u.js': `import _c from "./s.js";
+export const f = (r) => { const c = _c.set({ r: r * 3 }); return "f:" + c.v.r; };
+`,
+      // diag1: u 사용(u 는 diag1 전용 leaf). diag2: s 직접 사용 → s 를 공통 청크로 분리(cross-chunk).
+      'diag1.js': `import { f } from "./u.js";\nexport const d1 = () => f(2);\n`,
+      'diag2.js': `import s from "./s.js";\nexport const d2 = () => s.v.r;\n`,
+      'entry.js': `Promise.all([import("./diag1.js"), import("./diag2.js")]).then(([a, b]) => { console.log(a.d1() + " / " + b.d2()); });\n`,
+    };
+    const { dir, cleanup } = await createFixture(files);
+    try {
+      const outDir = join(dir, 'out');
+      const build = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--splitting',
+        '--outdir',
+        outDir,
+        '--format=esm',
+      ]);
+      expect(build.exitCode).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+      // s.js 의 c 가 u.js(diag1) 와 다른 청크여야 이 fix 가 발화(구조 검증).
+      const allChunks = readdirSync(outDir).filter((f) => f.endsWith('.js') && f !== 'entry.js');
+      const fChunk = allChunks.find((f) =>
+        /\bf\s*=|\bd1\b/.test(readFileSync(join(outDir, f), 'utf-8')),
+      );
+      const cChunk = allChunks.find((f) =>
+        readFileSync(join(outDir, f), 'utf-8').includes('new C('),
+      );
+      expect(fChunk, 'f/d1 청크 없음').toBeTruthy(); // fChunk undefined 면 아래 not.toBe 가 vacuous 통과
+      expect(cChunk, 'C 정의 청크 없음').toBeTruthy();
+      expect(cChunk, '싱글톤이 소비자 청크에 인라인 — cross-chunk 아님').not.toBe(fChunk);
+      const r = runNode(join(outDir, 'entry.js'));
+      expect(r.err, `모듈 평가 실패:\n${r.err}`).toBe('');
+      expect(r.out).toBe('f:6 / 6');
+    } finally {
+      await cleanup();
+    }
+  }, 120000);
+
+  test('#4566(B) preserve-modules: import 로컬이 함수-로컬을 shadow 하면 함수-로컬을 리네임한다', async () => {
+    // preserve-modules 는 import 를 문(statement)으로 보존하며 로컬명을 export 명으로 리네임한다:
+    // `import { default as c } from './s.js'`. 함수-로컬 `const c` 가 이 import 로컬 `c` 를 shadow →
+    // `const c = c.set(...)` self-TDZ. target(별도 출력 파일)은 못 건드리므로 함수-로컬을 리네임.
+    const files: Record<string, string> = {
+      's.js': `class C { constructor(v){ this.v = v; } set(x){ this.v = x; return this; } }
+const c = new C({ r: 0 });
+export default c;
+`,
+      'u.js': `import _c from "./s.js";
+export const f = (r) => { const c = _c.set({ r: r * 3 }); return "f:" + c.v.r; };
+`,
+      'entry.js': `import { f } from "./u.js";\nconsole.log(f(2));\n`,
+    };
+    const { dir, cleanup } = await createFixture(files);
+    try {
+      const outDir = join(dir, 'out');
+      const build = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--preserve-modules',
+        '--outdir',
+        outDir,
+        '--format=esm',
+      ]);
+      expect(build.exitCode).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+      // u.js 에 self-referencing const(`const c = c.…`) 가 없어야 한다.
+      const files2 = readdirSync(outDir).filter((f) => f.endsWith('.js'));
+      for (const f of files2) {
+        const src = readFileSync(join(outDir, f), 'utf-8');
+        const selfRef = /const (\w+)\s*=\s*\1[.[]/.exec(src);
+        expect(selfRef, `self-referencing const in ${f}: ${selfRef?.[0]}`).toBeNull();
+      }
+      const r = runNode(join(outDir, 'entry.js'));
+      expect(r.err, `모듈 평가 실패:\n${r.err}`).toBe('');
+      expect(r.out).toBe('f:6');
+    } finally {
+      await cleanup();
+    }
+  }, 120000);
+
   test('#4502 splitting: materialize 된 ns 객체 getter 가 같은 청크의 chunk-local 이름을 쓴다', async () => {
     // 네 번째 표면 — ns 를 **값으로** 쓰면(`const o = ns`) 정적 멤버 재작성이 불가능해
     // 객체가 materialize 된다: `var ns_ns = {get second(){return <name>}, ...}`.


### PR DESCRIPTION
## 문제 (#4566)

함수-로컬 `const x` 가 import 참조를 shadow 하면 초기화식이 로컬 자신을 참조하는 **self-TDZ** 가 된다. #4563 은 싱글톤과 소비자가 **같은 청크**인 경우만 고쳤고, `/code-review max` 가 잔여 토폴로지 3종을 확인했다:

```js
// s.js:  const c = new C(); export default c;   // 싱글톤
// u.js:
import _c from "./s.js";
export const f = (r) => { const c = _c.set(r); return c; };   // 함수-로컬 c 가 import c 를 shadow
// 버그: const c = c.set(r) → ReferenceError: Cannot access 'c' before initialization
```

- **(A) cross-chunk splitting** — 싱글톤이 공유돼 **다른 청크**로 hoist. target(싱글톤)의 canonical 을 이 청크서 못 건드림.
- **(B) preserve-modules** — import 를 문으로 보존하며 로컬명이 export 명으로 rename(`import { default as c }`) 돼 함수-로컬과 충돌. target 은 별도 출력 파일.
- **(C) dev-split** — same-chunk 인데 cross-chunk-export 도 돼, lazy override(2.5)가 target-rename 을 전역명으로 revert.

셋 다 target 의 canonical 을 못/안 건드리므로 #4563 의 target-rename 이 안 통했다.

## 수정

`resolveNestedShadowForModule` 분기: target 이 소비자와 **같은 청크 & cross-chunk-export 아님**이면 target canonical 을 rename(#4563), 아니면(다른 청크 / 파일경계 / cross-chunk-export) target 을 못/안 건드리므로 **소비자의 nested(scope 1+) 바인딩**을 rename. 소비자 로컬은 토폴로지 무관하게 항상 rename 가능하므로 세 케이스를 통합 해소한다.

### `/code-review max` 반영

- **참조 이름 = same-chunk 면 canonical local, cross-chunk 면 전역 공개명**: same-chunk 소비자는 로컬명으로 참조하므로 전역명으로 shadow 를 찾으면(local!=global) 놓쳐 #4563 이 회귀. `target_same_chunk` 판정 후 ref_name 결정.
- **eval/`with` 가드**: consumer-rename 는 `resolveWrapperConsumerShadows` 와 동일하게 `blocksMangling()` 모듈 skip(동적 이름 참조 → 리네임 시 ReferenceError). minify 도 skip(mangler 담당).
- **공유 헬퍼 `renameConsumerScopeBindings`**: consumer-nested-rename 루프를 `deconflictConsumerShadows`(#4533)와 공유 — 가드/scope 처리 단일 출처(드리프트 제거).
- 회귀 가드 cross-chunk 구조 검증에 `fChunk` 정의 확인(undefined 시 vacuous 통과 방지).

## 검증

- (A) cross-chunk splitting: `import { c }` + `const c$1 = c.set(...)`, 실행 `f:6 / 6`.
- (B) preserve-modules: `import { default as c }` + `const c$1 = c.set(...)`, 실행 `f:6`.
- (#4563) same-chunk(non-cross-export): `channels$1`(target rename) 유지, `rgba:10`.
- 실제 mermaid: minify·non-minify **양쪽 9종 다이어그램 브라우저 렌더 성공**.
- 회귀 가드: `split-runtime-smoke.test.ts` `#4566(A)`/`#4566(B)`. zig 전체 test + 통합 스위트(4272) 무회귀 — per-chunk 리네이머는 모든 splitting/preserve-modules 빌드 코어라 전량 검증.

Closes #4566

🤖 Generated with [Claude Code](https://claude.com/claude-code)