### PR TITLE
fix(bundler): #4595 splitting:false 동적 import 무진단 leak — 단일 권위 지점서 인라인 강제

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -810,6 +810,33 @@ pub const Bundler = struct {
             // --rn-version 이 있으면 버전별 정밀 매트릭스, 없으면 기존 blunt 프리셋.
             opts.unsupported = opts.rn_version_matrix orelse compat.fromHermesPreset();
         }
+
+        // (#4595) production 단일 번들 경로(!code_splitting && !preserve_modules && !dev_mode)
+        // 에서는 dynamic import 를 처리할 방법이 인라인밖에 없다 — 청크로 분리할 chunk graph 가
+        // 애초에 없다. inline_dynamic_imports 를 켜지 않으면 emitter(rewriteDynamicImportsSingleFile)
+        // 가 `import("./x")` 를 원문 그대로 흘려보내 청크 분리·경로 재작성·진단이 셋 다 빠진 채
+        // 런타임에 반드시 깨진다(빌드는 성공 보고 → 무증상 실패). esbuild(splitting:false)·
+        // rolldown(codeSplitting:false) 모두 이 경우 dynamic import 를 인라인한다.
+        //
+        // 이 승격은 그동안 CLI(cli/options.zig) 프론트엔드에만 있어 NAPI/app 빌더 경로에서
+        // 누락됐다(프론트엔드별 발산 → #4595). 모든 진입점(init/initWithResolveCache/
+        // initWithGraph)이 통과하는 여기를 **단일 권위 지점**으로 삼아 드리프트를 원천 차단한다.
+        // (CLI 의 중복 승격은 제거했고, `--no-inline-dynamic-imports` 명시 에러만 남겼다.)
+        //
+        // 게이트 근거:
+        //  - code_splitting / preserve_modules: 각자 chunk 재작성 경로가 있어 건드리지 않는다.
+        //  - dev_mode: dev 단일 번들은 HMR 레지스트리(__zntc_modules)를 쓰는 별도 lowering 이
+        //    있어 인라인과 상호작용이 다르다. 현재 dev 의 dynamic import 처리는 이 fix 범위 밖
+        //    (#4595 는 production build() 이슈) — dev 는 기존 동작을 그대로 보존한다.
+        //  - external dynamic import 는 resolved==.none 이라 인라인 대상에서 자연히 제외된다.
+        //
+        // 참고: 단일 번들에서 inline_dynamic_imports=false 는 "처리 불가능한 상태"이지 존중할
+        // preference 가 아니다(어떤 번들러도 청크 없이 raw import 를 유지하지 못한다). 따라서
+        // 여기서 true 로 정규화하는 것은 옵션을 override 하는 게 아니라 invalid 조합을 유일한
+        // 유효값으로 normalize 하는 것이다. CLI 는 이 조합에 친절한 에러를 추가로 낸다.
+        if (!opts.code_splitting and !opts.preserve_modules and !opts.dev_mode) {
+            opts.inline_dynamic_imports = true;
+        }
     }
 
     pub fn initResolveCacheFromOptions(allocator: std.mem.Allocator, options: BundleOptions) ResolveCache {

--- a/src/bundler/bundler_test/resolution.zig
+++ b/src/bundler/bundler_test/resolution.zig
@@ -450,6 +450,42 @@ test "DynamicImport: external dynamic import preserved" {
     try std.testing.expect(!result.hasErrors());
 }
 
+// (#4595) 단일 번들(splitting/preserve-modules 모두 false)에서 dynamic import 가 인라인되지
+// 않고 원문 `import("./dep")` 그대로 새어나가던 회귀 가드. 이 조합에서는 청크로 분리할 수단이
+// 없으므로 인라인만이 유일한 처리다. Bundler.init 이 진입점 무관하게 불변식을 강제한다(#4595
+// 이전엔 CLI 프론트엔드만 승격 → NAPI/app 경로 누락). esbuild(splitting:false)·rolldown
+// (codeSplitting:false) 동작과 동일. 기존 "static path" 테스트는 target 코드 존재만 봤는데,
+// side-effect 있는 모듈은 미인라인 깨진 번들에서도 문자열이 남아 통과했다 — 여기선 호출
+// 재작성까지 단언한다(side-effect 없는 순수 export 라 미인라인이면 tree-shake 로 사라짐).
+test "DynamicImport: single-bundle inlines dynamic import — no raw import() leaks (#4595)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export async function run() {
+        \\  const m = await import('./dep');
+        \\  return m.value;
+        \\}
+    );
+    try writeFile(tmp.dir, "dep.ts", "export const value = 'LOADED-4595';");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    // splitting/preserve-modules 미지정(기본 false) = 이슈 #4595 의 정확한 조합.
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .format = .esm });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // (1) dynamic target 코드가 번들에 인라인되어 있어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LOADED-4595") != null);
+    // (2) 원문 dynamic import 호출이 재작성되어 남아있으면 안 된다(런타임 깨짐 방지).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "import(\"./dep\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "import('./dep')") == null);
+    // (3) __esm 래퍼 init/exports lazy 호출로 인라인(esbuild/rolldown splitting:false 형태).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Promise.resolve().then") != null);
+}
+
 test "DynamicImport: combined with static import" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -1110,19 +1110,16 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator,
         opts.bundle_format = .iife;
     }
 
