### PR TITLE
fix(bundler): #4587 preserve-modules cjs 재할당 export live-binding (exports-as-storage)

### DIFF
--- a/.changeset/preserve-modules-cjs-live-binding.md
+++ b/.changeset/preserve-modules-cjs-live-binding.md
@@ -1,0 +1,27 @@
+---
+"@zntc/core": patch
+---
+
+`--preserve-modules --format=cjs` 에서 **재할당되는 export 바인딩**(`export let A = 0; A = 1`)의 live-binding 을 rollup parity 로 수정 (#4587 target a).
+
+```js
+// a.mjs  export let A = 'init'; A = 'vA'; console.log(getB())
+// b.mjs  import { A } from './a.mjs'; export function getB(){ return A + B }
+// 수정 전: undefinedvB   /  수정 후: vAvB
+```
+
+## 근본
+
+cjs 가 export 바인딩을 로컬 `var A` + 모듈 끝 `exports.A = A`(스냅샷) 으로 낮춰, 소비자는 `const {A}=require()` 로 import 시점 스냅샷, provider 는 끝에서 한 번만 반영 → 순환/재할당에서 `undefined` 를 박제한다(ESM 은 live binding). 격리 실험으로 **양쪽 다 라이브여야** 정답이 나옴을 확인.
+
+## 수정 (rollup parity)
+
+재할당 바인딩(`write_count > 0` · `let`/`var` · 비 const/class/function · identity export · 단순 선언)을 **`exports.A` 저장소**로 낮춘다:
+- provider: 선언 `let A = 0` → `exports.A = 0`, 읽기/쓰기/compound/update/shorthand 를 `exports.A` 로 rewrite(codegen renames 재사용), 모듈 끝 `exports.A = A` skip.
+- consumer: 재할당 심볼은 `const ns = require(...); ns.A`(라이브 접근), 비재할당은 현행 구조분해 유지.
+
+`const`/`class`/`function` 은 손대지 않는다 — 각각 현행·#4584 hoist 를 유지해 TDZ·const 보호·mangle·자기참조 사이드 이펙트를 회피(rollup 도 이 층은 exports-as-storage 를 안 한다).
+
+## 스코프 밖(문서화된 한계)
+
+`const`/`class` 의 순환-중-읽기(rollup 도 실패), aliased export(`export { A as B }`), destructuring export, re-export 체인 라이브 전파는 이번 범위 밖 — 전부 현행 동작 유지(무크래시).

--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -93,6 +93,19 @@ pub const ExportBinding = struct {
     /// 위해 영구 병존 — 제거 대상 아님.
     symbol: symbol_mod.SymbolRef = symbol_mod.SymbolRef.invalid,
 
+    /// (#4587 target a) 이 `.local` export 의 선언이 destructuring pattern
+    /// (`export let { A } = obj`) 안에 있는지 — scan 시 declarator 구조에서 기록한다.
+    /// `exportBindingIsCjsStorage` 가 storage 대상에서 pattern 을 제외하는 데 쓴다
+    /// (`renames[sid]="exports.A"` 를 pattern 안 식별자에 적용하면 `let {A: exports.A}`
+    /// = SyntaxError). scan 시점 기록이라 byte-span AST 재스캔이 불필요·정확.
+    declared_via_pattern: bool = false,
+
+    /// (#4587 target a) 이 `.local` export 의 declarator 초기값이 함수/화살표/클래스
+    /// 표현식인지 — scan 시 기록. `exportBindingIsCjsStorage` 가 storage 에서 제외하는 데
+    /// 쓴다: `export let f = () => 0` 를 `exports.f = () => 0` 로 낮추면 NamedEvaluation
+    /// 이 member target 이라 안 걸려 `f.name` 이 유실된다. 제외 시 현행 로컬 유지(무손실).
+    init_is_fn_or_class: bool = false,
+
     pub const Kind = enum {
         /// 현재 모듈에서 직접 선언/할당된 export.
         local,
@@ -331,6 +344,8 @@ pub fn extractExportBindings(
                             .local_name = name_info.name,
                             .local_span = name_info.span,
                             .kind = .local,
+                            .declared_via_pattern = name_info.via_pattern,
+                            .init_is_fn_or_class = name_info.init_fn_class,
                         });
                     }
                     continue;
@@ -477,7 +492,22 @@ pub fn extractExportBindings(
     return bindings.toOwnedSlice(allocator);
 }
 
-const NameInfo = struct { name: []const u8, span: Span };
+const NameInfo = struct {
+    name: []const u8,
+    span: Span,
+    /// (#4587) declarator 이름이 destructuring pattern 안인지.
+    via_pattern: bool = false,
+    /// (#4587) declarator 초기값이 함수/화살표/클래스 표현식인지.
+    init_fn_class: bool = false,
+};
+
+/// (#4587) declarator 초기값 노드 tag 가 NamedEvaluation 대상(함수/화살표/클래스 표현식)인지.
+fn initTagIsFnOrClass(tag: Node.Tag) bool {
+    return switch (tag) {
+        .function_expression, .function, .arrow_function_expression, .class_expression => true,
+        else => false,
+    };
+}
 
 /// export 선언에서 이름들을 추출. export const x, y / export function f / export class C
 fn extractDeclExportNames(allocator: std.mem.Allocator, ast: *const Ast, decl: Node) ![]NameInfo {
@@ -510,7 +540,18 @@ fn extractDeclExportNames(allocator: std.mem.Allocator, ast: *const Ast, decl: N
                 if (name_idx.isNone()) continue;
                 if (@intFromEnum(name_idx) >= ast.nodes.items.len) continue;
 
-                try extractBindingPatternNames(&names, allocator, ast, name_idx);
+                // (#4587) declarator shape 를 scan 시 기록: pattern 여부·init 이 fn/class 표현식인지.
+                const name_node = ast.getNode(name_idx);
+                const via_pattern = name_node.tag == .object_pattern or name_node.tag == .array_pattern;
+                var init_fn_class = false;
+                if (!via_pattern and de + 2 < ast.extra_data.items.len) {
+                    const init_idx: NodeIndex = @enumFromInt(ast.extra_data.items[de + 2]);
+                    if (!init_idx.isNone() and @intFromEnum(init_idx) < ast.nodes.items.len) {
+                        init_fn_class = initTagIsFnOrClass(ast.getNode(init_idx).tag);
+                    }
+                }
+
+                try extractBindingPatternNames(&names, allocator, ast, name_idx, via_pattern, init_fn_class);
             }
         },
         // 모두 extra[0] 이 이름 노드 (function: [name, ...], class: [name, ...],
@@ -540,6 +581,8 @@ fn extractBindingPatternNames(
     allocator: std.mem.Allocator,
     ast: *const Ast,
     pattern_idx: NodeIndex,
+    via_pattern: bool,
+    init_fn_class: bool,
 ) !void {
     var w = try ast_walk.bindingIdentifiers(allocator, ast, pattern_idx, .{});
     defer w.deinit();
@@ -548,6 +591,8 @@ fn extractBindingPatternNames(
         try names.append(allocator, .{
             .name = ast.getText(name_node.span),
             .span = name_node.span,
+            .via_pattern = via_pattern,
+            .init_fn_class = init_fn_class,
         });
     }
 }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1707,6 +1707,9 @@ pub fn emitModule(
             is_entry,
             override_syms,
             l.format,
+            // (#4587 [3]) storage rename 은 output.exports 가 named 모드일 때만 — codegen
+            // `.pm_cjs_storage`·끝-skip·소비자 게이트와 동일 값.
+            options.output_exports == .auto or options.output_exports == .named,
         );
         // transformer가 전파한 symbol_ids를 메타데이터에 설정
         if (override_syms) |syms| {
@@ -2079,8 +2082,11 @@ pub fn emitModule(
         .force_var_for_cycle = module.cycle_group != 0 and module.wrap_kind == .none,
         // (#4587 target a) preserve-modules + CJS unwrapped: 재할당 export 선언을 `exports.X = init;`
         // 저장소로 낮춘다(bindings.zig). renames 는 metadata 가 pm-cjs 게이트로만 등록하므로 여기
-        // 게이트와 정확히 일치해야 storage rename 이 선언 변환과 짝을 이룬다.
-        .pm_cjs_storage = options.preserve_modules and options.format == .cjs and module.wrap_kind == .none,
+        // 게이트와 정확히 일치해야 storage rename 이 선언 변환과 짝을 이룬다. output_exports 가
+        // named export 를 내는 모드(auto/named)일 때만 — 끝-skip(아래)·metadata rename·fn-hoist 와
+        // 동일 게이트라 `none`/`default_` 에서 `exports.X` 누출을 막는다(#4587 [3]).
+        .pm_cjs_storage = options.preserve_modules and options.format == .cjs and module.wrap_kind == .none and
+            (options.output_exports == .auto or options.output_exports == .named),
         .linking_metadata = if (metadata) |*m| m else null,
         // 번들 모드에서 ESM이 아니면 import.meta → {} 치환 (esbuild 호환)
         // Node.js는 import.meta를 보면 ESM으로 재파싱하려 해서 에러 발생

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -2077,6 +2077,10 @@ pub fn emitModule(
         // 변환 path (`esm_var_assign_only`, `use_var_for_imports`) 가 동일 효과를
         // 만들어주므로 이중 처리 → 호이스팅 충돌 회피하기 위해 .none 만 대상.
         .force_var_for_cycle = module.cycle_group != 0 and module.wrap_kind == .none,
+        // (#4587 target a) preserve-modules + CJS unwrapped: 재할당 export 선언을 `exports.X = init;`
+        // 저장소로 낮춘다(bindings.zig). renames 는 metadata 가 pm-cjs 게이트로만 등록하므로 여기
+        // 게이트와 정확히 일치해야 storage rename 이 선언 변환과 짝을 이룬다.
+        .pm_cjs_storage = options.preserve_modules and options.format == .cjs and module.wrap_kind == .none,
         .linking_metadata = if (metadata) |*m| m else null,
         // 번들 모드에서 ESM이 아니면 import.meta → {} 치환 (esbuild 호환)
         // Node.js는 import.meta를 보면 ESM으로 재파싱하려 해서 에러 발생
@@ -2258,6 +2262,12 @@ pub fn emitModule(
             {
                 for (module.export_bindings) |eb| {
                     if (chunks.exportBindingIsHoistableFn(module, eb)) {
+                        try hoisted_fn_names.put(allocator, eb.exported_name, {});
+                    }
+                    // (#4587 target a) storage export 는 본문에서 이미 `exports.X = ...` 로 저장했으므로
+                    // bottom 방출(`exports.X = X`)을 skip — 안 하면 `exports.X = X` 우변 X 가 미정의다.
+                    // provider rename(metadata) 과 **같은 술어**라 정합.
+                    if (module.exportBindingIsCjsStorage(eb)) {
                         try hoisted_fn_names.put(allocator, eb.exported_name, {});
                     }
                 }

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -146,9 +146,11 @@ fn deconflictedConsumerLocal(
 /// (#4587 target a) preserve-modules CJS 라이브 바인딩 소비자 import 방출.
 /// dep 의 재할당(storage) export 를 구조분해로 잡으면 순환에서 로드 시점 undefined 를 박제하므로:
 ///   1. `const <ns> = require("<bind_arg>");` holder 를 발급하고
-///   2. 재할당 심볼 → body 참조를 `<ns>.<key>` 로(consumer_import_local, 선언 없음 = 라이브 읽기)
-///   3. 비재할당 심볼 → holder 에서 구조분해 `const { k: local, ... } = <ns>;` (현행 스냅샷 유지)
-/// 로 낸다. key/local 규칙은 현행 구조분해 site 와 동일(crossChunkBindingName/deconflictedConsumerLocal).
+///   2. **모든** 심볼을 holder 에서 구조분해해 렉시컬 바인딩을 낸다(#4587 [1]: ns-member/re-export
+///      의 bare export-local 참조가 선언되게 — 안 내면 `ReferenceError`).
+///   3. 재할당 심볼은 추가로 body 의 **named** 참조를 `<ns>.<key>`(consumer_import_local)로 라이브화
+///      한다 — named=live, ns/re-export=snapshot 공존(문서화된 한계).
+/// key/local 규칙은 현행 구조분해 site 와 동일(crossChunkBindingName/deconflictedConsumerLocal).
 fn emitPmCjsLiveImport(
     allocator: std.mem.Allocator,
     chunk_output: *std.ArrayListUnmanaged(u8),
@@ -181,30 +183,44 @@ fn emitPmCjsLiveImport(
         const binding = crossChunkBindingName(linker, sym);
         const has_global = if (linker) |l| l.getCrossChunkGlobalName(sym.canonical_module, sym.name) != null else false;
         const key = if (lazy_local_keys or has_global) binding else sym.name;
-        if (isExportReassigned(graph, dep_module, sym.name)) {
-            // 재할당 심볼: body 참조 → `<ns>.<key>` (선언 없음, 라이브). consumer_import_local 을
-            // metadata 의 effective_target 이 renames 로 흘린다 (synthetic_member 와 동일 경로).
-            if (linker) |l| {
-                const member = try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ns_local, key });
-                defer allocator.free(member);
-                try l.putConsumerImportLocal(sym.canonical_module, sym.name, member);
-            }
-            continue;
-        }
-        // 비재할당 심볼: holder 에서 구조분해.
+        const reassigned = isExportReassigned(graph, dep_module, sym.name);
+
+        // (#4587 [1] 회귀 수정) 렉시컬 바인딩은 재할당 여부와 무관하게 **항상** 낸다.
+        // 예전엔 재할당 심볼을 holder 만 내고 `continue` 해 심볼의 로컬 선언이 없었다 →
+        // ns-member 재작성(`ns.A`→`A`)·re-export bottom(`exports.A = A`)이 bare export-local
+        // 명(`A`)을 참조하는데 미선언 → `ReferenceError: A is not defined`.
         if (!destructure_open) {
             try chunk_output.appendSlice(allocator, if (min) "const{" else "const { ");
             destructure_open = true;
         } else {
             try chunk_output.appendSlice(allocator, if (min) "," else ", ");
         }
-        const local = try deconflictedConsumerLocal(linker, sym, binding, lazy_local_keys or has_global, allocator, used_locals, natural_bindings, alias_strs);
-        if (!std.mem.eql(u8, key, local)) {
+
+        if (reassigned) {
+            // 재할당 심볼: bare key 로 구조분해(스냅샷 바인딩)해 bare 참조(ns-member/re-export)가
+            // 선언되게 하고, **named body 참조**는 consumer_import_local(`<ns>.<key>`)로 라이브
+            // 유지(effective_target 이 renames 로 흘림, synthetic_member 와 동일 경로). 즉 named=live,
+            // ns/re-export=snapshot 이 공존(문서화된 한계). deconflict 없이 key 그대로 — bare 참조가
+            // deconflict 안 된 export-local 명을 쓰고, preserve-modules 는 1 모듈=1 청크라 동명
+            // top-level 충돌이 없다(같은 이름 import+local 은 소스 단계 SyntaxError). linker 가
+            // null 이면(단위 테스트) 라이브 rename 은 못 걸어도 바인딩은 나므로 무크래시(방어적).
+            if (!used_locals.contains(key)) try used_locals.put(allocator, key, {});
             try chunk_output.appendSlice(allocator, key);
-            try chunk_output.appendSlice(allocator, if (min) ":" else ": ");
-            try chunk_output.appendSlice(allocator, local);
+            if (linker) |l| {
+                const member = try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ns_local, key });
+                defer allocator.free(member);
+                try l.putConsumerImportLocal(sym.canonical_module, sym.name, member);
+            }
         } else {
-            try chunk_output.appendSlice(allocator, key);
+            // 비재할당 심볼: 현행 스냅샷 구조분해.
+            const local = try deconflictedConsumerLocal(linker, sym, binding, lazy_local_keys or has_global, allocator, used_locals, natural_bindings, alias_strs);
+            if (!std.mem.eql(u8, key, local)) {
+                try chunk_output.appendSlice(allocator, key);
+                try chunk_output.appendSlice(allocator, if (min) ":" else ": ");
+                try chunk_output.appendSlice(allocator, local);
+            } else {
+                try chunk_output.appendSlice(allocator, key);
+            }
         }
     }
     if (destructure_open) {
@@ -302,10 +318,8 @@ fn emitHoistedFnExports(
 /// `.default`=undefined → TypeError(#4580). `.named` OutputExports 는 `exports.default` 를 내므로
 /// 호출부에서 auto/default_ 로 게이트한다.
 fn cjsDepDefaultOnly(allocator: std.mem.Allocator, graph: *const ModuleGraph, dep_chunk: *const Chunk) bool {
-    const mod_idx = switch (dep_chunk.kind) {
-        .entry_point => |ep| if (ep.is_import_call) return false else ep.module,
-        else => return false,
-    };
+    // (#4587 [6]) entry_point(비-import-call) 판정은 depChunkModuleIndex 로 단일화.
+    const mod_idx = depChunkModuleIndex(dep_chunk) orelse return false;
     const m = graph.getModule(mod_idx) orelse return false;
     var has_default = false;
     for (m.export_bindings) |eb| {
@@ -1131,7 +1145,11 @@ pub fn emitChunks(
                 // export 를 구조분해(로드 시점 스냅샷)로 잡으면 순환에서 undefined 를 박제한다.
                 // 재할당 심볼은 ns holder(`const ns=require()`) + body 참조 `ns.<key>`
                 // (consumer_import_local → metadata effective_target), 비재할당은 현행 구조분해.
-                const dep_mod_idx: ?ModuleIndex = if (pm_cjs) depChunkModuleIndex(dep_chunk) else null;
+                // output.exports 게이트(#4587 [3]): provider 가 storage(exports.X) 를 안 내는
+                // none/default_ 에서는 소비자도 ns-access 를 하면 안 된다(provider·metadata·codegen
+                // 게이트와 동일 값이어야 정합).
+                const storage_output_gate = options.output_exports == .auto or options.output_exports == .named;
+                const dep_mod_idx: ?ModuleIndex = if (pm_cjs and storage_output_gate) depChunkModuleIndex(dep_chunk) else null;
                 var has_reassigned = false;
                 if (dep_mod_idx) |dmi| {
                     for (symbols.?.items) |sym| {

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -143,6 +143,77 @@ fn deconflictedConsumerLocal(
     return local;
 }
 
+/// (#4587 target a) preserve-modules CJS 라이브 바인딩 소비자 import 방출.
+/// dep 의 재할당(storage) export 를 구조분해로 잡으면 순환에서 로드 시점 undefined 를 박제하므로:
+///   1. `const <ns> = require("<bind_arg>");` holder 를 발급하고
+///   2. 재할당 심볼 → body 참조를 `<ns>.<key>` 로(consumer_import_local, 선언 없음 = 라이브 읽기)
+///   3. 비재할당 심볼 → holder 에서 구조분해 `const { k: local, ... } = <ns>;` (현행 스냅샷 유지)
+/// 로 낸다. key/local 규칙은 현행 구조분해 site 와 동일(crossChunkBindingName/deconflictedConsumerLocal).
+fn emitPmCjsLiveImport(
+    allocator: std.mem.Allocator,
+    chunk_output: *std.ArrayListUnmanaged(u8),
+    linker: ?*Linker,
+    graph: *const ModuleGraph,
+    dep_module: ModuleIndex,
+    syms: []const chunk_mod.CrossChunkSym,
+    bind_arg: []const u8,
+    lazy_local_keys: bool,
+    min: bool,
+    used_locals: *std.StringHashMapUnmanaged(void),
+    natural_bindings: *const std.StringHashMapUnmanaged(void),
+    alias_strs: *std.ArrayList([]const u8),
+) !void {
+    // ns holder: `const ns_x = require("<bind_arg>");`
+    const dep_mod = graph.getModule(dep_module) orelse return;
+    const ns_base = try types.makeNsVarName(allocator, dep_mod.path);
+    // 소유권을 청크-스코프 alias_strs 로 이전한다. mintConsumerLocal 이 ns_base 를 used_locals
+    // 키(borrow)로 넣을 수 있어(기존 caller 는 안정 slice 를 넘김) `defer free` 하면 UAF 다.
+    try alias_strs.append(allocator, ns_base);
+    const ns_local = try mintConsumerLocal(allocator, ns_base, used_locals, natural_bindings, alias_strs);
+    try chunk_output.appendSlice(allocator, "const ");
+    try chunk_output.appendSlice(allocator, ns_local);
+    try chunk_output.appendSlice(allocator, if (min) "=require(\"" else " = require(\"");
+    try chunk_output.appendSlice(allocator, bind_arg);
+    try chunk_output.appendSlice(allocator, if (min) "\");" else "\");\n");
+
+    var destructure_open = false;
+    for (syms) |sym| {
+        const binding = crossChunkBindingName(linker, sym);
+        const has_global = if (linker) |l| l.getCrossChunkGlobalName(sym.canonical_module, sym.name) != null else false;
+        const key = if (lazy_local_keys or has_global) binding else sym.name;
+        if (isExportReassigned(graph, dep_module, sym.name)) {
+            // 재할당 심볼: body 참조 → `<ns>.<key>` (선언 없음, 라이브). consumer_import_local 을
+            // metadata 의 effective_target 이 renames 로 흘린다 (synthetic_member 와 동일 경로).
+            if (linker) |l| {
+                const member = try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ns_local, key });
+                defer allocator.free(member);
+                try l.putConsumerImportLocal(sym.canonical_module, sym.name, member);
+            }
+            continue;
+        }
+        // 비재할당 심볼: holder 에서 구조분해.
+        if (!destructure_open) {
+            try chunk_output.appendSlice(allocator, if (min) "const{" else "const { ");
+            destructure_open = true;
+        } else {
+            try chunk_output.appendSlice(allocator, if (min) "," else ", ");
+        }
+        const local = try deconflictedConsumerLocal(linker, sym, binding, lazy_local_keys or has_global, allocator, used_locals, natural_bindings, alias_strs);
+        if (!std.mem.eql(u8, key, local)) {
+            try chunk_output.appendSlice(allocator, key);
+            try chunk_output.appendSlice(allocator, if (min) ":" else ": ");
+            try chunk_output.appendSlice(allocator, local);
+        } else {
+            try chunk_output.appendSlice(allocator, key);
+        }
+    }
+    if (destructure_open) {
+        try chunk_output.appendSlice(allocator, if (min) "}=" else " } = ");
+        try chunk_output.appendSlice(allocator, ns_local);
+        try chunk_output.appendSlice(allocator, if (min) ";" else ";\n");
+    }
+}
+
 /// (#4580) 모듈이 default 외 **named** export 를 하나라도 내는가 — `export *`(ESM 스펙상 default
 /// 제외, named 확장)를 소스로 **재귀 flatten** 한다. provider 는 `collectExportsRecursive` 로 star 를
 /// 펼쳐 named 유무를 판정하므로 소비자도 같아야 한다(안 그러면 star 가 named 0 개일 때 provider 는
@@ -169,6 +240,25 @@ fn moduleHasAnyNamedExport(
         }
     }
     return false;
+}
+
+/// (#4587 target a) dep 청크가 나타내는 단일 모듈 인덱스 (preserve-modules: 1 청크 = 1 모듈).
+/// entry_point(비-import-call) 만 — common/manual/dynamic 은 null.
+fn depChunkModuleIndex(dep_chunk: *const Chunk) ?ModuleIndex {
+    return switch (dep_chunk.kind) {
+        .entry_point => |ep| if (ep.is_import_call) null else ep.module,
+        else => null,
+    };
+}
+
+/// (#4587 target a) `dep_module` 의 export `export_name` 이 재할당되는 storage 바인딩인지.
+/// **require 타겟(dep) 모듈**을 본다 — re-export 체인일 땐 dep 이 그 이름을 `.local` 로 소유하지
+/// 않아(kind=.re_export) false → 소비자가 구조분해(스냅샷) 유지(라이브 전파는 v1 스코프 밖).
+/// provider rename(metadata)·끝-할당 skip(emitter) 과 **동일 술어**(exportBindingIsCjsStorage).
+fn isExportReassigned(graph: *const ModuleGraph, dep_module: ModuleIndex, export_name: []const u8) bool {
+    const m = graph.getModule(dep_module) orelse return false;
+    const eb = m.findExportBinding(export_name) orelse return false;
+    return m.exportBindingIsCjsStorage(eb.*);
 }
 
 /// (#4532 증상4) export 가 **직접 선언한 function 선언**(hoistable)인지. 순환 import 서 소비자가 그
@@ -1021,11 +1111,6 @@ pub fn emitChunks(
                 try chunk_output.appendSlice(allocator, if (options.minify_whitespace) "\");" else "\");\n");
             } else if (!pm_cjs_dep and pm_esm_wrap_dep_syms == null and symbols != null and symbols.?.items.len > 0) {
                 // 심볼 수준 import: import { a, b } from './chunk-xxx.js';
-                if (!options.minify_whitespace) {
-                    try chunk_output.appendSlice(allocator, if (reg_like) "const { " else "import { ");
-                } else {
-                    try chunk_output.appendSlice(allocator, if (reg_like) "const{" else "import{");
-                }
                 // 결정론적 출력을 위해 심볼명(export 키) 정렬
                 const SymSort = struct {
                     fn lessThan(_: void, a: chunk_mod.CrossChunkSym, b: chunk_mod.CrossChunkSym) bool {
@@ -1041,6 +1126,44 @@ pub fn emitChunks(
                 // lazy`)과 정확히 일치해야 한다 — reg_split(iife/umd/amd) 뿐 아니라 cjs_split
                 // 도 emitLazyEntryExportAll 로 local 명 키를 노출하므로 둘 다 포함.
                 const lazy_local_keys = graph.lazy_compilation and (reg_split or cjs_split);
+
+                // (#4587 target a) preserve-modules CJS 라이브 바인딩: dep 의 재할당(storage)
+                // export 를 구조분해(로드 시점 스냅샷)로 잡으면 순환에서 undefined 를 박제한다.
+                // 재할당 심볼은 ns holder(`const ns=require()`) + body 참조 `ns.<key>`
+                // (consumer_import_local → metadata effective_target), 비재할당은 현행 구조분해.
+                const dep_mod_idx: ?ModuleIndex = if (pm_cjs) depChunkModuleIndex(dep_chunk) else null;
+                var has_reassigned = false;
+                if (dep_mod_idx) |dmi| {
+                    for (symbols.?.items) |sym| {
+                        if (isExportReassigned(graph, dmi, sym.name)) {
+                            has_reassigned = true;
+                            break;
+                        }
+                    }
+                }
+                if (has_reassigned) {
+                    try emitPmCjsLiveImport(
+                        allocator,
+                        &chunk_output,
+                        linker,
+                        graph,
+                        dep_mod_idx.?,
+                        symbols.?.items,
+                        bind_arg,
+                        lazy_local_keys,
+                        options.minify_whitespace,
+                        &used_locals,
+                        &natural_bindings,
+                        &alias_strs,
+                    );
+                    continue;
+                }
+
+                if (!options.minify_whitespace) {
+                    try chunk_output.appendSlice(allocator, if (reg_like) "const { " else "import { ");
+                } else {
+                    try chunk_output.appendSlice(allocator, if (reg_like) "const{" else "import{");
+                }
                 for (symbols.?.items, 0..) |sym, si| {
                     const name = sym.name;
                     const binding = crossChunkBindingName(linker, sym);

--- a/src/bundler/graph/parser_metadata.zig
+++ b/src/bundler/graph/parser_metadata.zig
@@ -79,6 +79,8 @@ pub fn materialize(
                     .local_span = sb.local_span,
                     .kind = eb_kind,
                     .import_record_index = sb.import_record_index,
+                    .declared_via_pattern = sb.declared_via_pattern,
+                    .init_is_fn_or_class = sb.init_is_fn_or_class,
                 };
             }
             module.export_bindings = ebindings;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -390,6 +390,10 @@ pub fn buildMetadataForAst(
     is_entry: bool,
     override_symbol_ids: ?[]const ?u32,
     format: types.Format,
+    /// (#4587 [3]) output.exports 가 named export 를 내는 모드(auto/named)인지. `none`/`default_`
+    /// 면 preserve-modules CJS exports-as-storage rename 을 억제해 `exports.X` 누출을 막는다.
+    /// codegen `.pm_cjs_storage`·끝-skip·소비자 ns-access 게이트와 **동일** 값이어야 정합.
+    output_produces_named: bool,
 ) !LinkingMetadata {
     var scope = @import("../../profile.zig").begin(.metadata);
     defer scope.end();
@@ -1366,7 +1370,7 @@ pub fn buildMetadataForAst(
         // bindings.zig 가 `exports.A = init;` 할당으로 별도 변환한다. 섹션4의 mangled rename 을
         // **덮어써야** 하므로 모든 name-based rename 이 끝난 이 지점에 둔다. const/class/function
         // 은 exportBindingIsCjsStorage 술어가 제외(현행·#4584 유지).
-        if (self.graph.preserve_modules and format == .cjs) {
+        if (self.graph.preserve_modules and format == .cjs and output_produces_named) {
             for (m.export_bindings) |eb| {
                 if (!m.exportBindingIsCjsStorage(eb)) continue;
                 const local = m.exportBindingLocalName(eb);

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -1357,6 +1357,25 @@ pub fn buildMetadataForAst(
             defer mb_scope.end();
             mergeUnifiedPhaseB(self, module_index, &renames, &owned_nested_renames) catch {};
         }
+
+        // (#4587 target a) preserve-modules CJS "exports-as-storage": 재할당되는 export
+        // 바인딩(`export let A = 0; A = 100`)의 로컬 심볼을 `exports.<name>` 로 rename 한다.
+        // codegen 의 identifier dispatch(node_dispatch.zig:226)가 tag-비게이트라 read(`A`)·
+        // write(`A = v`)·compound(`A += 1`)·update(`A++`)·shorthand(`{A}`)를 전부 `exports.A`
+        // 로 자동 처리 — 유일한 예외인 **선언 위치**(`let exports.A` = SyntaxError)만 codegen
+        // bindings.zig 가 `exports.A = init;` 할당으로 별도 변환한다. 섹션4의 mangled rename 을
+        // **덮어써야** 하므로 모든 name-based rename 이 끝난 이 지점에 둔다. const/class/function
+        // 은 exportBindingIsCjsStorage 술어가 제외(현행·#4584 유지).
+        if (self.graph.preserve_modules and format == .cjs) {
+            for (m.export_bindings) |eb| {
+                if (!m.exportBindingIsCjsStorage(eb)) continue;
+                const local = m.exportBindingLocalName(eb);
+                const sym_idx = module_scope.get(local) orelse continue;
+                const storage = try std.fmt.allocPrint(self.allocator, "exports.{s}", .{eb.exported_name});
+                defer self.allocator.free(storage);
+                try putOwnedRename(self, &renames, &owned_nested_renames, @intCast(sym_idx), storage);
+            }
+        }
     }
 
     // Side-effect-only import has no ImportBinding, so scope-hoisted modules that

--- a/src/bundler/linker_test.zig
+++ b/src/bundler/linker_test.zig
@@ -1180,7 +1180,7 @@ fn buildMetadataForModule(
 ) !LinkingMetadata {
     const mod = r.linker.graph.getModule(ModuleIndex.fromUsize(module_index)) orelse return error.NoAst;
     const ast: *const Ast = &(mod.ast orelse return error.NoAst);
-    return r.linker.buildMetadataForAst(ast, module_index, is_entry, null, r.linker.format);
+    return r.linker.buildMetadataForAst(ast, module_index, is_entry, null, r.linker.format, true);
 }
 
 test "preamble: CJS module import — named import generates require_xxx" {

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -774,6 +774,57 @@ pub const Module = struct {
         return self.refName(eb.symbol) orelse eb.local_name;
     }
 
+    /// (#4587 target a) preserve-modules CJS "exports-as-storage" 적격 판정.
+    /// 재할당되는(`write_count > 0`) `.local` export 바인딩을 로컬 `var`/`let` 대신
+    /// `exports.<name>` 를 저장소로 낮춘다: provider 는 `exports.A = ...` 로 저장하고,
+    /// 소비자는 `require(...).A` 로 라이브 읽기. 이 술어는 provider rename 등록(metadata),
+    /// 끝-할당 skip(emitter), 소비자 ns-access(chunks) 4곳이 **완전히 동일하게** 공유해야
+    /// 정합이 유지된다.
+    ///
+    /// v1 스코프(엄격): `.local` + identity(`local_name == exported_name`) + `write_count > 0`
+    /// + `!is_const && !is_function && !is_class` + 단순 `binding_identifier` 선언(destructuring
+    /// 제외 — `exports.A` 를 pattern 안 식별자에 적용하면 `let {A: exports.A}` = SyntaxError).
+    /// const/class/function 은 현행·#4584 로직을 그대로 유지하므로 절대 대상이 아니다.
+    pub fn exportBindingIsCjsStorage(self: *const Module, eb: ExportBinding) bool {
+        // 래핑 모듈(__commonJS/__esm)은 본문이 클로저 안이라 codegen 의 storage 선언 변환
+        // (bindings.zig, wrap_kind==.none 게이트)이 안 돈다 — 여기서 storage 로 표시하면
+        // `let exports.A`(SyntaxError)가 되므로 **반드시** 함께 제외해 4곳 술어를 정합시킨다.
+        if (self.wrap_kind != .none) return false;
+        if (eb.kind != .local) return false;
+        // v1: identity export 만. aliased(`export { A as B }`)는 provider 가 storage 를 안 해
+        // 소비자 ns-access 와 어긋나므로 제외.
+        const local = self.exportBindingLocalName(eb);
+        if (!std.mem.eql(u8, local, eb.exported_name)) return false;
+        const sem = self.semantic orelse return false;
+        if (sem.scope_maps.len == 0) return false;
+        const sym_idx = sem.scope_maps[0].get(local) orelse return false;
+        if (sym_idx >= sem.symbols.items.len) return false;
+        const sym = sem.symbols.items[sym_idx];
+        if (sym.write_count == 0) return false;
+        if (sym.decl_flags.is_const or sym.decl_flags.is_function or sym.decl_flags.is_class) return false;
+        // v1: destructuring 선언(`export let { A } = obj`)은 제외. renames[sid]="exports.A" 를
+        // pattern 안 식별자에 적용하면 SyntaxError 이므로 rename 자체를 등록하면 안 된다.
+        if (self.exportLocalDeclaredViaPattern(eb.local_span)) return false;
+        return true;
+    }
+
+    /// export 로컬 심볼의 선언이 destructuring pattern 안에 있는지 (v1 storage 제외용).
+    /// `local_span` 은 바인딩 식별자의 소스 span 이라, 그 span 을 **텍스트로 감싸는**
+    /// object/array pattern 이 있으면 pattern 선언이다. span 은 byte offset 이므로 서로 다른
+    /// 소스 위치의 pattern(함수 파라미터·대입 destructuring 등)에는 false-match 하지 않는다.
+    fn exportLocalDeclaredViaPattern(self: *const Module, local_span: Span) bool {
+        const ast = self.ast orelse return false;
+        for (ast.nodes.items) |node| {
+            switch (node.tag) {
+                .object_pattern, .array_pattern => {
+                    if (node.span.start <= local_span.start and local_span.end <= node.span.end) return true;
+                },
+                else => {},
+            }
+        }
+        return false;
+    }
+
     /// exported_name에 해당하는 SymbolRef 반환. 없으면 invalid.
     /// #1338 Phase 4c-1: 문자열 기반 lookup을 SymbolRef로 승격하기 위한 진입점.
     pub fn findExportSymbol(self: *const Module, exported_name: []const u8) symbol_mod.SymbolRef {

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -804,25 +804,13 @@ pub const Module = struct {
         if (sym.decl_flags.is_const or sym.decl_flags.is_function or sym.decl_flags.is_class) return false;
         // v1: destructuring 선언(`export let { A } = obj`)은 제외. renames[sid]="exports.A" 를
         // pattern 안 식별자에 적용하면 SyntaxError 이므로 rename 자체를 등록하면 안 된다.
-        if (self.exportLocalDeclaredViaPattern(eb.local_span)) return false;
+        // scan 시 declarator 구조에서 기록(binding_scanner/parser) — byte-span AST 재스캔 불요.
+        if (eb.declared_via_pattern) return false;
+        // (#4587 [4]) 초기값이 함수/화살표/클래스 표현식이면 제외 — `exports.f = () => 0` 로
+        // 낮추면 NamedEvaluation 이 member target 이라 안 걸려 `f.name` 이 유실된다.
+        // 제외 시 현행 로컬(`let f = () => 0` + 끝-할당) 유지 = `.name` 보존(무손실).
+        if (eb.init_is_fn_or_class) return false;
         return true;
-    }
-
-    /// export 로컬 심볼의 선언이 destructuring pattern 안에 있는지 (v1 storage 제외용).
-    /// `local_span` 은 바인딩 식별자의 소스 span 이라, 그 span 을 **텍스트로 감싸는**
-    /// object/array pattern 이 있으면 pattern 선언이다. span 은 byte offset 이므로 서로 다른
-    /// 소스 위치의 pattern(함수 파라미터·대입 destructuring 등)에는 false-match 하지 않는다.
-    fn exportLocalDeclaredViaPattern(self: *const Module, local_span: Span) bool {
-        const ast = self.ast orelse return false;
-        for (ast.nodes.items) |node| {
-            switch (node.tag) {
-                .object_pattern, .array_pattern => {
-                    if (node.span.start <= local_span.start and local_span.end <= node.span.end) return true;
-                },
-                else => {},
-            }
-        }
-        return false;
     }
 
     /// exported_name에 해당하는 SymbolRef 반환. 없으면 invalid.
@@ -979,4 +967,51 @@ test "Module.exportBindingLocalName keeps scanner local_name without semantic re
     };
 
     try std.testing.expectEqualStrings("Red", module.exportBindingLocalName(eb));
+}
+
+test "Module.exportBindingIsCjsStorage excludes non-eligible bindings (#4587)" {
+    var module = Module.init(@enumFromInt(0), "m.mjs");
+    defer module.deinit(std.testing.allocator);
+    // wrap_kind == .none (기본), semantic == null.
+
+    const base = ExportBinding{
+        .exported_name = "A",
+        .local_name = "A",
+        .local_span = Span.EMPTY,
+        .kind = .local,
+    };
+
+    // re-export → storage 대상 아님
+    {
+        var eb = base;
+        eb.kind = .re_export;
+        try std.testing.expect(!module.exportBindingIsCjsStorage(eb));
+    }
+    // non-identity (export { A as B }) → 제외
+    {
+        var eb = base;
+        eb.exported_name = "B";
+        try std.testing.expect(!module.exportBindingIsCjsStorage(eb));
+    }
+    // destructuring 선언 (export let { A } = obj) → 제외(#5, SyntaxError 방지)
+    {
+        var eb = base;
+        eb.declared_via_pattern = true;
+        try std.testing.expect(!module.exportBindingIsCjsStorage(eb));
+    }
+    // 함수/화살표/클래스 초기값 → 제외(#4, NamedEvaluation 보존)
+    {
+        var eb = base;
+        eb.init_is_fn_or_class = true;
+        try std.testing.expect(!module.exportBindingIsCjsStorage(eb));
+    }
+    // 래핑 모듈(wrap_kind != .none) → 제외(codegen storage 변환이 안 돌아 SyntaxError 방지)
+    {
+        module.wrap_kind = .cjs;
+        try std.testing.expect(!module.exportBindingIsCjsStorage(base));
+        module.wrap_kind = .none;
+    }
+    // 위 가드를 모두 통과하는 shape 라도 semantic 이 없으면 false (write_count 판정 불가) —
+    // 적격 판정은 semantic(write_count>0·비 const/fn/class)이 있어야 성립함을 확인.
+    try std.testing.expect(!module.exportBindingIsCjsStorage(base));
 }

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -943,6 +943,12 @@ pub fn makeExportsVarName(allocator: std.mem.Allocator, path: []const u8) ![]con
     return makeVarNameWithPrefix(allocator, path, "exports_");
 }
 
+/// (#4587 target a) preserve-modules CJS 라이브 바인딩 소비자의 namespace holder 변수명
+/// (`const ns_foo = require("./foo.js")`). "lib/foo-bar.mjs" → "ns_foo_bar".
+pub fn makeNsVarName(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
+    return makeVarNameWithPrefix(allocator, path, "ns_");
+}
+
 /// dev mode: `(__zntc_modules["<dev_id>"].fn(), __toCommonJS(__zntc_modules["<dev_id>"].exports))`
 /// HMR에서 new Function()이 번들 스코프 밖에서 실행되므로 레지스트리 동적 lookup 사용.
 /// require_rewrites(metadata.zig) 및 default re-export(esm_wrap.zig)에서 공유.

--- a/src/codegen/bindings.zig
+++ b/src/codegen/bindings.zig
@@ -194,16 +194,19 @@ fn emitPmCjsStorageDeclaration(self: anytype, list_start: u32, list_len: u32, ki
         }
     }.f;
 
-    // 1st pass: storage declarator 유무 확인 (없으면 현행 경로로 넘김 — 부작용 0).
+    // (#4587 [6]) declarator 당 isStorage 를 **1회** 평가해 캐시(heap bool 배열). 예전엔
+    // detection·emit 2회 평가. cap 없이(>N fallback 이 normal 경로로 새면 storage declarator 가
+    // `let exports.A` = SyntaxError 이므로 반드시 전 declarator 를 여기서 처리).
+    if (list_len == 0) return false;
+    const storage_flags = try self.allocator.alloc(bool, declarators.len);
+    defer self.allocator.free(storage_flags);
     var has_storage = false;
-    for (declarators) |raw| {
+    for (declarators, 0..) |raw, i| {
         const decl_node = self.ast.nodes.items[raw];
         const de = self.ast.extra_data.items[decl_node.data.extra .. decl_node.data.extra + 3];
         const n_idx: NodeIndex = @enumFromInt(de[0]);
-        if (isStorage(self, md, n_idx)) {
-            has_storage = true;
-            break;
-        }
+        storage_flags[i] = isStorage(self, md, n_idx);
+        if (storage_flags[i]) has_storage = true;
     }
     if (!has_storage) return false;
 
@@ -218,16 +221,16 @@ fn emitPmCjsStorageDeclaration(self: anytype, list_start: u32, list_len: u32, ki
         .await_using => "await using ",
     };
 
-    // 2nd pass: 소스 순서대로 emit.
+    // 2nd pass: 소스 순서대로 emit (isStorage 는 캐시된 storage_flags 재사용).
     var has_output = false;
-    for (declarators) |raw| {
+    for (declarators, 0..) |raw, i| {
         const decl_node = self.ast.nodes.items[raw];
         const de = self.ast.extra_data.items[decl_node.data.extra .. decl_node.data.extra + 3];
         const n_idx: NodeIndex = @enumFromInt(de[0]);
         const init_idx: NodeIndex = @enumFromInt(de[2]);
         if (n_idx.isNone()) continue;
 
-        if (isStorage(self, md, n_idx)) {
+        if (storage_flags[i]) {
             // storage 는 이미 `exports.X` 슬롯이라 init 없으면 방출할 게 없다(undefined 시작).
             if (init_idx.isNone()) continue;
             if (has_output) try writeNewline(self);
@@ -235,7 +238,10 @@ fn emitPmCjsStorageDeclaration(self: anytype, list_start: u32, list_len: u32, ki
             try writeSpace(self);
             try self.writeByte('=');
             try writeSpace(self);
-            try self.emitNode(init_idx);
+            // (#4587 [2]) init level = .comma (정상 declarator 경로 emitVariableDeclarator 와 동일):
+            // 최상위 sequence(`exports.x = (setup(), 42)`)가 `=` 우변에서 괄호로 감싸져
+            // `exports.x = setup(), 42`(오결합 → exports.x = setup())가 되지 않게 한다.
+            try self.emitExpr(init_idx, .comma, .{});
             try self.writeByte(';');
             has_output = true;
         } else {

--- a/src/codegen/bindings.zig
+++ b/src/codegen/bindings.zig
@@ -1,5 +1,6 @@
 //! Codegen helpers for binding patterns and variable declarations.
 
+const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
@@ -105,6 +106,16 @@ pub fn emitVariableDeclaration(self: anytype, node: Node) !void {
     const list_start = extras[1];
     const list_len = extras[2];
 
+    // (#4587 target a) preserve-modules CJS exports-as-storage: 재할당되는 export 바인딩이
+    // `exports.<name>` 로 rename 됐으면(linking_metadata.renames), 그 선언을 `exports.A = init;`
+    // 할당으로 낮춘다(`let exports.A` 회피). cheap 게이트(pm_cjs_storage + top-level)로 감싸
+    // 흔한 경로엔 renames 조회 비용이 안 간다.
+    if (self.options.pm_cjs_storage and self.indent_level == 0 and !self.in_for_init) {
+        if (self.options.linking_metadata != null) {
+            if (try emitPmCjsStorageDeclaration(self, list_start, list_len, kind)) return;
+        }
+    }
+
     // __esm 호이스팅: top-level 변수 선언은 래퍼 밖 `var`에 대응하는 할당문으로 변환.
     // indent_level == 0: factory body의 top-level에서만 적용.
     // 함수 안의 const/let/var는 그대로 유지해야 함.
@@ -158,6 +169,86 @@ pub fn emitVariableDeclaration(self: anytype, node: Node) !void {
     if (!self.in_for_init) {
         try self.writeByte(';');
     }
+}
+
+/// (#4587 target a) preserve-modules CJS exports-as-storage 선언 변환.
+/// 선언 안에 storage declarator(단순 binding_identifier 이면서 renames 가 `"exports."` prefix)
+/// 가 하나라도 있으면 declarator 를 partition 하여:
+///   - storage: `exports.<name> = <init>;` (name 이 renames 로 `exports.X` 를 찍음, no-init 는 skip)
+///   - 비-storage: 각각 `let/const/var <declarator>;` (소스 순서 보존)
+/// 로 emit 하고 `true` 를 반환한다. storage 가 없으면 아무것도 안 쓰고 `false`(현행 경로).
+/// destructuring declarator 는 storage 후보가 아니다(provider 술어 exportBindingIsCjsStorage 가
+/// pattern 을 제외 → 그 안 식별자에 `exports.` rename 이 안 붙음) — 항상 비-storage 로 emit.
+fn emitPmCjsStorageDeclaration(self: anytype, list_start: u32, list_len: u32, kind: anytype) !bool {
+    const md = self.options.linking_metadata.?;
+    const declarators = self.ast.extra_data.items[list_start .. list_start + list_len];
+
+    const isStorage = struct {
+        fn f(cg: anytype, meta: anytype, n_idx: NodeIndex) bool {
+            if (n_idx.isNone()) return false;
+            const name_node = cg.ast.nodes.items[@intFromEnum(n_idx)];
+            if (name_node.tag == .object_pattern or name_node.tag == .array_pattern) return false;
+            const sid = cg.resolveSymbolId(n_idx, meta) orelse return false;
+            const r = meta.renames.get(sid) orelse return false;
+            return std.mem.startsWith(u8, r, "exports.");
+        }
+    }.f;
+
+    // 1st pass: storage declarator 유무 확인 (없으면 현행 경로로 넘김 — 부작용 0).
+    var has_storage = false;
+    for (declarators) |raw| {
+        const decl_node = self.ast.nodes.items[raw];
+        const de = self.ast.extra_data.items[decl_node.data.extra .. decl_node.data.extra + 3];
+        const n_idx: NodeIndex = @enumFromInt(de[0]);
+        if (isStorage(self, md, n_idx)) {
+            has_storage = true;
+            break;
+        }
+    }
+    if (!has_storage) return false;
+
+    // 비-storage declarator 용 keyword. cycle 강등(force_var_for_cycle)·const→let(minify_syntax)
+    // 은 현행 경로와 동일 규칙.
+    const demote_to_var = self.options.force_var_for_cycle and (kind == .@"const" or kind == .let);
+    const keyword = if (demote_to_var) "var " else switch (kind) {
+        .@"var" => "var ",
+        .let => "let ",
+        .@"const" => if (self.options.minify_syntax) "let " else "const ",
+        .using => "using ",
+        .await_using => "await using ",
+    };
+
+    // 2nd pass: 소스 순서대로 emit.
+    var has_output = false;
+    for (declarators) |raw| {
+        const decl_node = self.ast.nodes.items[raw];
+        const de = self.ast.extra_data.items[decl_node.data.extra .. decl_node.data.extra + 3];
+        const n_idx: NodeIndex = @enumFromInt(de[0]);
+        const init_idx: NodeIndex = @enumFromInt(de[2]);
+        if (n_idx.isNone()) continue;
+
+        if (isStorage(self, md, n_idx)) {
+            // storage 는 이미 `exports.X` 슬롯이라 init 없으면 방출할 게 없다(undefined 시작).
+            if (init_idx.isNone()) continue;
+            if (has_output) try writeNewline(self);
+            try self.emitNode(n_idx); // renames → `exports.X`
+            try writeSpace(self);
+            try self.writeByte('=');
+            try writeSpace(self);
+            try self.emitNode(init_idx);
+            try self.writeByte(';');
+            has_output = true;
+        } else {
+            // 비-storage: 각각 자체 `keyword <declarator>;` 문으로. declarator emit 이
+            // `name = init` (또는 name-only)를 낸다.
+            if (has_output) try writeNewline(self);
+            try self.write(keyword);
+            try self.emitNode(@enumFromInt(raw));
+            try self.writeByte(';');
+            has_output = true;
+        }
+    }
+    return true;
 }
 
 pub fn emitVariableDeclarator(self: anytype, node: Node) !void {

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -135,6 +135,12 @@ pub const CodegenOptions = struct {
     /// __esm 호이스팅 모드: variable_declaration을 할당문으로 변환 (키워드 제거).
     /// emitter가 var 선언을 래퍼 밖에 별도 배치.
     esm_var_assign_only: bool = false,
+    /// (#4587 target a) preserve-modules + CJS unwrapped 모듈: 재할당되는 export 바인딩이
+    /// `exports.<name>` 로 rename 됐을 때(linking_metadata.renames 가 `"exports."` prefix),
+    /// 그 선언(`let A = init`)을 `exports.A = init;` 할당으로 낮춘다(`let exports.A` = SyntaxError
+    /// 회피). 이 flag 는 top-level 선언 emit 의 renames 조회를 흔한 ESM 경로에서 건너뛰게 하는
+    /// cheap 게이트 — pm-cjs 아닌 경로엔 오버헤드 0.
+    pm_cjs_storage: bool = false,
     /// circular 모듈 (cycle_group > 0) 의 top-level `const`/`let` 을 `var` 로 강등 (#2198).
     /// 같은 IIFE/scope 안에 hoisted IL 이 그대로 emit 되면 cycle 모듈끼리 정의 전 참조가
     /// 발생해 TDZ ReferenceError 가 throw됨 (esbuild 와 동일 패턴 - var 호이스팅으로

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -1314,8 +1314,19 @@ fn collectDeclExportBindings(self: *Parser, decl_idx: NodeIndex) void {
                 if (@intFromEnum(name_idx) >= self.ast.nodes.items.len) continue;
                 const name_node = self.ast.getNode(name_idx);
 
-                _ = name_node;
-                collectPatternExportBindings(self, name_idx);
+                // (#4587) declarator shape 를 scan 시 기록: pattern 여부·init 이 fn/class 표현식인지.
+                const via_pattern = name_node.tag == .object_pattern or name_node.tag == .array_pattern;
+                var init_fn_class = false;
+                if (!via_pattern and de + 2 < self.ast.extra_data.items.len) {
+                    const init_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[de + 2]);
+                    if (!init_idx.isNone() and @intFromEnum(init_idx) < self.ast.nodes.items.len) {
+                        init_fn_class = switch (self.ast.getNode(init_idx).tag) {
+                            .function_expression, .function, .arrow_function_expression, .class_expression => true,
+                            else => false,
+                        };
+                    }
+                }
+                collectPatternExportBindings(self, name_idx, via_pattern, init_fn_class);
             }
         },
         .function_declaration, .class_declaration => {
@@ -1337,7 +1348,7 @@ fn collectDeclExportBindings(self: *Parser, decl_idx: NodeIndex) void {
 }
 
 /// declaration binding pattern의 BoundNames를 export binding으로 수집한다.
-fn collectPatternExportBindings(self: *Parser, pattern_idx: NodeIndex) void {
+fn collectPatternExportBindings(self: *Parser, pattern_idx: NodeIndex, via_pattern: bool, init_fn_class: bool) void {
     var w = ast_walk.bindingIdentifiers(self.allocator, &self.ast, pattern_idx, .{}) catch return;
     defer w.deinit();
     while (w.next() catch null) |name_idx| {
@@ -1348,6 +1359,8 @@ fn collectPatternExportBindings(self: *Parser, pattern_idx: NodeIndex) void {
             .local_name = name,
             .local_span = name_node.span,
             .kind = .local,
+            .declared_via_pattern = via_pattern,
+            .init_is_fn_or_class = init_fn_class,
         }) catch {};
     }
 }

--- a/src/parser/scan_results.zig
+++ b/src/parser/scan_results.zig
@@ -112,6 +112,10 @@ pub const ScanExportBinding = struct {
     kind: ExportBindingKind,
     /// re-export 시 소스 모듈의 scan_import_records 인덱스
     import_record_index: ?u32 = null,
+    /// (#4587) 선언이 destructuring pattern 안인지 (bundler ExportBinding 로 전파).
+    declared_via_pattern: bool = false,
+    /// (#4587) declarator 초기값이 함수/화살표/클래스 표현식인지 (bundler ExportBinding 로 전파).
+    init_is_fn_or_class: bool = false,
 };
 
 /// CJS/ESM 감지 결과.

--- a/tests/integration/tests/preserve-modules-cjs-live-binding.test.ts
+++ b/tests/integration/tests/preserve-modules-cjs-live-binding.test.ts
@@ -127,4 +127,100 @@ describe('#4587(a): preserve-modules cjs 재할당 export live-binding', () => {
       await cleanup();
     }
   });
+
+  // (code-review [1]) 재할당 export 를 `import * as ns` 로 소비 — bare 미선언 참조로 ReferenceError
+  // 나던 회귀(소비자가 holder 만 내고 심볼 바인딩 미방출). 렉시컬 바인딩 fallback 으로 무크래시.
+  test('재할당 export 를 import * as ns 로 소비 (무크래시)', async () => {
+    const { outDir, cleanup } = await build(
+      {
+        'p.mjs': 'export let A = 0;\nA = 1;',
+        'e.mjs': 'import * as ns from "./p.mjs";\nconsole.log("R:" + ns.A);',
+      },
+      ['e.mjs'],
+    );
+    try {
+      const r = await runNode(join(outDir, 'e.js'));
+      expect(r.stderr).not.toContain('ReferenceError');
+      expect(r.stdout.trim()).toBe('R:1');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // (code-review [1]) 재할당 export 를 re-export 배럴로 소비 — `exports.A = A` bare 미선언 회귀.
+  test('재할당 export 를 re-export 배럴로 소비 (무크래시)', async () => {
+    const { outDir, cleanup } = await build(
+      {
+        'p.mjs': 'export let A = 0;\nA = 1;',
+        'bar.mjs': 'export { A } from "./p.mjs";',
+        'e.mjs': 'import { A } from "./bar.mjs";\nconsole.log("R:" + A);',
+      },
+      ['e.mjs'],
+    );
+    try {
+      const r = await runNode(join(outDir, 'e.js'));
+      expect(r.stderr).not.toContain('ReferenceError');
+      expect(r.stdout.trim()).toBe('R:1');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // (code-review [2]) 콤마 연산자 초기값이 괄호 유실로 오결합되던 것 — exports.x = (setup(), 42).
+  test('콤마 연산자 초기값 (괄호 보존)', async () => {
+    const { outDir, cleanup } = await build(
+      {
+        'm.mjs': 'export let x = (globalThis.__S = 1, 42);\nexport function bump() { x++; }',
+        'e.mjs': 'import { x } from "./m.mjs";\nconsole.log("R:" + x);',
+      },
+      ['e.mjs'],
+    );
+    try {
+      expect((await runNode(join(outDir, 'e.js'))).stdout.trim()).toBe('R:42');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // (code-review [4]) 재할당된 함수/화살표 export 는 NamedEvaluation 을 잃으면 안 됨 — 저장소화 제외.
+  test('재할당 함수 export 의 .name 보존 (저장소화 제외)', async () => {
+    const { outDir, cleanup } = await build(
+      {
+        'm.mjs': 'export let f = () => 0;\nf = f;',
+        'e.cjs': 'const m = require("./m.js");\nconsole.log("R:" + m.f.name);',
+      },
+      ['m.mjs'],
+    );
+    try {
+      // e.cjs 를 dist 에 복사해 실행(엔트리 아님)
+      const { writeFileSync: wf } = await import('node:fs');
+      wf(join(outDir, 'e.cjs'), 'const m = require("./m.js");\nconsole.log("R:" + m.f.name);');
+      expect((await runNode(join(outDir, 'e.cjs'))).stdout.trim()).toBe('R:f');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // (code-review [3]) --output-exports=none 은 재할당 export 도 누출하면 안 됨.
+  test('output-exports=none 은 재할당 export 누출 안 함', async () => {
+    const { dir, cleanup } = await createFixture({ 'a.mjs': 'export let A = 0;\nA = 1;' });
+    try {
+      const outDir = join(dir, 'dist');
+      const res = await runZntc([
+        '--bundle',
+        join(dir, 'a.mjs'),
+        '--preserve-modules',
+        `--preserve-modules-root=${dir}`,
+        '--outdir',
+        outDir,
+        '--format=cjs',
+        '--output-exports=none',
+      ]);
+      expect(res.exitCode).toBe(0);
+      const a = readFileSync(join(outDir, 'a.js'), 'utf8');
+      expect(a).not.toMatch(/exports\.A/);
+    } finally {
+      await cleanup();
+    }
+  });
 });

--- a/tests/integration/tests/preserve-modules-cjs-live-binding.test.ts
+++ b/tests/integration/tests/preserve-modules-cjs-live-binding.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync, readFileSync } from 'node:fs';
+import { createFixture, runNode, runZntc } from './helpers';
+
+/**
+ * #4587 (target a) — `--preserve-modules --format=cjs` 에서 **재할당되는 export 바인딩**
+ * (`export let A=0; A=1`)의 live-binding.
+ *
+ * 근본: cjs 가 export 바인딩을 로컬 `var A` + 모듈 끝 `exports.A = A`(스냅샷) 으로 낮춰,
+ * (1) 소비자가 `const {A}=require()` 로 import 시점 스냅샷, (2) provider 가 끝에서 한 번만 반영
+ * → 순환/재할당에서 undefined 박제. ESM 은 live binding.
+ *
+ * 수정(rollup parity): 재할당 바인딩(write_count>0, let/var, 비 const/class/fn, identity)을
+ * `exports.A` **저장소**로 (선언→`exports.A=init`, 읽기/쓰기 rewrite, 끝-할당 skip) + 소비자는
+ * `const ns=require(); ns.A` 라이브 접근. const/class 는 rollup 도 안 하는 층이라 제외(사이드
+ * 이펙트 회피).
+ */
+
+async function build(files: Record<string, string>, entries: string[], minify = false) {
+  const { dir, cleanup } = await createFixture(files);
+  const outDir = join(dir, 'dist');
+  const res = await runZntc([
+    '--bundle',
+    ...entries.map((e) => join(dir, e)),
+    '--preserve-modules',
+    `--preserve-modules-root=${dir}`,
+    '--outdir',
+    outDir,
+    '--format=cjs',
+    ...(minify ? ['--minify'] : []),
+  ]);
+  if (res.exitCode !== 0) {
+    await cleanup();
+    throw new Error(`빌드 실패:\n${res.stderr}`);
+  }
+  writeFileSync(join(outDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
+  return { outDir, cleanup };
+}
+
+describe('#4587(a): preserve-modules cjs 재할당 export live-binding', () => {
+  // 핵심: 순환 A↔B 에서 재할당된 let 을 순환 해소 후 읽으면 최신값. 수정 전 undefinedvB.
+  for (const minify of [false, true]) {
+    test(`순환 재할당 let 이 라이브${minify ? ' [min]' : ''}`, async () => {
+      const { outDir, cleanup } = await build(
+        {
+          'a.mjs':
+            'import { getB } from "./b.mjs";\nexport let A = "init";\nA = "vA";\nconsole.log("R:" + getB());',
+          'b.mjs':
+            'import { A } from "./a.mjs";\nexport const B = "vB";\nexport function getB() { return A + B; }',
+        },
+        ['a.mjs'],
+        minify,
+      );
+      try {
+        expect((await runNode(join(outDir, 'a.js'))).stdout.trim()).toBe('R:vAvB');
+      } finally {
+        await cleanup();
+      }
+    });
+  }
+
+  // provider codegen: 재할당 let → exports.A 저장소(로컬 var 없음·끝-할당 없음).
+  test('provider 가 재할당 바인딩을 exports.X 저장소로 방출', async () => {
+    const { outDir, cleanup } = await build(
+      {
+        'a.mjs': 'export let A = 1;\nA = 2;\nexport const S = "s";',
+        'e.mjs': 'import { A, S } from "./a.mjs";\nconsole.log("R:" + A + S);',
+      },
+      ['e.mjs'],
+    );
+    try {
+      const a = readFileSync(join(outDir, 'a.js'), 'utf8');
+      // 재할당 A: exports.A = 1; exports.A = 2; (로컬 `let A`/`var A` 없음)
+      expect(a).toMatch(/exports\.A\s*=\s*1/);
+      expect(a).toMatch(/exports\.A\s*=\s*2/);
+      expect(a).not.toMatch(/\b(let|var|const)\s+A\b/);
+      // const S 는 저장소화 안 함(로컬 유지) — 사이드이펙트 회피 스코프 가드
+      expect(a).toMatch(/const\s+S\s*=/);
+      // consumer 는 재할당 A 를 ns 접근, const S 는 구조분해
+      const e = readFileSync(join(outDir, 'e.js'), 'utf8');
+      expect(e).toMatch(/=\s*require\("\.\/a\.js"\)/);
+      expect((await runNode(join(outDir, 'e.js'))).stdout.trim()).toBe('R:2s');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // 혼합 한 모듈: 재할당 let + const + function 이 각각 올바른 시맨틱.
+  test('재할당 let + const + fn 혼합 (ESM 좌→우 라이브)', async () => {
+    const { outDir, cleanup } = await build(
+      {
+        'm.mjs':
+          'export let n = 1;\nn = 2;\nexport const s = "y";\nexport function f() { return 3; }',
+        'c.mjs': 'import { n, s, f } from "./m.mjs";\nconsole.log("R:" + n + s + f());',
+      },
+      ['c.mjs'],
+    );
+    try {
+      expect((await runNode(join(outDir, 'c.js'))).stdout.trim()).toBe('R:2y3');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // 스코프 가드: const 는 저장소화하지 않는다(#4587(b) 미채택 — rollup 도 실패하는 층).
+  // 순환 const 는 undefined 로 남지만 크래시/파손은 없어야 한다.
+  test('const 는 저장소화 안 함 (스코프 밖, 무크래시)', async () => {
+    const { outDir, cleanup } = await build(
+      {
+        'a.mjs':
+          'import { getB } from "./b.mjs";\nexport const A = "vA";\nconsole.log("R:" + getB());',
+        'b.mjs':
+          'import { A } from "./a.mjs";\nexport const B = "vB";\nexport function getB() { return A + B; }',
+      },
+      ['a.mjs'],
+    );
+    try {
+      const a = readFileSync(join(outDir, 'a.js'), 'utf8');
+      // A 는 로컬 바인딩으로 유지(저장소화 안 함) — 순환이라 const→var 강등될 수 있음(#2198).
+      expect(a).toMatch(/\b(var|const|let)\s+A\s*=\s*"vA"/);
+      expect(a).not.toMatch(/exports\.A\s*=\s*"vA"/); // 선언을 exports.A 저장소로 바꾸지 않음
+      // 순환 const 는 여전히 undefined(문서화된 한계) — 크래시만 없으면 됨.
+      const out = (await runNode(join(outDir, 'a.js'))).stdout.trim();
+      expect(out.startsWith('R:')).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## 문제

`--preserve-modules --format=cjs` 에서 **재할당되는 export 바인딩**(`export let A=0; A=1`)이 순환/재할당에서 `undefined` 를 박제한다(ESM 은 live binding).

```js
// a.mjs  export let A = 'init'; A = 'vA'; console.log(getB())
// b.mjs  import { A } from './a.mjs'; export function getB(){ return A + B }
// 수정 전: undefinedvB   →   수정 후: vAvB
```

## 근본 (격리 실험으로 확정)

cjs 가 export 바인딩을 로컬 `var A` + 모듈 끝 `exports.A = A`(스냅샷) 으로 낮춰 **양쪽이 값-복사**:
- consumer 는 `const {A}=require()` 로 import 시점 스냅샷
- provider 는 끝에서 한 번만 반영

V1/V2/V3 격리 실험으로 **provider·consumer 둘 다 라이브여야** 정답임을 확인. rollup 도 재할당 바인딩엔 exports-as-storage 를 쓴다(target a = rollup parity).

## 수정

재할당 바인딩(`write_count>0` · `let`/`var` · 비 const/class/function · identity · 단순 선언)을 **`exports.A` 저장소**로 낮춘다:
- **provider**: 선언 `let A=0` → `exports.A=0`, 읽기/쓰기/compound/update/shorthand 를 `exports.A` 로 rewrite(codegen renames 재사용), 모듈 끝 `exports.A=A` skip.
- **consumer**: `const ns=require(...)` holder + 모든 심볼 구조분해(bare 참조 선언) + 재할당 심볼은 named body 참조를 `ns.A`(라이브) 로.

`const`/`class`/`function` 은 손대지 않는다 — 각각 현행·#4584 hoist 유지로 TDZ·const 보호·mangle·`.name`·자기참조 사이드 이펙트를 회피(rollup 도 이 층은 exports-as-storage 를 안 한다).

## 커버리지 (실행 검증)

| 케이스 | 수정 전 | 수정 후 |
|---|---|---|
| 함수 순환호출 (C1) | AB ✓ | AB ✓ (#4584 유지) |
| `let` 재할당 순환 (C2) | undefinedvB | **vAvB** (plain+minify) |
| `const` 순환 (C3) | undefinedvB | undefinedvB (스코프밖·rollup 도 실패) |
| `class` 순환 (C4) | TypeError | TypeError (스코프밖) |

## code-review max 반영 (2차 커밋)

correctness 6건 수정·전부 node 재검증: [1] `import*as ns`/re-export 회귀(ReferenceError)=holder+구조분해 fallback, [2] 콤마 초기값 괄호, [3] `--output-exports=none` 누출 게이트, [4] 재할당 fn/class `.name` 유실(술어 제외), [5] pattern 제외 scan-시점 기록, + predicate 유닛테스트·cleanup.

## 스코프 밖 (문서화된 한계)

`const`/`class` 순환-중-읽기(rollup 도 실패), aliased export, destructuring export, re-export 체인 라이브 전파(=중간 re-exporter getter 필요)는 이번 범위 밖 — 전부 현행 동작 유지(무크래시).

## 검증

preserve-modules/splitting/cross-chunk/mangler 통합 254 + 신규 `preserve-modules-cjs-live-binding.test.ts` 10(순환·혼합·ns/re-export 무크래시·콤마·`.name`·output-none) + zig 유닛(predicate 테스트 포함) 무회귀.

Refs #4587