### PR TITLE
fix(bundler): #4596 JSX namespace 멤버가 미선언 식별자로 출력되는 문제 — 합성 import span 오염

### DIFF
--- a/src/bundler/bundler_test/jsx.zig
+++ b/src/bundler/bundler_test/jsx.zig
@@ -37,6 +37,149 @@ test "JSX: component composition" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "<div>") == null);
 }
 
+/// `s[start..]` 앞쪽 공백을 건너뛰고 식별자 하나를 잘라 반환. 식별자로 시작하지 않으면 null
+/// (JSX intrinsic 태그는 `_jsx("div", ...)` 처럼 문자열 리터럴이라 여기서 걸러진다).
+fn identAfter(s: []const u8, start: usize) ?[]const u8 {
+    const isPart = struct {
+        fn f(c: u8) bool {
+            return (c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z') or
+                (c >= '0' and c <= '9') or c == '_' or c == '$';
+        }
+    }.f;
+    var i = start;
+    while (i < s.len and (s[i] == ' ' or s[i] == '\n')) i += 1;
+    if (i >= s.len) return null;
+    const c0 = s[i];
+    if ((c0 >= '0' and c0 <= '9') or !isPart(c0)) return null;
+    var j = i;
+    while (j < s.len and isPart(s[j])) j += 1;
+    return s[i..j];
+}
+
+/// `output` 안에 `name` 의 *선언* 이 있는지. 이름 뒤가 식별자 문자면 다른 이름의 접두사이므로 제외.
+fn declaresName(output: []const u8, name: []const u8, buf: []u8) bool {
+    const kws = [_][]const u8{ "function ", "var ", "let ", "const ", "class " };
+    for (kws) |kw| {
+        const pat = std.fmt.bufPrint(buf, "{s}{s}", .{ kw, name }) catch continue;
+        var from: usize = 0;
+        while (std.mem.indexOfPos(u8, output, from, pat)) |idx| {
+            const after = idx + pat.len;
+            if (after >= output.len) return true;
+            const d = output[after];
+            const ident_char = (d >= 'A' and d <= 'Z') or (d >= 'a' and d <= 'z') or
+                (d >= '0' and d <= '9') or d == '_' or d == '$';
+            if (!ident_char) return true;
+            from = idx + 1;
+        }
+    }
+    return false;
+}
+
+/// 모든 `_jsx(IDENT` / `_jsxs(IDENT` / `_jsxDEV(IDENT` 호출의 callee 가 선언돼 있는지.
+/// provider 쪽 마커 grep 만으로는 "모듈은 살았지만 consumer 참조가 dangling" (#4560/#4564/#4566 류)
+/// 을 못 잡으므로, 참조된 식별자마다 선언 존재를 확인한다.
+fn allJsxCalleesDeclared(output: []const u8, buf: []u8) bool {
+    const calls = [_][]const u8{ "_jsx(", "_jsxs(", "_jsxDEV(" };
+    for (calls) |call| {
+        var from: usize = 0;
+        while (std.mem.indexOfPos(u8, output, from, call)) |idx| {
+            from = idx + call.len;
+            const name = identAfter(output, from) orelse continue;
+            if (!declaresName(output, name, buf)) {
+                std.debug.print("\n[dangling] _jsx callee `{s}` 선언 없음\n", .{name});
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+// (#4596) `import * as NS` 후 `NS.Root` 를 JSX 엘리먼트 이름으로만 쓰면 Root/Button export 가
+// tree-shake 되고 출력엔 `_jsx(Root)` dangling 참조만 남아 ReferenceError 였다(named import 은 정상).
+//
+// 두 결함의 합이었다:
+//  1. 합성 JSX runtime import 노드의 span 이 program root span (파일 전체) → `decl_ranges` 를
+//     오염시켜 그 모듈의 모든 namespace 접근이 "import 선언 내부" 로 skip
+//  2. `NamespaceAccessIndex` 가 `jsx_member_expression` 을 색인하지 않아 lowering 전 AST 에서
+//     JSX 멤버 사용이 안 보임
+//
+// **`jsx_runtime` 이 `.classic` 이면 (1) 의 주입 자체가 없어 재현되지 않는다** — 이슈와 동일한
+// `.automatic` 으로 고정해야 실제 가드가 된다(실측: classic 은 수정 전에도 통과).
+test "JSX: namespace member (`<NS.X>`) keeps target export from tree-shaking (#4596)" {
+    const cases = [_]struct { name: []const u8, rt: @import("../../codegen/codegen.zig").JsxRuntime, ext: []const u8 }{
+        .{ .name = "automatic", .rt = .automatic, .ext = "react/jsx-runtime" },
+        .{ .name = "automatic_dev", .rt = .automatic_dev, .ext = "react/jsx-dev-runtime" },
+    };
+    for (cases) |c| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        try writeFile(tmp.dir, "app.tsx",
+            \\import * as NS from './ns';
+            \\export function App() { return <NS.Root><NS.Button>hi</NS.Button></NS.Root>; }
+            \\console.log(App);
+        );
+        try writeFile(tmp.dir, "ns.tsx",
+            \\export function Root(p: any) { return "NS_ROOT_MARKER_" + p.children; }
+            \\export function Button(p: any) { return "NS_BTN_MARKER_" + p.children; }
+            \\export function Unused(p: any) { return "NS_UNUSED_MARKER_" + p.children; }
+        );
+
+        const entry = try absPath(&tmp, "app.tsx");
+        defer std.testing.allocator.free(entry);
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .jsx_runtime = c.rt,
+            .external = &.{c.ext},
+        });
+        defer b.deinit();
+        const result = try b.bundle(std.testing.io);
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expect(!result.hasErrors());
+        // 1) 두 컴포넌트 body 가 살아야 한다 (provider 쪽).
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_ROOT_MARKER_") != null);
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_BTN_MARKER_") != null);
+        // 2) consumer 쪽 `_jsx(...)` callee 가 전부 선언돼 있어야 한다 (dangling 참조 금지).
+        var buf: [128]u8 = undefined;
+        try std.testing.expect(allJsxCalleesDeclared(result.output, &buf));
+        // 3) 과보존 회귀 방지 — 안 쓴 export 는 여전히 제거돼야 한다.
+        try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_UNUSED_MARKER_") == null);
+    }
+}
+
+// (#4596) 중첩 멤버 체인 `<NS.Grp.Item>` — 바깥 jsx_member 의 object 는 다시 jsx_member 라
+// skip 되고 안쪽 노드가 NS→Grp 를 기록해야 한다. 이 규칙이 뒤집히면 `Item`(Grp 의 프로퍼티)을
+// NS 의 export 로 잘못 기록하거나 아무것도 기록하지 않아, `<Icons.Group.Item/>` 같은 흔한 형태가
+// dangling 이 된다.
+test "JSX: nested namespace member chain (`<NS.A.B>`) keeps target export (#4596)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app.tsx",
+        \\import * as NS from './ns';
+        \\export function App() { return <NS.Grp.Item>hi</NS.Grp.Item>; }
+        \\console.log(App);
+    );
+    try writeFile(tmp.dir, "ns.tsx",
+        \\export const Grp = { Item: (p: any) => "NS_GRP_ITEM_MARKER_" + p.children };
+        \\export function Unused(p: any) { return "NS_UNUSED_MARKER_" + p.children; }
+    );
+
+    const entry = try absPath(&tmp, "app.tsx");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .jsx_runtime = .automatic,
+        .external = &.{"react/jsx-runtime"},
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_GRP_ITEM_MARKER_") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_UNUSED_MARKER_") == null);
+}
+
 test "JSX: RN dev default component import from directory index keeps target module" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -884,4 +1027,63 @@ test "JSX: @jsx pragma + automatic runtime → warning diagnostic (D026)" {
         }
     }
     try std.testing.expect(has_pragma_warning);
+}
+
+// (#4596) `jsx_runtime = .preserve` — JSX 가 link 시점까지 원형으로 남는 유일한 경로.
+// 여기선 `NamespaceAccessIndex` 의 JSX 색인이 tree-shake 판단의 유일한 근거다(lowering 이 없어
+// static_member 로 회수될 기회가 없음). 멤버로만 쓴 export 는 살고, 안 쓴 export 는 제거돼야 한다.
+test "JSX: preserve runtime — namespace member drives tree-shaking precisely (#4596)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app.tsx",
+        \\import * as NS from './ns';
+        \\export function App() { return <NS.Root>hi</NS.Root>; }
+        \\console.log(App);
+    );
+    try writeFile(tmp.dir, "ns.tsx",
+        \\export function Root(p: any) { return "NS_ROOT_MARKER_" + p.children; }
+        \\export function Unused(p: any) { return "NS_UNUSED_MARKER_" + p.children; }
+    );
+
+    const entry = try absPath(&tmp, "app.tsx");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .jsx_runtime = .preserve });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_ROOT_MARKER_") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_UNUSED_MARKER_") == null);
+}
+
+// (#4596) namespace 자체를 JSX *값* 위치에 쓰면(`<NS/>` — 객체째 factory 로 전달) escape 다.
+// 멤버 사용(`<NS.Root/>`)만 보고 member_only 로 좁히면 `<NS/>` 는 멤버가 사라진 객체를 받아
+// undefined 컴포넌트가 된다. escape 감지가 살아 있어야 전체가 보존된다.
+test "JSX: bare namespace tag (`<NS/>`) is an escape — namespace fully retained (#4596)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app.tsx",
+        \\import * as NS from './ns';
+        \\const Both: any = NS;
+        \\export function App() { return <Both.Root>hi</Both.Root>; }
+        \\export function Raw() { return <NS>x</NS>; }
+        \\console.log(App, Raw);
+    );
+    try writeFile(tmp.dir, "ns.tsx",
+        \\export function Root(p: any) { return "NS_ROOT_MARKER_" + p.children; }
+        \\export function Other(p: any) { return "NS_OTHER_MARKER_" + p.children; }
+    );
+
+    const entry = try absPath(&tmp, "app.tsx");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .jsx_runtime = .preserve });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // escape 이므로 멤버 집합으로 좁히지 못하고 두 export 모두 보존돼야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_ROOT_MARKER_") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_OTHER_MARKER_") != null);
 }

