### PR TITLE
fix(bundler): #4612 URL 참조가 디렉토리 symlink 를 파일로 잡아 빌드가 죽던 문제

### DIFF
--- a/.changeset/sibling-probe-edges.md
+++ b/.changeset/sibling-probe-edges.md
@@ -1,0 +1,14 @@
+---
+"@zntc/core": patch
+---
+
+`url()` / `new URL()` 참조가 **디렉토리 symlink** 를 파일로 잡아 빌드가 죽던 문제를 고쳤다 (#4612).
+
+`DirEntryCache` 는 readdir 만으로 symlink 대상이 파일인지 디렉토리인지 알 수 없어 files·dirs
+양쪽에 등록한다. 그래서 참조 대상 자리에 디렉토리 symlink 가 있으면 그걸 파일로 넘겼고, 읽기
+단계에서 `ZNTC0200 Cannot read file` 로 **빌드 전체가 죽었다** — 해석 실패는 warning + 원문
+유지가 맞는 동작인데 fatal 이 됐다.
+
+이제 `.css_url` / `.worker` 는 디렉토리 후보를 거부한다. 판정은 **철자가 아니라 kind** 에
+걸리므로 `url(logo.png)` 와 `url(./logo.png)` 가 같이 동작한다. dir 로도 등록된 후보만
+`statFile` 로 확정하므로 파일 symlink 는 종전대로 이긴다.

--- a/docs/BUNDLER.md
+++ b/docs/BUNDLER.md
@@ -209,6 +209,18 @@ CSS 스펙상 `url()` 의 상대 참조는 **스타일시트 자신의 URL** 이
   없는 이름이고, `--alias` 와 마찬가지로 명시적 재작성이라 동명 형제로 뒤집히면 안 된다.
 - `--fallback:K=false` 로 끈 지정자도 형제 우선을 끈다. 형제가 있으면 정상 해석이 되어
   `applyFallback` 에 도달하지 못해, 라이선스·용량 때문에 일부러 뺀 자산이 그대로 방출된다.
+- **디렉토리는 대상이 될 수 없다.** URL 은 파일을 가리키는 참조라 디렉토리 인덱스로 해석되면
+  안 된다. 그런데 `DirEntryCache` 는 readdir 만으로 symlink 대상을 알 수 없어 files·dirs 양쪽에
+  등록하므로, 디렉토리 symlink 가 `fileExists` 에 걸려 파일로 넘어가고 읽기 단계에서
+  `ZNTC0200` 으로 **빌드 전체가 죽는다**. 그래서 `.css_url`/`.worker` 는 `Resolver.url_kind` 로
+  디렉토리 후보를 거부한다.
+  - ⚠️ 이 판정은 **kind** 에 걸어야 한다. bare 철자 경로(`trySiblingExact`)에만 넣으면
+    `url(logo.png)` 는 살고 `url(./logo.png)` 는 죽는다 (#4612 리뷰 실측).
+  - ⚠️ `dirExists` 만으로 자르면 **파일 symlink 까지 죽는다**(양쪽 등록). dir 로도 등록된
+    후보만 `statFile` 로 확정한다.
+  - ⚠️ stat 실패는 디렉토리가 **아닌** 것으로 친다. 후보를 버리면 깨진 symlink 나 일시적
+    EMFILE 이 조용히 "동명 패키지로 폴백" 이 되어, 파일 이름을 짚어 주던 `ZNTC0200` 이
+    사라지고 전혀 다른 자산이 실린다.
 - `block_list` 에 걸리는 형제 후보는 없는 것으로 친다. 그냥 돌려주면 상위 `resolve()` 가 차단 후
   `ModuleNotFound` 로 끝내 버려, 원래 이기던 paths·node_modules 대상에 도달하지 못한다.
 - `--fallback` 대상을 재해석할 때는 `url_relative` 를 **끈다**. 대상은 사용자가 옵션에 쓴 평범한

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4054,12 +4054,129 @@ fn bundleCatchAllPathsCss(tmp: *std.testing.TmpDir, sibling: bool) !CatchAllPath
             try is_sib.append(std.testing.allocator, std.mem.eql(u8, o.contents, &sibling_img));
         }
     }
