### PR TITLE
fix(bundler): #4576 preserve-modules 동명 export default 중복선언 (SyntaxError)

### DIFF
--- a/.changeset/preserve-modules-samename-default.md
+++ b/.changeset/preserve-modules-samename-default.md
@@ -1,0 +1,33 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules` 에서 서로 다른 파일이 **같은 로컬명으로 `export default`** 하고 한 소비자가 둘 다 default import 하면 `SyntaxError: Identifier 'foo' has already been declared` 로 파싱 실패하던 것 수정 (#4576).
+
+```js
+// m1.js: export default function foo(){ return "D1"; }
+// m2.js: export default function foo(){ return "D2"; }
+// entry: import a from "./m1.js"; import b from "./m2.js"; console.log(a() + b());
+```
+
+방출(esm) 이 `import { default as foo }` 를 두 번 내 `foo` 중복 선언으로 깨졌다.
+
+## 근본
+
+소비자 import 블록(chunks.zig)의 `$N` deconflict 는 **`key == binding`**(export 명 == 로컬명) 분기에서만 했다. default 는 key=`default`, binding=`foo`(익명은 `_default`)라 **`key != binding` 분기**로 가는데 그 분기가 deconflict 를 안 해 로컬명이 여러 dep 에서 중복됐다. #4572(named 동명)와 같은 계열이지만 emit 분기가 다르다.
+
+## 수정
+
+**선언되는 소비자-로컬은 항상 binding** 이므로, 충돌 카운트를 export-명-keyed → **binding-keyed 로 통일**하고 두 분기(`key==binding` 축약 / `key!=binding` alias) 모두에서 `binding$N` deconflict 를 적용한다. deconflict 된 이름은 `consumer_import_local`(#4572) 맵에 기록해 body 참조(effective_target)를 맞춘다. ESM-wrap dep 의 `let X;` forwarding 사이트(#4528)도 같은 binding-keyed 카운트를 공유해 `$N` 이 일치한다.
+
+`export const foo` + `export default function foo` 처럼 두 분기가 섞여 같은 로컬명을 만드는 cross-branch 충돌도 통일 카운트로 해소된다.
+
+## 검증
+
+- 회귀 스위트 `preserve-modules-samename-default.test.ts`: named/익명 default·cross-branch·3-way(esm plain/whitespace/syntax minify) → 각 정확한 출력. cjs 는 중복 로컬 선언이 사라짐을 emit 으로 확인.
+- preserve-modules·cross-chunk·splitting·wrapper 통합 전반 + zig 전체 test 무회귀.
+
+## 별개 선행 버그(별도 후속)
+
+- **`--minify-identifiers`**: mangler 가 소비자 default import 의 로컬은 개명하는데 body 참조는 다른 심볼로 취급해 발산(silent). 이 fix 유무와 무관하게 main 도 동일 — mangler 심볼-정체성 문제로 별도.
+- **cjs default interop**: `module.exports = foo` provider 를 소비자가 `{ default: foo }` 로 구조분해해 `foo is not a function`. 단일 default 도 실패(중복과 무관). 이 fix 로 중복선언 SyntaxError 는 제거되지만 interop 오류는 별도.

--- a/.changeset/preserve-modules-samename-default.md
+++ b/.changeset/preserve-modules-samename-default.md
@@ -18,14 +18,21 @@
 
 ## 수정
 
-**선언되는 소비자-로컬은 항상 binding** 이므로, 충돌 카운트를 export-명-keyed → **binding-keyed 로 통일**하고 두 분기(`key==binding` 축약 / `key!=binding` alias) 모두에서 `binding$N` deconflict 를 적용한다. deconflict 된 이름은 `consumer_import_local`(#4572) 맵에 기록해 body 참조(effective_target)를 맞춘다. ESM-wrap dep 의 `let X;` forwarding 사이트(#4528)도 같은 binding-keyed 카운트를 공유해 `$N` 이 일치한다.
+**선언되는 소비자-로컬은 항상 binding** 이므로, esbuild/rollup 리네이머처럼 **소비자 청크의 "이미 쓰인 로컬명" 집합(`used_locals`)으로 유일 이름을 발급**한다(`mintConsumerLocal`): 비었으면 binding 그대로, 이미 쓰였으면 `binding$N`(N=2,3,… 중 `used_locals`·다른 binding 의 자연명 집합에 없는 첫 이름). 두 emit 분기(`key==binding` 축약 / `key!=binding` alias)와 ESM-wrap dep 의 `let X;` forwarding 사이트(#4528)가 **같은 `used_locals` 를 공유**한다. deconflict 된 이름은 `consumer_import_local`(#4572) 맵에 기록해 body 참조(effective_target)를 맞춘다.
 
-`export const foo` + `export default function foo` 처럼 두 분기가 섞여 같은 로컬명을 만드는 cross-branch 충돌도 통일 카운트로 해소된다.
+핵심은 **per-binding 카운터가 아니라 집합 기반 유일성**이다 — 카운터는 한 그룹의 `foo$2` 가 다른 심볼의 자연명 `foo$2`(또는 사용자 심볼)와 충돌할 수 있다(아래 검증 [0]). 이름이 고정된 심볼(전역명 `has_global`·lazy)은 pre-pass 로 `used_locals` 에 먼저 예약해, 동명 plain 로컬이 그 이름과 충돌하면 순서와 무관하게 deconflict 된다(아래 [1]). `export const foo` + `export default function foo` 같은 cross-branch 충돌도 같은 집합으로 해소된다.
 
 ## 검증
 
-- 회귀 스위트 `preserve-modules-samename-default.test.ts`: named/익명 default·cross-branch·3-way(esm plain/whitespace/syntax minify) → 각 정확한 출력. cjs 는 중복 로컬 선언이 사라짐을 emit 으로 확인.
-- preserve-modules·cross-chunk·splitting·wrapper 통합 전반 + zig 전체 test 무회귀.
+- 회귀 스위트 `preserve-modules-samename-default.test.ts`: named/익명 default·cross-branch·3-way + **[0]** dedup 이름이 자연 `foo$2` 심볼과 충돌 회피(→`foo$3`)·**[1]** 전역명 고정 default + plain 동명(import 순서 무관 `PW`) — esm plain/whitespace/syntax minify. cjs 는 중복 로컬 선언이 없고 deconflict 됨을 emit 으로 확인.
+- preserve-modules 160·cross-chunk/splitting/wrapper 186 통합 + zig 전체 test 무회귀.
+
+## `/code-review max` 반영
+
+max 리뷰가 초기 커밋(per-binding 카운터)에서 두 correctness 회귀를 짚어 집합 기반(`used_locals`)으로 재설계했다:
+- **[0]** dedup `binding$N` 이 다른 binding 의 자연 `$N` 명과 충돌(재현) → `used_locals`+자연명 집합으로 유일성 판정.
+- **[1]** `!has_global` 게이트가 전역명 default 를 dedup 에서 제외해 순서-의존 중복(재현) → 고정명 pre-pass 예약.
+- **[2]** 중복 alias 분기 → `key != local` 단일 분기로 병합. **[3]** cjs 테스트 vacuous → positive 단언 추가.
 
 ## 별개 선행 버그(별도 후속)
 

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -501,22 +501,27 @@ pub fn emitChunks(
         // 2단계: 중복 이름은 `import { x as x$2 }` 형태로 alias 부여
         // (#4572) 이 청크 소비자-로컬 import 이름 오버라이드 맵을 리셋(직전 청크 잔재 제거).
         if (linker) |l| l.clearConsumerImportLocal();
-        var name_total_count: std.StringHashMapUnmanaged(u32) = .empty;
-        defer name_total_count.deinit(allocator);
+        // (#4576) 선언되는 소비자-로컬은 항상 **binding**(crossChunkBindingName)이다 — export 명이
+        // 아니라. 동명 `export default`(key=`default`, binding=`foo`/`_default`)처럼 export 명과
+        // 로컬명이 다르면 name-keyed 로 세면 충돌을 놓친다(→ `import { default as foo }` 이중선언
+        // SyntaxError). binding-keyed 로 통일해 두 분기(`key==binding` 축약 / `key!=binding` alias)
+        // 모두에서 로컬 충돌을 deconflict 한다.
+        var binding_total_count: std.StringHashMapUnmanaged(u32) = .empty;
+        defer binding_total_count.deinit(allocator);
         for (chunk.cross_chunk_imports.items) |dep_chunk_idx| {
             const dep_ci = @intFromEnum(dep_chunk_idx);
             if (chunk.imports_from.get(dep_ci)) |syms| {
                 for (syms.items) |sym| {
-                    const gop = try name_total_count.getOrPut(allocator, sym.name);
+                    const gop = try binding_total_count.getOrPut(allocator, crossChunkBindingName(linker, sym));
                     if (!gop.found_existing) gop.value_ptr.* = 0;
                     gop.value_ptr.* += 1;
                 }
             }
         }
 
-        // 2단계: import 문 생성 (중복 이름은 alias 부여)
-        var name_seen_count: std.StringHashMapUnmanaged(u32) = .empty;
-        defer name_seen_count.deinit(allocator);
+        // 2단계: import 문 생성 (중복 로컬명은 alias 부여)
+        var binding_seen_count: std.StringHashMapUnmanaged(u32) = .empty;
+        defer binding_seen_count.deinit(allocator);
 
         // alias 문자열을 임시 저장 (defer free)
         var alias_strs: std.ArrayList([]const u8) = .empty;
@@ -698,8 +703,10 @@ pub fn emitChunks(
                             const bind = crossChunkBindingName(linker, sym);
                             const global_name: ?[]const u8 = if (linker) |l| l.getCrossChunkGlobalName(sym.canonical_module, sym.name) else null;
                             const has_g = global_name != null;
-                            const total = name_total_count.get(sym.name) orelse 1;
-                            const seen_gop = try name_seen_count.getOrPut(allocator, sym.name);
+                            // (#4576) import 블록과 **같은** binding-keyed count 를 써야 `$N` 이
+                            // 일치한다(esm=import 블록 / cjs ESM-wrap=여기, dep 단위 상호배타·count 공유).
+                            const total = binding_total_count.get(bind) orelse 1;
+                            const seen_gop = try binding_seen_count.getOrPut(allocator, bind);
                             if (!seen_gop.found_existing) seen_gop.value_ptr.* = 0;
                             seen_gop.value_ptr.* += 1;
                             const seen = seen_gop.value_ptr.*;
@@ -863,42 +870,43 @@ pub fn emitChunks(
                     const has_global = if (linker) |l| l.getCrossChunkGlobalName(sym.canonical_module, sym.name) != null else false;
                     const key = if (lazy_local_keys or has_global) binding else name;
 
+                    // (#4572/#4576) 선언되는 소비자-로컬은 항상 **binding**. 같은 binding 이 여러 dep
+                    // 에서 오면(동명 named export=#4572, 동명 `export default`=#4576, 두 분기 혼합) 2번째
+                    // 부터 `binding$N` 로 deconflict. 전역 네이밍(has_global)/lazy 는 binding 이 이미 전역
+                    // deconflict(`v`/`v$1`)라 `$N` 불필요(이중 deconflict 로 소비자 참조와 어긋남).
+                    const total = binding_total_count.get(binding) orelse 1;
+                    const seen_gop = try binding_seen_count.getOrPut(allocator, binding);
+                    if (!seen_gop.found_existing) seen_gop.value_ptr.* = 0;
+                    seen_gop.value_ptr.* += 1;
+                    const seen = seen_gop.value_ptr.*;
+                    const need_dedup = total > 1 and seen > 1 and !lazy_local_keys and !has_global;
+                    const local = if (need_dedup) blk: {
+                        const alias = try std.fmt.allocPrint(allocator, "{s}${d}", .{ binding, seen });
+                        try alias_strs.append(allocator, alias);
+                        // 소비자-로컬 deconflict 이름을 맵에 적어, 뒤이어 도는 buildMetadataForAst 의
+                        // effective_target 이 body 참조를 같은 이름으로 맞추게 한다(안 하면 body 는
+                        // crossChunkBindingName=`binding` 으로 붕괴). provider public 명은 그대로 — 이건
+                        // 소비자 청크 로컬명일 뿐이다. preserve-modules 한정(splitting 은 has_global 이라
+                        // need_dedup 가 애초에 false).
+                        if (options.preserve_modules) if (linker) |l| try l.putConsumerImportLocal(sym.canonical_module, sym.name, alias);
+                        break :blk alias;
+                    } else binding;
+
                     if (!std.mem.eql(u8, key, binding)) {
-                        // key != binding(예약어 export 키 `default` → 소비자 local `_default`).
-                        // 좌변=dep 노출 키(문자열이라 예약어 OK), 우변=소비자 참조 식별자.
+                        // key != binding(예약어 export 키 `default` → 소비자 local `_default`/`foo`).
+                        // 좌변=dep 노출 키(문자열이라 예약어 OK), 우변=소비자 참조 식별자(deconflict 반영).
                         // 축약 `{ default }` 면 예약어를 바인딩으로 써 SyntaxError → alias 가 방지.
-                        // ⚠️ (#4576) binding(소비자 로컬)이 동명 다른 dep 와 충돌하는 케이스(동명
-                        // `export default`·`export { foo as tag }`)는 여기서 deconflict 안 한다 —
-                        // 여러 sub-issue(cjs/minify/aliased)가 얽혀 별도 후속.
                         try chunk_output.appendSlice(allocator, key);
                         try chunk_output.appendSlice(allocator, if (reg_like) ": " else " as ");
-                        try chunk_output.appendSlice(allocator, binding);
+                        try chunk_output.appendSlice(allocator, local);
+                    } else if (need_dedup) {
+                        // key == binding 이지만 로컬 충돌 → `key: key$N` / `key as key$N`.
+                        try chunk_output.appendSlice(allocator, key);
+                        try chunk_output.appendSlice(allocator, if (reg_like) ": " else " as ");
+                        try chunk_output.appendSlice(allocator, local);
                     } else {
-                        // key == binding → 축약. 단 같은 export 명이 여러 dep 에서 오면
-                        // 중복 로컬 선언 충돌 → 2번째부터 `key: key$N` deconfliction.
-                        // 전역 네이밍(has_global)/lazy 는 binding 이 이미 전역 deconflict
-                        // (`v`/`v$1`)라 `$N` 불필요(이중 deconflict 로 소비자 참조와 어긋남).
-                        const total = name_total_count.get(name) orelse 1;
-                        const seen_gop = try name_seen_count.getOrPut(allocator, name);
-                        if (!seen_gop.found_existing) seen_gop.value_ptr.* = 0;
-                        seen_gop.value_ptr.* += 1;
-                        const seen = seen_gop.value_ptr.*;
-
-                        if (total > 1 and seen > 1 and !lazy_local_keys and !has_global) {
-                            const alias = try std.fmt.allocPrint(allocator, "{s}${d}", .{ key, seen });
-                            try alias_strs.append(allocator, alias);
-                            try chunk_output.appendSlice(allocator, key);
-                            try chunk_output.appendSlice(allocator, if (reg_like) ": " else " as ");
-                            try chunk_output.appendSlice(allocator, alias);
-                            // (#4572) 소비자-로컬 deconflict 이름(`tag$3`)을 맵에 적어, 뒤이어 도는
-                            // buildMetadataForAst 의 effective_target 이 body 참조를 같은 이름으로
-                            // 맞추게 한다(안 하면 body 는 crossChunkBindingName=`tag` 로 붕괴). provider
-                            // public 명은 그대로 — 이건 소비자 청크 로컬명일 뿐이다. preserve-modules 한정
-                            // (splitting 은 전역명이 있어 이 `$N` 브랜치 자체를 안 탄다 — 명시 게이트).
-                            if (options.preserve_modules) if (linker) |l| try l.putConsumerImportLocal(sym.canonical_module, sym.name, alias);
-                        } else {
-                            try chunk_output.appendSlice(allocator, key);
-                        }
+                        // key == binding, 충돌 없음 → 축약 `{ key }`.
+                        try chunk_output.appendSlice(allocator, key);
                     }
                     if (si + 1 < symbols.?.items.len) {
                         if (!options.minify_whitespace) {

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -82,6 +82,36 @@ fn crossChunkBindingName(linker: ?*Linker, sym: chunk_mod.CrossChunkSym) []const
     return sym.name;
 }
 
+/// (#4576) 소비자 청크에서 `binding` 에 대한 **유일** 로컬명을 발급한다. 아직 안 쓰였으면 binding
+/// 그대로, 이미 쓰였으면 `binding$N`(N=2,3,…) 중 `used_locals`(선언됨)·`natural_bindings`(다른 binding
+/// 의 자연명)에 없는 첫 이름. per-binding 카운터로는 다른 그룹의 자연 `$N`(또는 사용자 `foo$2`)과
+/// 충돌하므로(#4576 리뷰 [0]) 반드시 집합으로 유일성을 판정한다.
+/// 반환은 borrowed(binding, 안정 slice) 또는 `alias_strs` 소유 slice(둘 다 청크 수명) — used_locals 는
+/// 둘 다 borrow 만 하고 테이블만 deinit. has_global/lazy 로 이름이 고정된 심볼은 호출 전에 예약해 둔다.
+fn mintConsumerLocal(
+    allocator: std.mem.Allocator,
+    binding: []const u8,
+    used_locals: *std.StringHashMapUnmanaged(void),
+    natural_bindings: *const std.StringHashMapUnmanaged(void),
+    alias_strs: *std.ArrayList([]const u8),
+) ![]const u8 {
+    if (!used_locals.contains(binding)) {
+        try used_locals.put(allocator, binding, {});
+        return binding;
+    }
+    var n: u32 = 2;
+    while (true) : (n += 1) {
+        const cand = try std.fmt.allocPrint(allocator, "{s}${d}", .{ binding, n });
+        if (used_locals.contains(cand) or natural_bindings.contains(cand)) {
+            allocator.free(cand);
+            continue;
+        }
+        try alias_strs.append(allocator, cand);
+        try used_locals.put(allocator, cand, {});
+        return cand;
+    }
+}
+
 /// cross-chunk export 의 **provider 측 로컬명**(이 청크에 선언된 실제 식별자, 전역 public 의
 /// RHS). owner 모듈 `mi` 가 export `name` 을 어떤 로컬로 들고 있는지 해석한다.
 /// - namespace re-export(`export * as X`)는 로컬 심볼이 elided 라 canonical 이 빗나간다 → 청크에
@@ -502,26 +532,28 @@ pub fn emitChunks(
         // (#4572) 이 청크 소비자-로컬 import 이름 오버라이드 맵을 리셋(직전 청크 잔재 제거).
         if (linker) |l| l.clearConsumerImportLocal();
         // (#4576) 선언되는 소비자-로컬은 항상 **binding**(crossChunkBindingName)이다 — export 명이
-        // 아니라. 동명 `export default`(key=`default`, binding=`foo`/`_default`)처럼 export 명과
-        // 로컬명이 다르면 name-keyed 로 세면 충돌을 놓친다(→ `import { default as foo }` 이중선언
-        // SyntaxError). binding-keyed 로 통일해 두 분기(`key==binding` 축약 / `key!=binding` alias)
-        // 모두에서 로컬 충돌을 deconflict 한다.
-        var binding_total_count: std.StringHashMapUnmanaged(u32) = .empty;
-        defer binding_total_count.deinit(allocator);
+        // 아니라. 동명 export(특히 `export default`, key=`default`≠binding)면 여러 dep 이 같은 로컬을
+        // 선언해 SyntaxError. 올바른 해소는 esbuild/rollup 리네이머처럼 **이미 쓰인 이름 집합**으로
+        // 유일 이름을 발급하는 것 — per-binding 카운터는 다른 binding 의 자연 `$N` 이름(또는 사용자
+        // 심볼 `foo$2`)과 충돌해 전역 유일성을 못 지킨다(#4576 리뷰 [0][1]).
+        //   · natural_bindings: imports_from 의 모든 binding 이름 집합. dedup 이름 발급 시 다른 binding
+        //     의 자연명을 침범하지 않도록 skip 판정에 쓴다([0]).
+        //   · used_locals: 이 청크에 실제 선언된 로컬명. has_global(전역명 고정)/lazy 는 이름을 못 바꾸니
+        //     **먼저** 예약해, 비-global 로컬이 그 이름과 충돌하면 deconflict 되게 한다([1] 순서-의존).
+        var natural_bindings: std.StringHashMapUnmanaged(void) = .empty;
+        defer natural_bindings.deinit(allocator);
+        var used_locals: std.StringHashMapUnmanaged(void) = .empty;
+        defer used_locals.deinit(allocator);
         for (chunk.cross_chunk_imports.items) |dep_chunk_idx| {
             const dep_ci = @intFromEnum(dep_chunk_idx);
-            if (chunk.imports_from.get(dep_ci)) |syms| {
-                for (syms.items) |sym| {
-                    const gop = try binding_total_count.getOrPut(allocator, crossChunkBindingName(linker, sym));
-                    if (!gop.found_existing) gop.value_ptr.* = 0;
-                    gop.value_ptr.* += 1;
-                }
+            const syms = chunk.imports_from.get(dep_ci) orelse continue;
+            for (syms.items) |sym| {
+                const b = crossChunkBindingName(linker, sym);
+                try natural_bindings.put(allocator, b, {});
+                const hg = if (linker) |l| l.getCrossChunkGlobalName(sym.canonical_module, sym.name) != null else false;
+                if (hg) try used_locals.put(allocator, b, {});
             }
         }
-
-        // 2단계: import 문 생성 (중복 로컬명은 alias 부여)
-        var binding_seen_count: std.StringHashMapUnmanaged(u32) = .empty;
-        defer binding_seen_count.deinit(allocator);
 
         // alias 문자열을 임시 저장 (defer free)
         var alias_strs: std.ArrayList([]const u8) = .empty;
@@ -703,17 +735,11 @@ pub fn emitChunks(
                             const bind = crossChunkBindingName(linker, sym);
                             const global_name: ?[]const u8 = if (linker) |l| l.getCrossChunkGlobalName(sym.canonical_module, sym.name) else null;
                             const has_g = global_name != null;
-                            // (#4576) import 블록과 **같은** binding-keyed count 를 써야 `$N` 이
-                            // 일치한다(esm=import 블록 / cjs ESM-wrap=여기, dep 단위 상호배타·count 공유).
-                            const total = binding_total_count.get(bind) orelse 1;
-                            const seen_gop = try binding_seen_count.getOrPut(allocator, bind);
-                            if (!seen_gop.found_existing) seen_gop.value_ptr.* = 0;
-                            seen_gop.value_ptr.* += 1;
-                            const seen = seen_gop.value_ptr.*;
-                            const local = if (total > 1 and seen > 1 and !has_g)
-                                try std.fmt.allocPrint(allocator, "{s}${d}", .{ bind, seen })
-                            else
-                                try allocator.dupe(u8, bind);
+                            // (#4576) import 블록과 **같은** used_locals 로 유일 로컬 발급(esm=import 블록 /
+                            // cjs ESM-wrap=여기, dep 단위 상호배타·집합 공유). has_g 는 전역명 고정(pre-pass
+                            // 예약). 발급은 청크 수명 slice → pm_locals 는 항목을 free 하므로 owned 복사.
+                            const mint = if (has_g) bind else try mintConsumerLocal(allocator, bind, &used_locals, &natural_bindings, &alias_strs);
+                            const local = try allocator.dupe(u8, mint);
                             try pm_locals.append(allocator, local);
                             // read = 전역명(있으면 provider 가 `exports.<global>`) 아니면 export 명(sym.name,
                             // provider 가 `exports.<export명>`). crossChunkBindingName 은 reserved-name 이
@@ -870,42 +896,29 @@ pub fn emitChunks(
                     const has_global = if (linker) |l| l.getCrossChunkGlobalName(sym.canonical_module, sym.name) != null else false;
                     const key = if (lazy_local_keys or has_global) binding else name;
 
-                    // (#4572/#4576) 선언되는 소비자-로컬은 항상 **binding**. 같은 binding 이 여러 dep
-                    // 에서 오면(동명 named export=#4572, 동명 `export default`=#4576, 두 분기 혼합) 2번째
-                    // 부터 `binding$N` 로 deconflict. 전역 네이밍(has_global)/lazy 는 binding 이 이미 전역
-                    // deconflict(`v`/`v$1`)라 `$N` 불필요(이중 deconflict 로 소비자 참조와 어긋남).
-                    const total = binding_total_count.get(binding) orelse 1;
-                    const seen_gop = try binding_seen_count.getOrPut(allocator, binding);
-                    if (!seen_gop.found_existing) seen_gop.value_ptr.* = 0;
-                    seen_gop.value_ptr.* += 1;
-                    const seen = seen_gop.value_ptr.*;
-                    const need_dedup = total > 1 and seen > 1 and !lazy_local_keys and !has_global;
-                    const local = if (need_dedup) blk: {
-                        const alias = try std.fmt.allocPrint(allocator, "{s}${d}", .{ binding, seen });
-                        try alias_strs.append(allocator, alias);
-                        // 소비자-로컬 deconflict 이름을 맵에 적어, 뒤이어 도는 buildMetadataForAst 의
-                        // effective_target 이 body 참조를 같은 이름으로 맞추게 한다(안 하면 body 는
-                        // crossChunkBindingName=`binding` 으로 붕괴). provider public 명은 그대로 — 이건
-                        // 소비자 청크 로컬명일 뿐이다. preserve-modules 한정(splitting 은 has_global 이라
-                        // need_dedup 가 애초에 false).
-                        if (options.preserve_modules) if (linker) |l| try l.putConsumerImportLocal(sym.canonical_module, sym.name, alias);
-                        break :blk alias;
-                    } else binding;
+                    // (#4572/#4576) 선언되는 소비자-로컬은 항상 binding. has_global/lazy 는 이름이 고정
+                    // (전역명·lazy export 키)이라 그대로 쓰고 pre-pass 에서 이미 예약됨. 그 외는
+                    // mintConsumerLocal 로 유일 이름 발급 — 이미 쓰였으면 `binding$N`(집합 판정).
+                    const local = if (lazy_local_keys or has_global)
+                        binding
+                    else
+                        try mintConsumerLocal(allocator, binding, &used_locals, &natural_bindings, &alias_strs);
+                    // 발급이 binding 과 다르면(=deconflict) consumer_import_local 맵에 적어 body 참조
+                    // (effective_target)를 맞춘다 — 안 하면 crossChunkBindingName=binding 으로 붕괴. provider
+                    // public 명은 그대로(소비자 청크 로컬명일 뿐). preserve-modules 한정(splitting 은
+                    // has_global 이라 여기 안 옴).
+                    if (!std.mem.eql(u8, local, binding)) {
+                        if (options.preserve_modules) if (linker) |l| try l.putConsumerImportLocal(sym.canonical_module, sym.name, local);
+                    }
 
-                    if (!std.mem.eql(u8, key, binding)) {
-                        // key != binding(예약어 export 키 `default` → 소비자 local `_default`/`foo`).
-                        // 좌변=dep 노출 키(문자열이라 예약어 OK), 우변=소비자 참조 식별자(deconflict 반영).
-                        // 축약 `{ default }` 면 예약어를 바인딩으로 써 SyntaxError → alias 가 방지.
-                        try chunk_output.appendSlice(allocator, key);
-                        try chunk_output.appendSlice(allocator, if (reg_like) ": " else " as ");
-                        try chunk_output.appendSlice(allocator, local);
-                    } else if (need_dedup) {
-                        // key == binding 이지만 로컬 충돌 → `key: key$N` / `key as key$N`.
+                    if (!std.mem.eql(u8, key, local)) {
+                        // key != local → `key: local` / `key as local`. key!=binding(예약어 export 키
+                        // `default`→소비자 local) 또는 deconflict(`binding$N`) 모두 alias 로 방출.
                         try chunk_output.appendSlice(allocator, key);
                         try chunk_output.appendSlice(allocator, if (reg_like) ": " else " as ");
                         try chunk_output.appendSlice(allocator, local);
                     } else {
-                        // key == binding, 충돌 없음 → 축약 `{ key }`.
+                        // key == local → 축약 `{ key }`.
                         try chunk_output.appendSlice(allocator, key);
                     }
                     if (si + 1 < symbols.?.items.len) {

--- a/tests/integration/tests/preserve-modules-samename-default.test.ts
+++ b/tests/integration/tests/preserve-modules-samename-default.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync, readFileSync } from 'node:fs';
+import { createFixture, runNode, runZntc } from './helpers';
+
+/**
+ * #4576 — preserve-modules 에서 서로 다른 파일이 **같은 로컬명으로 `export default`** 하고
+ * 한 소비자가 둘 다 default import 하면, 소비자 import 블록이 `import { default as foo }` 를
+ * 두 번 방출해 `Identifier 'foo' has already been declared`(SyntaxError)로 파싱 실패.
+ *
+ * 근본: 소비자 import 블록(chunks.zig)의 `$N` deconflict 는 `key == binding` 분기에서만 했다.
+ * default 는 key=`default`, binding=`foo`(또는 익명 `_default`)라 `key != binding` 분기로 가는데
+ * 거기서 deconflict 를 안 해 로컬명이 중복. 수정: 선언 로컬은 항상 binding 이므로 count 를
+ * **binding-keyed 로 통일** + `key != binding` 분기도 binding 충돌 시 `binding$N` deconflict +
+ * consumer_import_local(#4572) 맵에 기록해 body 참조를 맞춘다.
+ *
+ * ⚠️ 별개 선행 버그(이 PR 범위 밖, 별도 후속):
+ *  - `--minify-identifiers`: mangler 가 소비자 default import local 은 개명하는데 body 참조는 다른
+ *    심볼로 취급해 발산(silent). #4576 fix 유무와 무관(main 도 동일).
+ *  - cjs: `module.exports = foo` provider 를 소비자가 `{ default: foo }` 로 구조분해하는 default
+ *    interop 오류. 단일 default 도 실패(중복과 무관). #4576 fix 로 **중복선언 SyntaxError 는 제거**
+ *    되지만 interop 오류는 남는다 → 아래 cjs 테스트는 중복-제거(emit)만 검증한다.
+ */
+
+async function buildPmEsm(files: Record<string, string>, minifyFlags: string[]) {
+  const { dir, cleanup } = await createFixture(files);
+  const outDir = join(dir, 'dist');
+  const res = await runZntc([
+    '--bundle',
+    join(dir, 'entry.js'),
+    '--preserve-modules',
+    `--preserve-modules-root=${dir}`,
+    '--outdir',
+    outDir,
+    '--format=esm',
+    ...minifyFlags,
+  ]);
+  if (res.exitCode !== 0) {
+    await cleanup();
+    throw new Error(`빌드 실패:\n${res.stderr}`);
+  }
+  writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+  return { outDir, cleanup };
+}
+
+// identifier mangling 은 별개 선행 버그라 제외. whitespace/syntax 는 정상 동작.
+const ESM_VARIANTS: Array<{ label: string; flags: string[] }> = [
+  { label: 'plain', flags: [] },
+  { label: 'minify-whitespace', flags: ['--minify-whitespace'] },
+  { label: 'minify-syntax', flags: ['--minify-syntax'] },
+];
+
+const CASES: Array<{ name: string; files: Record<string, string>; expect: string }> = [
+  {
+    name: 'named default 동명 foo',
+    files: {
+      'm1.js': 'export default function foo(){ return "D1"; }',
+      'm2.js': 'export default function foo(){ return "D2"; }',
+      'entry.js': 'import a from "./m1.js";\nimport b from "./m2.js";\nconsole.log(a() + b());',
+    },
+    expect: 'D1D2',
+  },
+  {
+    name: '익명 default 동명 (_default)',
+    files: {
+      'm1.js': 'export default function(){ return "A1"; }',
+      'm2.js': 'export default function(){ return "A2"; }',
+      'entry.js': 'import a from "./m1.js";\nimport b from "./m2.js";\nconsole.log(a() + b());',
+    },
+    expect: 'A1A2',
+  },
+  {
+    name: 'cross-branch named(key==binding) + default(key!=binding) 동명',
+    files: {
+      'm1.js': 'export const foo = () => "N1";',
+      'm2.js': 'export default function foo(){ return "D2"; }',
+      'entry.js':
+        'import { foo } from "./m1.js";\nimport d from "./m2.js";\nconsole.log(foo() + d());',
+    },
+    expect: 'N1D2',
+  },
+  {
+    name: '3-way: 충돌 2 + 비충돌 1',
+    files: {
+      'm1.js': 'export default function foo(){ return "1"; }',
+      'm2.js': 'export default function foo(){ return "2"; }',
+      'm3.js': 'export default function bar(){ return "3"; }',
+      'entry.js':
+        'import a from "./m1.js";\nimport b from "./m2.js";\nimport c from "./m3.js";\nconsole.log(a() + b() + c());',
+    },
+    expect: '123',
+  },
+];
+
+describe('#4576: preserve-modules 동명 export default deconflict (esm)', () => {
+  for (const c of CASES) {
+    for (const v of ESM_VARIANTS) {
+      test(`${c.name} [${v.label}]`, async () => {
+        const { outDir, cleanup } = await buildPmEsm(c.files, v.flags);
+        try {
+          const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+          expect(stderr).not.toContain('SyntaxError'); // 중복 선언
+          expect(stderr).not.toContain('ReferenceError');
+          expect(stdout.trim()).toBe(c.expect);
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+});
+
+/**
+ * cjs — #4576 fix 는 **중복 선언 자체를 제거**한다(로컬 `foo`/`foo$2`). 런타임은 별개의 cjs
+ * default interop 선행 버그로 실패하므로 여기선 emit 에 동일 로컬 이중 선언이 없음만 확인한다.
+ */
+describe('#4576: cjs 동명 default 는 중복 로컬 선언을 만들지 않는다', () => {
+  test('두 default → 서로 다른 로컬 (const 중복 없음)', async () => {
+    const { dir, cleanup } = await createFixture({
+      'm1.js': 'export default function foo(){ return "D1"; }',
+      'm2.js': 'export default function foo(){ return "D2"; }',
+      'entry.js': 'import a from "./m1.js";\nimport b from "./m2.js";\nconsole.log(a() + b());',
+    });
+    const outDir = join(dir, 'dist');
+    try {
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'entry.js'),
+        '--preserve-modules',
+        `--preserve-modules-root=${dir}`,
+        '--outdir',
+        outDir,
+        '--format=cjs',
+      ]);
+      expect(res.exitCode).toBe(0);
+      const entry = readFileSync(join(outDir, 'entry.js'), 'utf8');
+      // 같은 로컬명 `foo` 를 두 번 선언하면 SyntaxError. deconflict 되면 `foo` 는 1회,
+      // 나머지는 `foo$2`. `foo` 정확 매칭(뒤에 `$`/word 없음)이 2 이상이면 중복.
+      const fooDecls = entry.match(/default:\s*foo(?![\w$])/g) ?? [];
+      expect(fooDecls.length).toBeLessThanOrEqual(1);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/tests/integration/tests/preserve-modules-samename-default.test.ts
+++ b/tests/integration/tests/preserve-modules-samename-default.test.ts
@@ -90,6 +90,19 @@ const CASES: Array<{ name: string; files: Record<string, string>; expect: string
     },
     expect: '123',
   },
+  {
+    // 리뷰 [0]: dedup 이름(`foo$2`)이 **다른 심볼의 자연명** `foo$2` 와 충돌하면 안 됨.
+    // per-binding 카운터는 여기서 둘 다 `foo$2` 를 내 SyntaxError. used_locals 는 `foo$3` 로 회피.
+    name: 'dedup 이름이 자연 foo$2 심볼과 충돌 회피',
+    files: {
+      'm1.js': 'export default function foo(){ return "1"; }',
+      'm2.js': 'export default function foo(){ return "2"; }',
+      'm3.js': 'export function foo$2(){ return "3"; }',
+      'entry.js':
+        'import a from "./m1.js";\nimport b from "./m2.js";\nimport { foo$2 } from "./m3.js";\nconsole.log(a() + b() + foo$2());',
+    },
+    expect: '123',
+  },
 ];
 
 describe('#4576: preserve-modules 동명 export default deconflict (esm)', () => {
@@ -134,12 +147,53 @@ describe('#4576: cjs 동명 default 는 중복 로컬 선언을 만들지 않는
       ]);
       expect(res.exitCode).toBe(0);
       const entry = readFileSync(join(outDir, 'entry.js'), 'utf8');
-      // 같은 로컬명 `foo` 를 두 번 선언하면 SyntaxError. deconflict 되면 `foo` 는 1회,
-      // 나머지는 `foo$2`. `foo` 정확 매칭(뒤에 `$`/word 없음)이 2 이상이면 중복.
-      const fooDecls = entry.match(/default:\s*foo(?![\w$])/g) ?? [];
-      expect(fooDecls.length).toBeLessThanOrEqual(1);
+      // 같은 로컬명 `foo` 를 두 번 선언하면 SyntaxError. deconflict 되면 `foo` 는 정확히 1회,
+      // 두 번째는 `foo$2`. 두 조건 모두 단언(음성 vacuous 방지 — 출력이 사라져도 통과하면 안 됨).
+      const bareFoo = entry.match(/default:\s*foo(?![\w$])/g) ?? []; // 정확히 `foo`
+      const deconflicted = entry.match(/default:\s*foo\$\d+/g) ?? []; // `foo$2` 등
+      expect(bareFoo.length).toBe(1); // 정확히 1회 (0 이면 출력 소실, 2 면 중복)
+      expect(deconflicted.length).toBe(1); // 두 번째는 deconflict
     } finally {
       await cleanup();
     }
   });
+});
+
+/**
+ * 리뷰 [1]: ESM-wrap(전역명 고정) default 와 plain default 가 동명이면, wrap 쪽은 이름을 못 바꾸므로
+ * plain 쪽이 deconflict 돼야 한다. import 순서와 무관하게 성립해야 함(pre-pass 로 전역명 예약).
+ */
+describe('#4576: 전역명 고정 default + plain default 동명 (순서 무관)', () => {
+  for (const wrapFirst of [false, true]) {
+    test(`plain deconflict [wrap ${wrapFirst ? '먼저' : '나중'}]`, async () => {
+      const imports = wrapFirst
+        ? 'import w from "./wrap.js";\nimport p from "./plain.js";'
+        : 'import p from "./plain.js";\nimport w from "./wrap.js";';
+      const { dir, cleanup } = await createFixture({
+        'plain.js': 'export default function foo(){ return "P"; }',
+        'wrap.js': 'export default function foo(){ return "W"; }',
+        'a.cjs': 'module.exports = require("./wrap.js");', // wrap 을 ESM-wrap 강제(전역명 부여)
+        'entry.js': `${imports}\nimport "./a.cjs";\nconsole.log(p() + w());`,
+      });
+      const outDir = join(dir, 'dist');
+      try {
+        const res = await runZntc([
+          '--bundle',
+          join(dir, 'entry.js'),
+          '--preserve-modules',
+          `--preserve-modules-root=${dir}`,
+          '--outdir',
+          outDir,
+          '--format=esm',
+        ]);
+        expect(res.exitCode).toBe(0);
+        writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+        const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+        expect(stderr).not.toContain('SyntaxError');
+        expect(stdout.trim()).toBe('PW');
+      } finally {
+        await cleanup();
+      }
+    });
+  }
 });


### PR DESCRIPTION
## 문제

`--preserve-modules` 에서 서로 다른 파일이 **같은 로컬명으로 `export default`** 하고 한 소비자가 둘 다 default import 하면 `SyntaxError: Identifier 'foo' has already been declared` 로 파싱 실패.

```js
// m1.js: export default function foo(){ return "D1"; }
// m2.js: export default function foo(){ return "D2"; }
// entry: import a from "./m1.js"; import b from "./m2.js"; console.log(a() + b());
```

방출(esm)이 `import { default as foo }` 를 두 번 내 `foo` 중복 선언으로 깨졌다.

## 근본

소비자 import 블록(chunks.zig)의 `$N` deconflict 가 **`key == binding`** 분기에서만 동작. default 는 key=`default`, binding=`foo`(익명 `_default`)라 **`key != binding` 분기**로 가는데 그 분기가 deconflict 를 안 해 로컬명이 여러 dep 에서 중복. #4572(named 동명)와 같은 계열이지만 emit 분기가 다르다.

## 수정

**선언되는 소비자-로컬은 항상 binding** 이므로, esbuild/rollup 리네이머처럼 소비자 청크의 **"이미 쓰인 로컬명" 집합(`used_locals`)으로 유일 이름을 발급**한다(`mintConsumerLocal`): 비었으면 binding, 이미 쓰였으면 `binding$N`(집합에 없는 첫 이름). 두 emit 분기와 ESM-wrap `let X;` forwarding(#4528)이 같은 집합을 공유. deconflict 된 이름은 `consumer_import_local`(#4572) 맵에 기록해 body 참조를 맞춘다. `export const foo` + `export default function foo` cross-branch 충돌도 해소.

## `/code-review max` 반영

초기 커밋(per-binding 카운터, ee3c8b5b)에서 리뷰가 두 correctness 회귀를 짚어 집합 기반(7e28f5de)으로 재설계:
- **[0]** dedup `binding$N` 이 다른 binding 의 자연 `$N` 명(또는 사용자 `foo$2`)과 충돌해 SyntaxError 재발(재현) → `used_locals`+자연명 집합으로 유일성 판정(`foo$3` 로 회피).
- **[1]** `!has_global` 게이트가 전역명 고정 default 를 dedup 에서 제외해 plain default 와 순서-의존 중복(재현) → 고정명 pre-pass 예약해 순서 무관 해소.
- **[2]** 중복 alias 분기 → `key != local` 단일 분기 병합. **[3]** cjs 테스트 positive 단언 추가.

## 검증

- `preserve-modules-samename-default.test.ts` **18종**: named/익명 default·cross-branch·3-way·**[0]** 자연 `foo$2` 충돌 회피(`123`)·**[1]** 전역명+plain 동명(import 순서 무관 `PW`) — esm plain/whitespace/syntax minify. cjs 는 중복 로컬 선언 없음+deconflict emit 확인.
- 직접 실행으로 [0]`123`·[1]`PW` 검증. preserve-modules 160·cross-chunk/splitting/wrapper 186 통합 + zig 전체 무회귀.

## 별개 선행 버그(별도 후속)

- **#4579** `--minify-identifiers`: mangler 가 소비자 default import 로컬은 개명·body 참조는 발산(silent). 이 fix 유무 무관(main 도 동일).
- **#4580** cjs default interop: `module.exports = X` provider 를 `{ default: X }` 로 구조분해. 단일 default 도 실패(중복과 무관). 이 fix 로 cjs 중복선언 SyntaxError 는 제거되나 interop 은 별도.

Refs #4576

🤖 Generated with [Claude Code](https://claude.com/claude-code)