--- a/src/bundler/bundler_test/jsx.zig
+++ b/src/bundler/bundler_test/jsx.zig
@@ -47,7 +47,9 @@ fn identAfter(s: []const u8, start: usize) ?[]const u8 {
         }
     }.f;
     var i = start;
-    while (i < s.len and (s[i] == ' ' or s[i] == '\n')) i += 1;
+    // 공백류 전부 skip — codegen 은 탭으로 들여쓰고 긴 호출을 줄바꿈할 수 있다. 탭을 빼먹으면
+    // callee 추출이 null 로 떨어지고 호출자가 `orelse continue` 로 넘겨 검사가 조용히 무력화된다.
+    while (i < s.len and (s[i] == ' ' or s[i] == '\n' or s[i] == '\t' or s[i] == '\r')) i += 1;
     if (i >= s.len) return null;
     const c0 = s[i];
     if ((c0 >= '0' and c0 <= '9') or !isPart(c0)) return null;
@@ -56,7 +58,19 @@ fn identAfter(s: []const u8, start: usize) ?[]const u8 {
     return s[i..j];
 }
 
-/// `output` 안에 `name` 의 *선언* 이 있는지. 이름 뒤가 식별자 문자면 다른 이름의 접두사이므로 제외.
+fn isIdentChar(c: u8) bool {
+    return (c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z') or
+        (c >= '0' and c <= '9') or c == '_' or c == '$';
+}
+
+/// `output` 안에 `name` 의 *선언* 이 있는지.
+///
+/// 두 형태를 인정한다:
+///  1. 키워드 직후 — `function Root(`, `var Root`, `let/const/class Root`
+///  2. 병합 선언자 — `var a = 1, Root = 2;` (decl coalescing #3417 / `--minify-syntax`).
+///     `, Root` 만 보면 `f(a, Root)` 같은 호출 인자도 선언으로 오인하므로, 같은 줄에서 콤마보다
+///     **앞에** var/let/const 가 있는지 역방향으로 확인한다. 이 구분이 없으면 가드가 약해지고,
+///     반대로 2번을 빼면 정상 번들에서 "dangling" 오탐이 나 없는 버그를 쫓게 된다.
 fn declaresName(output: []const u8, name: []const u8, buf: []u8) bool {
     const kws = [_][]const u8{ "function ", "var ", "let ", "const ", "class " };
     for (kws) |kw| {
@@ -64,13 +78,27 @@ fn declaresName(output: []const u8, name: []const u8, buf: []u8) bool {
         var from: usize = 0;
         while (std.mem.indexOfPos(u8, output, from, pat)) |idx| {
             const after = idx + pat.len;
-            if (after >= output.len) return true;
-            const d = output[after];
-            const ident_char = (d >= 'A' and d <= 'Z') or (d >= 'a' and d <= 'z') or
-                (d >= '0' and d <= '9') or d == '_' or d == '$';
-            if (!ident_char) return true;
+            if (after >= output.len or !isIdentChar(output[after])) return true;
             from = idx + 1;
         }
+    }
+
+    // 병합 선언자: `name` 을 온전한 단어로 찾고, 바로 앞이 (공백 무시) 콤마이며 같은 줄에서
+    // 그보다 앞에 선언 키워드가 있으면 선언으로 인정. `, Root` / `,Root` 양쪽 표기 모두 커버.
+    var from: usize = 0;
+    while (std.mem.indexOfPos(u8, output, from, name)) |idx| {
+        from = idx + 1;
+        const after = idx + name.len;
+        if (after < output.len and isIdentChar(output[after])) continue;
+        if (idx == 0) continue;
+        var b = idx;
+        while (b > 0 and (output[b - 1] == ' ' or output[b - 1] == '\t')) b -= 1;
+        if (b == 0 or output[b - 1] != ',') continue;
+        const line_start = if (std.mem.lastIndexOfScalar(u8, output[0..b], '\n')) |nl| nl + 1 else 0;
+        const line_head = output[line_start .. b - 1];
+        if (std.mem.indexOf(u8, line_head, "var ") != null or
+            std.mem.indexOf(u8, line_head, "let ") != null or
+            std.mem.indexOf(u8, line_head, "const ") != null) return true;
     }
     return false;
 }
@@ -1029,19 +1057,46 @@ test "JSX: @jsx pragma + automatic runtime → warning diagnostic (D026)" {
     try std.testing.expect(has_pragma_warning);
 }
 
+/// preserve 출력의 JSX 태그 root 가 모두 선언돼 있는지. `<NS.Root>` / `<NS>` 형태를 훑는다.
+/// preserve 경로엔 `_jsx(` 가 아예 없으므로 `allJsxCalleesDeclared` 로는 검사되지 않는다 —
+/// 이 검사가 없으면 "태그는 남고 선언은 없는" #4596 회귀가 마커 단언만으로 green 하게 통과한다.
+fn allJsxTagRootsDeclared(output: []const u8, buf: []u8) bool {
+    var from: usize = 0;
+    while (std.mem.indexOfScalarPos(u8, output, from, '<')) |lt| {
+        from = lt + 1;
+        if (lt + 1 >= output.len) break;
+        const name = identAfter(output, lt + 1) orelse continue;
+        // 소문자 시작 = intrinsic element (`<div>`) — 값 참조가 아니다.
+        if (name[0] >= 'a' and name[0] <= 'z') continue;
+        if (!declaresName(output, name, buf)) {
+            std.debug.print("\n[dangling] JSX 태그 root `{s}` 선언 없음\n", .{name});
+            return false;
+        }
+    }
+    return true;
+}
+
 // (#4596) `jsx_runtime = .preserve` — JSX 가 link 시점까지 원형으로 남는 유일한 경로.
 // 여기선 `NamespaceAccessIndex` 의 JSX 색인이 tree-shake 판단의 유일한 근거다(lowering 이 없어
-// static_member 로 회수될 기회가 없음). 멤버로만 쓴 export 는 살고, 안 쓴 export 는 제거돼야 한다.
+// static_member 로 회수될 기회가 없음). 세 가지를 함께 단언한다:
+//   1. 멤버로 쓴 export 는 살아야 한다
+//   2. 안 쓴 export 는 제거돼야 한다 (정밀도)
+//   3. **남은 JSX 태그 root 가 선언돼 있어야 한다** — codegen 은 preserve JSX 의 멤버를
+//      재작성하지 않으므로 namespace 객체가 실체화돼야 한다. 이 단언이 없으면
+//      `isNamespaceUsedAsValue` 에 JSX arm 을 넣어 force_inline 을 켜는 순간
+//      `<NS.Root>` 만 남고 `NS` 선언이 사라지는 회귀가 green 하게 통과한다.
 test "JSX: preserve runtime — namespace member drives tree-shaking precisely (#4596)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "app.tsx",
         \\import * as NS from './ns';
         \\export function App() { return <NS.Root>hi</NS.Root>; }
+        \\console.log(NS.helper());
         \\console.log(App);
     );
     try writeFile(tmp.dir, "ns.tsx",
         \\export function Root(p: any) { return "NS_ROOT_MARKER_" + p.children; }
+        \\export function helper() { return "NS_HELPER_MARKER_"; }
         \\export function Unused(p: any) { return "NS_UNUSED_MARKER_" + p.children; }
     );
 
@@ -1054,36 +1109,18 @@ test "JSX: preserve runtime — namespace member drives tree-shaking precisely (
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_ROOT_MARKER_") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_HELPER_MARKER_") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_UNUSED_MARKER_") == null);
+    // JSX 가 원형으로 남았음을 확인한 뒤(전제 검증) 태그 root 선언을 단언.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "<") != null);
+    var buf: [128]u8 = undefined;
+    try std.testing.expect(allJsxTagRootsDeclared(result.output, &buf));
 }
 
-// (#4596) namespace 자체를 JSX *값* 위치에 쓰면(`<NS/>` — 객체째 factory 로 전달) escape 다.
-// 멤버 사용(`<NS.Root/>`)만 보고 member_only 로 좁히면 `<NS/>` 는 멤버가 사라진 객체를 받아
-// undefined 컴포넌트가 된다. escape 감지가 살아 있어야 전체가 보존된다.
-test "JSX: bare namespace tag (`<NS/>`) is an escape — namespace fully retained (#4596)" {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    try writeFile(tmp.dir, "app.tsx",
-        \\import * as NS from './ns';
-        \\const Both: any = NS;
-        \\export function App() { return <Both.Root>hi</Both.Root>; }
-        \\export function Raw() { return <NS>x</NS>; }
-        \\console.log(App, Raw);
-    );
-    try writeFile(tmp.dir, "ns.tsx",
-        \\export function Root(p: any) { return "NS_ROOT_MARKER_" + p.children; }
-        \\export function Other(p: any) { return "NS_OTHER_MARKER_" + p.children; }
-    );
-
-    const entry = try absPath(&tmp, "app.tsx");
-    defer std.testing.allocator.free(entry);
-    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .jsx_runtime = .preserve });
-    defer b.deinit();
-    const result = try b.bundle(std.testing.io);
-    defer result.deinit(std.testing.allocator);
-
-    try std.testing.expect(!result.hasErrors());
-    // escape 이므로 멤버 집합으로 좁히지 못하고 두 export 모두 보존돼야 한다.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_ROOT_MARKER_") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_OTHER_MARKER_") != null);
-}
+// (#4596) bare `<NS/>` (namespace 자체를 JSX 값 위치에 전달) 의 escape 감지는 **번들 레벨에서
+// 가드할 수 없다** — 대문자로 시작하는 namespace local 이면 linker 의 symbol-aware 경로가
+// `prop_by_obj` 에 없는 태그 root 를 보고 독립적으로 opaque 를 반환해 전체를 보존하기 때문이다.
+// 실측: `NamespaceAccessIndex` 의 `jsx_element` escape 브랜치를 무력화해도 번들 출력이 동일했다.
+// 따라서 이 브랜치의 가드는 text-only 경로를 직접 찌르는 유닛 테스트가 담당한다 —
+// `linker/namespace_access_test.zig` 의 "bare JSX namespace tag (`<NS/>`) is an escape → opaque".
+// (여기에 번들 테스트를 두면 브랜치를 지워도 green 인 공허한 가드가 된다.)

