### PR TITLE
fix(bundler): #4532 증상1 minify — preserve-modules mangle 을 splitting 과 통합

### DIFF
--- a/.changeset/preserve-modules-minify-unified.md
+++ b/.changeset/preserve-modules-minify-unified.md
@@ -1,0 +1,47 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules --minify`(ESM/CJS)에서 서로 다른 wrap dep 의 동명 export 가 붕괴하던 것 수정 (#4532 증상1 minify 잔여). preserve-modules 의 minify 를 splitting 과 **동일한 per-chunk mangle + 전역명 브리지 모델로 통합**한다.
+
+```js
+// b.js: export function tag(){ return "B"; }
+// c.js: export function tag(){ return "C"; }
+// a.cjs: module.exports = require("./b.js"); require("./c.js");
+// entry: import { tag } from "./b.js"; import { tag as tag2 } from "./c.js"; import "./a.cjs";
+//        console.log(tag() + tag2());
+// node canonical: "BC"
+// 버그(--minify): "BB"  ← 전역명 게이트가 `!minify_identifiers` 로 닫혀 동명 붕괴
+```
+
+## 배경
+
+증상1(#4570)이 non-minify 만 고쳤다. minify 는 cross-file 네이밍 게이트(`pm_xchunk_naming`)가 `!minify_identifiers` 로 닫혀 여전히 `BB`. 게이트를 그냥 열면(band-aid) 소비자 함수의 mangled nested 로컬이 전역명(예 aliased import 의 `te`)과 충돌해 shadow → `te is not a function`(silent miscompile, `/code-review max` CONFIRMED). preserve-modules 는 mangle 를 finalize 에서 먼저 하고 전역명은 chunk phase(mangle 이후)에 negotiate 하는데, mangler 가 전역명을 미리 알 방법이 없기 때문.
+
+## 수정 (Approach 3 — splitting 과 메커니즘 통일)
+
+1. **`computeChunkMangling` 을 preserve-modules 에도 오픈**(linker.zig): splitting 처럼 chunk phase(전역명 negotiate **후**)에 per-chunk mangle 을 돌린다. `occupied_names`(= imports_from 의 `crossChunkBindingName` = 전역명 + 별칭)를 예약하므로 mangled nested 로컬이 소비 전역명을 shadow 하지 않는다.
+2. **`pm_xchunk_naming` 을 minify 에도 오픈**(bundler.zig, `!minify_identifiers` 제거): 전역명 브리지가 mangled 이름을 파일 경계 너머로 조율한다. provider 는 `export { mangled_local as public }`(ESM)·forwarding read(CJS)로 브리지 → top-level 을 mangle 해도 소비자는 공개명으로 import 한다(공개 API 계약 유지).
+3. **래퍼 심볼(`exports_X`/`init_X`/`require_X`)을 preserve-modules mangle 후보에서 제외**(linker.zig `collectUnifiedInput`): preserve-modules 는 `preserveModulesWrapperChunk`(#4528)가 wrapper export/declaration 을 **canonical(미-mangle)** 로 직접 찍는다. mangle 하면 본문(codegen rename)은 `var n={}`·`__export(n,…)` 인데 wrapper export 는 canonical `exports_b` 라 undefined. splitting 은 wrapper 를 rename_table 경유 브리지라 mangle 해도 일관돼 제외하지 않는다.
+
+추가로 `/code-review max` 반영:
+
+- **이중 mangle 제거**(bundler.zig): preserve-modules 는 per-chunk mangle(모든 모듈이 자기 청크)이 전담하므로 finalize 의 전역 mangle 은 중복 — `compute_mangling` 에 `!preserve_modules` 를 걸어 낭비되는 full-graph mangle 을 끈다(computeRenames 는 유지).
+- **helper virtual module 래퍼도 제외**(linker.zig `is_helper_module` 브랜치): 수정 3 의 가드가 main synthetic 루프에만 있어, wrapped 헬퍼 모듈이 자기 청크가 되면 래퍼가 mangle 되던 갭을 대칭으로 닫음.
+
+## 결과
+
+- preserve-modules minify 도 이제 **top-level 을 mangle**(rollup+terser 모델과 동일) — 공개 export 명은 브리지로 보존, 내부 로컬만 축약. 부수적 size 이점.
+- **ESM-wrap dep 의 동명 export**(a.cjs 가 require 로 wrap 강제) 붕괴·aliased 충돌·reserved default named import·배럴·ns 가 minify 에서 정상.
+
+## 검증
+
+- 새 회귀 스위트 `preserve-modules-minify.test.ts` 38종(esm/cjs × plain/minify): 동명 붕괴 BC, aliased-import 충돌 가드(70 로컬→`te` mangle 강제), reserved default, 배럴, 4-way, cross-file 참조, ns, default 값, CJS require_X 래퍼 — 전부 통과.
+- 충돌 repro: 수정 전 `TypeError` → 후 정상.
+- zig 전체 test 통과, 통합 스위트 무회귀. splitting 무회귀(모든 변경 preserve_modules 게이트).
+
+## 잔여 (#4532 epic — 이 PR 범위 밖, non-minify 에도 존재하는 별개 근본)
+
+- **비-ESM-wrap 동명 export 붕괴**: 동명 provider 가 CJS-flatten(a.cjs) 을 안 거치고 entry 만 import 하면(즉 ESM-wrap 이 아니면) 전역명이 안 붙어 여전히 붕괴(`T1T2T1`). 전역명이 ESM-wrap owner 로 한정돼 있어(chunk.zig, #4559 의도) 비-wrap owner 는 별도. minify·non-minify 동일.
+- **익명 `export default class{}`/`function(){}`** in ESM-wrap 모듈: 선언이 top-level 이 아니라 `__esm` 클로저 안에 assign → `export{X}` 가 미선언 참조(SyntaxError). codegen 문제로 minify·non-minify 동일. 별개 근본.
+- 증상4(multi-entry 순환), 배럴 자체 exports CJS 직접 `require("./r.js").X`(live getter).

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1583,7 +1583,13 @@ pub const Bundler = struct {
             const did_compute_renames = !self.options.code_splitting and !can_reuse;
             try l.finalize(.{
                 .compute_renames = did_compute_renames,
-                .compute_mangling = self.options.minify_identifiers and !will_tree_shake,
+                // (#4532 증상1 minify) preserve-modules 는 per-chunk computeChunkMangling(모든
+                // 모듈이 자기 청크)이 mangle 을 전담하므로 finalize 의 전역 mangle 은 중복
+                // (rename_table 을 청크마다 clear·재계산). code_splitting 이 did_compute_renames
+                // 로 전역 pass 를 통째로 건너뛰는 것과 같은 이유 — 여기선 computeRenames 는 유지하고
+                // (일부 populate* 가 canonical 을 참조) 낭비되는 mangle 만 끈다.
+                .compute_mangling = self.options.minify_identifiers and !will_tree_shake and
+                    !self.options.preserve_modules,
                 // reuse-hit 만 ref_count populate skip. splitting(can_reuse=false)은 per-chunk
                 // mangling 이 ref_count 를 소비하므로 반드시 populate(byte-identical 보존).
                 .skip_ref_counts = can_reuse,
@@ -1925,19 +1931,18 @@ pub const Bundler = struct {
                 chunk_mod.mergeSmallChunks(&chunk_graph, graph, self.options.min_chunk_size);
             }
 
-            // (#4532) preserve_modules(ESM/CJS·non-minify 출력)의 cross-file 심볼 네이밍 게이트.
+            // (#4532) preserve_modules(ESM/CJS 출력)의 cross-file 심볼 네이밍 게이트.
             // ESM 은 `import { X as global }` 로, CJS 는 forwarding 썽크(`let global; global =
             // m.global`, chunks.zig)로 전역명을 materialize 한다 — 소비자 본문·forwarding·provider
             // export 셋이 같은 전역명에 합의(증상1 동명 붕괴 `BB` 해소). CJS forwarding read 도
             // provider export 키(전역명 orelse export명)로 읽어야 provider 방출과 일치한다(chunks.zig).
