### PR TITLE
fix(bundler): #4572 preserve-modules 비-ESM-wrap 동명 export 붕괴 (소비자-로컬 공유)

### DIFF
--- a/.changeset/preserve-modules-nonwrap-samename.md
+++ b/.changeset/preserve-modules-nonwrap-samename.md
@@ -1,0 +1,40 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules`(ESM/CJS)에서 **비-ESM-wrap** 동명 export 를 한 소비자가 여러 파일에서 import 하면 붕괴하던 것 수정 (#4572).
+
+```js
+// m1.js/m2.js/m3.js: 각각 export function tag(){ return "T1/T2/T3"; }
+// a.cjs: module.exports = require("./m1.js"); require("./m2.js");   // m1·m2 만 ESM-wrap
+// entry: import { tag as t1 } from "./m1.js"; import { tag as t2 } from "./m2.js";
+//        import { tag as t3 } from "./m3.js"; import "./a.cjs";
+//        console.log(t1() + t2() + t3());
+// node canonical: "T1T2T3"
+// 버그: "T1T2T1"  ← t3 이 m1 의 tag 로 붕괴
+```
+
+## 근본 원인
+
+소비자 import 블록(emitter, `chunks.zig`)은 같은 export 명이 여러 dep 에서 오면 `import { tag as tag$3 }` 로 **소비자-로컬** deconflict 하는데(provider public 명 `export { tag }` 은 유지 — external API 계약), 소비자 **body 참조**(linker `effective_target`)는 `crossChunkBindingName` = `tag`(m1 과 충돌) 로 붕괴한다. 전역명이 ESM-wrap owner 로 한정(#4559)돼 non-wrap 은 전역명이 없고, import 블록의 `$N` deconflict 는 body 와 공유되지 않았다(코드 주석도 이 divergence 를 인정).
+
+## 수정 (rollup 식 — provider public 명 보존)
+
+전역명을 non-wrap 에 확장하면 provider public export 가 리네임돼 external consumer 가 깨진다(preserve-modules 계약 위반). 대신 **소비자-로컬 deconflict 를 body 와 공유**한다:
+
+- import 블록이 body codegen(`buildMetadataForAst`)보다 **먼저** 방출되므로, `$N` deconflict 로 정한 소비자-로컬명(`tag$3`)을 `consumer_import_local`(per-chunk transient, `canonical module → export명 → 로컬명`)에 적어 둔다(linker.zig).
+- `effective_target` 가 전역명이 없는 cross-chunk 참조에서 이 맵을 읽어 body 를 같은 이름(`tag$3`)으로 맞춘다. import 문·body 가 일치하고 provider 는 `export { tag }` 그대로다.
+
+`/code-review max` 반영:
+- **explicit preserve-modules 게이트**: `consumer_import_local` 의 write(chunks.zig)·read(effective_target)를 `preserve_modules` 로 명시 게이트(암묵적 `!has_global` 대신). splitting 은 전역명이 있어 이 경로를 안 타므로 무영향이 코드에 드러난다.
+- **borrowed `loc` UAF 회피 명시**: map 은 non-wrap(.none) canonical 에서만 채워지므로, per-chunk 수명 borrowed `loc` 이 esm-wrap 전용 `export_getter_overrides` 경로로 안 흘러감을 주석에 못박음(renames 경로는 이미 dupe).
+
+## 검증
+
+- 회귀 스위트 `preserve-modules-nonwrap-samename.test.ts` 24종(esm/cjs × plain/minify): 혼합(wrap+non-wrap), 순수 non-wrap, 동명 const, re-export 배럴, 다단계 re-export 체인, 2-consumer — 전부 통과(수정 전 전부 붕괴).
+- provider public 명(`export { tag }`)·entry 자체 export 자연명 유지 확인.
+- zig 전체 test, 통합 스위트 무회귀. splitting·단일 번들 무영향(write/read 모두 preserve_modules 게이트).
+
+## 잔여 (별개 근본 — #4576)
+
+- **동명 `export default` / `export { foo as tag }`**(export 명 ≠ 소비자 로컬명): import 블록의 `key != binding` 분기가 `$N` deconflict·map 기록을 안 해 로컬명 중복(default esm=SyntaxError·minify=silent ND1ND1·cjs 별도). binding-keyed deconflict + cjs/minify emit 경로별 처리 필요. #4572 인프라(`consumer_import_local`)를 확장하는 후속.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -499,6 +499,8 @@ pub fn emitChunks(
         // 여러 청크에서 같은 이름의 심볼을 import할 때 충돌 방지.
         // 1단계: 모든 청크로부터의 import 이름 출현 횟수 카운트
         // 2단계: 중복 이름은 `import { x as x$2 }` 형태로 alias 부여
+        // (#4572) 이 청크 소비자-로컬 import 이름 오버라이드 맵을 리셋(직전 청크 잔재 제거).
+        if (linker) |l| l.clearConsumerImportLocal();
         var name_total_count: std.StringHashMapUnmanaged(u32) = .empty;
         defer name_total_count.deinit(allocator);
         for (chunk.cross_chunk_imports.items) |dep_chunk_idx| {
@@ -865,6 +867,9 @@ pub fn emitChunks(
                         // key != binding(예약어 export 키 `default` → 소비자 local `_default`).
                         // 좌변=dep 노출 키(문자열이라 예약어 OK), 우변=소비자 참조 식별자.
                         // 축약 `{ default }` 면 예약어를 바인딩으로 써 SyntaxError → alias 가 방지.
+                        // ⚠️ (#4576) binding(소비자 로컬)이 동명 다른 dep 와 충돌하는 케이스(동명
+                        // `export default`·`export { foo as tag }`)는 여기서 deconflict 안 한다 —
+                        // 여러 sub-issue(cjs/minify/aliased)가 얽혀 별도 후속.
                         try chunk_output.appendSlice(allocator, key);
                         try chunk_output.appendSlice(allocator, if (reg_like) ": " else " as ");
                         try chunk_output.appendSlice(allocator, binding);
@@ -885,6 +890,12 @@ pub fn emitChunks(
                             try chunk_output.appendSlice(allocator, key);
                             try chunk_output.appendSlice(allocator, if (reg_like) ": " else " as ");
                             try chunk_output.appendSlice(allocator, alias);
+                            // (#4572) 소비자-로컬 deconflict 이름(`tag$3`)을 맵에 적어, 뒤이어 도는
+                            // buildMetadataForAst 의 effective_target 이 body 참조를 같은 이름으로
+                            // 맞추게 한다(안 하면 body 는 crossChunkBindingName=`tag` 로 붕괴). provider
+                            // public 명은 그대로 — 이건 소비자 청크 로컬명일 뿐이다. preserve-modules 한정
+                            // (splitting 은 전역명이 있어 이 `$N` 브랜치 자체를 안 탄다 — 명시 게이트).
+                            if (options.preserve_modules) if (linker) |l| try l.putConsumerImportLocal(sym.canonical_module, sym.name, alias);
                         } else {
                             try chunk_output.appendSlice(allocator, key);
                         }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -236,6 +236,15 @@ pub const Linker = struct {
     /// **Inc-1: 채우기만(비활성 read)** — 동작 변경 0, 후속 increment 가 wire.
     cross_chunk_global_names: std.AutoHashMapUnmanaged(u32, std.StringHashMapUnmanaged([]const u8)) = .empty,
 
+    /// (#4572) **per-chunk transient**. non-wrap ESM 동명 provider 는 전역명이 없어(#4559 owner
+    /// 한정) 소비자 import 블록(chunks.zig)이 `import { tag as tag$3 }` 로 소비자-로컬 deconflict
+    /// 하는데, provider public 명(`export { tag }`)은 유지된다(external API 계약). import 블록은
+    /// body codegen(effective_target) 보다 **먼저** 방출되므로, 그때 정한 소비자-로컬명을 여기
+    /// (`canonical module → export명 → 소비자 로컬명`)에 적어 두면 buildMetadataForAst 의
+    /// effective_target 이 읽어 body 참조를 같은 이름(`tag$3`)으로 맞춘다. 값은 이 맵 소유(dupe).
+    /// 청크마다 `clearConsumerImportLocal` 로 리셋(다른 소비자는 다른 deconflict).
+    consumer_import_local: std.AutoHashMapUnmanaged(u32, std.StringHashMapUnmanaged([]const u8)) = .empty,
+
     /// computeRenames 동안만 사는 메모이즈: `module_index → 그 모듈의 nested scope(scope 0 제외)
     /// 바인딩 이름 union set`. `hasNestedBinding` 이 후보(`name$N`)마다 모듈의 모든 scope_maps 를
     /// 재스캔하던 것(rename당 O(scopes), cold lRen 의 ~83%)을 O(1) 멤버십으로 바꾼다. 키는 borrow