-    // #2209: single-file output 모드에서 dynamic import 가 있으면 자동으로 entry chunk
-    // 에 인라인 (esbuild 호환). graph.zig::promoteExportsKinds Pass 4 가 dynamic
-    // target 을 `wrap_kind = .esm` 으로 promote → emitter 가 `import("./x")` 호출을
-    // `init_x()` + `x_exports` 로 재작성. 이렇게 안 하면 default 모드에서 dynamic
-    // target 이 inline 됐는데 호출은 외부 path 그대로 남아 `Cannot find module` 에러.
-    if (opts.is_bundle and !opts.splitting and !opts.preserve_modules) {
-        if (!opts.inline_dynamic_imports_explicit) {
-            // 명시 안 함 — 자동 승격 (esbuild 호환).
-            opts.inline_dynamic_imports = true;
-        } else if (!opts.inline_dynamic_imports) {
-            // 명시 false + single-file 은 논리 모순 (어떤 번들러도 처리 안 함).
-            // 자동 승격 대신 명확한 에러로 분리 정책 (--splitting / --preserve-modules)
-            // 선택을 요구.
+    // #2209/#4595: single-file output 모드에서 dynamic import 는 인라인만이 유일한 처리다
+    // (청크로 분리할 chunk graph 가 없다). 자동 승격 자체는 **Bundler.init(bundler.zig
+    // applyPlatformPreset)이 단일 권위 지점**으로 수행한다 — CLI/NAPI/app 어느 프론트엔드로
+    // 들어와도 동일하게 강제되도록 여기서 중복 승격하지 않는다(예전엔 CLI 만 승격해 NAPI 가
+    // 누락됐던 #4595 의 원인). 여기서는 명시 `--no-inline-dynamic-imports` 만 조기 차단한다:
+    // single-file + 명시 false 는 논리 모순(어떤 번들러도 처리 못 함)이라 친절한 에러로 분리
+    // 정책(--splitting / --preserve-modules) 선택을 요구한다. dev/serve/watch(dev_mode)는
+    // Bundler 가 승격 대상에서 제외하므로 여기 조건도 그와 어긋나지 않게 둔다.
+    if (opts.is_bundle and !opts.splitting and !opts.preserve_modules and !opts.dev) {
+        if (opts.inline_dynamic_imports_explicit and !opts.inline_dynamic_imports) {
             try stderr.print(
                 "error: --no-inline-dynamic-imports requires --splitting or --preserve-modules in bundle mode\n",
                 .{},


### PR DESCRIPTION
## 문제 (Closes #4595)

`splitting: false`(기본) + `@zntc/core`의 `build()` JS API로 번들하면, 동적 `import()`가 **인라인·청크분리·진단 셋 다 없이 원문 그대로** 출력됩니다. `errors: 0`으로 성공 보고하지만 런타임에 반드시 깨집니다(번들 성공 + 무증상 실패).

```js
// 출력 (버그)
const local = await import("./dep");              // ./dep 파일이 산출물 옆에 없어 404
const pkg = await import("@radix-ui/react-slot");  // TypeError: does not resolve to a valid URL
```

## 근본 원인 — 옵션 정규화 드리프트

단일 번들 경로에서는 동적 import를 처리할 방법이 **인라인밖에 없습니다** — 청크로 분리할 chunk graph 자체가 없기 때문입니다. 인라인 로직은 이미 존재하지만(`rewriteDynamicImportsSingleFile` → `Promise.resolve().then(()=>(init_x(),exports_x))`), `inline_dynamic_imports` 플래그로 게이트되어 있습니다.

이 플래그의 자동 승격이 **CLI 프론트엔드(`cli/options.zig`)에만 있고 NAPI/app 빌더 경로에는 복제되지 않았습니다.** 그래서 CLI(`-o`)로 번들하면 인라인되는데, 이슈의 `build()` JS API는 승격이 누락되어 leak됐습니다.

> Zig 초보자용 설명: `applyPlatformPreset`는 `Bundler.init` 계열 생성자가 옵션을 정규화하는 공용 함수입니다. CLI·NAPI·app 빌더 등 **모든 진입점이 이 한 곳을 통과**하므로, 여기에 불변식을 두면 어느 프론트엔드로 들어와도 동일하게 적용되어 "한쪽만 승격하는" 드리프트가 구조적으로 불가능해집니다.

## 수정

1. **단일 권위 지점화** — 모든 진입점이 통과하는 `Bundler.applyPlatformPreset`에서 `!code_splitting && !preserve_modules && !dev_mode`이면 `inline_dynamic_imports = true`로 강제. esbuild(`splitting: false`)·rolldown(`codeSplitting: false`) 동작과 동일합니다.
2. **CLI 중복 승격 제거** — 이제 bundler가 유일한 승격 지점입니다(드리프트 재발 차단). CLI는 `--no-inline-dynamic-imports` 명시 에러만 담당합니다.
3. **`!dev_mode` 게이트** — dev 단일 번들의 동적 import는 HMR 레지스트리(`__zntc_modules`)와 상호작용이 달라 별개 이슈이며(baseline에서도 raw import로 이미 깨져 있어 이 PR의 회귀가 아님), 기존 동작을 그대로 보존합니다. `--bundle --dev` 조합의 CLI/NAPI 발산도 이 게이트로 방지합니다.

## 레퍼런스 확인

| 번들러 | code splitting off 시 동적 import |
|---|---|
| esbuild (`splitting:false`) | 인라인 |
| rolldown (`codeSplitting:false`) | 인라인 |
| zntc (수정 후) | 인라인 ✅ |

## 검증

- ✅ `build()` splitting:false → 인라인 + 실제 실행 `run() === "LOADED"`
- ✅ `./dep`(상대) + `@radix-ui/react-slot`(패키지) 둘 다 인라인, `errors:0`
- ✅ RN production 단일 번들 → resolved 동적 import 인라인 (CLI RN과 일치)
- ✅ splitting:true / dev / external dynamic import → 미변경 (회귀 없음)
- ✅ CLI 기본 인라인 · 명시 true 인라인 · `--no-inline-dynamic-imports` 에러 유지
- ✅ 회귀 가드 테스트 추가: **수정을 무력화하면 정확히 `import("./dep") == null` 단언에서 실패**함을 확인(테스트가 실제로 버그를 잡음). 기존 "static path" 테스트는 side-effect 모듈이라 깨진 번들에서도 통과하던 약한 테스트였음.
- ✅ 유닛 테스트 lib 6252 + exe 전부 통과

## 코드 리뷰(`/code-review max`) 반영

4건 지적을 모두 반영했습니다:
- **RN·dev 회귀 우려 (PLAUSIBLE)**: 실증으로 dev·RN 모두 baseline에서 이미 raw import로 깨져 있었음을 확인 → `!dev_mode` 게이트로 dev를 완전 제외, RN production만 수정(개선이자 CLI와 일치).
- **승격 로직 중복 (finding 4)**: CLI 중복 승격 제거, bundler를 단일 권위 지점으로.
- **명시 `false` 무시 (finding 1)**: 단일 번들에서 `inline_dynamic_imports=false`는 존중할 preference가 아니라 처리 불가능한 invalid-state이므로 유일한 유효값으로 normalize하는 것으로 문서화. CLI는 이 조합에 친절한 에러를 추가로 냅니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)