### PR TITLE
fix(bundler): #4532 증상1 preserve-modules CJS 동명 export 심볼 붕괴

### DIFF
--- a/.changeset/preserve-modules-cjs-samename-collapse.md
+++ b/.changeset/preserve-modules-cjs-samename-collapse.md
@@ -1,0 +1,47 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules`(CJS)에서 **서로 다른 wrap dep 이 동명 export 를 내고 한 소비자가 둘 다 import** 하면, 소비자 본문이 한 이름으로 붕괴해 잘못된 값을 조용히 방출하던 것 수정 (#4532 증상1).
+
+```js
+// b.js:    export function tag(){ return "B"; }
+// c.js:    export function tag(){ return "C"; }
+// a.cjs:   module.exports = require("./b.js"); require("./c.js");   // b·c 를 ESM-wrap 강제
+// entry:   import { tag } from "./b.js"; import { tag as tag2 } from "./c.js"; import "./a.cjs";
+//          console.log(tag() + tag2());
+// node canonical: "BC"
+// 버그(CJS): "BB"  ← console.log(tag() + tag()) 로 붕괴 (에러 없는 조용한 오컴파일)
+```
+
+## 근본 원인
+
+동명 심볼을 파일 경계 너머로 구분하는 cross-file 네이밍(`computeCrossChunkGlobalNames`)이 preserve-modules 에서 **ESM 출력만** 켜져 있었다(`pm_xchunk_naming` 게이트에 `format == .esm`). CJS 출력에선:
+
+- **forwarding 썽크**(emitter, chunks.zig)는 `name_seen_count` 로컬 dedup 으로 `let tag$1` 을 만드는데,
+- **본문 참조**(linker, metadata.zig)는 `resolveToLocalName(canonical)` = `tag` 로 rename 한다.
+
+두 경로가 **공유 맵 없이 독립 계산**해 발산 → forwarding var `tag$1` 은 죽고 본문은 `tag`(b 의 canonical) 를 두 번 참조 → `BB`. ESM 은 전역명 맵을 provider·consumer·본문 셋이 공유해 일치한다.
+
+## 수정
+
+1. `pm_xchunk_naming` 게이트를 **CJS 출력에도** 오픈(`format == .esm or format == .cjs`). 전역명 맵이 채워져 본문 참조·forwarding var 가 같은 `tag$1` 에 합의한다.
+2. CJS forwarding 썽크의 **read** 를 전역명으로 정렬(chunks.zig): provider(ESM-wrap)는 `pm_wrapped_esm_provider`(#4528)로 `exports.tag$1` 을 내므로, `let tag$1; tag$1 = m.tag$1` 이 되도록 read 도 `crossChunkBindingName`(=provider export 키)로 읽는다. 예전 `m.tag`(자연명)는 undefined → `tag$1 is not a function`.
+
+`pm_esm_wrap_dep_syms`(chunks.zig)는 **preserve-modules × CJS 출력 × ESM-wrap dep** 에서만 채워지므로 read 변경은 이 경로에 정밀 스코프된다.
+
+`/code-review max` 반영:
+- **reserved-name(`default`) read 회귀 수정**: read 를 `crossChunkBindingName` 으로 쓰면 reserved-name 이 전역명 없을 때(minify/dev) provider **로컬**(`foo`)을 반환해 `exports.default` 과 어긋난다(`m.foo` undefined → TypeError). read = **`전역명 orelse export명`**(provider export 키)으로 정정하고, 첫 루프에서 `pm_reads` 배열에 캡처해 재계산도 제거.
+- **stale 주석 갱신**(chunk.zig): `pm_xchunk_naming` 이 CJS 를 포함하게 됐으므로 `import * as ns` fan-out(증상2) 게이트 주석을 `ESM/CJS` 로 갱신. CJS non-minify `import * as ns` 도 이제 동작(`1|hi`) — 부수 개선.
+
+## 검증
+
+- 증상1: CJS `BC`(수정 전 `BB`), ESM `BC`(무회귀).
+- splitting+preserve+cjs `BC`, 증상3 배럴 `42|F`(CJS/ESM×plain/minify), pure-CJS 동명 `BC` — 무회귀.
+- 회귀 가드: `preserve-modules-cjs.test.ts` 증상1 실행 가드(esm+cjs, node 실행 + 전역명 `tag$1` 방출 pin — 자연명 fallback 과 구분).
+- preserve-modules(-cjs) 39+ pass, splitting 77 pass, zig 전체 test 통과.
+
+## 잔여 (#4532 epic)
+
+- **minify 증상1**: `!minify_identifiers` 로 제외 유지 — identifier mangler(`computeChunkMangling`)가 preserve-modules 서 skip 이라 전역명 미예약 → mangled local ↔ 전역명 충돌 위험. mangler 전역명 예약 후속(ESM-minify 도 동일하게 BB 인 기존 잔여).
+- 증상4(multi-entry 순환), 배럴 자체 exports CJS 직접 `require("./r.js").X`(live getter) 도 별개 근본.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1925,14 +1925,18 @@ pub const Bundler = struct {
                 chunk_mod.mergeSmallChunks(&chunk_graph, graph, self.options.min_chunk_size);
             }
 
-            // (#4532) preserve_modules(ESM·non-minify 출력)의 cross-file 심볼 네이밍 게이트. CJS
-            // 출력은 소비자가 bare 전역명 bind 불가(materialize 필요), minify 는 identifier mangler 가
-            // 전역명 미예약(computeChunkMangling 은 code_splitting 게이트라 preserve-modules 서 skip)
-            // 충돌 위험 → 둘 다 후속. splitting(code_splitting and !preserve_modules)은 별개 항 유지.
+            // (#4532) preserve_modules(ESM/CJS·non-minify 출력)의 cross-file 심볼 네이밍 게이트.
+            // ESM 은 `import { X as global }` 로, CJS 는 forwarding 썽크(`let global; global =
+            // m.global`, chunks.zig)로 전역명을 materialize 한다 — 소비자 본문·forwarding·provider
+            // export 셋이 같은 전역명에 합의(증상1 동명 붕괴 `BB` 해소). CJS forwarding read 도
+            // provider export 키(전역명 orelse export명)로 읽어야 provider 방출과 일치한다(chunks.zig).
+            // minify 는 identifier mangler 가 전역명 미예약(computeChunkMangling 은 code_splitting
+            // 게이트라 preserve-modules 서 skip)이라 mangled local↔전역명 충돌 위험 → `!minify_
+            // identifiers` 로 후속. splitting(code_splitting and !preserve_modules)은 별개 항 유지.
             // ⚠️ `!dev_mode` 도 필수: dev 는 namespace member rewrite 가 wrapped local(`(init(),
             // exp.local)`)을 쓰고 negotiated 전역명 경로를 안 타 동명 멤버가 붕괴한다(code-review).
             const pm_xchunk_naming = self.options.preserve_modules and
