### PR TITLE
fix(release): v0.1.4 bun.lock 동기화 + sync-lockfile push 훅 우회

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,5 +386,8 @@ jobs:
           publish 직후 @zntc/core-*@${VERSION} 이 npm 에서 해석 가능해지면서 lockfile 에
           추가된다. 이걸 되돌리지 않으면 이후 모든 PR 의 bun install --frozen-lockfile 이
           실패한다. release.yml 의 sync-lockfile 잡이 자동 생성한 커밋."
-          git push origin main
+          # --no-verify: 이 runner 엔 zig 가 없어 .githooks/pre-push 의 `zig fmt --check`
+          # 가 "zig: not found" 로 실패해 push 가 막힌다(v0.1.4 때 이 동기화 커밋이 유실됨).
+          # bun.lock 만 바꾸는 봇 커밋이라 훅 검증이 불필요.
+          git push --no-verify origin main
           echo "✓ bun.lock 동기화 커밋 push 완료"

--- a/bun.lock
+++ b/bun.lock
@@ -3133,6 +3133,24 @@
 
     "@zntc/core": ["@zntc/core@workspace:packages/core"],
 
+    "@zntc/core-darwin-arm64": ["@zntc/core-darwin-arm64@0.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-H19RhsPzA8ulJh+znbFY3U9FFBEA1t7vGdZ+ArS1QgRLwqjpGEZq/Fd8+TmDsUJYm5QTeOrXq9mk2swaXxmDKw=="],
+
+    "@zntc/core-darwin-x64": ["@zntc/core-darwin-x64@0.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-OrU4Tewbql7X7xALyEZ9rZOS5dfZEYrJo1Md3IkPiNgALG1Hbn/Sr1IpHqOG1Y6Xl3y/k4aVyvrsppJZwZ99gA=="],
+
+    "@zntc/core-linux-arm64-gnu": ["@zntc/core-linux-arm64-gnu@0.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-G35t1UdUcmU2pbJMkY+UIbzZ6IDWF/L37FXCjh7zSVEv/ai6nFqMVQhjwc/hSZKOEXEzNNE6HTUz79MxXn5E7w=="],
+
+    "@zntc/core-linux-arm64-musl": ["@zntc/core-linux-arm64-musl@0.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-q4JOz8w243Ilv5S6TTTCQUA2kTaqUiJz7buts3mr0AMsIMyXsiZj4aBh7u6I8/GB0O/pddMnKE9rM3RRRtwsyQ=="],
+
+    "@zntc/core-linux-x64-gnu": ["@zntc/core-linux-x64-gnu@0.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-ZpZ07MZ3AvYeYijGgo8VYIZDy7PyeUCeXn02Q8sEZP55JRMMouwSXtNF5YwatWcSOx0oMrvYWoNBcCl5AtAX2A=="],
+
+    "@zntc/core-linux-x64-musl": ["@zntc/core-linux-x64-musl@0.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-ire3165Slz/sPtaLCkCtbQiZggEbVyzwHRwnr2LqprvL16HdH0tmY/2l6A3eO0EDp+G0EfBAVCSOP/GH4D3X7Q=="],
+
+    "@zntc/core-win32-arm64-msvc": ["@zntc/core-win32-arm64-msvc@0.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-m9Jokeha2QE+erTxank2dbH2MxRR+6k+NzFE1WoU59M9IuUlscmhVBoA/F5HBbBAzZmeI692YeviUK7k7GVlZw=="],
+
+    "@zntc/core-win32-ia32-msvc": ["@zntc/core-win32-ia32-msvc@0.1.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-OAaACFdk8ApjTXdRsRV6qzCZy2ny4CE65T27AERIR9aOWnZPxnFkm6/zuUipCxBPgcEr2SfIUFmc+9XFravCyQ=="],
+
+    "@zntc/core-win32-x64-msvc": ["@zntc/core-win32-x64-msvc@0.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CJfVQOGJLm1/7gLmUNVX5iGrIGjPKRt3o0icQNQ3rEhUS4KNOE5uWXAberVLLryckhRnsLkZWl+lMVU8R4JrOg=="],
+
     "@zntc/e2e": ["@zntc/e2e@workspace:tests/e2e"],
 
     "@zntc/example-module-federation": ["@zntc/example-module-federation@workspace:examples/module-federation"],


### PR DESCRIPTION
## 문제 (긴급 — 이후 모든 PR blocker)

v0.1.4 릴리스(run 29694716117)의 `Sync bun.lock (post-publish)` 잡이 실패했다:
- ✅ npm 색인 확인 → `bun install --no-frozen-lockfile` → bun.lock 커밋(`462d984`) 까지 성공
- ❌ `git push origin main` 이 `.githooks/pre-push` 에서 실패 — release runner 엔 zig 가 없어 `zig fmt --check` 가 **"zig: not found"** → push 거부

결과: platform 바이너리 npm refs(`@zntc/core-*@0.1.4`) 동기화 커밋이 origin/main 에 **유실**. `@zntc/core` 의 optionalDependencies 는 workspaces 밖이라 npm 에서 해석되는데, 그게 lockfile 에 없으니 **이후 모든 PR 의 `bun install --frozen-lockfile` 이 실패**한다 (docs/PUBLISH.md §5 가 경고한 바로 그 상황).

## 수정

1. **bun.lock 수동 동기화** — 러너가 하려던 것과 동일(`bun install --no-frozen-lockfile`). `@zntc/core-*@0.1.4` 9개 platform 바이너리 refs 추가(+18줄).
2. **release.yml `git push --no-verify`** — sync-lockfile 잡의 push 가 pre-push 훅을 건너뛰도록. bun.lock 만 바꾸는 봇 커밋이라 훅 검증 불필요. 재발 방지.

## 검증
- 로컬 `bun install` 재현 → bun.lock diff 가 정확히 9개 platform 바이너리 0.1.4 refs 만.
- 이 PR 브랜치는 동기화된 lockfile 을 포함하므로 자체 CI 의 `--frozen-lockfile` 통과.