### PR TITLE
perf(incremental): #4557 const-baked 소비자를 provider 변경 시에만 evict (B-precise)

### DIFF
--- a/.changeset/const-baked-precise-eviction.md
+++ b/.changeset/const-baked-precise-eviction.md
@@ -1,0 +1,31 @@
+---
+"@zntc/core": patch
+---
+
+증분(warm) 빌드에서 cross-module const 를 bake 한 소비자 모듈이 **provider 가 바뀌지 않아도 매번 reparse** 되던 perf 회귀 수정 (#4557, B-precise).
+
+## 배경
+
+#4544(crude-b)는 cross-module const 를 AST 에 리터럴로 bake 한 소비자(`m.const_baked`)를 `module_store` 에서 **무조건 evict** → correctness(warm==cold)는 완전하나, provider 불변 시에도 매 warm(프로덕션 증분/watch) 빌드마다 그 소비자를 reparse 했다. cross-module numeric const 사용량에 비례(date-fns 38/304 = 12.5%, 대부분 lib 0).
+
+## 수정 (B-precise)
+
+baked 소비자를 **캐시하되**, 각 소비자가 bake 한 값이 의존하는 **provider 경로 집합**(`const_providers` = canonical + 직접 import 대상)을 기록해 두고, warm 시작 시 `changed_files` 로부터 **전이 fixpoint** 로 provider 가 실제 바뀐 소비자만 evict:
+
+```
+dirty = changed_files
+repeat: for each cached baked C: if C.const_providers ∩ dirty ≠ ∅: evict(C); dirty += C.path
+until no change
+```
+
+provider 불변 → cache-hit(reparse 0). 전이 const 체인(`a→b→c`)은 `a` 변경 → `b` evict → `c` evict 로 자연 전파. `changed_files==null`(변경 정보 없음) 이면 보수적 전량 evict(= crude-b, correctness 안전).
+
+`const_providers` 소유권은 `import_specifiers` 패턴을 그대로 미러(Module=parse_arena 소유, CachedModule=store allocator dupe, freeCachedModule 대칭 해제).
+
+## 검증
+
+reparse-count 직접 계측 유닛: provider 불변 warm → baked 소비자 cache-hit(reparse 0, crude-b 는 여기서 reparse), provider 변경 warm → evict/reparse. 전이 체인 fixpoint(warm==cold). 기존 #4544 stale 가드 유지, GPA leak/double-free 0.
+
+## 한계
+
+re-export 다단 체인(중간 barrel 재-export 대상 변경)은 `{직접, canonical}` 만 수집이라 놓칠 수 있음 — 후속(`resolveExportChain` 전체 체인 수집).

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -987,6 +987,12 @@ pub fn buildIncremental(
     var cache_hit_modules: std.AutoHashMapUnmanaged(u32, void) = .empty;
     defer cache_hit_modules.deinit(self.allocator);
 
+    // (#4557 B-precise) store 소비(getIfFresh) 전에 baked 소비자 정밀 무효화. changed_files 로
+    // 시작해 전이 fixpoint 로 provider 가 실제 바뀐 baked 소비자만 evict → 그 소비자는 이어지는
+    // 캐시 조회에서 miss → clean reparse+fresh 재-materialize. provider 불변이면 store 에 남아
+    // cache-hit(reparse 0). changed_files==null 이면 보수적으로 전량 evict(crude-b 동형).
+    store.evictConstConsumers(changed_files);
+
     var discover_scope = profile.begin(.graph_discover);
 
     // 순차 처리 — 증분 빌드는 캐시 히트가 대부분이므로 스레드 풀 오버헤드보다 효율적.
@@ -1224,6 +1230,12 @@ pub fn buildIncrementalPreserved(
     // 가 남아 emit 이 A 외 전 모듈을 unchanged 오판→peek stale.
     if (self.changed_emit_paths) |*s| s.deinit(self.allocator);
     self.changed_emit_paths = null;
+
+    // (#4557 B-precise) store 소비 전에 baked 소비자 정밀 무효화(buildIncremental 와 동형). 보존
+    // 모드는 tree-shake OFF(dev) 라 baked 모듈이 없어 통상 fast-path no-op 이지만, fallbackFullRebuild
+    // → transferModulesToStore(예외적 1회) 후 buildIncremental 이 다시 무효화하는 경로와 정합. store
+    // 가 비었거나 baked 소비자 0 이면 즉시 반환(무비용).
+    store.evictConstConsumers(changed_files);
 
     // cold / 첫 빌드 / 직전 fallback 으로 graph 가 비워진 경우 → full discovery.
     // 보존 모드는 store 를 안 채워(transferModulesToStore 비활성) cold 빌드가 전량 cache-miss 다.
@@ -1697,14 +1709,10 @@ pub fn transferModulesToStore(self: *ModuleGraph, io: std.Io, store: *module_sto
     for (0..self.moduleCount()) |i| {
         const m = self.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         if (m.parse_arena == null) continue; // disabled 등 arena 없는 모듈 스킵
-        // (#4544) cross-module const 를 AST 에 bake 한 모듈은 캐시하지 않는다. baked 리터럴은
-        // provider const 에 의존하는 graph-derived 산출물이라, 소비자 자기 mtime 키로 캐시하면
-        // provider 변경 시 stale (#4535 2번째 층). store 에서 제외 → 다음 warm 빌드가 clean
-        // reparse 후 현재 provider 값으로 fresh 재-materialize. 과거 non-baked 시절 엔트리도 evict.
-        if (m.const_baked) {
-            store.evict(m.path);
-            continue;
-        }
+        // (#4557 B-precise) cross-module const 를 bake 한 모듈(m.const_baked)도 이제 캐시한다.
+        // putModule 이 m.const_providers 를 store-owned 로 복제해 저장 → 다음 warm 빌드 시작 시
+        // `evictConstConsumers(changed_files)` 가 provider 가 **실제 바뀐** 소비자만 전이 evict
+        // (crude-b(#4544)의 무조건 evict → 매 warm reparse 회귀 해소). provider 불변이면 cache-hit.
         // mtime 은 buildIncremental / build 가 이미 module.mtime 에 기록.
         // 여기서 재-stat 하면 watcher-driven mtime cache 효과가 half-revert
         // 됨 (Issue #1727 §3). 0 이면 초기 경로에서 실패했던 모듈 —

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -1709,8 +1709,17 @@ pub fn transferModulesToStore(self: *ModuleGraph, io: std.Io, store: *module_sto
     for (0..self.moduleCount()) |i| {
         const m = self.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
         if (m.parse_arena == null) continue; // disabled 등 arena 없는 모듈 스킵
-        // (#4557 B-precise) cross-module const 를 bake 한 모듈(m.const_baked)도 이제 캐시한다.
-        // putModule 이 m.const_providers 를 store-owned 로 복제해 저장 → 다음 warm 빌드 시작 시
+        // (#4557 B-precise, [3]) baked 인데 provider 를 정밀 추적 못한 모듈(다단 re-export 체인
+        // 미추적 / dupe OOM / parse_arena 없음 → const_providers 비어있음)은 **crude-b 폴백**:
+        // 캐시에서 제외(+과거 엔트리 evict)해 다음 warm 이 무조건 clean reparse 하도록 강제한다.
+        // evictConstConsumers 는 `const_providers.len>0` 게이트라 이런 baked-empty 를 못 잡으므로
+        // (그냥 캐시하면 영영 cache-hit stale — crude-b 보다 나빠짐), 여기서 원천 차단.
+        if (m.const_baked and m.const_providers.len == 0) {
+            store.evict(m.path);
+            continue;
+        }
+        // (#4557 B-precise) provider 를 정밀 추적한 baked 모듈(const_providers.len>0)은 그대로 캐시한다.
+        // putModule 이 m.const_providers 를 store-owned 로 복제 저장 → 다음 warm 시작 시
         // `evictConstConsumers(changed_files)` 가 provider 가 **실제 바뀐** 소비자만 전이 evict
         // (crude-b(#4544)의 무조건 evict → 매 warm reparse 회귀 해소). provider 불변이면 cache-hit.
         // mtime 은 buildIncremental / build 가 이미 module.mtime 에 기록.

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -3628,6 +3628,151 @@ test "reuse #4557: 전이 provider 체인 a→b→c fixpoint evict + warm==cold"
     try std.testing.expectEqualStrings(cold_r.output, warm_r.output);
 }
 
+// #4557 [1] 다단 re-export 체인 provider: index→barrel1→barrel2→origin 로 const V(100) bake. barrel2
+// 가 재-export 대상을 origin(V=100)→origin2(W as V=200)로 바꾸면 index 의 baked 값이 100→200 이 돼야
+// 한다. const_providers 가 **중간 barrel2** 를 포함(체인 전체 수집)해야 barrel2 편집 warm 에서 index 가
+// evict/reparse 된다. {직접,canonical}만 기록하던 버그면 barrel2 누락 → index cache-hit stale(101).
+test "reuse #4557 [1]: 다단 barrel 편집 → baked 소비자 evict/reparse + warm==cold" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "origin.js", "export const V = 100;\n");
+    try writeFile(tmp.dir, "origin2.js", "export const W = 200;\n");
+    try writeFile(tmp.dir, "barrel2.js", "export { V } from './origin.js';\n");
+    try writeFile(tmp.dir, "barrel1.js", "export { V } from './barrel2.js';\n");
+    try writeFile(tmp.dir, "index.js",
+        \\import { V } from './barrel1.js';
+        \\console.log(V + 1);
+        \\
+    );
+    const entry = try absPath(&tmp, "index.js");
+    defer alloc.free(entry);
+    const barrel2_abs = try absPath(&tmp, "barrel2.js");
+    defer alloc.free(barrel2_abs);
+
+    var store = module_store.PersistentModuleStore.init(alloc);
+    defer store.deinit();
+    var cc = CompiledOutputCache.init(alloc);
+    defer cc.deinit();
+    const base_opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = false,
+        .module_store = &store,
+        .compiled_cache = &cc,
+    });
+    {
+        var b = Bundler.init(alloc, base_opts);
+        var r = try b.bundle(std.testing.io);
+        try std.testing.expect(!r.hasErrors());
+        r.deinit(alloc);
+        b.deinit();
+    }
+    // index 의 const_providers 가 중간 barrel2 를 포함해야 한다(체인 전체 수집 — [1] 핵심).
+    {
+        var saw_barrel2 = false;
+        var it = store.modules.iterator();
+        while (it.next()) |e| {
+            if (std.mem.endsWith(u8, e.key_ptr.*, "index.js")) {
+                for (e.value_ptr.const_providers) |pp| {
+                    if (std.mem.endsWith(u8, pp, "barrel2.js")) saw_barrel2 = true;
+                }
+            }
+        }
+        try std.testing.expect(saw_barrel2);
+    }
+    // barrel2 만 편집: 재-export 대상을 origin2(W as V=200)로. index 소스는 불변.
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "barrel2.js", "export { W as V } from './origin2.js';\n");
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(alloc);
+    try touched.put(alloc, barrel2_abs, {});
+    var warm_opts = base_opts;
+    warm_opts.changed_files = &touched;
+    var warm = Bundler.init(alloc, warm_opts);
+    var warm_r = try warm.bundle(std.testing.io);
+    defer warm_r.deinit(alloc);
+    defer warm.deinit();
+    try std.testing.expect(!warm_r.hasErrors());
+    // 중간 barrel2 편집이 index 를 evict/reparse 해야 한다(체인 전체 추적).
+    try std.testing.expect(reparsedContains(warm_r.reparsed_paths, "index.js"));
+    // 정확성: V 가 200 으로 재해석 → console.log(201) == cold (stale 101 아님).
+    var cold = Bundler.init(alloc, .{ .entry_points = &.{entry}, .dev_mode = false });
+    var cold_r = try cold.bundle(std.testing.io);
+    defer cold_r.deinit(alloc);
+    defer cold.deinit();
+    try std.testing.expect(!cold_r.hasErrors());
+    try std.testing.expectEqualStrings(cold_r.output, warm_r.output);
+}
+
+// #4557 [3] 정밀 추적 불가(star re-export) → crude-b 폴백: `export *` 경유 const 는 chain walk 가
+// bail(export_map 에 named 엔트리 없음) → collector.incomplete → const_providers 빈 채. baked 지만
+// transferModulesToStore 가 그 소비자를 캐시에서 제외(무조건 evict)해 store 에 안 남긴다 → 매 warm
+// clean reparse. (버그: 빈 providers 를 그냥 캐시하면 evictConstConsumers 게이트(len>0)가 skip →
+// 영영 cache-hit stale, crude-b 보다 나빠짐.)
+test "reuse #4557 [3]: star re-export 경유 baked 소비자는 crude-b(캐시 제외) + warm==cold" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "origin.js", "export const W = 5;\n");
+    try writeFile(tmp.dir, "barrel.js", "export * from './origin.js';\n");
+    try writeFile(tmp.dir, "index.js",
+        \\import { W } from './barrel.js';
+        \\console.log(W + 1);
+        \\
+    );
+    const entry = try absPath(&tmp, "index.js");
+    defer alloc.free(entry);
+    const origin_abs = try absPath(&tmp, "origin.js");
+    defer alloc.free(origin_abs);
+
+    var store = module_store.PersistentModuleStore.init(alloc);
+    defer store.deinit();
+    var cc = CompiledOutputCache.init(alloc);
+    defer cc.deinit();
+    const base_opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = false,
+        .module_store = &store,
+        .compiled_cache = &cc,
+    });
+    {
+        var b = Bundler.init(alloc, base_opts);
+        var r = try b.bundle(std.testing.io);
+        try std.testing.expect(!r.hasErrors());
+        r.deinit(alloc);
+        b.deinit();
+    }
+    // crude-b 폴백: index 는 baked(incomplete providers)라 store 에 캐시되지 않아야 한다([3]).
+    {
+        var cached_index = false;
+        var it = store.modules.iterator();
+        while (it.next()) |e| {
+            if (std.mem.endsWith(u8, e.key_ptr.*, "index.js")) cached_index = true;
+        }
+        try std.testing.expect(!cached_index);
+    }
+    // origin 편집(W=9) → index 는 (캐시 안 됐으니) reparse → console.log(10). warm==cold.
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "origin.js", "export const W = 9;\n");
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(alloc);
+    try touched.put(alloc, origin_abs, {});
+    var warm_opts = base_opts;
+    warm_opts.changed_files = &touched;
+    var warm = Bundler.init(alloc, warm_opts);
+    var warm_r = try warm.bundle(std.testing.io);
+    defer warm_r.deinit(alloc);
+    defer warm.deinit();
+    try std.testing.expect(!warm_r.hasErrors());
+    try std.testing.expect(reparsedContains(warm_r.reparsed_paths, "index.js"));
+    var cold = Bundler.init(alloc, .{ .entry_points = &.{entry}, .dev_mode = false });
+    var cold_r = try cold.bundle(std.testing.io);
+    defer cold_r.deinit(alloc);
+    defer cold.deinit();
+    try std.testing.expect(!cold_r.hasErrors());
+    try std.testing.expectEqualStrings(cold_r.output, warm_r.output);
+}
+
 // #4535 [0]: transitive re-export barrel. origin(q.js)이 심볼을 rename 하면 barrel(barrel.js)의
 // emitFingerprint 가 origin canonical 을 chain-resolve 해 바뀌어야, barrel 통해 import 하는
 // main.js 가 miss 된다(안 그러면 옛 심볼명 참조 → ReferenceError). compiled_cache ON + dev OFF.

