### PR TITLE
fix(bundler): #4604 URL 상대 지정자가 형제 파일보다 tsconfig paths 를 먼저 타던 문제

### DIFF
--- a/.changeset/url-relative-specifier-resolution.md
+++ b/.changeset/url-relative-specifier-resolution.md
@@ -1,0 +1,43 @@
+---
+"@zntc/core": minor
+---
+
+CSS `url()` / `new URL()` 의 bare 지정자가 스타일시트 형제 파일보다 tsconfig `paths` 를 먼저 타던 문제 (#4604).
+
+## 증상
+
+catch-all `paths`(`"*": ["src/*"]` — 실사용 패턴)가 있으면 `url(logo.png)` 가 paths 에 가로채여
+스타일시트 형제 파일 대신 전혀 다른 디렉토리의 파일이 자산으로 방출됐다. 같은 URL 을 가리키는
+`url(./logo.png)` 는 형제로 가므로 **두 표기가 서로 다른 파일**이 된다 — 진단 0건, 자산 2개.
+`new URL('w.js', import.meta.url)` 도 같은 형태로 worker 청크가 2개 생기고 한쪽이 잘못된
+소스로 빌드됐다.
+
+## 계약 변경 (동작이 바뀝니다)
+
+`.css_url` / `.worker` 의 bare 지정자 해석 순서가
+**`--alias` > 형제 파일 > tsconfig `paths` > node_modules** 로 바뀐다.
+
+전엔 형제가 맨 뒤(패키지·paths 실패 시 폴백)였다. esbuild 를 같은 픽스처로 실측한 결과
+형제가 앞서고, 형제가 없을 때만 `paths`·패키지로 간다. `url(pkg/img.png)` 가 node_modules
+자산을 가리키는 동작과 `url(@/assets/logo.png)` 가 `paths` 로 해석되는 동작은 **그대로**다.
+
+형제는 **정확히 그 이름의 파일**일 때만 이긴다 — 확장자 붙이기나 `.js`→`.ts` 매핑, RN `@2x`
+variant, 디렉토리 인덱스로는 이기지 않는다. 즉 `url(x.png)` 옆에 진짜 `x.png` 가 있을 때만
+결과가 바뀐다.
+
+다음은 형제 우선에서 **제외**된다 (명시적 사용자 지시가 파일 존재 여부로 뒤집히면 안 된다):
+`--alias` 가 걸린 지정자, 패키지 `browser` 필드가 remap 한 지정자, `--fallback:K=false` 로
+끈 지정자, `block_list` 에 걸리는 후보.
+
+CSS `@import` 은 아직 이 순서가 아니다 (#4611).
+
+`--alias` 는 종전대로 형제보다 우선한다 — 사용자가 명시한 강제 재작성이 동명 파일의 존재
+여부로 뒤집히면 안 되기 때문이며, esbuild 도 같다. `--packages=external` 의 "bare = 패키지"
+자동 규칙도 종전 그대로다.
+
+## 구현 노트
+
+지정자 철자를 **재작성하지 않는다.** `ResolveCache` 가 kind 와 철자를 보고
+`Resolver.url_relative` 를 켜면 resolver 가 탐색 순서만 바꾼다. `"./" ++ spec` 을 만들어
+resolve 를 다시 돌리는 방식은 alias·`--fallback`·패키지 `browser` 필드·external 패턴·캐시
+키가 전부 다른 철자를 보게 돼 각각 어긋난다.

--- a/docs/BUNDLER.md
+++ b/docs/BUNDLER.md
@@ -162,31 +162,68 @@ url("./hero-a1b2c3d4.png")   ← span 구간만 치환, 나머지 바이트는 �
   유효할 수 있고(서버가 따로 서빙 / 배포 스크립트가 나중에 복사), 여기서 실패시키면 지금까지
   멀쩡히 빌드되던 프로젝트가 업그레이드하자마자 깨진다.
 
-### bare 지정자 해석 순서 — 패키지 우선 + 상대 폴백 (#4485)
+### bare 지정자 해석 순서 — alias > 형제 > paths > 패키지 (#4604)
 
 CSS 스펙상 `url()` 의 상대 참조는 **스타일시트 자신의 URL** 이 base 다 → `url(logo.png)` 와
-`url(./logo.png)` 는 같은 파일이어야 한다. 그런데 resolver 는 `./` 없는 지정자를 npm 패키지
-이름으로 보므로, bare 는 node_modules 를 뒤지다 실패해 원문 emit → 404 였다.
+`url(./logo.png)` 는 같은 파일이어야 한다. `new URL(spec, import.meta.url)` 도 같다.
+그런데 resolver 는 `./` 없는 지정자를 npm 패키지 이름으로 보므로, bare 는 node_modules 를
+뒤지다 실패해 원문 emit → 404 였다.
 
-`ResolveCache.resolveNormalized` 가 `.css_url`(과 `.worker`) kind 에 대해 이렇게 처리한다:
+`ResolveCache` 가 kind 와 철자를 보고(`urlRelativeFor`) `Resolver.url_relative` 를 켜면
+`Resolver.resolveInner` 가:
 
-1. **원문 그대로 먼저 해석**한다 → `url(imgpkg/pic.png)` 같은 **패키지 경로 자산**은 예전처럼
-   node_modules 로 해석된다 (기존 동작 보존).
-2. `error.ModuleNotFound` 일 때만 `"./" ++ specifier` 로 **한 번 더** 해석한다 → 형제 파일
-   `url(logo.png)` 가 잡힌다.
+1. `--alias` 를 **원문 철자**에 먼저 적용한다 (사용자가 명시한 강제 재작성).
+2. alias 가 안 걸렸으면 `source_dir + specifier` 가 **정확히 그 이름의 파일**인지 본다 (`trySiblingExact`).
+3. 없으면 tsconfig `paths` → node_modules 순으로 폴백한다.
 
-**이 순서가 계약이다.** 정규화를 먼저 하면 동명의 형제 디렉토리가 node_modules 패키지를 조용히
-가려 지금 잘 동작하는 CSS 가 다른 자산을 가리키게 된다(회귀). 반대급부로 동명의 패키지가 있으면
-형제 파일이 가려지는데, 그건 이미 그렇게 동작하던 것이라 회귀가 아니다.
+**형제가 `paths` 와 패키지보다 앞선다**는 것이 이 수정의 전부다. URL 의 base 가 파일 자신이므로
+형제가 곧 그 URL 의 대상이고, 나머지는 형제가 없을 때의 폴백이다. esbuild 실측과 같은 순서다.
 
-- 정규화 대상은 bare 뿐 — `./`·`../`·`/abs`·scheme(`https:`/`data:`/`blob:`)·protocol-relative 는
-  제외한다 (`isBareUrlRelativeSpecifier`). `?query`/`#fragment` 는 css_scanner 가 미리 suffix 로
+> ⚠️ **`paths` 를 배제하지는 않는다.** #4604 의 2차 시도는 URL 참조에서 `paths` 를 통째로
+> 껐는데, esbuild 는 `url(@/assets/logo.png)` 를 `paths` 로 정상 해석한다(실측). 배제하면
+> `"@/*": ["src/*"]` 같은 가장 흔한 prefix 매핑이 URL 참조에서만 깨져 자산 404 가 되고,
+> CLI 기본 IIFE 포맷에선 `new URL("@/w.ts", "")` 가 TypeError 로 번들 전체를 죽인다.
+
+> ⚠️ **지정자를 재작성하는 방식으로 구현하면 안 된다.** #4604 의 1차 시도는 `"./" ++ spec` 을
+> 만들어 resolve 를 한 번 더 돌렸는데, 그러면 alias·`--fallback`·패키지 `browser` 필드·external
+> 패턴·캐시 키가 전부 **다른 철자**를 보게 돼 각각 어긋났다. 철자는 그대로 두고 **탐색 순서만**
+> 바꾼다.
+
+> #4485 는 패키지가 형제보다 앞이었다. 형제가 패키지를 가리는 것을 회귀로 봤기 때문인데,
+> 그 전제가 참조 번들러와 어긋나 있었다. 부작용으로 catch-all `paths` 매핑이 bare url() 을
+> 가로채, 형제가 있는데도 `url(logo.png)` 와 `url(./logo.png)` 가 **서로 다른 파일**로 갈렸다.
+
+- 형제 우선 대상은 bare 뿐 — `./`·`../`·`/abs`·scheme(`https:`/`data:`/`blob:`)·protocol-relative
+  는 제외한다 (`isBareUrlRelativeSpecifier`). `?query`/`#fragment` 는 css_scanner 가 미리 suffix 로
   떼어내므로 bare + suffix(`url(f.eot?#iefix)`) 도 정상 재작성된다.
-- 정규화된 문자열은 **resolve 레이어 밖으로 나가지 않는다.** `record.specifier` 는 원문 그대로다 —
-  css_emitter 가 원문 span 구간을 치환하는 구조라 스캔 시점에 고치면 lookup 이 어긋난다.
-- **알려진 한계**: `--packages=external` 은 "bare = npm 패키지" 규칙을 css_url 에도 그대로
-  적용한다(worker 는 #4483 이 제외). 이 플래그를 켜면 bare url() 이 external 로 빠져 원문
-  방출된다 — `url(./logo.png)` 로 쓰면 정상 재작성된다.
+- `record.specifier` 는 **원문 그대로다** — css_emitter 가 원문 span 구간을 치환하고 bundler 의
+  worker_map 키도 소스 원문이라, 스캔 시점에 고치면 lookup 이 어긋나 다시 원문 emit(= 404)이 된다.
+- **정확히 그 이름의 파일일 때만** 이긴다. 일반 경로 해석 사다리(`tryResolvePathLike`)를 태우면
+  확장자 붙이기·`.js`→`.ts` 매핑·RN `@2x` variant·디렉토리 인덱스까지 걸려, 동명 형제가 없는데도
+  패키지·paths 대상이 조용히 가려진다. URL 은 실제 파일명을 그대로 쓰므로 확장자 추론이 애초에
+  URL 의미론에 없다.
+- `--alias` 대상이 없으면 **그대로 실패**한다. 원문 철자의 형제로 폴백해 봤지만 되돌렸다 —
+  alias 대상이 단지 그 subpath 만 없는 경우까지 터져서, 사용자가 의도한 패키지 대신 무관한 앱
+  로컬 파일이 조용히 번들됐다. 실패는 warning 으로 눈에 보이지만 잘못된 파일은 안 보인다.
+- 패키지 `browser` 필드가 remap 한 지정자는 형제 우선을 **끈다**. remap 된 철자는 사용자가 쓴 적
+  없는 이름이고, `--alias` 와 마찬가지로 명시적 재작성이라 동명 형제로 뒤집히면 안 된다.
+- `--fallback:K=false` 로 끈 지정자도 형제 우선을 끈다. 형제가 있으면 정상 해석이 되어
+  `applyFallback` 에 도달하지 못해, 라이선스·용량 때문에 일부러 뺀 자산이 그대로 방출된다.
+- `block_list` 에 걸리는 형제 후보는 없는 것으로 친다. 그냥 돌려주면 상위 `resolve()` 가 차단 후
+  `ModuleNotFound` 로 끝내 버려, 원래 이기던 paths·node_modules 대상에 도달하지 못한다.
+- `--fallback` 대상을 재해석할 때는 `url_relative` 를 **끈다**. 대상은 사용자가 옵션에 쓴 평범한
+  모듈 지정자지 URL 상대 참조가 아니다 — 켠 채로 재진입하면 대상이 동명 형제에 가려진다.
+- `--fallback:K=V`(재작성 형태)는 **형제가 없을 때만** 걸린다. `--fallback` 이 "정상 해석 실패
+  시" 계약이고 형제는 정상 해석이므로 일관된 동작이다. NODE_PATH 와 symlink-sibling 복구도 같다.
+- ⚠️ CSS `@import` 은 아직 이 순서가 아니다 — 레코드 kind 가 `.side_effect` 라 JS 의
+  `import 'normalize.css'` 와 구분되지 않아 kind 로 편입할 수 없다. #4611 에서 다룬다.
+- `--packages=external` 의 "bare = npm 패키지" 자동 규칙은 `.css_url` 에 **그대로 적용된다**
+  (#4485 알려진 한계, worker 는 #4483 이 제외). #4604 에서 빼 봤더니 의존성을 미해석 상태로
+  두려는 라이브러리 빌드가 의존성 자산 **사본**을 dist 에 싣게 돼 되돌렸다.
+- ⚠️ **알려진 한계 (선행 이슈)**: `ResolveCache` 는 무효화 API 가 없어, watch 세션 중에 새로
+  만든 파일이 기존 해석을 가려야 하는 경우 warm 재빌드가 이전 결과를 그대로 쓴다. 이 변경과
+  무관한 기존 축이다 — `url(logo.png)` 가 처음엔 없어서 경고났다가 나중에 파일을 만들어도
+  warm 은 계속 경고를 내고 cold 만 자산을 방출한다(main 에서도 동일 재현).
 
 ### 기본 asset 로더 + inline limit
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -364,11 +364,14 @@ Options:
     없으면 출력 CSS 위치 기준 상대경로
   - `?query` / `#fragment` suffix 보존 — `url(./f.eot?#iefix)` → `url("./f-a1b2c3d4.eot?#iefix")`
     (IE9 훅), `url(./i.svg#icon)` 도 fragment 유지
-  - **`./` 없는 bare 도 재작성** (#4485) — CSS 스펙상 `url()` 의 base 는 스타일시트 자신의 URL 이라
-    `url(logo.png)` 와 `url(./logo.png)` 는 같은 파일이다. 해석 순서는 **패키지 우선 + 상대 폴백** —
-    `url(imgpkg/pic.png)` 는 예전처럼 node_modules 패키지 자산으로 해석되고, 거기서 못 찾은
-    bare 만 스타일시트 형제 파일로 해석된다. 단 `--packages=external` 을 켜면 bare 는 여전히
-    패키지로 간주돼 external 로 빠진다(원문 방출) — 이때는 `url(./logo.png)` 로 쓴다.
+  - **`./` 없는 bare 도 재작성** (#4485, 순서는 #4604) — CSS 스펙상 `url()` 의 base 는 스타일시트
+    자신의 URL 이라 `url(logo.png)` 와 `url(./logo.png)` 는 같은 파일이다. 해석 순서는
+    **`--alias` > 형제 파일 > tsconfig `paths` > node_modules 패키지** (esbuild 동일) —
+    `url(logo.png)` 는 **정확히 그 이름의** 형제 파일이 있으면 그걸로 가고, 없으면 `paths` 매핑
+    (`url(@/assets/logo.png)`) 이나 패키지 자산(`url(imgpkg/pic.png)`)으로 해석된다
+    (확장자 추론으로는 형제가 이기지 않는다). CSS `@import` 는 아직 이 순서가 아니다 (#4611).
+    단 `--packages=external` 을 켜면 bare 는 여전히 패키지로 간주돼 external 로 빠진다
+    (원문 방출) — 이때는 `url(./logo.png)` 로 쓴다.
   - **재작성 제외**(원문 그대로 통과): `url(#gradient)` (SVG filter/gradient 참조 — 파일 아님),
     `url(/abs.png)` (절대경로 = `public/` 디렉토리 규약), `url(https://…)` / `url(//cdn…)` /
     `url(data:…)` / `url(blob:…)` (external)

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -3911,10 +3911,12 @@ test "#4485 CSS url(): ./ 없는 bare 도 자산으로 재작성된다" {
     try std.testing.expectEqual(@as(usize, 1), png_count);
 }
 
-test "#4485 CSS url(): 패키지로 해석되던 bare 는 그대로 패키지가 이긴다" {
-    // 순서가 핵심 — 기존 해석을 **먼저** 시도하고 ModuleNotFound 일 때만 `./` 폴백.
-    // `./` 를 먼저 붙였다면 아래 형제 디렉토리(`imgpkg/pic.png`)가 node_modules 패키지를
-    // 조용히 가려서, 지금 잘 동작하던 사용자의 CSS 가 다른 자산을 가리키게 된다.
+test "#4604 CSS url(): 형제 파일이 동명 패키지를 이긴다" {
+    // #4485 는 반대(패키지 우선)로 뒀었다. esbuild 와 rspack 을 같은 픽스처로 실측한 결과
+    // **둘 다 형제가 이긴다** — CSS 의 url() base 는 스타일시트 자신의 URL 이므로 형제가
+    // 곧 그 URL 의 대상이고, node_modules 해석은 생태계 편의로 얹은 폴백이다.
+    // 폴백이 살아 있다는 것은 바로 아래 "형제가 없으면 패키지로 폴백" 테스트가 지킨다 —
+    // 그게 없으면 패키지 해석을 통째로 꺼도 이 테스트가 통과해 가드가 공허해진다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts", "import './style.css';");
@@ -3923,11 +3925,10 @@ test "#4485 CSS url(): 패키지로 해석되던 bare 는 그대로 패키지가
         \\{"name":"imgpkg"}
     );
     const pkg_img = [_]u8{0xAA} ** 5000;
-    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/imgpkg/pic.png", .data = &pkg_img });
+    try writeFile(tmp.dir, "node_modules/imgpkg/pic.png", &pkg_img);
     // 동명의 형제 디렉토리 (내용이 달라야 어느 쪽이 이겼는지 구분된다).
     const sibling_img = [_]u8{0xBB} ** 5000;
-    try writeFile(tmp.dir, "imgpkg/.keep", "");
-    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "imgpkg/pic.png", .data = &sibling_img });
+    try writeFile(tmp.dir, "imgpkg/pic.png", &sibling_img);
 
     const entry = try absPath(&tmp, "entry.ts");
     defer std.testing.allocator.free(entry);
@@ -3939,13 +3940,233 @@ test "#4485 CSS url(): 패키지로 해석되던 bare 는 그대로 패키지가
 
     try std.testing.expect(!result.hasErrors());
     const outs = result.asset_outputs orelse return error.ExpectedAssetOutput;
-    var found_pkg = false;
+    var found = false;
     for (outs) |o| {
         if (!std.mem.endsWith(u8, o.path, ".png")) continue;
-        try std.testing.expectEqualSlices(u8, &pkg_img, o.contents); // 패키지 쪽 내용
-        found_pkg = true;
+        try std.testing.expectEqualSlices(u8, &sibling_img, o.contents); // 형제 쪽 내용
+        found = true;
     }
-    try std.testing.expect(found_pkg);
+    try std.testing.expect(found);
+}
+
+test "#4604 CSS url(): 형제가 없으면 여전히 패키지로 폴백한다" {
+    // 위 테스트의 비공허성 대조군. `url(pkg/x.png)` 가 node_modules 자산을 가리키는 것은
+    // esbuild·rspack 도 그대로 지원하는 동작이라, "형제 우선" 이 패키지 해석을 없애는
+    // 것으로 번지면 안 된다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import './style.css';");
+    try writeFile(tmp.dir, "style.css", ".c { background: url(imgpkg/pic.png); }");
+    try writeFile(tmp.dir, "node_modules/imgpkg/package.json",
+        \\{"name":"imgpkg"}
+    );
+    const pkg_img = [_]u8{0xAA} ** 5000;
+    try writeFile(tmp.dir, "node_modules/imgpkg/pic.png", &pkg_img);
+    // 형제 디렉토리는 **두지 않는다** — 이 픽스처의 위험 조건이 "형제 부재" 다.
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .format = .esm });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.asset_outputs orelse return error.ExpectedAssetOutput;
+    var found = false;
+    for (outs) |o| {
+        if (!std.mem.endsWith(u8, o.path, ".png")) continue;
+        try std.testing.expectEqualSlices(u8, &pkg_img, o.contents);
+        found = true;
+    }
+    try std.testing.expect(found);
+}
+
+/// #4604 재현 픽스처 — catch-all `"*": ["src/*"]` 와 두 철자의 같은 url().
+/// `sibling` 이 true 면 스타일시트 형제 자산을 함께 둔다.
+const CatchAllPathsCss = struct {
+    css: []u8,
+    diag_count: usize,
+    png_paths: [][]u8,
+    png_is_sibling: []bool,
+
+    fn deinit(self: CatchAllPathsCss) void {
+        std.testing.allocator.free(self.css);
+        for (self.png_paths) |p| std.testing.allocator.free(p);
+        std.testing.allocator.free(self.png_paths);
+        std.testing.allocator.free(self.png_is_sibling);
+    }
+};
+
+fn bundleCatchAllPathsCss(tmp: *std.testing.TmpDir, sibling: bool) !CatchAllPathsCss {
+    const root_img = [_]u8{0xC1} ** 5000;
+    const sibling_img = [_]u8{0xC2} ** 5000;
+    try writeFile(tmp.dir, "src/assets/logo.png", &root_img);
+    if (sibling) try writeFile(tmp.dir, "src/components/assets/logo.png", &sibling_img);
+    try writeFile(tmp.dir, "src/components/card.css", ".card { background: url(assets/logo.png); }");
+    try writeFile(tmp.dir, "src/components/panel.css", ".panel { background: url(./assets/logo.png); }");
+    try writeFile(tmp.dir, "src/main.ts",
+        \\import './components/card.css';
+        \\import './components/panel.css';
+    );
+
+    const root = try absPath(tmp, ".");
+    defer std.testing.allocator.free(root);
+    const src_prefix = try std.fmt.allocPrint(std.testing.allocator, "{s}/src/", .{root});
+    defer std.testing.allocator.free(src_prefix);
+    const targets = [_]@import("../../config.zig").TsConfig.PathEntry.Target{
+        .{ .prefix = src_prefix, .suffix = "" },
+    };
+    // catch-all `"*": ["src/*"]` — 실사용 패턴.
+    const paths = [_]@import("../../config.zig").TsConfig.PathEntry{
+        .{ .key_prefix = "", .key_suffix = "", .has_wildcard = true, .targets = &targets },
+    };
+
+    const entry = try absPath(tmp, "src/main.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .ts_paths = &paths,
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const css = findCssOutput(result) orelse return error.ExpectedCssOutput;
+    var paths_list: std.ArrayList([]u8) = .empty;
+    // 실패 경로에서 **복제한 문자열까지** 해제한다 — 버퍼만 비우면 이미 소유권을 넘긴
+    // slice 들이 샌다.
+    errdefer {
+        for (paths_list.items) |it| std.testing.allocator.free(it);
+        paths_list.deinit(std.testing.allocator);
+    }
+    var is_sib: std.ArrayList(bool) = .empty;
+    errdefer is_sib.deinit(std.testing.allocator);
+    if (result.asset_outputs) |outs| {
+        for (outs) |o| {
+            if (!std.mem.endsWith(u8, o.path, ".png")) continue;
+            try paths_list.append(std.testing.allocator, try std.testing.allocator.dupe(u8, o.path));
+            try is_sib.append(std.testing.allocator, std.mem.eql(u8, o.contents, &sibling_img));
+        }
+    }
+    return .{
+        .css = try std.testing.allocator.dupe(u8, css),
+        .diag_count = result.getDiagnostics().len,
+        .png_paths = try paths_list.toOwnedSlice(std.testing.allocator),
+        .png_is_sibling = try is_sib.toOwnedSlice(std.testing.allocator),
+    };
+}
+
+test "#4604 CSS url(): catch-all tsconfig paths 가 bare url() 을 가로채지 않는다 (형제 있음)" {
+    // 신고된 재현 그대로. `"paths": { "*": ["src/*"] }` 하에서 `url(assets/logo.png)` 가
+    // paths 에 걸려 `src/assets/logo.png` 로, `url(./assets/logo.png)` 는 형제로 가서
+    // **같은 URL 을 쓴 두 표기가 서로 다른 파일**이 됐다 (진단 0건, 자산 2개).
+    //
+    // tsconfig `paths` 는 TypeScript 의 **모듈 해석** 기능이다. CSS 의 url() 은 TS 가 보지도
+    // 않는 URL 참조라 애초에 적용 대상이 아니다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const r = try bundleCatchAllPathsCss(&tmp, true);
+    defer r.deinit();
+
+    // 자산은 정확히 1개, 내용은 형제 쪽.
+    try std.testing.expectEqual(@as(usize, 1), r.png_paths.len);
+    try std.testing.expect(r.png_is_sibling[0]);
+
+    // ⚠️ 자산 개수만 세면 **bare url() 해석이 통째로 깨져도** 통과한다 (해석 실패는 error 가
+    // 아니라 warning 이고, 그러면 `./` 쪽 자산 1개만 남는다). 그래서 최종 CSS 를 직접 본다:
+    // 두 규칙이 **같은 해시 자산**을 가리켜야 하고, 원문 철자는 남아 있으면 안 된다.
+    const hashed = r.png_paths[0];
+    var occurrences: usize = 0;
+    var idx: usize = 0;
+    while (std.mem.indexOfPos(u8, r.css, idx, hashed)) |at| {
+        occurrences += 1;
+        idx = at + hashed.len;
+    }
+    try std.testing.expectEqual(@as(usize, 2), occurrences);
+    try std.testing.expect(std.mem.indexOf(u8, r.css, "url(assets/logo.png)") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.css, "url(./assets/logo.png)") == null);
+    // 해석이 다 됐으므로 경고도 없어야 한다.
+    try std.testing.expectEqual(@as(usize, 0), r.diag_count);
+}
+
+test "#4604 CSS url(): 형제가 없으면 bare 는 tsconfig paths 로 폴백한다" {
+    // 위 테스트의 비공허성 대조군 **이자** 계약 자체. `paths` 를 URL 참조에서 통째로 배제하면
+    // `"@/*": ["src/*"]` 같은 가장 흔한 prefix alias 가 url() 에서만 깨진다 — esbuild 는
+    // `url(@/assets/logo.png)` 를 paths 로 정상 해석한다(실측). 필요한 건 배제가 아니라
+    // **형제가 paths 보다 앞서는 것**이다.
+    //
+    // 그래서 형제가 없으면 bare 는 paths 대상으로 가고, 명시적 상대인 `./` 쪽만 실패한다.
+    // esbuild 도 같은 픽스처에서 `./assets/logo.png` 만 에러를 낸다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const r = try bundleCatchAllPathsCss(&tmp, false);
+    defer r.deinit();
+
+    // bare 는 paths 로 해석돼 자산 1개 (형제가 아니라 루트 쪽 내용).
+    try std.testing.expectEqual(@as(usize, 1), r.png_paths.len);
+    try std.testing.expect(!r.png_is_sibling[0]);
+    // 명시적 상대 경로는 실패 → 경고 + 원문 유지 (Vite parity).
+    try std.testing.expect(std.mem.indexOf(u8, r.css, "url(./assets/logo.png)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.css, "url(assets/logo.png)") == null);
+}
+
+test "#4604 CSS url(): prefix paths 매핑(@/*)이 url() 에서 계속 동작한다" {
+    // #4604 1차 정공법 시도가 URL 참조에서 `paths` 를 통째로 배제했다가 이걸 깼다 —
+    // `@/*` 는 TS 프로젝트에서 가장 흔한 매핑이고, `url(@/assets/logo.png)` 는 형제로는
+    // 절대 해석될 수 없어 paths 가 유일한 경로다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const img = [_]u8{0xD5} ** 5000;
+    try writeFile(tmp.dir, "src/assets/logo.png", &img);
+    try writeFile(tmp.dir, "src/components/card.css", ".card { background: url(@/assets/logo.png); }");
+    try writeFile(tmp.dir, "src/main.ts", "import './components/card.css';");
+
+    const root = try absPath(&tmp, ".");
+    defer std.testing.allocator.free(root);
+    const src_prefix = try std.fmt.allocPrint(std.testing.allocator, "{s}/src/", .{root});
+    defer std.testing.allocator.free(src_prefix);
+    const targets = [_]@import("../../config.zig").TsConfig.PathEntry.Target{
+        .{ .prefix = src_prefix, .suffix = "" },
+    };
+    // `"@/*": ["src/*"]` — prefix 매핑.
+    const paths = [_]@import("../../config.zig").TsConfig.PathEntry{
+        .{ .key_prefix = "@/", .key_suffix = "", .has_wildcard = true, .targets = &targets },
+    };
+
+    const entry = try absPath(&tmp, "src/main.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .ts_paths = &paths,
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 해석 실패는 warning 이라 자산/CSS 를 직접 봐야 한다.
+    for (result.getDiagnostics()) |d| {
+        try std.testing.expect(std.mem.indexOf(u8, d.message, "Cannot resolve CSS url()") == null);
+    }
+    const outs = result.asset_outputs orelse return error.ExpectedAssetOutput;
+    var found = false;
+    for (outs) |o| {
+        if (!std.mem.endsWith(u8, o.path, ".png")) continue;
+        try std.testing.expectEqualSlices(u8, &img, o.contents);
+        found = true;
+    }
+    try std.testing.expect(found);
+    const css = findCssOutput(result) orelse return error.ExpectedCssOutput;
+    try std.testing.expect(std.mem.indexOf(u8, css, "url(@/assets/logo.png)") == null);
 }
 
 test "#4485 CSS url(): scheme / data / root-absolute 는 여전히 무변경" {
@@ -4475,9 +4696,8 @@ test "#4482 bundle: emit 시점 fold 로 살아남는 분기의 부호 토큰 �
 // npm 패키지 이름으로 보고 node_modules 를 뒤져 ModuleNotFound → 경고만 남기고 원문
 // 방출 → 런타임 404. (#4483 의 worker 와 같은 루트커즈.)
 //
-// 처방도 같다 — **기존 해석을 먼저 시도하고 실패했을 때만** `./` 를 붙인다.
-// 순서가 핵심: `url(pkg/img.png)` 처럼 지금 node_modules 로 해석되는 bare url() 이
-// 그대로 살아남는다 (Vite 도 "패키지 우선 + 상대 폴백").
+// 처방도 같다 — resolver 가 kind 를 보고 **형제 파일을 먼저** 찾는다 (#4604).
+// 형제가 없으면 node_modules 로 폴백하므로 `url(pkg/img.png)` 도 그대로 살아남는다.
 
 test "#4485 CSS url(): `./` 없는 bare 상대 지정자도 자산으로 재작성된다" {
     var tmp = std.testing.tmpDir(.{});

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -5087,8 +5087,9 @@ test "#4483 Worker: alias 로 매핑되는 worker 지정자가 형제 파일에 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    // `./` 를 **먼저** 시도하면 alias/tsconfig paths 로 매핑되던 worker 가 같은 이름의
-    // 형제 파일에 조용히 가려진다. 기존 해석을 먼저 시도하고 실패했을 때만 `./` 를 붙인다.
+    // #4604 에서 형제 우선으로 바꾼 뒤에도 **alias 는 형제보다 앞**이다. `--alias` 는 사용자가
+    // 명시한 강제 재작성이라 동명 형제 파일의 존재 여부로 뒤집히면 안 된다 (esbuild 동일).
+    // resolver 가 alias 를 형제 탐색보다 먼저 적용하므로 성립한다.
     try writeFile(tmp.dir, "entry.ts",
         \\const w = new Worker(new URL("shared/task.ts", import.meta.url));
         \\w.postMessage(1);
@@ -5116,6 +5117,135 @@ test "#4483 Worker: alias 로 매핑되는 worker 지정자가 형제 파일에 
         try std.testing.expect(std.mem.indexOf(u8, a.contents, "SIBLING") == null);
     }
     try std.testing.expect(found_aliased);
+}
+
+test "#4604 Worker: catch-all tsconfig paths 가 bare worker 지정자를 가로채지 않는다" {
+    // CSS url() 과 같은 루트커즈의 worker 쪽 표면. `"paths": { "*": ["src/*"] }` 하에서
+    // `new URL('w.ts', …)` 는 paths 에 걸려 `src/w.ts` 로, `new URL('./w.ts', …)` 는 형제로
+    // 가서 **worker 청크가 2개** 만들어졌다 (한쪽은 잘못된 소스). 같은 URL 이므로 1개여야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "src/w.ts", "self.postMessage('ROOT_WORKER');");
+    try writeFile(tmp.dir, "src/feature/w.ts", "self.postMessage('SIBLING_WORKER');");
+    try writeFile(tmp.dir, "src/feature/entry.ts",
+        \\const a = new Worker(new URL("w.ts", import.meta.url));
+        \\const b = new Worker(new URL("./w.ts", import.meta.url));
+        \\a.postMessage(1); b.postMessage(2);
+    );
+
+    const root = try absPath(&tmp, ".");
+    defer std.testing.allocator.free(root);
+    const src_prefix = try std.fmt.allocPrint(std.testing.allocator, "{s}/src/", .{root});
+    defer std.testing.allocator.free(src_prefix);
+    const targets = [_]@import("../../config.zig").TsConfig.PathEntry.Target{
+        .{ .prefix = src_prefix, .suffix = "" },
+    };
+    const paths = [_]@import("../../config.zig").TsConfig.PathEntry{
+        .{ .key_prefix = "", .key_suffix = "", .has_wildcard = true, .targets = &targets },
+    };
+
+    const entry = try absPath(&tmp, "src/feature/entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .ts_paths = &paths });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const assets = result.asset_outputs orelse return error.TestUnexpectedResult;
+    var worker_chunks: usize = 0;
+    var chunk_name: []const u8 = "";
+    for (assets) |a| {
+        if (std.mem.indexOf(u8, a.contents, "_WORKER") == null) continue;
+        worker_chunks += 1;
+        chunk_name = a.path;
+        // paths 가 가로챈 루트 파일은 어느 청크에도 들어가면 안 된다.
+        try std.testing.expect(std.mem.indexOf(u8, a.contents, "ROOT_WORKER") == null);
+    }
+    try std.testing.expectEqual(@as(usize, 1), worker_chunks);
+
+    // ⚠️ 청크 개수만 세면 **bare 철자가 아예 해석을 멈춰도** 통과한다 (worker resolve 실패는
+    // warning 이라 `./w.ts` 쪽 청크 1개만 남는다). 그래서 두 호출부가 **모두** 그 청크로
+    // 재작성됐는지 직접 본다 — 원문 `"w.ts"` 가 남아 있으면 런타임 404 다.
+    const needle = try std.fmt.allocPrint(std.testing.allocator, "new URL(\"./{s}\", import.meta.url)", .{chunk_name});
+    defer std.testing.allocator.free(needle);
+    const first = std.mem.indexOf(u8, result.output, needle) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOfPos(u8, result.output, first + needle.len, needle) != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"w.ts\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"./w.ts\"") == null);
+}
+
+test "#4604 Worker: 형제가 동명 패키지를 이기고, 없으면 패키지로 폴백한다" {
+    // 우선순위 반전은 `.css_url` 뿐 아니라 `.worker` 에도 적용된다. worker 쪽은 청크가
+    // 만들어지므로 자산 내용으로 어느 쪽이 이겼는지 직접 구분한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "node_modules/wpkg/package.json",
+        \\{"name":"wpkg"}
+    );
+    try writeFile(tmp.dir, "node_modules/wpkg/w.js", "self.postMessage('PKG_WORKER');");
+    try writeFile(tmp.dir, "wpkg/w.js", "self.postMessage('SIBLING_WORKER');");
+    try writeFile(tmp.dir, "entry.ts",
+        \\const a = new Worker(new URL("wpkg/w.js", import.meta.url));
+        \\a.postMessage(1);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const assets = result.asset_outputs orelse return error.TestUnexpectedResult;
+    var found = false;
+    for (assets) |a| {
+        if (std.mem.indexOf(u8, a.contents, "_WORKER") == null) continue;
+        try std.testing.expect(std.mem.indexOf(u8, a.contents, "SIBLING_WORKER") != null);
+        found = true;
+    }
+    try std.testing.expect(found);
+    // 원문이 남아 있으면 런타임 404 — 재작성됐는지 함께 본다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"wpkg/w.js\"") == null);
+}
+
+test "#4604 Worker: 형제가 없으면 bare 는 node_modules 패키지로 폴백한다" {
+    // 위 테스트의 비공허성 대조군 — 형제 우선이 패키지 해석을 없애는 것으로 번지면 안 된다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "node_modules/wpkg/package.json",
+        \\{"name":"wpkg"}
+    );
+    try writeFile(tmp.dir, "node_modules/wpkg/w.js", "self.postMessage('PKG_WORKER');");
+    // 형제 `wpkg/` 는 두지 않는다.
+    try writeFile(tmp.dir, "entry.ts",
+        \\const a = new Worker(new URL("wpkg/w.js", import.meta.url));
+        \\a.postMessage(1);
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const assets = result.asset_outputs orelse return error.TestUnexpectedResult;
+    var found = false;
+    for (assets) |a| {
+        if (std.mem.indexOf(u8, a.contents, "PKG_WORKER") == null) continue;
+        found = true;
+    }
+    try std.testing.expect(found);
 }
 
 test "#4483 Worker: external worker 는 UMD/AMD 의존성 배열에 들어가지 않는다" {

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -422,7 +422,11 @@ pub const ResolveCache = struct {
         var bd_it = self.browser_overrides_cache.iterator();
         while (bd_it.next()) |entry| {
             self.allocator.free(entry.key_ptr.*);
-            if (entry.value_ptr.*) |*overrides| overrides.deinit(self.allocator);
+            // ⚠️ 슬롯을 **직접** 가리켜야 한다. `if (entry.value_ptr.*) |*overrides|` 형태로
+            // 두면 browser map 을 가진 패키지마다 3 allocation 이 샌다 (zig 0.16.0 에서 A/B
+            // 측정 — 이 줄만 되돌리면 GPA 가 leak 을 잡는다). 원인은 언어 의미론이 아니라
+            // 이 자리에서 관측된 사실로만 적는다.
+            if (entry.value_ptr.* != null) entry.value_ptr.*.?.deinit(self.allocator);
         }
         self.browser_overrides_cache.deinit(self.allocator);
         if (self.conditions_allocated) {
@@ -441,7 +445,7 @@ pub const ResolveCache = struct {
         specifier: []const u8,
         kind: ImportKind,
     ) ResolveError!?ResolvedModule {
-        return self.resolveNormalized(false, io, source_dir, specifier, kind);
+        return self.resolveInner(false, io, source_dir, specifier, kind);
     }
 
     /// 스레드 안전 resolve. 병렬 resolve 의 union 직접 사용.
@@ -452,57 +456,20 @@ pub const ResolveCache = struct {
         specifier: []const u8,
         kind: ImportKind,
     ) ResolveError!?ResolvedModule {
-        return self.resolveNormalized(true, io, source_dir, specifier, kind);
-    }
-
-    /// URL 상대 참조(worker #4483 / CSS `url()` #4485) 를 URL 의미론까지 고려해 resolve.
-    ///
-    /// 두 지정자 모두 base 가 **참조하는 파일 자신의 URL** 이다:
-    /// - `new URL(spec, import.meta.url)` — base = 모듈 자신의 URL
-    /// - CSS `url(spec)` — base = 스타일시트 자신의 URL (CSS 스펙)
-    ///
-    /// 그래서 `"x.png"` 와 `"./x.png"` 는 **같은 파일**을 가리켜야 한다. 그런데 resolver 는
-    /// `./` 없는 지정자를 npm 패키지 이름으로 보고 node_modules 를 뒤져 ModuleNotFound 를
-    /// 냈고, worker/css_url 의 resolve 실패는 warning 으로만 삼켜져 원문이 그대로 방출됐다
-    /// → 해시된 산출물 이름과 어긋나 런타임 404.
-    ///
-    /// **기존 해석을 먼저 시도하고, 못 찾았을 때만 `./` 를 붙여 재시도한다.** 순서가 중요하다 —
-    /// `./` 를 먼저 시도하면
-    /// - `--alias` / tsconfig `paths` 로 매핑되던 worker 지정자가 같은 이름의 형제 파일에
-    ///   조용히 가려지고,
-    /// - 지금 node_modules 패키지로 해석되고 있는 `url(imgpkg/pic.png)` 가 형제 디렉토리에
-    ///   가려진다 (#4485 이전부터 동작하던 것 → 회귀).
-    ///
-    /// 이 순서면 기존에 resolve 되던 것은 **하나도 바뀌지 않고**, 지금까지 실패하던 bare
-    /// 형제 파일만 새로 해석된다 (= "패키지 우선 + 상대 폴백"). 대가로 동명의 패키지가 있으면
-    /// 형제 파일이 가려지지만, 그건 **지금도 그렇게 동작하는 것**이라 회귀가 아니다.
-    ///
-    /// import record 의 원문 specifier 는 **절대 건드리지 않는다**: bundler 의 worker_map 키와
-    /// codegen 의 조회 키가 둘 다 소스 원문이라, 스캔 시점에 고쳐 놓으면 lookup 이 어긋나
-    /// 다시 원문 emit (= 같은 버그) 으로 돌아간다. CSS 도 같다 — css_emitter 는 record 의
-    /// span/suffix 로 원문 구간을 치환하므로 정규화가 resolve 레이어 밖으로 새면 안 된다.
-    fn resolveNormalized(
-        self: *ResolveCache,
-        comptime thread_safe: bool,
-        io: std.Io,
-        source_dir: []const u8,
-        specifier: []const u8,
-        kind: ImportKind,
-    ) ResolveError!?ResolvedModule {
-        if (self.resolveInner(thread_safe, io, source_dir, specifier, kind)) |resolved| {
-            return resolved; // null(external) 포함 — 기존 동작 그대로.
-        } else |err| switch (err) {
-            error.ModuleNotFound => {},
-            else => return err,
-        }
-        // 여기까지 왔다 = 기존 해석으로는 못 찾음.
-        // worker / css_url 의 bare 상대 참조면 URL 의미론으로 재시도.
-        var buf: [MAX_URL_RELATIVE_SPEC_BYTES]u8 = undefined;
-        const normalized = normalizeUrlRelativeSpecifier(kind, specifier, &buf) orelse return error.ModuleNotFound;
-        return self.resolveInner(thread_safe, io, source_dir, normalized, kind);
+        return self.resolveInner(true, io, source_dir, specifier, kind);
     }
 
     /// resolve 공통 구현. thread_safe=true이면 mutex로 캐시 접근 보호 + resolver 스택 복사.
+    ///
+    /// URL 상대 참조(worker #4483 / CSS `url()` #4485)는 지정자 철자를 **바꾸지 않고**
+    /// `Resolver.url_relative` 플래그로 처리한다 (#4604). 이전엔 `"./" ++ spec` 을 만들어
+    /// resolve 를 한 번 더 돌렸는데, 그러면 alias·`--fallback`·패키지 `browser` 필드·external
+    /// 패턴·캐시 키가 전부 다른 철자를 보게 돼 각각 어긋났다.
+    ///
+    /// import record 의 원문 specifier 도 **절대 건드리지 않는다**: bundler 의 worker_map 키와
+    /// codegen 의 조회 키가 둘 다 소스 원문이라, 스캔 시점에 고쳐 놓으면 lookup 이 어긋나
+    /// 원문 emit (= 404) 으로 돌아간다. CSS 도 같다 — css_emitter 는 record 의 span/suffix 로
+    /// 원문 구간을 치환한다.
     fn resolveInner(
         self: *ResolveCache,
         comptime thread_safe: bool,
@@ -610,6 +577,17 @@ pub const ResolveCache = struct {
         // 실제 resolve — thread_safe 모드에서는 resolver를 스택 복사하여 conditions 수정 방지
         var local_resolver = self.resolver;
         local_resolver.conditions = self.conditionsFor(kind);
+        // 지정자가 모듈 이름이 아니라 URL 상대 참조인지 (#4604) — resolver 가 형제 파일을
+        // paths·node_modules 보다 먼저 보게 한다.
+        //
+        // ⚠️ **원문 철자와 넘기는 철자가 같을 때만** 켠다. 위 루프에서 패키지 `browser` 필드가
+        // remap 했다면 `effective_spec` 은 사용자가 쓴 적 없는 이름이고, 그건 `--alias` 와
+        // 마찬가지로 **명시적 재작성**이라 동명 형제로 뒤집히면 안 된다 (resolver 쪽 alias
+        // carve-out 과 같은 이유). 켜 두면 remap 대상 패키지가 패키지 내부의 동명 디렉토리에
+        // 가려져 엉뚱한 자산이 방출된다.
+        local_resolver.url_relative = std.mem.eql(u8, effective_spec, specifier) and
+            urlRelativeFor(kind, specifier) and
+            !self.hasFallbackDisable(specifier);
         local_resolver.dir_cache = &self.dir_cache;
         local_resolver.realpath_cache = &self.realpath_cache;
         local_resolver.pkg_json_cache = &self.pkg_json_cache;
@@ -619,6 +597,7 @@ pub const ResolveCache = struct {
             // 유일하게 남은 fresh-stat 경로다. 붙이면 watch 재빌드가 무효화 API 없는
             // 이전 빌드 스냅샷을 보고 새로 만든 파일을 "없다" 고 답한다.
             self.resolver.conditions = local_resolver.conditions;
+            self.resolver.url_relative = local_resolver.url_relative;
         }
         const resolve_ptr = if (thread_safe) &local_resolver else &self.resolver;
 
@@ -1109,8 +1088,9 @@ pub const ResolveCache = struct {
         // `.css_url` 은 **일부러 제외하지 않는다** (#4485 알려진 한계). worker 와 달리 CSS 의
         // bare url() 은 이 플래그 하에서 지금도 external 로 빠져 원문 방출되고 있고
         // (`url(imgpkg/pic.png)`), 여기서 carve-out 하면 그게 갑자기 node_modules 자산으로
-        // **해석·방출**돼 `--packages=external` 사용자의 산출물이 바뀐다. 그 정책 변경은
-        // 이 수정의 범위가 아니다.
+        // **해석·방출**된다 — `--packages=external` 로 의존성을 미해석 상태로 두려는 라이브러리
+        // 빌드가 의존성 자산 **사본**을 dist 에 싣게 되고, 소비자 쪽 사본이 안 쓰여 버전 간
+        // 발산한다 (#4604 에서 실제로 그렇게 만들었다가 되돌렸다).
         // 그래서 `--packages=external` + `url(logo.png)` 는 여전히 external 로 빠져
         // 원문 그대로 방출된다 (재작성하려면 `url(./logo.png)` 로 쓴다).
         if (self.packages_external and !is_path and kind != .worker) return true;
@@ -1118,6 +1098,22 @@ pub const ResolveCache = struct {
         for (self.external_patterns) |pattern| {
             if (matchGlob(pattern, specifier)) return true;
             if (matchPackageSubPath(pattern, specifier)) return true;
+        }
+        return false;
+    }
+
+    /// `--fallback:K=false` (webpack `resolve.fallback` 의 `false`) 로 **비활성화**된 지정자인지.
+    ///
+    /// 그런 지정자는 형제 우선 탐색을 끈다 (#4604). 형제가 있으면 정상 해석이 되어
+    /// `applyFallback` 에 도달하지 못하고, 사용자가 라이선스·용량·별도 파이프라인 때문에
+    /// 일부러 뺀 자산이 그대로 번들·방출된다. `=false` 는 "이 이름은 쓰지 마라" 는 명시적
+    /// 지시라 파일 존재 여부로 뒤집히면 안 된다.
+    ///
+    /// 재작성 형태(`=V`)는 여기서 보지 않는다 — 그건 "정상 해석 실패 시" 계약이고 형제는
+    /// 정상 해석이다.
+    fn hasFallbackDisable(self: *const ResolveCache, specifier: []const u8) bool {
+        for (self.resolver.fallback) |entry| {
+            if (entry.to == null and std.mem.eql(u8, specifier, entry.from)) return true;
         }
         return false;
     }
@@ -1147,10 +1143,22 @@ pub fn findPackageDirPath(path: []const u8) ?[]const u8 {
     return path[0 .. nm_pos + nm.len + pkg_end];
 }
 
-/// URL 상대 참조 정규화 버퍼 크기 (`"./"` + specifier). 소스에 리터럴로 박히는
-/// 지정자라 이 상한이면 충분하다. 초과하면 정규화를 건너뛴다(= 기존 동작).
-/// `std.fs.max_path_bytes` 를 쓰면 Windows 에서 96KB 스택 프레임이 되므로 고정값을 쓴다.
-const MAX_URL_RELATIVE_SPEC_BYTES: usize = 1024;
+/// resolver 의 형제-우선 탐색을 켤지 — kind 와 지정자 철자를 함께 본다 (#4604).
+/// 테스트도 이 함수를 그대로 써야 프로덕션 게이트가 바뀔 때 같이 깨진다.
+pub fn urlRelativeFor(kind: ImportKind, specifier: []const u8) bool {
+    return isUrlRelativeKind(kind) and isBareUrlRelativeSpecifier(specifier);
+}
+
+/// 지정자가 모듈 이름이 아니라 **URL 상대 참조**인 kind 인지.
+/// `new URL(spec, import.meta.url)` (#4483) 과 CSS `url(spec)` (#4485) — 둘 다 base 가
+/// 참조하는 파일 자신의 URL 이다. `.static_import`/`.require`/`.dynamic_import` 의 bare 는
+/// 진짜 npm 패키지 이름이라 해당하지 않는다 (`import "react"` 가 형제로 가면 안 된다).
+fn isUrlRelativeKind(kind: ImportKind) bool {
+    return switch (kind) {
+        .worker, .css_url => true,
+        else => false,
+    };
+}
 
 /// specifier 가 `./` 가 생략된 bare 상대 참조인지 (#4483 worker / #4485 CSS url).
 ///
@@ -1167,10 +1175,10 @@ const MAX_URL_RELATIVE_SPEC_BYTES: usize = 1024;
 fn isBareUrlRelativeSpecifier(specifier: []const u8) bool {
     if (specifier.len == 0) return false;
     // query/fragment 가 붙은 지정자는 건드리지 않는다.
-    // - `?worker`/`?sharedworker` 같은 알려진 쿼리를 정규화하면 resolver 가 형제 파일로
-    //   해석해 **WorkerWrapper 팩토리** 청크를 만든다 (worker 본문이 아니라).
+    // - `?worker`/`?sharedworker` 같은 알려진 쿼리를 형제로 해석하면 **WorkerWrapper 팩토리**
+    //   청크가 잡힌다 (worker 본문이 아니라).
     // - `?v=1` 같은 미지의 쿼리는 resolver 가 벗기지 못해 어차피 못 연다.
-    // 둘 다 지금(= `./` 를 붙인 형태)과 동작이 같아야 하므로 정규화 대상에서 뺀다.
+    // 둘 다 명시적 상대 경로(`./x?worker`)와 동작이 같아야 하므로 형제 우선에서 뺀다.
     // (`.css_url` 은 css_scanner 가 `?query`/`#fragment` 를 `css_url_suffix` 로 미리
     //  떼어 두므로 여기 도달하는 specifier 에 `?#` 가 없다 — 이 가드는 worker 용이다.)
     if (std.mem.indexOfAny(u8, specifier, "?#") != null) return false;
@@ -1180,35 +1188,6 @@ fn isBareUrlRelativeSpecifier(specifier: []const u8) bool {
     // `https:` / `data:` / `blob:` … (Windows 드라이브 `C:` 는 scheme 으로 안 침).
     if (css_scanner.hasUriScheme(specifier)) return false;
     return true;
-}
-
-/// URL 상대 참조 지정자를 URL 의미론에 맞춰 정규화 (#4483 worker / #4485 CSS url).
-///
-/// bare 상대 참조면 `buf` 에 `"./" ++ specifier` 를 써서 그 slice 를 반환한다.
-/// 반환 slice 는 `buf` 를 빌리므로 buf 의 수명 안에서만 유효.
-///
-/// null = 정규화 대상 아님 (worker/css_url 이 아닌 kind / 이미 상대 경로 / 절대 URL /
-/// `"./" ++ specifier` 가 buf 를 넘김) → caller 는 원문 그대로 resolve.
-///
-/// **`resolveNormalized` 의 폴백 경로에서만 쓴다.** 정규화된 문자열이 resolve 레이어
-/// 밖으로 새면 (record.specifier 를 고치는 등) emitter/codegen 의 조회 키와 어긋난다.
-///
-/// `.static_import` / `.require` / `.dynamic_import` 의 bare 는 진짜 npm 패키지 이름이라
-/// 정규화 대상이 아니다 — `import "react"` 가 `./react` 로 바뀌면 resolution 이 깨진다.
-pub fn normalizeUrlRelativeSpecifier(kind: ImportKind, specifier: []const u8, buf: []u8) ?[]const u8 {
-    switch (kind) {
-        // `new URL(spec, import.meta.url)` — base 는 모듈 자신의 URL (#4483).
-        // CSS `url(spec)` — base 는 스타일시트 자신의 URL (#4485).
-        .worker, .css_url => {},
-        else => return null,
-    }
-    if (!isBareUrlRelativeSpecifier(specifier)) return null;
-    // 버퍼 초과 — 이만큼 긴 경로는 어차피 파일 시스템에서 안 열린다. 원문으로 진행.
-    if (specifier.len + 2 > buf.len) return null;
-    buf[0] = '.';
-    buf[1] = '/';
-    @memcpy(buf[2 .. 2 + specifier.len], specifier);
-    return buf[0 .. specifier.len + 2];
 }
 
 /// specifier가 Node.js 빌트인 모듈인지 판별.

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -4,7 +4,6 @@ const ResolveCache = resolve_cache.ResolveCache;
 const matchGlob = resolve_cache.matchGlob;
 const matchPackageSubPath = resolve_cache.matchPackageSubPath;
 const isNodeBuiltin = resolve_cache.isNodeBuiltin;
-const normalizeUrlRelativeSpecifier = resolve_cache.normalizeUrlRelativeSpecifier;
 const profile = @import("../profile.zig");
 const ResolvedModule = @import("plugin.zig").ResolvedModule;
 
@@ -711,74 +710,64 @@ test "internResolvedModule: .dataurl mime OOM 시 errdefer 가 mime + data 둘 �
 // #4483 — worker specifier 는 URL 상대 참조 (`./` 생략 가능)
 // ============================================================
 
-/// 테스트 헬퍼 — worker kind 정규화 결과. null = 정규화 대상 아님(원문 사용).
-fn normWorker(buf: []u8, specifier: []const u8) ?[]const u8 {
-    return normalizeUrlRelativeSpecifier(.worker, specifier, buf);
-}
+/// resolver 의 `url_relative` 플래그가 켜지는 조건 (#4604).
+/// ⚠️ 술어를 여기서 재구현하면 프로덕션 게이트가 바뀌어도 아래 테스트가 안 깨진다 —
+/// `ResolveCache` 가 실제로 부르는 것과 **같은 함수**를 쓴다.
+const urlRelative = resolve_cache.urlRelativeFor;
 
-/// 테스트 헬퍼 — CSS `url()` kind 정규화 결과 (#4485).
-fn normCssUrl(buf: []u8, specifier: []const u8) ?[]const u8 {
-    return normalizeUrlRelativeSpecifier(.css_url, specifier, buf);
-}
-
-test "#4483 normalizeUrlRelativeSpecifier: bare 상대 지정자에 ./ 를 붙인다" {
-    var buf: [1024]u8 = undefined;
-    // `new URL("x.worker.js", import.meta.url)` 의 base 는 모듈 자신의 URL →
-    // `./x.worker.js` 와 같은 파일. resolver 가 npm 패키지로 오인하지 않게 정규화.
-    try std.testing.expectEqualStrings("./x.worker.js", normWorker(&buf, "x.worker.js").?);
-    try std.testing.expectEqualStrings("./sub/dir/w.js", normWorker(&buf, "sub/dir/w.js").?);
+test "#4604 url_relative: bare 상대 지정자에 켜진다" {
+    // `new URL("x.worker.js", import.meta.url)` 의 base 는 모듈 자신의 URL → `./x.worker.js`
+    // 와 같은 파일. resolver 가 npm 패키지로 오인하지 않게 형제를 먼저 보게 한다.
+    try std.testing.expect(urlRelative(.worker, "x.worker.js"));
+    try std.testing.expect(urlRelative(.worker, "sub/dir/w.js"));
     // monaco-editor 의 실제 형태 (cssMode.js → css.worker.js).
-    try std.testing.expectEqualStrings("./css.worker.js", normWorker(&buf, "css.worker.js").?);
-    // `..foo` 는 상대 경로가 아니라 그냥 파일명 — `./..foo` 가 맞다.
-    try std.testing.expectEqualStrings("./..foo.js", normWorker(&buf, "..foo.js").?);
+    try std.testing.expect(urlRelative(.worker, "css.worker.js"));
+    // `..foo` 는 상대 경로가 아니라 그냥 파일명.
+    try std.testing.expect(urlRelative(.worker, "..foo.js"));
+    // CSS url() 도 같다 (#4485).
+    try std.testing.expect(urlRelative(.css_url, "logo.png"));
+    try std.testing.expect(urlRelative(.css_url, "img/hero.png"));
 }
 
-test "#4483 normalizeUrlRelativeSpecifier: 이미 상대 경로면 정규화 안 함" {
-    var buf: [1024]u8 = undefined;
-    try std.testing.expect(normWorker(&buf, "./w.js") == null);
-    try std.testing.expect(normWorker(&buf, "../w.js") == null);
-    try std.testing.expect(normWorker(&buf, "../../a/w.js") == null);
+test "#4604 url_relative: 이미 상대 경로면 꺼진다 (일반 경로 조합이 처리)" {
+    try std.testing.expect(!urlRelative(.worker, "./w.js"));
+    try std.testing.expect(!urlRelative(.worker, "../w.js"));
+    try std.testing.expect(!urlRelative(.worker, "../../a/w.js"));
+    try std.testing.expect(!urlRelative(.css_url, "./logo.png"));
 }
 
-test "#4483 normalizeUrlRelativeSpecifier: scheme/root-absolute/protocol-relative 는 건드리지 않는다" {
-    var buf: [1024]u8 = undefined;
+test "#4604 url_relative: scheme/root-absolute/protocol-relative 는 건드리지 않는다" {
     // scheme 있는 절대 URL — base 를 무시하는 valid worker 소스.
-    try std.testing.expect(normWorker(&buf, "https://cdn.example.com/w.js") == null);
-    try std.testing.expect(normWorker(&buf, "http://a/w.js") == null);
-    try std.testing.expect(normWorker(&buf, "data:text/javascript,1") == null);
-    try std.testing.expect(normWorker(&buf, "blob:abc") == null);
-    try std.testing.expect(normWorker(&buf, "chrome-extension://id/w.js") == null);
+    try std.testing.expect(!urlRelative(.worker, "https://cdn.example.com/w.js"));
+    try std.testing.expect(!urlRelative(.worker, "http://a/w.js"));
+    try std.testing.expect(!urlRelative(.worker, "data:text/javascript,1"));
+    try std.testing.expect(!urlRelative(.worker, "blob:abc"));
+    try std.testing.expect(!urlRelative(.worker, "chrome-extension://id/w.js"));
     // root-absolute + protocol-relative — origin 기준이라 파일 시스템 상대가 아니다.
-    try std.testing.expect(normWorker(&buf, "/abs/w.js") == null);
-    try std.testing.expect(normWorker(&buf, "//cdn.example.com/w.js") == null);
+    try std.testing.expect(!urlRelative(.worker, "/abs/w.js"));
+    try std.testing.expect(!urlRelative(.worker, "//cdn.example.com/w.js"));
     // query/fragment 가 붙은 지정자는 전부 제외.
-    // - `?worker`/`?sharedworker` 를 정규화하면 resolver 가 형제 파일로 해석해
-    //   **WorkerWrapper 팩토리** 청크를 만든다 (worker 본문이 아니라) → 워커가 응답 안 함.
-    // - `?v=1` 같은 미지의 쿼리는 resolver 가 벗기지 못해 어차피 못 연다 (`./` 를 붙여도 동일).
-    try std.testing.expect(normWorker(&buf, "w.js?worker") == null);
-    try std.testing.expect(normWorker(&buf, "w.js?v=1") == null);
-    try std.testing.expect(normWorker(&buf, "w.js#frag") == null);
-    try std.testing.expect(normWorker(&buf, "?v=1") == null);
-    try std.testing.expect(normWorker(&buf, "#frag") == null);
-    try std.testing.expect(normWorker(&buf, "") == null);
+    // - `?worker`/`?sharedworker` 를 형제로 해석하면 **WorkerWrapper 팩토리** 청크가 잡힌다
+    //   (worker 본문이 아니라) → 워커가 응답 안 함.
+    // - `?v=1` 같은 미지의 쿼리는 resolver 가 벗기지 못해 어차피 못 연다.
+    try std.testing.expect(!urlRelative(.worker, "w.js?worker"));
+    try std.testing.expect(!urlRelative(.worker, "w.js?v=1"));
+    try std.testing.expect(!urlRelative(.worker, "w.js#frag"));
+    try std.testing.expect(!urlRelative(.worker, "?v=1"));
+    try std.testing.expect(!urlRelative(.worker, "#frag"));
+    try std.testing.expect(!urlRelative(.worker, ""));
+    try std.testing.expect(!urlRelative(.css_url, "https://cdn/a.png"));
+    try std.testing.expect(!urlRelative(.css_url, "/abs.png"));
 }
 
-test "#4483 normalizeUrlRelativeSpecifier: import/require kind 는 bare 를 그대로 (npm 패키지)" {
-    var buf: [1024]u8 = undefined;
-    // import/require 의 bare 는 npm 패키지 — 정규화하면 resolution 이 깨진다.
-    try std.testing.expect(normalizeUrlRelativeSpecifier(.static_import, "react", &buf) == null);
-    try std.testing.expect(normalizeUrlRelativeSpecifier(.dynamic_import, "react-dom/client", &buf) == null);
-    try std.testing.expect(normalizeUrlRelativeSpecifier(.require, "lodash", &buf) == null);
-    try std.testing.expect(normalizeUrlRelativeSpecifier(.side_effect, "normalize.css", &buf) == null);
-}
-
-test "#4483 normalizeUrlRelativeSpecifier: 버퍼보다 긴 specifier 는 정규화 생략 (fallback)" {
-    var small: [8]u8 = undefined;
-    // `"./" + spec` 이 버퍼에 안 들어가면 정규화를 포기 → caller 가 원문으로 resolve (기존 동작).
-    try std.testing.expect(normWorker(&small, "verylongspecifier.js") == null);
-    // 경계: len + 2 == buf.len 은 정규화 성공.
-    var exact: [8]u8 = undefined;
-    try std.testing.expectEqualStrings("./abcdef", normWorker(&exact, "abcdef").?);
+test "#4604 url_relative: import/require kind 는 bare 를 그대로 (npm 패키지)" {
+    // import/require 의 bare 는 npm 패키지 — 형제로 가면 resolution 이 깨진다.
+    try std.testing.expect(!urlRelative(.static_import, "react"));
+    try std.testing.expect(!urlRelative(.dynamic_import, "react-dom/client"));
+    try std.testing.expect(!urlRelative(.require, "lodash"));
+    try std.testing.expect(!urlRelative(.side_effect, "normalize.css"));
+    // 같은 철자라도 kind 가 URL 이면 켜진다 — 갈리는 축이 kind 라는 것 자체를 박제한다.
+    try std.testing.expect(urlRelative(.css_url, "normalize.css"));
 }
 
 test "#4483 isExternal: --packages=external 의 \"bare = 패키지\" 자동 규칙은 worker 에 적용 안 함" {
@@ -888,35 +877,32 @@ test "#4483 resolve: 사용자 external 패턴은 원문 철자로도 계속 먹
 //
 // CSS 스펙상 `url()` 의 base 는 **스타일시트 자신의 URL** 이라
 // `url(logo.png)` 와 `url(./logo.png)` 는 같은 파일을 가리켜야 한다.
-// #4483 이 worker 에 쓴 "기존 해석 우선 + `./` 폴백" 구조를 그대로 확장한 것.
+// #4483 이 worker 에 쓴 구조를 그대로 확장한 것 — 해석 순서는 #4604 에서
+// `--alias` > 형제 > 패키지 로 정리했다 (esbuild·rspack 실측).
 // ============================================================
 
-test "#4485 normalizeUrlRelativeSpecifier: css_url 의 bare 에도 ./ 를 붙인다" {
-    var buf: [1024]u8 = undefined;
-    // #4483 은 css_url 을 일부러 정규화 대상에서 뺐다 (bare 가 패키지로도 해석돼
-    // 우선순위 결정이 필요했다). #4485 에서 "기존 해석 우선 + `./` 폴백" 순서로
-    // 회귀 없이 확장 가능함이 확인돼 전제가 바뀌었다.
-    try std.testing.expectEqualStrings("./logo.png", normCssUrl(&buf, "logo.png").?);
-    try std.testing.expectEqualStrings("./img/logo.png", normCssUrl(&buf, "img/logo.png").?);
-    try std.testing.expectEqualStrings("./fonts/x.woff2", normCssUrl(&buf, "fonts/x.woff2").?);
-    // 패키지 경로처럼 보이는 것도 **정규화 자체는** 한다 — 다만 resolveNormalized 가
-    // 원문 해석을 먼저 시도하므로 실재하는 패키지는 이 폴백까지 오지 않는다.
-    try std.testing.expectEqualStrings("./imgpkg/pic.png", normCssUrl(&buf, "imgpkg/pic.png").?);
+test "#4604 url_relative: css_url 의 bare 도 형제 우선 대상" {
+    // #4483 은 css_url 을 일부러 뺐고(bare 가 패키지로도 해석돼 우선순위 결정이 필요했다),
+    // #4485 가 "패키지 우선 + `./` 폴백" 으로 넣었다가, #4604 에서 esbuild·rspack 실측에
+    // 맞춰 형제 우선으로 정리했다.
+    try std.testing.expect(urlRelative(.css_url, "logo.png"));
+    try std.testing.expect(urlRelative(.css_url, "img/logo.png"));
+    try std.testing.expect(urlRelative(.css_url, "fonts/x.woff2"));
+    // 패키지 경로처럼 보이는 것도 대상이다 — 형제가 없으면 아래 node_modules 로 폴백한다.
+    try std.testing.expect(urlRelative(.css_url, "imgpkg/pic.png"));
 }
 
-test "#4485 normalizeUrlRelativeSpecifier: css_url 의 상대/절대/scheme 은 건드리지 않는다" {
-    var buf: [1024]u8 = undefined;
-    // 이미 명시적 상대 경로.
-    try std.testing.expect(normCssUrl(&buf, "./logo.png") == null);
-    try std.testing.expect(normCssUrl(&buf, "../assets/logo.png") == null);
+test "#4604 url_relative: css_url 의 상대/절대/scheme 은 건드리지 않는다" {
+    // 이미 명시적 상대 경로 — 일반 경로 조합이 그대로 처리한다.
+    try std.testing.expect(!urlRelative(.css_url, "./logo.png"));
+    try std.testing.expect(!urlRelative(.css_url, "../assets/logo.png"));
     // root-absolute — public 디렉토리 규약 (loaders 가 애초에 record 도 안 만든다).
-    try std.testing.expect(normCssUrl(&buf, "/logo.png") == null);
-    try std.testing.expect(normCssUrl(&buf, "//cdn.example.com/logo.png") == null);
+    try std.testing.expect(!urlRelative(.css_url, "/logo.png"));
+    try std.testing.expect(!urlRelative(.css_url, "//cdn.example.com/logo.png"));
     // scheme 있는 절대 URL — 그대로 방출돼야 한다.
-    try std.testing.expect(normCssUrl(&buf, "https://cdn.example.com/z.png") == null);
-    try std.testing.expect(normCssUrl(&buf, "data:image/png;base64,iVBOR") == null);
-    try std.testing.expect(normCssUrl(&buf, "blob:abc") == null);
-    try std.testing.expect(normCssUrl(&buf, "") == null);
+    try std.testing.expect(!urlRelative(.css_url, "https://cdn.example.com/z.png"));
+    try std.testing.expect(!urlRelative(.css_url, "data:image/png;base64,iVBOR"));
+    try std.testing.expect(!urlRelative(.css_url, "blob:abc"));
 }
 
 test "#4485 resolve: bare css url() 이 스타일시트 형제 파일로 해석된다" {
@@ -946,20 +932,302 @@ test "#4485 resolve: bare css url() 이 스타일시트 형제 파일로 해석�
     );
 }
 
-test "#4485 resolve: 패키지로 해석되던 bare css url() 은 그대로 패키지가 이긴다" {
+test "#4604 resolve: bare css url() 은 형제가 동명 패키지를 이긴다" {
+    // #4485 는 패키지 우선으로 뒀었다 (형제가 패키지를 가리는 것을 회귀로 봤다).
+    // esbuild·rspack 을 같은 픽스처로 실측한 결과 둘 다 형제를 우선한다 — URL 의 base 가
+    // 스타일시트 자신이라 형제가 그 URL 의 대상이고, node_modules 해석은 형제가 없을 때의
+    // 폴백이다. 폴백이 살아 있다는 것은 바로 아래 테스트가 지킨다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    // node_modules/imgpkg/pic.png — 현재도 정상 해석되는 형태 (data URL 로 인라인됨).
     try tmp.dir.createDir(std.testing.io, "node_modules", .default_dir);
     try tmp.dir.createDir(std.testing.io, "node_modules/imgpkg", .default_dir);
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/imgpkg/package.json", .data = "{\"name\":\"imgpkg\"}" });
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/imgpkg/pic.png", .data = "PKG" });
 
-    // 같은 이름의 형제 디렉토리도 함께 둔다 — 정규화를 **먼저** 시도했다면 이게 이겨서
-    // 기존 사용자의 패키지 자산이 조용히 바뀐다 (= 회귀). 순서가 이걸 막는다.
+    // 동명의 형제 디렉토리 — 이게 이겨야 한다.
     try tmp.dir.createDir(std.testing.io, "imgpkg", .default_dir);
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "imgpkg/pic.png", .data = "SIBLING" });
+
+    const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
+    defer std.testing.allocator.free(dir_path);
+
+    var cache = ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+
+    const resolved = try cache.resolve(std.testing.io, dir_path, "imgpkg/pic.png", .css_url);
+    try std.testing.expect(resolved != null);
+    try std.testing.expect(std.mem.indexOf(u8, resolved.?.file.path, "node_modules") == null);
+
+    // `url(./imgpkg/pic.png)` 와 **같은 파일**이어야 한다 — 이게 #4604 의 본질이다.
+    const dotted = try cache.resolve(std.testing.io, dir_path, "./imgpkg/pic.png", .css_url);
+    try std.testing.expectEqualStrings(resolved.?.file.path, dotted.?.file.path);
+
+    // 대조군 — `.static_import` 는 진짜 모듈 지정자라 **패키지**로 가야 한다.
+    // 이게 없으면 "모든 kind 에서 형제 우선" 으로 바꿔도 위 단언이 전부 통과한다.
+    const as_module = try cache.resolve(std.testing.io, dir_path, "imgpkg/pic.png", .static_import);
+    try std.testing.expect(as_module != null);
+    try std.testing.expect(std.mem.indexOf(u8, as_module.?.file.path, "node_modules") != null);
+}
+
+test "#4604 resolve: alias 대상이 bare 여도 동명 형제가 alias 를 가리지 않는다" {
+    // 형제 프로브가 **alias 치환 후** 철자로 돌면 alias 대상 패키지가 동명 형제 디렉토리에
+    // 가려진다. `--alias:x=somepkg` 는 사용자가 그 패키지를 강제한 것이라 파일 존재 여부로
+    // 뒤집히면 안 된다. (alias 대상이 절대경로면 이 분기를 안 타므로 bare 대상이 핵심.)
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDir(std.testing.io, "node_modules", .default_dir);
+    try tmp.dir.createDir(std.testing.io, "node_modules/imgpkg", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/imgpkg/package.json", .data = "{\"name\":\"imgpkg\"}" });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/imgpkg/pic.png", .data = "PKG" });
+    // alias 대상과 동명인 형제 디렉토리.
+    try tmp.dir.createDir(std.testing.io, "imgpkg", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "imgpkg/pic.png", .data = "SIBLING" });
+
+    const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
+    defer std.testing.allocator.free(dir_path);
+
+    const aliases = [_]@import("resolver.zig").AliasEntry{
+        .{ .from = "alias-name", .to = "imgpkg" }, // 대상이 **bare**
+    };
+    var cache = ResolveCache.init(std.testing.allocator, .{ .alias = &aliases });
+    defer cache.deinit();
+
+    const resolved = try cache.resolve(std.testing.io, dir_path, "alias-name/pic.png", .css_url);
+    try std.testing.expect(resolved != null);
+    try std.testing.expect(std.mem.indexOf(u8, resolved.?.file.path, "node_modules") != null);
+
+    // 대조군 — alias 가 안 걸리는 이름은 형제가 이긴다 (alias 분기가 형제 우선을 통째로
+    // 꺼 버린 게 아님을 보인다).
+    const plain = try cache.resolve(std.testing.io, dir_path, "imgpkg/pic.png", .css_url);
+    try std.testing.expect(plain != null);
+    try std.testing.expect(std.mem.indexOf(u8, plain.?.file.path, "node_modules") == null);
+}
+
+test "#4604 resolve: --fallback 대상은 URL 의미론으로 해석되지 않는다" {
+    // `url_relative` 는 Resolver 인스턴스 상태라, `applyFallback` 이 수행하는 **재진입**
+    // resolve 에서 끄지 않으면 fallback 대상까지 형제 우선으로 해석된다. 대상은 사용자가
+    // 옵션에 쓴 평범한 모듈 지정자지 URL 상대 참조가 아니다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDir(std.testing.io, "node_modules", .default_dir);
+    try tmp.dir.createDir(std.testing.io, "node_modules/imgpkg", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/imgpkg/package.json", .data = "{\"name\":\"imgpkg\"}" });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/imgpkg/pic.png", .data = "PKG" });
+    // fallback 대상과 동명인 형제 디렉토리 — 재진입 resolve 가 URL 의미론이면 이게 이긴다.
+    try tmp.dir.createDir(std.testing.io, "imgpkg", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "imgpkg/pic.png", .data = "SIBLING" });
+
+    const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
+    defer std.testing.allocator.free(dir_path);
+
+    // `logo.png` 는 형제로도 패키지로도 없으므로 fallback 이 걸린다.
+    const fallbacks = [_]@import("resolver.zig").FallbackEntry{
+        .{ .from = "logo.png", .to = "imgpkg/pic.png" },
+    };
+    var cache = ResolveCache.init(std.testing.allocator, .{ .fallback = &fallbacks });
+    defer cache.deinit();
+
+    const resolved = try cache.resolve(std.testing.io, dir_path, "logo.png", .css_url);
+    try std.testing.expect(resolved != null);
+    try std.testing.expect(std.mem.indexOf(u8, resolved.?.file.path, "node_modules") != null);
+
+    // 대조군 — 같은 지정자를 **직접** URL 참조로 쓰면 형제가 이긴다. 이게 없으면
+    // "형제 우선 자체가 꺼졌다" 는 회귀에서도 위 단언이 통과한다.
+    const direct = try cache.resolve(std.testing.io, dir_path, "imgpkg/pic.png", .css_url);
+    try std.testing.expect(direct != null);
+    try std.testing.expect(std.mem.indexOf(u8, direct.?.file.path, "node_modules") == null);
+}
+
+test "#4604 resolve: alias 대상이 없으면 마지막 수단으로 원문 형제를 본다" {
+    // alias 가 걸리면 exact 형제 프로브는 건너뛰지만, 아무것도 해석되지 않으면 마지막에
+    // 원문 철자로 전체 경로 사다리를 태운다 (main 의 `"./" ++ spec` 재시도와 같은 자리).
+    // 없애 봤더니 alias 대상이 깨진 프로젝트에서 지금까지 방출되던 자산이 조용히 사라졌다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "logo.png", .data = "SIBLING" });
+
+    const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
+    defer std.testing.allocator.free(dir_path);
+
+    const aliases = [_]@import("resolver.zig").AliasEntry{
+        .{ .from = "logo.png", .to = "no-such-package-anywhere" },
+    };
+    var cache = ResolveCache.init(std.testing.allocator, .{ .alias = &aliases });
+    defer cache.deinit();
+
+    const resolved = try cache.resolve(std.testing.io, dir_path, "logo.png", .css_url);
+    try std.testing.expect(resolved != null);
+    try std.testing.expect(std.mem.endsWith(u8, resolved.?.file.path, "logo.png"));
+
+    // 대조군 — URL kind 가 아니면 이 마지막 수단은 없다 (진짜 모듈 import 는 alias 실패 = 실패).
+    try std.testing.expectError(
+        error.ModuleNotFound,
+        cache.resolve(std.testing.io, dir_path, "logo.png", .static_import),
+    );
+}
+
+test "#4604 resolve: bare 지정자도 마지막 수단에서 확장자 추론이 살아 있다" {
+    // exact 프로브만 남기고 마지막 수단을 지웠더니, `new URL("worker.js")` + 디스크의
+    // `worker.ts`(moduleResolution NodeNext 가 요구하는 철자)가 **해석 자체를 못 해**
+    // warning 만 남기고 원문이 방출됐다 → 404. 추론은 아무것도 해석 안 됐을 때만 돈다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "worker.ts", .data = "self.postMessage(1);" });
+
+    const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
+    defer std.testing.allocator.free(dir_path);
+
+    var cache = ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+
+    const resolved = try cache.resolve(std.testing.io, dir_path, "worker.js", .worker);
+    try std.testing.expect(resolved != null);
+    try std.testing.expect(std.mem.endsWith(u8, resolved.?.file.path, "worker.ts"));
+
+    // 대조군 — 추론이 **패키지보다 앞서면** 안 된다. 아래 테스트가 그걸 지킨다.
+}
+
+test "#4604 resolve: 형제 우선은 정확한 파일명일 때만 (확장자 추론 없음)" {
+    // 프로브가 일반 경로 해석 사다리를 타면 확장자 붙이기·`.js`→`.ts` 매핑·RN @2x·디렉토리
+    // 인덱스까지 걸려, **동명 형제가 없는데도** 패키지가 조용히 가려진다. URL 은 실제
+    // 파일명을 그대로 쓰므로 추론이 애초에 URL 의미론에 없다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDir(std.testing.io, "node_modules", .default_dir);
+    try tmp.dir.createDir(std.testing.io, "node_modules/wpkg", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/wpkg/package.json", .data = "{\"name\":\"wpkg\"}" });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/wpkg/w.js", .data = "PKG" });
+    // 로컬엔 `w.ts` 만 있다 — `w.js` 라는 이름의 형제는 **없다**.
+    try tmp.dir.createDir(std.testing.io, "wpkg", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "wpkg/w.ts", .data = "LOCAL_TS" });
+
+    const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
+    defer std.testing.allocator.free(dir_path);
+
+    var cache = ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+
+    const resolved = try cache.resolve(std.testing.io, dir_path, "wpkg/w.js", .worker);
+    try std.testing.expect(resolved != null);
+    try std.testing.expect(std.mem.indexOf(u8, resolved.?.file.path, "node_modules") != null);
+
+    // 대조군 — 정확히 그 이름의 형제가 있으면 이긴다. `ResolveCache` 는 무효화 API 가
+    // 없으므로(같은 키 = 위 결과 재사용) **새 캐시**로 재본다.
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "wpkg/w.js", .data = "LOCAL_JS" });
+    var fresh = ResolveCache.init(std.testing.allocator, .{});
+    defer fresh.deinit();
+    const exact = try fresh.resolve(std.testing.io, dir_path, "wpkg/w.js", .worker);
+    try std.testing.expect(exact != null);
+    try std.testing.expect(std.mem.indexOf(u8, exact.?.file.path, "node_modules") == null);
+}
+
+test "#4604 resolve: --fallback:K=false 로 끈 지정자는 형제가 있어도 비활성 유지" {
+    // 형제 우선이 `applyFallback` 보다 앞서므로, 그냥 두면 사용자가 일부러 뺀 자산이
+    // 형제로 해석돼 번들·방출된다. `=false` 는 "이 이름은 쓰지 마라" 는 명시적 지시다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "logo.png", .data = "SIBLING" });
+
+    const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
+    defer std.testing.allocator.free(dir_path);
+
+    const fallbacks = [_]@import("resolver.zig").FallbackEntry{
+        .{ .from = "logo.png", .to = null },
+    };
+    var cache = ResolveCache.init(std.testing.allocator, .{ .fallback = &fallbacks });
+    defer cache.deinit();
+
+    const resolved = try cache.resolve(std.testing.io, dir_path, "logo.png", .css_url);
+    try std.testing.expect(resolved != null);
+    try std.testing.expect(resolved.? == .disabled); // 빈 모듈 — 자산으로 방출되지 않는다
+
+    // 대조군 — 끄지 않은 이름은 형제로 정상 해석된다.
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "keep.png", .data = "SIBLING2" });
+    const kept = try cache.resolve(std.testing.io, dir_path, "keep.png", .css_url);
+    try std.testing.expect(kept != null);
+    try std.testing.expect(kept.? == .file);
+}
+
+test "#4604 resolve: block_list 에 막힌 형제가 패키지 폴백을 막지 않는다" {
+    // 형제 히트를 그대로 돌려주면 상위 `resolve()` 가 차단 후 ModuleNotFound 로 끝내 버려,
+    // 원래 이기던 node_modules 대상까지 도달하지 못한다 → 원문 방출 404.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDir(std.testing.io, "node_modules", .default_dir);
+    try tmp.dir.createDir(std.testing.io, "node_modules/legacy", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/legacy/package.json", .data = "{\"name\":\"legacy\"}" });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/legacy/logo.png", .data = "PKG" });
+    try tmp.dir.createDir(std.testing.io, "legacy", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "legacy/logo.png", .data = "BLOCKED" });
+
+    const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
+    defer std.testing.allocator.free(dir_path);
+    const blocked = try std.fmt.allocPrint(std.testing.allocator, "{s}/legacy/.*", .{dir_path});
+    defer std.testing.allocator.free(blocked);
+
+    const block_list = [_][]const u8{blocked};
+    var cache = ResolveCache.init(std.testing.allocator, .{ .block_list = &block_list });
+    defer cache.deinit();
+
+    const resolved = try cache.resolve(std.testing.io, dir_path, "legacy/logo.png", .css_url);
+    try std.testing.expect(resolved != null);
+    try std.testing.expect(std.mem.indexOf(u8, resolved.?.file.path, "node_modules") != null);
+}
+
+test "#4604 resolve: 패키지 browser 필드 remap 이 동명 형제에 가리지 않는다" {
+    // `url_relative` 판정은 원문 철자로 하는데 resolver 에는 remap 된 철자를 넘긴다.
+    // 켠 채로 넘기면 browser 필드가 가리킨 대상이 **패키지 내부의 동명 디렉토리**에 가려져
+    // 엉뚱한 자산이 방출된다. browser 필드도 `--alias` 와 같은 명시적 재작성이다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDir(std.testing.io, "node_modules", .default_dir);
+    try tmp.dir.createDir(std.testing.io, "node_modules/pkg", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = "node_modules/pkg/package.json",
+        .data = "{\"name\":\"pkg\",\"browser\":{\"icons/a.png\":\"shared-icons/a.png\"}}",
+    });
+    try tmp.dir.createDir(std.testing.io, "node_modules/pkg/icons", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/pkg/icons/a.png", .data = "ORIG" });
+    // remap 대상과 동명인 **패키지 내부** 디렉토리 — 형제 우선이 켜져 있으면 이게 이긴다.
+    try tmp.dir.createDir(std.testing.io, "node_modules/pkg/shared-icons", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/pkg/shared-icons/a.png", .data = "STRAY" });
+    // browser 필드가 실제로 가리키는 패키지.
+    try tmp.dir.createDir(std.testing.io, "node_modules/shared-icons", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/shared-icons/package.json", .data = "{\"name\":\"shared-icons\"}" });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/shared-icons/a.png", .data = "REMAP_TARGET" });
+
+    const pkg_dir = try tmp.dir.realPathFileAlloc(std.testing.io, "node_modules/pkg", std.testing.allocator);
+    defer std.testing.allocator.free(pkg_dir);
+
+    var cache = ResolveCache.init(std.testing.allocator, .{});
+    defer cache.deinit();
+
+    const resolved = try cache.resolve(std.testing.io, pkg_dir, "icons/a.png", .css_url);
+    try std.testing.expect(resolved != null);
+    // remap 대상 패키지여야 한다 — `node_modules/pkg/shared-icons/` 가 아니라.
+    try std.testing.expect(std.mem.indexOf(u8, resolved.?.file.path, "node_modules/shared-icons") != null);
+}
+
+test "#4604 resolve: 형제가 없으면 bare css url() 은 여전히 패키지로 폴백한다" {
+    // 위 테스트의 비공허성 대조군 — 형제 우선이 패키지 해석 자체를 없애는 것으로 번지면
+    // 안 된다 (esbuild·rspack 도 이 경우 패키지 자산을 쓴다).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDir(std.testing.io, "node_modules", .default_dir);
+    try tmp.dir.createDir(std.testing.io, "node_modules/imgpkg", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/imgpkg/package.json", .data = "{\"name\":\"imgpkg\"}" });
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "node_modules/imgpkg/pic.png", .data = "PKG" });
+    // 형제 디렉토리는 두지 않는다 — 이 픽스처의 위험 조건이 "형제 부재" 다.
 
     const dir_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", std.testing.allocator);
     defer std.testing.allocator.free(dir_path);
@@ -998,9 +1266,8 @@ test "#4485 isExternal: --packages=external 의 bare 규칙은 css_url 에 그�
 
     // worker 는 #4483 이 이 규칙에서 뺐다.
     try std.testing.expect(!cache.isExternalForKind("logo.png", .worker));
-    // css_url 은 **일부러 빼지 않는다** — 이 플래그 하에서 bare url() 은 지금도 external 로
-    // 빠져 원문 방출된다. carve-out 하면 그게 갑자기 node_modules 자산으로 해석·방출돼
-    // `--packages=external` 사용자의 산출물이 바뀐다 (이 수정의 범위 밖).
+    // css_url 은 **일부러 빼지 않는다** — #4604 에서 빼 봤더니 `--packages=external` 로 의존성을
+    // 미해석 상태로 두려는 라이브러리 빌드가 의존성 자산 사본을 dist 에 싣게 됐다(실측).
     // 재작성이 필요하면 `url(./logo.png)` 로 쓴다.
     try std.testing.expect(cache.isExternalForKind("logo.png", .css_url));
     // 명시적 상대 경로는 이 규칙과 무관 (is_path).

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -452,6 +452,17 @@ pub const Resolver = struct {
     /// React Native asset resolver 호환: `name.ext` base 파일이 없어도
     /// `name@2x.ext` / `name@3x.ext` 같은 scale variant가 있으면 그 파일로 해석한다.
     react_native_asset_scale_fallback: bool = false,
+    /// 이 resolve 의 지정자가 **모듈 지정자가 아니라 URL 상대 참조**인지 (#4604).
+    /// CSS `url(spec)` 과 `new URL(spec, import.meta.url)` — 둘 다 base 가 참조하는 파일
+    /// 자신의 URL 이라 `"x.png"` 와 `"./x.png"` 가 같은 파일을 가리켜야 한다.
+    ///
+    /// 호출자(`ResolveCache`)가 kind 를 보고 `conditions` 와 같은 방식으로 매 resolve 마다
+    /// 지정한다. 켜지면 `resolveInner` 가 tsconfig `paths` 를 건너뛰고 형제 파일을 먼저 찾는다.
+    ///
+    /// ⚠️ **지정자를 재작성하는 방식으로 구현하면 안 된다.** `"./" ++ spec` 을 만들어 다시
+    /// 태우면 alias·`--fallback`·패키지 `browser` 필드·external 패턴·캐시 키가 전부 **다른
+    /// 철자**를 보게 돼 각각 어긋난다. 그래서 철자는 그대로 두고 탐색 순서만 바꾼다.
+    url_relative: bool = false,
     /// 0.16: fs 연산이 io 를 요구한다. Resolver 는 fs 프로빙이 25+ 메서드에 깊게
     /// 퍼진 stateful 서브시스템이라, public 진입점 `resolve()` 에서 1회 저장한
     /// per-instance io 를 내부 메서드가 self.io 로 읽는다 (전역 아님 — resolve_cache
@@ -510,6 +521,12 @@ pub const Resolver = struct {
                 const saved = self.fallback;
                 self.fallback = &.{};
                 defer self.fallback = saved;
+                // `url_relative` 도 함께 끈다 (#4604). fallback **대상**은 사용자가 옵션에 쓴
+                // 평범한 모듈 지정자지, URL 상대 참조가 아니다. 켠 채로 재진입하면 대상이
+                // 형제 우선으로 해석돼 `--fallback:logo.png=somepkg` 가 동명 형제에 가려진다.
+                const saved_url_relative = self.url_relative;
+                self.url_relative = false;
+                defer self.url_relative = saved_url_relative;
                 return try self.resolve(self.io, source_dir, target);
             }
             // target=null → 빈 모듈 (webpack `false`)
@@ -748,8 +765,36 @@ pub const Resolver = struct {
             (applyAlias(self.allocator, self.alias, specifier) catch return error.OutOfMemory) orelse specifier
         else
             specifier;
-        defer if (self.alias.len > 0 and effective_specifier.ptr != specifier.ptr)
-            self.allocator.free(effective_specifier);
+        const alias_applied = effective_specifier.ptr != specifier.ptr;
+        defer if (alias_applied) self.allocator.free(effective_specifier);
+
+        return self.resolveResolved(source_dir, specifier, effective_specifier, alias_applied) catch |err| {
+            if (err != error.ModuleNotFound or !self.url_relative) return err;
+            // **마지막 수단** — 원문 철자로 전체 경로 사다리를 태운다 (확장자 추론·`.js`→`.ts`
+            // 매핑·디렉토리 인덱스·RN `@2x`).
+            //
+            // 앞의 `trySiblingExact` 는 "형제가 paths·패키지를 이긴다" 만 담당하고 추론은 하지
+            // 않는다. 추론까지 앞세우면 동명 형제가 없는데도 패키지가 조용히 가려지기 때문이다.
+            // 하지만 추론 자체를 없애면 `new URL("worker.js")` + 디스크의 `worker.ts`
+            // (moduleResolution NodeNext 가 요구하는 철자) 같은 게 **해석 자체를 못 해**
+            // warning 만 남기고 원문이 방출된다 → 404. 그래서 아무것도 해석되지 않았을 때만
+            // 여기서 돌린다.
+            //
+            // main 의 `"./" ++ spec` 재시도와 같은 위치·같은 효과다. 다만 **철자를 바꾸지
+            // 않으므로** alias·`--fallback`·`browser` 필드·external 패턴·캐시 키가 어긋나지
+            // 않는다. alias 대상이 없을 때 원문 형제로 구제되는 것도 이 경로다 (main 동일).
+            if (try self.tryJoinedPath(source_dir, specifier)) |r| return r;
+            return err;
+        };
+    }
+
+    fn resolveResolved(
+        self: *Resolver,
+        source_dir: []const u8,
+        specifier: []const u8,
+        effective_specifier: []const u8,
+        alias_applied: bool,
+    ) ResolveError!ResolveResult {
 
         // tsconfig paths 적용 시점.
         //
@@ -770,9 +815,24 @@ pub const Resolver = struct {
         // 치환 후 이름으로 paths 를 태워 봤지만 되돌렸다 — catch-all(`"*"`) 이 alias target 을
         // 가로채 `--alias:oldname=realpkg` 가 설치된 패키지 대신 동명의 앱 파일을 조용히
         // 번들했다(실측). alias target 을 paths 로 표현하는 조합은 #4606 에서 따로 다룬다.
-        if (self.ts_paths.len > 0 and effective_specifier.ptr == specifier.ptr and
-            !isRelativePath(specifier))
-        {
+
+        // URL 상대 참조(`.css_url` / `.worker`)의 bare 지정자는 **형제 파일을 먼저** 본다
+        // (#4604). base 가 파일 자신의 URL 이므로 형제가 곧 그 URL 의 대상이고, paths·패키지
+        // 해석은 형제가 없을 때의 폴백이다. esbuild 실측과 같은 순서다.
+        //
+        // ⚠️ `paths` 를 **배제하지는 않는다.** esbuild 는 `url(@/assets/logo.png)` 를 tsconfig
+        // `paths` 로 정상 해석한다 — 배제하면 `"@/*": ["src/*"]` 같은 가장 흔한 prefix alias 가
+        // URL 참조에서만 통째로 깨진다. 필요한 건 배제가 아니라 **형제가 앞서는 것**이다.
+        //
+        // ⚠️ **정확히 그 이름의 파일이 있을 때만** 이긴다 (`trySiblingExact`). 일반 경로 해석
+        // 사다리(`tryResolvePathLike`)를 태우면 확장자 붙이기·`.js`→`.ts` 매핑·RN `@2x`
+        // variant·디렉토리 인덱스까지 걸려, 동명 형제가 없는데도 패키지가 조용히 가려진다.
+        // URL 은 실제 파일명을 그대로 쓰므로 확장자 추론이 애초에 URL 의미론이 아니다.
+        if (self.url_relative and !alias_applied and !isRelativeOrAbsolute(specifier)) {
+            if (try self.trySiblingExact(source_dir, specifier)) |r| return r;
+        }
+
+        if (self.ts_paths.len > 0 and !alias_applied and !isRelativePath(specifier)) {
             if (try self.tryTsPaths(specifier)) |r| return r;
         }
 
@@ -802,17 +862,57 @@ pub const Resolver = struct {
         }
 
         // 경로 조합
+        if (try self.tryJoinedPath(source_dir, effective_specifier)) |result| return result;
+
+        return error.ModuleNotFound;
+    }
+
+    /// URL 상대 참조의 형제 우선 탐색 (#4604) — `source_dir/specifier` 가 **정확히 그 이름의
+    /// 파일**로 존재할 때만 결과를 돌려준다. 없으면 null 이라 호출자가 paths·node_modules 로
+    /// 계속 간다.
+    ///
+    /// 일반 경로 해석(`tryResolvePathLike`)과 달리 확장자 붙이기·TS 확장자 매핑·RN scale
+    /// variant·디렉토리 인덱스를 **타지 않는다**. URL 은 실제 파일명을 그대로 쓰므로 추론이
+    /// 의미론에 없고, 태우면 동명 형제가 없는데도 패키지·paths 대상이 조용히 가려진다.
+    ///
+    /// `block_list` 에 걸리는 후보는 없는 것으로 친다. 여기서 그냥 돌려주면 상위 `resolve()`
+    /// 가 차단 후 `ModuleNotFound` 로 끝내 버려, 원래 이기던 paths·node_modules 대상까지
+    /// 도달하지 못한다.
+    fn trySiblingExact(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!?ResolveResult {
+        const joined = std.fs.path.resolve(self.allocator, &.{ source_dir, specifier }) catch
+            return error.OutOfMemory;
+        defer self.allocator.free(joined);
+
+        if (!self.fileExists(joined)) return null;
+
+        const result = (try self.makeResult(joined)) orelse return null;
+        // ⚠️ 검사는 **`makeResult` 뒤**(= realpath 적용 후) 여야 한다. 상위 `resolve()` 의
+        // block_list 가드가 realpath 기준이라, 여기서 joined(심볼릭 링크 해석 전) 로 보면
+        // canonical 경로가 차단 대상인 형제가 이 검사를 통과해 반환된 뒤 상위에서 hard-block
+        // 되고, 그 시점엔 paths·node_modules 를 이미 건너뛴 뒤라 폴백에 도달하지 못한다.
+        if (self.block_list.len > 0) {
+            const bl = @import("block_list.zig");
+            for (self.block_list) |pat| {
+                if (!bl.matches(pat, result.path)) continue;
+                self.allocator.free(result.path);
+                if (result.resolve_dir) |dir| self.allocator.free(dir);
+                return null;
+            }
+        }
+        return result;
+    }
+
+    /// `source_dir` 기준으로 지정자를 이어붙여 파일을 찾는다. 못 찾으면 null.
+    fn tryJoinedPath(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!?ResolveResult {
         const joined = blk: {
             var path_scope = profile.begin(.resolve_path);
             defer path_scope.end();
-            break :blk std.fs.path.resolve(self.allocator, &.{ source_dir, effective_specifier }) catch
+            break :blk std.fs.path.resolve(self.allocator, &.{ source_dir, specifier }) catch
                 return error.OutOfMemory;
         };
         defer self.allocator.free(joined);
 
-        if (try self.tryResolvePathLike(joined)) |result| return result;
-
-        return error.ModuleNotFound;
+        return self.tryResolvePathLike(joined);
     }
 
     /// 상대 specifier 판별. 정의와 테스트는 `src/module_specifier.zig` 가 단일 권위 —

--- a/tests/integration/tests/css-bundle.test.ts
+++ b/tests/integration/tests/css-bundle.test.ts
@@ -391,15 +391,16 @@ describe('CSS Bundling', () => {
     expect(emitted).toHaveLength(2);
   });
 
-  it('#4485 CSS url() bare 는 node_modules 패키지 자산으로 먼저 해석된다 (기존 동작 보존)', async () => {
-    // 순서가 핵심 — 기존 해석을 **먼저** 시도하고 ModuleNotFound 일 때만 `./` 폴백.
-    // `./` 를 먼저 붙였다면 동명의 형제 디렉토리가 패키지를 조용히 가려 회귀가 된다.
+  it('#4604 CSS url() bare 는 형제 파일이 동명 패키지를 이긴다', async () => {
+    // #4485 는 반대(패키지 우선)로 뒀었다. esbuild·rspack 을 같은 픽스처로 실측한 결과
+    // 둘 다 형제를 우선한다 — url() 의 base 는 스타일시트 자신의 URL 이라 형제가 그 대상이고,
+    // node_modules 해석은 형제가 없을 때의 폴백이다.
     const fixture = await createFixture({
       'index.ts': `import './style.css';`,
       'style.css': `.c { background: url(imgpkg/pic.png); }`,
       'node_modules/imgpkg/package.json': `{"name":"imgpkg"}`,
       'node_modules/imgpkg/pic.png': 'P'.repeat(5000), // 패키지 쪽
-      'imgpkg/pic.png': 'S'.repeat(5000), // 동명의 형제 디렉토리 (가리면 안 됨)
+      'imgpkg/pic.png': 'S'.repeat(5000), // 동명의 형제 디렉토리 — 이게 이겨야 한다
     });
     cleanup = fixture.cleanup;
 
@@ -410,7 +411,67 @@ describe('CSS Bundling', () => {
     const emitted = (await readdir(fixture.dir)).filter((f) => /^pic-[0-9a-f]{8}\.png$/.test(f));
     expect(emitted).toHaveLength(1);
     const asset = await readFile(join(fixture.dir, emitted[0]!), 'utf-8');
-    expect(asset).toBe('P'.repeat(5000)); // 패키지가 이긴다 (형제 파일 'S' 가 아니라)
+    expect(asset).toBe('S'.repeat(5000)); // 형제가 이긴다
+  });
+
+  it('#4604 CSS url() bare 는 형제가 없으면 여전히 패키지로 폴백한다', async () => {
+    // 위 테스트의 비공허성 대조군 — 형제 우선이 패키지 해석 자체를 없애는 것으로 번지면
+    // 안 된다 (esbuild·rspack 도 이 경우 패키지 자산을 쓴다).
+    const fixture = await createFixture({
+      'index.ts': `import './style.css';`,
+      'style.css': `.c { background: url(imgpkg/pic.png); }`,
+      'node_modules/imgpkg/package.json': `{"name":"imgpkg"}`,
+      'node_modules/imgpkg/pic.png': 'P'.repeat(5000),
+      // 형제 디렉토리는 두지 않는다 — 이 픽스처의 위험 조건이 '형제 부재' 다.
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc(['--bundle', join(fixture.dir, 'index.ts'), '-o', outJs]);
+    expect(result.exitCode).toBe(0);
+
+    const emitted = (await readdir(fixture.dir)).filter((f) => /^pic-[0-9a-f]{8}\.png$/.test(f));
+    expect(emitted).toHaveLength(1);
+    const asset = await readFile(join(fixture.dir, emitted[0]!), 'utf-8');
+    expect(asset).toBe('P'.repeat(5000));
+  });
+
+  // #4604 — 유닛 테스트는 `ts_paths` 를 Bundler 옵션으로 직접 주입하므로 tsconfig **파일**
+  // 파싱부터 resolver 까지의 사슬은 안 덮인다. 여기서 진짜 tsconfig.json 으로 종단 검증한다.
+  it('#4604 실제 tsconfig.json 에서 형제 파일이 catch-all paths 를 이긴다', async () => {
+    const fixture = await createFixture({
+      'tsconfig.json': `{ "compilerOptions": { "baseUrl": ".", "paths": { "*": ["src/*"] } } }`,
+      'src/assets/logo.png': 'R'.repeat(5000), // 형제가 없을 때만 쓰이는 paths 대상
+      'src/components/assets/logo.png': 'S'.repeat(5000), // 스타일시트 형제 — 형제가 이긴다
+      'src/components/card.css': `.card { background: url(assets/logo.png); }`,
+      'src/components/panel.css': `.panel { background: url(./assets/logo.png); }`,
+      'src/main.ts': `import './components/card.css';\nimport './components/panel.css';`,
+    });
+    cleanup = fixture.cleanup;
+
+    const outJs = join(fixture.dir, 'out.js');
+    const result = await runZntc([
+      '--bundle',
+      join(fixture.dir, 'src/main.ts'),
+      '-o',
+      outJs,
+      '-p',
+      join(fixture.dir, 'tsconfig.json'),
+    ]);
+    expect(result.exitCode).toBe(0);
+
+    // 두 철자가 같은 파일로 수렴 → 자산 1개, 내용은 형제 쪽.
+    const emitted = (await readdir(fixture.dir)).filter((f) => /^logo-[0-9a-f]{8}\.png$/.test(f));
+    expect(emitted).toHaveLength(1);
+    expect(await readFile(join(fixture.dir, emitted[0]!), 'utf-8')).toBe('S'.repeat(5000));
+
+    // 자산 개수만 보면 bare 해석이 통째로 깨져도 통과한다(실패는 warning). 최종 CSS 에서
+    // 두 규칙이 같은 해시 자산을 가리키는지 직접 확인한다.
+    const css = await readFile(join(fixture.dir, 'main.css'), 'utf-8');
+    const hits = css.split(emitted[0]!).length - 1;
+    expect(hits).toBe(2);
+    expect(css).not.toContain('url(assets/logo.png)');
+    expect(css).not.toContain('url(./assets/logo.png)');
   });
 
   it('CSS imported from dynamically imported module', async () => {


### PR DESCRIPTION
## 문제

catch-all `paths`(`"*": ["src/*"]` — 실사용 패턴)가 있으면 CSS `url(logo.png)` 와
`new URL('w.js', import.meta.url)` 의 `./` 없는 지정자가 paths 에 가로채여, **형제 파일이
있는데도** 같은 URL 을 가리키는 두 표기가 서로 다른 파일로 갈렸다. 진단 0건.

| | zntc (수정 전) | esbuild |
|---|---|---|
| `url(./logo.png)` | SIBLING | SIBLING |
| `url(logo.png)` | **ROOT** ❌ | SIBLING |
| 방출 자산 | **2개** | 1개 |

worker 도 같은 형태로 청크가 2개 생기고 한쪽이 잘못된 소스로 빌드됐다.

## 해석 순서 (계약)

```
1. --alias                    사용자가 명시한 강제 재작성
2. 정확히 그 이름의 형제 파일    trySiblingExact
3. tsconfig paths
4. node_modules
5. 마지막 수단 — 원문 철자로 전체 경로 사다리 (확장자 추론·.js→.ts·디렉토리 인덱스·RN @2x)
```

**2 와 5 를 나눈 게 핵심이다.** 추론을 앞세우면 동명 형제가 없는데도 패키지가 조용히 가려지고,
추론을 없애면 `new URL("worker.js")` + 디스크의 `worker.ts`(NodeNext 가 요구하는 철자)가
해석 자체를 못 해 원문이 방출된다(404). 5 는 main 의 `"./" ++ spec` 재시도와 같은 자리지만
**철자를 바꾸지 않으므로** alias·`--fallback`·`browser` 필드·external 패턴·캐시 키가 어긋나지
않는다.

형제 우선에서 제외 — 명시적 지시가 파일 존재 여부로 뒤집히면 안 된다:
`--alias`, 패키지 `browser` 필드 remap, `--fallback:K=false`, `block_list` 후보.

## 참조 번들러 실측

rolldown 은 CSS 번들링 지원을 제거해(`UNSUPPORTED_FEATURE`) 이 축은 대조군이 없다.

| `url(imgpkg/pic.png)` | esbuild | rspack | 수정 전 | 수정 후 |
|---|---|---|---|---|
| 패키지만 존재 | PKG | PKG | PKG | PKG |
| 형제+패키지 동시 | SIBLING | SIBLING | **PKG** | SIBLING |
| catch-all paths (신고건) | SIBLING | — | **ROOT** | SIBLING |
| alias+형제 동시 | ALIAS | — | ALIAS | ALIAS |
| `@/*` paths (형제 없음) | VIA_PATHS | — | VIA_PATHS | VIA_PATHS |

## ⚠️ 폐기한 접근 3개

`/code-review max` 5라운드에서 각각 반증됐다. 이 표면을 다시 만질 때 반드시 읽을 것.

1. **철자 재작성** — `"./" ++ spec` 을 주 경로로 두면 alias·`--fallback`·`browser` 필드·
   external 패턴·캐시 키가 전부 다른 철자를 보게 돼 어긋난다. 게다가 형제가 없으면
   신고 버그가 그대로 재현됐다(순서만 바뀌고 paths 는 여전히 적용).
2. **`paths` 배제** — esbuild 는 `url(@/assets/logo.png)` 를 `paths` 로 정상 해석한다.
   배제하면 `"@/*"` 가 URL 참조에서만 깨져 자산 404 가 되고, CLI 기본 IIFE 포맷에선
   `new URL("@/w.ts", "")` 가 TypeError 로 번들 전체를 죽인다.
3. **정확 매칭만 남기고 마지막 수단 제거** — 확장자 추론이 통째로 사라져 404.

`--packages=external` carve-out 도 넣었다가 되돌렸다 — 의존성을 미해석 상태로 두려는
라이브러리 빌드가 의존성 자산 **사본**을 dist 에 싣게 됐다.

## 부수 수정 — 기존 leak

`ResolveCache.deinit` 이 browser override 맵 슬롯을 직접 가리키지 않아 `browser` map 을 가진
패키지마다 3 allocation 이 샜다. 이 변경과 무관한 선행 버그이며, 새 테스트가 처음 그 경로를
밟았다 (그 줄만 되돌리면 GPA 가 다시 잡는 것으로 A/B 확인).

## 검증

- 신고 repro 를 **형제 있음/없음 두 축 모두** 확인 — 1차 시도가 놓친 게 두 번째 축이었다.
- 라운드별 지적을 빌드 바이너리로 재검증: `@/*` paths · alias 대상이 bare · `--packages=external` ·
  `--fallback` 대상 · `--fallback:K=false` · block_list · browser remap · `.js`→`.ts` 추론.
- A/B 비공허: 형제 우선 제거 → 18건 실패. 각 carve-out 도 개별 A/B 로 확인.
- 유닛 **6297 통과**, 통합 **4448 pass**. 실패 2건(`watch RSS`, `Hermes __copyProps`)은
  main baseline 에서도 동일하게 실패하는 기존 실패다.

## 분리한 것

- **#4611** — CSS `@import` 도 같은 증상이 살아있다. 레코드 kind 가 `.side_effect` 라
  JS 의 `import 'normalize.css'` 와 구분되지 않아 kind 편입이 불가능하다.
- **#4612** — 잔여 엣지 5종 (심볼릭 링크 디렉토리 · 가상 모듈의 cwd 기준 · latent 상태 등).
  전부 PLAUSIBLE 등급으로 재현 픽스처를 못 만들었거나 위생 범주다.
- watch warm/cold 발산은 **main 에서도 동일 재현** — `ResolveCache` 무효화 API 부재라는 기존 축.

Closes #4604
Refs #4611, #4612

🤖 Generated with [Claude Code](https://claude.com/claude-code)