### PR TITLE
fix(bundler): #4574 preserve-modules × RN downlevel class 헬퍼 이중선언·경로 오류

### DIFF
--- a/.changeset/preserve-modules-rn-class-helper.md
+++ b/.changeset/preserve-modules-rn-class-helper.md
@@ -1,0 +1,34 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules --platform=react-native`(+`--preserve-modules-root`)에서 **class 를 export** 하면 로드 실패하던 것 수정 (#4574).
+
+```js
+// b.js:  export class Bar { greet(){ return "bar"; } }
+// a.cjs: module.exports = require("./b.js");   // b 를 ESM-wrap 강제
+// entry: import { Bar } from "./b.js"; import "./a.cjs"; console.log(new Bar().greet());
+```
+
+RN 다운레벨은 class 를 `__classCallCheck`/`__extends` 헬퍼로 낮추고 그 헬퍼를 runtime helper **virtual module** 에서 import 한다. 두 버그가 겹쳐 있었다:
+
+## 버그 1 — 헬퍼 이름 이중 선언 (SyntaxError)
+
+transform 이 헬퍼를 `var __classCallCheck = function(){…}` 로 인라인한다. 링커가 그 헬퍼를 별도 모듈에서 `import { __classCallCheck }` 로도 가져오면, 인라인 initializer 는 elide 되지만 ESM-wrap hoisting 이 수집한 **이름**이 import 와 이중 선언(`var __classCallCheck` + `import { __classCallCheck }` → `Identifier '__classCallCheck' has already been declared`).
+
+**수정**: `emitEsmWrappedModule`(esm_wrap.zig)에서 **helper-module import 로컬명을 hoisted var 에서 제외** — import 문이 그 바인딩을 선언하므로 진짜 소스.
+
+## 버그 2 — 헬퍼 모듈 import 경로 오류 (ERR_MODULE_NOT_FOUND)
+
+virtual helper 모듈은 outdir **최상위**에 놓이는데(bare sanitize id `runtime-class-call-check`), `computeRelativeImportPath` 가 root 아래가 아닌 그 bare id 를 소스의 **원본 절대 dir** 기준으로 상대 계산해 `../../../../runtime-…` 가 됐다.
+
+**수정**: src 가 root 아래이고 dep 이 bare id(virtual helper)면 outdir 최상위 파일로 취급해 `./runtime-…` 로 상대 계산.
+
+## 검증
+
+- 회귀 스위트 `preserve-modules-rn-class.test.ts` 4종(esm/cjs × plain/minify): named/익명 default/`extends`/plain function class + 헬퍼 import — 전부 `NDPE-B` (수정 전 SyntaxError·ERR_MODULE_NOT_FOUND).
+- zig 전체 test, 통합 스위트 무회귀.
+
+## 한계
+
+- `--preserve-modules-root` 미지정 시 virtual helper 경로 계산은 출력 base 추론과 어긋나 여전히 부정확(RN/Metro 는 project root 를 주므로 실사용 영향 없음). 별도 base-추론 이슈로 후속.

--- a/.changeset/preserve-modules-rn-class-helper.md
+++ b/.changeset/preserve-modules-rn-class-helper.md
@@ -16,19 +16,27 @@ RN 다운레벨은 class 를 `__classCallCheck`/`__extends` 헬퍼로 낮추고 
 
 transform 이 헬퍼를 `var __classCallCheck = function(){…}` 로 인라인한다. 링커가 그 헬퍼를 별도 모듈에서 `import { __classCallCheck }` 로도 가져오면, 인라인 initializer 는 elide 되지만 ESM-wrap hoisting 이 수집한 **이름**이 import 와 이중 선언(`var __classCallCheck` + `import { __classCallCheck }` → `Identifier '__classCallCheck' has already been declared`).
 
-**수정**: `emitEsmWrappedModule`(esm_wrap.zig)에서 **helper-module import 로컬명을 hoisted var 에서 제외** — import 문이 그 바인딩을 선언하므로 진짜 소스.
+**수정**: `emitEsmWrappedModule`(esm_wrap.zig)에서 **helper-module import 로컬명을 hoisted var 에서 제외** — import 문이 그 바인딩을 선언하므로 진짜 소스. 단:
+
+- **`preserve_modules` 로 게이트** — non-preserve 는 헬퍼를 별도 모듈에서 import 하지 않고 **inline** 하며(is_helper hoist 의 `var __extends; __extends = …` assign-only preamble, #1209), 그 var 는 필요하다. 제외 필터를 non-preserve 에 걸면 회귀하므로 preserve-modules 로 한정.
+- **키는 `getCanonicalByRef`**(rename 반영) — hoisted 이름이 resolveNodeName 이라 raw 로 매칭하면 minify/deconflict 시 놓친다.
+- **필터 후 남은 이름이 0 이면 `var` emit 자체를 건너뜀** — 모든 hoisted 이름이 helper import 인 모듈에서 `var ;`(SyntaxError)가 되던 것 방지.
 
 ## 버그 2 — 헬퍼 모듈 import 경로 오류 (ERR_MODULE_NOT_FOUND)
 
 virtual helper 모듈은 outdir **최상위**에 놓이는데(bare sanitize id `runtime-class-call-check`), `computeRelativeImportPath` 가 root 아래가 아닌 그 bare id 를 소스의 **원본 절대 dir** 기준으로 상대 계산해 `../../../../runtime-…` 가 됐다.
 
-**수정**: src 가 root 아래이고 dep 이 bare id(virtual helper)면 outdir 최상위 파일로 취급해 `./runtime-…` 로 상대 계산.
+**수정**: dep 이 bare id(virtual helper)면 outdir 최상위 파일로 취급해 상대 계산. src 가 root 아래면 src_rel dir 에서, **src 도 root 밖이면**(RN 모노레포 hoisted dep) stem-only 로 최상위에 놓이므로 형제 `./runtime-…` 로.
 
 ## 검증
 
-- 회귀 스위트 `preserve-modules-rn-class.test.ts` 4종(esm/cjs × plain/minify): named/익명 default/`extends`/plain function class + 헬퍼 import — 전부 `NDPE-B` (수정 전 SyntaxError·ERR_MODULE_NOT_FOUND).
-- zig 전체 test, 통합 스위트 무회귀.
+- 회귀 스위트 `preserve-modules-rn-class.test.ts` 8종:
+  - 4종(esm/cjs × plain/minify): named/익명 default/`extends`/plain function class + 헬퍼 import → `NDPE-B` (수정 전 SyntaxError·ERR_MODULE_NOT_FOUND).
+  - `[0]` 2종: non-preserve ESM-wrap × RN downlevel 이 헬퍼 var 를 보존하며 정상 실행(`E-B`).
+  - `[1]` 2종: out-of-root 소스의 헬퍼 경로가 `./runtime-…` 로 정상(`W`).
+- zig 전체 test, preserve/wrapper/cross-chunk 통합 스위트 무회귀.
 
 ## 한계
 
 - `--preserve-modules-root` 미지정 시 virtual helper 경로 계산은 출력 base 추론과 어긋나 여전히 부정확(RN/Metro 는 project root 를 주므로 실사용 영향 없음). 별도 base-추론 이슈로 후속.
+- out-of-root **non-helper 모듈**의 entry→module 지정자(같은 dir 이 아닐 때)는 이 PR 범위 밖의 일반 base-추론 문제로 남는다.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -3797,6 +3797,15 @@ fn computeRelativeImportPath(
             const rel = try computeRelativePath(allocator, src_dir, dep_rel_no_ext, ext);
             return rel;
         }
+        // (#4574) src 는 root 아래인데 dep 이 root 밖 **bare id**(virtual runtime helper 의
+        // sanitize 된 rel_dir, 예 `runtime-class-call-check`)면, 헬퍼는 outdir **최상위**에 놓이므로
+        // root-level 파일로 취급해 src_dir(root 기준) 에서 상대 계산한다. 이 가드가 없으면 절대경로
+        // fallback 이 src 의 원본 절대 dir(`/tmp/x`)에서 bare id 로 올라가 `../../../../helper` 가 된다.
+        if (src_rel != null and std.mem.indexOfScalar(u8, dep_abs, '/') == null) {
+            const src_dir = std.fs.path.dirname(src_rel.?) orelse "";
+            const dep_no_ext = dep_abs[0 .. dep_abs.len - std.fs.path.extension(dep_abs).len];
+            return try computeRelativePath(allocator, src_dir, dep_no_ext, ext);
+        }
     }
 
     // root 없거나 매칭 실패 → 절대 경로 기준으로 computeRelativePath에 위임

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -3797,13 +3797,17 @@ fn computeRelativeImportPath(
             const rel = try computeRelativePath(allocator, src_dir, dep_rel_no_ext, ext);
             return rel;
         }
-        // (#4574) src 는 root 아래인데 dep 이 root 밖 **bare id**(virtual runtime helper 의
-        // sanitize 된 rel_dir, 예 `runtime-class-call-check`)면, 헬퍼는 outdir **최상위**에 놓이므로
-        // root-level 파일로 취급해 src_dir(root 기준) 에서 상대 계산한다. 이 가드가 없으면 절대경로
-        // fallback 이 src 의 원본 절대 dir(`/tmp/x`)에서 bare id 로 올라가 `../../../../helper` 가 된다.
-        if (src_rel != null and std.mem.indexOfScalar(u8, dep_abs, '/') == null) {
-            const src_dir = std.fs.path.dirname(src_rel.?) orelse "";
+        // (#4574) dep 이 root 밖 **bare id**(virtual runtime helper 의 sanitize 된 rel_dir, 예
+        // `runtime-class-call-check`)면 헬퍼는 outdir **최상위**에 놓인다(computePreserveModulesPath).
+        // src 의 **출력 위치** 기준으로 상대 계산해야 한다:
+        //  · src 가 root 아래  → src_rel dir 에서 root-level 헬퍼로 상대 (`../helper` 또는 `./helper`).
+        //  · src 도 root 밖    → computePreserveModulesPath 가 stem-only 로 outdir 최상위에 놓으므로
+        //                        헬퍼와 형제 → `./helper` (src_dir="" 로 계산).
+        // 이 가드가 없으면 절대경로 fallback 이 src 의 원본 절대 dir(`/tmp/x`)에서 올라가 `../../helper`.
+        // 실제 모듈의 dep_abs 는 항상 절대경로('/'), virtual helper 만 bare 라 slash-부재로 판별 안전.
+        if (std.mem.indexOfScalar(u8, dep_abs, '/') == null) {
             const dep_no_ext = dep_abs[0 .. dep_abs.len - std.fs.path.extension(dep_abs).len];
+            const src_dir = if (src_rel) |sr| (std.fs.path.dirname(sr) orelse "") else "";
             return try computeRelativePath(allocator, src_dir, dep_no_ext, ext);
         }
     }

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -204,20 +204,27 @@ pub fn emitEsmWrappedModule(
 
     // (#4574) preserve-modules × RN downlevel: 런타임 헬퍼(`__classCallCheck` 등)를 transform 이
     // `var __classCallCheck = function(){…}` 로 인라인한 뒤, 링커가 헬퍼 모듈에서 `import