--- a/src/bundler/linker/namespace_access.zig
+++ b/src/bundler/linker/namespace_access.zig
@@ -29,6 +29,14 @@ pub fn isNamespaceUsedAsValue(allocator: std.mem.Allocator, ast: *const Ast, sym
                 const obj_idx = ast.readExtra(e, 0);
                 if (obj_idx < node_count) safe.set(obj_idx);
             }
+        } else if (node.tag == .jsx_member_expression) {
+            // (#4596) `<NS.Root>` 의 `NS` 도 멤버 접근의 object 위치다 — lowering 전 AST
+            // (`jsx_runtime = .preserve`, link 시점까지 JSX 유지) 에서 이걸 안 세면
+            // `NamespaceAccessIndex` 는 member_only 로 보는데 이 술어만 "값으로 escape" 라고
+            // 답해, 같은 파일 안 두 분석기가 동일 입력에 불일치한다 (모듈 doc 불변식 위반).
+            // `jsx_member_expression` 은 data.binary { left=object, right=property }.
+            const obj_idx: u32 = @intFromEnum(node.data.binary.left);
+            if (obj_idx < node_count) safe.set(obj_idx);
         }
     }
 
@@ -177,6 +185,68 @@ pub const NamespaceAccessIndex = struct {
                 try gop.value_ptr.append(allocator, .{
                     .prop_node_idx = prop_idx,
                     .obj_span_start = obj_node.span.start,
+                });
+            } else if (node.tag == .jsx_member_expression) {
+                // (#4596) JSX 엘리먼트 이름의 namespace 멤버 접근(`<NS.Root>`)도 static_member_expression
+                // 과 동일하게 색인한다. `jsx_member_expression` 은 data.binary { left=object, right=property }.
+                //
+                // 이 index 가 구축되는 시점은 두 번이다: parse 직후 (parser_metadata.zig — JSX 원본
+                // 그대로) 와 transform pre-pass 후 (transform_prepass.zig — 덮어씀, linker 가 읽는 쪽).
+                // 후자 AST 에서 classic/automatic JSX 는 이미 `static_member_expression` 으로 lowered 라
+                // 위 브랜치가 잡는다. 이 JSX 브랜치가 실제로 유일한 근거가 되는 경우:
+                //   - `jsx_runtime = .preserve` — JSX 가 link 시점까지 원형 유지
+                //   - parse 직후 1차 pass — 그 결과(`namespace_used_properties`)는 2차 결과와 union
+                //     되므로(transform_prepass.zig, counter$4 fix), 2차가 놓쳐도 1차가 보강한다
+                // 안 잡으면 "JSX 로만 쓰인 export" 가 미사용으로 판정돼 제거되고, 출력엔 `_jsx(Root)`
+                // 참조만 남아 dangling ReferenceError 가 된다.
+                const obj_idx: u32 = @intFromEnum(node.data.binary.left);
+                const prop_idx: u32 = @intFromEnum(node.data.binary.right);
+                if (obj_idx >= node_count or prop_idx >= node_count) continue;
+                try self.prop_by_obj.put(allocator, obj_idx, prop_idx);
+                // text fallback 색인: object 가 root 식별자(jsx_identifier)인 경우만. 중첩
+                // `<NS.A.B>` 의 바깥 노드는 object 가 다시 jsx_member 라 skip — 안쪽 노드가 NS→A 를
+                // 이미 기록한다(static_member 의 non-identifier obj skip 과 동일 규칙).
+                const obj_node = ast.nodes.items[obj_idx];
+                if (obj_node.tag != .jsx_identifier) continue;
+                const obj_text = ast.getText(obj_node.span);
+                if (obj_text.len == 0) continue;
+                if (interest_text_set) |s| if (!s.contains(obj_text)) continue;
+                const gop = try self.accesses_by_obj_text.getOrPut(allocator, obj_text);
+                if (!gop.found_existing) gop.value_ptr.* = .empty;
+                try gop.value_ptr.append(allocator, .{
+                    .prop_node_idx = prop_idx,
+                    .obj_span_start = obj_node.span.start,
+                });
+            } else if (node.tag == .jsx_element) {
+                // (#4596) `<NS/>` — namespace 자체가 JSX 태그 = *값* 위치 사용(factory 에 객체째
+                // 전달)이다. escape 색인(`idents_by_text`) 은 `identifier_reference` 만 담으므로
+                // JSX 태그 root (`jsx_identifier`) 는 보이지 않는다. 위 JSX 멤버 브랜치로 멤버
+                // 집합이 non-empty 가 된 뒤에도 이 escape 를 못 보면, `<NS.Root/>` 하나 때문에
+                // member_only{Root} 로 좁혀지고 `<NS/>` 는 멤버가 사라진 객체를 받아 undefined
+                // 컴포넌트가 된다. 그래서 태그 root 를 escape 후보로 색인한다 — 멤버 접근의
+                // object 였다면 `prop_by_obj` 에 있어 escape 로 세지 않는다(검사 로직 그대로).
+                //
+                // `jsx_element` extras[0] = tag_name. tag_name 이 `jsx_member_expression` 이면
+                // 위 브랜치가 이미 처리하므로 여기선 bare `jsx_identifier` 만 본다.
+                // `hasExtra(base, max_offset)` 는 `base + max_offset < len` — jsx_element 는
+                // 5 슬롯(offset 0..4)이므로 최대 offset 은 4.
+                const e = node.data.extra;
+                if (!ast.hasExtra(e, 4)) continue;
+                const name_idx = ast.readExtra(e, 0);
+                if (name_idx >= node_count) continue;
+                const name_node = ast.nodes.items[name_idx];
+                if (name_node.tag != .jsx_identifier) continue;
+                const name_text = ast.getText(name_node.span);
+                if (name_text.len == 0) continue;
+                // 소문자 시작 = intrinsic element (`<div>`) — jsx_lowering 이 string literal 로
+                // 낮추므로 값 참조가 아니다 (lowerTagName 의 판정 규칙과 동일하게 유지).
+                if (name_text[0] >= 'a' and name_text[0] <= 'z') continue;
+                if (interest_text_set) |s| if (!s.contains(name_text)) continue;
+                const gop = try self.idents_by_text.getOrPut(allocator, name_text);
+                if (!gop.found_existing) gop.value_ptr.* = .empty;
+                try gop.value_ptr.append(allocator, .{
+                    .node_idx = name_idx,
+                    .span_start = name_node.span.start,
                 });
             } else if (node.tag == .computed_member_expression) {
                 // dynamic access — text-only mode 의 escape 감지에 활용.

--- a/src/bundler/linker/namespace_access.zig
+++ b/src/bundler/linker/namespace_access.zig
@@ -29,15 +29,18 @@ pub fn isNamespaceUsedAsValue(allocator: std.mem.Allocator, ast: *const Ast, sym
                 const obj_idx = ast.readExtra(e, 0);
                 if (obj_idx < node_count) safe.set(obj_idx);
             }
-        } else if (node.tag == .jsx_member_expression) {
-            // (#4596) `<NS.Root>` 의 `NS` 도 멤버 접근의 object 위치다 — lowering 전 AST
-            // (`jsx_runtime = .preserve`, link 시점까지 JSX 유지) 에서 이걸 안 세면
-            // `NamespaceAccessIndex` 는 member_only 로 보는데 이 술어만 "값으로 escape" 라고
-            // 답해, 같은 파일 안 두 분석기가 동일 입력에 불일치한다 (모듈 doc 불변식 위반).
-            // `jsx_member_expression` 은 data.binary { left=object, right=property }.
-            const obj_idx: u32 = @intFromEnum(node.data.binary.left);
-            if (obj_idx < node_count) safe.set(obj_idx);
         }