+    // ⚠️ 구조체 리터럴 안에서 바로 `toOwnedSlice` 하면 안 된다 (#4612). 필드는 순서대로
+    // 평가되는데, 소유권이 넘어간 뒤 **뒤 필드가 실패하면** 위 errdefer 들은 이미 비워진
+    // 리스트를 보고 아무것도 해제하지 않아 넘긴 슬라이스와 duped CSS 가 샌다.
+    // 하나씩 지역 변수로 받고 각자 errdefer 를 건다.
+    const css_owned = try std.testing.allocator.dupe(u8, css);
+    errdefer std.testing.allocator.free(css_owned);
+
+    const png_paths = try paths_list.toOwnedSlice(std.testing.allocator);
+    errdefer {
+        for (png_paths) |it| std.testing.allocator.free(it);
+        std.testing.allocator.free(png_paths);
+    }
+
+    const png_is_sibling = try is_sib.toOwnedSlice(std.testing.allocator);
+
     return .{
-        .css = try std.testing.allocator.dupe(u8, css),
+        .css = css_owned,
         .diag_count = result.getDiagnostics().len,
-        .png_paths = try paths_list.toOwnedSlice(std.testing.allocator),
-        .png_is_sibling = try is_sib.toOwnedSlice(std.testing.allocator),
+        .png_paths = png_paths,
+        .png_is_sibling = png_is_sibling,
     };