-    // { __classCallCheck }` 로도 가져온다. 인라인 initializer 는 elide 되지만 variable_declaration
-    // 로 hoisting 된 **이름**이 import 와 이중 선언(SyntaxError)이 된다. helper-module import 로컬명은
-    // hoisted var 에서 제외한다 — import 문이 그 바인딩을 선언하므로(진짜 소스).
+    // { __classCallCheck }` 로도 가져온다. 인라인 initializer 는 elide 되지만 hoisting 된 **이름**이
+    // import 와 이중 선언(SyntaxError)이 된다. **preserve-modules 한정**으로 helper-module import
+    // 로컬명을 hoisted var 에서 제외 — import 문이 그 바인딩을 선언한다(진짜 소스).
+    // ⚠️ **non-preserve** 에선 helper import 가 skip 되고 assign-only preamble(`__extends = …`)로
+    // 치환돼 top-level `var __extends;`(is_helper hoist)가 **필요**하므로 제외하면 안 된다(#1209 회귀).
+    // 키는 `getCanonicalByRef`(rename 반영) — hoisted_var_names 가 resolveNodeName 이라 raw 로 매칭하면
+    // minify/deconflict 시 놓친다(is_helper hoist 도 line 아래에서 같은 getCanonicalByRef 를 쓴다).
     var helper_import_locals: std.StringHashMapUnmanaged(void) = .empty;
     defer helper_import_locals.deinit(allocator);
