### PR TITLE
fix(bundler): jsx preserve 에서 실체화된 namespace 변수가 intrinsic 태그로 해석되던 문제

### DIFF
--- a/src/bundler/bundler_test/jsx.zig
+++ b/src/bundler/bundler_test/jsx.zig
@@ -1124,3 +1124,63 @@ test "JSX: preserve runtime — namespace member drives tree-shaking precisely (
 // 따라서 이 브랜치의 가드는 text-only 경로를 직접 찌르는 유닛 테스트가 담당한다 —
 // `linker/namespace_access_test.zig` 의 "bare JSX namespace tag (`<NS/>`) is an escape → opaque".
 // (여기에 번들 테스트를 두면 브랜치를 지워도 green 인 공허한 가드가 된다.)
+
+// (#4599) `jsx: preserve` 에서 실체화된 namespace 변수가 **JSX 태그 자리**에 그대로 남는데,
+// 이름이 소문자로 시작하면 downstream 툴이 **intrinsic 태그**(문자열)로 바꾼다:
+// `<ns_ns>` → `jsx("ns_ns", …)`. 컴포넌트가 실행되지 않고 알 수 없는 DOM 엘리먼트가 마운트되며
+// 에러도 나지 않는다. esbuild 로 실측 확인 — 수정 전 `jsx("ns_ns", …)`, 수정 후 `jsx(Ns_ns, …)`.
+//
+// base 는 모듈 파일명에서 오므로(`ns.tsx` → `ns`) 소문자 모듈명이면 항상 걸린다.
+test "JSX: preserve — 실체화된 namespace 변수는 컴포넌트로 해석되는 이름이어야 (#4599)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app.tsx",
+        \\import * as NS from './ns';
+        \\export function Raw() { return <NS>x</NS>; }
+        \\export function Member() { return <NS.Root/>; }
+    );
+    try writeFile(tmp.dir, "ns.tsx",
+        \\export const Root = () => null;
+        \\export const Other = () => null;
+    );
+
+    const entry = try absPath(&tmp, "app.tsx");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .jsx_runtime = .preserve });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 전제 검증 — JSX 가 원형으로 남았고 namespace 가 실체화됐는지 먼저 확인한다.
+    // 이게 없으면 (실체화가 아예 안 되는 회귀에서도) 아래 단언이 공허하게 통과한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_ns = {get Root()") != null);
+
+    // 소문자로 시작하는 태그가 남아 있으면 안 된다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "<ns_ns>") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Ns_ns") != null);
+}
+
+// 대조군 — preserve 가 아니면 이름을 건드리지 않는다. 변수는 식별자 표현식으로만 쓰여
+// 대소문자가 무의미한데, 전역으로 바꾸면 기존 출력의 변수명이 통째로 흔들린다.
+// 이 테스트가 없으면 "항상 대문자화" 로 바꿔도 위 테스트가 통과해 범위 가드가 사라진다.
+test "JSX: classic 런타임에서는 namespace 변수명을 바꾸지 않는다 (#4599 범위 가드)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app.tsx",
+        \\import * as NS from './ns';
+        \\export const v = NS;
+    );
+    try writeFile(tmp.dir, "ns.tsx", "export const Root = () => null;\n");
+
+    const entry = try absPath(&tmp, "app.tsx");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .jsx_runtime = .classic });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ns_ns") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Ns_ns") == null);
+}

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -844,6 +844,24 @@ fn rankFold(self: *const Linker, target_mod_idx: u32) u64 {
     return @as(u64, rank) *% 0x9e3779b1;
 }
 
