### PR TITLE
fix(linker): #4532 증상3 — preserve-modules 배럴 경유 ESM-wrap dep re-export

### DIFF
--- a/.changeset/preserve-modules-cjs-reexport-wrap-dep.md
+++ b/.changeset/preserve-modules-cjs-reexport-wrap-dep.md
@@ -1,0 +1,35 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules`(CJS/ESM)에서 **소비자가 re-export 배럴 경유로 ESM-wrap dep 을 import** 하면 `undefined` 를 잡아 `TypeError: X is not a function` 나던 것 수정 (#4532 증상3).
+
+```js
+// b.js:  export const CONST = 42; export function fn(){ return "F"; }
+// a.cjs: module.exports = require("./b.js");   // b 를 ESM-wrap 강제
+// r.js:  export { CONST, fn } from "./b.js";   // re-export 배럴
+// entry: import { CONST, fn } from "./r.js"; import "./a.cjs"; console.log(CONST + "|" + fn());
+// 버그(CJS/minify): TypeError: fn is not a function
+```
+
+## 근본 원인
+
+ESM 소비자가 배럴 경유로 import 하면 re-export 체인이 wrap dep(b.js)로 직접 해석돼, 소비자 preamble 이 forwarding 썽크(`let X; const init_X = ...`)의 `init_X()` 를 호출해야 X 가 채워진다("소비자는 심볼을 쓰기 전 init_X() 를 부른다"는 계약). 그런데 init 주입 게이트가 **직접 import 대상**(`canonical_m_opt` = 배럴, non-wrap)만 봐서 막혀 `init_X()` 를 안 깔았다 → 소비자가 undefined X 를 참조.
+
+## 수정
+
+소비자 init 주입에서, 직접 대상이 non-wrap 이어도 **`resolved.canonical`(re-export 체인 끝)이 ESM-wrap 이면 그 wrap dep 의 `init_X()` 를 소비자 preamble 에 주입**한다. `esm_init_set` 로 중복 방지, tree-shake 가드 유지.
+
+`/code-review max` 반영:
+- **preserve-modules 한정**: 각 모듈이 별도 파일이라 forwarding 썽크(init_X)가 소비자 파일에 로컬 정의된다. splitting 은 init_X 가 cross-chunk 라 이 청크서 undefined 일 수 있어(그쪽은 cross-chunk 네이밍이 별도 처리) 제외.
+
+## 검증
+
+- CJS/ESM × plain/minify **전부** `42|F` (수정 전 CJS/minify 는 `TypeError`).
+- splitting(비-preserve-modules)은 게이트로 미적용 — 자체 경로로 정상(`42|F`), 무회귀.
+- 회귀 가드: `preserve-modules-cjs.test.ts` 에 증상3 실행 가드(node 실제 실행).
+- zig 전체 test + 통합 스위트 무회귀.
+
+## 잔여 (#4532 epic)
+
+- 배럴 **자체** exports 를 CJS 로 직접 `require("./r.js").X` 하는 경로는 별도(live getter 필요 — `__export`/minify 이름·default·wrapped 포맷·accessor 시맨틱 엣지 다수라 별도 설계). 증상 1(동명 붕괴 `BB`) CJS, 증상 4(순환) 도 별개 근본. 후속.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -941,6 +941,32 @@ pub fn buildMetadataForAst(
                 // import binding은 아래의 rename 경로로 처리 (continue하지 않음)
             }
 
+            // (#4532 증상3) 직접 import 대상(canonical_m_opt)이 **배럴**(non-wrap)이라 위 ESM 게이트를
+            // 못 탔지만, re-export 체인 끝(resolved.canonical)이 **ESM-wrap** 이면 그 wrap dep 의 init_X()
+            // 를 소비자 preamble 에 주입한다. 안 하면 forwarding 썽크(`let X; const init_X = ...`)가 호출
+            // 안 돼 소비자가 undefined X 를 참조(`X is not a function`) — 배럴이 wrap dep 을 re-export 하는
+            // 흔한 위상. canon 이 wrap 인 케이스는 위 블록이 이미 처리하므로 여기선 non-wrap 만.
+            // ⚠️ **preserve-modules 한정**: 각 모듈이 별도 파일이라 forwarding 썽크(init_X)가 소비자
+            // 파일에 로컬 정의된다. splitting 은 init_X 가 cross-chunk 라 이 청크서 undefined 일 수 있어
+            // (그쪽은 cross-chunk 네이밍이 별도 처리) 여기선 제외 (code-review).
+            if (self.graph.preserve_modules and
+                !(canonical_m_opt != null and canonical_m_opt.?.wrap_kind == .esm))
+            {
+                if (resolved) |rb| {
+                    const rb_idx: u32 = @intCast(@intFromEnum(rb.canonical.module_index));
+                    if (rb_idx != canonical_mod) {
+                        if (self.graph.getModule(rb.canonical.module_index)) |rw| {
+                            if (rw.wrap_kind == .esm and !(self.tree_shaker_active and !rw.is_included) and
+                                !esm_init_set.contains(rb_idx))
+                            {
+                                try esm_init_set.put(self.allocator, rb_idx, {});
+                                try appendEsmInitCall(self, &preamble, rw);
+                            }
+                        }
+                    }
+                }
+            }
+
             // namespace import: esbuild 방식 — ns.prop → canonical_name 직접 치환.
             // __esm 타겟도 동일: rolldown 방식으로 변수가 래퍼 밖에 호이스팅되므로
             // canonical name으로 직접 치환 가능. exports_xxx rename은 변수 덮어쓰기 버그 유발.

--- a/tests/integration/tests/preserve-modules-cjs.test.ts
+++ b/tests/integration/tests/preserve-modules-cjs.test.ts
@@ -350,6 +350,32 @@ describe('#4524: --preserve-modules × CJS', () => {
       await cleanup();
     }
   });
+  test('#4532 증상3: re-export 배럴이 ESM-wrap dep 을 re-export 해도 소비자가 undefined 를 안 잡는다', async () => {
+    // r.js 가 `export { CONST, fn } from "./b.js"`(b 는 ESM-wrap) 하면, CJS 배럴 r.js 는 `let CONST,
+    // fn` + init_b forwarding 썽크를 깔지만 자기 `exports.X = X` 스냅샷 전에 init_b 를 안 불러
+    // undefined 를 박제한다. (b) ESM 소비자가 배럴 경유로 import 하면 re-export 체인이 b 로 직접
+    // 해석돼 소비자 preamble 이 init_b() 를 주입해야 하는데 게이트가 배럴(non-wrap)을 봐서 놓친다.
+    // 버그 시 `TypeError: fn is not a function`.
+    const { outDir, cleanup } = await buildPm(
+      {
+        'b.js': 'export const CONST = 42;\nexport function fn(){ return "F"; }',
+        'a.cjs': 'module.exports = require("./b.js");', // b 를 ESM-wrap 강제
+        'r.js': 'export { CONST, fn } from "./b.js";', // 배럴
+        'entry.js':
+          'import { CONST, fn } from "./r.js";\nimport "./a.cjs";\nconsole.log(CONST + "|" + fn());',
+      },
+      'entry.js',
+      'cjs',
+    );
+    try {
+      const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+      expect(stderr).not.toContain('TypeError'); // 수정 전: fn is not a function
+      expect(stdout.trim()).toBe('42|F');
+    } finally {
+      await cleanup();
+    }
+  });
+
   // ─── #4528: wrap 된 모듈의 남은 구멍 3건 ───
 
   const WRAPPED = {


### PR DESCRIPTION
## 문제 (#4532 증상3)

`--preserve-modules`(CJS/ESM)에서 **소비자가 re-export 배럴 경유로 ESM-wrap dep 을 import** 하면 `undefined` 를 잡아 `TypeError: X is not a function`.

```js
// b.js:  export const CONST = 42; export function fn(){ return "F"; }
// a.cjs: module.exports = require("./b.js");   // b 를 ESM-wrap 강제
// r.js:  export { CONST, fn } from "./b.js";   // re-export 배럴
// entry: import { CONST, fn } from "./r.js"; import "./a.cjs"; console.log(CONST + "|" + fn());
// 버그(CJS/minify): TypeError: fn is not a function
```

## 근본 원인

ESM 소비자가 배럴 경유로 import 하면 re-export 체인이 wrap dep(b.js)로 직접 해석돼, 소비자 preamble 이 forwarding 썽크(`let X; const init_X = ...`)의 `init_X()` 를 불러야 X 가 채워진다("소비자는 심볼을 쓰기 전 init_X() 를 부른다"는 계약). 그런데 init 주입 게이트가 **직접 import 대상**(`canonical_m_opt` = 배럴, non-wrap)만 봐서 막혀 `init_X()` 를 안 깔았다 → 소비자가 undefined X 참조.

## 수정

소비자 init 주입에서, 직접 대상이 non-wrap 이어도 **`resolved.canonical`(re-export 체인 끝)이 ESM-wrap 이면 그 wrap dep 의 `init_X()` 를 소비자 preamble 에 주입**한다. `esm_init_set` 중복방지 + tree-shake 가드.

### `/code-review max` 반영

- **preserve-modules 한정**: 각 모듈이 별도 파일이라 forwarding 썽크(init_X)가 소비자 파일에 로컬 정의된다. splitting 은 init_X 가 cross-chunk 라 이 청크서 undefined 일 수 있어(그쪽은 cross-chunk 네이밍이 별도 처리) 제외.
- 초기 구현에 있던 **배럴 자체 exports live getter**(CJS `require("./r.js").X` 경로)는 리뷰가 다수 엣지 확인(`__export`/`$x` minify 이름, getter_init↔__export 주입 술어 발산 → splitting `__export is not defined`, default-only·wrapped(umd/amd/iife) 포맷 미처리, read-only accessor 로 monkey-patch 깨짐) → **드롭**하고 별도 설계로 후속. 이 PR 은 소비자 init 주입(위 근본)에 집중.

## 검증

- CJS/ESM × plain/minify **전부** `42|F` (수정 전 CJS/minify 는 `TypeError`).
- splitting(비-preserve-modules)은 게이트로 미적용 — 자체 경로로 정상(`42|F`), 무회귀.
- 회귀 가드: `preserve-modules-cjs.test.ts` 증상3 실행 가드(node 실제 실행).
- zig 전체 test + 통합 스위트(4273) 무회귀.

## 잔여 (epic #4532)

배럴 자체 exports CJS 직접 require(live getter), 증상 1(동명 붕괴 `BB`) CJS, 증상 4(순환) 는 별개 근본이라 후속. epic 미종결.

Refs #4532

🤖 Generated with [Claude Code](https://claude.com/claude-code)