-            // minify 는 identifier mangler 가 전역명 미예약(computeChunkMangling 은 code_splitting
-            // 게이트라 preserve-modules 서 skip)이라 mangled local↔전역명 충돌 위험 → `!minify_
-            // identifiers` 로 후속. splitting(code_splitting and !preserve_modules)은 별개 항 유지.
+            // minify 도 포함(증상1 minify): computeChunkMangling 을 preserve-modules 에도 열어
+            // (linker.zig) per-chunk mangle 이 occupied_names(전역명)를 예약하므로, mangled nested
+            // 로컬이 소비 전역명을 shadow 하지 않는다 — splitting 과 동일 메커니즘으로 통일.
             // ⚠️ `!dev_mode` 도 필수: dev 는 namespace member rewrite 가 wrapped local(`(init(),
             // exp.local)`)을 쓰고 negotiated 전역명 경로를 안 타 동명 멤버가 붕괴한다(code-review).
             const pm_xchunk_naming = self.options.preserve_modules and
                 (self.options.format == .esm or self.options.format == .cjs) and
-                !self.options.minify_identifiers and
                 !self.options.dev_mode;
             // (#4532 증상2) computeCrossChunkLinks 의 direct `import * as ns`(leaf ESM-wrap dep) fan-out
             // 을 이 게이트로 한정 — dep export 를 소비자 imports_from 에 등록해 아래 네이밍/provider

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1735,6 +1735,11 @@ pub const Linker = struct {
                                 .cjs_exports, .cjs_require, .esm_init => {},
                                 else => continue,
                             }