--- a/src/bundler/incremental_test.zig
+++ b/src/bundler/incremental_test.zig
@@ -3439,6 +3439,195 @@ test "reuse #4544: sensitive + dead-branch consumer warm==cold" {
     }, "index.js", "flags.js", "export const N = 2;\nexport const FLAG = 1;\n");
 }
 
+// (#4557 B-precise) reparsed_paths(=cache-miss 모듈)로 reparse 여부를 직접 계측하는 헬퍼.
+fn reparsedContains(paths: ?[]const []const u8, needle: []const u8) bool {
+    const ps = paths orelse return false;
+    for (ps) |p| {
+        if (std.mem.endsWith(u8, p, needle)) return true;
+    }
+    return false;
+}
+
+// #4557 (B-precise) perf 핵심: provider **불변** warm 빌드면 baked 소비자가 store cache-hit(reparse 0).
+// crude-b(#4544)는 baked 소비자를 매 warm 무조건 evict→reparse 했다(date-fns 38/304 회귀). B-precise 는
+// const_providers 로 provider 가 실제 바뀔 때만 evict. index(baked, `console.log(P+1)`)가 provider.js 의
+// P 를 bake — helper.js(무관)만 바꾼 warm2 는 index cache-hit, provider.js 를 바꾼 warm3 는 index evict/reparse.
+test "reuse #4557: provider 불변 warm → baked 소비자 cache-hit (reparse 0), provider 변경 시에만 evict" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "provider.js", "export const P = 10;\n");
+    try writeFile(tmp.dir, "helper.js", "export function fn(){ console.log('h'); }\n");
+    try writeFile(tmp.dir, "index.js",
+        \\import { P } from './provider.js';
+        \\import { fn } from './helper.js';
+        \\console.log(P + 1);
+        \\fn();
+        \\
+    );
+    const entry = try absPath(&tmp, "index.js");
+    defer alloc.free(entry);
+    const provider_abs = try absPath(&tmp, "provider.js");
+    defer alloc.free(provider_abs);
+    const helper_abs = try absPath(&tmp, "helper.js");
+    defer alloc.free(helper_abs);
+
+    var store = module_store.PersistentModuleStore.init(alloc);
+    defer store.deinit();
+    var cc = CompiledOutputCache.init(alloc);
+    defer cc.deinit();
+    const base_opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = false,
+        .module_store = &store,
+        .compiled_cache = &cc,
+    });
+
+    // build 1 (cold): store seed. B-precise 는 baked 소비자(index)를 evict 하지 않고 const_providers 와
+    // 함께 저장한다(crude-b 는 여기서 evict 했음). change 1~4 배선을 store 내용으로 직접 검증.
+    {
+        var b = Bundler.init(alloc, base_opts);
+        var r = try b.bundle(std.testing.io);
+        try std.testing.expect(!r.hasErrors());
+        r.deinit(alloc);
+        b.deinit();
+    }
+    {
+        var found_index = false;
+        var it = store.modules.iterator();
+        while (it.next()) |e| {
+            if (std.mem.endsWith(u8, e.key_ptr.*, "index.js")) {
+                found_index = true;
+                // baked 소비자가 provider 경로와 함께 store 에 남아있어야 한다.
+                try std.testing.expect(e.value_ptr.const_providers.len > 0);
+                var saw_provider = false;
+                for (e.value_ptr.const_providers) |pp| {
+                    if (std.mem.endsWith(u8, pp, "provider.js")) saw_provider = true;
+                }
+                try std.testing.expect(saw_provider);
+            }
+        }
+        try std.testing.expect(found_index);
+    }
+
+    // warm 2: provider 와 무관한 helper.js 만 변경. index(baked)는 cache-hit — reparse 안 됨.
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "helper.js", "export function fn(){ console.log('h2'); }\n");
+    var touched2: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched2.deinit(alloc);
+    try touched2.put(alloc, helper_abs, {});
+    var warm2_opts = base_opts;
+    warm2_opts.changed_files = &touched2;
+    {
+        var b = Bundler.init(alloc, warm2_opts);
+        var r = try b.bundle(std.testing.io);
+        defer r.deinit(alloc);
+        defer b.deinit();
+        try std.testing.expect(!r.hasErrors());
+        // 핵심(B-precise vs crude-b): provider 불변 → index reparse 안 됨. crude-b 면 여기서 index reparse.
+        try std.testing.expect(!reparsedContains(r.reparsed_paths, "index.js"));
+        // helper 는 자기 변경으로 reparse (계측이 non-vacuous 임을 보장).
+        try std.testing.expect(reparsedContains(r.reparsed_paths, "helper.js"));
+    }
+
+    // warm 3: provider.js 의 const 값 변경 → index(baked)는 evict/reparse 되고 새 값 반영.
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "provider.js", "export const P = 20;\n");
+    var touched3: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched3.deinit(alloc);
+    try touched3.put(alloc, provider_abs, {});
+    var warm3_opts = base_opts;
+    warm3_opts.changed_files = &touched3;
+    var warm3 = Bundler.init(alloc, warm3_opts);
+    var warm3_r = try warm3.bundle(std.testing.io);
+    defer warm3_r.deinit(alloc);
+    defer warm3.deinit();
+    try std.testing.expect(!warm3_r.hasErrors());
+    // 핵심: provider 변경 → baked 소비자 evict → reparse.
+    try std.testing.expect(reparsedContains(warm3_r.reparsed_paths, "index.js"));
+    // 정확성: 새 P(20) 재-materialize == cold.
+    var cold = Bundler.init(alloc, .{ .entry_points = &.{entry}, .dev_mode = false });
+    var cold_r = try cold.bundle(std.testing.io);
+    defer cold_r.deinit(alloc);
+    defer cold.deinit();
+    try std.testing.expect(!cold_r.hasErrors());
+    try std.testing.expectEqualStrings(cold_r.output, warm3_r.output);
+}
+
+// #4557 전이 체인: a(const)→b(baked, `B=A+10`)→c(baked, `C=B+100`). a.js 변경 warm 이 b 를 evict 하고,
+// b 가 dirty 로 확장돼 c 까지 evict(fixpoint)해야 한다. 직접({a})만 봤다면 c 는 stale B 를 박제.
+test "reuse #4557: 전이 provider 체인 a→b→c fixpoint evict + warm==cold" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "a.js", "export const A = 1;\n");
+    try writeFile(tmp.dir, "b.js", "import { A } from './a.js';\nexport const B = A + 10;\n");
+    try writeFile(tmp.dir, "c.js", "import { B } from './b.js';\nexport const C = B + 100;\n");
+    try writeFile(tmp.dir, "index.js",
+        \\import { C } from './c.js';
+        \\console.log(C);
+        \\
+    );
+    const entry = try absPath(&tmp, "index.js");
+    defer alloc.free(entry);
+    const a_abs = try absPath(&tmp, "a.js");
+    defer alloc.free(a_abs);
+
+    var store = module_store.PersistentModuleStore.init(alloc);
+    defer store.deinit();
+    var cc = CompiledOutputCache.init(alloc);
+    defer cc.deinit();
+    const base_opts = @as(@import("bundler.zig").BundleOptions, .{
+        .entry_points = &.{entry},
+        .dev_mode = false,
+        .module_store = &store,
+        .compiled_cache = &cc,
+    });
+    {
+        var b = Bundler.init(alloc, base_opts);
+        var r = try b.bundle(std.testing.io);
+        try std.testing.expect(!r.hasErrors());
+        r.deinit(alloc);
+        b.deinit();
+    }
+    // b, c 둘 다 baked (const_providers 기록) — 전이 체인 전제.
+    {
+        var saw_b = false;
+        var saw_c = false;
+        var it = store.modules.iterator();
+        while (it.next()) |e| {
+            if (std.mem.endsWith(u8, e.key_ptr.*, "b.js")) saw_b = e.value_ptr.const_providers.len > 0;
+            if (std.mem.endsWith(u8, e.key_ptr.*, "c.js")) saw_c = e.value_ptr.const_providers.len > 0;
+        }
+        try std.testing.expect(saw_b);
+        try std.testing.expect(saw_c);
+    }
+
+    // a.js 변경 → fixpoint: {a} → b evict(provider a) → {a,b} → c evict(provider b).
+    std.testing.io.sleep(std.Io.Duration.fromMilliseconds(50), .awake) catch {};
+    try writeFile(tmp.dir, "a.js", "export const A = 2;\n");
+    var touched: std.StringHashMapUnmanaged(void) = .empty;
+    defer touched.deinit(alloc);
+    try touched.put(alloc, a_abs, {});
+    var warm_opts = base_opts;
+    warm_opts.changed_files = &touched;
+    var warm = Bundler.init(alloc, warm_opts);
+    var warm_r = try warm.bundle(std.testing.io);
+    defer warm_r.deinit(alloc);
+    defer warm.deinit();
+    try std.testing.expect(!warm_r.hasErrors());
+    // 전이 evict 검증: b(직접 provider a) + c(provider b, fixpoint) 모두 reparse.
+    try std.testing.expect(reparsedContains(warm_r.reparsed_paths, "b.js"));
+    try std.testing.expect(reparsedContains(warm_r.reparsed_paths, "c.js"));
+    // 정확성: C = (2+10)+100 = 112 == cold (c 가 stale 11 을 박제하지 않음).
+    var cold = Bundler.init(alloc, .{ .entry_points = &.{entry}, .dev_mode = false });
+    var cold_r = try cold.bundle(std.testing.io);
+    defer cold_r.deinit(alloc);
+    defer cold.deinit();
+    try std.testing.expect(!cold_r.hasErrors());
+    try std.testing.expectEqualStrings(cold_r.output, warm_r.output);
+}
+
 // #4535 [0]: transitive re-export barrel. origin(q.js)이 심볼을 rename 하면 barrel(barrel.js)의
 // emitFingerprint 가 origin canonical 을 chain-resolve 해 바뀌어야, barrel 통해 import 하는
 // main.js 가 miss 된다(안 그러면 옛 심볼명 참조 → ReferenceError). compiled_cache ON + dev OFF.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2527,6 +2527,7 @@ pub const Linker = struct {
     pub const buildRequireRewrites = metadata_mod.buildRequireRewrites;
     pub const buildFinalExports = metadata_mod.buildFinalExports;
     pub const ConstValuesProfile = metadata_mod.ConstValuesProfile;
