### PR TITLE
fix(bundler): #4573 익명 export default class/function 이 ESM-wrap 에서 미선언 참조

### DIFF
--- a/.changeset/preserve-modules-anon-default-class.md
+++ b/.changeset/preserve-modules-anon-default-class.md
@@ -1,0 +1,35 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules`(ESM 출력)에서 **익명 `export default class {}` / `function(){}`** 를 낸 모듈이 ESM-wrap 되면 `SyntaxError: Export '_default' is not defined` 로 모듈이 로드되지 않던 것 수정 (#4573).
+
+```js
+// b.js:  export default class { greet(){ return "hi"; } }
+// a.cjs: module.exports = require("./b.js");   // b 를 ESM-wrap 강제
+// entry: import D from "./b.js"; import "./a.cjs"; console.log(new D().greet());
+```
+
+## 근본 원인
+
+ESM-wrap lowering(`esm_wrap.zig`)은 export 를 `__esm(() => {…})` 클로저 밖 top-level 로 hoist 한다(`var X;` 선언 + 클로저 안 `X = …` 할당). `.class_declaration` 분기는 **클래스 이름이 있을 때만** 그 이름을 hoist 했다. 익명 default class 는 이름이 없어 synthetic `_default` 의 `var _default;` 가 hoist 되지 않았고, codegen 은 클로저 안에서 `_default = class {…}` 로 할당 + top-level `export { _default }` 를 방출 → 미선언 참조.
+
+value/arrow default(`export default expr` / `() => …`)는 `effective_tag` 가 선언이 아니라 `else` 분기가 이미 `_default` 를 hoist 했고, named class·function, 익명 function 도 정상이었다.
+
+## 수정
+
+익명이고 `export default` 면 `default_export_name`(`_default`)을 hoist 한다:
+- `.class_declaration` 분기(`class_name_idx.isNone()`) — 익명 default class.
+- `.function_declaration` strict_execution_order 분기(`fn_name_idx.isNone()`) — 익명 default function. `/code-review max` 적발: RN 프리셋(strict)에서 codegen 이 `_default = function(){}` 로 할당해 class 와 동일 버그. 5곳으로 중복돼 있던 default 이름 파생을 `defaultExportName` 헬퍼로 통합.
+
+## 검증
+
+- 회귀 스위트 `preserve-modules-default-export.test.ts`: default 형태(익명 class/function/arrow/extends, named class/function, value) × esm/cjs × plain/minify + **익명 function RN(strict)** — 전부 통과(익명 class ESM·익명 function RN 이 수정 전 실패).
+- 방출: `var _default;` top-level 선언 + 클로저 안 `_default = class {…}`/`_default = function(){}` + `export { _default }` 일관.
+- zig 전체 test, 통합 스위트 무회귀.
+
+## 별개 잔여 (이 PR 범위 밖)
+
+- **RN downlevel class 헬퍼 중복**(#4574): `--preserve-modules --platform=react-native` 에서 class 를 export 하면 다운레벨 헬퍼(`__classCallCheck`/`__extends`)가 import + hoisted var 로 이중 선언 → SyntaxError. 익명·named·default 무관(class 다운레벨 특정).
+
+Refs #4573

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -67,6 +67,13 @@ inline fn cjsInteropMode(options: *const EmitOptions, importer: *const Module) t
     return if (importer.def_format.isEsm()) .node else .babel;
 }
 
+/// synthetic default(`_default`)의 확정 이름. 충돌 시 linker/mangler 가 `_default$1` 등으로
+/// 바꾼 것을 metadata 가 들고 있다(없으면 fallback `_default`). 값은 metadata 소유(borrow) —
+/// hoisted_var_names 수집 시 dupe 불요(emitEsmWrappedModule 의 여러 site 가 이미 그렇게 쓴다).
+fn defaultExportName(metadata: ?*const LinkingMetadata) []const u8 {
+    return if (metadata) |md| md.default_export_name else "_default";
+}
+
 /// re_export_alias에 linker가 주입한 canonical_name을 반환. null이면
 /// alias 심볼이 아니거나 linker가 resolve하지 못한 경우.
 /// re-export 의 source 모듈을 resolve. resolved + non-self-cycle 인 정상 record 만 반환,
@@ -251,6 +258,12 @@ pub fn emitEsmWrappedModule(
                             const resolved = try arena_alloc.dupe(u8, resolveNodeName(metadata, @intFromEnum(fn_name_idx), raw_name));
                             try hoisted_var_names.append(allocator, resolved);
                         }
+                    } else if (stmt_node.tag == .export_default_declaration) {
+                        // (#4573) 익명 `export default function(){}` — 함수명이 없어 위 분기가
+                        // hoist 를 못 한다. strict 경로는 codegen 이 `_default = function(){}` 로
+                        // 할당하므로(익명 class 와 동일), synthetic `_default` 를 hoist 하지 않으면
+                        // `export { _default }` 가 미선언 참조(SyntaxError). RN 프리셋에서만 strict.
+                        try hoisted_var_names.append(allocator, defaultExportName(metadata));
                     }
                     // body_func_stmts: factory body 최상단에 배치 → forward reference 보존
                     try body_func_stmts.append(allocator, raw_idx);
@@ -276,6 +289,14 @@ pub fn emitEsmWrappedModule(
                         const resolved = try arena_alloc.dupe(u8, resolveNodeName(metadata, @intFromEnum(class_name_idx), raw_name));
                         try hoisted_var_names.append(allocator, resolved);
                     }
+                } else if (stmt_node.tag == .export_default_declaration) {
+                    // (#4573) 익명 `export default class {}` — 클래스 이름이 없어 위 분기가
+                    // hoist 를 못 한다. codegen 은 body(`__esm` 클로저) 안에서 synthetic
+                    // `_default = class {…}` 로 할당하므로, 그 `var _default;` 를 top-level 로
+                    // hoist 하지 않으면 `export { _default }` 가 미선언 참조(SyntaxError)가 된다.
+                    // value/arrow default 는 else 분기(effective_tag ∉ decl)가 이미 hoist 한다.
+                    const def_name = defaultExportName(metadata);
+                    try hoisted_var_names.append(allocator, def_name);
                 }
                 try body_stmts.append(allocator, raw_idx);
             },
@@ -343,7 +364,7 @@ pub fn emitEsmWrappedModule(
                 // effective_tag는 내부 노드의 태그이므로 export_default_declaration은
                 // 이 분기에 도달한다. stmt_node.tag로 원본 태그를 확인하여 호이스팅.
                 if (stmt_node.tag == .export_default_declaration) {
-                    const def_name = if (metadata) |md| md.default_export_name else "_default";
+                    const def_name = defaultExportName(metadata);
                     try hoisted_var_names.append(allocator, def_name);
                 }
                 try body_stmts.append(allocator, raw_idx);
@@ -358,7 +379,7 @@ pub fn emitEsmWrappedModule(
         for (module.export_bindings) |eb| {
             if (eb.kind == .re_export and eb.hasSyntheticDefault(module.semanticSymbols())) {
                 if (!shouldEmitSyntheticDefaultReExport(linker, module, eb)) continue;
-                const def_name = if (metadata) |md| md.default_export_name else "_default";
+                const def_name = defaultExportName(metadata);
                 try hoisted_var_names.append(allocator, def_name);
                 break;
             }
@@ -583,7 +604,7 @@ pub fn emitEsmWrappedModule(
                         // 표현 → linker가 canonical_name을 채운다. barrel `export { X }`같은
                         // kind 오분류에도 영향받지 않음 (#1321 방어).
                         if (isSyntheticDefault(eb.symbol, module)) {
-                            break :blk if (metadata) |md| md.default_export_name else "_default";
+                            break :blk defaultExportName(metadata);
                         }
                         // direct re-export는 현재 모듈에 로컬 변수가 선언되지 않으므로
                         // source module의 getter/value를 직접 참조해야 한다 (#1425).
@@ -821,7 +842,7 @@ pub fn emitEsmWrappedModule(
         // 자기 자신을 re-export하는 경우 skip (자기참조 init 호출 방지)
         if (source_mod_idx == module.index) continue;
 
-        const def_name = if (metadata) |md| md.default_export_name else "_default";
+        const def_name = defaultExportName(metadata);
         const source_mod_i = @intFromEnum(source_mod_idx);
 
         if (linker) |l| {

--- a/tests/integration/tests/preserve-modules-default-export.test.ts
+++ b/tests/integration/tests/preserve-modules-default-export.test.ts
@@ -1,0 +1,170 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { createFixture, runNode, runZntc } from './helpers';
+
+/**
+ * #4573 — `--preserve-modules` 에서 ESM-wrap 모듈의 default export 형태별 회귀.
+ *
+ * 익명 `export default class {}` 가 ESM-wrap 되면(예 `a.cjs = require("./b.js")`) synthetic
+ * `_default` 의 top-level `var _default;` 선언이 `__esm` 클로저 밖으로 hoist 되지 않아
+ * `export { _default }` 가 미선언 참조 → `SyntaxError: Export '_default' is not defined`.
+ * named class·function·value 는 정상이었다. minify·non-minify 공통.
+ */
+
+async function buildPm(
+  files: Record<string, string>,
+  entry: string,
+  format: 'esm' | 'cjs',
+  minify: boolean,
+) {
+  const { dir, cleanup } = await createFixture(files);
+  const outDir = join(dir, 'dist');
+  const res = await runZntc([
+    '--bundle',
+    join(dir, entry),
+    '--preserve-modules',
+    '--outdir',
+    outDir,
+    `--format=${format}`,
+    ...(minify ? ['--minify'] : []),
+  ]);
+  if (res.exitCode !== 0) {
+    await cleanup();
+    throw new Error(`빌드 실패:\n${res.stderr}`);
+  }
+  writeFileSync(
+    join(outDir, 'package.json'),
+    JSON.stringify({ type: format === 'esm' ? 'module' : 'commonjs' }),
+  );
+  return { dir, outDir, cleanup };
+}
+
+const FORMATS = ['esm', 'cjs'] as const;
+const MINIFY = [false, true] as const;
+
+// default export 형태별 소스 + entry 사용 코드 + 기대 출력
+const CASES: Array<{ name: string; dexpr: string; use: string; expect: string }> = [
+  {
+    name: '익명 class',
+    dexpr: 'export default class { greet(){ return "hi"; } }',
+    use: 'console.log(new D().greet());',
+    expect: 'hi',
+  },
+  {
+    name: '익명 function',
+    dexpr: 'export default function(){ return "fn"; }',
+    use: 'console.log(D());',
+    expect: 'fn',
+  },
+  {
+    name: '익명 arrow',
+    dexpr: 'export default () => "arrow";',
+    use: 'console.log(D());',
+    expect: 'arrow',
+  },
+  {
+    name: 'named class',
+    dexpr: 'export default class Foo { greet(){ return "named-cls"; } }',
+    use: 'console.log(new D().greet());',
+    expect: 'named-cls',
+  },
+  {
+    name: 'named function',
+    dexpr: 'export default function foo(){ return "named-fn"; }',
+    use: 'console.log(D());',
+    expect: 'named-fn',
+  },
+  {
+    name: 'value',
+    dexpr: 'const secret = 41;\nexport default secret + 1;',
+    use: 'console.log(D);',
+    expect: '42',
+  },
+];
+
+describe('#4573: preserve-modules ESM-wrap default export 형태', () => {
+  // 익명 default class + extends (클래스 표현식, 이름 없음)
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`익명 class extends [${format}${minify ? ' minify' : ''}]`, async () => {
+        const { outDir, cleanup } = await buildPm(
+          {
+            'b.js':
+              'class Base { base(){ return "base"; } }\n' +
+              'export default class extends Base { greet(){ return "ext-" + this.base(); } }',
+            'a.cjs': 'module.exports = require("./b.js");',
+            'entry.js': 'import D from "./b.js";\nimport "./a.cjs";\nconsole.log(new D().greet());',
+          },
+          'entry.js',
+          format,
+          minify,
+        );
+        try {
+          // runNode 는 non-zero exit(SyntaxError 등)에 throw 하므로, 빌드/실행 실패는 여기서
+          // 던져져 테스트가 깨진다(별도 stderr 단언 불요). stdout 이 정답이면 성공.
+          const { stdout } = await runNode(join(outDir, 'entry.js'));
+          expect(stdout.trim()).toBe('ext-base');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // 익명 default function 을 strict_execution_order(RN 프리셋)에서 — `--code-review max` 적발:
+  // strict 경로는 함수를 __esm factory 안에 유지하고 `_default = function(){}` 로 할당하므로,
+  // 익명 함수도 top-level `var _default;` hoist 가 없으면 미선언(SyntaxError). RN 은 strict 강제.
+  // (RN downlevel 클래스는 별개 pre-existing 헬퍼 중복 버그라 여기선 function 만.)
+  test('익명 default function (RN strict_execution_order)', async () => {
+    const { dir, cleanup } = await createFixture({
+      'b.js': 'export default function(){ return "sfn"; }',
+      'a.cjs': 'module.exports = require("./b.js");',
+      'entry.js': 'import D from "./b.js";\nimport "./a.cjs";\nconsole.log(D());',
+    });
+    const outDir = join(dir, 'dist');
+    try {
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--preserve-modules',
+        '--outdir',
+        outDir,
+        '--format=esm',
+        '--platform=react-native', // strict_execution_order 강제
+      ]);
+      expect(res.exitCode, res.stderr).toBe(0);
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+      const { stdout } = await runNode(join(outDir, 'entry.js')); // 수정 전: SyntaxError → throw
+      expect(stdout.trim()).toBe('sfn');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  for (const c of CASES) {
+    for (const format of FORMATS) {
+      for (const minify of MINIFY) {
+        test(`${c.name} [${format}${minify ? ' minify' : ''}]`, async () => {
+          const { outDir, cleanup } = await buildPm(
+            {
+              'b.js': c.dexpr,
+              'a.cjs': 'module.exports = require("./b.js");', // b 를 ESM-wrap 강제
+              'entry.js': `import D from "./b.js";\nimport "./a.cjs";\n${c.use}`,
+            },
+            'entry.js',
+            format,
+            minify,
+          );
+          try {
+            // runNode 가 non-zero exit 에 throw → 빌드/실행 실패는 여기서 던져져 테스트 fail.
+            const { stdout } = await runNode(join(outDir, 'entry.js'));
+            expect(stdout.trim()).toBe(c.expect);
+          } finally {
+            await cleanup();
+          }
+        });
+      }
+    }
+  }
+});


### PR DESCRIPTION
## 문제

`--preserve-modules`(ESM 출력)에서 **익명** `export default class {}` / `export default function(){}` 를 낸 모듈이 ESM-wrap 되면 `SyntaxError: Export '_default' is not defined` 로 모듈이 로드되지 않았습니다.

```js
// b.js:  export default class { greet(){ return "hi"; } }
// a.cjs: module.exports = require("./b.js");   // b 를 ESM-wrap 강제
// entry: import D from "./b.js"; import "./a.cjs"; console.log(new D().greet());
```

## 근본 원인

ESM-wrap lowering(`esm_wrap.zig`)은 export 를 `__esm(() => {…})` 클로저 밖 top-level 로 hoist 합니다(`var X;` 선언 + 클로저 안 `X = …` 할당). `.class_declaration`·`.function_declaration` 분기가 **이름이 있을 때만** 그 이름을 hoist 해서, 익명 default 는 synthetic `_default` 의 `var _default;` 가 hoist 되지 않았습니다. codegen 은 클로저 안 `_default = class{…}` / `_default = function(){}` + top-level `export { _default }` 를 방출 → 미선언 참조.

value/arrow default(`export default expr` / `() => …`)는 `else` 분기가, named class·function 은 각자 정상이었습니다.

## 수정

익명이고 `export default` 면 `default_export_name`(`_default`)을 hoist:
- `.class_declaration` 분기(`class_name_idx.isNone()`).
- `.function_declaration` strict_execution_order 분기(`fn_name_idx.isNone()`) — `/code-review max` 적발: RN 프리셋(strict)에서 codegen 이 `_default = function(){}` 로 할당해 class 와 동일 버그.
- 중복돼 있던 default 이름 파생 5곳을 `defaultExportName` 헬퍼로 통합.

## 검증

- 회귀 스위트 `preserve-modules-default-export.test.ts`: default 형태(익명 class/function/arrow/extends, named class/function, value) × esm/cjs × plain/minify + **익명 function RN(strict)** — 전부 통과(익명 class ESM·익명 function RN 이 수정 전 실패).
- 방출: `var _default;` top-level 선언 + 클로저 안 `_default = class{…}`/`_default = function(){}` + `export { _default }` 일관.
- zig 전체 test, 통합 스위트 **4342 pass / 0 fail**.

## 별개 잔여 (이 PR 범위 밖 — 조사 중 발견)

- **RN downlevel class 헬퍼 중복**(#4574): `--preserve-modules --platform=react-native` 에서 class 를 export 하면 다운레벨 헬퍼(`__classCallCheck`/`__extends`)가 import + hoisted var 로 이중 선언 → SyntaxError. 익명·named·default 무관(class 다운레벨 특정).

Refs #4573

🤖 Generated with [Claude Code](https://claude.com/claude-code)