+        // (#4596) ⚠️ `jsx_member_expression` 의 object 는 **의도적으로 safe 로 세지 않는다**.
+        // 이 술어의 실제 질문은 "namespace 객체 생성을 생략하고 멤버를 직접 치환할 수 있나" 다
+        // (`linker/metadata.zig` 의 force_inline). 그런데 `codegen/jsx.zig::emitJsxMemberExpression`
+        // 은 `meta.ns_member_rewrites` 를 보지 않으므로, JSX 가 원형으로 남는 경로
+        // (`jsx_runtime = .preserve`) 에서는 `<NS.Root>` 의 `NS` 를 치환하지 못한다. 여기서 safe
+        // 로 세면 force_inline 이 켜져 namespace 객체가 생성되지 않는데 출력엔 `<NS.Root>` 가
+        // 그대로 남아 **선언 없는 참조**가 된다(`NS.helper()` 같은 static member 만 재작성되는
+        // 반쪽 상태). `NamespaceAccessIndex` 가 JSX 멤버를 색인하는 것과 이 술어가 JSX 를
+        // escape 로 보는 것은 모순이 아니다 — 전자는 "어떤 export 가 살아야 하나"(tree-shake),
+        // 후자는 "객체를 생략해도 되나"(codegen 능력) 라는 서로 다른 질문에 답한다.
+        // codegen 이 preserve JSX 멤버 재작성을 지원하게 되면 그때 이 arm 을 추가해야 한다.
     }
 
     for (symbol_ids, 0..) |maybe_sid, node_i| {
@@ -74,7 +77,10 @@ pub const NamespaceAccess = struct {
 /// `analyzeNamespaceAccess` 의 ns_sym_id-독립 인덱스.
 /// 같은 AST 를 여러 namespace import 로 분석할 때 공유해 AST 전체 순회를 줄인다 (#1735).
 pub const NamespaceAccessIndex = struct {
-    /// obj_node_idx → prop_node_idx 매핑 (static/private member expression).
+    /// obj_node_idx → prop_node_idx 매핑.
+    /// 대상: `static_member_expression` / `private_field_expression` / (#4596)
+    /// `jsx_member_expression`. **key/value 노드가 `identifier_reference` 라고 가정하지 말 것** —
+    /// JSX 항목은 `jsx_identifier` 이고 symbol_id 가 안 붙어 있을 수 있다.
     prop_by_obj: std.AutoHashMapUnmanaged(u32, u32) = .empty,
     /// import declaration span 범위 — 이 안의 identifier_reference 는 선언이므로 skip.
     decl_ranges: std.ArrayListUnmanaged(DeclRange) = .empty,
@@ -86,9 +92,13 @@ pub const NamespaceAccessIndex = struct {
     /// 즉 build → analyze 동안 ast 가 mutate (transformer 의 addString 등) 되면 invalidate. 단일 단계 사용 강제.
     accesses_by_obj_text: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(IdentAccess)) = .empty,
 
-    /// escape 색인 (F1 fix): 모든 identifier_reference 의 `text → [(node_idx, span_start)...]`.
+    /// escape 색인 (F1 fix): `text → [(node_idx, span_start)...]`.
+    /// 대상: 모든 `identifier_reference` + (#4596) JSX 태그 root 인 `jsx_identifier`
+    /// (bare `<NS/>` = 값 위치. 소문자 시작 intrinsic 태그는 제외).
     /// text fallback 진입 시 `idents_by_text[local_name]` 의 각 node_idx 가 `prop_by_obj` 에
     /// 있으면 member-obj, 없으면 escape (value position) — opaque return 으로 over-prune 회피.
+    /// **node_idx 가 `identifier_reference` 라고 가정하지 말 것** — `jsx_identifier` 항목이 섞여
+    /// 있고 symbol_ids/rename 테이블에 그대로 넘기면 symbol 이 null 이라 판정이 뒤집힌다.
     idents_by_text: std.StringHashMapUnmanaged(std.ArrayListUnmanaged(IdentRef)) = .empty,
     /// computed_member_expression 의 obj 가 identifier_reference 인 경우 `text → [...]`.
     /// `M[dyn]` 같은 dynamic access — text-only mode 의 escape 감지에 사용 (binding_scanner 동치).

--- a/src/bundler/linker/namespace_access_test.zig
+++ b/src/bundler/linker/namespace_access_test.zig
@@ -12,13 +12,34 @@ const ast_mod = @import("../../parser/ast.zig");
 const Ast = ast_mod.Ast;
 const Tag = ast_mod.Node.Tag;
 
-/// JSX 소스를 module + jsx 모드로 파싱. AST 는 `parser.ast` 소유 — caller 가 parser 를 살려둬야 한다.
-fn parseJsx(parser: *Parser, scanner: *Scanner, source: []const u8) !void {
-    scanner.* = try Scanner.init(std.testing.allocator, source);
-    parser.* = Parser.init(std.testing.allocator, scanner);
-    parser.is_module = true;
-    parser.is_jsx = true;
-    _ = try parser.parse();
+/// JSX 소스를 module + jsx 모드로 파싱한 Scanner+Parser 묶음.
+/// `parser.ast` 의 text 슬라이스가 scanner 의 source 를 가리키므로 **parser 를 먼저** 해제한다
+/// (caller 의 `defer` 2개로 나누면 등록 역순 때문에 scanner 가 먼저 죽는다).
+/// 생성 중 실패해도 이미 만든 리소스를 여기서 정리한다 — caller 의 defer 는 아직 등록 전이다.
+const ParsedJsx = struct {
+    scanner: Scanner,
+    parser: Parser,
+
+    fn deinit(self: *ParsedJsx) void {
+        self.parser.deinit();
+        self.scanner.deinit();
+    }
+
+    fn ast(self: *ParsedJsx) *Ast {
+        return &self.parser.ast;
+    }
+};
+
+/// `out` 은 caller 스택에 있어야 한다 — `Parser` 가 `&out.scanner` 를 들고 있어서
+/// 값 복사로 반환하면 포인터가 뜬다.
+fn parseJsx(out: *ParsedJsx, source: []const u8) !void {
+    out.scanner = try Scanner.init(std.testing.allocator, source);
+    errdefer out.scanner.deinit();
+    out.parser = Parser.init(std.testing.allocator, &out.scanner);
+    errdefer out.parser.deinit();
+    out.parser.is_module = true;
+    out.parser.is_jsx = true;
+    _ = try out.parser.parse();
 }
 
 /// 파싱이 실제로 JSX 노드를 만들었는지 — parse 가 조용히 실패하면 모든 단언이 공허해진다.
@@ -31,15 +52,13 @@ fn countTag(ast: *const Ast, tag: Tag) usize {
 }
 
 test "NamespaceAccessIndex: JSX member tag (`<NS.Root>`) is indexed as a namespace member (#4596)" {
-    var scanner: Scanner = undefined;
-    var parser: Parser = undefined;
-    try parseJsx(&parser, &scanner,
+    var p: ParsedJsx = undefined;
+    try parseJsx(&p,
         \\import * as NS from "./ns";
         \\export const App = () => <NS.Root><NS.Button>hi</NS.Button></NS.Root>;
     );
-    defer parser.deinit();
-    defer scanner.deinit();
-    const ast = &parser.ast;
+    defer p.deinit();
+    const ast = p.ast();
     try std.testing.expect(countTag(ast, .jsx_member_expression) >= 2);
 
     var index = try ns_access.NamespaceAccessIndex.build(std.testing.allocator, ast);
@@ -55,15 +74,13 @@ test "NamespaceAccessIndex: JSX member tag (`<NS.Root>`) is indexed as a namespa
 }
 
 test "NamespaceAccessIndex: nested JSX member chain records only the first hop (#4596)" {
-    var scanner: Scanner = undefined;
-    var parser: Parser = undefined;
-    try parseJsx(&parser, &scanner,
+    var p: ParsedJsx = undefined;
+    try parseJsx(&p,
         \\import * as NS from "./ns";
         \\export const App = () => <NS.Grp.Item>hi</NS.Grp.Item>;
     );
-    defer parser.deinit();
-    defer scanner.deinit();
-    const ast = &parser.ast;
+    defer p.deinit();
+    const ast = p.ast();
     try std.testing.expect(countTag(ast, .jsx_member_expression) >= 2);
 
     var index = try ns_access.NamespaceAccessIndex.build(std.testing.allocator, ast);
@@ -80,16 +97,14 @@ test "NamespaceAccessIndex: nested JSX member chain records only the first hop (
 }
 
 test "NamespaceAccessIndex: bare JSX namespace tag (`<NS/>`) is an escape → opaque (#4596)" {
-    var scanner: Scanner = undefined;
-    var parser: Parser = undefined;
-    try parseJsx(&parser, &scanner,
+    var p: ParsedJsx = undefined;
+    try parseJsx(&p,
         \\import * as NS from "./ns";
         \\export const A = () => <NS.Root>hi</NS.Root>;
         \\export const B = () => <NS>x</NS>;
     );
-    defer parser.deinit();
-    defer scanner.deinit();
-    const ast = &parser.ast;
+    defer p.deinit();
+    const ast = p.ast();
 
     var index = try ns_access.NamespaceAccessIndex.build(std.testing.allocator, ast);
     defer index.deinit(std.testing.allocator);
@@ -105,15 +120,13 @@ test "NamespaceAccessIndex: bare JSX namespace tag (`<NS/>`) is an escape → op
 test "NamespaceAccessIndex: intrinsic tag (`<div>`) does not escape a same-named namespace (#4596)" {
     // 소문자 태그는 jsx_lowering 이 string literal 로 낮추므로 값 참조가 아니다.
     // 이름이 같다는 이유로 escape 로 세면 불필요하게 opaque 가 된다.
-    var scanner: Scanner = undefined;
-    var parser: Parser = undefined;
-    try parseJsx(&parser, &scanner,
+    var p: ParsedJsx = undefined;
+    try parseJsx(&p,
         \\import * as div from "./ns";
         \\export const A = () => <div>{div.value}</div>;
     );
-    defer parser.deinit();
-    defer scanner.deinit();
-    const ast = &parser.ast;
+    defer p.deinit();
+    const ast = p.ast();
 
     var index = try ns_access.NamespaceAccessIndex.build(std.testing.allocator, ast);
     defer index.deinit(std.testing.allocator);
@@ -136,18 +149,20 @@ fn symbolIdsForJsxIdent(ast: *const Ast, text: []const u8, sym: u32) ![]?u32 {
     return sids;
 }
 
-test "isNamespaceUsedAsValue: JSX member object is not a value use (#4596)" {
-    // 형제 술어 정합 — 색인은 member_only 로 보는데 이 술어만 "값으로 escape" 라고 답하면
-    // 같은 파일의 두 분석기가 동일 입력에 대해 불일치한다 (모듈 doc 불변식 위반).
-    var scanner: Scanner = undefined;
-    var parser: Parser = undefined;
-    try parseJsx(&parser, &scanner,
+test "isNamespaceUsedAsValue: JSX member object IS a value use — codegen can't rewrite preserved JSX (#4596)" {
+    // ⚠️ 이 술어의 질문은 "namespace 객체 생성을 생략해도 되나"(force_inline) 다. JSX 가 원형으로
+    // 남는 경로(`jsx_runtime = .preserve`)에서는 `codegen/jsx.zig::emitJsxMemberExpression` 이
+    // `ns_member_rewrites` 를 보지 않아 `<NS.Root>` 의 `NS` 를 치환하지 못한다. 따라서 JSX 멤버의
+    // object 를 "safe"(치환 가능) 로 세면 객체가 생성되지 않는데 출력엔 `<NS.Root>` 가 남아
+    // **선언 없는 참조**가 된다. `NamespaceAccessIndex` 가 JSX 멤버를 색인하는 것과는 다른 질문 —
+    // 색인은 "어떤 export 가 살아야 하나", 이 술어는 "객체를 생략해도 되나" 에 답한다.
+    var p: ParsedJsx = undefined;
+    try parseJsx(&p,
         \\import * as NS from "./ns";
         \\export const App = () => <NS.Root>hi</NS.Root>;
     );
-    defer parser.deinit();
-    defer scanner.deinit();
-    const ast = &parser.ast;
+    defer p.deinit();
+    const ast = p.ast();
 
     const sids = try symbolIdsForJsxIdent(ast, "NS", 42);
     defer std.testing.allocator.free(sids);
@@ -158,19 +173,17 @@ test "isNamespaceUsedAsValue: JSX member object is not a value use (#4596)" {
     }
     try std.testing.expect(planted >= 1);
 
-    try std.testing.expect(!ns_access.isNamespaceUsedAsValue(std.testing.allocator, ast, sids, 42));
+    try std.testing.expect(ns_access.isNamespaceUsedAsValue(std.testing.allocator, ast, sids, 42));
 }
 
 test "isNamespaceUsedAsValue: bare JSX namespace tag is a value use (#4596)" {
-    var scanner: Scanner = undefined;
-    var parser: Parser = undefined;
-    try parseJsx(&parser, &scanner,
+    var p: ParsedJsx = undefined;
+    try parseJsx(&p,
         \\import * as NS from "./ns";
         \\export const B = () => <NS>x</NS>;
     );
-    defer parser.deinit();
-    defer scanner.deinit();
-    const ast = &parser.ast;
+    defer p.deinit();
+    const ast = p.ast();
 
     const sids = try symbolIdsForJsxIdent(ast, "NS", 42);
     defer std.testing.allocator.free(sids);

--- a/src/bundler/linker/namespace_access_test.zig
+++ b/src/bundler/linker/namespace_access_test.zig
@@ -1,0 +1,179 @@
+//! `namespace_access.zig` 유닛 테스트 — JSX 태그 위치의 namespace 접근 색인 (#4596).
+//!
+//! 번들 end-to-end 테스트(`bundler_test/jsx.zig`)는 "증상이 사라졌는지" 를 보지만,
+//! #4596 은 두 결함의 합이라 어느 한쪽만 되돌려도 증상이 안 나온다. 그래서 이 파일은
+//! 색인 계층 하나만 떼어내 직접 단언한다 — 색인 브랜치가 지워지면 여기서 바로 실패한다.
+
+const std = @import("std");
+const Scanner = @import("../../lexer/scanner.zig").Scanner;
+const Parser = @import("../../parser/parser.zig").Parser;
+const ns_access = @import("namespace_access.zig");
+const ast_mod = @import("../../parser/ast.zig");
+const Ast = ast_mod.Ast;
+const Tag = ast_mod.Node.Tag;
+
+/// JSX 소스를 module + jsx 모드로 파싱. AST 는 `parser.ast` 소유 — caller 가 parser 를 살려둬야 한다.
+fn parseJsx(parser: *Parser, scanner: *Scanner, source: []const u8) !void {
+    scanner.* = try Scanner.init(std.testing.allocator, source);
+    parser.* = Parser.init(std.testing.allocator, scanner);
+    parser.is_module = true;
+    parser.is_jsx = true;
+    _ = try parser.parse();
+}
+
+/// 파싱이 실제로 JSX 노드를 만들었는지 — parse 가 조용히 실패하면 모든 단언이 공허해진다.
+fn countTag(ast: *const Ast, tag: Tag) usize {
+    var n: usize = 0;
+    for (ast.nodes.items) |node| {
+        if (node.tag == tag) n += 1;
+    }
+    return n;
+}
+
+test "NamespaceAccessIndex: JSX member tag (`<NS.Root>`) is indexed as a namespace member (#4596)" {
+    var scanner: Scanner = undefined;
+    var parser: Parser = undefined;
+    try parseJsx(&parser, &scanner,
+        \\import * as NS from "./ns";
+        \\export const App = () => <NS.Root><NS.Button>hi</NS.Button></NS.Root>;
+    );
+    defer parser.deinit();
+    defer scanner.deinit();
+    const ast = &parser.ast;
+    try std.testing.expect(countTag(ast, .jsx_member_expression) >= 2);
+
+    var index = try ns_access.NamespaceAccessIndex.build(std.testing.allocator, ast);
+    defer index.deinit(std.testing.allocator);
+
+    var access = try ns_access.analyzeNamespaceAccessTextOnly(std.testing.allocator, ast, &index, "NS", null);
+    defer access.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(ns_access.NamespaceAccess.Kind.member_only, access.kind);
+    try std.testing.expectEqual(@as(u32, 2), access.members.count());
+    try std.testing.expect(access.members.contains("Root"));
+    try std.testing.expect(access.members.contains("Button"));
+}
+
+test "NamespaceAccessIndex: nested JSX member chain records only the first hop (#4596)" {
+    var scanner: Scanner = undefined;
+    var parser: Parser = undefined;
+    try parseJsx(&parser, &scanner,
+        \\import * as NS from "./ns";
+        \\export const App = () => <NS.Grp.Item>hi</NS.Grp.Item>;
+    );
+    defer parser.deinit();
+    defer scanner.deinit();
+    const ast = &parser.ast;
+    try std.testing.expect(countTag(ast, .jsx_member_expression) >= 2);
+
+    var index = try ns_access.NamespaceAccessIndex.build(std.testing.allocator, ast);
+    defer index.deinit(std.testing.allocator);
+
+    var access = try ns_access.analyzeNamespaceAccessTextOnly(std.testing.allocator, ast, &index, "NS", null);
+    defer access.deinit(std.testing.allocator);
+
+    // NS 의 export 는 `Grp` 뿐 — `Item` 은 Grp 객체의 프로퍼티지 NS 의 export 가 아니다.
+    try std.testing.expectEqual(ns_access.NamespaceAccess.Kind.member_only, access.kind);
+    try std.testing.expectEqual(@as(u32, 1), access.members.count());
+    try std.testing.expect(access.members.contains("Grp"));
+    try std.testing.expect(!access.members.contains("Item"));
+}
+
+test "NamespaceAccessIndex: bare JSX namespace tag (`<NS/>`) is an escape → opaque (#4596)" {
+    var scanner: Scanner = undefined;
+    var parser: Parser = undefined;
+    try parseJsx(&parser, &scanner,
+        \\import * as NS from "./ns";
+        \\export const A = () => <NS.Root>hi</NS.Root>;
+        \\export const B = () => <NS>x</NS>;
+    );
+    defer parser.deinit();
+    defer scanner.deinit();
+    const ast = &parser.ast;
+
+    var index = try ns_access.NamespaceAccessIndex.build(std.testing.allocator, ast);
+    defer index.deinit(std.testing.allocator);
+
+    var access = try ns_access.analyzeNamespaceAccessTextOnly(std.testing.allocator, ast, &index, "NS", null);
+    defer access.deinit(std.testing.allocator);
+
+    // namespace 객체 자체가 factory 로 전달되므로 멤버 집합으로 좁힐 수 없다.
+    try std.testing.expectEqual(ns_access.NamespaceAccess.Kind.@"opaque", access.kind);
+    try std.testing.expectEqual(@as(u32, 0), access.members.count());
+}
+
+test "NamespaceAccessIndex: intrinsic tag (`<div>`) does not escape a same-named namespace (#4596)" {
+    // 소문자 태그는 jsx_lowering 이 string literal 로 낮추므로 값 참조가 아니다.
+    // 이름이 같다는 이유로 escape 로 세면 불필요하게 opaque 가 된다.
+    var scanner: Scanner = undefined;
+    var parser: Parser = undefined;
+    try parseJsx(&parser, &scanner,
+        \\import * as div from "./ns";
+        \\export const A = () => <div>{div.value}</div>;
+    );
+    defer parser.deinit();
+    defer scanner.deinit();
+    const ast = &parser.ast;
+
+    var index = try ns_access.NamespaceAccessIndex.build(std.testing.allocator, ast);
+    defer index.deinit(std.testing.allocator);
+
+    var access = try ns_access.analyzeNamespaceAccessTextOnly(std.testing.allocator, ast, &index, "div", null);
+    defer access.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(ns_access.NamespaceAccess.Kind.member_only, access.kind);
+    try std.testing.expect(access.members.contains("value"));
+}
+
+/// `text` 인 jsx_identifier 노드 전부에 `sym` 을 심은 symbol_ids 배열.
+fn symbolIdsForJsxIdent(ast: *const Ast, text: []const u8, sym: u32) ![]?u32 {
+    const sids = try std.testing.allocator.alloc(?u32, ast.nodes.items.len);
+    @memset(sids, null);
+    for (ast.nodes.items, 0..) |node, i| {
+        if (node.tag != .jsx_identifier) continue;
+        if (std.mem.eql(u8, ast.getText(node.span), text)) sids[i] = sym;
+    }
+    return sids;
+}
+
+test "isNamespaceUsedAsValue: JSX member object is not a value use (#4596)" {
+    // 형제 술어 정합 — 색인은 member_only 로 보는데 이 술어만 "값으로 escape" 라고 답하면
+    // 같은 파일의 두 분석기가 동일 입력에 대해 불일치한다 (모듈 doc 불변식 위반).
+    var scanner: Scanner = undefined;
+    var parser: Parser = undefined;
+    try parseJsx(&parser, &scanner,
+        \\import * as NS from "./ns";
+        \\export const App = () => <NS.Root>hi</NS.Root>;
+    );
+    defer parser.deinit();
+    defer scanner.deinit();
+    const ast = &parser.ast;
+
+    const sids = try symbolIdsForJsxIdent(ast, "NS", 42);
+    defer std.testing.allocator.free(sids);
+    // NS 심볼이 실제로 심어졌는지 (안 심겼으면 단언이 공허).
+    var planted: usize = 0;
+    for (sids) |s| {
+        if (s != null) planted += 1;
+    }
+    try std.testing.expect(planted >= 1);
+
+    try std.testing.expect(!ns_access.isNamespaceUsedAsValue(std.testing.allocator, ast, sids, 42));
+}
+
+test "isNamespaceUsedAsValue: bare JSX namespace tag is a value use (#4596)" {
+    var scanner: Scanner = undefined;
+    var parser: Parser = undefined;
+    try parseJsx(&parser, &scanner,
+        \\import * as NS from "./ns";
+        \\export const B = () => <NS>x</NS>;
+    );
+    defer parser.deinit();
+    defer scanner.deinit();
+    const ast = &parser.ast;
+
+    const sids = try symbolIdsForJsxIdent(ast, "NS", 42);
+    defer std.testing.allocator.free(sids);
+
+    try std.testing.expect(ns_access.isNamespaceUsedAsValue(std.testing.allocator, ast, sids, 42));
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -139,6 +139,7 @@ test {
     _ = @import("tree_shaker_test.zig");
     _ = @import("linker_test.zig");
     _ = @import("linker/preamble_writer_test.zig"); // #4510 CJS interop 회귀 가드
+    _ = @import("linker/namespace_access_test.zig"); // #4596 JSX 태그 namespace 접근 색인 가드
     _ = @import("emitter_test.zig");
     _ = @import("chunk_test.zig");
     _ = @import("mf_integrity.zig"); // #3422 inline test (computeSri)

--- a/src/transformer/jsx_runtime_imports.zig
+++ b/src/transformer/jsx_runtime_imports.zig
@@ -87,6 +87,17 @@ fn emitImportDeclaration(
     span: Span,
     out: *std.ArrayList(NodeIndex),
 ) !void {
+    // (#4596) 합성 노드 span 은 *위치 anchor* 로만 쓰고 길이 0 으로 접는다.
+    // 호출자(`driver.zig`)는 prepend 대상인 program root 의 span 을 넘긴다 = 파일 전체 범위.
+    // 그걸 그대로 노드 span 으로 쓰면, span 포함 관계로 "이 참조가 선언 안에 있나" 를 판정하는
+    // 소비자에게 이 import_declaration 이 *파일 전체를 덮는 선언 범위* 로 보인다
+    // (`NamespaceAccessIndex.decl_ranges` → `isInDecl`). 그러면 그 모듈의 모든 namespace
+    // 참조가 "import 선언 내부라 참조 아님" 으로 skip 돼 멤버 사용이 0건으로 집계되고,
+    // tree-shaker 가 실제로 살아있는 export 를 제거한다 → 출력엔 `_jsx(Root)` 참조만 남고
+    // 선언이 없는 dangling ReferenceError (#4596: `import * as NS` + `<NS.Root>`).
+    // 합성 import 는 대응하는 원본 소스 텍스트가 없으므로 zero-length 가 정확한 표현이다.
+    const anchor: Span = .{ .start = span.start, .end = span.start };
+
     // source string_literal — codegen 이 raw span text 그대로 출력하므로 quote 포함 저장.
     const quoted = try std.fmt.allocPrint(self.allocator, "\"{s}\"", .{source_specifier});
     defer self.allocator.free(quoted);
@@ -118,7 +129,7 @@ fn emitImportDeclaration(
 
         const spec = try self.ast.addNode(.{
             .tag = .import_specifier,
-            .span = span,
+            .span = anchor,
             .data = .{ .binary = .{ .left = imported_node, .right = local_node, .flags = 0 } },
         });
         try self.scratch.append(self.allocator, spec);
@@ -135,7 +146,7 @@ fn emitImportDeclaration(
     });
     const decl = try self.ast.addNode(.{
         .tag = .import_declaration,
-        .span = span,
+        .span = anchor,
         .data = .{ .extra = extra_start },
     });
     try out.append(self.allocator, decl);

--- a/src/transformer/runtime_helper_imports.zig
+++ b/src/transformer/runtime_helper_imports.zig
@@ -145,6 +145,13 @@ fn emitOne(
     span: Span,
     out: *std.ArrayList(NodeIndex),
 ) !void {
+    // (#4596) 합성 노드 span 은 *위치 anchor* 로만 쓰고 길이 0 으로 접는다 — 자세한 근거는
+    // `jsx_runtime_imports.zig::emitImportDeclaration` 의 동일 주석. 요약: 호출자가 넘기는
+    // program root span (파일 전체) 을 노드 span 으로 쓰면 span 포함 관계 소비자
+    // (`NamespaceAccessIndex.decl_ranges` → `isInDecl`) 에게 이 import 가 파일 전체를 덮는
+    // 선언 범위로 보여, 그 모듈의 모든 참조가 "선언 내부" 로 skip 된다.
+    const anchor: Span = .{ .start = span.start, .end = span.start };
+
     // bases[0] 이 module 안의 한 helper. moduleShortFor 가 module short 를 반환.
     const id = (try helper_modules.idForBase(self.allocator, bases[0])) orelse return;
     defer self.allocator.free(id);
@@ -191,7 +198,7 @@ fn emitOne(
 
         const spec = try self.ast.addNode(.{
             .tag = .import_specifier,
-            .span = span,
+            .span = anchor,
             .data = .{ .binary = .{ .left = imported_node, .right = local_node, .flags = 0 } },
         });
         try self.scratch.append(self.allocator, spec);
@@ -208,7 +215,7 @@ fn emitOne(
     });
     const decl = try self.ast.addNode(.{
         .tag = .import_declaration,
-        .span = span,
+        .span = anchor,
         .data = .{ .extra = extra_start },
     });
     try out.append(self.allocator, decl);

--- a/src/transformer/transformer/driver.zig
+++ b/src/transformer/transformer/driver.zig
@@ -4,6 +4,34 @@ const es2015_params = @import("../es2015_params.zig");
 
 const NodeIndex = ast_mod.NodeIndex;
 const Error = std.mem.Allocator.Error;
+const Span = @import("../../lexer/token.zig").Span;
+
+/// (#4596) **program 앞에 prepend 되는 합성 top-level 문장의 span 불변식**:
+/// 대응하는 원본 소스 텍스트가 없으므로 span 은 *위치 anchor* 로만 쓰고 길이는 0 이어야 한다.
+///
+/// 여기서 prepend 하는 문장들의 span 후보로 손에 잡히는 것은 program root span(= 파일 전체)
+/// 또는 변환을 유발한 원본 식(파일 중간) 인데, 둘 다 실제 소스 범위가 아니다. 그대로 달면:
+///   - 파일 전체 범위: span 포함 관계로 "이 참조가 선언 안에 있나" 를 보는 소비자
+///     (`NamespaceAccessIndex.decl_ranges` → `isInDecl`) 에게 모듈 전체를 덮는 선언 범위로
+///     보여 그 모듈의 모든 참조가 skip 된다 → namespace 멤버 사용 0건 → tree-shaker 가
+///     살아있는 export 제거 → dangling ReferenceError (#4596 의 루트커즈)
+///   - 파일 중간 범위: prepend 로 문장 순서상 맨 앞에 오는데 span.start 는 뒤쪽이라
+///     "top-level stmt span 은 소스 순서·비중첩" 을 가정하는 `stmt_info.findStmtForPos` /
+///     `findContainingStmt` 의 이분 탐색 전제가 깨진다
+///
+/// zero-length anchor 는 두 소비자 모두에게 안전하다 — 아무 위치도 "포함" 하지 않고,
+/// 정렬 기준으로도 program 시작이라 prepend 순서와 일치한다.
+///
+/// 강제 지점은 둘: (1) 여기 — 직접 prepend 하는 문장, (2) 주입 import 를 만드는
+/// `jsx_runtime_imports.zig` / `runtime_helper_imports.zig` (자기가 만드는 하위 노드까지 접음).
+fn anchorSyntheticTopLevel(self: anytype, stmts: []const NodeIndex, anchor_start: u32) void {
+    for (stmts) |stmt| {
+        if (stmt == .none) continue;
+        const i: usize = @intFromEnum(stmt);
+        if (i >= self.ast.nodes.items.len) continue;
+        self.ast.nodes.items[i].span = .{ .start = anchor_start, .end = anchor_start };
+    }
+}
 
 pub fn transform(self: anytype) Error!NodeIndex {
     const profile = @import("../../profile.zig");
@@ -55,13 +83,24 @@ pub fn transform(self: anytype) Error!NodeIndex {
     var finalize_scope = profile.begin(.transform_finalize);
     defer finalize_scope.end();
 
+    // 합성 top-level prepend 의 span anchor — `anchorSyntheticTopLevel` 의 doc 참고 (#4596).
+    const synthetic_anchor: Span = blk: {
+        const s = self.ast.getNode(root_idx).span.start;
+        break :blk .{ .start = s, .end = s };
+    };
+
     // top-level 임시 변수 호이스팅: var _a, _b, ... 선언을 program 앞에 삽입
     if (self.temp_var_counter > saved_temp_counter and !root.isNone()) {
-        root = try self.hoistTempVars(root, saved_temp_counter, self.ast.getNode(root_idx).span);
+        // program root span (파일 전체) 대신 zero-length anchor — 생성되는 var_declaration /
+        // variable_declarator 가 모듈 전체를 덮는 범위를 갖지 않도록 (#4596).
+        root = try self.hoistTempVars(root, saved_temp_counter, synthetic_anchor);
     }
 
     // ES2015 tagged template: _templateObject 캐싱 함수를 program 맨 앞에 호이스팅
     if (self.tagged_template_fns.items.len > 0 and !root.isNone()) {
+        // 이 함수 노드의 span 은 변환을 유발한 템플릿 식(파일 중간) 이라, prepend 후 stmt span
+        // 정렬 전제를 깨뜨린다 → anchor 로 접는다 (#4596).
+        anchorSyntheticTopLevel(self, self.tagged_template_fns.items, synthetic_anchor.start);
         root = try self.prependStatementsToBody(root, self.tagged_template_fns.items);
     }
 

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -3405,6 +3405,48 @@ test "initFromOwnedAst: deinit 이 caller 의 ast 를 건드리지 않는다" {
 // arena allocator 사용: JSX lowering 의 임시 버퍼(quoteString/processJSXText)는 개별 free 하지
 // 않는 arena 전제 코드다 (production 은 transpile.zig / emitter.zig / transform_prepass.zig 모두
 // arena_alloc 전달). GPA 로 돌리면 그 임시 버퍼가 leak 으로 잡힌다.
+/// 합성(transformer 생성) import 판별 — 소스 specifier 리터럴의 span 이 string_table 참조면
+/// transformer 가 `ast.addString` 으로 만든 노드다. 원본 import 의 specifier 는 실제 소스 범위다.
+/// specifier **텍스트**로 나누면(`"jsx-runtime"` 포함 여부 등) runtime helper import 가 원본으로
+/// 오분류돼, 정작 같이 고친 injector 가 무검증으로 남고 반대 단언에 걸린다.
+fn isSyntheticImport(source_span_start: u32) bool {
+    return (source_span_start & Ast.STRING_TABLE_BIT) != 0;
+}
+
+/// 주입 import 의 span 불변식 검사 — `(합성 건수, 원본 건수)` 반환.
+fn checkInjectedImportSpans(ast: *Ast) !struct { synthetic: usize, original: usize } {
+    const module_mod = @import("../parser/module.zig");
+    var synthetic: usize = 0;
+    var original: usize = 0;
+    for (ast.nodes.items) |node| {
+        if (node.tag != .import_declaration) continue;
+        const extras = module_mod.readImportDeclExtras(ast, node.data.extra);
+        const source_node = ast.getNode(extras.source);
+        if (isSyntheticImport(source_node.span.start)) {
+            synthetic += 1;
+            // 합성 노드: zero-length anchor 여야 한다.
+            try std.testing.expectEqual(node.span.start, node.span.end);
+        } else {
+            original += 1;
+            // 원본 import 는 실제 소스 범위를 유지해야 한다 (전부 접어버리는 회귀 방지).
+            try std.testing.expect(node.span.end > node.span.start);
+        }
+    }
+    return .{ .synthetic = synthetic, .original = original };
+}
+
+// transformer 가 주입하는 import_declaration (JSX automatic runtime / runtime helper) 은
+// 대응하는 원본 소스 텍스트가 없다. 그런데 호출자(`driver.zig`)는 prepend 대상인 program root
+// 의 span = **파일 전체 범위** 를 넘긴다. 이를 노드 span 으로 그대로 쓰면, span 포함 관계로
+// "이 참조가 선언 안에 있나" 를 판정하는 소비자에게 이 import 가 *모듈 전체를 덮는 선언 범위*
+// 로 보인다 (`NamespaceAccessIndex.decl_ranges` → `isInDecl`). 그러면 그 모듈의 모든 namespace
+// 참조가 "선언 내부라 참조 아님" 으로 skip 되어 멤버 사용이 0건으로 집계되고, tree-shaker 가
+// 살아있는 export 를 제거한다 → 출력엔 `_jsx(Root)` 참조만 남는 dangling ReferenceError (#4596).
+// 그래서 합성 노드 span 은 zero-length anchor 여야 한다.
+//
+// arena allocator 사용: JSX lowering 의 임시 버퍼(quoteString/processJSXText)는 개별 free 하지
+// 않는 arena 전제 코드다 (production 은 transpile.zig / emitter.zig / transform_prepass.zig 모두
+// arena_alloc 전달). GPA 로 돌리면 그 임시 버퍼가 leak 으로 잡힌다.
 test "Transformer: injected jsx runtime import span must not span the module (#4596)" {
     const src =
         \\import * as NS from "./ns";
@@ -3427,26 +3469,93 @@ test "Transformer: injected jsx runtime import span must not span the module (#4
     });
     _ = try t.transform();
 
-    const module_mod = @import("../parser/module.zig");
-    var injected: usize = 0;
-    var original: usize = 0;
-    for (t.ast.nodes.items) |node| {
-        if (node.tag != .import_declaration) continue;
-        const extras = module_mod.readImportDeclExtras(t.ast, node.data.extra);
-        const source_node = t.ast.getNode(extras.source);
-        const spec_text = t.ast.getText(source_node.span);
-        if (std.mem.indexOf(u8, spec_text, "jsx-runtime") != null) {
-            injected += 1;
-            // 합성 노드: zero-length anchor.
-            try std.testing.expectEqual(node.span.start, node.span.end);
-        } else {
-            original += 1;
-            // 원본 import 는 실제 소스 범위를 유지해야 한다 (전부 접어버리는 회귀 방지).
-            try std.testing.expect(node.span.end > node.span.start);
-        }
-    }
+    const counts = try checkInjectedImportSpans(t.ast);
     // 주입/원본이 실제로 관측돼야 위 단언이 공허하지 않다. transformer 는 노드를 새로 만들고
     // 옛 노드를 배열에 남기므로(orphan) 개수는 1 이상으로만 단언한다.
-    try std.testing.expect(injected >= 1);
-    try std.testing.expect(original >= 1);
+    try std.testing.expect(counts.synthetic >= 1);
+    try std.testing.expect(counts.original >= 1);
+}
+
+// (#4596) 같은 불변식을 **runtime helper import** injector 로도 검증한다. 위 테스트만 있으면
+// `runtime_helper_imports.zig` 의 동일 수정은 커버되지 않는다(그 specifier 는 helper module id
+// 라서 JSX 픽스처에서는 한 건도 안 나온다) — 되돌려도 테스트가 green 하게 남는다.
+test "Transformer: injected runtime helper import span must not span the module (#4596)" {
+    // generator 다운레벨 → `__generator` helper import 주입.
+    const src =
+        \\export function* gen() { yield 1; }
+    ;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var scanner = try Scanner.init(alloc, src);
+    var parser = Parser.init(alloc, &scanner);
+    parser.is_module = true;
+    _ = try parser.parse();
+
+    var t = try Transformer.init(alloc, &parser.ast, .{
+        .unsupported = TransformOptions.compat.fromESTarget(.es5),
+        .emit_runtime_helper_imports = true,
+    });
+    _ = try t.transform();
+
+    const counts = try checkInjectedImportSpans(t.ast);
+    // helper import 가 실제로 주입됐는지 (안 됐으면 단언이 공허 — 위 테스트의 실패 원인이었다).
+    try std.testing.expect(counts.synthetic >= 1);
+}
+
+// (#4596) 합성 top-level prepend 의 span 불변식 — 주입 import 뿐 아니라 hoistTempVars 의
+// `var _a;` 와 tagged-template `_templateObject` 함수도 같은 규칙을 지켜야 한다.
+// (`driver.zig::anchorSyntheticTopLevel` 의 doc 참고: 파일 전체 범위는 `isInDecl` 을,
+// 파일 중간 범위는 `findStmtForPos` 의 정렬 전제를 깨뜨린다.)
+//
+// 문장 span 이 program 순서로 비내림차순인지 검사한다 — prepend 된 합성 문장이 원본 span 을
+// 들고 맨 앞에 오면 이 단언이 깨진다. 실측으로 사용자 가시 파손을 재현하진 못했지만
+// (출력은 적용 전후 바이트 동일), 불변식을 절반만 적용해 두면 다시 드리프트한다.
+test "Transformer: prepended synthetic top-level stmts keep stmt-span ordering (#4596)" {
+    const Case = struct { src: []const u8, opts: TransformOptions };
+    const cases = [_]Case{
+        // optional chaining 다운레벨 → hoistTempVars 가 `var _a;` prepend
+        .{
+            .src = "export const v = globalThis?.a?.b;\nexport const w = 1;\n",
+            .opts = .{ .unsupported = TransformOptions.compat.fromESTarget(.es2019) },
+        },
+        // tagged template 다운레벨 → `_templateObject` 함수 prepend
+        .{
+            .src = "const tag = (s) => s;\nexport const t = tag`aaa${1}bbb`;\n",
+            .opts = .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) },
+        },
+    };
+    for (cases) |c| {
+        var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+        defer arena.deinit();
+        const alloc = arena.allocator();
+
+        var scanner = try Scanner.init(alloc, c.src);
+        var parser = Parser.init(alloc, &scanner);
+        parser.is_module = true;
+        _ = try parser.parse();
+
+        var t = try Transformer.init(alloc, &parser.ast, c.opts);
+        const root = try t.transform();
+
+        const prog = t.ast.getNode(root);
+        try std.testing.expectEqual(Tag.program, prog.tag);
+        const list = prog.data.list;
+        try std.testing.expect(list.len >= 2); // 합성 문장 + 원본 문장이 실제로 있어야 의미 있음
+
+        var prev_start: u32 = 0;
+        var saw_synthetic_anchor = false;
+        for (0..list.len) |i| {
+            const stmt_idx: NodeIndex = @enumFromInt(t.ast.extra_data.items[list.start + i]);
+            const span = t.ast.getNode(stmt_idx).span;
+            // string_table 참조 span 은 소스 좌표가 아니므로 순서 비교 대상이 아니다.
+            if ((span.start & Ast.STRING_TABLE_BIT) != 0) continue;
+            if (span.end == span.start) saw_synthetic_anchor = true;
+            try std.testing.expect(span.start >= prev_start);
+            prev_start = span.start;
+        }
+        // prepend 된 합성 문장이 zero-length anchor 로 접혔는지 (안 접혔으면 위 단언이 공허).
+        try std.testing.expect(saw_synthetic_anchor);
+    }
 }

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -3388,3 +3388,65 @@ test "initFromOwnedAst: deinit 이 caller 의 ast 를 건드리지 않는다" {
     const root_node = src_ast.getNode(@enumFromInt(src_ast.nodes.items.len - 1));
     try std.testing.expectEqual(Tag.program, root_node.tag);
 }
+
+// ============================================================
+// (#4596) 합성(주입) import 노드의 span 불변식
+// ============================================================
+
+// transformer 가 주입하는 import_declaration (JSX automatic runtime / runtime helper) 은
+// 대응하는 원본 소스 텍스트가 없다. 그런데 호출자(`driver.zig`)는 prepend 대상인 program root
+// 의 span = **파일 전체 범위** 를 넘긴다. 이를 노드 span 으로 그대로 쓰면, span 포함 관계로
+// "이 참조가 선언 안에 있나" 를 판정하는 소비자에게 이 import 가 *모듈 전체를 덮는 선언 범위*
+// 로 보인다 (`NamespaceAccessIndex.decl_ranges` → `isInDecl`). 그러면 그 모듈의 모든 namespace
+// 참조가 "선언 내부라 참조 아님" 으로 skip 되어 멤버 사용이 0건으로 집계되고, tree-shaker 가
+// 살아있는 export 를 제거한다 → 출력엔 `_jsx(Root)` 참조만 남는 dangling ReferenceError (#4596).
+// 그래서 합성 노드 span 은 zero-length anchor 여야 한다.
+//
+// arena allocator 사용: JSX lowering 의 임시 버퍼(quoteString/processJSXText)는 개별 free 하지
+// 않는 arena 전제 코드다 (production 은 transpile.zig / emitter.zig / transform_prepass.zig 모두
+// arena_alloc 전달). GPA 로 돌리면 그 임시 버퍼가 leak 으로 잡힌다.
+test "Transformer: injected jsx runtime import span must not span the module (#4596)" {
+    const src =
+        \\import * as NS from "./ns";
+        \\export const App = () => <NS.Root>hi</NS.Root>;
+    ;
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var scanner = try Scanner.init(alloc, src);
+    var parser = Parser.init(alloc, &scanner);
+    parser.is_module = true;
+    parser.is_jsx = true;
+    _ = try parser.parse();
+
+    var t = try Transformer.init(alloc, &parser.ast, .{
+        .jsx_transform = true,
+        .jsx_runtime = .automatic,
+        .emit_runtime_helper_imports = true,
+    });
+    _ = try t.transform();
+
+    const module_mod = @import("../parser/module.zig");
+    var injected: usize = 0;
+    var original: usize = 0;
+    for (t.ast.nodes.items) |node| {
+        if (node.tag != .import_declaration) continue;
+        const extras = module_mod.readImportDeclExtras(t.ast, node.data.extra);
+        const source_node = t.ast.getNode(extras.source);
+        const spec_text = t.ast.getText(source_node.span);
+        if (std.mem.indexOf(u8, spec_text, "jsx-runtime") != null) {
+            injected += 1;
+            // 합성 노드: zero-length anchor.
+            try std.testing.expectEqual(node.span.start, node.span.end);
+        } else {
+            original += 1;
+            // 원본 import 는 실제 소스 범위를 유지해야 한다 (전부 접어버리는 회귀 방지).
+            try std.testing.expect(node.span.end > node.span.start);
+        }
+    }
+    // 주입/원본이 실제로 관측돼야 위 단언이 공허하지 않다. transformer 는 노드를 새로 만들고
+    // 옛 노드를 배열에 남기므로(orphan) 개수는 1 이상으로만 단언한다.
+    try std.testing.expect(injected >= 1);
+    try std.testing.expect(original >= 1);
+}


### PR DESCRIPTION
## 문제

`import * as NS from "pkg"` 후 `<NS.Root>` 처럼 JSX 엘리먼트 이름으로만 쓰면, 빌드는 `errors: 0`
으로 성공하는데 출력이 **선언되지 않은 식별자**를 참조해 런타임 `ReferenceError` 가 났습니다
(named import 는 정상). `minifyIdentifiers` 유무와 무관합니다.

```js
_jsx(Root4, { children: _jsx(Button, { ... }) })   // Root4 선언이 번들 어디에도 없음
```

## 루트커즈 — 합성 import 노드의 span 이 파일 전체

transformer 가 주입하는 `import_declaration` (JSX automatic runtime / runtime helper) 은 호출자
(`driver.zig`) 가 prepend 대상인 **program root 의 span = 파일 전체 범위** 를 넘겨 그대로 노드
span 이 됐습니다. span 포함 관계로 "이 참조가 선언 안에 있나" 를 판정하는 소비자
(`NamespaceAccessIndex.decl_ranges` → `isInDecl`) 에게 이 import 는 *모듈 전체를 덮는 선언 범위*
로 보입니다. 그래서 그 모듈의 **모든** namespace 참조가 "선언 내부라 참조 아님" 으로 skip 되어
멤버 사용이 0건으로 집계되고, tree-shaker 가 살아있는 export 를 제거했습니다 → `_jsx(Root)`
참조만 남는 dangling.

`jsx_runtime = .classic` 이 멀쩡했던 이유도 이것입니다 — **주입 자체가 없습니다.**

판별 실험: 수정 없이 주입 span 만 zero-length 로 접었더니 `automatic`/`automatic_dev`/nested 가
전부 복구됐습니다.

합성 노드는 대응하는 원본 소스 텍스트가 없으므로 zero-length anchor 가 정확한 표현입니다.
같은 결함이 runtime helper import 주입에도 있어 함께 교정했고, 같은 finalize 블록의 다른 합성
prepend(`hoistTempVars` 의 `var _a;`, tagged-template `_templateObject` 함수) 도 `driver.zig` 의
`anchorSyntheticTopLevel` 한 지점에서 강제합니다 (#4595 교훈 — 단일 권위 지점).

## 두 번째 결함 — `NamespaceAccessIndex` 가 `jsx_member_expression` 미색인

`jsx_runtime = .preserve` 는 JSX 가 link 시점까지 원형으로 남아 lowered `static_member` 로 회수될
기회가 없습니다. 이 경로에선 JSX 색인이 tree-shake 판단의 유일한 근거입니다. 또 `<NS/>` 처럼
namespace 자체가 태그인 **값 위치**는 escape 로 색인해 멤버 집합으로 잘못 좁히지 않게 했습니다
(소문자 intrinsic 태그는 제외 — `jsx_lowering.lowerTagName` 판정 규칙과 동일).

`isNamespaceUsedAsValue` 는 **의도적으로 JSX arm 을 넣지 않습니다.** 이 술어의 질문은 "객체 생성을
생략해도 되나"(force_inline) 이고, `codegen/jsx.zig` 는 preserve JSX 의 멤버를 재작성하지 않으므로
객체가 필요합니다. 첫 커밋에서 "형제 정합" 이라며 arm 을 넣었다가 preserve 회귀를 만들었고
(`/code-review max` CONFIRMED), 되돌린 뒤 근거를 코드 주석·테스트 이름에 남겼습니다.

## 검증

| 항목 | 결과 |
|---|---|
| 이슈 재현 (radix-toolbar, `jsx: automatic` + `minifyIdentifiers`) | `Root4` dangling 0건, 번들 10130줄 = **named import 대조군과 정확히 일치**, 실행 시 ReferenceError 없음 |
| preserve 경로 | `var ns_ns = {get Root(){…}, get helper(){…}}` + `<ns_ns.Root>` (태그 root 선언됨), 미사용 export 제거 |
| runtime helper 주입 경로 (es5, `__async`/`__generator`/`__rest`/`__toConsumableArray`) | baseline 과 **바이트 동일** + 실행 정상 |
| `hoistTempVars` / tagged-template | 적용 전후 **바이트 동일** |
| 유닛 테스트 | **6264개 전부 통과**, 누수 0 |

### A/B 로 각 테스트가 진짜 가드임을 증명

첫 회귀 테스트는 `jsx_runtime` 기본값이 `.classic` 이라 **수정 없이도 통과**했습니다(가드 0).
이슈와 동일한 `.automatic` 으로 고정했고, 모든 새 테스트에 대해 대응 수정을 되돌려 실패를 확인했습니다.

| 되돌린 것 | 실패 |
|---|---|
| JSX 색인 | 색인 유닛 4건 + preserve 번들 1건 |
| 루트커즈(주입 span, JSX) | jsx span 불변식 1건 |
| 루트커즈(주입 span, helper) | helper span 불변식 1건 |
| 합성 prepend anchor | stmt span 정렬 1건 |
| 둘 다 | 8건 (automatic 증상 가드 포함) |
| preserve 회귀 재도입 | 유닛 + preserve 번들 2건 |

`.preserve` 테스트는 마커 grep 만으로는 consumer dangling 을 못 잡으므로 `_jsx(...)` callee 와 JSX
태그 root 의 **선언 존재**를 단언합니다.

## 별도 이슈로 분리

- #4599 — preserve 에서 실체화된 `<local>_ns` 가 소문자라 bare 태그가 intrinsic 으로 해석 (main 기존 결함)
- #4600 — linker 가 부분 멤버 집합으로 `binding_scanner` union 을 덮어씀 (정밀도/번들 크기 트레이드오프라 size 측정 필요)
- #4598 — (무관한 별건) top-level await + `--target<es2022` 번들이 무진단으로 실행 불가 코드 방출

Closes #4596
