### PR TITLE
fix(bundler): #4611 CSS @import 의 bare 지정자가 tsconfig paths 에 가로채이던 문제

### DIFF
--- a/.changeset/css-import-kind.md
+++ b/.changeset/css-import-kind.md
@@ -1,0 +1,14 @@
+---
+"@zntc/core": patch
+---
+
+CSS `@import "base.css"` 의 `./` 없는 지정자가 tsconfig `paths` 에 가로채여 전혀 다른
+스타일시트가 번들되던 문제를 고쳤다 (#4611).
+
+catch-all `paths`(`"*": ["src/*"]`) 가 있으면 `@import "vars.css"` 가 형제 스타일시트 대신
+`paths` 가 가리키는 파일로 갔다. `@import "./vars.css"` 는 형제로 가므로 **같은 URL 을 가리키는
+두 표기가 서로 다른 스타일시트**가 됐다 — 진단 0건.
+
+`@import` 레코드에 전용 kind(`css_import`)를 도입해 `url()` / `new URL()` 과 같은 URL 참조
+축으로 편입했다. JS 의 `import "normalize.css"` 는 종전대로 npm 패키지로 해석된다 — 예전엔
+둘이 같은 kind 라 규칙을 나눌 수 없었다.

--- a/docs/BUNDLER.md
+++ b/docs/BUNDLER.md
@@ -227,8 +227,10 @@ CSS 스펙상 `url()` 의 상대 참조는 **스타일시트 자신의 URL** 이
   모듈 지정자지 URL 상대 참조가 아니다 — 켠 채로 재진입하면 대상이 동명 형제에 가려진다.
 - `--fallback:K=V`(재작성 형태)는 **형제가 없을 때만** 걸린다. `--fallback` 이 "정상 해석 실패
   시" 계약이고 형제는 정상 해석이므로 일관된 동작이다. NODE_PATH 와 symlink-sibling 복구도 같다.
-- ⚠️ CSS `@import` 은 아직 이 순서가 아니다 — 레코드 kind 가 `.side_effect` 라 JS 의
-  `import 'normalize.css'` 와 구분되지 않아 kind 로 편입할 수 없다. #4611 에서 다룬다.
+- CSS `@import` 도 같은 순서다 (#4611). 전용 kind `.css_import` 를 써서 편입했다.
+  ⚠️ JS 의 `import 'normalize.css'`(`.side_effect`)는 **들어오면 안 된다** — 진짜 패키지
+  지정자라 앱 로컬 동명 파일에 가려지면 안 된다. 그래서 kind 를 나눴다. 나머지 동작(평가
+  순서·tree-shaking·external 그룹핑)은 `.side_effect` 와 같다.
 - `--packages=external` 의 "bare = npm 패키지" 자동 규칙은 `.css_url` 에 **그대로 적용된다**
   (#4485 알려진 한계, worker 는 #4483 이 제외). #4604 에서 빼 봤더니 의존성을 미해석 상태로
   두려는 라이브러리 빌드가 의존성 자산 **사본**을 dist 에 싣게 돼 되돌렸다.

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4179,6 +4179,60 @@ test "#4612 CSS url(): 파일 symlink 는 두 철자 모두 그대로 이긴다"
     }
 }
 
+/// #4611 — 같은 지정자를 CSS `@import` 와 JS `import` 로 각각 태워 **kind 로 갈리는지** 본다.
+/// 형제 파일과 동명 패키지를 **둘 다** 두는 게 핵심이다. 한쪽만 두면 어느 규칙이 이겼는지
+/// 구분이 안 돼 테스트가 공허해진다.
+fn bundleBareCssSpecifier(tmp: *std.testing.TmpDir, via_css_import: bool) ![]const u8 {
+    try writeFile(tmp.dir, "node_modules/normalize.css/package.json", "{\"name\":\"normalize.css\",\"main\":\"normalize.css\"}");
+    try writeFile(tmp.dir, "node_modules/normalize.css/normalize.css", "body{--src:FROM_PKG}");
+    try writeFile(tmp.dir, "src/normalize.css", "body{--src:APP_SIBLING}");
+
+    if (via_css_import) {
+        try writeFile(tmp.dir, "src/card.css", "@import \"normalize.css\";\n.a{color:red}");
+        try writeFile(tmp.dir, "src/main.ts", "import './card.css';");
+    } else {
+        try writeFile(tmp.dir, "src/main.ts", "import 'normalize.css';");
+    }
+
+    const entry = try absPath(tmp, "src/main.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .format = .esm });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const css = findCssOutput(result) orelse return error.ExpectedCssOutput;
+    return std.testing.allocator.dupe(u8, css);
+}
+
+test "#4611 CSS @import 의 bare 지정자는 형제 스타일시트로 간다" {
+    // `@import` 의 base 는 스타일시트 자신의 URL 이라 `url()` 과 같은 축이다.
+    // esbuild 실측 일치.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const css = try bundleBareCssSpecifier(&tmp, true);
+    defer std.testing.allocator.free(css);
+
+    try std.testing.expect(std.mem.indexOf(u8, css, "APP_SIBLING") != null);
+    try std.testing.expect(std.mem.indexOf(u8, css, "FROM_PKG") == null);
+}
+
+test "#4611 JS 의 bare CSS import 는 여전히 npm 패키지로 간다" {
+    // **kind 를 나눈 이유가 이것이다.** `.side_effect` 를 그대로 URL 축에 넣었으면
+    // `import 'normalize.css'` 가 앱 로컬 동명 파일에 가려졌을 것이다. esbuild 실측 일치.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const css = try bundleBareCssSpecifier(&tmp, false);
+    defer std.testing.allocator.free(css);
+
+    try std.testing.expect(std.mem.indexOf(u8, css, "FROM_PKG") != null);
+    try std.testing.expect(std.mem.indexOf(u8, css, "APP_SIBLING") == null);
+}
+
 test "#4604 CSS url(): catch-all tsconfig paths 가 bare url() 을 가로채지 않는다 (형제 있음)" {
     // 신고된 재현 그대로. `"paths": { "*": ["src/*"] }` 하에서 `url(assets/logo.png)` 가
     // paths 에 걸려 `src/assets/logo.png` 로, `url(./assets/logo.png)` 는 형제로 가서

--- a/src/bundler/graph/loaders.zig
+++ b/src/bundler/graph/loaders.zig
@@ -92,7 +92,10 @@ pub fn parseCssModule(self: *ModuleGraph, io: std.Io, module: *Module) void {
         for (raw_imports, 0..) |imp, i| {
             records[i] = .{
                 .specifier = imp.specifier,
-                .kind = .side_effect,
+                // CSS `@import` 전용 kind (#4611). JS 의 `import "normalize.css"` 와 같은
+                // `.side_effect` 를 쓰면 해석 규칙을 구분할 수 없다 — `@import` 의 base 는
+                // 스타일시트 자신의 URL 이라 `url()` 과 같은 URL 참조다.
+                .kind = .css_import,
                 .span = imp.span,
                 // External URL (`http:`/`https:`/`//`/`data:`) — resolver 가 skip
                 // 하고 emitter 가 출력 CSS 상단에 보존 (esbuild parity, #3321 P0-3).

--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -151,7 +151,7 @@ pub fn shouldLinkResolvedRecordForModule(self: anytype, mod_idx: usize, rec_i: u
     switch (record.kind) {
         // .css_url: asset 을 찾으려면 resolve 는 반드시 돌아야 한다. JS 의존성
         // 엣지를 만들지 않는 것은 recordResolvedDep 이 따로 처리 (#4466).
-        .side_effect, .require, .dynamic_import, .worker, .glob, .require_context, .css_url => return true,
+        .side_effect, .css_import, .require, .dynamic_import, .worker, .glob, .require_context, .css_url => return true,
         .static_import, .re_export => {},
     }
 
@@ -380,7 +380,7 @@ pub fn requestDependencyExports(
             defer s.end();
             return requestedExportsForReExportRecord(self, importer, rec_i, dep_idx);
         },
-        .side_effect, .require, .dynamic_import, .worker, .glob, .require_context => {
+        .side_effect, .css_import, .require, .dynamic_import, .worker, .glob, .require_context => {
             var s = profile.begin(.graph_discover_incr_req_simple);
             defer s.end();
             return requestAll(self, dep_idx);

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -1170,7 +1170,10 @@ pub fn urlRelativeFor(kind: ImportKind, specifier: []const u8) bool {
 /// 진짜 npm 패키지 이름이라 해당하지 않는다 (`import "react"` 가 형제로 가면 안 된다).
 fn isUrlRelativeKind(kind: ImportKind) bool {
     return switch (kind) {
-        .worker, .css_url => true,
+        // `.css_import` = CSS 의 `@import` (#4611). base 가 스타일시트 자신의 URL 이라
+        // `url()` 과 같은 축이다. JS 의 `import "normalize.css"`(`.side_effect`)는 진짜
+        // 패키지 지정자라 여기 들어오면 안 된다 — 그래서 kind 를 나눴다.
+        .worker, .css_url, .css_import => true,
         else => false,
     };
 }

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -300,11 +300,23 @@ pub const ImportKind = enum {
     /// `__commonJS` 래퍼로 번들에 실린다.
     css_url,
 
+    /// CSS 의 `@import "./base.css"` (#4611).
+    ///
+    /// JS 의 `import "./x.css"` / `import "normalize.css"` 와 **kind 를 나눈다.** 둘 다
+    /// 예전엔 `.side_effect` 였는데, 그러면 해석 규칙을 구분할 수 없다 — CSS `@import` 의
+    /// base 는 스타일시트 자신의 URL 이라 `url()` 과 같은 URL 참조인 반면, JS 의 bare
+    /// `import "normalize.css"` 는 진짜 npm 패키지 지정자다.
+    ///
+    /// 평가 순서·tree-shaking·external 그룹핑 등 **나머지 동작은 `.side_effect` 와 같다.**
+    /// 갈라지는 건 resolve 순서 하나뿐이다 (`isUrlRelativeKind`).
+    css_import,
+
     /// importer 본문보다 먼저 평가 효과가 발생해야 하는 정적 ESM 의존성 종류.
     /// `export { x } from`/`export * from`(re_export)도 source 모듈의 side effect 를
     /// eager 초기화해야 하므로 포함한다.
     pub fn isEagerEvalDependency(self: ImportKind) bool {
-        return self == .static_import or self == .side_effect or self == .re_export;
+        return self == .static_import or self == .side_effect or self == .re_export or
+            self == .css_import;
     }
 };
 


### PR DESCRIPTION
## 문제

catch-all `paths`(`"*": ["src/*"]`) 가 있으면 CSS `@import "vars.css"` 가 형제 스타일시트 대신
`paths` 가 가리키는 파일로 갔다. 진단 0건, exit 0 — 스타일시트가 잘못된 custom property·색을
조용히 받는다.

| 같은 파일 안 | 수정 전 | 수정 후 | esbuild |
|---|---|---|---|
| `@import "vars.css"` | **ROOT_VARS** ❌ | SIBLING_VARS | SIBLING_VARS |
| `@import "./vars.css"` | SIBLING_VARS | SIBLING_VARS | SIBLING_VARS |

#4604 가 `url()` / `new URL()` 에 대해 같은 증상을 고쳤는데, `@import` 는 바로 그 한 줄 아래에서
살아남았다. `@import` 의 base 도 스타일시트 자신의 URL 이라 의미론은 완전히 같다.

## 루트커즈

`@import` 레코드가 `.side_effect` kind 였다. 이건 JS 의 `import './x.css'` /
`import 'normalize.css'` 와 **같은 kind** 라 해석 규칙을 나눌 수 없었다. `.side_effect` 를
통째로 URL 축에 넣으면 `import 'normalize.css'` 같은 진짜 패키지 지정자가 앱 로컬 동명 파일에
가려진다.

## 수정

전용 kind `.css_import` 를 도입해 `isUrlRelativeKind` 에 편입했다. **갈라지는 건 resolve 순서
하나뿐**이고 평가 순서·tree-shaking·external 그룹핑은 `.side_effect` 와 같다
(`isEagerEvalDependency` 포함).

⚠️ 새 `ImportKind` 는 kind 로 분기하는 모든 지점을 훑어야 한다. exhaustive switch 는
**컴파일러가 전수로 잡아준다**(2곳 — 이게 이 작업의 안전망이다). 나머지 `.side_effect` 비교
12곳은 `@import` 가 종전과 같이 동작해야 하므로 그대로 뒀다.

## 검증 — kind 분리의 핵심 대조군

형제 파일과 동명 패키지를 **둘 다** 둔 픽스처에서 같은 지정자를 두 경로로 태웠다:

```
node_modules/normalize.css/normalize.css   body{--src:FROM_PKG}
src/normalize.css                          body{--src:APP_SIBLING}
```

| | 결과 | esbuild |
|---|---|---|
| `@import "normalize.css"` (CSS) | APP_SIBLING | APP_SIBLING |
| `import 'normalize.css'` (JS) | FROM_PKG | FROM_PKG |

⚠️ 한쪽만 두면 어느 규칙이 이겼는지 구분이 안 돼 **테스트가 공허해진다.**

**3방향 A/B 비공허 증명:**
1. `.css_import` 를 URL 축에서 빼면 → @import 테스트 실패
2. 로더를 다시 `.side_effect` 로 되돌리면 → 실패
3. **`.side_effect` 를 URL 축에 넣으면 → 3건 실패** (= kind 분리가 필수였음)

esbuild 3케이스 전부 일치. 유닛 **6302 통과**, 통합 **4448 pass** (실패 2건은 main baseline 과
동일한 기존 실패).

Closes #4611
Refs #4604

🤖 Generated with [Claude Code](https://claude.com/claude-code)