+                            // (#4532 증상1 minify) preserve-modules 는 래퍼 심볼을 canonical 로 emit
+                            // (preserveModulesWrapperChunk) 하므로 mangle 후보에서 제외 — wrapped
+                            // 헬퍼 virtual module 도 자기 chunk 라 동일 규칙. 아래 line 1832 의 일반
+                            // synthetic 루프 가드와 대칭.
+                            if (self.graph.preserve_modules) continue;
                             // RFC #3940 L.4c: dedup key 도 build-scope rename_table 경유. miss → synthetic_name.
                             const key = self.rename_table.get(bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(mi)), si)) orelse sym.synthetic_name;
                             if (key.len <= 1) continue;
@@ -1821,6 +1826,15 @@ pub const Linker = struct {
                         // ref=0 이면 어디서도 import 하지 않아 codegen 이 binding 을 emit
                         // 하지 않는다. 그런 candidate 는 mangle 풀에서 제외.
                         if (sk == .default_export and sym.reference_count == 0) continue;
+                        // (#4532 증상1 minify) preserve-modules 는 래퍼 심볼(exports_X/init_X/
+                        // require_X)을 **canonical(미-mangle) 이름**으로 emit 한다 —
+                        // `preserveModulesWrapperChunk`(chunks.zig #4528)가 wrapper export/declaration
+                        // 을 `wrapperNamesFor(em, null)`(rename_table 미사용)로 직접 찍는다. mangle
+                        // 하면 본문(codegen rename)은 `var n={}`·`__export(n,…)` 인데 wrapper export
+                        // 는 canonical `exports_b` 라 undefined → ReferenceError. splitting 은 wrapper
+                        // 를 rename_table 경유로 브리지하므로 mangle 해도 일관돼 제외하지 않는다.
+                        // default_export 는 canonical wrapper 경로가 아니라 일반 export 브리지라 제외 안 함.
+                        if (self.graph.preserve_modules and sk != .default_export) continue;
                         // RFC #3940 L.4c: dedup key 를 build-scope rename_table 경유 (parity 로 동치).
                         const key = self.rename_table.get(bundler_symbol.SymbolID.make(@as(ModuleIndex, @enumFromInt(mi)), si)) orelse sym.synthetic_name;
                         if (key.len <= 1) continue;
@@ -3888,7 +3902,15 @@ pub const Linker = struct {
         // cross-module 충돌 등 mangleAll 이 skip 하는 케이스가 먼저 해소된다.
         // cross-chunk export 이름은 emit 의 `export { local as public }` 브리지가
         // 보존하므로 별도 예약 불필요. import 경계 이름만 occupied_names 로 보호.
-        if (self.graph.minify_identifiers and self.graph.code_splitting) {
+        //
+        // (#4532 증상1 minify) preserve-modules 도 포함한다. preserve-modules 는 각 모듈이
+        // 별도 청크(파일)라, 전역명은 mangle **이후** chunk phase 에 negotiate 된다. 여기서
+        // per-chunk mangle 을 돌리면 occupied_names(= imports_from 의 crossChunkBindingName =
+        // 전역명 + 별칭)가 예약돼, mangled nested 로컬이 소비 전역명(예 `te`)을 shadow 하지
+        // 않는다(splitting 과 동일 메커니즘으로 통일). provider 는 `export { local as global }`
+        // (ESM)·forwarding read(CJS)로 브리지하므로 top-level 을 mangle 해도 파일 경계 참조가
+        // 유지된다. splitting+preserve 조합도 code_splitting 항으로 이미 포함됐다.
+        if (self.graph.minify_identifiers and (self.graph.code_splitting or self.graph.preserve_modules)) {
             try self.computeChunkMangling(module_indices, occupied_names);
         }
     }

--- a/tests/integration/tests/preserve-modules-minify.test.ts
+++ b/tests/integration/tests/preserve-modules-minify.test.ts
@@ -1,0 +1,341 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { createFixture, runNode, runZntc } from './helpers';
+
+/**
+ * #4532 증상1 minify — `--preserve-modules --minify` 의 cross-file 심볼 네이밍.
+ *
+ * 배경: non-minify 증상1 은 #4570 으로 해결(전역명 `tag$1` 로 동명 붕괴 `BB`→`BC`). 그러나
+ * minify 는 게이트가 `!minify_identifiers` 로 닫혀 여전히 `BB` 였다. 게이트를 열면 소비자 함수의
+ * mangled nested 로컬이 전역명(예 `te`)과 충돌해 shadow → silent miscompile 이 드러난다.
+ *
+ * Approach 3: preserve-modules 를 splitting 과 동일한 per-chunk mangle + 전역명 브리지 모델로
+ * 통합한다. 아래 테스트는 **관측 가능한 런타임 동작**(내부 네이밍 무관)을 스펙으로 고정한다 —
+ * 빌드 exit 0·파싱 통과·실행만 실패하는 계열이라 반드시 node 로 돌려 값을 본다.
+ */
+
+async function buildPm(
+  files: Record<string, string>,
+  entry: string,
+  format: 'esm' | 'cjs',
+  minify: boolean,
+) {
+  const { dir, cleanup } = await createFixture(files);
+  const outDir = join(dir, 'dist');
+  const res = await runZntc([
+    '--bundle',
+    join(dir, entry),
+    '--preserve-modules',
+    '--outdir',
+    outDir,
+    `--format=${format}`,
+    ...(minify ? ['--minify'] : []),
+  ]);
+  // 빌드 실패 시 temp fixture 를 먼저 정리한 뒤 throw — 안 하면 assert 가 cleanup 반환 전에
+  // 던져 caller 의 finally 가 안 돌아 temp dir 이 샌다.
+  if (res.exitCode !== 0) {
+    await cleanup();
+    throw new Error(`빌드 실패:\n${res.stderr}`);
+  }
+  writeFileSync(
+    join(outDir, 'package.json'),
+    JSON.stringify({ type: format === 'esm' ? 'module' : 'commonjs' }),
+  );
+  return { dir, outDir, cleanup };
+}
+
+async function run(outDir: string) {
+  const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+  return { stdout: stdout.trim(), stderr };
+}
+
+const FORMATS = ['esm', 'cjs'] as const;
+const MINIFY = [false, true] as const;
+
+describe('#4532 증상1 minify: preserve-modules cross-file 네이밍', () => {
+  // ── 동명 export 붕괴 (BB → BC) ──
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`동명 export 가 붕괴하지 않는다 [${format}${minify ? ' minify' : ''}]`, async () => {
+        const { outDir, cleanup } = await buildPm(
+          {
+            'b.js': 'export function tag(){ return "B"; }',
+            'c.js': 'export function tag(){ return "C"; }',
+            'a.cjs': 'module.exports = require("./b.js");\nrequire("./c.js");',
+            'entry.js':
+              'import { tag } from "./b.js";\n' +
+              'import { tag as tag2 } from "./c.js";\n' +
+              'import "./a.cjs";\n' +
+              'console.log(tag() + tag2());',
+          },
+          'entry.js',
+          format,
+          minify,
+        );
+        try {
+          const { stdout, stderr } = await run(outDir);
+          expect(stderr).not.toContain('Error');
+          expect(stdout).toBe('BC'); // 수정 전 minify: BB
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // ── aliased import + 전역명 ↔ mangled 로컬 shadow 충돌 ──
+  // Approach 3 핵심 가드: 소비자 함수의 mangled nested 로컬이 cross-chunk 전역명과 같은 base54
+  // 이름(`te`)으로 mangle 돼도 import 를 shadow 하면 안 된다. 로컬을 2회 이상 사용해 폴딩/인라인을
+  // 피하고, ~70개로 base54 가 2글자 이름(`te`)에 도달하게 강제한다.
+  for (const format of FORMATS) {
+    test(`aliased import: mangled 로컬이 전역명을 shadow 안 함 [${format} minify]`, async () => {
+      const N = 70;
+      let body = '  let s = myAlias();\n';
+      for (let i = 1; i <= N; i++) body += `  const v${i} = x * ${i} + 1;\n`;
+      for (let i = 1; i <= N; i++) body += `  s += v${i} * v${i};\n`;
+      let expected = 7;
+      for (let i = 1; i <= N; i++) {
+        const v = 2 * i + 1;
+        expected += v * v;
+      }
+      const { outDir, cleanup } = await buildPm(
+        {
+          'provider.js': 'export function te(){ return 7; }',
+          'w.cjs': 'module.exports = require("./provider.js");',
+          'entry.js':
+            'import { te as myAlias } from "./provider.js";\n' +
+            'import "./w.cjs";\n' +
+            `export function big(x){\n${body}  return s;\n}\n` +
+            'console.log(big(2));',
+        },
+        'entry.js',
+        format,
+        true,
+      );
+      try {
+        const { stdout, stderr } = await run(outDir);
+        expect(stderr).not.toContain('is not a function'); // 수정 전: te is not a function
+        expect(stdout).toBe(String(expected));
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+
+  // ── reserved-name(default) named import forwarding ──
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`default(reserved) named import forwarding [${format}${minify ? ' minify' : ''}]`, async () => {
+        const { outDir, cleanup } = await buildPm(
+          {
+            'b.js': 'export default function foo(){ return "B"; }',
+            'a.cjs': 'module.exports = require("./b.js");',
+            'entry.js': 'import foo from "./b.js";\nimport "./a.cjs";\nconsole.log(foo());',
+          },
+          'entry.js',
+          format,
+          minify,
+        );
+        try {
+          const { stdout, stderr } = await run(outDir);
+          expect(stderr).not.toContain('TypeError');
+          expect(stdout).toBe('B');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // ── re-export 배럴 (증상3) ──
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`re-export 배럴이 ESM-wrap dep 을 re-export [${format}${minify ? ' minify' : ''}]`, async () => {
+        const { outDir, cleanup } = await buildPm(
+          {
+            'b.js': 'export const CONST = 42;\nexport function fn(){ return "F"; }',
+            'a.cjs': 'module.exports = require("./b.js");',
+            'r.js': 'export { CONST, fn } from "./b.js";',
+            'entry.js':
+              'import { CONST, fn } from "./r.js";\nimport "./a.cjs";\nconsole.log(CONST + "|" + fn());',
+          },
+          'entry.js',
+          format,
+          minify,
+        );
+        try {
+          const { stdout, stderr } = await run(outDir);
+          expect(stderr).not.toContain('TypeError');
+          expect(stdout).toBe('42|F');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // ── 4-way 동명 stress ──
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`4-way 동명 export 가 서로 구분된다 [${format}${minify ? ' minify' : ''}]`, async () => {
+        const files: Record<string, string> = {
+          'w.cjs':
+            'module.exports = require("./m1.js");\nrequire("./m2.js"); require("./m3.js"); require("./m4.js");',
+          'entry.js':
+            'import { tag as t1 } from "./m1.js";\nimport { tag as t2 } from "./m2.js";\n' +
+            'import { tag as t3 } from "./m3.js";\nimport { tag as t4 } from "./m4.js";\n' +
+            'import "./w.cjs";\nconsole.log([t1(),t2(),t3(),t4()].join("|"));',
+        };
+        for (const n of [1, 2, 3, 4]) {
+          files[`m${n}.js`] = `export function tag(){ return "T${n}"; }`;
+        }
+        const { outDir, cleanup } = await buildPm(files, 'entry.js', format, minify);
+        try {
+          const { stdout, stderr } = await run(outDir);
+          expect(stderr).not.toContain('Error');
+          expect(stdout).toBe('T1|T2|T3|T4');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // ── cross-file 기본: top-level 이 mangle 돼도 파일 경계 참조가 유지된다 ──
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`cross-file named import/const 가 유지된다 [${format}${minify ? ' minify' : ''}]`, async () => {
+        const { outDir, cleanup } = await buildPm(
+          {
+            'lib.js':
+              'export function computeSomething(someArgument){ const intermediateValue = someArgument * 2; return intermediateValue + 1; }\n' +
+              'export const LIB_CONST = 100;',
+            'entry.js':
+              'import { computeSomething, LIB_CONST } from "./lib.js";\n' +
+              'const reallyLongLocalName = computeSomething(21);\n' +
+              'console.log(reallyLongLocalName + "|" + LIB_CONST);',
+          },
+          'entry.js',
+          format,
+          minify,
+        );
+        try {
+          const { stdout, stderr } = await run(outDir);
+          expect(stderr).not.toContain('Error');
+          expect(stdout).toBe('43|100');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // ── namespace import (`import * as ns`) ──
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`import * as ns (leaf ESM-wrap dep) [${format}${minify ? ' minify' : ''}]`, async () => {
+        const { outDir, cleanup } = await buildPm(
+          {
+            'lib.js': 'export const val = 1;\nexport function greet(){ return "hi"; }',
+            'a.cjs': 'module.exports = require("./lib.js");',
+            'entry.js':
+              'import * as ns from "./lib.js";\nimport "./a.cjs";\nconsole.log(ns.val + "|" + ns.greet());',
+          },
+          'entry.js',
+          format,
+          minify,
+        );
+        try {
+          const { stdout, stderr } = await run(outDir);
+          expect(stderr).not.toContain('Error');
+          expect(stdout).toBe('1|hi');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // ── 동명 export + 각 파일 내부 로컬 (전역명 $N ↔ 내부 mangle 교차) ──
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`동명 export + 내부 로컬 stress [${format}${minify ? ' minify' : ''}]`, async () => {
+        const files: Record<string, string> = {
+          'w.cjs': 'module.exports = require("./m1.js");\nrequire("./m2.js");',
+          'entry.js':
+            'import { e as e1, v as v1 } from "./m1.js";\n' +
+            'import { e as e2, v as v2 } from "./m2.js";\n' +
+            'import "./w.cjs";\n' +
+            'console.log(e1(3) + "|" + e2(3) + "|" + v1 + "|" + v2);',
+        };
+        files['m1.js'] =
+          'export function e(x){ const a=x+1, b=a*2, c=b-1; return "P1:"+(a+b+c); }\nexport const v = 10;';
+        files['m2.js'] =
+          'export function e(y){ const a=y+2, b=a*3, d=b+5; return "P2:"+(a+b+d); }\nexport const v = 20;';
+        const { outDir, cleanup } = await buildPm(files, 'entry.js', format, minify);
+        try {
+          const { stdout, stderr } = await run(outDir);
+          expect(stderr).not.toContain('Error');
+          // m1.e(3): a=4,b=8,c=7 → 19 ; m2.e(3): a=5,b=15,d=20 → 40
+          expect(stdout).toBe('P1:19|P2:40|10|20');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // ── default export **값**(named 아님): 브리지로 mangle+공개 조율 ──
+  // 래퍼 심볼은 제외하지만 default_export synthetic 은 mangle 후보로 유지(일반 export 브리지).
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`default export 값이 mangle 되어도 동작 [${format}${minify ? ' minify' : ''}]`, async () => {
+        const { outDir, cleanup } = await buildPm(
+          {
+            'd.js': 'const secret = 41;\nexport default secret + 1;',
+            'w.cjs': 'module.exports = require("./d.js");',
+            'entry.js':
+              'import myDefault from "./d.js";\nimport "./w.cjs";\nconsole.log(myDefault);',
+          },
+          'entry.js',
+          format,
+          minify,
+        );
+        try {
+          const { stdout, stderr } = await run(outDir);
+          expect(stderr).not.toContain('Error');
+          expect(stdout).toBe('42');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // ── CJS 래퍼(require_X): 래퍼 심볼 canonical 유지가 minify 에서도 성립 ──
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`CJS require_X 래퍼가 canonical 로 유지된다 [${format}${minify ? ' minify' : ''}]`, async () => {
+        const { outDir, cleanup } = await buildPm(
+          {
+            'a.cjs':
+              'const dep = require("./dep.cjs");\nexports.run = function(){ return "R-" + dep.helper(); };',
+            'dep.cjs': 'exports.helper = function(){ return "H"; };',
+            'entry.js': 'import { run } from "./a.cjs";\nconsole.log(run());',
+          },
+          'entry.js',
+          format,
+          minify,
+        );
+        try {
+          const { stdout, stderr } = await run(outDir);
+          expect(stderr).not.toContain('Error');
+          expect(stdout).toBe('R-H');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+});


### PR DESCRIPTION
## 문제

`--preserve-modules --minify`(ESM/CJS)에서 **ESM-wrap dep 의 동명 export** 가 붕괴했습니다 (#4532 증상1 minify 잔여).

```js
// b.js: export function tag(){ return "B"; }
// c.js: export function tag(){ return "C"; }
// a.cjs: module.exports = require("./b.js"); require("./c.js");   // b·c 를 ESM-wrap 강제
// entry: import { tag } from "./b.js"; import { tag as tag2 } from "./c.js"; import "./a.cjs";
//        console.log(tag() + tag2());
// node canonical: "BC"
// 버그(--minify): "BB"
```

## 배경 — 왜 band-aid 로 안 되는가

증상1(#4570)은 non-minify 만 고쳤습니다. minify 는 cross-file 네이밍 게이트(`pm_xchunk_naming`)가 `!minify_identifiers` 로 닫혀 여전히 `BB`. **게이트만 여는 band-aid** 는 `/code-review max` 에서 **CONFIRMED silent miscompile** 로 판명됐습니다: 소비자 함수의 mangled nested 로컬이 전역명(aliased import 의 `te`)과 shadow 충돌 → `te is not a function`. 근본은 **preserve-modules 가 mangle 을 finalize 에서 먼저 하고 전역명은 chunk phase(mangle 이후)에 negotiate** 해서, mangler 가 전역명을 미리 알 수 없다는 것입니다.

## 수정 (Approach 3 — splitting 과 메커니즘 통일)

splitting 은 이 문제를 **per-chunk mangle(전역명 negotiate 후) + occupied_names 예약 + `export { local as public }` 브리지** 로 이미 풉니다. preserve-modules 를 같은 모델로 통합합니다:

1. **`computeChunkMangling` 을 preserve-modules 에 오픈**(linker.zig): chunk phase 에 per-chunk mangle. `occupied_names`(= 전역명)를 예약해 mangled nested 로컬이 소비 전역명을 shadow 하지 않습니다.
2. **`pm_xchunk_naming` 을 minify 에 오픈**(bundler.zig): 전역명 브리지가 mangled 이름을 파일 경계 너머로 조율. **공개 export 명은 `export { local as public }` 로 보존**(공개 API 계약 유지), 내부 로컬만 축약 → rollup+terser 모델과 동일한 부수적 size 이점.
3. **래퍼 심볼(`exports_X`/`init_X`/`require_X`)을 preserve-modules mangle 후보에서 제외**(linker.zig `collectUnifiedInput` main + `is_helper_module` 두 루프): `preserveModulesWrapperChunk`(#4528)가 wrapper 를 canonical 로 직접 찍으므로 mangle 하면 `var n={}` 본문 ↔ canonical `export{exports_b}` 가 어긋나 undefined. splitting 은 rename_table 브리지라 제외하지 않습니다.

모든 변경은 `preserve_modules` 게이트라 splitting/단일 번들은 무영향입니다.

## `/code-review max` 반영

- **이중 mangle 제거**(bundler.zig): preserve-modules 는 per-chunk mangle 전담이라 finalize 전역 mangle 이 중복 → `compute_mangling` 에 `!preserve_modules`(computeRenames 는 유지).
- **helper virtual module 래퍼 제외**(is_helper_module 브랜치): 수정 3 가드를 대칭으로 추가.
- **테스트 fixture 누수**: 빌드 실패 시 cleanup 후 throw.

## 검증

- 새 회귀 스위트 `preserve-modules-minify.test.ts` **38종**(esm/cjs × plain/minify): 동명 붕괴 BC, **aliased-import 충돌 가드**(70 로컬 → `te` mangle 강제 → 수정 전 `TypeError`), reserved default named import, 배럴, 4-way, cross-file 참조, ns, default 값, CJS `require_X` 래퍼 — 전부 통과.
- zig 전체 test 통과, 통합 스위트 **4313 pass / 0 fail**. splitting 무회귀.

## 잔여 (별개 근본 — 이 PR 범위 밖, **non-minify 에도 존재**)

- **비-ESM-wrap 동명 export 붕괴**: 동명 provider 가 CJS-flatten(a.cjs)을 안 거치면(ESM-wrap 아님) 전역명이 안 붙어 `T1T2T1`. 전역명이 ESM-wrap owner 로 한정(#4559 의도)돼 별도.
- **익명 `export default class{}`/`function(){}`** in ESM-wrap 모듈: 선언이 `__esm` 클로저 안에 assign → `export{X}` 미선언 참조(SyntaxError). codegen 문제, minify·non-minify 동일.
- 증상4(multi-entry 순환).

Refs #4532

🤖 Generated with [Claude Code](https://claude.com/claude-code)