+}
+
+/// #4612 symlink 케이스 — 형제 자리에 symlink 를 두고 `url(logo.png)` 를 번들한다.
+///
+/// ⚠️ **번들러 경로여야 재현된다.** `ResolveCache` 를 직접 부르는 유닛 테스트는 `dir_cache`
+/// 가 null 이라 `fileExists` 가 `statFile` 로 떨어져 디렉토리를 알아서 걸러낸다. 버그는
+/// `DirEntryCache` 가 살아 있을 때만 난다 — readdir 만으로 symlink 대상을 알 수 없어
+/// files·dirs 양쪽에 등록하기 때문이다.
+///
+/// ⚠️ `with_package` 를 **반드시 양쪽으로** 돌린다. 처음엔 패키지를 심어 둔 픽스처만 있었는데,
+/// 그러면 폴백이 실패를 흡수해 버려 "동명 패키지가 없는" 흔한 위상(= 빌드가 죽는 진짜 조건)을
+/// 한 번도 밟지 않는다. 리뷰가 이걸 잡았다.
+///
+/// ⚠️ `bare_spelling` 도 양쪽으로 돌린다. 수정을 bare 철자 경로에만 넣으면 `url(./logo.png)`
+/// 는 그대로 죽는다 — 성질이 철자가 아니라 kind 에 속한다.
+fn bundleSiblingSymlink(
+    tmp: *std.testing.TmpDir,
+    dir_symlink: bool,
+    with_package: bool,
+    bare_spelling: bool,
+) !struct {
+    has_errors: bool,
+    from_pkg: bool,
+} {
+    // ⚠️ 자산은 인라인 임계값보다 커야 한다 — 작으면 data URI 로 인라인돼 `asset_outputs`
+    // 가 비고, 어느 쪽이 이겼는지 구분 자체가 안 된다 (테스트가 공허해진다).
+    const pkg_img = [_]u8{0xC3} ** 5000;
+    const file_img = [_]u8{0xC4} ** 5000;
+
+    const css = if (bare_spelling)
+        ".card { background: url(logo.png); }"
+    else
+        ".card { background: url(./logo.png); }";
+    try writeFile(tmp.dir, "src/card.css", css);
+    try writeFile(tmp.dir, "src/main.ts", "import './card.css';");
+
+    if (with_package) {
+        try writeFile(tmp.dir, "node_modules/logo.png/package.json", "{\"name\":\"logo.png\",\"main\":\"a.png\"}");
+        try writeFile(tmp.dir, "node_modules/logo.png/a.png", &pkg_img);
+    }
+
+    if (dir_symlink) {
+        // 인덱스 파일이 **없는** 디렉토리 — `tryDirectoryIndex` 가 흡수하지 못한다.
+        try writeFile(tmp.dir, "real_dir/unrelated.txt", "x");
+        try tmp.dir.symLink(std.testing.io, "../real_dir", "src/logo.png", .{ .is_directory = true });
+    } else {
+        try writeFile(tmp.dir, "real_file.png", &file_img);
+        try tmp.dir.symLink(std.testing.io, "../real_file.png", "src/logo.png", .{});
+    }
+
+    const entry = try absPath(tmp, "src/main.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .format = .esm });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    var from_pkg = false;
+    if (result.asset_outputs) |outs| {
+        for (outs) |o| {
+            if (std.mem.eql(u8, o.contents, &pkg_img)) from_pkg = true;
+        }
+    }
+    return .{ .has_errors = result.hasErrors(), .from_pkg = from_pkg };
+}
+
+test "#4612 CSS url(): 디렉토리 symlink 는 동명 패키지가 없어도 빌드를 죽이지 않는다" {
+    // **핵심 위상** — 폴백이 흡수해 주지 않는 경우. 잡으면 읽기 단계에서 ZNTC0200 으로
+    // 빌드 전체가 죽는다 (해석 실패는 warning + 원문 유지가 맞는 동작이다).
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+
+    for ([_]bool{ true, false }) |bare| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const r = try bundleSiblingSymlink(&tmp, true, false, bare);
+        try std.testing.expect(!r.has_errors);
+    }
+}
+
+test "#4612 CSS url(): 디렉토리 symlink 면 동명 패키지로 폴백한다" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const r = try bundleSiblingSymlink(&tmp, true, true, true);
+    try std.testing.expect(!r.has_errors);
+    try std.testing.expect(r.from_pkg);
+}
+
+test "#4612 CSS url(): 파일 symlink 는 두 철자 모두 그대로 이긴다" {
+    // 가드를 `dirExists` 만으로 넓게 잡으면 이게 깨진다 — DirEntryCache 가 양쪽에 등록하므로
+    // 파일 symlink 도 dirExists 가 true 다. stat 으로 확정해야 한다.
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+
+    for ([_]bool{ true, false }) |bare| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const r = try bundleSiblingSymlink(&tmp, false, true, bare);
+        try std.testing.expect(!r.has_errors);
+        try std.testing.expect(!r.from_pkg); // 형제(symlink 대상)가 이긴다
+    }
 }
 
 test "#4604 CSS url(): catch-all tsconfig paths 가 bare url() 을 가로채지 않는다 (형제 있음)" {

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -585,6 +585,9 @@ pub const ResolveCache = struct {
         // 마찬가지로 **명시적 재작성**이라 동명 형제로 뒤집히면 안 된다 (resolver 쪽 alias
         // carve-out 과 같은 이유). 켜 두면 remap 대상 패키지가 패키지 내부의 동명 디렉토리에
         // 가려져 엉뚱한 자산이 방출된다.
+        // `url_kind` 는 **철자와 무관하게 kind 만** 본다 — `url(./x)` 도 URL 참조라
+        // 디렉토리가 대상이 될 수 없다. `url_relative`(탐색 순서) 와 축이 다르다.
+        local_resolver.url_kind = isUrlRelativeKind(kind);
         local_resolver.url_relative = std.mem.eql(u8, effective_spec, specifier) and
             urlRelativeFor(kind, specifier) and
             !self.hasFallbackDisable(specifier);
@@ -598,7 +601,19 @@ pub const ResolveCache = struct {
             // 이전 빌드 스냅샷을 보고 새로 만든 파일을 "없다" 고 답한다.
             self.resolver.conditions = local_resolver.conditions;
             self.resolver.url_relative = local_resolver.url_relative;
+            self.resolver.url_kind = local_resolver.url_kind;
         }
+        // `url_relative` 는 **per-resolve** 상태라 공유 인스턴스에 남기지 않는다 (#4612).
+        // 매 resolve 직전에 항상 대입되므로 현재 오동작은 없지만, 같은 필드를
+        // save/clear/restore 하는 `Resolver.applyFallback` 과 비대칭이면 다음에 이 필드를
+        // 읽는 코드가 생겼을 때 조용히 이전 호출의 값을 본다.
+        //
+        // `conditions` 는 여기서 건드리지 않는다 — 복원 대상이 아니라 kind 별로 갈아끼우는
+        // 기존 계약이고, 이 변경의 범위 밖이다.
+        defer if (!thread_safe) {
+            self.resolver.url_relative = false;
+            self.resolver.url_kind = false;
+        };
         const resolve_ptr = if (thread_safe) &local_resolver else &self.resolver;
 
         const result = blk: {
@@ -1174,13 +1189,19 @@ fn isUrlRelativeKind(kind: ImportKind) bool {
 /// - `?query` / `#fragment` 만 있는 참조 — 대상 파일이 자기 자신이다
 fn isBareUrlRelativeSpecifier(specifier: []const u8) bool {
     if (specifier.len == 0) return false;
-    // query/fragment 가 붙은 지정자는 건드리지 않는다.
-    // - `?worker`/`?sharedworker` 같은 알려진 쿼리를 형제로 해석하면 **WorkerWrapper 팩토리**
-    //   청크가 잡힌다 (worker 본문이 아니라).
+    // query/fragment 가 붙은 지정자는 형제 우선에서 뺀다.
+    // - `?worker`/`?sharedworker` 같은 알려진 쿼리를 형제로 해석하면 worker 본문이 아니라
+    //   **WorkerWrapper 팩토리** 청크가 잡힌다.
     // - `?v=1` 같은 미지의 쿼리는 resolver 가 벗기지 못해 어차피 못 연다.
-    // 둘 다 명시적 상대 경로(`./x?worker`)와 동작이 같아야 하므로 형제 우선에서 뺀다.
-    // (`.css_url` 은 css_scanner 가 `?query`/`#fragment` 를 `css_url_suffix` 로 미리
-    //  떼어 두므로 여기 도달하는 specifier 에 `?#` 가 없다 — 이 가드는 worker 용이다.)
+    //
+    // ⚠️ 근거는 위 두 줄이 전부다. 예전 주석은 "`./x?worker` 와 동작이 같아야 하므로" 라고
+    // 적었는데 **그 등가성은 성립하지 않는다** — `./x?worker` 는 상대 경로로 정상 해석되고
+    // bare `x?worker` 는 여기서 걸러져 paths·node_modules 로 간다. 즉 #4604 가 없앤 종류의
+    // 발산이 `?query` 축에는 남아 있으며, 팩토리 청크를 잡는 것보다는 낫다고 보고 의도적으로
+    // 둔 것이다. 근거를 등가성으로 적어 두면 다음 사람이 "등가니까 켜도 된다" 로 뒤집는다.
+    //
+    // (`.css_url` 은 css_scanner 가 `?query`/`#fragment` 를 `css_url_suffix` 로 미리 떼어
+    //  두므로 여기 도달하는 specifier 에 `?#` 가 없다 — 이 가드는 worker 용이다.)
     if (std.mem.indexOfAny(u8, specifier, "?#") != null) return false;
     // `./` `../` 명시적 상대 + `/abs.js` root-absolute + `//cdn/w.js` protocol-relative
     // (셋 다 isRelativeOrAbsolute 가 true).

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -463,6 +463,19 @@ pub const Resolver = struct {
     /// 태우면 alias·`--fallback`·패키지 `browser` 필드·external 패턴·캐시 키가 전부 **다른
     /// 철자**를 보게 돼 각각 어긋난다. 그래서 철자는 그대로 두고 탐색 순서만 바꾼다.
     url_relative: bool = false,
+
+    /// 이 resolve 가 **URL 참조**인지 (`.css_url` / `.worker`). `url_relative` 와 달리
+    /// 철자와 무관하게 **kind 만** 본다.
+    ///
+    /// URL 은 파일을 가리키는 참조라 디렉토리는 결코 유효한 대상이 아니다. 그런데
+    /// `DirEntryCache` 는 readdir 만으로 symlink 대상을 알 수 없어 files·dirs 양쪽에
+    /// 등록하므로, 디렉토리 symlink 가 `fileExists` 에 걸려 파일로 넘어가고 나중에 읽기
+    /// 단계에서 `ZNTC0200` 으로 **빌드 전체가 죽는다**.
+    ///
+    /// ⚠️ 이 판정을 `url_relative`(bare 철자 전용)에 얹으면 안 된다 — `url(logo.png)` 는
+    /// 살고 `url(./logo.png)` 는 죽어서, #4604 가 없애려던 바로 그 "두 철자가 갈린다" 가
+    /// 다시 생긴다. 성질이 철자가 아니라 kind 에 속하므로 플래그도 kind 로 둔다.
+    url_kind: bool = false,
     /// 0.16: fs 연산이 io 를 요구한다. Resolver 는 fs 프로빙이 25+ 메서드에 깊게
     /// 퍼진 stateful 서브시스템이라, public 진입점 `resolve()` 에서 1회 저장한
     /// per-instance io 를 내부 메서드가 self.io 로 읽는다 (전역 아님 — resolve_cache
@@ -629,22 +642,39 @@ pub const Resolver = struct {
     /// `tryDirectoryIndex` 를 먼저 시도해 package entry(index/main/exports) 로 간다.
     fn tryResolvePathLike(self: *Resolver, abs_path: []const u8) ResolveError!?ResolveResult {
         const maybe_dir = self.dirExists(abs_path);
-        if (maybe_dir) {
+        if (maybe_dir and !self.url_kind) {
             // DirEntryCache 는 symlink target 을 readdir 만으로 알 수 없어 file+dir
             // 양쪽에 등록한다. pnpm package symlink root 를 alias 로 직접 가리키면
             // fileExists 가 먼저 true 가 되어 package entry(index/main/exports)를 건너뛰므로,
             // ambiguous directory 후보는 package/directory resolve 를 먼저 시도한다.
+            //
+            // URL kind 는 제외 — `url(x)` 가 디렉토리 인덱스로 해석되면 안 된다.
             if (try self.tryDirectoryIndex(abs_path)) |result| return result;
         }
 
-        if (self.fileExists(abs_path)) return try self.makeResult(abs_path);
+        if (self.fileExists(abs_path) and self.confirmNotDirectory(abs_path, maybe_dir))
+            return try self.makeResult(abs_path);
         if (try self.tryReactNativeScaleAssetFallback(abs_path)) |result| return result;
         if (try self.tryExtensions(abs_path)) |result| return result;
         if (try self.tryTsExtensionMapping(abs_path)) |result| return result;
-        if (!maybe_dir) {
+        if (!maybe_dir and !self.url_kind) {
             if (try self.tryDirectoryIndex(abs_path)) |result| return result;
         }
         return null;
+    }
+
+    /// URL kind 에서 `fileExists` 히트가 **정말 파일인지** 확인한다. dir 로도 등록된
+    /// (= symlink 라 대상을 모르는) 후보만 stat 으로 확정하므로, 순수 파일인 흔한 경우는
+    /// 추가 syscall 이 없다.
+    ///
+    /// ⚠️ stat 실패는 **디렉토리가 아닌 것으로 친다.** 여기서 후보를 버리면 깨진 symlink 나
+    /// 일시적 EMFILE 이 조용히 "동명 패키지로 폴백" 으로 바뀌어, 원래 파일 이름을 짚어 주던
+    /// `ZNTC0200` 이 사라지고 전혀 다른 자산이 실린다 (같은 빌드가 실행마다 다른 결과를
+    /// 낼 수도 있다). 못 읽는 건 못 읽는다고 시끄럽게 실패하는 편이 낫다.
+    fn confirmNotDirectory(self: *Resolver, abs_path: []const u8, maybe_dir: bool) bool {
+        if (!self.url_kind or !maybe_dir) return true;
+        const st = fs.statFile(self.io, abs_path) catch return true;
+        return !st.is_dir;
     }
 
     fn isReactNativeScaleAssetExt(ext: []const u8) bool {
@@ -884,6 +914,9 @@ pub const Resolver = struct {
         defer self.allocator.free(joined);
 
         if (!self.fileExists(joined)) return null;
+        // 디렉토리 symlink 배제는 `tryResolvePathLike` 와 **같은 헬퍼**를 쓴다. 여기서만
+        // 막으면 bare 철자는 살고 `./` 철자는 죽는다 (#4612 리뷰에서 실측).
+        if (!self.confirmNotDirectory(joined, self.dirExists(joined))) return null;
 
         const result = (try self.makeResult(joined)) orelse return null;
         // ⚠️ 검사는 **`makeResult` 뒤**(= realpath 적용 후) 여야 한다. 상위 `resolve()` 의


### PR DESCRIPTION
## 문제

`url()` / `new URL()` 참조 자리에 **디렉토리 symlink** 가 있으면 읽기 단계에서
`ZNTC0200 Cannot read file` 로 **빌드 전체가 죽었다.**

```
src/logo.png -> ../real_dir     (디렉토리 symlink)
src/card.css  .card { background: url(logo.png); }
```
```
[ZNTC0200] error: src/logo.png: Cannot read file
→ 산출물 없음
```

해석 실패는 warning + 원문 유지가 맞는 동작인데 fatal 이 됐고, tsconfig `paths`·node_modules
폴백에도 도달하지 못했다.

## 루트커즈

`DirEntryCache` 는 readdir 만으로 symlink 대상이 파일인지 디렉토리인지 알 수 없어 files·dirs
**양쪽**에 등록한다 (bun/pnpm 이 node_modules 에 디렉토리 symlink 를 만들기 때문에 필수).
그래서 `fileExists` 히트가 곧 파일이라는 뜻이 아니다.

## 수정

`.css_url` / `.worker` 는 디렉토리 후보를 거부한다 (`Resolver.url_kind`). URL 은 파일을
가리키는 참조라 디렉토리 인덱스가 대상이 될 수 없다.

**판정을 kind 에 걸었다 — 철자가 아니라.** 1차 수정은 bare 철자 경로(`trySiblingExact`)에만
넣었는데, 그러면 이렇게 갈린다:

| 같은 스타일시트 안 | 1차 수정 | 현재 |
|---|---|---|
| `url(logo.png)` | 빌드 성공 | 빌드 성공 |
| `url(./logo.png)` | **ZNTC0200 사망** | 빌드 성공 |

성질이 철자가 아니라 kind 에 속하므로 `tryResolvePathLike` 라는 공유 계층에 뒀다 — 마지막
수단 사다리까지 한 번에 덮인다.

⚠️ `dirExists` 만으로 자르면 **파일 symlink 까지 죽는다**(양쪽 등록 때문에 파일 symlink 도
dirExists 가 true). dir 로도 등록된 후보만 `statFile` 로 확정한다.

⚠️ stat 실패는 디렉토리가 **아닌** 것으로 친다. 후보를 버리면 깨진 symlink 나 일시적 EMFILE 이
조용히 "동명 패키지로 폴백" 이 되어, 파일 이름을 짚어 주던 `ZNTC0200` 이 사라지고 전혀 다른
자산이 실린다.

## ⚠️ 폐기한 두 가드

- **`!isAbsolute(source_dir)`** (가상 모듈의 cwd 상대 방지) — 재현 픽스처를 못 만든 채 넣었는데,
  WASM API 는 host VFS 키를 그대로 넘겨(`packages/wasm/index.ts` `build(entryPath)`) 상대 경로가
  정상 입력이다. 그런 빌드에서 #4604 형제 우선이 통째로 꺼진다. 게다가 마지막 수단 사다리는
  여전히 cwd 를 봐서 **불완전하기까지** 했다. 되돌리고 #4612 에 남긴다.
- **구분자 없는 지정자의 alloc 생략** — 근거로 적은 "형제 프로브는 bare 지정자마다 돈다" 가
  거짓이다(`.worker`/`.css_url` 에서만 돈다). 이득 없이 정규화 경로만 갈라진다.

## 그 외

- `url_relative` / `url_kind` 를 공유 resolver 인스턴스에 남기지 않는다 (per-resolve 상태).
- `?#` 제외의 근거 주석 수정 — "`./x?worker` 와 동작이 같아야 하므로" 라고 적었지만 그 등가성은
  성립하지 않는다. 실제 이유와 남은 발산을 명시했다. 동작은 그대로.
- 테스트 헬퍼 `bundleCatchAllPathsCss` 의 errdefer 구멍.

## ⚠️ 테스트가 위험 조건을 인코딩하는지

1차 테스트는 **`node_modules/logo.png` 를 심어 둔 픽스처뿐**이었다. 그러면 폴백이 실패를
흡수해 버려 "동명 패키지가 없는" 흔한 위상 — 빌드가 실제로 죽는 조건 — 을 한 번도 밟지 않는다.
A/B 는 통과했지만 위상이 빠져 있었다. 이제 `with_package` × `bare_spelling` 을 모두 돌린다.

또 symlink 회귀는 **번들러 레벨**이어야 재현된다 (`ResolveCache` 직접 호출은 `dir_cache` 가
null 이라 `statFile` 이 알아서 걸러낸다). 자산 크기도 인라인 임계값보다 커야 한다.

## 검증

- 양방향 A/B 비공허: 가드 무력화 → 디렉토리 테스트 2종 실패 / 넓은 가드 → 파일 symlink 테스트
  실패. **1차 A/B 는 컴파일 에러라 아무것도 증명하지 못했다**(파라미터 미사용) — 다시 돌렸다.
- CLI 바이너리로 패키지 없음/있음 × bare/`./` **4조합 전부 빌드 완주** 확인.
- esbuild 대조: 같은 픽스처에서 두 철자 모두 resolve 에러 — 조용한 발산도, fatal read 도 없다.
- #4604 계약 4종 회귀 없음 (신고 repro · 절대/상대 엔트리 · 확장자 추론 · 추론이 패키지 안 가림).
- 유닛 **6300 통과**, 통합 **4448 pass**. 실패 2건은 main baseline 과 동일한 기존 실패.

Refs #4612, #4604

🤖 Generated with [Claude Code](https://claude.com/claude-code)