+    pub const ConstProviderCollector = metadata_mod.ConstProviderCollector;
     pub const buildCrossModuleConstValues = metadata_mod.buildCrossModuleConstValues;
     pub const buildCrossModuleConstValuesProfiled = metadata_mod.buildCrossModuleConstValuesProfiled;
     pub const finalizeNamespaceData = metadata_mod.finalizeNamespaceData;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -1719,14 +1719,20 @@ pub fn buildCrossModuleConstValues(
     m: *const Module,
     sem: @import("../module.zig").ModuleSemanticData,
 ) !std.AutoHashMapUnmanaged(u32, semantic_symbol.ConstValue) {
-    return buildCrossModuleConstValuesProfiled(self, m, sem, .{});
+    return buildCrossModuleConstValuesProfiled(self, m, sem, .{}, null);
 }
 
+/// `providers` (#4557 B-precise): non-null 이면, const 값이 확정되는 각 import binding 의
+/// **provider 모듈 경로**({직접 import 대상, canonical} 둘 다)를 이 집합에 채운다. key 는
+/// provider module.path 를 borrow(이 함수 스코프 내 transient — caller 가 dupe 해 소유). warm
+/// invalidation 이 baked 소비자의 의존 provider 를 알아내는 데 쓴다. re-export 다단 체인은 v1
+/// 범위 밖 — 직접+canonical 만.
 pub fn buildCrossModuleConstValuesProfiled(
     self: *const Linker,
     m: *const Module,
     _: @import("../module.zig").ModuleSemanticData,
     profile_cats: ConstValuesProfile,
+    providers: ?*std.StringHashMapUnmanaged(void),
 ) !std.AutoHashMapUnmanaged(u32, semantic_symbol.ConstValue) {
     var const_values: std.AutoHashMapUnmanaged(u32, semantic_symbol.ConstValue) = .empty;
     if (m.import_bindings.len == 0) return const_values;
@@ -1791,6 +1797,13 @@ pub fn buildCrossModuleConstValuesProfiled(
         // import binding의 local symbol에 매핑
         if (ib.local_symbol.semanticIndex()) |local_sym| {
             try const_values.put(self.allocator, local_sym, cv);
+            // (#4557 B-precise) 이 const 값이 의존하는 provider 경로 수집: canonical provider
+            // (canon.module_index) + 직접 import 대상(rec.resolved) 둘 다. re-export 다단 체인은
+            // v1 범위 밖(직접·canonical 만). key 는 module.path borrow — caller 가 dupe 소유.
+            if (providers) |p| {
+                if (self.graph.getModule(canon.module_index)) |pm| try p.put(self.allocator, pm.path, {});
+                if (self.graph.getModule(rec.resolved)) |dm| try p.put(self.allocator, dm.path, {});
+            }
         }
     }
     return const_values;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -1714,6 +1714,17 @@ pub const ConstValuesProfile = struct {
     lookup: ?profile.Category = null,
 };
 
+/// (#4557 B-precise) const provider 경로 수집기. `paths` 는 **diskPath 정규화**된 provider 경로들
+/// (changed_files 도메인과 일치 — query strip, [2]). `incomplete` 는 어떤 const 라도 정밀 추적
+/// 불가(다단 re-export 체인의 중간 barrel 을 clean named `.re_export` 로 끝까지 못 따라감 — star/
+/// synthetic/.local 위장/cjs/깊이초과, [1])일 때 set. **all-or-nothing**: incomplete 면 caller 가
+/// paths 를 버리고 소비자 `const_providers` 를 비워 두어 transferModulesToStore 가 crude-b(무조건
+/// evict)로 폴백한다 → staleness 원천 차단([3]).
+pub const ConstProviderCollector = struct {
+    paths: std.StringHashMapUnmanaged(void) = .empty,
+    incomplete: bool = false,
+};
+
 pub fn buildCrossModuleConstValues(
     self: *const Linker,
     m: *const Module,
@@ -1722,17 +1733,18 @@ pub fn buildCrossModuleConstValues(
     return buildCrossModuleConstValuesProfiled(self, m, sem, .{}, null);
 }
 
-/// `providers` (#4557 B-precise): non-null 이면, const 값이 확정되는 각 import binding 의
-/// **provider 모듈 경로**({직접 import 대상, canonical} 둘 다)를 이 집합에 채운다. key 는
-/// provider module.path 를 borrow(이 함수 스코프 내 transient — caller 가 dupe 해 소유). warm
-/// invalidation 이 baked 소비자의 의존 provider 를 알아내는 데 쓴다. re-export 다단 체인은 v1
-/// 범위 밖 — 직접+canonical 만.
+/// `collector` (#4557 B-precise): non-null 이면, const 값이 확정되는 각 import binding 에 대해
+/// **소비자→직접 import 대상→…→canonical origin** 의 re-export 체인 전체(중간 barrel 포함)를
+/// clean named `.re_export` 로 따라가며 방문 모듈의 **diskPath** 를 `collector.paths` 에 넣는다
+/// ([1][2]). 체인을 canon 까지 확실히 못 따라가면(star/synthetic/.local 위장/깊이초과) 그 소비자를
+/// `collector.incomplete=true` 로 표시 → caller 가 crude-b 폴백. paths 키는 module.path 를 borrow
+/// (이 함수 스코프 transient — caller 가 dupe 해 소유).
 pub fn buildCrossModuleConstValuesProfiled(
     self: *const Linker,
     m: *const Module,
     _: @import("../module.zig").ModuleSemanticData,
     profile_cats: ConstValuesProfile,
-    providers: ?*std.StringHashMapUnmanaged(void),
+    collector: ?*ConstProviderCollector,
 ) !std.AutoHashMapUnmanaged(u32, semantic_symbol.ConstValue) {
     var const_values: std.AutoHashMapUnmanaged(u32, semantic_symbol.ConstValue) = .empty;
     if (m.import_bindings.len == 0) return const_values;
@@ -1797,16 +1809,49 @@ pub fn buildCrossModuleConstValuesProfiled(
         // import binding의 local symbol에 매핑
         if (ib.local_symbol.semanticIndex()) |local_sym| {
             try const_values.put(self.allocator, local_sym, cv);
-            // (#4557 B-precise) 이 const 값이 의존하는 provider 경로 수집: canonical provider
-            // (canon.module_index) + 직접 import 대상(rec.resolved) 둘 다. re-export 다단 체인은
-            // v1 범위 밖(직접·canonical 만). key 는 module.path borrow — caller 가 dupe 소유.
-            if (providers) |p| {
-                if (self.graph.getModule(canon.module_index)) |pm| try p.put(self.allocator, pm.path, {});
-                if (self.graph.getModule(rec.resolved)) |dm| try p.put(self.allocator, dm.path, {});
+            // (#4557 B-precise, [1][2]) 이 const 의 re-export 체인 전체(중간 barrel 포함)를 diskPath 로
+            // 수집. canon 까지 clean named `.re_export` 로 못 따라가면 incomplete → 소비자 crude-b 폴백.
+            if (collector) |c| {
+                const complete = collectConstProviderChain(self, rec.resolved, ib.imported_name, canon.module_index, &c.paths) catch false;
+                if (!complete) c.incomplete = true;
             }
         }
     }
     return const_values;
+}
+
+/// (#4557 B-precise, [1][2]) 소비자가 import 하는 const 의 re-export 체인을 `start`(직접 import
+/// 대상)에서 `canon_mi`(canonical origin)까지 따라가며 **방문 모든 모듈의 diskPath**(query strip,
+/// changed_files 도메인 일치)를 `out` 에 넣는다. clean named `.re_export` forwarding 만 따라간다.
+/// canon 에 확실히 도달하면 `true`(체인 전체 정확 수집). star/namespace re-export·.local 위장·cjs·
+/// 깊이초과 등 정밀 추적 불가 시 `false` → caller 가 소비자를 crude-b(무조건 evict) 폴백.
+/// **불변식**: `true` 를 반환하면 `out` 에 canon 을 포함한 체인 전체가 누락 없이 들어있다(over-
+/// collect 도 wrong-complete 도 아님 — 실제 resolver 와 동일 edge 만 따라가고 canon 도달을 확인).
+fn collectConstProviderChain(
+    self: *const Linker,
+    start: ModuleIndex,
+    name: []const u8,
+    canon_mi: ModuleIndex,
+    out: *std.StringHashMapUnmanaged(void),
+) !bool {
+    var cur = start;
+    var cur_name = name;
+    var depth: u32 = 0;
+    while (depth <= 100) : (depth += 1) { // linker max_chain_depth 와 동형 상한
+        const cm = self.graph.getModule(cur) orelse return false;
+        try out.put(self.allocator, cm.diskPath(), {});
+        if (@intFromEnum(cur) == @intFromEnum(canon_mi)) return true; // origin 도달 → 완전
+        const entry = self.export_map.get(.{ .module_index = @intCast(@intFromEnum(cur)), .name = cur_name }) orelse return false;
+        if (entry.binding.kind != .re_export) return false; // .local(위장 re-export 포함)/star/ns → 추적 불가
+        const rec_idx = entry.binding.import_record_index orelse return false;
+        if (std.mem.eql(u8, entry.binding.local_name, "*")) return false; // namespace re-export
+        if (rec_idx >= cm.import_records.len) return false;
+        const next = cm.import_records[rec_idx].resolved;
+        if (next.isNone()) return false;
+        cur = next;
+        cur_name = entry.binding.local_name;
+    }
+    return false; // 깊이 초과 → 폴백
 }
 
 /// namespace 리스트의 소유권을 이동하고, namespace preamble을 CJS preamble과 합친다.

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -293,11 +293,17 @@ pub const Module = struct {
     /// 안 함): cache-miss 재파스마다 false 로 초기화되고, cross-module bake 발생 시에만 set.
     const_baked: bool = false,
 
-    /// (#4557 B-precise) `const_baked` 모듈이 bake 한 값이 의존하는 **provider 모듈 경로** 집합.
-    /// const-materialize 가 소비자에 인라인한 cross-module const 의 {직접 import 대상, canonical}
-    /// provider path 를 기록한다(re-export 다단 체인은 v1 범위 밖). warm(증분) 빌드가 이 집합으로
-    /// **provider 가 실제 바뀔 때만** baked 소비자를 evict(전이 fixpoint) — provider 불변이면 캐시
-    /// hit(reparse 0). crude-b(#4544)의 무조건 evict 를 대체.
+    /// (#4557 B-precise) `const_baked` 모듈이 bake 한 값이 의존하는 **provider 모듈 경로**(diskPath,
+    /// query strip) 집합. const-materialize 가 소비자에 인라인한 cross-module const 의 re-export 체인
+    /// 전체(소비자→직접 import 대상→중간 barrel→canonical origin)를 기록한다([1]). warm(증분) 빌드가
+    /// 이 집합으로 **provider 가 실제 바뀔 때만** baked 소비자를 evict(전이 fixpoint) — provider
+    /// 불변이면 캐시 hit(reparse 0). crude-b(#4544)의 무조건 evict 를 대체.
+    ///
+    /// **diskPath 도메인([2])**: changed_files/dirty 와 매칭하려면 query 없는 diskPath 여야 한다.
+    ///
+    /// **빈 채로 남으면 = crude-b 폴백([3])**: `const_baked=true` 인데 이 집합이 비면(다단 체인 미추적/
+    /// dupe OOM/parse_arena 없음) provider 를 정밀히 모른다는 뜻 → `transferModulesToStore` 가 그 모듈을
+    /// 캐시에서 제외(무조건 evict)해 다음 warm 이 clean reparse 하게 강제한다(staleness 원천 차단).
     ///
     /// **소유권**: `parse_arena` 에서 alloc (materialize 시 dupe). arena.deinit 가 일괄 해제하므로
     /// 개별 free 금지(#1287). module_store 로 round-trip 시엔 CachedModule.const_providers 가 store

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -293,6 +293,18 @@ pub const Module = struct {
     /// 안 함): cache-miss 재파스마다 false 로 초기화되고, cross-module bake 발생 시에만 set.
     const_baked: bool = false,
 
+    /// (#4557 B-precise) `const_baked` 모듈이 bake 한 값이 의존하는 **provider 모듈 경로** 집합.
+    /// const-materialize 가 소비자에 인라인한 cross-module const 의 {직접 import 대상, canonical}
+    /// provider path 를 기록한다(re-export 다단 체인은 v1 범위 밖). warm(증분) 빌드가 이 집합으로
+    /// **provider 가 실제 바뀔 때만** baked 소비자를 evict(전이 fixpoint) — provider 불변이면 캐시
+    /// hit(reparse 0). crude-b(#4544)의 무조건 evict 를 대체.
+    ///
+    /// **소유권**: `parse_arena` 에서 alloc (materialize 시 dupe). arena.deinit 가 일괄 해제하므로
+    /// 개별 free 금지(#1287). module_store 로 round-trip 시엔 CachedModule.const_providers 가 store
+    /// allocator 로 별도 dupe/free 해 보관(import_specifiers 미러). 이 build-scope 필드는 cache-miss
+    /// 재파스마다 `&.{}` 로 초기화되고 bake 발생 시에만 채워진다.
+    const_providers: []const []const u8 = &.{},
+
     /// wrap_kind != .none 모듈의 `init_<path>` 함수 심볼 id (semantic 공간).
     /// null = 미래핑 또는 semantic 없음 (fallback: makeInitVarName 재할당).
     init_symbol: ?SemanticSymbolId = null,

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -137,36 +137,56 @@ pub const PersistentModuleStore = struct {
     /// 바뀌었는지 알 수 없으므로 모든 baked 소비자(const_providers.len>0)를 evict = crude-b 와
     /// 동일한 보수적 correctness (절대 stale 안 남김, perf 는 non-null 경로에서만 회복).
     ///
-    /// **순회 안전(HashMap 수정)**: evict 대상 path 를 먼저 수집 후 일괄 evict — iterator 무효화
-    /// 회피. evict 가 store key(및 provider 경로 backing)를 free 하므로, 전이 확장용 dirty 에는
-    /// evict *전에* path 를 dupe 해 넣는다(dangling 방지). dirty/dupe 는 self.allocator 소유, 종료 시 해제.
+    /// **도메인 정합(#4557 [2])**: `const_providers` 와 dirty 는 모두 **diskPath**(query strip)
+    /// 도메인이다 — changed_files 는 build_flow 가 `diskPath()` 로 매칭하고, const_providers 는
+    /// materialize 가 `diskPath()` 로 수집한다. 전이 확장(dirty += 소비자)도 소비자의 **diskPath**
+    /// (`cm.module.diskPath()`)를 넣어 도메인을 맞춘다. evict 자체는 store key(=m.path, query 포함)로.
+    ///
+    /// **순회 안전(HashMap 수정)**: evict 대상을 먼저 수집 후 일괄 evict — iterator 무효화 회피.
+    /// **OOM 견고성(#4557 [4])**: 정밀 경로가 alloc 실패하면 under-evict(stale) 대신 보수적 전량
+    /// evict(alloc-free)로 폴백. null(변경 정보 없음)도 동일 전량 evict.
     pub fn evictConstConsumers(self: *PersistentModuleStore, changed_files: ?*const std.StringHashMapUnmanaged(void)) void {
         // fast path: baked 소비자가 하나도 없으면 즉시 반환(비-tree-shake/dev 빌드 = 대부분).
-        var any_baked = false;
-        {
-            var it = self.modules.valueIterator();
-            while (it.next()) |cm| {
-                if (cm.const_providers.len > 0) {
-                    any_baked = true;
+        // (O(M) 스캔 — store-level baked_count 로 O(1) 화는 [7] deferred, 절대비용 무시가능.)
+        if (!self.hasBakedConsumer()) return;
+
+        if (changed_files) |cf| {
+            // 정밀 전이 evict. OOM 이면 보수적 전량 evict 로 폴백([4]) — 절대 under-evict(stale) 금지.
+            self.evictConstConsumersPrecise(cf) catch self.evictAllBakedConsumers();
+        } else {
+            // 변경 정보 없음(initial-after-warm / CLI) → 보수적 전량 evict (crude-b 동형).
+            self.evictAllBakedConsumers();
+        }
+    }
+
+    fn hasBakedConsumer(self: *PersistentModuleStore) bool {
+        var it = self.modules.valueIterator();
+        while (it.next()) |cm| {
+            if (cm.const_providers.len > 0) return true;
+        }
+        return false;
+    }
+
+    /// alloc-free 전량 evict: baked 소비자(const_providers.len>0)를 스캔-후-evict 반복. null 경로 +
+    /// 정밀 경로 OOM 폴백 공용. O(baked²) 지만 **alloc 0** 이라 OOM 상황에서도 안전(추가 실패 없음).
+    fn evictAllBakedConsumers(self: *PersistentModuleStore) void {
+        while (true) {
+            var victim: ?[]const u8 = null;
+            var it = self.modules.iterator();
+            while (it.next()) |e| {
+                if (e.value_ptr.const_providers.len > 0) {
+                    victim = e.key_ptr.*;
                     break;
                 }
             }
+            const v = victim orelse break;
+            self.evict(v); // v 는 삭제될 key 를 alias — fetchRemove 가 값 읽은 뒤 free, 이후 미사용.
         }
-        if (!any_baked) return;
+    }
 
-        const cf = changed_files orelse {
-            // 보수적 폴백: 모든 baked 소비자 evict (crude-b 동형).
-            var targets: std.ArrayListUnmanaged([]const u8) = .empty;
-            defer targets.deinit(self.allocator);
-            var it = self.modules.iterator();
-            while (it.next()) |e| {
-                if (e.value_ptr.const_providers.len > 0) targets.append(self.allocator, e.key_ptr.*) catch {};
-            }
-            for (targets.items) |p| self.evict(p);
-            return;
-        };
-
-        // dirty set: changed_files 키(borrowed, 이 호출 동안 유효) + evict 된 path 의 dupe(self 소유).
+    /// 정밀 전이 fixpoint evict. 모든 alloc 은 `try` — 실패 시 error 전파해 caller 가 전량 폴백.
+    fn evictConstConsumersPrecise(self: *PersistentModuleStore, cf: *const std.StringHashMapUnmanaged(void)) !void {
+        // dirty(diskPath 도메인): changed_files 키(borrowed) + evict 된 소비자 diskPath(dupe, self 소유).
         var dirty: std.StringHashMapUnmanaged(void) = .empty;
         var owned: std.ArrayListUnmanaged([]const u8) = .empty;
         defer {
@@ -174,18 +194,17 @@ pub const PersistentModuleStore = struct {
             for (owned.items) |s| self.allocator.free(s);
             owned.deinit(self.allocator);
         }
-        {
-            var cit = cf.iterator();
-            while (cit.next()) |e| dirty.put(self.allocator, e.key_ptr.*, {}) catch {};
-        }
+        var cit = cf.iterator();
+        while (cit.next()) |e| try dirty.put(self.allocator, e.key_ptr.*, {});
 
         // 전이 fixpoint: 매 pass 마다 provider 가 dirty 에 있는 baked 소비자를 수집→일괄 evict.
-        // evict 된 소비자 path 를 dirty 에 추가해 다음 pass 가 그 소비자를 provider 로 삼는 모듈을
-        // 잡게 한다. 생산적 pass 마다 map 이 줄어 유한 종료.
+        // evict 된 소비자의 diskPath 를 dirty 에 추가해 다음 pass 가 그 소비자를 provider 로 삼는
+        // 모듈까지 잡게 한다(a→b→c). 생산적 pass 마다 map 이 줄어 유한 종료.
+        const Target = struct { key: []const u8, disk: []const u8 };
         var changed_any = true;
         while (changed_any) {
             changed_any = false;
-            var targets: std.ArrayListUnmanaged([]const u8) = .empty;
+            var targets: std.ArrayListUnmanaged(Target) = .empty;
             defer targets.deinit(self.allocator);
             var it = self.modules.iterator();
             while (it.next()) |e| {
@@ -193,18 +212,18 @@ pub const PersistentModuleStore = struct {
                 if (cm.const_providers.len == 0) continue;
                 for (cm.const_providers) |p| {
                     if (dirty.contains(p)) {
-                        targets.append(self.allocator, e.key_ptr.*) catch {};
+                        // key(evict 용) + diskPath(dirty 확장용, 도메인 일치 [2]) 동시 캡처.
+                        try targets.append(self.allocator, .{ .key = e.key_ptr.*, .disk = cm.module.diskPath() });
                         break;
                     }
                 }
             }
-            for (targets.items) |path| {
-                // evict 전에 path 를 dupe 해 dirty 에 추가(evict 가 key backing 을 free 하므로).
-                if (self.allocator.dupe(u8, path)) |dup| {
-                    owned.append(self.allocator, dup) catch {};
-                    dirty.put(self.allocator, dup, {}) catch {};
-                } else |_| {}
-                self.evict(path);
+            for (targets.items) |t| {
+                // evict 전에 diskPath 를 dupe 해 dirty 에 추가(evict 가 module/key backing 을 free 하므로).
+                const dup = try self.allocator.dupe(u8, t.disk);
+                try owned.append(self.allocator, dup);
+                try dirty.put(self.allocator, dup, {});
+                self.evict(t.key);
                 changed_any = true;
             }
         }
@@ -353,33 +372,36 @@ pub const PersistentModuleStore = struct {
         self.allocator.free(providers);
     }
 
-    fn extractImportSpecifiers(self: *PersistentModuleStore, module: *const Module) ![]const []const u8 {
+    /// (#4557 cleanup [5]) 문자열 슬라이스 각 원소를 store allocator 로 dupe 해 owned 슬라이스 반환.
+    /// import_specifiers / const_providers 복제 공용. OOM 시 부분 dupe 를 errdefer 로 회수.
+    fn dupeStringSlice(self: *PersistentModuleStore, src: []const []const u8) ![]const []const u8 {
         var list: std.ArrayListUnmanaged([]const u8) = .empty;
         errdefer {
             for (list.items) |s| self.allocator.free(s);
             list.deinit(self.allocator);
         }
-        for (module.import_records) |rec| {
-            const dupe = try self.allocator.dupe(u8, rec.specifier);
-            try list.append(self.allocator, dupe);
-        }
+        try list.ensureTotalCapacityPrecise(self.allocator, src.len);
+        for (src) |s| list.appendAssumeCapacity(try self.allocator.dupe(u8, s));
         return try list.toOwnedSlice(self.allocator);
     }
 
-    /// (#4557 B-precise) module.const_providers(parse_arena 소유)를 store allocator 로 dupe.
-    /// extractImportSpecifiers 미러 — parse_arena 가 store 로 양도된 후에도 evictConstConsumers
-    /// 가 provider 경로를 안전히 참조하도록 store-owned 사본을 둔다. non-baked 모듈은 빈 슬라이스.
-    fn extractConstProviders(self: *PersistentModuleStore, module: *const Module) ![]const []const u8 {
+    fn extractImportSpecifiers(self: *PersistentModuleStore, module: *const Module) ![]const []const u8 {
+        // import_records 의 specifier 만 뽑아 store-owned dupe. (record 구조를 순회하므로 별도 loop.)
         var list: std.ArrayListUnmanaged([]const u8) = .empty;
         errdefer {
             for (list.items) |s| self.allocator.free(s);
             list.deinit(self.allocator);
         }
-        for (module.const_providers) |p| {
-            const dupe = try self.allocator.dupe(u8, p);
-            try list.append(self.allocator, dupe);
-        }
+        try list.ensureTotalCapacityPrecise(self.allocator, module.import_records.len);
+        for (module.import_records) |rec| list.appendAssumeCapacity(try self.allocator.dupe(u8, rec.specifier));
         return try list.toOwnedSlice(self.allocator);
+    }
+
+    /// (#4557 B-precise) module.const_providers(parse_arena 소유, diskPath)를 store allocator 로 dupe.
+    /// parse_arena 가 store 로 양도된 후에도 evictConstConsumers 가 provider 경로를 안전히 참조하도록
+    /// store-owned 사본을 둔다. non-baked(또는 crude-b 폴백) 모듈은 빈 슬라이스.
+    fn extractConstProviders(self: *PersistentModuleStore, module: *const Module) ![]const []const u8 {
+        return self.dupeStringSlice(module.const_providers);
     }
 
     /// 캐시된 모듈의 import specifiers가 새 모듈과 동일한지 확인.
@@ -592,6 +614,77 @@ test "PersistentModuleStore: evictConstConsumers 전이 fixpoint + 불변 no-op 
     store.evictConstConsumers(null);
     try testing.expect(!store.modules.contains("/noise.js"));
     try testing.expect(store.modules.contains("/a.js"));
+}
+
+// #4557 [2] query-suffix 도메인 정합: store key 는 m.path(query 포함)지만 const_providers/dirty 는
+// diskPath(query strip). 전이 확장이 evict 된 소비자의 **diskPath** 를 dirty 에 넣어야, 그 소비자를
+// provider 로 삼는 하위 모듈이 매칭돼 evict 된다. store key(query 포함)를 넣던 도메인 불일치면 매칭
+// 실패 → 하위 소비자 stale.
+test "PersistentModuleStore: evictConstConsumers query-suffix 전이 도메인 정합 (#4557 [2])" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+    var store = PersistentModuleStore.init(allocator);
+    defer store.deinit();
+
+    const putBaked = struct {
+        fn call(s: *PersistentModuleStore, a: std.mem.Allocator, path: []const u8, providers: []const []const u8) void {
+            var m = Module.init(@enumFromInt(0), path);
+            m.const_providers = providers;
+            s.putModule(path, &m, 1);
+            m.deinit(a);
+        }
+    }.call;
+
+    // b 의 store key 는 "/b.js?raw"(query) 지만 diskPath 는 "/b.js". c 는 provider 로 diskPath "/b.js" 를 본다.
+    putBaked(&store, allocator, "/b.js?raw", &.{"/a.js"});
+    putBaked(&store, allocator, "/c.js", &.{"/b.js"});
+
+    var dirty: std.StringHashMapUnmanaged(void) = .empty;
+    defer dirty.deinit(allocator);
+    try dirty.put(allocator, "/a.js", {}); // diskPath 도메인
+
+    store.evictConstConsumers(&dirty);
+    // a 변경 → b(provider a) evict → 전이 dirty += diskPath(b)="/b.js" → c(provider "/b.js") evict.
+    // 버그(store key "/b.js?raw" 를 dirty 에 넣음)면 c.provider "/b.js" 와 불일치 → c 잔존(stale).
+    try testing.expect(!store.modules.contains("/b.js?raw"));
+    try testing.expect(!store.modules.contains("/c.js"));
+}
+
+// #4557 [4] OOM 견고성: 정밀 evict 경로가 alloc 실패하면 under-evict(stale) 대신 보수적 전량 evict.
+// FailingAllocator 로 dirty seed alloc 을 실패시키면 fallback(evictAllBakedConsumers, alloc-free)이
+// 모든 baked 소비자를 evict 해야 한다. changed_files 는 무관 경로라 정밀 경로가 정상 실행되면 0 evict —
+// 따라서 b/c 가 모두 사라지면 fallback 이 동작했다는 증거.
+test "PersistentModuleStore: evictConstConsumers OOM → 전량 evict 폴백 (#4557 [4])" {
+    const testing = std.testing;
+    var store = PersistentModuleStore.init(testing.allocator);
+    defer store.deinit();
+
+    const putBaked = struct {
+        fn call(s: *PersistentModuleStore, a: std.mem.Allocator, path: []const u8, providers: []const []const u8) void {
+            var m = Module.init(@enumFromInt(0), path);
+            m.const_providers = providers;
+            s.putModule(path, &m, 1);
+            m.deinit(a);
+        }
+    }.call;
+    putBaked(&store, testing.allocator, "/b.js", &.{"/a.js"});
+    putBaked(&store, testing.allocator, "/c.js", &.{"/b.js"});
+
+    var dirty: std.StringHashMapUnmanaged(void) = .empty;
+    defer dirty.deinit(testing.allocator);
+    try dirty.put(testing.allocator, "/unrelated.js", {}); // 어떤 provider 와도 무관.
+
+    // FailingAllocator 는 alloc 만 fail injection, free 는 underlying(testing.allocator) passthrough.
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    const orig = store.allocator;
+    store.allocator = failing.allocator();
+    // precise 경로의 첫 alloc(dirty seed put)이 OOM → catch → evictAllBakedConsumers(alloc-free).
+    store.evictConstConsumers(&dirty);
+    store.allocator = orig; // deinit 은 원 allocator 로 일관.
+
+    // fallback 이 전량 evict: b, c 모두 제거. (정밀 경로만 돌았다면 "/unrelated" 무관이라 0 evict.)
+    try testing.expect(!store.modules.contains("/b.js"));
+    try testing.expect(!store.modules.contains("/c.js"));
 }
 
 // Regression #3755: putModule OOM rollback 시 cached_module = module.* shallow copy 의

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -55,6 +55,10 @@ pub const PersistentModuleStore = struct {
         module: Module,
         /// import specifier 목록 (store allocator 소유). import 변경 감지용.
         import_specifiers: []const []const u8,
+        /// (#4557 B-precise) 이 모듈이 bake 한 cross-module const 의 provider 경로 목록
+        /// (store allocator 소유 — import_specifiers 미러). 비어있으면(non-baked) warm
+        /// invalidation 대상이 아니다. 채워져 있으면 warm 시작 시 provider 변경 감지로 evict.
+        const_providers: []const []const u8,
     };
 
     pub fn init(allocator: std.mem.Allocator) PersistentModuleStore {
@@ -100,6 +104,9 @@ pub const PersistentModuleStore = struct {
         // import_specifiers 해제
         for (cached.import_specifiers) |s| self.allocator.free(s);
         self.allocator.free(cached.import_specifiers);
+        // (#4557) const_providers 해제 (import_specifiers 미러)
+        for (cached.const_providers) |s| self.allocator.free(s);
+        self.allocator.free(cached.const_providers);
     }
 
     /// 캐시에서 모듈을 조회. mtime이 일치하면 캐시 히트.
@@ -119,11 +126,101 @@ pub const PersistentModuleStore = struct {
         self.freeCachedModule(&cached);
     }
 
+    /// (#4557 B-precise) warm 빌드 시작 시 baked 소비자 정밀 무효화.
+    /// `changed_files` (watcher 보고 절대경로 set) 로 시작해 전이적 fixpoint 로 baked 소비자를
+    /// evict 한다: 어떤 cached module C 의 `const_providers` 중 하나라도 dirty 에 있으면 evict 하고
+    /// C.path 를 dirty 에 추가(전이 — a→b→c 체인에서 a 변경이 b, 그 다음 c 를 evict). provider 가
+    /// 안 바뀐 baked 소비자는 store 에 남아 cache-hit(reparse 0) → crude-b(#4544 무조건 evict)의 perf
+    /// 회귀를 해소.
+    ///
+    /// `changed_files == null`(변경 정보 없음: initial-after-warm / CLI)이면 어떤 provider 가
+    /// 바뀌었는지 알 수 없으므로 모든 baked 소비자(const_providers.len>0)를 evict = crude-b 와
+    /// 동일한 보수적 correctness (절대 stale 안 남김, perf 는 non-null 경로에서만 회복).
+    ///
+    /// **순회 안전(HashMap 수정)**: evict 대상 path 를 먼저 수집 후 일괄 evict — iterator 무효화
+    /// 회피. evict 가 store key(및 provider 경로 backing)를 free 하므로, 전이 확장용 dirty 에는
+    /// evict *전에* path 를 dupe 해 넣는다(dangling 방지). dirty/dupe 는 self.allocator 소유, 종료 시 해제.
+    pub fn evictConstConsumers(self: *PersistentModuleStore, changed_files: ?*const std.StringHashMapUnmanaged(void)) void {
+        // fast path: baked 소비자가 하나도 없으면 즉시 반환(비-tree-shake/dev 빌드 = 대부분).
+        var any_baked = false;
+        {
+            var it = self.modules.valueIterator();
+            while (it.next()) |cm| {
+                if (cm.const_providers.len > 0) {
+                    any_baked = true;
+                    break;
+                }
+            }
+        }
+        if (!any_baked) return;
+
+        const cf = changed_files orelse {
+            // 보수적 폴백: 모든 baked 소비자 evict (crude-b 동형).
+            var targets: std.ArrayListUnmanaged([]const u8) = .empty;
+            defer targets.deinit(self.allocator);
+            var it = self.modules.iterator();
+            while (it.next()) |e| {
+                if (e.value_ptr.const_providers.len > 0) targets.append(self.allocator, e.key_ptr.*) catch {};
+            }
+            for (targets.items) |p| self.evict(p);
+            return;
+        };
+
+        // dirty set: changed_files 키(borrowed, 이 호출 동안 유효) + evict 된 path 의 dupe(self 소유).
+        var dirty: std.StringHashMapUnmanaged(void) = .empty;
+        var owned: std.ArrayListUnmanaged([]const u8) = .empty;
+        defer {
+            dirty.deinit(self.allocator);
+            for (owned.items) |s| self.allocator.free(s);
+            owned.deinit(self.allocator);
+        }
+        {
+            var cit = cf.iterator();
+            while (cit.next()) |e| dirty.put(self.allocator, e.key_ptr.*, {}) catch {};
+        }
+
+        // 전이 fixpoint: 매 pass 마다 provider 가 dirty 에 있는 baked 소비자를 수집→일괄 evict.
+        // evict 된 소비자 path 를 dirty 에 추가해 다음 pass 가 그 소비자를 provider 로 삼는 모듈을
+        // 잡게 한다. 생산적 pass 마다 map 이 줄어 유한 종료.
+        var changed_any = true;
+        while (changed_any) {
+            changed_any = false;
+            var targets: std.ArrayListUnmanaged([]const u8) = .empty;
+            defer targets.deinit(self.allocator);
+            var it = self.modules.iterator();
+            while (it.next()) |e| {
+                const cm = e.value_ptr;
+                if (cm.const_providers.len == 0) continue;
+                for (cm.const_providers) |p| {
+                    if (dirty.contains(p)) {
+                        targets.append(self.allocator, e.key_ptr.*) catch {};
+                        break;
+                    }
+                }
+            }
+            for (targets.items) |path| {
+                // evict 전에 path 를 dupe 해 dirty 에 추가(evict 가 key backing 을 free 하므로).
+                if (self.allocator.dupe(u8, path)) |dup| {
+                    owned.append(self.allocator, dup) catch {};
+                    dirty.put(self.allocator, dup, {}) catch {};
+                } else |_| {}
+                self.evict(path);
+                changed_any = true;
+            }
+        }
+    }
+
     /// 빌드 완료 후 모듈을 캐시에 저장.
     /// Module의 parse_arena 소유권을 store로 이전 (Module.parse_arena = null 설정).
     pub fn putModule(self: *PersistentModuleStore, path: []const u8, module: *Module, mtime: i128) void {
         // import specifiers 복제 (store allocator 소유)
         const specs = self.extractImportSpecifiers(module) catch return;
+        // (#4557) const_providers 복제 (store allocator 소유). 실패 시 specs 누수 차단 후 return.
+        const providers = self.extractConstProviders(module) catch {
+            for (specs) |s| self.allocator.free(s);
+            self.allocator.free(specs);
+            return;
+        };
 
         // 기존 캐시가 있으면 제거. (#3755 sweep) freeCachedModule 가 contents 만 free
         // 하므로 entry 자체는 그대로 — 다음 단계에서 map.put 으로 *값* 만 update.
@@ -167,14 +264,14 @@ pub const PersistentModuleStore = struct {
         for (cached_module.resolved_deps.items, 0..) |*dep, i| {
             const new_path = clonePathRefIfNeeded(self.allocator, dep.path) catch {
                 rollbackOomCloned(cached_module.resolved_deps.items[0..i], self.allocator);
-                self.abortPutModule(path, had_existing, specs);
+                self.abortPutModule(path, had_existing, specs, providers);
                 return;
             };
             const new_rd = if (dep.resolve_dir) |rd|
                 clonePathRefIfNeeded(self.allocator, rd) catch {
                     new_path.deinit(self.allocator);
                     rollbackOomCloned(cached_module.resolved_deps.items[0..i], self.allocator);
-                    self.abortPutModule(path, had_existing, specs);
+                    self.abortPutModule(path, had_existing, specs, providers);
                     return;
                 }
             else
@@ -213,13 +310,14 @@ pub const PersistentModuleStore = struct {
                 .mtime = mtime,
                 .module = cached_module,
                 .import_specifiers = specs,
+                .const_providers = providers,
             }) catch {
-                var orphan: CachedModule = .{ .mtime = mtime, .module = cached_module, .import_specifiers = specs };
+                var orphan: CachedModule = .{ .mtime = mtime, .module = cached_module, .import_specifiers = specs, .const_providers = providers };
                 self.freeCachedModule(&orphan);
             };
         } else {
             const key = self.allocator.dupe(u8, path) catch {
-                var orphan: CachedModule = .{ .mtime = mtime, .module = cached_module, .import_specifiers = specs };
+                var orphan: CachedModule = .{ .mtime = mtime, .module = cached_module, .import_specifiers = specs, .const_providers = providers };
                 self.freeCachedModule(&orphan);
                 return;
             };
@@ -228,9 +326,10 @@ pub const PersistentModuleStore = struct {
                 .mtime = mtime,
                 .module = cached_module,
                 .import_specifiers = specs,
+                .const_providers = providers,
             }) catch {
                 self.allocator.free(key);
-                var orphan: CachedModule = .{ .mtime = mtime, .module = cached_module, .import_specifiers = specs };
+                var orphan: CachedModule = .{ .mtime = mtime, .module = cached_module, .import_specifiers = specs, .const_providers = providers };
                 self.freeCachedModule(&orphan);
             };
         }
@@ -241,8 +340,8 @@ pub const PersistentModuleStore = struct {
     ///    dangling CachedModule entry — 다음 getIfFresh UAF + 다음 putModule 의 freeCachedModule 가
     ///    이미 freed 메모리 또 free → double-free. fetchRemove 로 key 까지 회수.
     /// 2) specs (extractImportSpecifiers 결과) 가 N dupe + 1 slice alloc 인데 rollback
-    ///    early return 으로 free 안 됨 → 매 OOM 마다 누적 leak.
-    fn abortPutModule(self: *PersistentModuleStore, path: []const u8, had_existing: bool, specs: []const []const u8) void {
+    ///    early return 으로 free 안 됨 → 매 OOM 마다 누적 leak. (#4557) providers 도 동형.
+    fn abortPutModule(self: *PersistentModuleStore, path: []const u8, had_existing: bool, specs: []const []const u8, providers: []const []const u8) void {
         if (had_existing) {
             if (self.modules.fetchRemove(path)) |kv| {
                 self.allocator.free(kv.key);
@@ -250,6 +349,8 @@ pub const PersistentModuleStore = struct {
         }
         for (specs) |s| self.allocator.free(s);
         self.allocator.free(specs);
+        for (providers) |s| self.allocator.free(s);
+        self.allocator.free(providers);
     }
 
     fn extractImportSpecifiers(self: *PersistentModuleStore, module: *const Module) ![]const []const u8 {
@@ -260,6 +361,22 @@ pub const PersistentModuleStore = struct {
         }
         for (module.import_records) |rec| {
             const dupe = try self.allocator.dupe(u8, rec.specifier);
+            try list.append(self.allocator, dupe);
+        }
+        return try list.toOwnedSlice(self.allocator);
+    }
+
+    /// (#4557 B-precise) module.const_providers(parse_arena 소유)를 store allocator 로 dupe.
+    /// extractImportSpecifiers 미러 — parse_arena 가 store 로 양도된 후에도 evictConstConsumers
+    /// 가 provider 경로를 안전히 참조하도록 store-owned 사본을 둔다. non-baked 모듈은 빈 슬라이스.
+    fn extractConstProviders(self: *PersistentModuleStore, module: *const Module) ![]const []const u8 {
+        var list: std.ArrayListUnmanaged([]const u8) = .empty;
+        errdefer {
+            for (list.items) |s| self.allocator.free(s);
+            list.deinit(self.allocator);
+        }
+        for (module.const_providers) |p| {
+            const dupe = try self.allocator.dupe(u8, p);
             try list.append(self.allocator, dupe);
         }
         return try list.toOwnedSlice(self.allocator);
@@ -422,6 +539,59 @@ test "PersistentModuleStore: evict 완전 저장 엔트리 + parse_arena=null da
     store.evict("\x00zntc:evict/dangling"); // null arena → freeCachedModule 이 arena free 안 함
     try testing.expect(!store.modules.contains("\x00zntc:evict/dangling"));
     Module_mod.destroyParseArena(allocator, arena); // graph 가 소유하므로 여기서 해제
+}
+
+// (#4557 B-precise) evictConstConsumers: provider 변경 시에만(전이 fixpoint) baked 소비자 evict.
+// helper 로직을 full bundler 없이 직접 계측 — (1) provider 불변 no-op, (2) a→b→c fixpoint,
+// (3) null 보수적 전량 evict. store-owned const_providers dupe/free 왕복도 GPA 로 검증(leak 0).
+test "PersistentModuleStore: evictConstConsumers 전이 fixpoint + 불변 no-op + null 보수 (#4557)" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var store = PersistentModuleStore.init(allocator);
+    defer store.deinit();
+
+    const putBaked = struct {
+        fn call(s: *PersistentModuleStore, a: std.mem.Allocator, path: []const u8, providers: []const []const u8) void {
+            var m = Module.init(@enumFromInt(0), path);
+            m.const_providers = providers; // borrowed — putModule 이 store allocator 로 dupe.
+            s.putModule(path, &m, 1);
+            m.deinit(a); // graph 쪽 잔여 해제 (const_providers 는 borrowed 라 free 안 함).
+        }
+    }.call;
+
+    putBaked(&store, allocator, "/a.js", &.{}); // non-baked provider (const_providers 빈)
+    putBaked(&store, allocator, "/b.js", &.{"/a.js"}); // baked: provider a
+    putBaked(&store, allocator, "/c.js", &.{"/b.js"}); // baked: provider b (전이)
+    putBaked(&store, allocator, "/noise.js", &.{"/other.js"}); // baked: 무관 provider
+
+    // (1) provider 불변(무관 파일만 dirty) → 아무것도 evict 안 함(핵심 perf 경로).
+    {
+        var dirty: std.StringHashMapUnmanaged(void) = .empty;
+        defer dirty.deinit(allocator);
+        try dirty.put(allocator, "/unrelated.js", {});
+        store.evictConstConsumers(&dirty);
+        try testing.expect(store.modules.contains("/b.js"));
+        try testing.expect(store.modules.contains("/c.js"));
+        try testing.expect(store.modules.contains("/noise.js"));
+    }
+
+    // (2) a 변경 → b(provider a) evict → dirty 확장 {a,b} → c(provider b) evict(fixpoint). noise 유지.
+    {
+        var dirty: std.StringHashMapUnmanaged(void) = .empty;
+        defer dirty.deinit(allocator);
+        try dirty.put(allocator, "/a.js", {});
+        store.evictConstConsumers(&dirty);
+        try testing.expect(!store.modules.contains("/b.js"));
+        try testing.expect(!store.modules.contains("/c.js"));
+        try testing.expect(store.modules.contains("/noise.js")); // provider 무관 → 유지
+        try testing.expect(store.modules.contains("/a.js")); // 이 헬퍼는 provider 자신 evict 안 함(mtime 경로 담당)
+    }
+
+    // (3) null(변경 정보 없음) → 남은 baked 소비자(noise) 보수적 전량 evict. non-baked(a)는 유지.
+    store.evictConstConsumers(null);
+    try testing.expect(!store.modules.contains("/noise.js"));
+    try testing.expect(store.modules.contains("/a.js"));
 }
 
 // Regression #3755: putModule OOM rollback 시 cached_module = module.* shallow copy 의

--- a/src/bundler/tree_shaker/const_materialize.zig
+++ b/src/bundler/tree_shaker/const_materialize.zig
@@ -335,6 +335,10 @@ fn materializeCrossModuleConstFactsForIndex(
     if (m.import_bindings.len == 0) return false;
     const sem = m.semantic orelse return false;
     const ast = &(m.ast orelse return false);
+    // (#4557 B-precise) provider 경로 수집 집합. GPA(self.allocator)로 만들고 함수 끝 deinit.
+    // buildCrossModuleConstValuesProfiled 가 채운 뒤, bake 확정 시 parse_arena 로 dupe 해 module 에 기록.
+    var providers_set: std.StringHashMapUnmanaged(void) = .empty;
+    defer providers_set.deinit(self.allocator);
     var const_values = blk: {
         var build_scope = profile.beginMaybe(const_profile.build_facts);
         defer build_scope.end();
@@ -345,7 +349,7 @@ fn materializeCrossModuleConstFactsForIndex(
             }
         else
             Linker.ConstValuesProfile{};
-        break :blk try self.linker.buildCrossModuleConstValuesProfiled(m, sem, build_profile);
+        break :blk try self.linker.buildCrossModuleConstValuesProfiled(m, sem, build_profile, &providers_set);
     };
     const should_materialize = blk: {
         var gate_scope = profile.beginMaybe(const_profile.candidate_gate);
@@ -379,8 +383,33 @@ fn materializeCrossModuleConstFactsForIndex(
     if (!materialized.changed) return false;
 
     // (#4544) 이 모듈 AST 에 cross-module const 를 bake 함 → module_store 캐시에서 제외되도록 표시.
-    // baked 값은 provider const 에 의존하므로 소비자 mtime 캐시로 재사용하면 stale (transferModulesToStore 가 evict).
+    // baked 값은 provider const 에 의존하므로 소비자 mtime 캐시로 재사용하면 stale.
     m.const_baked = true;
+
+    // (#4557 B-precise) 이 bake 가 의존하는 provider 경로를 parse_arena 로 dupe 해 module 에 기록한다.
+    // arena 소유(arena.deinit 가 일괄 해제 — #1287, 수동 free 금지). warm invalidation 이 이 집합으로
+    // provider 변경 시에만 baked 소비자를 evict(전이 fixpoint). parse_arena 없으면(virtual 등) 애초에
+    // module_store 캐시 대상이 아니라 skip 해도 무방. providers_set 이 비면(edge: getModule 실패 등)
+    // const_providers 는 &.{} 로 남아 crude-b 처럼 무조건 evict 로 폴백(보수적 correctness 유지).
+    if (m.parse_arena) |arena| {
+        const aa = arena.allocator();
+        const n = providers_set.count();
+        if (n > 0) {
+            if (aa.alloc([]const u8, n)) |slice| {
+                var it = providers_set.keyIterator();
+                var i: usize = 0;
+                var ok = true;
+                while (it.next()) |k| : (i += 1) {
+                    slice[i] = aa.dupe(u8, k.*) catch {
+                        // dupe OOM: 부분 기록보다 전량 폴백(빈 채로 두면 conservative evict).
+                        ok = false;
+                        break;
+                    };
+                }
+                if (ok) m.const_providers = slice;
+            } else |_| {}
+        }
+    }
 
     const skip_minify = const_profile.policy.skipMinifyIfSafe() and !materialized.needs_minify;
     minifyAndResyncModule(self, m, sem, ast, const_profile, skip_minify);

--- a/src/bundler/tree_shaker/const_materialize.zig
+++ b/src/bundler/tree_shaker/const_materialize.zig
@@ -335,10 +335,11 @@ fn materializeCrossModuleConstFactsForIndex(
     if (m.import_bindings.len == 0) return false;
     const sem = m.semantic orelse return false;
     const ast = &(m.ast orelse return false);
-    // (#4557 B-precise) provider 경로 수집 집합. GPA(self.allocator)로 만들고 함수 끝 deinit.
-    // buildCrossModuleConstValuesProfiled 가 채운 뒤, bake 확정 시 parse_arena 로 dupe 해 module 에 기록.
-    var providers_set: std.StringHashMapUnmanaged(void) = .empty;
-    defer providers_set.deinit(self.allocator);
+    // (#4557 B-precise) provider 경로 수집기. GPA(self.allocator)로 만들고 함수 끝 deinit.
+    // buildCrossModuleConstValuesProfiled 가 체인 전체를 채운 뒤, bake 확정 시 parse_arena 로 dupe 해
+    // module 에 기록. collector.incomplete(다단 체인 미추적)면 crude-b 폴백.
+    var collector: Linker.ConstProviderCollector = .{};
+    defer collector.paths.deinit(self.allocator);
     var const_values = blk: {
         var build_scope = profile.beginMaybe(const_profile.build_facts);
         defer build_scope.end();
@@ -349,7 +350,7 @@ fn materializeCrossModuleConstFactsForIndex(
             }
         else
             Linker.ConstValuesProfile{};
-        break :blk try self.linker.buildCrossModuleConstValuesProfiled(m, sem, build_profile, &providers_set);
+        break :blk try self.linker.buildCrossModuleConstValuesProfiled(m, sem, build_profile, &collector);
     };
     const should_materialize = blk: {
         var gate_scope = profile.beginMaybe(const_profile.candidate_gate);
@@ -386,28 +387,31 @@ fn materializeCrossModuleConstFactsForIndex(
     // baked 값은 provider const 에 의존하므로 소비자 mtime 캐시로 재사용하면 stale.
     m.const_baked = true;
 
-    // (#4557 B-precise) 이 bake 가 의존하는 provider 경로를 parse_arena 로 dupe 해 module 에 기록한다.
-    // arena 소유(arena.deinit 가 일괄 해제 — #1287, 수동 free 금지). warm invalidation 이 이 집합으로
-    // provider 변경 시에만 baked 소비자를 evict(전이 fixpoint). parse_arena 없으면(virtual 등) 애초에
-    // module_store 캐시 대상이 아니라 skip 해도 무방. providers_set 이 비면(edge: getModule 실패 등)
-    // const_providers 는 &.{} 로 남아 crude-b 처럼 무조건 evict 로 폴백(보수적 correctness 유지).
-    if (m.parse_arena) |arena| {
-        const aa = arena.allocator();
-        const n = providers_set.count();
-        if (n > 0) {
-            if (aa.alloc([]const u8, n)) |slice| {
-                var it = providers_set.keyIterator();
-                var i: usize = 0;
-                var ok = true;
-                while (it.next()) |k| : (i += 1) {
-                    slice[i] = aa.dupe(u8, k.*) catch {
-                        // dupe OOM: 부분 기록보다 전량 폴백(빈 채로 두면 conservative evict).
-                        ok = false;
-                        break;
-                    };
-                }
-                if (ok) m.const_providers = slice;
-            } else |_| {}
+    // (#4557 B-precise, [1][3]) 이 bake 가 의존하는 provider 경로(diskPath, 체인 전체)를 parse_arena 로
+    // dupe 해 module 에 기록. arena 소유(arena.deinit 일괄 해제 — #1287, 수동 free 금지). warm
+    // invalidation 이 이 집합으로 provider 변경 시에만 baked 소비자를 evict(전이 fixpoint).
+    // **crude-b 폴백**: collector.incomplete(다단 re-export 체인 미추적, [1]) 또는 dupe OOM 또는
+    // parse_arena 없음(virtual)이면 const_providers 를 **빈 채로 둔다** → transferModulesToStore 가
+    // `const_baked && const_providers.len==0` 게이트로 crude-b(무조건 evict, 캐시 안 함)로 폴백 →
+    // staleness 원천 차단([3]). "빈=conservative evict" 는 [3] 게이트가 실제로 보장한다.
+    if (!collector.incomplete) {
+        if (m.parse_arena) |arena| {
+            const aa = arena.allocator();
+            const n = collector.paths.count();
+            if (n > 0) {
+                if (aa.alloc([]const u8, n)) |slice| {
+                    var it = collector.paths.keyIterator();
+                    var i: usize = 0;
+                    var ok = true;
+                    while (it.next()) |k| : (i += 1) {
+                        slice[i] = aa.dupe(u8, k.*) catch {
+                            ok = false; // dupe OOM → 빈 채로 두어 crude-b 폴백.
+                            break;
+                        };
+                    }
+                    if (ok) m.const_providers = slice;
+                } else |_| {}
+            }
         }
     }
 


### PR DESCRIPTION
## 문제

#4544(crude-b, MERGED)는 cross-module const 를 AST 에 리터럴로 bake 한 소비자(`m.const_baked`)를 `module_store` 에서 **무조건 evict** → correctness(warm==cold)는 완전하나, **provider 가 바뀌지 않아도** 매 warm(프로덕션 증분/watch) 빌드마다 그 소비자를 reparse 하는 perf 회귀. cross-module numeric const 사용량에 비례:

| lib | const_baked / total |
|---|---|
| zod / three | 0 |
| effect | 2 / 361 |
| **date-fns** | **38 / 304 (12.5%)** |

## 수정 (B-precise)

baked 소비자를 **캐시하되**, 각 소비자가 bake 한 값이 의존하는 **provider 경로 집합**(`const_providers`)을 기록해, warm 시작 시 `changed_files` 로부터 **전이 fixpoint** 로 provider 가 실제 바뀐 소비자만 evict. provider 불변 → cache-hit(reparse 0).

**핵심 원칙 = staleness 0**: 정밀 추적이 불확실하면 항상 crude-b(무조건 evict)로 폴백해 correctness 를 crude-b 수준으로 보장.
- provider 수집: `collectConstProviderChain` 이 소비자→직접 import→**중간 barrel**→canonical origin 의 re-export 체인 전체를 diskPath(query strip)로 수집.
- 체인을 canon 까지 못 따라감(star/synthetic/.local 위장/cjs/깊이초과) 또는 dupe OOM → `const_providers` 빈 채로 → `transferModulesToStore` 가 `const_baked && len==0` 게이트로 crude-b 폴백.
- 전이 체인(`a→b→c`)은 fixpoint 로 전파. `changed_files==null` 또는 evict OOM → 보수적 전량 evict.
- 소유권은 `import_specifiers` 패턴 미러(Module=parse_arena, CachedModule=store dupe, freeCachedModule 대칭).

## 검증 (실제 실행 계측)

- **perf(reparse-count 직접 계측)**: provider 불변 warm → baked 소비자 cache-hit(reparse 0, crude-b 는 reparse), provider 변경 warm → evict/reparse.
- **correctness(warm==cold)**: 다단 barrel 편집·query-suffix provider·전이 체인 fixpoint·star crude-b·OOM 폴백 각각 유닛으로 evict+warm==cold 확인. 기존 #4544 stale 가드 유지.
- **UAF/leak**: zig 전체 유닛 GPA leak/double-free 0. ReleaseFast green.

## code-review max 반영 (2차 커밋)

staleness 홀 4건 수정: [1] 다단 re-export 체인 provider 누락(체인 전체 수집), [2] query-suffix 도메인 불일치(diskPath 정규화), [3] 빈 const_providers 미evict(crude-b 게이트), [4] OOM catch{} 삼킴(전량 evict 폴백) + cleanup.

## 한계

정밀 추적은 clean named `.re_export` 체인만 — `export *`/synthetic/cjs re-export 경유 const 는 crude-b 폴백(매 warm reparse, stale 없음). fixpoint/any_baked O(M) micro-opt 은 baking=프로덕션 전용·fast-path 즉시반환이라 <0.1% 예산 → 후속.

Refs #4557