### PR TITLE
fix(bundler): #4579 preserve-modules minify default import body 참조 발산

### DIFF
--- a/.changeset/preserve-modules-minify-default-ref.md
+++ b/.changeset/preserve-modules-minify-default-ref.md
@@ -21,11 +21,16 @@ default 는 안정된 public export 명이 없어(`module.exports = X`) provider
 
 ## 수정
 
-import 블록은 rename_table 이 유효한 시점에 이미 올바른 provider-mangled 로컬(`t`)을 구한다. 이를 `deconflictedConsumerLocal` 에서 **항상** `consumer_import_local`(#4576) 에 기록하도록 바꿔(기존엔 deconflict `local != binding` 일 때만), body 의 effective_target 이 그 값을 읽어 정합시킨다. import 문이 body 참조의 유일 권위.
+import 블록은 rename_table 이 유효한 시점에 이미 올바른 provider-mangled 로컬(`t`)을 구한다. 이를 `deconflictedConsumerLocal` 에서 **무조건** `consumer_import_local`(#4576) 에 기록하도록 바꿔(기존엔 deconflict `local != binding` 일 때만), body 의 effective_target 이 그 값을 읽어 정합시킨다. import 문이 body 참조의 유일 권위. write 는 read(metadata.zig)와 같은 `preserve_modules` 게이트라 splitting 은 생략(낭비 방지).
 
 이 fix 로 #4576(동명 default)·#4580(default interop) 의 `--minify` 도 함께 풀린다(그 PR 들이 남긴 minify 한계 해소).
 
 ## 검증
 
-- 회귀 스위트 `preserve-modules-minify-default-ref.test.ts` 8종: 단일 default·동명 default 2개·default+named·default class × esm/cjs, 전부 `--minify` 로 정확한 출력.
-- preserve-modules·cross-chunk·splitting·wrapper 통합 310 + zig 전체 무회귀.
+- 회귀 스위트 `preserve-modules-minify-default-ref.test.ts` **16종**: 단일 default·동명 default 2개·default+named·default class × esm/cjs × **minify/non-minify**(always-write 가 non-minify 도 건드리므로 양쪽 가드).
+- preserve-modules·cross-chunk·splitting·wrapper 통합 326 + zig 전체 무회귀.
+
+## `/code-review max` 반영
+
+- **[3]** 무조건 write 를 `preserve_modules` 게이트로(splitting 은 read 가 gated 라 write 도 낭비 → 생략).
+- **[0]** 테스트에 non-minify 케이스 추가. **[1]** dead stderr 단언 제거(runNode 가 non-zero exit 시 throw → stdout 단언+throw 가 실제 가드). **[2]** 실패 경로 temp-dir 누수 → try/finally.

--- a/.changeset/preserve-modules-minify-default-ref.md
+++ b/.changeset/preserve-modules-minify-default-ref.md
@@ -1,0 +1,31 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules --minify`(또는 `--minify-identifiers`)에서 소비자의 **default import** body 참조가 발산해 `foo is not defined`/`TypeError` 로 실패하던 것 수정 (#4579).
+
+```js
+// m1.js: export default function foo(){ return "D1"; }
+// entry: import a from "./m1.js"; console.log(a());
+// (minify) → const t = require("./m1.js"); console.log(foo());  // ← import=t, body=foo 발산
+```
+
+## 근본 (per-chunk rename_table 타이밍)
+
+import 문 로컬명과 body 참조 둘 다 `resolveToLocalName(provider,"default")` → `rename_table` 을 읽는다. 그런데 `computeRenamesForModules` 는 **청크마다** 맨 처음 `clearCanonicalNames()` 로 `rename_table` 을 비우고 현재 청크만 다시 mangle 한다.
+
+- **import 블록**은 그 clear **전**에 방출돼 provider(m1) 청크의 mangle `foo→t` 를 본다 → `t`.
+- **body 참조**(effective_target)는 소비자 청크 emit 중(clear **후**)에 계산돼 m1 의 mangle 이 wipe된 stale `rename_table` 을 읽는다 → 원본 `foo`.
+
+default 는 안정된 public export 명이 없어(`module.exports = X`) provider 의 **로컬명**을 써야 하므로 특히 발산한다(named import 는 public 명 `exports.foo` 라 무영향). splitting 은 cross-chunk 전역명이 있어 무영향.
+
+## 수정
+
+import 블록은 rename_table 이 유효한 시점에 이미 올바른 provider-mangled 로컬(`t`)을 구한다. 이를 `deconflictedConsumerLocal` 에서 **항상** `consumer_import_local`(#4576) 에 기록하도록 바꿔(기존엔 deconflict `local != binding` 일 때만), body 의 effective_target 이 그 값을 읽어 정합시킨다. import 문이 body 참조의 유일 권위.
+
+이 fix 로 #4576(동명 default)·#4580(default interop) 의 `--minify` 도 함께 풀린다(그 PR 들이 남긴 minify 한계 해소).
+
+## 검증
+
+- 회귀 스위트 `preserve-modules-minify-default-ref.test.ts` 8종: 단일 default·동명 default 2개·default+named·default class × esm/cjs, 전부 `--minify` 로 정확한 출력.
+- preserve-modules·cross-chunk·splitting·wrapper 통합 310 + zig 전체 무회귀.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -114,13 +114,15 @@ fn mintConsumerLocal(
 
 /// (#4572/#4576/#4580/#4579) 소비자 청크에서 `sym` 의 로컬명을 발급하고 body 참조를 정합시킨다.
 /// `fixed`(has_global/lazy → 이름 고정)면 binding 그대로, 아니면 mintConsumerLocal 로 유일 발급.
-/// 발급한 로컬을 **항상** `consumer_import_local` 에 적어, 뒤이어 도는 buildMetadataForAst 의
-/// effective_target 이 body 참조를 그 로컬로 맞추게 한다. import 문(여기)이 body 참조의 유일 권위다.
+/// 발급한 로컬을 preserve-modules 일 때 `consumer_import_local` 에 적어, 뒤이어 도는 buildMetadataForAst
+/// 의 effective_target 이 body 참조를 그 로컬로 맞추게 한다. import 문(여기)이 body 참조의 유일 권위다.
 /// ⚠️ (#4579) deconflict 됐을 때만 적으면, minify-identifiers 서 body 의 fallback(target_name)이
 /// provider **원본** 로컬명을, import 문은 crossChunkBindingName=provider **mangled** 로컬명을 써 발산
 /// (`const t=require();foo()` → foo undefined). default 는 public 명이 없어(=`module.exports=X`) 특히
-/// 그렇다. 항상 기록으로 둘을 강제 일치시킨다. read 는 preserve-modules 게이트라(metadata.zig)
-/// splitting 무해(write 만). symbol-level import 블록과 #4580 default 전체바인딩 두 site 공용.
+/// 그렇다. **무조건** 기록으로 둘을 강제 일치시킨다(원인=per-chunk rename_table 이 clearCanonicalNames
+/// 로 청크 사이 wipe돼 body path 가 provider mangle 을 못 봄). read(metadata.zig)와 같은 preserve_modules
+/// 게이트라 splitting 은 write 도 생략(낭비 방지·gate 를 write 와 co-locate).
+/// symbol-level import 블록과 #4580 default 전체바인딩 두 site 공용.
 fn deconflictedConsumerLocal(
     linker: ?*Linker,
     sym: chunk_mod.CrossChunkSym,
@@ -135,7 +137,9 @@ fn deconflictedConsumerLocal(
         binding
     else
         try mintConsumerLocal(allocator, binding, used_locals, natural_bindings, alias_strs);
-    if (linker) |l| try l.putConsumerImportLocal(sym.canonical_module, sym.name, local);
+    if (linker) |l| {
+        if (l.graph.preserve_modules) try l.putConsumerImportLocal(sym.canonical_module, sym.name, local);
+    }
     return local;
 }
 

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -112,12 +112,15 @@ fn mintConsumerLocal(
     }
 }
 
-/// (#4572/#4576/#4580) 소비자 청크에서 `sym` 의 로컬명을 발급하고 body 참조를 정합시킨다.
+/// (#4572/#4576/#4580/#4579) 소비자 청크에서 `sym` 의 로컬명을 발급하고 body 참조를 정합시킨다.
 /// `fixed`(has_global/lazy → 이름 고정)면 binding 그대로, 아니면 mintConsumerLocal 로 유일 발급.
-/// 발급이 binding 과 다르면(=deconflict) `consumer_import_local` 에 적어 뒤이어 도는 buildMetadataForAst
-/// 의 effective_target 이 body 를 같은 이름으로 맞추게 한다(안 하면 crossChunkBindingName=binding 으로
-/// 붕괴). 기록의 read 는 preserve-modules 게이트라(metadata.zig) splitting 에선 무해(write 만).
-/// symbol-level import 블록과 #4580 default 전체바인딩 두 site 공용 — 정책 발산 방지.
+/// 발급한 로컬을 **항상** `consumer_import_local` 에 적어, 뒤이어 도는 buildMetadataForAst 의
+/// effective_target 이 body 참조를 그 로컬로 맞추게 한다. import 문(여기)이 body 참조의 유일 권위다.
+/// ⚠️ (#4579) deconflict 됐을 때만 적으면, minify-identifiers 서 body 의 fallback(target_name)이
+/// provider **원본** 로컬명을, import 문은 crossChunkBindingName=provider **mangled** 로컬명을 써 발산
+/// (`const t=require();foo()` → foo undefined). default 는 public 명이 없어(=`module.exports=X`) 특히
+/// 그렇다. 항상 기록으로 둘을 강제 일치시킨다. read 는 preserve-modules 게이트라(metadata.zig)
+/// splitting 무해(write 만). symbol-level import 블록과 #4580 default 전체바인딩 두 site 공용.
 fn deconflictedConsumerLocal(
     linker: ?*Linker,
     sym: chunk_mod.CrossChunkSym,
@@ -132,9 +135,7 @@ fn deconflictedConsumerLocal(
         binding
     else
         try mintConsumerLocal(allocator, binding, used_locals, natural_bindings, alias_strs);
-    if (!std.mem.eql(u8, local, binding)) {
-        if (linker) |l| try l.putConsumerImportLocal(sym.canonical_module, sym.name, local);
-    }
+    if (linker) |l| try l.putConsumerImportLocal(sym.canonical_module, sym.name, local);
     return local;
 }
 

--- a/tests/integration/tests/preserve-modules-minify-default-ref.test.ts
+++ b/tests/integration/tests/preserve-modules-minify-default-ref.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { createFixture, runNode, runZntc } from './helpers';
+
+/**
+ * #4579 — `--preserve-modules --minify(-identifiers)` 에서 소비자의 **default import** body 참조가
+ * 발산해 실패하던 것 수정.
+ *
+ * 근본(타이밍): import 문 로컬명과 body 참조 둘 다 `resolveToLocalName(provider,"default")` →
+ * `rename_table` 을 읽는다. import 블록은 `computeRenamesForModules`(per-chunk `clearCanonicalNames`)
+ * **전**에 돌아 provider chunk 의 mangle(`foo→t`)을 보지만, body(effective_target, emitModule)는 **후**라
+ * provider mangle 이 wipe돼 stale 원본 `foo` 로 fallback → `const t=require();foo()` (foo undefined).
+ * default 는 public 명이 없어(`module.exports=X`) 특히 그렇다.
+ *
+ * 수정: import 블록이 이미 rename_table 유효 시점에 구한 로컬(`t`)을 **항상** `consumer_import_local`
+ * 에 기록해, body 의 effective_target 이 그 값을 읽어 정합시킨다(#4576 deconflict 시에만 기록하던 것을
+ * 무조건으로). 이 fix 로 #4576(동명 default)·#4580(default interop) 의 minify 도 함께 풀린다.
+ */
+
+async function buildRun(files: Record<string, string>, format: 'esm' | 'cjs') {
+  const { dir, cleanup } = await createFixture(files);
+  const outDir = join(dir, 'dist');
+  const res = await runZntc([
+    '--bundle',
+    join(dir, 'entry.js'),
+    '--preserve-modules',
+    `--preserve-modules-root=${dir}`,
+    '--outdir',
+    outDir,
+    `--format=${format}`,
+    '--minify',
+  ]);
+  if (res.exitCode !== 0) {
+    await cleanup();
+    throw new Error(`빌드 실패:\n${res.stderr}`);
+  }
+  writeFileSync(
+    join(outDir, 'package.json'),
+    JSON.stringify({ type: format === 'esm' ? 'module' : 'commonjs' }),
+  );
+  const out = await runNode(join(outDir, 'entry.js'));
+  await cleanup();
+  return out;
+}
+
+const FORMATS = ['esm', 'cjs'] as const;
+
+const CASES: Array<{ name: string; files: Record<string, string>; expect: string }> = [
+  {
+    name: '단일 default',
+    files: {
+      'm1.js': 'export default function foo(){ return "D1"; }',
+      'entry.js': 'import a from "./m1.js";\nconsole.log(a());',
+    },
+    expect: 'D1',
+  },
+  {
+    name: '동명 default 2개 (#4576 minify)',
+    files: {
+      'm1.js': 'export default function foo(){ return "D1"; }',
+      'm2.js': 'export default function foo(){ return "D2"; }',
+      'entry.js': 'import a from "./m1.js";\nimport b from "./m2.js";\nconsole.log(a() + b());',
+    },
+    expect: 'D1D2',
+  },
+  {
+    name: 'default + named',
+    files: {
+      'm1.js': 'export default function foo(){ return "D1"; }\nexport const bar = "B";',
+      'entry.js': 'import a, { bar } from "./m1.js";\nconsole.log(a() + bar);',
+    },
+    expect: 'D1B',
+  },
+  {
+    name: 'default class',
+    files: {
+      'm1.js': 'export default class Foo { greet(){ return "C"; } }',
+      'entry.js': 'import A from "./m1.js";\nconsole.log(new A().greet());',
+    },
+    expect: 'C',
+  },
+];
+
+describe('#4579: preserve-modules --minify default import body 참조 정합', () => {
+  for (const c of CASES) {
+    for (const format of FORMATS) {
+      test(`${c.name} [${format}]`, async () => {
+        const { stdout, stderr } = await buildRun(c.files, format);
+        expect(stderr).not.toContain('TypeError');
+        expect(stderr).not.toContain('ReferenceError');
+        expect(stderr).not.toContain('is not defined');
+        expect(stdout.trim()).toBe(c.expect);
+      });
+    }
+  }
+});

--- a/tests/integration/tests/preserve-modules-minify-default-ref.test.ts
+++ b/tests/integration/tests/preserve-modules-minify-default-ref.test.ts
@@ -13,38 +13,44 @@ import { createFixture, runNode, runZntc } from './helpers';
  * provider mangle 이 wipe돼 stale 원본 `foo` 로 fallback → `const t=require();foo()` (foo undefined).
  * default 는 public 명이 없어(`module.exports=X`) 특히 그렇다.
  *
- * 수정: import 블록이 이미 rename_table 유효 시점에 구한 로컬(`t`)을 **항상** `consumer_import_local`
- * 에 기록해, body 의 effective_target 이 그 값을 읽어 정합시킨다(#4576 deconflict 시에만 기록하던 것을
- * 무조건으로). 이 fix 로 #4576(동명 default)·#4580(default interop) 의 minify 도 함께 풀린다.
+ * 수정: import 블록이 이미 rename_table 유효 시점에 구한 로컬(`t`)을 **무조건** `consumer_import_local`
+ * 에 기록해(#4576 deconflict 시에만 → 무조건, preserve_modules 게이트), body 의 effective_target 이
+ * 그 값을 읽어 정합. 이 fix 로 #4576(동명 default)·#4580(default interop) 의 minify 도 함께 풀린다.
+ *
+ * ⚠️ 무조건 write 는 non-minify preserve-modules 에도 적용되므로(리뷰 [0]), minify/non-minify 양쪽을
+ *    검증해 always-write 회귀를 가드한다.
  */
 
-async function buildRun(files: Record<string, string>, format: 'esm' | 'cjs') {
+async function buildRun(files: Record<string, string>, format: 'esm' | 'cjs', minify: boolean) {
   const { dir, cleanup } = await createFixture(files);
-  const outDir = join(dir, 'dist');
-  const res = await runZntc([
-    '--bundle',
-    join(dir, 'entry.js'),
-    '--preserve-modules',
-    `--preserve-modules-root=${dir}`,
-    '--outdir',
-    outDir,
-    `--format=${format}`,
-    '--minify',
-  ]);
-  if (res.exitCode !== 0) {
+  try {
+    const outDir = join(dir, 'dist');
+    const res = await runZntc([
+      '--bundle',
+      join(dir, 'entry.js'),
+      '--preserve-modules',
+      `--preserve-modules-root=${dir}`,
+      '--outdir',
+      outDir,
+      `--format=${format}`,
+      ...(minify ? ['--minify'] : []),
+    ]);
+    if (res.exitCode !== 0) throw new Error(`빌드 실패:\n${res.stderr}`);
+    writeFileSync(
+      join(outDir, 'package.json'),
+      JSON.stringify({ type: format === 'esm' ? 'module' : 'commonjs' }),
+    );
+    // runNode 는 non-zero exit(런타임 ReferenceError/TypeError) 시 throw → 그 자체가 가드.
+    // exit-0 wrong-output 은 stdout 단언이 가드.
+    const { stdout } = await runNode(join(outDir, 'entry.js'));
+    return stdout.trim();
+  } finally {
     await cleanup();
-    throw new Error(`빌드 실패:\n${res.stderr}`);
   }
-  writeFileSync(
-    join(outDir, 'package.json'),
-    JSON.stringify({ type: format === 'esm' ? 'module' : 'commonjs' }),
-  );
-  const out = await runNode(join(outDir, 'entry.js'));
-  await cleanup();
-  return out;
 }
 
 const FORMATS = ['esm', 'cjs'] as const;
+const MINIFY = [false, true] as const;
 
 const CASES: Array<{ name: string; files: Record<string, string>; expect: string }> = [
   {
@@ -82,16 +88,14 @@ const CASES: Array<{ name: string; files: Record<string, string>; expect: string
   },
 ];
 
-describe('#4579: preserve-modules --minify default import body 참조 정합', () => {
+describe('#4579: preserve-modules default import body 참조 정합 (minify/non-minify)', () => {
   for (const c of CASES) {
     for (const format of FORMATS) {
-      test(`${c.name} [${format}]`, async () => {
-        const { stdout, stderr } = await buildRun(c.files, format);
-        expect(stderr).not.toContain('TypeError');
-        expect(stderr).not.toContain('ReferenceError');
-        expect(stderr).not.toContain('is not defined');
-        expect(stdout.trim()).toBe(c.expect);
-      });
+      for (const minify of MINIFY) {
+        test(`${c.name} [${format}${minify ? ' --minify' : ''}]`, async () => {
+          expect(await buildRun(c.files, format, minify)).toBe(c.expect);
+        });
+      }
     }
   }
 });


### PR DESCRIPTION
## 문제

`--preserve-modules --minify`(또는 `--minify-identifiers`)에서 소비자의 **default import** body 참조가 발산해 `foo is not defined`/`TypeError` 로 실패.

```js
// m1.js: export default function foo(){ return "D1"; }
// entry: import a from "./m1.js"; console.log(a());
// (minify) → const t = require("./m1.js"); console.log(foo());  // import=t, body=foo 발산
```

## 근본 (per-chunk rename_table 타이밍)

import 문 로컬명과 body 참조 둘 다 `resolveToLocalName(provider,"default")` → `rename_table` 을 읽는다. 그런데 `computeRenamesForModules` 는 **청크마다** 맨 처음 `clearCanonicalNames()` 로 `rename_table` 을 비우고 현재 청크만 다시 mangle 한다.

- **import 블록**은 그 clear **전**에 방출돼 provider(m1) 청크의 mangle `foo→t` 를 본다 → `t`.
- **body 참조**(effective_target, emitModule)는 소비자 청크 emit 중(clear **후**)이라 m1 의 mangle 이 wipe된 stale `rename_table` 을 읽는다 → 원본 `foo`.

default 는 안정된 public export 명이 없어(`module.exports = X`) provider 의 **로컬명**을 써야 하므로 특히 발산(named import 는 public 명 `exports.foo` 라 무영향, splitting 은 cross-chunk 전역명 있어 무영향). *(서브에이전트 트레이스로 확정)*

## 수정

import 블록은 rename_table 유효 시점에 이미 올바른 provider-mangled 로컬(`t`)을 구한다. 이를 `deconflictedConsumerLocal` 에서 **무조건** `consumer_import_local`(#4576) 에 기록(기존엔 deconflict 시에만)해, body 의 effective_target 이 그 값을 읽어 정합. import 문이 body 참조의 유일 권위. write 는 read 와 같은 `preserve_modules` 게이트.

**이 fix 로 #4576(동명 default)·#4580(default interop) 의 `--minify` 한계도 함께 해소된다.**

## `/code-review max` 반영

product code miscompile 없음. 4건 반영:
- **[3]** write 를 read 와 동일한 `preserve_modules` 게이트로(splitting 낭비 제거).
- **[0]** non-minify 케이스 추가(always-write 양쪽 가드). **[1]** dead stderr 단언 제거. **[2]** 실패 경로 temp-dir 누수 → try/finally.

## 검증

- `preserve-modules-minify-default-ref.test.ts` **16종**: 단일 default·동명 default 2개·default+named·default class × esm/cjs × minify/non-minify.
- preserve-modules·cross-chunk·splitting·wrapper 통합 326 + zig 전체 무회귀.

Closes #4579

🤖 Generated with [Claude Code](https://claude.com/claude-code)