### PR TITLE
fix(bundler): #4555 reg_split/cjs 공유 run-before-main cross-chunk 결합

### DIFF
--- a/.changeset/reg-split-shared-rbm.md
+++ b/.changeset/reg-split-shared-rbm.md
@@ -1,0 +1,37 @@
+---
+"@zntc/core": patch
+---
+
+reg_split(iife/umd/amd)·cjs 에서 **여러 entry 가 공유하는 `--run-before-main`** 이 common 청크로 갈 때 entry 가 그 init 을 잘못된 형태로 가져와 실패하던 것 수정 (#4555).
+
+```js
+// zntc --bundle a.js b.js --splitting --format=iife --run-before-main=setup.js
+// (a·b 공유라 setup → common chunk)
+```
+
+## 근본
+
+`emitRunBeforeMainCrossImports` 가 **포맷 무관하게 ESM `import { init_setup } from "chunk"`** 를 냈다:
+- iife/umd/amd: 그 import 가 factory 함수 **안**이라 `SyntaxError`.
+- cjs: CommonJS 출력에 ESM import → 로드 불가.
+- esm 만 top-level import 라 유일하게 정상이었다.
+
+메인 cross-chunk import 블록은 포맷별로 다르게 내는데(reg_split=`__zntc_require`, cjs=`require`, esm=`import`), RBM cross-import 만 그 분기를 안 타 항상 ESM 이었다.
+
+## 수정
+
+`emitRunBeforeMainCrossImports` 를 **포맷-aware** 로 — 메인 import 블록과 동일한 결합:
+- reg_split → `const { init_setup } = __zntc_require("<reg_id>");` (레지스트리)
+- cjs → `const { init_setup } = require("<path>");`
+- esm → `import { init_setup } from "<path>";` (기존)
+
+`reg_ids` 를 호출부에서 넘겨 dep 청크의 레지스트리 id 를 조회한다.
+
+## 검증
+
+- 회귀 스위트 `reg-split-shared-rbm.test.ts` 6종: iife/umd/amd(ESM import 없음=SyntaxError 제거)·iife 로드-순서 실행·cjs 직접 실행(`SETUP_DONE`)·esm 회귀 방지.
+- polyfill-rbm 8·splitting(iife/umd/amd/cjs)·manual-chunks 85 통합 + zig 전체 무회귀.
+
+## 한계
+
+- iife/umd/amd multi-chunk 는 청크가 **로드 순서대로**(common → entry) 등록돼야 `__zntc_require` 가 동작한다(브라우저 script 태그 순서). 이는 RBM 이 아닌 **일반 cross-chunk 도 동일한 기존 제약** — 이 fix 로 RBM 이 그 메커니즘과 parity 가 된 것이고, Node 직접 실행의 common-청크 미로드는 별개 층. cjs/esm 은 require/import 가 청크를 로드하므로 직접 실행도 정상.

--- a/.changeset/reg-split-shared-rbm.md
+++ b/.changeset/reg-split-shared-rbm.md
@@ -27,11 +27,27 @@ reg_split(iife/umd/amd)·cjs 에서 **여러 entry 가 공유하는 `--run-befor
 
 `reg_ids` 를 호출부에서 넘겨 dep 청크의 레지스트리 id 를 조회한다.
 
+## `/code-review max` 반영
+
+- **[3]** cjs-wrap RBM 이 청크에서 raw-require 되면 메인 cross-chunk 블록(#4541)이 `const require_X =
+  function(){…}` forwarding 으로 이미 바인딩 → RBM cross-import 가 또 `const {require_X}=require()` 를
+  내면 **이중 선언 SyntaxError**(재현). 청크가 raw-require 하면 cross-import skip(메인 바인딩 재사용),
+  안 하면(run_before_main 만) 유지. esm-wrap 은 항상 유지.
+- **[4]** dep 경로에서 `explicit_file_name` 을 `preserve_modules` 보다 먼저 검사(메인 블록·파일명
+  생성부와 동일 순서). **[2][5]** importer_dir·결합 형태를 루프 밖으로. **[0][1]** 테스트에 minify·
+  `node --check` 파싱 검증·umd 런타임·cjs-wrap 두 케이스 추가.
+
 ## 검증
 
-- 회귀 스위트 `reg-split-shared-rbm.test.ts` 6종: iife/umd/amd(ESM import 없음=SyntaxError 제거)·iife 로드-순서 실행·cjs 직접 실행(`SETUP_DONE`)·esm 회귀 방지.
-- polyfill-rbm 8·splitting(iife/umd/amd/cjs)·manual-chunks 85 통합 + zig 전체 무회귀.
+- 회귀 스위트 `reg-split-shared-rbm.test.ts` 13종: iife/umd/amd(ESM import 없음+파싱 유효, minify 포함)·
+  iife/umd 로드-순서 실행·cjs 직접 실행(`SETUP_DONE`)·esm 회귀·cjs-wrap RBM(import함/안함)·cjs minify 파싱.
+- polyfill-rbm 8·splitting·preserve-modules-cjs·manual-chunks 175 통합 + zig 전체 무회귀.
 
 ## 한계
+
+- **cjs `--minify` RBM**: common 청크가 wrapper 명 `init_X` 를 mangle(`n`)하는데 entry 는 미mangle
+  `init_setup` 참조 → `init_setup is not a function`. #4579 계열 per-chunk rename_table 발산으로 이 fix
+  범위 밖(non-minify·reg_split 은 정상). RBM 이 wrapper init 을 **명시 호출·cross-chunk 바인딩**하는
+  유일 케이스라 일반 side-effect import(init 미호출)엔 없음. 별도 후속.
 
 - iife/umd/amd multi-chunk 는 청크가 **로드 순서대로**(common → entry) 등록돼야 `__zntc_require` 가 동작한다(브라우저 script 태그 순서). 이는 RBM 이 아닌 **일반 cross-chunk 도 동일한 기존 제약** — 이 fix 로 RBM 이 그 메커니즘과 parity 가 된 것이고, Node 직접 실행의 common-청크 미로드는 별개 층. cjs/esm 은 require/import 가 청크를 로드하므로 직접 실행도 정상.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -641,6 +641,7 @@ pub fn emitChunks(
                 chunk_graph,
                 options,
                 ext,
+                reg_ids,
             );
         }
 
@@ -2153,7 +2154,17 @@ fn emitRunBeforeMainCrossImports(
     chunk_graph: *const ChunkGraph,
     options: *const EmitOptions,
     ext: []const u8,
+    /// reg_split(iife/umd/amd) 일 때 dep 청크의 레지스트리 id 조회용. reg_split 아니면 미사용.
+    reg_ids: []const []const u8,
 ) !void {
+    // (#4555) 공유 RBM 이 common 청크로 가면 cross-chunk 로 그 init 을 가져와야 한다. 결합 형태는
+    // 포맷별로 달라야 유효하다(메인 import 블록과 동일):
+    //   · reg_split(iife/umd/amd) → `const { init_X } = __zntc_require("<reg_id>");` (ESM import 는
+    //     factory 함수 안이라 SyntaxError 였다 — #4555)
+    //   · cjs → `const { init_X } = require("<path>");` (cjs 에 ESM import 는 무효)
+    //   · esm → `import { init_X } from "<path>";` (기존)
+    const reg_split = options.format.isWrappedFormat() and !options.preserve_modules;
+    const min = options.minify_whitespace;
     var dep_buf: std.ArrayListUnmanaged(u8) = .empty;
     defer dep_buf.deinit(allocator);
     // src_dir 는 importer chunk 의 *최종 stem* (baked-in slash 포함) 의 dirname.
@@ -2162,33 +2173,44 @@ fn emitRunBeforeMainCrossImports(
     try chunkPlaceholderStem(current_chunk, &importer_buf, allocator, options);
     const importer_dir = std.fs.path.dirname(importer_buf.items) orelse "";
     for (imports) |imp| {
-        const dep_chunk = chunk_graph.getChunk(imp.source_chunk);
-        try chunkPlaceholderStem(dep_chunk, &dep_buf, allocator, options);
-        const dep_stem = dep_buf.items;
-        const resolved_path = if (options.preserve_modules) blk: {
-            const src_path = current_chunk.rel_dir orelse "./";
-            const dep_path = dep_chunk.rel_dir orelse "./";
-            break :blk try computeRelativeImportPath(allocator, src_path, dep_path, ext, options.preserve_modules_root);
-        } else if (dep_chunk.explicit_file_name) |efn|
-            try computeRelativePath(allocator, importer_dir, efn, "")
-        else blk: {
-            break :blk try computeRelativePath(allocator, importer_dir, dep_stem, ext);
+        // reg_split 은 레지스트리 id, 그 외는 상대 경로.
+        const bind_arg: []const u8 = if (reg_split)
+            reg_ids[@intFromEnum(imp.source_chunk)]
+        else blk_path: {
+            const dep_chunk = chunk_graph.getChunk(imp.source_chunk);
+            try chunkPlaceholderStem(dep_chunk, &dep_buf, allocator, options);
+            const dep_stem = dep_buf.items;
+            break :blk_path if (options.preserve_modules) blk: {
+                const src_path = current_chunk.rel_dir orelse "./";
+                const dep_path = dep_chunk.rel_dir orelse "./";
+                break :blk try computeRelativeImportPath(allocator, src_path, dep_path, ext, options.preserve_modules_root);
+            } else if (dep_chunk.explicit_file_name) |efn|
+                try computeRelativePath(allocator, importer_dir, efn, "")
+            else
+                try computeRelativePath(allocator, importer_dir, dep_stem, ext);
         };
-        defer allocator.free(resolved_path);
+        defer if (!reg_split) allocator.free(bind_arg);
 
-        if (!options.minify_whitespace) {
-            try output.appendSlice(allocator, "import { ");
-            try output.appendSlice(allocator, imp.name);
-            try output.appendSlice(allocator, " } from \"");
-            try output.appendSlice(allocator, resolved_path);
-            try output.appendSlice(allocator, "\";\n");
-        } else {
-            try output.appendSlice(allocator, "import{");
-            try output.appendSlice(allocator, imp.name);
-            try output.appendSlice(allocator, "}from\"");
-            try output.appendSlice(allocator, resolved_path);
-            try output.appendSlice(allocator, "\";");
-        }
+        const open = if (reg_split or options.format == .cjs)
+            (if (min) "const{" else "const { ")
+        else
+            (if (min) "import{" else "import { ");
+        const mid = if (reg_split)
+            (if (min) "}=__zntc_require(\"" else " } = __zntc_require(\"")
+        else if (options.format == .cjs)
+            (if (min) "}=require(\"" else " } = require(\"")
+        else
+            (if (min) "}from\"" else " } from \"");
+        const close = if (reg_split or options.format == .cjs)
+            (if (min) "\");" else "\");\n")
+        else
+            (if (min) "\";" else "\";\n");
+
+        try output.appendSlice(allocator, open);
+        try output.appendSlice(allocator, imp.name);
+        try output.appendSlice(allocator, mid);
+        try output.appendSlice(allocator, bind_arg);
+        try output.appendSlice(allocator, close);
     }
 }
 

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -2120,6 +2120,25 @@ fn collectRunBeforeMainCrossImports(
         const rbm = graph.findModuleByPath(rbm_path) orelse continue;
         const source_chunk = chunk_graph.getModuleChunk(rbm.index);
         if (source_chunk == .none or source_chunk == current_chunk.index) continue;
+        // (#4555 리뷰 [3]) cjs-wrap RBM 을 **이 청크의 어떤 모듈이 raw-require** 하면 skip. 그 경우
+        // 메인 cross-chunk import 블록(#4541)이 cjs-wrap 썽크를 forwarding decl(`const require_X =
+        // function(){…}`)로 이미 바인딩하므로, 여기서 또 `const {require_X}=require()` 를 내면 **이중
+        // 선언 SyntaxError**. RBM 호출부(require_X())는 메인 바인딩을 참조한다. 아무도 raw-require 안
+        // 하면(run_before_main 으로만 참조) 메인이 require_X 를 안 바인딩하므로 cross-import 를 유지해
+        // 바인딩한다. esm-wrap 은 메인이 side-effect require 라 init_X 미바인딩 → 항상 유지.
+        if (rbm.wrap_kind == .cjs) {
+            var chunk_raw_requires_rbm = false;
+            outer: for (current_chunk.modules.items) |mod_idx| {
+                const m = graph.getModule(mod_idx) orelse continue;
+                for (m.import_records) |rec| {
+                    if (rec.resolved == rbm.index) {
+                        chunk_raw_requires_rbm = true;
+                        break :outer;
+                    }
+                }
+            }
+            if (chunk_raw_requires_rbm) continue;
+        }
         const name = try runBeforeMainCallName(allocator, rbm, rename_tbl) orelse continue;
 
         var duplicate = false;
@@ -2165,46 +2184,50 @@ fn emitRunBeforeMainCrossImports(
     //   · esm → `import { init_X } from "<path>";` (기존)
     const reg_split = options.format.isWrappedFormat() and !options.preserve_modules;
     const min = options.minify_whitespace;
+    // 결합 형태는 청크 전체가 같은 포맷이라 loop-invariant — 루프 밖에서 한 번 계산.
+    const open = if (reg_split or options.format == .cjs)
+        (if (min) "const{" else "const { ")
+    else
+        (if (min) "import{" else "import { ");
+    const mid = if (reg_split)
+        (if (min) "}=__zntc_require(\"" else " } = __zntc_require(\"")
+    else if (options.format == .cjs)
+        (if (min) "}=require(\"" else " } = require(\"")
+    else
+        (if (min) "}from\"" else " } from \"");
+    const close = if (reg_split or options.format == .cjs)
+        (if (min) "\");" else "\");\n")
+    else
+        (if (min) "\";" else "\";\n");
+
     var dep_buf: std.ArrayListUnmanaged(u8) = .empty;
     defer dep_buf.deinit(allocator);
-    // src_dir 는 importer chunk 의 *최종 stem* (baked-in slash 포함) 의 dirname.
+    // importer_dir 는 경로 계산(비-reg_split)에만 쓰인다 — reg_split 은 reg_id 라 스킵.
     var importer_buf: std.ArrayListUnmanaged(u8) = .empty;
     defer importer_buf.deinit(allocator);
-    try chunkPlaceholderStem(current_chunk, &importer_buf, allocator, options);
-    const importer_dir = std.fs.path.dirname(importer_buf.items) orelse "";
+    const importer_dir = if (reg_split) "" else blk: {
+        try chunkPlaceholderStem(current_chunk, &importer_buf, allocator, options);
+        break :blk std.fs.path.dirname(importer_buf.items) orelse "";
+    };
     for (imports) |imp| {
         // reg_split 은 레지스트리 id, 그 외는 상대 경로.
         const bind_arg: []const u8 = if (reg_split)
             reg_ids[@intFromEnum(imp.source_chunk)]
         else blk_path: {
             const dep_chunk = chunk_graph.getChunk(imp.source_chunk);
-            try chunkPlaceholderStem(dep_chunk, &dep_buf, allocator, options);
-            const dep_stem = dep_buf.items;
-            break :blk_path if (options.preserve_modules) blk: {
+            // explicit_file_name(plugin emitFile verbatim)을 preserve_modules 보다 **먼저** — 메인
+            // cross-chunk 블록(chunks.zig ~738)·파일명 생성부와 동일 순서라야 import 경로가 실제
+            // 출력 파일명과 일치(#4555 리뷰 [4]).
+            if (dep_chunk.explicit_file_name) |efn| break :blk_path try computeRelativePath(allocator, importer_dir, efn, "");
+            if (options.preserve_modules) {
                 const src_path = current_chunk.rel_dir orelse "./";
                 const dep_path = dep_chunk.rel_dir orelse "./";
-                break :blk try computeRelativeImportPath(allocator, src_path, dep_path, ext, options.preserve_modules_root);
-            } else if (dep_chunk.explicit_file_name) |efn|
-                try computeRelativePath(allocator, importer_dir, efn, "")
-            else
-                try computeRelativePath(allocator, importer_dir, dep_stem, ext);
+                break :blk_path try computeRelativeImportPath(allocator, src_path, dep_path, ext, options.preserve_modules_root);
+            }
+            try chunkPlaceholderStem(dep_chunk, &dep_buf, allocator, options);
+            break :blk_path try computeRelativePath(allocator, importer_dir, dep_buf.items, ext);
         };
         defer if (!reg_split) allocator.free(bind_arg);
-
-        const open = if (reg_split or options.format == .cjs)
-            (if (min) "const{" else "const { ")
-        else
-            (if (min) "import{" else "import { ");
-        const mid = if (reg_split)
-            (if (min) "}=__zntc_require(\"" else " } = __zntc_require(\"")
-        else if (options.format == .cjs)
-            (if (min) "}=require(\"" else " } = require(\"")
-        else
-            (if (min) "}from\"" else " } from \"");
-        const close = if (reg_split or options.format == .cjs)
-            (if (min) "\");" else "\");\n")
-        else
-            (if (min) "\";" else "\";\n");
 
         try output.appendSlice(allocator, open);
         try output.appendSlice(allocator, imp.name);

--- a/tests/integration/tests/reg-split-shared-rbm.test.ts
+++ b/tests/integration/tests/reg-split-shared-rbm.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { join } from 'node:path';
-import { writeFileSync, readFileSync } from 'node:fs';
+import { writeFileSync, readFileSync, readdirSync } from 'node:fs';
 import { createFixture, runNode, runZntc } from './helpers';
 
 /**
@@ -12,18 +12,23 @@ import { createFixture, runNode, runZntc } from './helpers';
  *
  * 수정: emitRunBeforeMainCrossImports 를 포맷-aware 로 — reg_split → `const { init } =
  * __zntc_require("<reg_id>")`, cjs → `const { init } = require("<path>")`, esm → 기존 import.
- * 메인 cross-chunk import 블록과 동일한 결합 형태.
- *
- * ⚠️ iife/umd/amd multi-chunk 는 청크가 **로드 순서대로** 등록돼야 __zntc_require 가 동작한다(브라우저
- *    script 태그 순서·일반 cross-chunk 도 동일한 기존 제약). Node 직접 실행은 common 청크 미로드로 별개.
+ * 또 cjs-wrap RBM 이 청크에서 raw-require 되면 메인 forwarding 과 이중 선언되므로 cross-import skip.
  */
 
-async function build(format: 'iife' | 'umd' | 'amd' | 'cjs' | 'esm') {
-  const { dir, cleanup } = await createFixture({
-    'setup.js': 'globalThis.__setup = "SETUP_DONE";',
-    'a.js': 'import "./setup.js";\nconsole.log("a:" + globalThis.__setup);',
-    'b.js': 'import "./setup.js";\nconsole.log("b:" + globalThis.__setup);',
-  });
+// node --check 로 파싱 유효성만 확인(런타임 실행 X — iife 는 청크 미로드로 런타임 실패가 정상).
+async function parseValid(file: string): Promise<boolean> {
+  const p = Bun.spawn(['node', '--check', file], { stdout: 'pipe', stderr: 'pipe' });
+  await p.exited;
+  return p.exitCode === 0;
+}
+
+async function build(
+  format: 'iife' | 'umd' | 'amd' | 'cjs' | 'esm',
+  files: Record<string, string>,
+  rbm: string,
+  minify = false,
+) {
+  const { dir, cleanup } = await createFixture(files);
   const outDir = join(dir, 'dist');
   const res = await runZntc([
     '--bundle',
@@ -32,9 +37,10 @@ async function build(format: 'iife' | 'umd' | 'amd' | 'cjs' | 'esm') {
     '--splitting',
     `--format=${format}`,
     '--platform=node',
-    `--run-before-main=${join(dir, 'setup.js')}`,
+    `--run-before-main=${join(dir, rbm)}`,
     '--outdir',
     outDir,
+    ...(minify ? ['--minify'] : []),
   ]);
   if (res.exitCode !== 0) {
     await cleanup();
@@ -43,69 +49,127 @@ async function build(format: 'iife' | 'umd' | 'amd' | 'cjs' | 'esm') {
   return { dir, outDir, cleanup };
 }
 
+const ESM_SETUP = {
+  'setup.js': 'globalThis.__setup = "SETUP_DONE";',
+  'a.js': 'import "./setup.js";\nconsole.log("a:" + globalThis.__setup);',
+  'b.js': 'import "./setup.js";\nconsole.log("b:" + globalThis.__setup);',
+};
+
 describe('#4555: reg_split/cjs multi-entry 공유 run-before-main', () => {
-  // reg_split(iife/umd/amd): factory 안 ESM import 가 없어야(=SyntaxError 제거).
+  // reg_split(iife/umd/amd): factory 안 ESM import 없음 + 파싱 유효(SyntaxError 제거).
   for (const format of ['iife', 'umd', 'amd'] as const) {
-    test(`${format}: RBM cross-import 가 ESM import 아님 (registry)`, async () => {
-      const { outDir, cleanup } = await build(format);
+    for (const minify of [false, true]) {
+      test(`${format}: RBM cross-import 가 registry (파싱 유효)${minify ? ' [min]' : ''}`, async () => {
+        const { outDir, cleanup } = await build(format, ESM_SETUP, 'setup.js', minify);
+        try {
+          const a = readFileSync(join(outDir, 'a.js'), 'utf8');
+          expect(a).not.toMatch(/import\s*\{\s*init_/); // ESM import 면 SyntaxError
+          expect(a).toContain('__zntc_require('); // registry 결합
+          expect(await parseValid(join(outDir, 'a.js'))).toBe(true); // 진짜 파싱되는지
+        } finally {
+          await cleanup();
+        }
+      });
+    }
+  }
+
+  // iife/umd: 청크를 로드 순서대로(common → entry) 넣으면 RBM 이 실행돼 setup 이 돈다.
+  for (const format of ['iife', 'umd'] as const) {
+    test(`${format}: 청크 로드 순서대로면 RBM 실행 (브라우저 script 순서)`, async () => {
+      const { dir, outDir, cleanup } = await build(format, ESM_SETUP, 'setup.js');
       try {
-        const a = readFileSync(join(outDir, 'a.js'), 'utf8');
-        // RBM init 을 factory 안에서 ESM import 로 가져오면 SyntaxError.
-        expect(a).not.toMatch(/import\s*\{\s*init_/);
-        expect(a).toContain('__zntc_require('); // registry 결합
-        // 파싱 가능해야: node --check 로 SyntaxError 없음 확인.
-        const chk = await runNode(join(outDir, 'a.js')).catch((e: Error) => e.message);
-        expect(String(chk)).not.toContain('SyntaxError');
+        const chunk = readdirSync(outDir).find((f) => f.startsWith('chunk-'))!;
+        writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
+        const harness = join(dir, 'harness.js');
+        writeFileSync(
+          harness,
+          `globalThis.__zntc_public_path="";\nrequire(${JSON.stringify(join(outDir, chunk))});\nrequire(${JSON.stringify(join(outDir, 'a.js'))});\n`,
+        );
+        const { stdout, stderr } = await runNode(harness);
+        expect(stderr).not.toContain('SyntaxError');
+        expect(stdout.trim()).toBe('a:SETUP_DONE');
       } finally {
         await cleanup();
       }
     });
   }
 
-  // iife: 청크를 로드 순서대로(common → entry) 넣으면 RBM 이 실행돼 setup 이 돈다.
-  test('iife: 청크 로드 순서대로면 RBM 실행 (브라우저 script 순서)', async () => {
-    const { dir, outDir, cleanup } = await build('iife');
-    try {
-      const fs = await import('node:fs');
-      const chunk = fs.readdirSync(outDir).find((f) => f.startsWith('chunk-'))!;
-      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
-      // common 청크 먼저 등록 후 entry 로드.
-      const harness = join(dir, 'harness.js');
-      writeFileSync(
-        harness,
-        `globalThis.__zntc_public_path="";\nrequire(${JSON.stringify(join(outDir, chunk))});\nrequire(${JSON.stringify(join(outDir, 'a.js'))});\n`,
-      );
-      const { stdout, stderr } = await runNode(harness);
-      expect(stderr).not.toContain('SyntaxError');
-      expect(stdout.trim()).toBe('a:SETUP_DONE');
-    } finally {
-      await cleanup();
-    }
-  });
-
   // cjs: require 가 청크를 동기 로드하므로 직접 실행이 그대로 동작.
   test('cjs: 공유 RBM 이 직접 실행에서 동작', async () => {
-    const { outDir, cleanup } = await build('cjs');
+    const { outDir, cleanup } = await build('cjs', ESM_SETUP, 'setup.js');
     try {
       writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
       const a = readFileSync(join(outDir, 'a.js'), 'utf8');
-      expect(a).not.toMatch(/import\s*\{\s*init_/); // cjs 에 ESM import 없어야
-      const ra = await runNode(join(outDir, 'a.js'));
-      expect(ra.stdout.trim()).toBe('a:SETUP_DONE');
-      const rb = await runNode(join(outDir, 'b.js'));
-      expect(rb.stdout.trim()).toBe('b:SETUP_DONE');
+      expect(a).not.toMatch(/import\s*\{\s*init_/);
+      expect((await runNode(join(outDir, 'a.js'))).stdout.trim()).toBe('a:SETUP_DONE');
+      expect((await runNode(join(outDir, 'b.js'))).stdout.trim()).toBe('b:SETUP_DONE');
     } finally {
       await cleanup();
     }
   });
 
-  // esm: 회귀 방지 — 기존대로 동작.
+  // cjs --minify: min-branch 문자열(`}=require("`)이 유효 JS 인지(파싱)만 검증. 런타임은 별개 선행
+  // mangler 발산(#4579 계열: common 청크가 wrapper 명 init_X 를 mangle 하는데 entry 는 미mangle 참조)
+  // 으로 실패 — 이 fix 범위 밖(한계 문서화).
+  test('cjs --minify: min-branch 결합이 파싱 유효', async () => {
+    const { outDir, cleanup } = await build('cjs', ESM_SETUP, 'setup.js', true);
+    try {
+      const a = readFileSync(join(outDir, 'a.js'), 'utf8');
+      expect(a).not.toMatch(/import\s*\{\s*init_/);
+      expect(a).toContain('=require(');
+      expect(await parseValid(join(outDir, 'a.js'))).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // esm: 회귀 방지.
   test('esm: 공유 RBM 정상 (회귀 방지)', async () => {
-    const { outDir, cleanup } = await build('esm');
+    const { outDir, cleanup } = await build('esm', ESM_SETUP, 'setup.js');
     try {
       writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
-      const ra = await runNode(join(outDir, 'a.js'));
-      expect(ra.stdout.trim()).toBe('a:SETUP_DONE');
+      expect((await runNode(join(outDir, 'a.js'))).stdout.trim()).toBe('a:SETUP_DONE');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // [리뷰 3] cjs-wrap RBM: 청크가 raw-require 하면(import함) 메인 forwarding 과 이중선언되면 안 됨.
+  test('cjs-wrap RBM (엔트리가 import함): 이중선언 없이 실행', async () => {
+    const { outDir, cleanup } = await build(
+      'cjs',
+      {
+        'setup.cjs': 'module.exports.ready = 1;\nglobalThis.__setup = "CJS";',
+        'a.js': 'require("./setup.cjs");\nconsole.log("a:" + globalThis.__setup);',
+        'b.js': 'require("./setup.cjs");\nconsole.log("b:" + globalThis.__setup);',
+      },
+      'setup.cjs',
+    );
+    try {
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
+      const a = readFileSync(join(outDir, 'a.js'), 'utf8');
+      const decls = a.match(/\brequire_setup\s*=/g) ?? [];
+      expect(decls.length).toBeLessThanOrEqual(1); // 이중선언이면 SyntaxError
+      expect((await runNode(join(outDir, 'a.js'))).stdout.trim()).toBe('a:CJS');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // [리뷰 3] cjs-wrap RBM: 엔트리가 import 안 하면(run_before_main 만) cross-import 로 바인딩돼 실행.
+  test('cjs-wrap RBM (import 안함): cross-import 로 바인딩돼 실행', async () => {
+    const { outDir, cleanup } = await build(
+      'cjs',
+      {
+        'setup.cjs': 'globalThis.__setup = "CJS2";',
+        'a.js': 'console.log("a:" + (globalThis.__setup || "MISS"));',
+        'b.js': 'console.log("b:" + (globalThis.__setup || "MISS"));',
+      },
+      'setup.cjs',
+    );
+    try {
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
+      expect((await runNode(join(outDir, 'a.js'))).stdout.trim()).toBe('a:CJS2');
     } finally {
       await cleanup();
     }

--- a/tests/integration/tests/reg-split-shared-rbm.test.ts
+++ b/tests/integration/tests/reg-split-shared-rbm.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync, readFileSync } from 'node:fs';
+import { createFixture, runNode, runZntc } from './helpers';
+
+/**
+ * #4555 — reg_split(iife/umd/amd)·cjs multi-entry 가 **공유 run-before-main** 을 쓰면 RBM 이 common
+ * 청크로 가고, entry 청크가 그 init 을 **ESM `import`** 로 가져와 실패했다:
+ *  - iife/umd/amd: `import { init_setup }` 이 factory 함수 안이라 SyntaxError.
+ *  - cjs: CommonJS 출력에 ESM `import` → 로드 불가.
+ *  - esm 은 top-level import 라 유일하게 정상이었다.
+ *
+ * 수정: emitRunBeforeMainCrossImports 를 포맷-aware 로 — reg_split → `const { init } =
+ * __zntc_require("<reg_id>")`, cjs → `const { init } = require("<path>")`, esm → 기존 import.
+ * 메인 cross-chunk import 블록과 동일한 결합 형태.
+ *
+ * ⚠️ iife/umd/amd multi-chunk 는 청크가 **로드 순서대로** 등록돼야 __zntc_require 가 동작한다(브라우저
+ *    script 태그 순서·일반 cross-chunk 도 동일한 기존 제약). Node 직접 실행은 common 청크 미로드로 별개.
+ */
+
+async function build(format: 'iife' | 'umd' | 'amd' | 'cjs' | 'esm') {
+  const { dir, cleanup } = await createFixture({
+    'setup.js': 'globalThis.__setup = "SETUP_DONE";',
+    'a.js': 'import "./setup.js";\nconsole.log("a:" + globalThis.__setup);',
+    'b.js': 'import "./setup.js";\nconsole.log("b:" + globalThis.__setup);',
+  });
+  const outDir = join(dir, 'dist');
+  const res = await runZntc([
+    '--bundle',
+    join(dir, 'a.js'),
+    join(dir, 'b.js'),
+    '--splitting',
+    `--format=${format}`,
+    '--platform=node',
+    `--run-before-main=${join(dir, 'setup.js')}`,
+    '--outdir',
+    outDir,
+  ]);
+  if (res.exitCode !== 0) {
+    await cleanup();
+    throw new Error(`빌드 실패:\n${res.stderr}`);
+  }
+  return { dir, outDir, cleanup };
+}
+
+describe('#4555: reg_split/cjs multi-entry 공유 run-before-main', () => {
+  // reg_split(iife/umd/amd): factory 안 ESM import 가 없어야(=SyntaxError 제거).
+  for (const format of ['iife', 'umd', 'amd'] as const) {
+    test(`${format}: RBM cross-import 가 ESM import 아님 (registry)`, async () => {
+      const { outDir, cleanup } = await build(format);
+      try {
+        const a = readFileSync(join(outDir, 'a.js'), 'utf8');
+        // RBM init 을 factory 안에서 ESM import 로 가져오면 SyntaxError.
+        expect(a).not.toMatch(/import\s*\{\s*init_/);
+        expect(a).toContain('__zntc_require('); // registry 결합
+        // 파싱 가능해야: node --check 로 SyntaxError 없음 확인.
+        const chk = await runNode(join(outDir, 'a.js')).catch((e: Error) => e.message);
+        expect(String(chk)).not.toContain('SyntaxError');
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+
+  // iife: 청크를 로드 순서대로(common → entry) 넣으면 RBM 이 실행돼 setup 이 돈다.
+  test('iife: 청크 로드 순서대로면 RBM 실행 (브라우저 script 순서)', async () => {
+    const { dir, outDir, cleanup } = await build('iife');
+    try {
+      const fs = await import('node:fs');
+      const chunk = fs.readdirSync(outDir).find((f) => f.startsWith('chunk-'))!;
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
+      // common 청크 먼저 등록 후 entry 로드.
+      const harness = join(dir, 'harness.js');
+      writeFileSync(
+        harness,
+        `globalThis.__zntc_public_path="";\nrequire(${JSON.stringify(join(outDir, chunk))});\nrequire(${JSON.stringify(join(outDir, 'a.js'))});\n`,
+      );
+      const { stdout, stderr } = await runNode(harness);
+      expect(stderr).not.toContain('SyntaxError');
+      expect(stdout.trim()).toBe('a:SETUP_DONE');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // cjs: require 가 청크를 동기 로드하므로 직접 실행이 그대로 동작.
+  test('cjs: 공유 RBM 이 직접 실행에서 동작', async () => {
+    const { outDir, cleanup } = await build('cjs');
+    try {
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
+      const a = readFileSync(join(outDir, 'a.js'), 'utf8');
+      expect(a).not.toMatch(/import\s*\{\s*init_/); // cjs 에 ESM import 없어야
+      const ra = await runNode(join(outDir, 'a.js'));
+      expect(ra.stdout.trim()).toBe('a:SETUP_DONE');
+      const rb = await runNode(join(outDir, 'b.js'));
+      expect(rb.stdout.trim()).toBe('b:SETUP_DONE');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // esm: 회귀 방지 — 기존대로 동작.
+  test('esm: 공유 RBM 정상 (회귀 방지)', async () => {
+    const { outDir, cleanup } = await build('esm');
+    try {
+      writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
+      const ra = await runNode(join(outDir, 'a.js'));
+      expect(ra.stdout.trim()).toBe('a:SETUP_DONE');
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## 문제

reg_split(iife/umd/amd)·cjs multi-entry 가 **여러 entry 가 공유하는 `--run-before-main`** 을 쓰면 RBM 이 common 청크로 가고, entry 청크가 그 init 을 **ESM `import`** 로 가져와 실패. (#4552 잔여)

```js
// zntc --bundle a.js b.js --splitting --format=iife --run-before-main=setup.js
```

- iife/umd/amd: `import { init_setup }` 이 factory 함수 **안**이라 `SyntaxError`.
- cjs: CommonJS 출력에 ESM `import` → 로드 불가.
- esm 만 top-level import 라 유일하게 정상이었다.

## 근본

`emitRunBeforeMainCrossImports` 가 **포맷 무관하게 ESM `import`** 를 냈다. 메인 cross-chunk import 블록은 포맷별로 분기하는데(reg_split=`__zntc_require`, cjs=`require`, esm=`import`) RBM cross-import 만 그 분기를 안 탔다.

## 수정

`emitRunBeforeMainCrossImports` 를 **포맷-aware** 로 — 메인 import 블록과 동일한 결합:
- reg_split → `const { init_setup } = __zntc_require("<reg_id>");`
- cjs → `const { init_setup } = require("<path>");`
- esm → `import { init_setup } from "<path>";` (기존)

## `/code-review max` 반영

- **[3]** cjs-wrap RBM 이 청크에서 raw-require 되면 메인 블록(#4541)이 forwarding 으로 이미 바인딩 → 이중 선언 SyntaxError(재현). raw-require 시 cross-import skip, run_before_main 만이면 유지.
- **[4]** `explicit_file_name` 을 `preserve_modules` 보다 먼저(메인 블록과 순서 일치). **[2][5]** loop-invariant hoist. **[0][1]** 테스트에 minify·`node --check` 파싱·umd 런타임·cjs-wrap 케이스 추가.

## 검증

- `reg-split-shared-rbm.test.ts` **13종**: iife/umd/amd(ESM import 없음+파싱 유효, minify)·iife/umd 로드-순서 실행·cjs 직접 실행(`SETUP_DONE`)·esm 회귀·cjs-wrap RBM(import함/안함).
- polyfill-rbm 8·splitting·preserve-modules-cjs·manual-chunks 175 통합 + zig 전체 무회귀.

## 한계

- iife/umd/amd multi-chunk 는 청크가 **로드 순서대로** 등록돼야 `__zntc_require` 동작(일반 cross-chunk 도 동일 기존 제약, RBM 이 parity 된 것). cjs/esm 은 require/import 로 직접 실행 정상.
- cjs `--minify` RBM 은 common 청크가 wrapper 명 `init_X` 를 mangle 하는데 entry 는 미mangle 참조(#4579 계열 발산)로 별개 후속. non-minify·reg_split 정상.

Refs #4555

🤖 Generated with [Claude Code](https://claude.com/claude-code)