+/// (#4599) `jsx: preserve` 에서 namespace 변수가 **JSX 태그 자리**에 그대로 남을 때,
+/// 소문자로 시작하면 downstream 툴(babel/tsc/vite)이 **intrinsic 태그**(문자열)로 바꿔 버린다:
+/// `<ns_ns>` → `_jsx("ns_ns", …)`. 컴포넌트가 실행되지 않고 알 수 없는 DOM 엘리먼트가 마운트되며
+/// 에러도 나지 않는다. 판별 규칙은 `/^[a-z]/` 이므로 **첫 글자만 대문자면** 충분하다.
+///
+/// preserve 가 아닐 때는 이름이 항상 식별자 표현식으로만 쓰여 대소문자가 무의미하므로 건드리지
+/// 않는다 — 전역으로 바꾸면 기존 출력의 변수명이 통째로 흔들린다.
+///
+/// 멤버 태그(`<ns_ns.Root/>`)는 대소문자와 무관하게 컴포넌트로 해석되므로 원래 문제가 없다.
+fn jsxSafeNsBase(self: *const Linker, base: []const u8) std.mem.Allocator.Error![]const u8 {
+    if (self.graph.jsx_runtime != .preserve) return base;
+    if (base.len == 0 or !std.ascii.isLower(base[0])) return base;
+    const owned = try self.allocator.alloc(u8, base.len);
+    @memcpy(owned, base);
+    owned[0] = std.ascii.toUpper(owned[0]);
+    return owned;
+}
+
 /// rank 0 → `{base}_ns`, rank N>0 → `{base}_ns_{N+1}` (예: `core_ns`, `core_ns_2`).
 /// rank 가 target 의 module_index 로 결정되므로 병렬 materialize 순서와 무관 (#3966).
 /// 잔여 충돌(target 자체 export 와 동명 등 희소 케이스)은 결정적으로 증가.
@@ -853,16 +871,20 @@ fn makeUniqueSharedNsVarNameLocked(
     rank: u32,
     seen_exports: *std.StringHashMapUnmanaged(void),
 ) std.mem.Allocator.Error![]const u8 {
+    // JSX preserve 에서 태그 자리에 남을 수 있으므로 컴포넌트로 해석되는 형태로 정규화.
+    const jsx_base = try jsxSafeNsBase(self, base);
+    defer if (jsx_base.ptr != base.ptr) self.allocator.free(jsx_base);
+
     var candidate = if (rank == 0)
-        try std.fmt.allocPrint(self.allocator, "{s}_ns", .{base})
+        try std.fmt.allocPrint(self.allocator, "{s}_ns", .{jsx_base})
     else
-        try std.fmt.allocPrint(self.allocator, "{s}_ns_{d}", .{ base, rank + 1 });
+        try std.fmt.allocPrint(self.allocator, "{s}_ns_{d}", .{ jsx_base, rank + 1 });
     if (!seen_exports.contains(candidate) and !self.ns_shared_var_names.contains(candidate)) return candidate;
 
     var i: usize = if (rank == 0) 2 else rank + 2;
     while (true) : (i += 1) {
         self.allocator.free(candidate);
-        candidate = try std.fmt.allocPrint(self.allocator, "{s}_ns_{d}", .{ base, i });
+        candidate = try std.fmt.allocPrint(self.allocator, "{s}_ns_{d}", .{ jsx_base, i });
         if (!seen_exports.contains(candidate) and !self.ns_shared_var_names.contains(candidate)) return candidate;
     }
 }