-    if (linker) |l| {
-        const helper_modules = @import("../../runtime_helper_modules.zig");
-        for (module.import_bindings) |ib| {
-            if (ib.import_record_index >= module.import_records.len) continue;
-            const tgt = module.import_records[ib.import_record_index].resolved;
-            if (tgt.isNone()) continue;
-            const tm = l.graph.getModule(tgt) orelse continue;
-            if (!helper_modules.isVirtualId(tm.path)) continue;
-            try helper_import_locals.put(allocator, module.importBindingLocalName(ib), {});
+    if (options.preserve_modules) {
+        if (linker) |l| {
+            const helper_modules = @import("../../runtime_helper_modules.zig");
+            for (module.import_bindings) |ib| {
+                if (ib.import_record_index >= module.import_records.len) continue;
+                const tgt = module.import_records[ib.import_record_index].resolved;
+                if (tgt.isNone()) continue;
+                const tm = l.graph.getModule(tgt) orelse continue;
+                if (!helper_modules.isVirtualId(tm.path)) continue;
+                const local = l.getCanonicalByRef(ib.local_symbol) orelse module.importBindingLocalName(ib);
+                try helper_import_locals.put(allocator, local, {});
+            }
         }
     }
 
@@ -454,12 +461,17 @@ pub fn emitEsmWrappedModule(
         }
         hoisted_var_names.shrinkRetainingCapacity(dedup_count);
 
-        try wrapped.appendSlice(allocator, "var ");
-        for (hoisted_var_names.items, 0..) |name, i| {
-            if (i > 0) try wrapped.appendSlice(allocator, ", ");
-            try wrapped.appendSlice(allocator, name);
+        // (#4574) 필터(helper_import_locals) 후 남은 이름이 하나도 없으면 `var ;`(SyntaxError)가
+        // 되므로 emit 자체를 건너뛴다. 모든 hoisted 이름이 helper-module import 인 모듈(예: class
+        // side-effect 만 있는 wrap 모듈)에서 발생.
+        if (hoisted_var_names.items.len > 0) {
+            try wrapped.appendSlice(allocator, "var ");
+            for (hoisted_var_names.items, 0..) |name, i| {
+                if (i > 0) try wrapped.appendSlice(allocator, ", ");
+                try wrapped.appendSlice(allocator, name);
+            }
+            try wrapped.appendSlice(allocator, ";\n");
         }
-        try wrapped.appendSlice(allocator, ";\n");
     }
 
     // 3. 호이스팅된 function 선언 (rolldown 방식: canonical 변수 직접 참조)

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -202,6 +202,25 @@ pub fn emitEsmWrappedModule(
     var hoisted_var_names: std.ArrayList([]const u8) = .empty;
     defer hoisted_var_names.deinit(allocator);
 
+    // (#4574) preserve-modules × RN downlevel: 런타임 헬퍼(`__classCallCheck` 등)를 transform 이
+    // `var __classCallCheck = function(){…}` 로 인라인한 뒤, 링커가 헬퍼 모듈에서 `import
+    // { __classCallCheck }` 로도 가져온다. 인라인 initializer 는 elide 되지만 variable_declaration
+    // 로 hoisting 된 **이름**이 import 와 이중 선언(SyntaxError)이 된다. helper-module import 로컬명은
+    // hoisted var 에서 제외한다 — import 문이 그 바인딩을 선언하므로(진짜 소스).
+    var helper_import_locals: std.StringHashMapUnmanaged(void) = .empty;
+    defer helper_import_locals.deinit(allocator);
+    if (linker) |l| {
+        const helper_modules = @import("../../runtime_helper_modules.zig");
+        for (module.import_bindings) |ib| {
+            if (ib.import_record_index >= module.import_records.len) continue;
+            const tgt = module.import_records[ib.import_record_index].resolved;
+            if (tgt.isNone()) continue;
+            const tm = l.graph.getModule(tgt) orelse continue;
+            if (!helper_modules.isVirtualId(tm.path)) continue;
+            try helper_import_locals.put(allocator, module.importBindingLocalName(ib), {});
+        }
+    }
+
     for (all_stmts) |raw_idx| {
         const ni: NodeIndex = @enumFromInt(raw_idx);
         if (ni.isNone()) continue;
@@ -428,7 +447,8 @@ pub fn emitEsmWrappedModule(
             const is_dup = for (hoisted_var_names.items[0..dedup_count]) |prev| {
                 if (std.mem.eql(u8, prev, name)) break true;
             } else false;
-            if (is_dup) continue;
+            // (#4574) helper-module import 로컬명은 import 문이 선언 → hoisted var 중복 제거.
+            if (is_dup or helper_import_locals.contains(name)) continue;
             hoisted_var_names.items[dedup_count] = name;
             dedup_count += 1;
         }

--- a/tests/integration/tests/preserve-modules-rn-class.test.ts
+++ b/tests/integration/tests/preserve-modules-rn-class.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { createFixture, runNode, runZntc } from './helpers';
+
+/**
+ * #4574 — `--preserve-modules --platform=react-native` 에서 class export.
+ *
+ * RN 다운레벨은 class 를 `__classCallCheck`/`__extends` 헬퍼로 낮추고 그 헬퍼를 runtime helper
+ * **virtual module** 에서 import 한다. 두 버그가 겹쳐 있었다:
+ *  (1) transform 이 헬퍼를 `var __classCallCheck = function(){…}` 로 인라인한 흔적(이름만 남음)이
+ *      hoisted var 로 수집돼 `import { __classCallCheck }` 와 이중 선언(SyntaxError).
+ *  (2) 그 헬퍼 모듈 import 의 상대 경로가 `../../../../runtime-…` 로 잘못 계산(ERR_MODULE_NOT_FOUND).
+ *      → helper-module import 로컬명을 hoisted var 에서 제외 + bare-id dep 을 root-level 로 상대 계산.
+ *
+ * RN(Metro)은 project root 를 주므로 `--preserve-modules-root` 로 빌드한다.
+ */
+
+async function buildRnPm(files: Record<string, string>, format: 'esm' | 'cjs', minify: boolean) {
+  const { dir, cleanup } = await createFixture(files);
+  const outDir = join(dir, 'dist');
+  const res = await runZntc([
+    '--bundle',
+    join(dir, 'entry.js'),
+    '--preserve-modules',
+    `--preserve-modules-root=${dir}`,
+    '--outdir',
+    outDir,
+    `--format=${format}`,
+    '--platform=react-native',
+    ...(minify ? ['--minify'] : []),
+  ]);
+  if (res.exitCode !== 0) {
+    await cleanup();
+    throw new Error(`빌드 실패:\n${res.stderr}`);
+  }
+  writeFileSync(
+    join(outDir, 'package.json'),
+    JSON.stringify({ type: format === 'esm' ? 'module' : 'commonjs' }),
+  );
+  return { outDir, cleanup };
+}
+
+const FORMATS = ['esm', 'cjs'] as const;
+const MINIFY = [false, true] as const;
+
+describe('#4574: preserve-modules × RN downlevel class', () => {
+  for (const format of FORMATS) {
+    for (const minify of MINIFY) {
+      test(`class(named/default/extends) + 헬퍼 import [${format}${minify ? ' minify' : ''}]`, async () => {
+        const { outDir, cleanup } = await buildRnPm(
+          {
+            'b.js':
+              'export class Named { greet(){ return "N"; } }\n' +
+              'export default class { greet(){ return "D"; } }\n' +
+              'export function plain(){ return "P"; }',
+            'ext.js':
+              'class Base { b(){ return "B"; } }\n' +
+              'export class Ext extends Base { greet(){ return "E-" + this.b(); } }',
+            'a.cjs': 'module.exports = require("./b.js");\nrequire("./ext.js");', // ESM-wrap 강제
+            'entry.js':
+              'import D, { Named, plain } from "./b.js";\nimport { Ext } from "./ext.js";\nimport "./a.cjs";\n' +
+              'console.log(new Named().greet() + new D().greet() + plain() + new Ext().greet());',
+          },
+          format,
+          minify,
+        );
+        try {
+          const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+          expect(stderr).not.toContain('SyntaxError'); // 수정 전(1): __classCallCheck 중복 선언
+          expect(stderr).not.toContain('ERR_MODULE_NOT_FOUND'); // 수정 전(2): 헬퍼 경로
+          expect(stdout.trim()).toBe('NDPE-B');
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+});

--- a/tests/integration/tests/preserve-modules-rn-class.test.ts
+++ b/tests/integration/tests/preserve-modules-rn-class.test.ts
@@ -77,3 +77,85 @@ describe('#4574: preserve-modules × RN downlevel class', () => {
     }
   }
 });
+
+/**
+ * [0] 스모크 — 헬퍼-이름 제외 필터는 `preserve_modules` 로 게이트돼 **non-preserve** 에선 no-op 다.
+ * non-preserve 는 헬퍼를 virtual 모듈에서 import 하지 않고 **inline** 하므로(is_helper hoist 의
+ * `var __extends; __extends = …` assign-only preamble, #1209) 필터가 그 var 를 건드리면 안 된다.
+ * 게이트가 그걸 보장한다 — 본 테스트는 non-preserve ESM-wrap × RN downlevel 이 정상 실행됨을 고정한다.
+ */
+describe('#4574 [0]: non-preserve ESM-wrap 은 헬퍼 var 를 보존한다', () => {
+  for (const minify of MINIFY) {
+    test(`extends 헬퍼 var 보존 [esm${minify ? ' minify' : ''}]`, async () => {
+      const { dir, cleanup } = await createFixture({
+        'b.js':
+          'class Base { b(){ return "B"; } }\n' +
+          'export class Ext extends Base { greet(){ return "E-" + this.b(); } }',
+        'a.cjs': 'module.exports = require("./b.js");', // b 를 ESM-wrap 강제
+        'entry.js':
+          'import { Ext } from "./b.js";\nimport "./a.cjs";\nconsole.log(new Ext().greet());',
+      });
+      const out = join(dir, 'out.mjs');
+      try {
+        const res = await runZntc([
+          '--bundle',
+          join(dir, 'entry.js'),
+          '--format=esm',
+          '--platform=react-native',
+          ...(minify ? ['--minify'] : []),
+          '-o',
+          out,
+        ]);
+        expect(res.exitCode).toBe(0);
+        const { stdout, stderr } = await runNode(out);
+        expect(stderr).not.toContain('ReferenceError'); // 필터 과도 → 헬퍼 var 소멸
+        expect(stderr).not.toContain('SyntaxError');
+        expect(stdout.trim()).toBe('E-B');
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+});
+
+/**
+ * [1] 회귀 가드 — 소스가 `--preserve-modules-root` **밖**이면 stem-only 로 outdir 최상위에 놓인다.
+ * virtual helper 도 최상위이므로 helper import 는 `./runtime-…` 여야 한다(기존 `../../…` → ERR_MODULE_NOT_FOUND).
+ * entry·widget 을 같은 out-of-root dir 에 두어 모듈 간 경로도 정상 실행되게 한다.
+ */
+describe('#4574 [1]: out-of-root 소스의 헬퍼 경로', () => {
+  for (const format of FORMATS) {
+    test(`out-of-root class 헬퍼 → ./runtime-… [${format}]`, async () => {
+      const { dir, cleanup } = await createFixture({
+        'app/widget.js': 'export class Widget { greet(){ return "W"; } }',
+        'app/entry.js': 'import { Widget } from "./widget.js";\nconsole.log(new Widget().greet());',
+        'root/.keep': '', // root 는 app 을 포함하지 않는 무관 dir
+      });
+      const outDir = join(dir, 'dist');
+      try {
+        const res = await runZntc([
+          '--bundle',
+          join(dir, 'app/entry.js'),
+          '--preserve-modules',
+          `--preserve-modules-root=${join(dir, 'root')}`,
+          '--outdir',
+          outDir,
+          `--format=${format}`,
+          '--platform=react-native',
+        ]);
+        expect(res.exitCode).toBe(0);
+        const widget = await Bun.file(join(outDir, 'widget.js')).text();
+        expect(widget).not.toMatch(/from ["']\.\.\//); // `../…/runtime-…` 이면 회귀
+        writeFileSync(
+          join(outDir, 'package.json'),
+          JSON.stringify({ type: format === 'esm' ? 'module' : 'commonjs' }),
+        );
+        const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+        expect(stderr).not.toContain('ERR_MODULE_NOT_FOUND');
+        expect(stdout.trim()).toBe('W');
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+});


### PR DESCRIPTION
## 문제

`--preserve-modules --platform=react-native`(+`--preserve-modules-root`)에서 **class 를 export** 하면 로드에 실패했다.

```js
// b.js:  export class Bar { greet(){ return "bar"; } }
// a.cjs: module.exports = require("./b.js");   // b 를 ESM-wrap 강제
// entry: import { Bar } from "./b.js"; import "./a.cjs"; console.log(new Bar().greet());
```

RN 다운레벨은 class 를 `__classCallCheck`/`__extends` 헬퍼로 낮추고 그 헬퍼를 runtime helper **virtual module** 에서 import 한다. 두 버그가 겹쳐 있었다.

### 버그 1 — 헬퍼 이름 이중 선언 (SyntaxError)

transform 이 헬퍼를 `var __classCallCheck = function(){…}` 로 인라인한다. 링커가 그 헬퍼를 별도 모듈에서 `import { __classCallCheck }` 로도 가져오면, 인라인 initializer 는 elide 되지만 ESM-wrap hoisting 이 수집한 **이름**이 import 와 이중 선언(`var __classCallCheck` + `import { __classCallCheck }` → `Identifier '__classCallCheck' has already been declared`).

**수정** — `emitEsmWrappedModule`(esm_wrap.zig)에서 **helper-module import 로컬명을 hoisted var 에서 제외**(import 문이 진짜 선언). 단:
- **`preserve_modules` 로 게이트** — non-preserve 는 헬퍼를 별도 모듈에서 import 하지 않고 **inline** 하며(is_helper hoist assign-only preamble, #1209) 그 `var __extends;` 는 필요하다. 필터를 non-preserve 에 걸면 회귀.
- **키는 `getCanonicalByRef`**(rename 반영) — hoisted 이름이 resolveNodeName 이라 raw 매칭 시 minify/deconflict 에서 놓친다.
- **필터 후 남은 이름이 0 이면 `var` emit 을 건너뜀** — `var ;`(SyntaxError) 방지.

### 버그 2 — 헬퍼 모듈 import 경로 오류 (ERR_MODULE_NOT_FOUND)

virtual helper 모듈은 outdir **최상위**에 놓이는데(bare sanitize id `runtime-class-call-check`), `computeRelativeImportPath` 가 그 bare id 를 소스의 **원본 절대 dir** 기준으로 상대 계산해 `../../../../runtime-…` 가 됐다.

**수정** — dep 이 bare id(virtual helper)면 outdir 최상위 파일로 취급. src 가 root 아래면 src_rel dir 에서, **src 도 root 밖이면**(RN 모노레포 hoisted dep) stem-only 로 최상위에 놓이므로 형제 `./runtime-…` 로 상대 계산.

## `/code-review max` 반영

max 리뷰가 초기 커밋(e64c11d5)에서 회귀 우려를 짚어 두 번째 커밋(251ffff0)에서 반영했다:
- **[0]** 필터가 non-preserve is_helper 의 `var` 를 지울 수 있다는 지적 → **직접 재현** 결과 non-preserve 는 헬퍼가 inline 이라 필터가 애초에 no-op 이었으나, 안전하게 `preserve_modules` 게이트 추가.
- **empty `var ;`** — 필터가 모든 hoisted 이름을 제거하면 `var ;` 가 되던 경로 → 잔여 0 이면 emit skip.
- **[1]** 경로 fix 가 root 아래 소스만 처리 → out-of-root 소스도 형제 `./` 로 처리하도록 일반화.
- **[2]** rename 키 불일치 → `getCanonicalByRef` 로 변경.

## 검증

- `preserve-modules-rn-class.test.ts` **8종**:
  - 4종(esm/cjs × plain/minify): named/익명 default/`extends`/plain function class + 헬퍼 → `NDPE-B`.
  - `[0]` 2종: non-preserve ESM-wrap × RN downlevel 이 헬퍼 var 보존·정상 실행(`E-B`).
  - `[1]` 2종: out-of-root 소스의 헬퍼 경로 `./runtime-…`·정상 실행(`W`).
- zig 전체 test, preserve/wrapper/cross-chunk 통합 무회귀.

## 한계

- `--preserve-modules-root` 미지정 시 virtual helper 경로는 출력 base 추론과 어긋나 여전히 부정확(RN/Metro 는 project root 를 주므로 실사용 영향 없음). 별도 base-추론 이슈로 후속.
- out-of-root **non-helper 모듈**의 entry→module 지정자(다른 dir 일 때)는 이 PR 범위 밖의 일반 base-추론 문제.

Refs #4574

🤖 Generated with [Claude Code](https://claude.com/claude-code)