### PR TITLE
feat(bundler): #4616 external 지정자를 다른 이름으로 방출하는 매핑

### DIFF
--- a/.changeset/external-alias.md
+++ b/.changeset/external-alias.md
@@ -1,0 +1,17 @@
+---
+"@zntc/core": minor
+---
+
+`externalAlias` / `--external-alias:K=V` 추가 — external 로 남는 지정자를 **다른 이름으로 방출**한다 (#4616).
+
+rollup `output.paths` / webpack object-form `externals` 대응. `alias` 와 달리 **해석에는 관여하지
+않고** 이미 external 로 확정된 지정자를 출력에 쓸 때만 이름을 바꾼다.
+
+```bash
+zntc --bundle src/main.ts --external crypto --external-alias:crypto=crypto-browserify
+# → import { x } from "crypto-browserify"
+```
+
+브라우저용 shim 을 번들하지 않고 이름만 갈아끼울 때 쓴다. 종전에는 `--external:crypto` 가 원문
+`crypto` 를 방출해 브라우저가 해석에 실패했고, `--external:crypto-browserify` 는 external 판정이
+원문 기준이라 매칭되지 않고 그냥 번들됐다.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -367,6 +367,7 @@ Options:
   - **`./` 없는 bare 도 재작성** (#4485, 순서는 #4604) — CSS 스펙상 `url()` 의 base 는 스타일시트
     자신의 URL 이라 `url(logo.png)` 와 `url(./logo.png)` 는 같은 파일이다. 해석 순서는
     **`--alias` > 형제 파일 > tsconfig `paths` > node_modules 패키지** (esbuild 동일) —
+- `--external-alias:K=V` — external 지정자 `K` 를 `V` 라는 이름으로 **방출**한다 (rollup `output.paths` 대응). `--alias` 와 달리 해석에는 관여하지 않는다. JS API 는 `externalAlias: { K: 'V' }`.
     `url(logo.png)` 는 **정확히 그 이름의** 형제 파일이 있으면 그걸로 가고, 없으면 `paths` 매핑
     (`url(@/assets/logo.png)`) 이나 패키지 자산(`url(imgpkg/pic.png)`)으로 해석된다
     (확장자 추론으로는 형제가 이기지 않는다). CSS `@import` 는 아직 이 순서가 아니다 (#4611).

--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -239,6 +239,7 @@ export const FLAG_REGISTRY = [
   // ─── kind=key-value — `--key:K=V` → opts[target][K]=V ───
   { kind: 'key-value', flag: '--define', target: 'define' },
   { kind: 'key-value', flag: '--alias', target: 'alias' },
+  { kind: 'key-value', flag: '--external-alias', target: 'externalAlias' },
   // Fallback resolution — 해석 실패 시에만 적용 (webpack resolve.fallback /
   // Metro extraNodeModules 호환). `--fallback:crypto=crypto-browserify`.
   // 값 "false" → 빈-모듈 강제 + specifier 제약은 normalizeFallback 참조.

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -296,6 +296,7 @@ function parseArgs(argv) {
     packagesExternal: false,
     define: {},
     alias: {},
+    externalAlias: {},
     banner: undefined,
     footer: undefined,
     globalName: undefined,
@@ -1477,7 +1478,7 @@ function mergeConfigIntoOpts(opts, config) {
     }
   }
 
-  for (const key of ['define', 'alias', 'loader', 'globals', 'fallback']) {
+  for (const key of ['define', 'alias', 'externalAlias', 'loader', 'globals', 'fallback']) {
     if (config[key] && typeof config[key] === 'object') {
       opts[key] = { ...config[key], ...opts[key] };
     }
@@ -1561,6 +1562,9 @@ async function buildBundleOptions(opts, config, { filterCallerPreWarmCss = false
     packagesExternal: opts.packagesExternal,
     // `--alias:K=V` 플래그 (webpack/rollup 스타일) — JS 옵션이 tsconfig paths 보다 우선 적용됨.
     alias: Object.keys(opts.alias).length > 0 ? opts.alias : undefined,
+    // #4616 external 지정자를 다른 이름으로 방출 (rollup output.paths 대응).
+    externalAlias:
+      Object.keys(opts.externalAlias ?? {}).length > 0 ? opts.externalAlias : undefined,
     define: Object.keys(opts.define).length > 0 ? opts.define : undefined,
     loader: Object.keys(opts.loader).length > 0 ? opts.loader : undefined,
     minify: opts.minify,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1046,6 +1046,16 @@ interface BuildOptionsCommon {
    * `fallback` instead (applied only on failure). The array form is also
    * supported in buildSync(), which uses only sync hooks. */
   alias?: Record<string, string> | Array<{ find: string | RegExp; replacement: string }>;
+  /**
+   * external 로 남는 지정자를 **다른 이름으로 방출** (rollup `output.paths` /
+   * webpack object-form `externals` 대응).
+   *
+   * `alias` 와 달리 **해석에는 관여하지 않는다** — 이미 external 로 확정된 지정자를
+   * 출력에 쓸 때만 이름을 바꾼다. 브라우저용 shim 을 번들하지 않고 이름만 갈아끼울 때 쓴다.
+   *
+   * @example { crypto: 'crypto-browserify' }  // import ... from "crypto-browserify"
+   */
+  externalAlias?: Record<string, string>;
   /** alias 의 prefix matching 을 끄는 from 목록 — exact 매칭만 허용.
    *
    * `alias` object form 의 기본 동작은 esbuild 처럼 정확/접두사 둘 다 매칭이라

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -502,6 +502,19 @@ pub fn parseBuildOptions(
         }
     }
 
+    // externalAlias: { "crypto": "crypto-browserify" } → []AliasEntry (#4616).
+    // 해석에는 관여하지 않고 external 방출 시 지정자만 바꾼다 (rollup output.paths 대응).
+    const ext_alias_pairs = getObjectKeyValuePairs(env, opts_obj, "externalAlias", native_alloc);
+    var ext_alias_list: std.ArrayList(bundler_mod.types.AliasEntry) = .empty;
+    if (ext_alias_pairs) |pairs| {
+        defer native_alloc.free(pairs);
+        for (pairs) |pair| {
+            if (!trackStr(owned_strings, pair[0])) return null;
+            if (!trackStr(owned_strings, pair[1])) return null;
+            ext_alias_list.append(native_alloc, .{ .from = pair[0], .to = pair[1] }) catch return null;
+        }
+    }
+
     // fallback: { "crypto": "crypto-browserify", "fs": false } → []FallbackEntry
     // 값이 `false`면 빈 모듈, 문자열이면 해당 specifier로 재해석.
     const fallback_pairs = getObjectKeyValuePairsWithNullable(env, opts_obj, "fallback", native_alloc);
@@ -813,6 +826,7 @@ pub fn parseBuildOptions(
         .debug = debug_categories orelse &.{},
         .define = define_entries,
         .alias = alias_entries,
+        .external_alias = ext_alias_list.items,
         .ts_paths = ts_path_entries,
         .fallback = fallback_entries,
         .block_list = blk: {

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -512,6 +512,8 @@ pub fn parseBuildOptions(
         for (pairs) |pair| {
             if (!trackStr(owned_strings, pair[0])) return null;
             if (!trackStr(owned_strings, pair[1])) return null;
+            // #4616: 방출 문자열 리터럴에 그대로 들어가므로 검증 (빈 값·따옴표·백슬래시·개행).
+            if (!bundler_mod.types.isValidExternalAliasTarget(pair[1])) continue;
             ext_alias_list.append(native_alloc, .{ .from = pair[0], .to = pair[1] }) catch return null;
         }
     }

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -249,6 +249,7 @@ pub fn freeOptionsTypedSlices(opts: *const BundleOptions) void {
     if (opts.define.len > 0) native_alloc.free(opts.define);
     if (opts.module_specifier_map.len > 0) native_alloc.free(opts.module_specifier_map);
     if (opts.alias.len > 0) native_alloc.free(opts.alias);
+    if (opts.external_alias.len > 0) native_alloc.free(opts.external_alias);
     if (opts.ts_paths.len > 0) {
         for (opts.ts_paths) |entry| {
             if (entry.targets.len > 0) native_alloc.free(entry.targets);
@@ -671,6 +672,11 @@ pub fn parseBuildOptions(
     const jsx_import_source_eff = merged_tsconfig.jsx_import_source;
 
     const alias_entries: []const bundler_mod.types.AliasEntry = alias_list.toOwnedSlice(native_alloc) catch return null;
+    // #4616: `alias` 와 **같은 소유권 계약**을 쓴다 — `toOwnedSlice` 로 넘기고
+    // `freeOptionsTypedSlices` 가 해제한다. `.items` 를 그대로 넘기면 지역 ArrayList 의
+    // 버퍼가 아무도 해제하지 않아 빌드 호출마다 샌다.
+    const external_alias_entries: []const bundler_mod.types.AliasEntry =
+        ext_alias_list.toOwnedSlice(native_alloc) catch return null;
 
     // tsconfig paths → resolver 의 ts_paths 로 전달 (alias 와 독립 경로).
     // TS 스펙대로 wildcard anywhere + 다중 후보 순차 시도를 resolver 가 담당.
@@ -826,7 +832,7 @@ pub fn parseBuildOptions(
         .debug = debug_categories orelse &.{},
         .define = define_entries,
         .alias = alias_entries,
-        .external_alias = ext_alias_list.items,
+        .external_alias = external_alias_entries,
         .ts_paths = ts_path_entries,
         .fallback = fallback_entries,
         .block_list = blk: {

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -138,6 +138,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   // ─── 모듈 / Resolve ───
   'external',
   'alias',
+  'externalAlias',
   // alias 의 exact-match 변형 (프로그램틱/config 전용 — `--alias` 만 CLI 노출).
   'aliasExact',
   'define',

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -272,6 +272,10 @@ pub const BundleOptions = struct {
     disable_hierarchical_lookup: bool = false,
     /// import 경로 별칭 (--alias:K=V). resolve 시 specifier 앞부분을 치환.
     alias: []const types.AliasEntry = &.{},
+    /// external 지정자를 **다른 이름으로 방출** (--external-alias:K=V, #4616).
+    /// rollup `output.paths` / webpack object-form `externals` 대응. 해석은 건드리지 않고
+    /// emit 시점의 지정자만 바꾼다.
+    external_alias: []const types.AliasEntry = &.{},
     /// tsconfig `paths` (절대 경로로 정규화된 형태). `*` wildcard + 다중 후보 순차 시도.
     /// alias 보다 먼저 매칭되며, resolver 가 파일 존재 확인까지 수행.
     ts_paths: []const @import("../config.zig").TsConfig.PathEntry = &.{},
@@ -843,6 +847,7 @@ pub const Bundler = struct {
         return ResolveCache.init(allocator, .{
             .platform = options.platform,
             .external_patterns = options.external,
+            .external_alias = options.external_alias,
             .custom_conditions = options.conditions,
             .preserve_symlinks = options.preserve_symlinks,
             .resolve_symlink_siblings = options.resolve_symlink_siblings,

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4366,6 +4366,60 @@ test "#4607 isUnderNodeModules 는 세그먼트 단위로 본다" {
     try std.testing.expect(f("/a/xnode_modules/node_modules/pkg"));
 }
 
+fn bundleExternalAlias(tmp: *std.testing.TmpDir, with_alias: bool, fmt: @import("../emitter.zig").EmitOptions.Format) ![]const u8 {
+    try writeFile(tmp.dir, "src/main.ts", "import { x } from 'crypto';\nconsole.log(x);");
+    const entry = try absPath(tmp, "src/main.ts");
+    defer std.testing.allocator.free(entry);
+
+    const ext = [_][]const u8{"crypto"};
+    const ext_alias = [_]@import("../types.zig").AliasEntry{.{ .from = "crypto", .to = "crypto-browserify" }};
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = fmt,
+        .external = &ext,
+        .external_alias = if (with_alias) &ext_alias else &.{},
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    return std.testing.allocator.dupe(u8, result.output);
+}
+
+test "#4616 --external-alias 가 external 지정자를 다른 이름으로 방출한다 (esm)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const js = try bundleExternalAlias(&tmp, true, .esm);
+    defer std.testing.allocator.free(js);
+
+    try std.testing.expect(std.mem.indexOf(u8, js, "\"crypto-browserify\"") != null);
+    // 원문이 남으면 브라우저에서 Node 빌트인을 로드하려 해 실패한다.
+    try std.testing.expect(std.mem.indexOf(u8, js, "from \"crypto\"") == null);
+}
+
+test "#4616 --external-alias 없으면 원문 그대로 (대조군)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const js = try bundleExternalAlias(&tmp, false, .esm);
+    defer std.testing.allocator.free(js);
+
+    try std.testing.expect(std.mem.indexOf(u8, js, "crypto-browserify") == null);
+    try std.testing.expect(std.mem.indexOf(u8, js, "crypto") != null);
+}
+
+test "#4616 --external-alias 가 cjs require 방출에도 적용된다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const js = try bundleExternalAlias(&tmp, true, .cjs);
+    defer std.testing.allocator.free(js);
+
+    try std.testing.expect(std.mem.indexOf(u8, js, "crypto-browserify") != null);
+}
+
 test "#4604 CSS url(): catch-all tsconfig paths 가 bare url() 을 가로채지 않는다 (형제 있음)" {
     // 신고된 재현 그대로. `"paths": { "*": ["src/*"] }` 하에서 `url(assets/logo.png)` 가
     // paths 에 걸려 `src/assets/logo.png` 로, `url(./assets/logo.png)` 는 형제로 가서

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4410,6 +4410,48 @@ test "#4616 --external-alias 없으면 원문 그대로 (대조군)" {
     try std.testing.expect(std.mem.indexOf(u8, js, "crypto") != null);
 }
 
+test "#4616 동적 import 도 같은 이름으로 방출된다" {
+    // ⚠️ external 은 `resolved == .none` 이라 동적 import 재작성 루프가 통째로 건너뛴다.
+    // 안 고치면 정적은 새 이름·동적은 옛 이름이 나가 **한 번들에 두 철자가 섞인다**.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "src/main.ts", "import { x } from 'crypto';\nconst d = await import('crypto');\nconsole.log(x, d);");
+    const entry = try absPath(&tmp, "src/main.ts");
+    defer std.testing.allocator.free(entry);
+
+    const ext = [_][]const u8{"crypto"};
+    const ext_alias = [_]@import("../types.zig").AliasEntry{.{ .from = "crypto", .to = "crypto-browserify" }};
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .external = &ext,
+        .external_alias = &ext_alias,
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "import(\"crypto-browserify\")") != null);
+    // 옛 철자가 어디에도 남으면 안 된다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "import(\"crypto\")") == null);
+}
+
+test "#4616 대체 지정자 검증 — 빈 값·따옴표·백슬래시 거부" {
+    // 이 값은 방출되는 문자열 리터럴 **안에 그대로** 들어간다. 검증 없으면 번들이
+    // SyntaxError 가 되거나(따옴표) 엉뚱한 모듈을 요청한다(백슬래시 escape).
+    const f = @import("../types.zig").isValidExternalAliasTarget;
+    try std.testing.expect(f("crypto-browserify"));
+    try std.testing.expect(f("./shims/crypto.js"));
+    try std.testing.expect(f("@scope/pkg"));
+    try std.testing.expect(!f(""));
+    try std.testing.expect(!f("a\"b"));
+    try std.testing.expect(!f("crypto\\shim"));
+    try std.testing.expect(!f("a\nb"));
+}
+
 test "#4616 --globals 는 원문 지정자 기준 (external-alias 와 축이 다르다)" {
     // ⚠️ rolldown 실측: `output.paths` 로 방출 이름을 바꿔도 `output.globals` 키는 **원래 id** 다.
     // 방출 이름으로 조회하면 `--external-alias` 와 `--globals` 를 같이 쓴 사용자가 매칭에

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4410,6 +4410,38 @@ test "#4616 --external-alias 없으면 원문 그대로 (대조군)" {
     try std.testing.expect(std.mem.indexOf(u8, js, "crypto") != null);
 }
 
+test "#4616 --globals 는 원문 지정자 기준 (external-alias 와 축이 다르다)" {
+    // ⚠️ rolldown 실측: `output.paths` 로 방출 이름을 바꿔도 `output.globals` 키는 **원래 id** 다.
+    // 방출 이름으로 조회하면 `--external-alias` 와 `--globals` 를 같이 쓴 사용자가 매칭에
+    // 실패해 external 이 IIFE 에서 통째로 빠진다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "src/main.ts", "import { x } from 'crypto';\nconsole.log(x);");
+    const entry = try absPath(&tmp, "src/main.ts");
+    defer std.testing.allocator.free(entry);
+
+    const ext = [_][]const u8{"crypto"};
+    const ext_alias = [_]@import("../types.zig").AliasEntry{.{ .from = "crypto", .to = "crypto-browserify" }};
+    const globals = [_]@import("../types.zig").GlobalEntry{.{ .specifier = "crypto", .global_name = "CryptoGlobal" }};
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .iife,
+        .global_name = "App",
+        .external = &ext,
+        .external_alias = &ext_alias,
+        .globals = &globals,
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    // 원문 키로 매칭돼 전역이 주입돼야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CryptoGlobal") != null);
+}
+
 test "#4616 --external-alias 가 cjs require 방출에도 적용된다" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -291,7 +291,10 @@ const ExternalImportCollector = struct {
             if (rec.kind == .css_url) continue;
             if (!rec.is_external) continue;
             if (rec.specifier.len == 0) continue;
-            const composite_key = try std.fmt.allocPrint(allocator, "{s}\x00{s}", .{ rec.specifier, rec.css_condition_tail });
+            // #4616: 방출·dedupe 모두 대체 지정자 기준. 원문만 쓰면 JS 쪽은 새 이름,
+            // CSS 쪽은 옛 이름이 나가 한 빌드에서 두 철자가 섞인다.
+            const emit_spec = rec.externalName();
+            const composite_key = try std.fmt.allocPrint(allocator, "{s}\x00{s}", .{ emit_spec, rec.css_condition_tail });
             errdefer allocator.free(composite_key);
             const gop = try self.seen.getOrPut(allocator, composite_key);
             if (gop.found_existing) {
@@ -300,7 +303,7 @@ const ExternalImportCollector = struct {
             }
             // append 실패하면 errdefer 가 key 회수 + getOrPut 한 entry 도 제거.
             self.list.append(allocator, .{
-                .specifier = rec.specifier,
+                .specifier = emit_spec, // #4616
                 .condition_tail = rec.css_condition_tail,
             }) catch |e| {
                 _ = self.seen.remove(composite_key);

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -485,20 +485,21 @@ pub fn emitWithTreeShaking(
         defer seen.deinit(allocator);
         for (sorted.items) |m| {
             for (m.import_records) |rec| {
-                if (!rec.is_external or seen.contains(rec.specifier)) continue;
+                const ext_name = rec.externalName(); // #4616
+                if (!rec.is_external or seen.contains(ext_name)) continue;
                 // worker / css_url 은 import 가 아니라 **URL 문자열**이다. external 로
                 // 분류돼도 UMD/AMD 의존성 배열에 넣으면 AMD 로더가 그 URL 을 메인 번들의
                 // 모듈 의존성으로 fetch·실행하려 들어 페이지가 부팅에 실패한다 (#4483).
                 if (rec.kind == .worker or rec.kind == .css_url) continue;
-                const mapped = types.GlobalEntry.lookup(options.globals, rec.specifier);
+                const mapped = types.GlobalEntry.lookup(options.globals, ext_name);
                 if (requires_globals_mapping and mapped == null) continue;
                 const param = if (mapped) |gname|
                     try allocator.dupe(u8, gname)
                 else
-                    try types.specifierToParamName(allocator, rec.specifier);
+                    try types.specifierToParamName(allocator, ext_name);
                 errdefer allocator.free(param);
-                try seen.put(allocator, rec.specifier, {});
-                try ext_specifiers.append(allocator, rec.specifier);
+                try seen.put(allocator, ext_name, {});
+                try ext_specifiers.append(allocator, ext_name);
                 try ext_param_names_buf.append(allocator, param);
             }
         }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -491,7 +491,10 @@ pub fn emitWithTreeShaking(
                 // 분류돼도 UMD/AMD 의존성 배열에 넣으면 AMD 로더가 그 URL 을 메인 번들의
                 // 모듈 의존성으로 fetch·실행하려 들어 페이지가 부팅에 실패한다 (#4483).
                 if (rec.kind == .worker or rec.kind == .css_url) continue;
-                const mapped = types.GlobalEntry.lookup(options.globals, ext_name);
+                // ⚠️ `--globals` 는 **원문 지정자** 기준이다 (rolldown 실측: `paths` 로 이름을
+                // 바꿔도 `globals` 키는 원래 id). 방출 이름으로 조회하면 `--external-alias` 와
+                // `--globals` 를 같이 쓴 사용자가 매칭에 실패해 external 이 통째로 빠진다.
+                const mapped = types.GlobalEntry.lookup(options.globals, rec.specifier);
                 if (requires_globals_mapping and mapped == null) continue;
                 const param = if (mapped) |gname|
                     try allocator.dupe(u8, gname)

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -2611,6 +2611,12 @@ fn rewriteDynamicImports(
     // 리라이트할 레코드가 있는지 먼저 확인 (불필요한 할당 방지)
     var has_dynamic = false;
     for (module.import_records) |rec| {
+        // #4616: external 동적 import 는 `resolved == .none` 이라 아래 판정에 안 걸린다.
+        // `--external-alias` 대상이면 지정자를 바꿔야 하므로 여기서도 켠다.
+        if (rec.kind == .dynamic_import and rec.resolved == .none and rec.external_specifier != null) {
+            has_dynamic = true;
+            break;
+        }
         if (rec.kind == .dynamic_import and rec.resolved != .none) {
             const target_chunk = chunk_graph.getModuleChunk(rec.resolved);
             if (target_chunk != .none) {
@@ -2633,7 +2639,18 @@ fn rewriteDynamicImports(
 
     for (module.import_records) |rec| {
         if (rec.kind != .dynamic_import) continue;
-        if (rec.resolved == .none) continue;
+        if (rec.resolved == .none) {
+            // external: 청크가 없으므로 호출 전체를 바꾸지 않고 **지정자 문자열만** 바꾼다.
+            // 안 하면 정적 import 는 새 이름, 동적 import 는 옛 이름이 나가 한 번들에 두
+            // 철자가 섞인다 (#4616).
+            if (rec.external_specifier) |ext_name| {
+                if (try rewriteImportCallSpecifier(allocator, result, rec.specifier, ext_name)) |nr| {
+                    allocator.free(result);
+                    result = nr;
+                }
+            }
+            continue;
+        }
 
         const target_chunk_idx = chunk_graph.getModuleChunk(rec.resolved);
         if (target_chunk_idx == .none) continue;
@@ -2899,7 +2916,9 @@ pub fn rewriteDynamicImportsSingleFile(
 
     var has_dynamic = false;
     for (module.import_records) |rec| {
-        if (rec.kind == .dynamic_import and (rec.resolved != .none or lower_unresolved_dynamic_imports)) {
+        if (rec.kind != .dynamic_import) continue;
+        // #4616: external alias 대상도 켠다 — `resolved == .none` 이라 아래 조건에 안 걸린다.
+        if (rec.resolved != .none or lower_unresolved_dynamic_imports or rec.external_specifier != null) {
             has_dynamic = true;
             break;
         }
@@ -2912,6 +2931,14 @@ pub fn rewriteDynamicImportsSingleFile(
     for (module.import_records) |rec| {
         if (rec.kind != .dynamic_import) continue;
         if (rec.resolved == .none) {
+            // #4616: external alias — 호출 전체가 아니라 지정자 문자열만 바꾼다.
+            if (rec.external_specifier) |ext_name| {
+                if (try rewriteImportCallSpecifier(allocator, result, rec.specifier, ext_name)) |nr| {
+                    allocator.free(result);
+                    result = nr;
+                }
+                continue;
+            }
             if (!lower_unresolved_dynamic_imports) continue;
 
             // RN 릴리즈 번들은 Hermes가 전체 파일을 먼저 파싱한다. 실제로 실행되지
@@ -3170,6 +3197,44 @@ fn rewriteImportCallToWrapper(
     const spec_pos = std.mem.indexOf(u8, code, specifier) orelse return null;
     const span = importCallSpanAt(code, spec_pos, specifier.len) orelse return null;
     return try std.mem.concat(allocator, u8, &.{ code[0..span.call_start], replacement, code[span.call_end..] });
+}
+
+/// `import("K")` 의 **지정자 문자열만** `V` 로 바꾼다 (#4616 external alias).
+///
+/// `rewriteImportCallToWrapper` 와 달리 호출 전체를 치환하지 않는다 — external 은 청크가 없어
+/// 바꿀 표현식이 없고 지정자만 갈아끼우면 된다.
+///
+/// ⚠️ 모든 등장을 훑되 **치환 결과 뒤에서 이어 찾는다.** 새 이름이 옛 이름을 부분 문자열로
+/// 포함하면(`crypto` → `crypto-browserify`) 방금 쓴 자리를 다시 찾아 무한 반복이 된다.
+fn rewriteImportCallSpecifier(
+    allocator: std.mem.Allocator,
+    code: []const u8,
+    specifier: []const u8,
+    new_spec: []const u8,
+) !?[]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var scan: usize = 0;
+    var hit = false;
+    while (scan < code.len) {
+        const rel = std.mem.indexOf(u8, code[scan..], specifier) orelse break;
+        const pos = scan + rel;
+        if (importSpecifierCloseAt(code, pos, specifier.len) != null) {
+            try out.appendSlice(allocator, code[scan..pos]);
+            try out.appendSlice(allocator, new_spec);
+            scan = pos + specifier.len;
+            hit = true;
+        } else {
+            try out.appendSlice(allocator, code[scan .. pos + specifier.len]);
+            scan = pos + specifier.len;
+        }
+    }
+    if (!hit) {
+        out.deinit(allocator);
+        return null;
+    }
+    try out.appendSlice(allocator, code[scan..]);
+    return try out.toOwnedSlice(allocator);
 }
 
 const ImportCallSpan = struct { call_start: usize, call_end: usize };

--- a/src/bundler/emitter/external_imports.zig
+++ b/src/bundler/emitter/external_imports.zig
@@ -99,7 +99,8 @@ pub fn emitChunkExternalImports(
             else
                 m.importBindingLocalName(ib);
 
-            const gop = try per_spec.getOrPut(allocator, rec.specifier);
+            // #4616: 그룹핑·방출 모두 대체 지정자 기준 (없으면 원문).
+            const gop = try per_spec.getOrPut(allocator, rec.externalName());
             if (!gop.found_existing) gop.value_ptr.* = .{};
             try addBinding(gop.value_ptr, allocator, ib.kind, ib.imported_name, local_name);
         }
@@ -108,7 +109,8 @@ pub fn emitChunkExternalImports(
         for (m.import_records) |rec| {
             if (!rec.is_external) continue;
             if (rec.kind != .side_effect) continue;
-            const gop = try per_spec.getOrPut(allocator, rec.specifier);
+            // #4616: 그룹핑·방출 모두 대체 지정자 기준 (없으면 원문).
+            const gop = try per_spec.getOrPut(allocator, rec.externalName());
             if (!gop.found_existing) {
                 gop.value_ptr.* = .{ .side_effect_only = true };
             }

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -104,6 +104,8 @@ pub fn replayCachedResolvedDeps(self: *ModuleGraph, io: std.Io, mod_idx: usize) 
                 if (dep.record_index) |rec_idx| {
                     if (rec_idx < mod_ptr.import_records.len) {
                         mod_ptr.import_records[rec_idx].is_external = true;
+                        mod_ptr.import_records[rec_idx].external_specifier =
+                            self.resolve_cache.externalAliasFor(mod_ptr.import_records[rec_idx].specifier);
                         var s_re = profile.begin(.graph_discover_incr_replay_request_exports);
                         _ = try graph_requested_exports.requestDependencyExports(self, mod_idx, rec_idx, mod_ptr.import_records[rec_idx], ext_idx);
                         s_re.end();
@@ -537,6 +539,10 @@ pub fn applyResolveResult(
         const src_mod = self.modules.at(mod_idx);
         src_mod.import_records[rec_i].is_external = true;
         src_mod.import_records[rec_i].is_lazy_resolved = false;
+        // #4616: 방출 지정자만 바꾼다. 원문 `specifier` 와 그래프 identity 는 그대로 —
+        // 원문은 worker_map 키·CSS span 조회 키라 고치면 lookup 이 어긋난다.
+        src_mod.import_records[rec_i].external_specifier =
+            self.resolve_cache.externalAliasFor(record.specifier);
         _ = try graph_requested_exports.requestDependencyExports(self, mod_idx, rec_i, record, ext_idx);
         try appendResolvedDep(self, mod_idx, .{
             .record_index = @intCast(rec_i),

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -105,7 +105,8 @@ inline fn mappedExternalParam(
     allocator: std.mem.Allocator,
 ) std.mem.Allocator.Error!?[]const u8 {
     if (!rec.is_external) return null;
-    const mapped = types.GlobalEntry.lookup(globals, rec.externalName()); // #4616
+    // `--globals` 는 원문 지정자 기준 (rolldown 실측) — #4616 방출 이름과 축이 다르다.
+    const mapped = types.GlobalEntry.lookup(globals, rec.specifier);
     switch (format) {
         .iife => {
             const gname = mapped orelse return null;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -1532,6 +1532,13 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module, format: types
                     const owned = try std.fmt.allocPrint(self.allocator, "({s})", .{param});
                     try require_rewrites.put(self.allocator, rec.specifier, owned);
                 }
+            } else if (rec.external_specifier) |ext_name| {
+                // #4616: 소스의 `require('K')` 를 `require("V")` 로. 위 분기(UMD/AMD/IIFE
+                // 매개변수 주입)가 안 걸리는 cjs/esm 출력에서 alias 가 통째로 누락됐다.
+                if (!require_rewrites.contains(rec.specifier)) {
+                    const owned = try std.fmt.allocPrint(self.allocator, "require(\"{s}\")", .{ext_name});
+                    try require_rewrites.put(self.allocator, rec.specifier, owned);
+                }
             }
             continue;
         }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -105,7 +105,7 @@ inline fn mappedExternalParam(
     allocator: std.mem.Allocator,
 ) std.mem.Allocator.Error!?[]const u8 {
     if (!rec.is_external) return null;
-    const mapped = types.GlobalEntry.lookup(globals, rec.specifier);
+    const mapped = types.GlobalEntry.lookup(globals, rec.externalName()); // #4616
     switch (format) {
         .iife => {
             const gname = mapped orelse return null;
@@ -113,7 +113,7 @@ inline fn mappedExternalParam(
         },
         .umd, .amd => {
             if (mapped) |gname| return try allocator.dupe(u8, gname);
-            return try types.specifierToParamName(allocator, rec.specifier);
+            return try types.specifierToParamName(allocator, rec.externalName()); // #4616
         },
         else => return null,
     }
@@ -727,9 +727,9 @@ pub fn buildMetadataForAst(
                     } else {
                         // CJS / ESM-wrapped + helper / 그 외: require() preamble 생성.
                         if (is_helper_esm) {
-                            try preamble.writeUnresolvedRequireAssignOnly(preamble_name, rec.specifier, ib.imported_name, ib.kind == .namespace);
+                            try preamble.writeUnresolvedRequireAssignOnly(preamble_name, rec.externalName(), ib.imported_name, ib.kind == .namespace);
                         } else {
-                            try preamble.writeUnresolvedRequire(preamble_name, rec.specifier, ib.imported_name, ib.kind == .namespace);
+                            try preamble.writeUnresolvedRequire(preamble_name, rec.externalName(), ib.imported_name, ib.kind == .namespace);
                         }
                     }
                 }

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -172,6 +172,8 @@ pub const ResolveCache = struct {
     dataurl_arena: std.heap.ArenaAllocator,
     dataurl_arena_mutex: spin.SpinLock = .{},
     external_patterns: []const []const u8,
+    /// external 방출 시 지정자를 바꾸는 매핑 (#4616). 해석에는 관여하지 않는다.
+    external_alias: []const resolver_mod.AliasEntry = &.{},
     platform: Platform,
     packages_external: bool = false,
 
@@ -321,6 +323,7 @@ pub const ResolveCache = struct {
     pub const InitOptions = struct {
         platform: Platform = .browser,
         external_patterns: []const []const u8 = &.{},
+        external_alias: []const resolver_mod.AliasEntry = &.{},
         custom_conditions: []const []const u8 = &.{},
         preserve_symlinks: bool = false,
         /// 일반 node_modules 탐색 실패 시 source_dir 의 realpath 디렉토리로 한 번 더 탐색.
@@ -386,6 +389,7 @@ pub const ResolveCache = struct {
             .path_pool = PathInternPool.init(allocator),
             .dataurl_arena = std.heap.ArenaAllocator.init(allocator),
             .external_patterns = external_patterns,
+            .external_alias = options.external_alias,
             .platform = platform,
             .packages_external = options.packages_external,
             .dir_cache = resolver_mod.DirEntryCache.init(allocator),
@@ -1074,6 +1078,18 @@ pub const ResolveCache = struct {
     }
 
     /// `kind` 를 모르는 호출자용 (기존 API 유지 — 테스트/도구).
+    /// external 로 방출할 때 쓸 대체 지정자 (#4616). 없으면 null.
+    ///
+    /// ⚠️ **정확 일치만** 본다. `--alias` 는 prefix 치환이지만 이건 rollup `output.paths` /
+    /// webpack object-form `externals` 대응이라 키가 지정자 전체다. prefix 로 하면
+    /// `react` 매핑이 `react-dom` 까지 잡는다.
+    pub fn externalAliasFor(self: *const ResolveCache, specifier: []const u8) ?[]const u8 {
+        for (self.external_alias) |e| {
+            if (std.mem.eql(u8, specifier, e.from)) return e.to;
+        }
+        return null;
+    }
+
     pub fn isExternal(self: *const ResolveCache, specifier: []const u8) bool {
         return self.isExternalForKind(specifier, .static_import);
     }

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -131,6 +131,23 @@ pub const ModuleIndex = enum(u32) {
 /// `exact = true` 인 entry 는 prefix 매칭을 건너뛴다 — `from` 과 specifier 가 완전
 /// 일치할 때만 적용. `to` 가 디렉토리가 아닌 단일 파일인 경우 prefix 매칭이
 /// `from/subpath` → `file.js/subpath` (디렉토리 취급) 으로 깨지므로 명시적 opt-in.
+/// `--external-alias` 의 **대체 지정자** 가 방출 가능한 값인지 (#4616).
+///
+/// 이 값은 `import ... from "<여기>"` / `require("<여기>")` 의 **큰따옴표 문자열 안에 그대로**
+/// 들어간다. 원문 `specifier` 는 파서가 이미 받아들인 리터럴에서 왔지만 이건 사용자가 옵션에
+/// 직접 쓴 문자열이라, 검증하지 않으면 산출물이 파싱 불가가 되거나 엉뚱한 모듈을 요청한다:
+/// - 빈 값 → `import ... from ""` (런타임 `Invalid module specifier`)
+/// - `"` 포함 → 문자열 리터럴이 조기 종료돼 **번들 전체가 SyntaxError**
+/// - `\` 포함 → `\s` 같은 escape 로 조용히 먹혀 다른 경로를 요청
+/// - 개행 → 리터럴 안에서 불법
+pub fn isValidExternalAliasTarget(v: []const u8) bool {
+    if (v.len == 0) return false;
+    for (v) |c| {
+        if (c == '"' or c == '\\' or c == '\n' or c == '\r') return false;
+    }
+    return true;
+}
+
 pub const AliasEntry = struct {
     from: []const u8,
     to: []const u8,

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -740,6 +740,11 @@ pub const LoaderOverride = struct {
 /// AST에서 추출한 단일 import/export 정보.
 /// import_scanner가 AST 순회로 수집하고, 모듈 그래프가 resolve에 사용.
 pub const ImportRecord = struct {
+    /// external emit 에 쓸 지정자 — `--external-alias` 대상이면 그 이름, 아니면 원문 (#4616).
+    pub fn externalName(self: *const @This()) []const u8 {
+        return self.external_specifier orelse self.specifier;
+    }
+
     /// 원본 import 경로 (예: "./foo", "react", "../utils")
     specifier: []const u8,
     /// import 종류
@@ -756,6 +761,15 @@ pub const ImportRecord = struct {
     is_lazy_resolved: bool = false,
     /// --external로 명시적으로 제외된 모듈 (resolve 실패와 구분)
     is_external: bool = false,
+    /// external 로 방출할 때 쓸 **대체 지정자** (`--external-alias:K=V`, #4616).
+    ///
+    /// rollup `output.paths` / webpack object-form `externals` 대응. null 이면 원문을 쓴다.
+    ///
+    /// ⚠️ 원문 `specifier` 를 덮어쓰지 않고 **별도 필드**로 둔다. 원문은 worker_map 키와
+    /// CSS span 치환의 조회 키라, 고치면 lookup 이 어긋나 원문이 그대로 방출된다(= 404).
+    /// #4604 1차 시도가 정확히 이걸로 깨졌다. 그래프 identity 도 원문 기준을 유지한다
+    /// (rollup 도 `output.paths` 는 emit 만 바꾸고 module id 는 그대로다).
+    external_specifier: ?[]const u8 = null,
     /// resolve 가 hard-error 로 확정 실패한 record. 성공(resolved 설정)·external·
     /// lazy 와 마찬가지로 "재resolve 불필요" 상태 마커. 이게 없으면
     /// shouldResolveRecordForModule / resolveModuleImports 가 resolved==.none 만 보고

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -384,6 +384,12 @@ fn applyZntcConfigJson(opts: *CliOptions, io: std.Io, allocator: std.mem.Allocat
             .to = try allocator.dupe(u8, a.to),
         });
     };
+    if (dto.externalAlias) |list| for (list) |a| {
+        try opts.external_alias_list.append(allocator, .{
+            .from = try allocator.dupe(u8, a.from),
+            .to = try allocator.dupe(u8, a.to),
+        });
+    };
     if (dto.define) |list| for (list) |d| {
         try opts.define_list.append(allocator, .{
             .key = try allocator.dupe(u8, d.key),
@@ -920,9 +926,17 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator,
             // **방출할 때만** 다른 이름으로 쓴다.
             const kv = arg["--external-alias:".len..];
             if (std.mem.indexOf(u8, kv, "=")) |eq_pos| {
+                const to = kv[eq_pos + 1 ..];
+                if (!lib.bundler.types.isValidExternalAliasTarget(to)) {
+                    try stderr.print(
+                        "zntc: --external-alias target must be a non-empty specifier without quotes/backslashes: {s}\n",
+                        .{arg},
+                    );
+                    std.process.exit(1);
+                }
                 try opts.external_alias_list.append(allocator, .{
                     .from = kv[0..eq_pos],
-                    .to = kv[eq_pos + 1 ..],
+                    .to = to,
                 });
             } else {
                 try stderr.print("zntc: --external-alias requires FROM=TO format: {s}\n", .{arg});

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -108,6 +108,7 @@ pub const CliOptions = struct {
     /// Metro `resolver.disableHierarchicalLookup` 호환 — parent dir walk-up 차단.
     disable_hierarchical_lookup: bool = false,
     alias_list: std.ArrayList(AliasEntry) = .empty,
+    external_alias_list: std.ArrayList(AliasEntry) = .empty,
     /// --fallback:NAME=PATH (webpack resolve.fallback). 일반 해석 실패 시에만 적용.
     /// PATH 대신 "false"로 쓰면 빈 모듈로 대체.
     fallback_list: std.ArrayList(FallbackEntry) = .empty,
@@ -290,6 +291,7 @@ pub const CliOptions = struct {
         self.define_list.deinit(alloc);
         self.conditions_list.deinit(alloc);
         self.alias_list.deinit(alloc);
+        self.external_alias_list.deinit(alloc);
         self.fallback_list.deinit(alloc);
         self.manual_chunks_list.deinit(alloc);
         self.block_list.deinit(alloc);
@@ -911,6 +913,21 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator,
                 try stderr.print("zntc: --alias requires FROM=TO format: {s}\n", .{arg});
                 std.process.exit(1);
             }
+        } else if (std.mem.startsWith(u8, arg, "--external-alias:")) {
+            // --external-alias:crypto=crypto-browserify (#4616)
+            // rollup `output.paths` / webpack object-form `externals` 대응.
+            // ⚠️ `--alias` 와 달리 해석은 건드리지 않는다 — external 로 확정된 지정자를
+            // **방출할 때만** 다른 이름으로 쓴다.
+            const kv = arg["--external-alias:".len..];
+            if (std.mem.indexOf(u8, kv, "=")) |eq_pos| {
+                try opts.external_alias_list.append(allocator, .{
+                    .from = kv[0..eq_pos],
+                    .to = kv[eq_pos + 1 ..],
+                });
+            } else {
+                try stderr.print("zntc: --external-alias requires FROM=TO format: {s}\n", .{arg});
+                std.process.exit(1);
+            }
         } else if (std.mem.startsWith(u8, arg, "--block-list=")) {
             try opts.block_list.append(allocator, arg["--block-list=".len..]);
         } else if (std.mem.startsWith(u8, arg, "--fallback:")) {
@@ -1185,6 +1202,7 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator,
     // 객체 옵션: 키 기준 last-wins — config(앞) 항목을 동일 키의 CLI(뒤) 항목이 override.
     dedupKeepLast(&opts.define_list, "key");
     dedupKeepLast(&opts.alias_list, "from");
+    dedupKeepLast(&opts.external_alias_list, "from");
     dedupKeepLast(&opts.loader_list, "ext");
 
     return opts;

--- a/src/cli/usage.zig
+++ b/src/cli/usage.zig
@@ -80,6 +80,7 @@ pub fn printUsage(writer: anytype) !void {
         \\  --globals=SPEC=GLOBAL[,...]      Same, comma-separated form
         \\  --global-name=<name>             IIFE/UMD container global identifier
         \\  --alias:K=V                      Force-rewrite import specifier K → V (resolve전)
+        \\  --external-alias:K=V             Emit external K as V (rollup output.paths)
         \\  --fallback:K=V                   Map K → V only when normal resolve fails (`=false` → empty)
         \\                                   For both: V is a package name or absolute path. A relative
         \\                                   V resolves against the *importing file*, so prefer absolute.

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -41,6 +41,7 @@ const bundler_only_fields = [_][]const u8{
     "external",
     "alias",
     "aliasExact",
+    "externalAlias",
     "loader",
     "conditions",
     "resolveExtensions",

--- a/src/main.zig
+++ b/src/main.zig
@@ -754,6 +754,7 @@ pub fn main(init: std.process.Init) !void {
             .resolve_symlink_siblings = opts.resolve_symlink_siblings,
             .disable_hierarchical_lookup = opts.disable_hierarchical_lookup,
             .alias = opts.alias_list.items,
+            .external_alias = opts.external_alias_list.items,
             .ts_paths = resolved_paths.entries,
             .fallback = opts.fallback_list.items,
             .manual_chunks = opts.manual_chunks_list.items,

--- a/src/transpile/options.zig
+++ b/src/transpile/options.zig
@@ -151,6 +151,8 @@ pub const ConfigOptionsDto = struct {
     // JSON 에서는 record form (`[{name, patterns}]`) 만 지원.
     external: ?[]const []const u8 = null,
     alias: ?[]const AliasDto = null,
+    /// #4616 external 방출 지정자 매핑 (rollup output.paths 대응).
+    externalAlias: ?[]const AliasDto = null,
     loader: ?[]const LoaderDto = null,
     conditions: ?[]const []const u8 = null,
     resolveExtensions: ?[]const []const u8 = null,


### PR DESCRIPTION
## 왜 필요했나

`--alias:crypto=crypto-browserify` 로 shim 을 걸면서 그 shim 을 **번들하지 않고 external 로
두고 싶은** 요구를 표현할 수단이 없었다 (#4605 에서 분리):

| 종전 시도 | 결과 |
|---|---|
| `--external crypto` | external 이 되지만 산출물에 원문 `crypto` 가 남아 브라우저가 실패 |
| `--external crypto-browserify` | external 판정이 **원문 기준**이라 매칭 안 되고 그냥 번들됨 |

`--globals` 는 IIFE/UMD 의 **전역 변수** 매핑이라 ESM/CJS 지정자 재작성에는 쓸 수 없다.

## 추가한 것

```bash
zntc --bundle src/main.ts --external crypto --external-alias:crypto=crypto-browserify
# → import { x } from "crypto-browserify"
```

```js
await build({ external: ['crypto'], externalAlias: { crypto: 'crypto-browserify' } });
```

rollup `output.paths` / webpack object-form `externals` 대응. `alias` 와 달리 **해석에는 관여하지
않고** 이미 external 로 확정된 지정자를 출력에 쓸 때만 이름을 바꾼다.

## ⚠️ 설계 — 원문 specifier 를 덮어쓰지 않는다

별도 필드(`ImportRecord.external_specifier`)를 둔다. 원문은 worker_map 키와 CSS span 치환의
조회 키라, 고치면 lookup 이 어긋나 **원문이 그대로 방출된다(= 404)**. #4604 1차 시도가 정확히
이걸로 깨졌다.

그래프 identity 도 원문 기준을 유지한다 — rollup 도 `output.paths` 는 emit 만 바꾸고 module id
는 그대로다.

⚠️ 매칭은 **정확 일치**다. `--alias` 는 prefix 치환이지만 이건 `output.paths` 대응이라 키가
지정자 전체다. prefix 로 하면 `react` 매핑이 `react-dom` 까지 잡는다.

## 배선 — 5표면 + 스키마가드

부분 구현은 **"네이티브 CLI 만 고치면 npm CLI/JS API 에서 도달 불가"** 함정에 걸린다:

1. 네이티브 CLI: `options.zig`(파싱) · `main.zig`(적용) · `usage.zig`(help)
2. npm CLI: `cli-flags.mjs`(FLAG_REGISTRY) · `zntc.mjs`(기본값·config 머지·전달)
3. JS API: `index.ts`(타입 + 문서)
4. NAPI: `napi/options.zig`(읽기 + BundleOptions 세팅)
5. 스키마 가드: `config_options_dto_test.zig` · `typo-suggest.ts`

emit 측은 `ImportRecord.externalName()` 하나로 통일 — ESM/CJS import 그룹핑,
UMD/AMD/IIFE 의존성 배열·param, `--globals` 조회, CJS `require` 방출.

## 검증

**세 표면 전부 실동작 확인** (모두 `import { x } from "crypto-browserify"`):

| 경로 | 결과 |
|---|---|
| 네이티브 CLI `zig-out/bin/zntc` | ✅ |
| npm CLI `zntc.mjs` (NAPI in-process) | ✅ |
| JS API `build({ externalAlias })` | ✅ |

- A/B 비공허: `externalName()` 을 원문 반환으로 무력화 → ESM·CJS 테스트 2건 실패.
- 유닛 **6310 통과**, `@zntc/core` TS **1079 pass**, 통합 **4448 pass** (실패 2건은 main baseline
  동일), `zig build napi` 통과.

Closes #4616
Refs #4605

🤖 Generated with [Claude Code](https://claude.com/claude-code)