@@ -870,8 +892,12 @@ fn makeUniqueSharedNsVarNameLocked(
 /// namespace preamble 변수명을 export 이름과 충돌하지 않도록 생성.
 /// "z" → "z_ns", 충돌 시 "z_ns2", "z_ns3", ...
 fn makeUniqueNsVarName(self: *const Linker, base: []const u8, exports: *const std.StringHashMapUnmanaged(void)) std.mem.Allocator.Error![]const u8 {
+    // JSX preserve 에서 태그 자리에 남을 수 있으므로 컴포넌트로 해석되는 형태로 정규화.
+    const jsx_base = try jsxSafeNsBase(self, base);
+    defer if (jsx_base.ptr != base.ptr) self.allocator.free(jsx_base);
+
     // 첫 시도: base_ns
-    const first = try std.mem.concat(self.allocator, u8, &.{ base, "_ns" });
+    const first = try std.mem.concat(self.allocator, u8, &.{ jsx_base, "_ns" });
     if (!exports.contains(first)) return first;
     self.allocator.free(first);
 
@@ -881,7 +907,7 @@ fn makeUniqueNsVarName(self: *const Linker, base: []const u8, exports: *const st
     while (true) : (suffix += 1) {
         var buf: [16]u8 = undefined;
         const num_str = std.fmt.bufPrint(&buf, "{d}", .{suffix}) catch unreachable;
-        const candidate = try std.mem.concat(self.allocator, u8, &.{ base, "_ns", num_str });
+        const candidate = try std.mem.concat(self.allocator, u8, &.{ jsx_base, "_ns", num_str });
         if (!exports.contains(candidate)) return candidate;
         self.allocator.free(candidate);
     }


### PR DESCRIPTION
## 요약

`jsx: preserve` 로 namespace 를 JSX **값** 위치에 쓰면(`<NS>` — 객체째 factory 로 전달) 실체화된
변수명이 `<local>_ns` 라 **소문자로 시작**합니다. downstream 툴(babel/tsc/vite/esbuild)의 판별
규칙은 `/^[a-z]/` 이므로 이걸 **intrinsic 엘리먼트**(문자열 태그)로 바꿔 버립니다 — 컴포넌트가
실행되지 않고 알 수 없는 DOM 엘리먼트가 마운트되며 **에러도 나지 않습니다**.

## 실측 — downstream 변환에 직접 통과시켜 확인

```jsx
// zntc --jsx=preserve 출력
var ns_ns = {get Root() { return Root; }, get Other() { return Other; }};
return <ns_ns>x</ns_ns>;
```

이걸 esbuild 의 JSX 변환에 넣으면:

```js
before:  jsx("ns_ns", { children: "x" })   // ← 문자열 태그. 컴포넌트 미실행
after :  jsx(Ns_ns,   { children: "x" })   // ← 컴포넌트
```

base 는 **모듈 파일명**에서 오므로(`ns.tsx` → `ns`) 소문자 모듈명이면 항상 걸립니다.
멤버 태그(`<ns_ns.Root/>`)는 대소문자와 무관하게 컴포넌트로 해석되므로 원래 문제가 없었습니다.

## 수정

이름 생성 두 지점(shared / 비-shared)이 공통으로 쓰는 `jsxSafeNsBase` 를 두고, `preserve` 일 때만
첫 글자를 대문자로 만듭니다. 판별 규칙이 `/^[a-z]/` 라 **첫 글자만** 바꾸면 충분합니다.
충돌 회피 루프(`_ns2`, `_ns_3` …)는 정규화된 base 위에서 그대로 돕니다.

## 왜 `preserve` 로 범위를 좁혔나 — A/B 로 확인했습니다

preserve 가 아니면 이 이름은 항상 식별자 표현식으로만 쓰여 대소문자가 무의미합니다.
전역으로 대문자화해 봤더니 **기존 테스트 7건이 깨졌습니다**(incremental cache 의 shared-ns rank,
default deconflict 등 변수명을 직접 단언하는 곳). 범위를 좁힌 것이 맞았고, 그 사실을 **대조군
테스트로 고정**했습니다 — 없으면 "항상 대문자화" 로 바꿔도 새 테스트가 통과해 범위 가드가
사라집니다.

## 검증

- 유닛 **6276** · 통합 **4448 pass / 0 fail**
- **A/B 비공허 증명**: 수정을 되돌리면 새 테스트 **1건만** 정확히 실패, 전역 대문자화하면 **7건** 실패
- 새 테스트는 전제("JSX 가 원형으로 남았고 namespace 가 실체화됐는가")를 먼저 단언합니다 —
  실체화가 아예 안 되는 회귀에서도 통과하는 공허한 가드가 되지 않도록

## 남은 것 (이슈 후반부 — 별도)

`semantic/analyzer.zig` 가 bare JSX 태그를 `std.ascii.isUpper(name[0])` 일 때만 resolve 해서,
`import * as _ns` 처럼 **소문자로 시작하는 namespace local** 은 escape 자체가 잡히지 않습니다
(`<_ns/>` 가 선언 없이 방출되고 소스의 export 가 전부 tree-shake 됨). tree-shaking 판정을 바꾸는
변경이라 이 PR 과 분리하고 #4599 에 남깁니다.

Refs #4599

🤖 Generated with [Claude Code](https://claude.com/claude-code)