### PR TITLE
fix(linker): #4600 namespace 부분 멤버 집합이 binding_scanner union 을 덮어쓰던 문제

### DIFF
--- a/.changeset/ns-partial-member-union.md
+++ b/.changeset/ns-partial-member-union.md
@@ -1,0 +1,12 @@
+---
+"@zntc/core": patch
+---
+
+namespace 멤버 분석이 **부분** 집합을 반환할 때 `binding_scanner` union 을 덮어써 export 가
+누락될 수 있던 문제를 고쳤다 (#4600).
+
+기존 가드는 결과가 **정확히 비었을 때만** 이전 결과를 유지했다. symbol-aware 분석이 일부만
+잡으면 union 에만 있던 멤버가 tree-shake 돼 namespace getter 가 dangling 됐다 — `counter$4`
+계열 증상의 부분 케이스. 이제 두 결과를 합친다.
+
+번들 크기 영향은 실측 0 (합성 픽스처 전체 동일, axios·chalk·clsx `--minify` 각 +0 B).

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -3378,7 +3378,22 @@ pub const Linker = struct {
                 // 1차 결과 (non-empty) 를 덮어쓰면 → tree-shake namespace import seed 0회 →
                 // namespace getter dangling (effect-ts `counter$4 is not defined`).
                 // 따라서 empty result 면 binding_scanner 결과 유지.
-                const count = access.members.count();
+                // #4600: **부분** 집합이 union 을 덮어쓰지 않게 기존 결과와 합친다.
+                //
+                // `count == 0` 만 막던 예전 가드는 "전부 놓친 경우" 만 막았다. symbol-aware
+                // 분석이 일부만 잡으면(예: `["other"]` 인데 `"counter"` 누락) union 에만 있던
+                // 멤버의 export 가 tree-shake 돼 dangling 이 된다 — `counter$4` 와 같은 증상이
+                // 부분 케이스에서 재발한다.
+                var merged = std.StringArrayHashMapUnmanaged(void).empty;
+                defer merged.deinit(self.allocator);
+                {
+                    var mit = access.members.iterator();
+                    while (mit.next()) |e| merged.put(self.allocator, e.key_ptr.*, {}) catch {};
+                    if (ib.namespace_used_properties) |prev| {
+                        for (prev) |name| merged.put(self.allocator, name, {}) catch {};
+                    }
+                }
+                const count = merged.count();
                 if (count == 0) continue;
                 const props = arena.alloc([]const u8, count) catch continue;
                 const prop_stmts: ?[][]const u32 = if (stmt_spans_opt != null)
@@ -3387,11 +3402,14 @@ pub const Linker = struct {
                     null;
 
                 var prop_i: usize = 0;
-                var it = access.members.iterator();
+                var it = merged.iterator();
                 while (it.next()) |entry| : (prop_i += 1) {
                     props[prop_i] = entry.key_ptr.*;
                     if (prop_stmts) |ps| {
-                        const src = entry.value_ptr.items;
+                        // stmt span 은 symbol-aware 결과에만 있다. union 에서만 온 멤버는
+                        // span 이 없으므로 빈 슬라이스 — 소비자가 "이 멤버의 문장을 특정할 수
+                        // 없다" 로 보수적으로 처리한다.
+                        const src: []const u32 = if (access.members.get(entry.key_ptr.*)) |v| v.items else &.{};
                         const dst = arena.alloc(u32, src.len) catch continue;
                         @memcpy(dst, src);
                         ps[prop_i] = dst;


### PR DESCRIPTION
## 문제

`linker.zig` 의 `if (count == 0) continue;` 는 symbol-aware 분석 결과가 **정확히 비었을 때만**
이전 결과를 유지했다. 부분 집합(예: `["other"]` 인데 `"counter"` 누락)은 그대로 통과해
`binding_scanner`(parse) ∪ `transform_prepass`(post-transform) union 을 덮어썼고, union 에만
있던 멤버의 export 가 tree-shake 돼 namespace getter 가 dangling 됐다.

즉 `counter$4` 보호막(#3736 / effect-ts `counter$4 is not defined`)이 **"전부 놓친 경우" 만 막고
"일부만 놓친 경우" 는 막지 못했다.** 이제 두 결과를 합친다.

## ⚠️ 재현 케이스가 없고 회귀 테스트도 없다

부분-집합 상황을 만들려고 JSX 멤버 + 일반 멤버 혼용 등을 시도했지만 **재현하지 못했다**(모든
멤버 생존). 이슈 본문도 "실제 재현 케이스가 나올 때까지 보류" 를 선택지로 두고 있다.

그럼에도 넣는 근거는 두 가지다:

1. **안전 방향 단방향** — export 를 더 살릴 뿐 없애지 않으므로 이 변경이 dangling 을 만들 수
   없다. 유일한 리스크는 번들 크기다.
2. **그 크기가 0 으로 측정됐다.**

## size 실측 — 이슈가 요구한 측정

이슈가 "union 은 보수적이라 크기가 늘 수 있음, `--minify` size 회귀 측정 필요
(#3417/#3409 size lever 와 상호작용)" 이라고 적었다. 증가 없음:

| 대상 | before | after | 차이 |
|---|---:|---:|---:|
| tree-shake 합성 픽스처 전체 | — | — | **완전 동일**(diff) |
| axios `--minify` | 37,736 | 37,736 | **+0** |
| chalk `--minify` | 5,725 | 5,725 | **+0** |
| clsx `--minify` | 479 | 479 | **+0** |

## 구현 노트

stmt span 은 symbol-aware 결과에만 있으므로, union 에서만 온 멤버는 빈 슬라이스를 준다 —
소비자가 "이 멤버의 문장을 특정할 수 없다" 로 보수적으로 처리한다.

## 검증

유닛 **6307 통과**, 통합 **4448 pass** (실패 2건은 main baseline 동일).
재현이 없어 **A/B 비공허 증명은 하지 못했다** — 이 변경의 알려진 한계다.

Closes #4600

🤖 Generated with [Claude Code](https://claude.com/claude-code)