### PR TITLE
fix(bundler): #4532 증상4 preserve-modules cjs 순환 function export live-binding

### DIFF
--- a/.changeset/preserve-modules-cjs-circular-fn.md
+++ b/.changeset/preserve-modules-cjs-circular-fn.md
@@ -1,0 +1,34 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules --format=cjs` 순환 import 에서 **function 선언 export** 가 소비자 로드 중 `undefined` 로 잡혀 `TypeError` 나던 것 수정 (#4532 증상4).
+
+```js
+// e1.js: import { b } from "./e2.js"; export function a(){ return "A"; }
+// e2.js: import { a } from "./e1.js"; export function b(){}  a();  // ← 로드 중 e1.a() 호출
+```
+
+## 근본
+
+cjs 는 `exports.a = a` 를 모듈 본문 **끝**(require 뒤)에 방출한다. 순환에서 e2 가 e1 을 require 하는 시점엔 e1 의 `exports.a = a` 가 아직 실행 전 → e2 의 `require("./e1.js").a` = undefined. ESM 은 function 선언이 hoisting 돼 live-binding 으로 항상 함수(`typeof a === "function"`). esm 출력은 정상이라 **cjs 전용**.
+
+## 수정
+
+unwrapped preserve-modules cjs 모듈의 **named function 선언 export** 를 `exports.<fn> = <local>;` 로 require 블록 **앞**에 hoist(function 은 스코프 상단으로 hoisting 되므로 참조 가능) + bottom 방출에서 제외(중복 방지).
+
+- 판정 `exportBindingIsHoistableFn`: 직접 `.local` 선언 + semantic `decl_flags.is_function`. re-export 는 소스가 자기 것 hoist 하므로 제외. default 는 `module.exports`/`exports.default` 모드 로직과 충돌해 제외.
+- 삽입은 `computeRenamesForModules` 후(리네임명 확정), `ns_preamble` insert 앞(위치 shift 방지). `ns_preamble_pos`/insertSlice 선례를 따름.
+- bottom 제외는 `emitCjsEntryExports` 에 hoisted-이름 집합 전달(같은 predicate 공유 → 발산 없음).
+- live getter(#4532 증상3 서 엣지 다수로 드롭)를 피하고 값 hoist 로 처리.
+
+## 검증
+
+- 회귀 스위트 `preserve-modules-cjs-circular-fn.test.ts` 6종: 다중-entry 순환 function 호출(esm/cjs × plain/minify)·default 병존 named 순환·non-circular(hoist 무해).
+- preserve-modules 189·cross-chunk/splitting/wrapper 186 통합 + zig 전체 무회귀.
+
+## 한계 (별개, 이 fix 범위 밖)
+
+- **소비자 자신의 import 가 TDZ**: 순환 중 paused 모듈의 `const { b } = require(...)` 는 아직 미초기화라, 그 모듈의 함수가 자기 import 를 참조하면 TDZ. 소비자-측 lazy 참조 필요(별개 층).
+- **const/let/class export** 는 hoisting 불가·ESM 도 순환서 TDZ 라 대상 아님.
+- **default 의 순환 접근** 은 `module.exports` bind-whole + partial 로 별개.

--- a/.changeset/preserve-modules-cjs-circular-fn.md
+++ b/.changeset/preserve-modules-cjs-circular-fn.md
@@ -27,6 +27,11 @@ unwrapped preserve-modules cjs 모듈의 **named function 선언 export** 를 `e
 - 회귀 스위트 `preserve-modules-cjs-circular-fn.test.ts` 6종: 다중-entry 순환 function 호출(esm/cjs × plain/minify)·default 병존 named 순환·non-circular(hoist 무해).
 - preserve-modules 189·cross-chunk/splitting/wrapper 186 통합 + zig 전체 무회귀.
 