-                self.options.format == .esm and
+                (self.options.format == .esm or self.options.format == .cjs) and
                 !self.options.minify_identifiers and
                 !self.options.dev_mode;
             // (#4532 증상2) computeCrossChunkLinks 의 direct `import * as ns`(leaf ESM-wrap dep) fan-out

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -347,9 +347,10 @@ pub const ChunkGraph = struct {
     /// 이름을 소비자가 `import { default as … }` 로 가져와 링크 에러가 난다.
     preserve_modules: bool = false,
 
-    /// (#4532) preserve-modules(ESM·non-minify) cross-file 심볼 네이밍이 켜졌는지. bundler.zig 가
-    /// computeCrossChunkLinks 전에 세팅. direct `import * as ns`(ESM-wrap dep) fan-out(증상2)을
-    /// 이 게이트 + dep `wrap_kind==.esm` 로 한정해, 네이밍이 켜진 경우에만 imports_from 에 등록한다.
+    /// (#4532) preserve-modules(ESM/CJS·non-minify·non-dev) cross-file 심볼 네이밍이 켜졌는지.
+    /// bundler.zig 가 computeCrossChunkLinks 전에 세팅. direct `import * as ns`(ESM-wrap dep)
+    /// fan-out(증상2)을 이 게이트 + dep `wrap_kind==.esm` 로 한정해, 네이밍이 켜진 경우에만
+    /// imports_from 에 등록한다. CJS 출력도 forwarding 썽크로 전역명을 materialize 하므로 포함(증상1).
     pm_xchunk_naming: bool = false,
 
     /// module_count 크기의 빈 ChunkGraph를 생성한다.
@@ -2077,7 +2078,7 @@ pub fn computeCrossChunkLinks(
                     //     가 lazy 다이어그램 청크서 bare `channel` → render() ReferenceError 였다. dev 는
                     //     member rewrite 가 wrapped local 을 써 전역명 경로를 안 타므로 preserve-modules 와
                     //     동일하게 제외한다.
-                    //   - **preserve-modules**(#4532): pm_xchunk_naming(ESM·non-minify·non-dev) 한정.
+                    //   - **preserve-modules**(#4532): pm_xchunk_naming(ESM/CJS·non-minify·non-dev) 한정.
                     const ns_fanout_ok = if (chunk_graph.preserve_modules) chunk_graph.pm_xchunk_naming else !graph.dev_mode;
                     if (ns_fanout_ok and ib.kind == .namespace) {
                         if (graph.getModule(src_mod)) |dep| {

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -687,10 +687,15 @@ pub fn emitChunks(
                         for (pm_locals.items) |x| allocator.free(x);
                         pm_locals.deinit(allocator);
                     }
+                    // pm_locals 와 인덱스 병행: 각 sym 의 forwarding **read**(provider export 키).
+                    // 항목은 borrowed(전역명 맵 slice 또는 sym.name — 둘 다 emit 수명) → list 만 deinit.
+                    var pm_reads: std.ArrayListUnmanaged([]const u8) = .empty;
+                    defer pm_reads.deinit(allocator);
                     if (pm_esm_wrap_dep_syms) |syms| {
                         for (syms) |sym| {
                             const bind = crossChunkBindingName(linker, sym);
-                            const has_g = if (linker) |l| l.getCrossChunkGlobalName(sym.canonical_module, sym.name) != null else false;
+                            const global_name: ?[]const u8 = if (linker) |l| l.getCrossChunkGlobalName(sym.canonical_module, sym.name) else null;
+                            const has_g = global_name != null;
                             const total = name_total_count.get(sym.name) orelse 1;
                             const seen_gop = try name_seen_count.getOrPut(allocator, sym.name);
                             if (!seen_gop.found_existing) seen_gop.value_ptr.* = 0;
@@ -701,6 +706,10 @@ pub fn emitChunks(
                             else
                                 try allocator.dupe(u8, bind);
                             try pm_locals.append(allocator, local);
+                            // read = 전역명(있으면 provider 가 `exports.<global>`) 아니면 export 명(sym.name,
+                            // provider 가 `exports.<export명>`). crossChunkBindingName 은 reserved-name 이
+                            // 전역명 없을 때 로컬을 반환하므로 read 로는 부적합.
+                            try pm_reads.append(allocator, global_name orelse sym.name);
                         }
                         try chunk_output.appendSlice(allocator, "let ");
                         for (pm_locals.items, 0..) |local, si| {
@@ -733,11 +742,17 @@ pub fn emitChunks(
                         try chunk_output.appendSlice(allocator, if (min) "const r=m." else "\t\tconst r = m.");
                         try chunk_output.appendSlice(allocator, names.a);
                         try chunk_output.appendSlice(allocator, if (min) ".apply(this,arguments);" else ".apply(this, arguments);\n");
-                        for (syms, 0..) |sym, si| {
+                        for (0..syms.len) |si| {
                             try chunk_output.appendSlice(allocator, if (min) "" else "\t\t");
                             try chunk_output.appendSlice(allocator, pm_locals.items[si]);
                             try chunk_output.appendSlice(allocator, if (min) "=m." else " = m.");
-                            try chunk_output.appendSlice(allocator, sym.name);
+                            // (#4532 증상1) read 는 **provider 의 export 키**여야 한다: 전역명이 배정됐으면
+                            // provider(`pm_wrapped_esm_provider`, #4528)가 `exports.tag$1` 을 내므로 전역명,
+                            // 아니면(minify/dev 로 전역명 off) `exports.<export명>` 이라 sym.name. 첫 루프에서
+                            // `global_name orelse sym.name` 로 캡처(pm_reads). ⚠️ crossChunkBindingName 은
+                            // reserved-name(`default`)이 전역명 없을 때 provider 로컬(`foo`)을 반환해 export
+                            // 키(`default`)와 어긋난다 — 그걸 read 로 쓰면 `m.foo` undefined → TypeError.
+                            try chunk_output.appendSlice(allocator, pm_reads.items[si]);
                             try chunk_output.appendSlice(allocator, if (min) ";" else ";\n");
                         }
                         try chunk_output.appendSlice(allocator, if (min) "return r};" else "\t\treturn r;\n\t};\n");

--- a/tests/integration/tests/preserve-modules-cjs.test.ts
+++ b/tests/integration/tests/preserve-modules-cjs.test.ts
@@ -376,6 +376,73 @@ describe('#4524: --preserve-modules × CJS', () => {
     }
   });
 
+  // ─── #4532 증상1: 동명 export 심볼 붕괴 (BB → BC) ───
+
+  for (const format of ['esm', 'cjs'] as const) {
+    test(`#4532 증상1 ${format}: 서로 다른 wrap dep 의 동명 export 가 붕괴하지 않는다`, async () => {
+      // b.js·c.js 가 **둘 다** `export function tag()` 을 내고 entry 가 둘 다 import 하면, 소비자
+      // 본문 참조가 canonical 로컬명(`tag`) 하나로 붕괴한다(`tag()+tag()`) → node canonical `BC`
+      // 대신 `BB`(에러 없는 조용한 오컴파일). ESM 은 `import { tag as tag$1 }` 로, CJS 는 forwarding
+      // 썽크(`let tag$1; tag$1 = m.tag$1`)로 전역명을 materialize 해 본문·forwarding·provider export
+      // 셋이 `tag$1` 에 합의해야 한다. a.cjs 가 b·c 를 require 해 **ESM-wrap 강제**(fix 코드는
+      // ESM-wrap owner 한정 — natural-ESM fallback 이 아니라 네이밍 경로를 타야 한다).
+      const { outDir, cleanup } = await buildPm(
+        {
+          'b.js': 'export function tag(){ return "B"; }',
+          'c.js': 'export function tag(){ return "C"; }',
+          'a.cjs': 'module.exports = require("./b.js");\nrequire("./c.js");', // b·c 를 ESM-wrap 강제
+          'entry.js':
+            'import { tag } from "./b.js";\n' +
+            'import { tag as tag2 } from "./c.js";\n' +
+            'import "./a.cjs";\n' +
+            'console.log(tag() + tag2());',
+        },
+        'entry.js',
+        format,
+      );
+      try {
+        const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+        expect(stderr).not.toContain('Error');
+        expect(stdout.trim()).toBe('BC'); // 수정 전: BB
+        // 네이밍 경로 pin: 전역명 `tag$1` 이 방출돼야 fix 코드가 탄 것(단순 자연명 fallback 이면
+        // 두 참조가 같은 `tag` 라 BB 인데도 우연히 통과할 여지를 차단). 본문에 두 번째 참조가
+        // deconflict 됐는지 확인.
+        const entryOut = readFileSync(join(outDir, 'entry.js'), 'utf8');
+        expect(entryOut).toContain('tag$1');
+        expect(entryOut).not.toContain('tag() + tag()');
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+
+  // reserved-name(`default`) forwarding read 회귀 가드. 증상1 수정에서 CJS forwarding 썽크의 read
+  // 를 전역명으로 정렬할 때, `crossChunkBindingName` 은 **reserved-name(`default`)이 전역명 없을 때
+  // provider 로컬(`foo`)을 반환**한다 → provider 는 `exports.default` 를 내는데 `m.foo`(undefined)
+  // 를 읽어 `TypeError`. 전역명이 꺼지는 **minify** 에서만 드러나므로 minify 도 함께 돈다. 올바른
+  // read = `전역명 orelse export 명`(= `m.default`). (`/code-review max` 적발.)
+  for (const minify of [false, true] as const) {
+    test(`#4532 증상1 CJS${minify ? ' --minify' : ''}: default(reserved) named import forwarding read`, async () => {
+      const { outDir, cleanup } = await buildPm(
+        {
+          'b.js': 'export default function foo(){ return "B"; }',
+          'a.cjs': 'module.exports = require("./b.js");', // b 를 ESM-wrap 강제
+          'entry.js': 'import foo from "./b.js";\nimport "./a.cjs";\nconsole.log(foo());',
+        },
+        'entry.js',
+        'cjs',
+        minify,
+      );
+      try {
+        const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+        expect(stderr).not.toContain('TypeError'); // 수정 전(minify): foo is not a function
+        expect(stdout.trim()).toBe('B');
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+
   // ─── #4528: wrap 된 모듈의 남은 구멍 3건 ───
 
   const WRAPPED = {


### PR DESCRIPTION
## 문제

`--preserve-modules --format=cjs` 에서 **서로 다른 wrap dep 이 동명 export 를 내고 한 소비자가 둘 다 import** 하면, 소비자 본문이 한 이름으로 붕괴해 잘못된 값을 조용히 방출했습니다 (#4532 증상1).

```js
// b.js:    export function tag(){ return "B"; }
// c.js:    export function tag(){ return "C"; }
// a.cjs:   module.exports = require("./b.js"); require("./c.js");   // b·c 를 ESM-wrap 강제
// entry:   import { tag } from "./b.js"; import { tag as tag2 } from "./c.js"; import "./a.cjs";
//          console.log(tag() + tag2());
// node canonical: "BC"
// 버그(CJS): "BB"  ← console.log(tag() + tag()) 로 붕괴 (에러 없는 조용한 오컴파일)
```

## 근본 원인

동명 심볼을 파일 경계 너머로 구분하는 cross-file 네이밍(`computeCrossChunkGlobalNames`)이 preserve-modules 에서 **ESM 출력만** 켜져 있었습니다. CJS 출력에선:

- **forwarding 썽크**(emitter, `chunks.zig`)는 로컬 dedup 으로 `let tag$1` 을 만드는데,
- **본문 참조**(linker, `metadata.zig`)는 `resolveToLocalName(canonical)` = `tag` 로 rename.

두 경로가 **공유 맵 없이 독립 계산**해 발산 → forwarding var `tag$1` 은 죽고 본문은 `tag`(b 의 canonical) 를 두 번 참조 → `BB`. ESM 은 전역명 맵을 provider·consumer·본문 셋이 공유해 일치합니다.

## 수정

1. `pm_xchunk_naming` 게이트를 **CJS 출력에도** 오픈(`bundler.zig`). 전역명 맵이 채워져 본문 참조·forwarding var 가 같은 `tag$1` 에 합의합니다.
2. CJS forwarding 썽크의 **read** 를 provider export 키로 정렬(`chunks.zig`): provider(ESM-wrap)는 `pm_wrapped_esm_provider`(#4528)로 `exports.tag$1` 을 내므로, `let tag$1; tag$1 = m.tag$1` 이 되도록 read 도 provider export 키로 읽습니다.

`pm_esm_wrap_dep_syms` 는 **preserve-modules × CJS 출력 × ESM-wrap dep** 에서만 채워지므로 read 변경은 이 경로에 정밀 스코프됩니다.

## `/code-review max` 반영

- **reserved-name(`default`) read 회귀 수정** (CONFIRMED): read 를 `crossChunkBindingName` 으로 쓰면 reserved-name 이 전역명 없을 때(minify/dev) provider **로컬**(`foo`)을 반환해 `exports.default` 과 어긋납니다(`m.foo` undefined → `TypeError`). read = **`전역명 orelse export명`**(provider export 키)으로 정정하고, 첫 루프에서 `pm_reads` 배열에 캡처해 재계산도 제거.
- **stale 주석 갱신**(`chunk.zig`): `pm_xchunk_naming` 이 CJS 를 포함하게 됐으므로 `import * as ns` fan-out(증상2) 게이트 주석을 `ESM/CJS` 로 갱신. CJS non-minify `import * as ns` 도 이제 동작(`1|hi`) — 부수 개선.

## 검증

- 증상1: CJS `BC`(수정 전 `BB`), ESM `BC`(무회귀). reserved-name default plain/minify `B`.
- splitting+preserve+cjs `BC`, 증상3 배럴 `42|F`(CJS/ESM×plain/minify), pure-CJS 동명 `BC` — 무회귀.
- 회귀 가드: `preserve-modules-cjs.test.ts` 증상1(esm+cjs, node 실행 + 전역명 `tag$1` 방출 pin) + reserved-name default(plain+minify) 4건 추가.
- zig 전체 test 통과, 통합 스위트 **4275 pass / 0 fail**.

## 잔여 (#4532 epic — 계속 열림)

- **minify 증상1**: `!minify_identifiers` 로 제외 유지 — identifier mangler(`computeChunkMangling`)가 preserve-modules 서 skip 이라 전역명 미예약 → mangled local ↔ 전역명 충돌 위험(ESM-minify 도 동일하게 BB 인 기존 잔여). mangler 전역명 예약 후속.
- 증상4(multi-entry 순환), 배럴 자체 exports 를 CJS 로 직접 `require("./r.js").X`(live getter) 하는 경로도 별개 근본.

Refs #4532

🤖 Generated with [Claude Code](https://claude.com/claude-code)