@@ -500,6 +509,9 @@ pub const Linker = struct {
         // cross-chunk 전역 이름(#4101): owned value 해제 + inner/outer 맵 deinit.
         self.clearCrossChunkGlobalNames();
         self.cross_chunk_global_names.deinit(self.allocator);
+        // (#4572) per-chunk consumer-local import 이름 맵.
+        self.clearConsumerImportLocal();
+        self.consumer_import_local.deinit(self.allocator);
         // chain_cache: 키는 allocator로 dupe됨
         var cc_it = self.chain_cache.keyIterator();
         while (cc_it.next()) |key| self.allocator.free(key.*);
@@ -2102,6 +2114,35 @@ pub const Linker = struct {
     pub fn getCrossChunkGlobalName(self: *const Linker, module_index: u32, export_name: []const u8) ?[]const u8 {
         const inner = self.cross_chunk_global_names.get(module_index) orelse return null;
         return inner.get(export_name);
+    }
+
+    /// (#4572) per-chunk consumer-local import 이름 등록. `local_name` 을 맵이 dupe 소유.
+    /// key 는 `(canonical_module, export_name)` — import 블록이 그 sym 을 소비자-로컬로 deconflict
+    /// 한 이름(예 `tag$3`). `export_name` 키는 borrow(sym.name, bundle 수명).
+    pub fn putConsumerImportLocal(self: *Linker, module_index: u32, export_name: []const u8, local_name: []const u8) !void {
+        const gop = try self.consumer_import_local.getOrPut(self.allocator, module_index);
+        if (!gop.found_existing) gop.value_ptr.* = .empty;
+        const dup = try self.allocator.dupe(u8, local_name);
+        if (try gop.value_ptr.fetchPut(self.allocator, export_name, dup)) |old| {
+            self.allocator.free(old.value);
+        }
+    }
+
+    /// (#4572) consumer-local import 이름 조회. 없으면 null.
+    pub fn getConsumerImportLocal(self: *const Linker, module_index: u32, export_name: []const u8) ?[]const u8 {
+        const inner = self.consumer_import_local.get(module_index) orelse return null;
+        return inner.get(export_name);
+    }
+
+    /// (#4572) per-chunk 리셋 — 다음 청크 import 블록 전에 owned value 해제.
+    pub fn clearConsumerImportLocal(self: *Linker) void {
+        var it = self.consumer_import_local.valueIterator();
+        while (it.next()) |inner| {
+            var vit = inner.valueIterator();
+            while (vit.next()) |v| self.allocator.free(v.*);
+            inner.deinit(self.allocator);
+        }
+        self.consumer_import_local.clearRetainingCapacity();
     }
 
     /// (#4120) consumer 모듈과 canonical 모듈이 *다른* 청크에 있는지. `module_to_chunk` 가

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -1163,7 +1163,18 @@ pub fn buildMetadataForAst(
             const effective_target = if (resolved) |rb| blk_eff: {
                 const canon_mi = @intFromEnum(rb.canonical.module_index);
                 if (!self.isCrossChunkConsumer(module_index, canon_mi)) break :blk_eff target_name;
-                break :blk_eff self.getCrossChunkGlobalName(canon_mi, rb.canonical.export_name) orelse target_name;
+                if (self.getCrossChunkGlobalName(canon_mi, rb.canonical.export_name)) |g| break :blk_eff g;
+                // (#4572) non-wrap ESM 동명 provider: 전역명이 없어(#4559 owner 한정) crossChunkBindingName
+                // = `tag`(m1 과 충돌)로 붕괴한다. import 블록(먼저 방출)이 소비자-로컬로 deconflict 한
+                // 이름(`import { tag as tag$3 }`)을 consumer_import_local 에 적어 뒀으면, body 참조도 그
+                // 이름을 써서 import 문과 일치한다. provider public 명(`export { tag }`)은 그대로 유지.
+                // preserve-modules 한정(splitting 은 전역명이 있어 map 미populate) — 명시 게이트.
+                // ⚠️ canonical 이 non-wrap(.none)일 때만 map 이 채워지므로 `loc` 은 esm-wrap canonical
+                // 전용인 export_getter_overrides(아래 1193) 경로에 절대 안 흘러간다(borrowed loc UAF 회피).
+                if (self.graph.preserve_modules) {
+                    if (self.getConsumerImportLocal(canon_mi, rb.canonical.export_name)) |loc| break :blk_eff loc;
+                }
+                break :blk_eff target_name;
             } else target_name;
             if (!isReservedName(effective_target) and effective_target.len > 0 and isValidIdentStartByte(effective_target[0])) {
                 if (ib.local_symbol.semanticIndex()) |sym_idx| {

--- a/tests/integration/tests/preserve-modules-nonwrap-samename.test.ts
+++ b/tests/integration/tests/preserve-modules-nonwrap-samename.test.ts
@@ -1,0 +1,186 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { createFixture, runNode, runZntc } from './helpers';
+
+/**
+ * #4572 — `--preserve-modules` 에서 **비-ESM-wrap** 동명 export 붕괴.
+ *
+ * 서로 다른 파일이 동명 export(`tag`)를 내고, provider 가 CJS-flatten(`a.cjs = require(...)`)을
+ * 안 거쳐 **ESM-wrap 이 아니면**, 소비자 본문이 한 이름으로 붕괴한다(예 `t1()+t3()` 가 둘 다
+ * m1 의 `tag`). import 문은 `import { tag as tag$3 }` 로 deconflict 되는데 body 참조가
+ * `resolveToLocalName(canonical)` = `tag` 로 발산하는 게 근본. 전역명이 ESM-wrap owner 로
+ * 한정(#4559)돼 non-wrap owner 는 전역명이 안 붙었다. minify·non-minify 공통.
+ *
+ * 관측 가능한 런타임 값으로 스펙 고정 — node 로 실행해 값을 본다.
+ */
+
+async function buildPm(files: Record<string, string>, format: 'esm' | 'cjs', minify: boolean) {
+  const { dir, cleanup } = await createFixture(files);
+  const outDir = join(dir, 'dist');
+  const res = await runZntc([
+    '--bundle',
+    join(dir, 'entry.js'),
+    '--preserve-modules',
+    '--outdir',
+    outDir,
+    `--format=${format}`,
+    ...(minify ? ['--minify'] : []),
+  ]);
+  if (res.exitCode !== 0) {
+    await cleanup();
+    throw new Error(`빌드 실패:\n${res.stderr}`);
+  }
+  writeFileSync(
+    join(outDir, 'package.json'),
+    JSON.stringify({ type: format === 'esm' ? 'module' : 'commonjs' }),
+  );
+  return { outDir, cleanup };
+}
+
+const FORMATS = ['esm', 'cjs'] as const;
+const MINIFY = [false, true] as const;
+
+describe('#4572: preserve-modules 비-ESM-wrap 동명 export', () => {
+  // 기본: m1·m2 는 ESM-wrap(a.cjs 가 require), m3 은 non-wrap(entry 만 import)
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`혼합(wrap m1·m2 + non-wrap m3) [${format}${minify ? ' minify' : ''}]`, async () => {
+        const files: Record<string, string> = {
+          'a.cjs': 'module.exports = require("./m1.js");\nrequire("./m2.js");',
+          'entry.js':
+            'import { tag as t1 } from "./m1.js";\nimport { tag as t2 } from "./m2.js";\n' +
+            'import { tag as t3 } from "./m3.js";\nimport "./a.cjs";\n' +
+            'console.log(t1() + t2() + t3());',
+        };
+        for (const n of [1, 2, 3]) files[`m${n}.js`] = `export function tag(){ return "T${n}"; }`;
+        const { outDir, cleanup } = await buildPm(files, format, minify);
+        try {
+          const { stdout } = await runNode(join(outDir, 'entry.js'));
+          expect(stdout.trim()).toBe('T1T2T3'); // 수정 전: T1T2T1
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // 순수 non-wrap: 아무도 ESM-wrap 되지 않은 동명 import (CJS-flatten 없음)
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`순수 non-wrap 동명 [${format}${minify ? ' minify' : ''}]`, async () => {
+        const files: Record<string, string> = {
+          'entry.js':
+            'import { tag as t1 } from "./m1.js";\nimport { tag as t2 } from "./m2.js";\n' +
+            'import { tag as t3 } from "./m3.js";\n' +
+            'console.log(t1() + t2() + t3());',
+        };
+        for (const n of [1, 2, 3]) files[`m${n}.js`] = `export function tag(){ return "N${n}"; }`;
+        const { outDir, cleanup } = await buildPm(files, format, minify);
+        try {
+          const { stdout } = await runNode(join(outDir, 'entry.js'));
+          expect(stdout.trim()).toBe('N1N2N3');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // 동명 const export (함수 아님)
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`non-wrap 동명 const [${format}${minify ? ' minify' : ''}]`, async () => {
+        const files: Record<string, string> = {
+          'entry.js':
+            'import { v as v1 } from "./m1.js";\nimport { v as v2 } from "./m2.js";\n' +
+            'console.log(v1 + "|" + v2);',
+          'm1.js': 'export const v = "A";',
+          'm2.js': 'export const v = "B";',
+        };
+        const { outDir, cleanup } = await buildPm(files, format, minify);
+        try {
+          const { stdout } = await runNode(join(outDir, 'entry.js'));
+          expect(stdout.trim()).toBe('A|B');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // non-wrap 동명을 re-export 배럴 경유로 소비 (배럴 local 도 전역명 브리지 필요)
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`non-wrap 동명 re-export 배럴 [${format}${minify ? ' minify' : ''}]`, async () => {
+        const files: Record<string, string> = {
+          'm1.js': 'export function tag(){ return "R1"; }',
+          'm2.js': 'export function tag(){ return "R2"; }',
+          'r1.js': 'export { tag } from "./m1.js";',
+          'r2.js': 'export { tag } from "./m2.js";',
+          'entry.js':
+            'import { tag as a } from "./r1.js";\nimport { tag as b } from "./r2.js";\n' +
+            'console.log(a() + b());',
+        };
+        const { outDir, cleanup } = await buildPm(files, format, minify);
+        try {
+          const { stdout } = await runNode(join(outDir, 'entry.js'));
+          expect(stdout.trim()).toBe('R1R2'); // 수정 전: 붕괴/크래시
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // 다단계 re-export 체인(top → mid → m) 동명
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`non-wrap 동명 다단계 re-export 체인 [${format}${minify ? ' minify' : ''}]`, async () => {
+        const files: Record<string, string> = {
+          'm1.js': 'export function tag(){ return "C1"; }',
+          'm2.js': 'export function tag(){ return "C2"; }',
+          'mid1.js': 'export { tag } from "./m1.js";',
+          'top1.js': 'export { tag } from "./mid1.js";',
+          'top2.js': 'export { tag } from "./m2.js";',
+          'entry.js':
+            'import { tag as a } from "./top1.js";\nimport { tag as b } from "./top2.js";\n' +
+            'console.log(a() + b());',
+        };
+        const { outDir, cleanup } = await buildPm(files, format, minify);
+        try {
+          const { stdout } = await runNode(join(outDir, 'entry.js'));
+          expect(stdout.trim()).toBe('C1C2');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // non-wrap provider 를 두 소비자가 각각 import (전역명 일관성)
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`non-wrap 동명 + 2 consumer [${format}${minify ? ' minify' : ''}]`, async () => {
+        const files: Record<string, string> = {
+          'm1.js': 'export function tag(){ return "X1"; }',
+          'm2.js': 'export function tag(){ return "X2"; }',
+          'mid.js':
+            'import { tag as a } from "./m1.js";\nimport { tag as b } from "./m2.js";\n' +
+            'export function combined(){ return a() + b(); }',
+          'entry.js':
+            'import { tag as t1 } from "./m1.js";\nimport { tag as t2 } from "./m2.js";\n' +
+            'import { combined } from "./mid.js";\n' +
+            'console.log(t1() + t2() + "|" + combined());',
+        };
+        const { outDir, cleanup } = await buildPm(files, format, minify);
+        try {
+          const { stdout } = await runNode(join(outDir, 'entry.js'));
+          expect(stdout.trim()).toBe('X1X2|X1X2');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+});


### PR DESCRIPTION
## 문제

`--preserve-modules`(ESM/CJS)에서 **non-wrap ESM provider** 의 동명 export 를 한 소비자가 여러 파일에서 import 하면 붕괴했습니다 (#4572).

```js
// m1.js/m2.js/m3.js: 각각 export function tag(){ return "T1/T2/T3"; }
// a.cjs: module.exports = require("./m1.js"); require("./m2.js");   // m1·m2 만 ESM-wrap
// entry: import { tag as t1 } from "./m1.js"; import { tag as t2 } from "./m2.js";
//        import { tag as t3 } from "./m3.js"; import "./a.cjs";
//        console.log(t1() + t2() + t3());
// node canonical: "T1T2T3"
// 버그: "T1T2T1"  ← t3 이 m1 의 tag 로 붕괴
```

## 근본 원인 (실행 추적으로 확정)

소비자 import 블록(emitter, `chunks.zig`)은 같은 export 명이 여러 dep 에서 오면 `import { tag as tag$3 }` 로 **소비자-로컬** deconflict 하는데(provider public 명 `export { tag }` 은 유지 — external API 계약), 소비자 **body 참조**(linker `effective_target`)는 `crossChunkBindingName` = `tag`(m1 과 충돌)로 붕괴합니다. 전역명이 ESM-wrap owner 로 한정(#4559)돼 non-wrap 은 전역명이 없고, import 블록의 `$N` deconflict 이 body 와 공유되지 않았습니다(코드 주석도 이 divergence 를 인정). ⚠️ `tag$3` 은 codegen 이 아니라 **emitter** 가 만듭니다(디버그 실행 추적으로 확정).

## 수정 (rollup 식 — provider public 명 보존)

전역명을 non-wrap 에 확장하면 provider public export 가 리네임돼 external consumer 가 깨집니다(preserve-modules 계약 위반, `/code-review max` CONFIRMED). 대신 **소비자-로컬 deconflict 를 body 와 공유**합니다:

- import 블록이 body codegen(`buildMetadataForAst`)보다 **먼저** 방출되므로, `$N` deconflict 로 정한 소비자-로컬명(`tag$3`)을 `consumer_import_local`(per-chunk transient map, `canonical module → export명 → 로컬명`)에 기록(linker.zig).
- `effective_target` 가 전역명 없는 cross-chunk 참조에서 이 맵을 읽어 body 를 같은 이름(`tag$3`)으로 맞춥니다. import 문·body 가 일치하고 provider 는 `export { tag }` 그대로입니다.

## `/code-review max` 반영

- `consumer_import_local` write(chunks.zig)·read(effective_target) 를 **explicit `preserve_modules` 게이트**(암묵적 `!has_global` 대신) — splitting 무영향이 코드에 드러남.
- borrowed `loc` 은 non-wrap(`.none`) canonical 에서만 채워져 esm-wrap 전용 `export_getter_overrides` 경로에 안 흘러감을 주석에 못박음(UAF 회피, renames 경로는 이미 dupe).

## 검증

- 회귀 스위트 `preserve-modules-nonwrap-samename.test.ts` **24종**(esm/cjs × plain/minify): 혼합(wrap+non-wrap), 순수 non-wrap, 동명 const, re-export 배럴, 다단계 re-export 체인, 2-consumer — 전부 통과(수정 전 전부 붕괴).
- provider public 명(`export { tag }`)·entry 자체 export 자연명 유지 확인.
- zig 전체 test, 통합 스위트 **4366 pass / 0 fail**. splitting·단일 번들 무영향(write/read 모두 preserve_modules 게이트).

## 잔여 (별개 근본 — #4576)

- **동명 `export default` / `export { foo as tag }`**(export 명 ≠ 소비자 로컬명): import 블록의 `key != binding` 분기가 `$N` deconflict·map 기록을 안 해 로컬명이 중복됩니다(default esm=SyntaxError·minify=silent ND1ND1·cjs 별도 경로). binding-keyed deconflict + cjs/minify emit 경로별 처리가 필요해 별도 후속(#4576, `consumer_import_local` 인프라 확장).

Refs #4572

🤖 Generated with [Claude Code](https://claude.com/claude-code)