+## `/code-review max` 반영
+
+- **[0]** hoist 게이트가 `output_exports` 를 안 봐 `--output-exports=none`/`default_` 에서도 `exports.fn=fn` 이 새던 것 → `.auto`/`.named` 로 게이트(hoist·skip 양쪽).
+- **[1][2]** `exports.X=X` 방출을 `appendCjsExportBinding(live=false, min=false)` 재사용으로 단일화 — 같은-파일 bottom(emitCjsEntryExports, minify 무시 ` = `/`;\n`)과 형식 일치.
+
 ## 한계 (별개, 이 fix 범위 밖)
 
 - **소비자 자신의 import 가 TDZ**: 순환 중 paused 모듈의 `const { b } = require(...)` 는 아직 미초기화라, 그 모듈의 함수가 자기 import 를 참조하면 TDZ. 소비자-측 lazy 참조 필요(별개 층).

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -2253,7 +2253,9 @@ pub fn emitModule(
             // (chunks.zig)하므로 여기 bottom 방출에서 제외(중복 방지). 같은 predicate 공유.
             var hoisted_fn_names: std.StringHashMapUnmanaged(void) = .empty;
             defer hoisted_fn_names.deinit(allocator);
-            if (options.preserve_modules and options.format == .cjs and module.wrap_kind == .none) {
+            if (options.preserve_modules and options.format == .cjs and module.wrap_kind == .none and
+                (options.output_exports == .auto or options.output_exports == .named))
+            {
                 for (module.export_bindings) |eb| {
                     if (chunks.exportBindingIsHoistableFn(module, eb)) {
                         try hoisted_fn_names.put(allocator, eb.exported_name, {});

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -2249,8 +2249,19 @@ pub fn emitModule(
             break :blk @as(?[]const u8, null);
         }
         if (options.format == .cjs or options.iife_split_factory) {
+            // (#4532 증상4) unwrapped pm-cjs 는 function-decl named export 를 require 앞에 hoist
+            // (chunks.zig)하므로 여기 bottom 방출에서 제외(중복 방지). 같은 predicate 공유.
+            var hoisted_fn_names: std.StringHashMapUnmanaged(void) = .empty;
+            defer hoisted_fn_names.deinit(allocator);
+            if (options.preserve_modules and options.format == .cjs and module.wrap_kind == .none) {
+                for (module.export_bindings) |eb| {
+                    if (chunks.exportBindingIsHoistableFn(module, eb)) {
+                        try hoisted_fn_names.put(allocator, eb.exported_name, {});
+                    }
+                }
+            }
             // mode (auto/named/default_/none) 별 emit 분기는 emitCjsEntryExports 에서 결정.
-            final_exports_buf = emitCjsEntryExports(allocator, entries, options.output_exports) catch |err| switch (err) {
+            final_exports_buf = emitCjsEntryExports(allocator, entries, options.output_exports, &hoisted_fn_names) catch |err| switch (err) {
                 error.OutputExportsDefaultRequiresSingleDefault => {
                     // default mode 인데 named 섞임 — Rollup 도 동일 케이스 throw.
                     // graph diagnostic 으로 emit (result.errors 노출, 사용자 fail-fast).

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -189,23 +189,20 @@ pub fn exportBindingIsHoistableFn(m: *const Module, eb: ExportBinding) bool {
 
 /// (#4532 증상4) unwrapped pm-cjs 모듈의 function-decl named export 를 `exports.<X> = <local>;` 로
 /// `out` 에 append. 호출부가 require 블록 **앞**에 insert 한다(function 은 hoisted 라 참조 가능).
+/// `appendCjsExportBinding(live=false, min=false)` 재사용 — 같은-파일 bottom(emitCjsEntryExports)이
+/// minify 무시하고 ` = `/`;\n` 로 내므로 형식 일치(min=false) + export-line 방출 로직 단일화.
 fn emitHoistedFnExports(
     l: *Linker,
     graph: *const ModuleGraph,
     mod_idx: u32,
     out: *std.ArrayList(u8),
     allocator: std.mem.Allocator,
-    min: bool,
 ) !void {
     const m = graph.getModule(@enumFromInt(mod_idx)) orelse return;
     for (m.export_bindings) |eb| {
         if (!exportBindingIsHoistableFn(m, eb)) continue;
         const local = l.getCanonicalForExport(eb, mod_idx);
-        try out.appendSlice(allocator, "exports.");
-        try out.appendSlice(allocator, eb.exported_name);
-        try out.appendSlice(allocator, if (min) "=" else " = ");
-        try out.appendSlice(allocator, local);
-        try out.appendSlice(allocator, if (min) ";" else ";\n");
+        try appendCjsExportBinding(allocator, out, eb.exported_name, local, false, false);
     }
 }
 
@@ -707,8 +704,12 @@ pub fn emitChunks(
 
         // (#4532 증상4) unwrapped pm-cjs 순환에서 function-decl export 를 require 블록 **앞**에 hoist 할
         // 위치·대상 모듈. require 뒤(모듈 본문 끝)에 두면 순환 소비자가 로드 중 undefined 를 집는다.
-        // pm-cjs & 비-wrap & entry 청크만. 실제 삽입은 computeRenamesForModules 후(리네임명 확정).
-        const fn_hoist_entry: ?u32 = if (pm_cjs and preserveModulesWrapperChunk(chunk, graph, options) == null)
+        // pm-cjs & 비-wrap & entry 청크 & **named export 를 내는 모드(auto/named)** 만 — output_exports
+        // `.none`(export 억제)/`.default_`(default 만)에선 hoist 하면 안 된다(#4532 증상4 리뷰 [0]).
+        // 실제 삽입은 computeRenamesForModules 후(리네임명 확정).
+        const fn_hoist_entry: ?u32 = if (pm_cjs and
+            (options.output_exports == .auto or options.output_exports == .named) and
+            preserveModulesWrapperChunk(chunk, graph, options) == null)
             (switch (chunk.kind) {
                 .entry_point => |info| @intFromEnum(info.module),
                 .common, .manual => null,
@@ -1189,7 +1190,7 @@ pub fn emitChunks(
         if (fn_hoist_pos) |pos| if (fn_hoist_entry) |emi| if (linker) |l| {
             var fn_exports: std.ArrayList(u8) = .empty;
             defer fn_exports.deinit(allocator);
-            try emitHoistedFnExports(l, graph, emi, &fn_exports, allocator, options.minify_whitespace);
+            try emitHoistedFnExports(l, graph, emi, &fn_exports, allocator);
             if (fn_exports.items.len > 0) {
                 try chunk_output.insertSlice(allocator, pos, fn_exports.items);
             }

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -171,6 +171,44 @@ fn moduleHasAnyNamedExport(
     return false;
 }
 
+/// (#4532 증상4) export 가 **직접 선언한 function 선언**(hoistable)인지. 순환 import 서 소비자가 그
+/// export 를 로드 중 접근하면 provider 의 `exports.X = X`(모듈 본문 끝)가 아직 실행 전이라 undefined 다.
+/// ESM 은 function 선언이 hoisting 돼 live-binding 으로 항상 함수 → cjs 도 `exports.X=X` 를 require 전에
+/// hoist 해 맞춘다. function 선언만 대상(const/let/class 는 hoisting 불가·ESM 도 순환서 TDZ). re-export 는
+/// 소스 모듈이 자기 것 hoist 하므로 `.local` 만.
+pub fn exportBindingIsHoistableFn(m: *const Module, eb: ExportBinding) bool {
+    if (eb.kind != .local) return false;
+    // default 는 제외 — `module.exports = X`(default-only) / `exports.default`(mixed) 모드 로직이
+    // 별도 처리(hoist 하면 그 로직과 충돌). named function export 만 대상.
+    if (std.mem.eql(u8, eb.exported_name, "default")) return false;
+    const idx = eb.symbol.semanticIndex() orelse return false;
+    const sem = m.semantic orelse return false;
+    if (idx >= sem.symbols.items.len) return false;
+    return sem.symbols.items[idx].decl_flags.is_function;
+}
+
+/// (#4532 증상4) unwrapped pm-cjs 모듈의 function-decl named export 를 `exports.<X> = <local>;` 로
+/// `out` 에 append. 호출부가 require 블록 **앞**에 insert 한다(function 은 hoisted 라 참조 가능).
+fn emitHoistedFnExports(
+    l: *Linker,
+    graph: *const ModuleGraph,
+    mod_idx: u32,
+    out: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    min: bool,
+) !void {
+    const m = graph.getModule(@enumFromInt(mod_idx)) orelse return;
+    for (m.export_bindings) |eb| {
+        if (!exportBindingIsHoistableFn(m, eb)) continue;
+        const local = l.getCanonicalForExport(eb, mod_idx);
+        try out.appendSlice(allocator, "exports.");
+        try out.appendSlice(allocator, eb.exported_name);
+        try out.appendSlice(allocator, if (min) "=" else " = ");
+        try out.appendSlice(allocator, local);
+        try out.appendSlice(allocator, if (min) ";" else ";\n");
+    }
+}
+
 /// (#4580) preserve-modules 단일-모듈 dep 청크의 export shape 가 **default-only** — 즉 provider 가
 /// `module.exports = <default>`(default = exports 전체) 를 방출하는지. 이 경우 소비자는 `require()`
 /// 결과 **전체**를 default 로 바인딩해야 한다: `const x = require(...)`. `{ default: x }` 구조분해는
@@ -667,6 +705,18 @@ pub fn emitChunks(
         try chunkPlaceholderStem(chunk, &importer_buf, allocator, options);
         const importer_dir = std.fs.path.dirname(importer_buf.items) orelse "";
 
+        // (#4532 증상4) unwrapped pm-cjs 순환에서 function-decl export 를 require 블록 **앞**에 hoist 할
+        // 위치·대상 모듈. require 뒤(모듈 본문 끝)에 두면 순환 소비자가 로드 중 undefined 를 집는다.
+        // pm-cjs & 비-wrap & entry 청크만. 실제 삽입은 computeRenamesForModules 후(리네임명 확정).
+        const fn_hoist_entry: ?u32 = if (pm_cjs and preserveModulesWrapperChunk(chunk, graph, options) == null)
+            (switch (chunk.kind) {
+                .entry_point => |info| @intFromEnum(info.module),
+                .common, .manual => null,
+            })
+        else
+            null;
+        const fn_hoist_pos: ?usize = if (fn_hoist_entry != null) chunk_output.items.len else null;
+
         for (chunk.cross_chunk_imports.items) |dep_chunk_idx| {
             const dep_chunk = chunk_graph.getChunk(dep_chunk_idx);
             try chunkPlaceholderStem(dep_chunk, &dep_buf, allocator, options);
@@ -1132,6 +1182,18 @@ pub fn emitChunks(
         if (linker) |l| {
             try l.computeRenamesForModules(sorted_mods, occupied.items);
         }
+
+        // (#4532 증상4) 리네임 확정 후 function-decl export 를 require 블록 앞에 insert.
+        // ns_preamble insert(아래)보다 **먼저** — ns_preamble_pos(더 앞) 을 먼저 넣으면 fn_hoist_pos 가
+        // 밀린다. 여기서 넣고 나서 ns_preamble 을 더 앞에 넣으면 순서/위치 모두 정확.
+        if (fn_hoist_pos) |pos| if (fn_hoist_entry) |emi| if (linker) |l| {
+            var fn_exports: std.ArrayList(u8) = .empty;
+            defer fn_exports.deinit(allocator);
+            try emitHoistedFnExports(l, graph, emi, &fn_exports, allocator, options.minify_whitespace);
+            if (fn_exports.items.len > 0) {
+                try chunk_output.insertSlice(allocator, pos, fn_exports.items);
+            }
+        };
 
         // (#4502) 이제 이 청크의 chunk-local 이름이 확정됐다 — 공유 namespace preamble 을
         // 생성해 위에서 잡아 둔 자리에 삽입. getter 본문이 (같은 청크 선언 → 확정 local 명 /

--- a/src/bundler/emitter/entry_exports.zig
+++ b/src/bundler/emitter/entry_exports.zig
@@ -126,9 +126,18 @@ pub fn emitCjsEntryExports(
     allocator: std.mem.Allocator,
     entries: []const FinalExportEntry,
     mode: OutputExports,
+    /// (#4532 증상4) require 앞에 hoist 된 function-decl export 명 집합 — bottom 방출서 제외(중복 방지).
+    /// null 이면 제외 없음.
+    skip_hoisted: ?*const std.StringHashMapUnmanaged(void),
 ) ![]const u8 {
     if (mode == .none) return try allocator.dupe(u8, "");
     if (entries.len == 0) return try allocator.dupe(u8, "");
+
+    const skip = struct {
+        fn f(s: ?*const std.StringHashMapUnmanaged(void), e: FinalExportEntry) bool {
+            return if (s) |set| (!e.isDefault() and set.contains(e.exported)) else false;
+        }
+    }.f;
 
     // default / named 분리
     var default_local: ?[]const u8 = null;
@@ -156,6 +165,7 @@ pub fn emitCjsEntryExports(
         },
         .named => {
             for (entries) |e| {
+                if (skip(skip_hoisted, e)) continue;
                 try out.print(allocator, "exports.{s} = {s};\n", .{ e.exported, e.local });
             }
             if (default_local != null) {
@@ -170,6 +180,7 @@ pub fn emitCjsEntryExports(
                 } else {
                     // mixed — named 형태 + esModule flag
                     for (entries) |e| {
+                        if (skip(skip_hoisted, e)) continue;
                         try out.print(allocator, "exports.{s} = {s};\n", .{ e.exported, e.local });
                     }
                     try out.appendSlice(allocator, "Object.defineProperty(exports, \"__esModule\", {value: true});\n");
@@ -177,6 +188,7 @@ pub fn emitCjsEntryExports(
             } else {
                 // named-only — esModule flag 없음 (Rollup 기본 auto 동작)
                 for (entries) |e| {
+                    if (skip(skip_hoisted, e)) continue;
                     try out.print(allocator, "exports.{s} = {s};\n", .{ e.exported, e.local });
                 }
             }
@@ -188,7 +200,7 @@ pub fn emitCjsEntryExports(
 
 test "emitCjsEntryExports: auto mode default-only → module.exports" {
     const entries = &.{FinalExportEntry{ .local = "x", .exported = "default" }};
-    const out = try emitCjsEntryExports(std.testing.allocator, entries, .auto);
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .auto, null);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("module.exports = x;\n", out);
 }
@@ -198,7 +210,7 @@ test "emitCjsEntryExports: auto mode named-only → exports.X (no esModule)" {
         FinalExportEntry{ .local = "a", .exported = "a" },
         FinalExportEntry{ .local = "b", .exported = "b" },
     };
-    const out = try emitCjsEntryExports(std.testing.allocator, entries, .auto);
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .auto, null);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("exports.a = a;\nexports.b = b;\n", out);
 }
@@ -208,7 +220,7 @@ test "emitCjsEntryExports: auto mode mixed → exports.X + esModule" {
         FinalExportEntry{ .local = "a", .exported = "a" },
         FinalExportEntry{ .local = "b", .exported = "default" },
     };
-    const out = try emitCjsEntryExports(std.testing.allocator, entries, .auto);
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .auto, null);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "exports.a = a;") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "exports.default = b;") != null);
@@ -217,7 +229,7 @@ test "emitCjsEntryExports: auto mode mixed → exports.X + esModule" {
 
 test "emitCjsEntryExports: named mode → 항상 named + esModule (default 있으면)" {
     const entries = &.{FinalExportEntry{ .local = "x", .exported = "default" }};
-    const out = try emitCjsEntryExports(std.testing.allocator, entries, .named);
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .named, null);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "exports.default = x;") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "__esModule") != null);
@@ -225,7 +237,7 @@ test "emitCjsEntryExports: named mode → 항상 named + esModule (default 있�
 
 test "emitCjsEntryExports: default_ mode default-only → module.exports" {
     const entries = &.{FinalExportEntry{ .local = "x", .exported = "default" }};
-    const out = try emitCjsEntryExports(std.testing.allocator, entries, .default_);
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .default_, null);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("module.exports = x;\n", out);
 }
@@ -235,7 +247,7 @@ test "emitCjsEntryExports: default_ mode named 섞이면 error" {
         FinalExportEntry{ .local = "a", .exported = "a" },
         FinalExportEntry{ .local = "b", .exported = "default" },
     };
-    const result = emitCjsEntryExports(std.testing.allocator, entries, .default_);
+    const result = emitCjsEntryExports(std.testing.allocator, entries, .default_, null);
     try std.testing.expectError(error.OutputExportsDefaultRequiresSingleDefault, result);
 }
 
@@ -244,7 +256,7 @@ test "emitCjsEntryExports: none mode → 빈 string" {
         FinalExportEntry{ .local = "a", .exported = "a" },
         FinalExportEntry{ .local = "b", .exported = "b" },
     };
-    const out = try emitCjsEntryExports(std.testing.allocator, entries, .none);
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .none, null);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("", out);
 }

--- a/tests/integration/tests/preserve-modules-cjs-circular-fn.test.ts
+++ b/tests/integration/tests/preserve-modules-cjs-circular-fn.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { join } from 'node:path';
-import { writeFileSync } from 'node:fs';
+import { writeFileSync, readFileSync } from 'node:fs';
 import { createFixture, runNode, runZntc } from './helpers';
 
 /**
@@ -92,6 +92,34 @@ describe('#4532 증상4: preserve-modules cjs 순환 function export live-bindin
       const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
       expect(stderr).not.toContain('TypeError');
       expect(stdout.trim()).toBe('A');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // 리뷰 [0]: --output-exports=none 은 export 를 억제하므로 hoist 도 하면 안 된다.
+  test('--output-exports=none 은 function export 를 hoist 하지 않는다', async () => {
+    const { dir, cleanup } = await createFixture({
+      'e1.js':
+        'import { b } from "./e2.js";\nexport function a(){ return "A"; }\nconsole.log(typeof b);',
+      'e2.js': 'import { a } from "./e1.js";\nexport function b(){}',
+    });
+    const outDir = join(dir, 'dist');
+    try {
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'e1.js'),
+        join(dir, 'e2.js'),
+        '--preserve-modules',
+        `--preserve-modules-root=${dir}`,
+        '--outdir',
+        outDir,
+        '--format=cjs',
+        '--output-exports=none',
+      ]);
+      expect(res.exitCode).toBe(0);
+      const e1 = readFileSync(join(outDir, 'e1.js'), 'utf8');
+      expect(e1).not.toContain('exports.a'); // none 이면 어떤 export 도 없어야
     } finally {
       await cleanup();
     }

--- a/tests/integration/tests/preserve-modules-cjs-circular-fn.test.ts
+++ b/tests/integration/tests/preserve-modules-cjs-circular-fn.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { createFixture, runNode, runZntc } from './helpers';
+
+/**
+ * #4532 증상4 — `--preserve-modules --format=cjs` 순환 import 에서 **function 선언 export** 가
+ * 소비자 로드 중 `undefined` 로 잡히던 것 수정.
+ *
+ * 근본: cjs 는 `exports.a = a` 를 모듈 본문 **끝**(require 뒤)에 방출한다. 순환에서 e2 가 e1 을
+ * require 하는 시점엔 e1 의 `exports.a = a` 가 아직 실행 전 → `a`=undefined. ESM 은 function 선언이
+ * hoisting 돼 live-binding 으로 항상 함수(`typeof a === "function"`).
+ *
+ * 수정: unwrapped pm-cjs 모듈의 **named function 선언 export** 를 `exports.<fn> = <fn>` 로 require
+ * **앞**에 hoist(function 은 hoisted 라 참조 가능) + bottom 중복 제외. const/let/class 는 hoisting
+ * 불가·ESM 도 순환서 TDZ 라 대상 아님. default 도 별도(module.exports 모드) 제외.
+ */
+
+async function build(
+  files: Record<string, string>,
+  entries: string[],
+  format: 'esm' | 'cjs',
+  minify = false,
+) {
+  const { dir, cleanup } = await createFixture(files);
+  const outDir = join(dir, 'dist');
+  const res = await runZntc([
+    '--bundle',
+    ...entries.map((e) => join(dir, e)),
+    '--preserve-modules',
+    `--preserve-modules-root=${dir}`,
+    '--outdir',
+    outDir,
+    `--format=${format}`,
+    ...(minify ? ['--minify'] : []),
+  ]);
+  if (res.exitCode !== 0) {
+    await cleanup();
+    throw new Error(`빌드 실패:\n${res.stderr}`);
+  }
+  writeFileSync(
+    join(outDir, 'package.json'),
+    JSON.stringify({ type: format === 'esm' ? 'module' : 'commonjs' }),
+  );
+  return { outDir, cleanup };
+}
+
+describe('#4532 증상4: preserve-modules cjs 순환 function export live-binding', () => {
+  // 순환 중 e2 가 로드되며 e1 의 function export a() 를 **호출**한다 — 수정 전엔 a=undefined → TypeError.
+  for (const format of ['esm', 'cjs'] as const) {
+    for (const minify of [false, true]) {
+      test(`순환 중 function 호출 성공 [${format}${minify ? ' minify' : ''}]`, async () => {
+        const { outDir, cleanup } = await build(
+          {
+            'e1.js':
+              'import { b } from "./e2.js";\nexport function a(){ return "A"; }\nexport function callB(){ return b(); }',
+            'e2.js':
+              'import { a } from "./e1.js";\nexport function b(){ return "B"; }\nglobalThis.__r = a();', // 로드 중 e1.a() 호출
+            'entry.js':
+              'import "./e2.js";\nimport { callB } from "./e1.js";\nconsole.log(globalThis.__r + callB());',
+          },
+          ['entry.js'],
+          format,
+          minify,
+        );
+        try {
+          const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+          expect(stderr).not.toContain('TypeError');
+          expect(stdout.trim()).toBe('AB'); // a()="A"(순환 중 호출), b()="B"
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // default 가 함께 있어도 named function export 는 순환서 hoist 돼 접근 가능해야 한다.
+  // (default 자체의 순환 접근은 #4580 bind-whole + 순환 partial 로 별개 — 여기선 named 만 검증.)
+  test('default 병존 시 named function 순환 접근 [cjs]', async () => {
+    const { outDir, cleanup } = await build(
+      {
+        'e1.js':
+          'import { b } from "./e2.js";\nexport default function d(){ return "D"; }\nexport function a(){ return "A"; }',
+        'e2.js':
+          'import { a } from "./e1.js";\nexport function b(){ return "B"; }\nglobalThis.__o = a();', // 로드 중 e1.a() 호출
+        'entry.js': 'import "./e1.js";\nimport "./e2.js";\nconsole.log(globalThis.__o);',
+      },
+      ['entry.js'],
+      'cjs',
+    );
+    try {
+      const { stdout, stderr } = await runNode(join(outDir, 'entry.js'));
+      expect(stderr).not.toContain('TypeError');
+      expect(stdout.trim()).toBe('A');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('non-circular 는 정상 (hoist 무해)', async () => {
+    const { outDir, cleanup } = await build(
+      {
+        'm.js': 'export function a(){ return "A"; }\nexport const x = 5;',
+        'entry.js': 'import { a, x } from "./m.js";\nconsole.log(a() + x);',
+      },
+      ['entry.js'],
+      'cjs',
+    );
+    try {
+      const { stdout } = await runNode(join(outDir, 'entry.js'));
+      expect(stdout.trim()).toBe('A5');
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## 문제

`--preserve-modules --format=cjs` 순환 import 에서 **function 선언 export** 가 소비자 로드 중 `undefined` 로 잡혀 `TypeError`. #4532 epic 증상4 잔여(단일-entry 순환도 동일).

```js
// e1.js: import { b } from "./e2.js"; export function a(){ return "A"; }
// e2.js: import { a } from "./e1.js"; export function b(){}  a();  // ← 로드 중 e1.a() 호출 → undefined
```

## 근본

cjs 는 `exports.a = a` 를 모듈 본문 **끝**(require 뒤)에 방출한다. 순환에서 e2 가 e1 을 require 하는 시점엔 e1 의 `exports.a = a` 가 아직 실행 전 → undefined. ESM 은 function 선언이 hoisting 돼 live-binding 으로 항상 함수. esm 출력은 정상이라 **cjs 전용**.

## 수정

unwrapped preserve-modules cjs 모듈의 **named function 선언 export** 를 `exports.<fn> = <local>;` 로 require 블록 **앞**에 hoist(function 은 스코프 상단 hoisting 되므로 참조 가능) + bottom 방출서 제외(중복 방지).

- `exportBindingIsHoistableFn`: 직접 `.local` + semantic `decl_flags.is_function`. re-export/default 제외.
- 삽입=`computeRenamesForModules` 후(리네임명 확정)·`ns_preamble` insert 앞(위치 shift 방지). bottom 제외=`emitCjsEntryExports` 에 hoisted-이름 집합 전달(같은 predicate 공유). live getter(#4532 증상3 서 드롭) 회피·값 hoist.

## `/code-review max` 반영

초기 커밋에서 리뷰가 correctness 1건 + cleanup 2건을 짚어 반영(product miscompile 없음):
- **[0]** hoist 가 `output_exports` 를 안 봐 `--output-exports=none`/`default_` 에서도 export 가 새던 것(재현) → `.auto`/`.named` 게이트.
- **[1][2]** export-line 방출을 `appendCjsExportBinding(live=false, min=false)` 재사용으로 단일화 — bottom 과 형식 일치.
- ⚠️ 테스트가 실제 버그를 가드하는지 직접 검증(hoist·skip off → fixture 실패, on → 통과).

## 검증

- `preserve-modules-cjs-circular-fn.test.ts` **7종**: 다중-entry 순환 function 호출(esm/cjs×minify)·default 병존 named·output-exports=none·non-circular.
- preserve-modules 129·cross-chunk/splitting 81 통합 + zig 전체 무회귀.

## 한계 (별개, 범위 밖)

- 소비자 자신의 import 가 순환 paused 중 TDZ(소비자-측 lazy 참조 필요)·const/let/class 순환 TDZ·default 순환 접근(#4580 bind-whole partial) 은 별개 층.

Refs #4532

🤖 Generated with [Claude Code](https://claude.com/claude-code)