### PR TITLE
fix(bundler): #4621 external re-export 가 파싱 불가 출력 / 재export 소실을 내던 문제

### DIFF
--- a/.changeset/external-reexport.md
+++ b/.changeset/external-reexport.md
@@ -1,0 +1,12 @@
+---
+"@zntc/core": patch
+---
+
+external 모듈에서 re-export 하면 산출물이 파싱 불가가 되거나 재export 가 사라지던 문제를 고쳤다 (#4621).
+
+- `export { x } from '<external>'` → 예전엔 바인딩 없는 `export { x };` 만 나가 **SyntaxError**.
+  이제 `import { x } from "…"; export { x };`
+- `export * from '<external>'` → 예전엔 **통째로 사라짐**. 이제 그대로 통과.
+- `export * as ns from '<external>'` → namespace import + export 로 편다.
+
+esbuild·rolldown 실측과 일치한다.

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4387,6 +4387,70 @@ fn bundleExternalAlias(tmp: *std.testing.TmpDir, with_alias: bool, fmt: @import(
     return std.testing.allocator.dupe(u8, result.output);
 }
 
+fn bundleExternalReexport(tmp: *std.testing.TmpDir, src: []const u8) ![]const u8 {
+    try writeFile(tmp.dir, "src/main.ts", src);
+    const entry = try absPath(tmp, "src/main.ts");
+    defer std.testing.allocator.free(entry);
+    const ext = [_][]const u8{"extdep"};
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .external = &ext,
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    return std.testing.allocator.dupe(u8, result.output);
+}
+
+test "#4621 external named re-export 는 import 를 동반한다" {
+    // 예전엔 `export { x };` 만 방출돼 **바인딩 없는 export → SyntaxError** 였다.
+    // esbuild·rolldown 실측: `import { x } from "…"; export { x };`
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const js = try bundleExternalReexport(&tmp, "export { x } from 'extdep';");
+    defer std.testing.allocator.free(js);
+
+    try std.testing.expect(std.mem.indexOf(u8, js, "import { x } from \"extdep\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, js, "export { x }") != null);
+}
+
+test "#4621 external re-export alias 는 export 절이 참조하는 이름으로 import 한다" {
+    // ⚠️ import 로컬명을 `exported_name`(y) 으로 잡으면 로컬은 y 인데 export 절은 x 를
+    // 참조해 여전히 바인딩이 없다 — 실측으로 잡은 함정.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const js = try bundleExternalReexport(&tmp, "export { x as y } from 'extdep';");
+    defer std.testing.allocator.free(js);
+
+    try std.testing.expect(std.mem.indexOf(u8, js, "import { x } from \"extdep\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, js, "export { x as y }") != null);
+}
+
+test "#4621 external export * 는 그대로 통과한다" {
+    // 예전엔 재export 가 **통째로 사라졌다**. ESM 이 정적으로 표현 가능하므로 그대로 낸다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const js = try bundleExternalReexport(&tmp, "export * from 'extdep';");
+    defer std.testing.allocator.free(js);
+
+    try std.testing.expect(std.mem.indexOf(u8, js, "export*from\"extdep\"") != null);
+}
+
+test "#4621 external export * as ns 는 namespace import + export 로 편다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const js = try bundleExternalReexport(&tmp, "export * as ns from 'extdep';");
+    defer std.testing.allocator.free(js);
+
+    try std.testing.expect(std.mem.indexOf(u8, js, "import * as ns from \"extdep\"") != null);
+}
+
 test "#4616 --external-alias 가 external 지정자를 다른 이름으로 방출한다 (esm)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/emitter/external_imports.zig
+++ b/src/bundler/emitter/external_imports.zig
@@ -38,6 +38,8 @@ const SpecifierGroup = struct {
     namespace_local: ?[]const u8 = null,
     named: std.ArrayListUnmanaged(NamedBinding) = .empty,
     side_effect_only: bool = false,
+    /// `export * from '<external>'` — ESM 이 정적으로 표현 가능해 그대로 통과시킨다 (#4621).
+    star_reexport: bool = false,
     aliases: std.ArrayListUnmanaged(AliasBinding) = .empty,
 
     fn deinit(self: *SpecifierGroup, allocator: std.mem.Allocator) void {
@@ -103,6 +105,40 @@ pub fn emitChunkExternalImports(
             const gop = try per_spec.getOrPut(allocator, rec.externalName());
             if (!gop.found_existing) gop.value_ptr.* = .{};
             try addBinding(gop.value_ptr, allocator, ib.kind, ib.imported_name, local_name);
+        }
+
+        // (2.5) **external re-export** (#4621). `export { x } from '<external>'` 은
+        // ImportBinding 을 만들지 않고 ExportBinding 만 만들어서, 위 (1) 루프는 이걸 볼 수
+        // 없다. 그래서 예전엔 import 가 생성되지 않고 export 절만 방출돼
+        // `export { x };` 가 바인딩 없이 남아 **SyntaxError** 였고, `export *` 는 통째로
+        // 사라졌다. (esbuild·rolldown 실측 일치: named 는 import+export, star 는 그대로 통과)
+        for (m.export_bindings) |eb| {
+            const rec_idx = eb.import_record_index orelse continue;
+            if (rec_idx >= m.import_records.len) continue;
+            const rec = m.import_records[rec_idx];
+            if (!rec.is_external) continue;
+            if (rec.kind != .re_export) continue;
+
+            const gop = try per_spec.getOrPut(allocator, rec.externalName());
+            if (!gop.found_existing) gop.value_ptr.* = .{};
+
+            if (eb.kind == .re_export_star) {
+                // `export * from '…'` — 이름 목록을 정적으로 알 수 없으므로 그대로 내보낸다.
+                gop.value_ptr.star_reexport = true;
+                continue;
+            }
+            if (eb.kind == .re_export_namespace) {
+                // `export * as ns from '…'` → `import * as ns from '…'; export { ns };`
+                try addBinding(gop.value_ptr, allocator, .namespace, "*", eb.exported_name);
+                continue;
+            }
+            if (eb.kind != .re_export) continue;
+            // `export { a as b } from '…'` → `import { a } from '…'; export { a as b };`
+            //
+            // ⚠️ import 로컬명은 **export 절이 참조하는 이름**(`local_name`)이어야 한다.
+            // `exported_name` 으로 잡으면 `import { a as b }` 가 되어 로컬은 `b` 인데
+            // export 절은 `a` 를 참조해 여전히 바인딩이 없다 (실측으로 잡음).
+            try addBinding(gop.value_ptr, allocator, .named, eb.local_name, eb.local_name);
         }
 
         // (2) side-effect import (specs 0개) — import_records 에서 직접 감지.
@@ -207,6 +243,16 @@ fn emitOneImport(
     const has_default_or_named = group.default_local != null or group.named.items.len > 0;
     const has_any = has_default_or_named or group.namespace_local != null;
 
+    // `export * from "spec";` (#4621) — 이름 목록을 정적으로 알 수 없어 그대로 통과시킨다.
+    // import 구문보다 **먼저** 내보낸다: 같은 specifier 에 named re-export 가 섞여 있어도
+    // 두 구문이 각각 유효하고, side-effect import 는 이걸로 이미 보장된다.
+    if (group.star_reexport) {
+        try output.appendSlice(allocator, "export*from\"");
+        try output.appendSlice(allocator, spec);
+        try output.appendSlice(allocator, "\";");
+        try output.appendSlice(allocator, eol);
+    }
+
     // side-effect only: `import "spec";`
     if (!has_any and group.side_effect_only) {
         try output.appendSlice(allocator, "import\"");
@@ -215,7 +261,7 @@ fn emitOneImport(
         try output.appendSlice(allocator, eol);
         return;
     }
-    if (!has_any) return;
+    if (!has_any) return; // star 는 위에서 이미 방출됨
 
     // (1) default + named — 한 줄. rolldown 의 `create_import_declaration` 동일.
     //     ESM spec 상 `import D, { x } from "spec"` 합법. namespace 는 같이 못 묶음.


### PR DESCRIPTION
## 문제

external 로 분류된 모듈에서 re-export 하면 산출물이 깨졌다.

| 입력 | 수정 전 | 수정 후 = esbuild = rolldown |
|---|---|---|
| `export { x } from '<ext>'` | `export { x };` → **SyntaxError** | `import { x } from "…"; export { x };` |
| `export { x as y } from '<ext>'` | `export { x as y };` → **SyntaxError** | `import { x } from "…"; export { x as y };` |
| `export * from '<ext>'` | (아무것도 없음) | `export*from"…";` |
| `export * as ns from '<ext>'` | (아무것도 없음) | `import * as ns from "…";` |

바인딩 없는 `export { x }` 는 로드 시 `SyntaxError: Export 'x' is not defined in module` 이다.
`export *` 는 **아무 진단 없이 통째로 사라졌다**.

## 루트커즈

`export { x } from '…'` 은 **ImportBinding 을 만들지 않고 ExportBinding 만** 만든다.
`emitter/external_imports.zig` 의 external 수집 루프는 `m.import_bindings` 만 훑으므로 이 경우를
아예 볼 수 없었고, export 절은 별도 경로로 방출돼 짝이 안 맞았다.

⚠️ 처음엔 그 루프의 `if (!ib.local_symbol.isValid()) continue;` 가드를 완화하는 쪽으로 고쳤는데
**아무 변화가 없었다** — 애초에 바인딩이 존재하지 않아 루프에 진입조차 못 하기 때문이다.
`m.export_bindings` 를 훑는 수집 단계를 새로 넣는 게 맞았다.

## ⚠️ 이름 조율 함정

import 로컬명은 **export 절이 참조하는 이름**(`local_name`)이어야 한다. `exported_name` 으로
잡으면 `export { x as y }` 에 대해 `import { x as y }` 가 되어 로컬은 `y` 인데 export 절은 `x` 를
참조해 **여전히 바인딩이 없다**. 실측으로 잡았다.

## 3사 실측 (착수 전)

esbuild 와 rolldown 이 **완전히 일치**해 계약이 명확했다 — `export *` 는 ESM 이 정적으로 표현
가능하므로 그대로 통과시키는 게 정답이다.

## 검증 — Node 에서 실제 로드

| 케이스 | 결과 |
|---|---|
| `export { x } from` | `{"x":"REAL_X"}` ✅ |
| `export { x as y } from` | `{"y":"REAL_X"}` ✅ |
| `export * from` | `{"x":"REAL_X","z":"REAL_Z"}` ✅ |
| `export * as ns from` | `{"ns":{…}}` ✅ |

⚠️ 1차 검증은 픽스처에 Node 빌트인 이름(`crypto`)을 써서 link 에러가 났다 — 문법은 이미 고쳐진
상태였는데 실패로 오독할 뻔했다. 비빌트인 이름으로 다시 쟀다.

- A/B 비공허: 수집 블록 제거 → 4개 테스트 전부 실패.
- 유닛 **6317 통과**, 통합 **4448 pass** (실패 2건은 main baseline 동일), `zig build napi` 통과.

Closes #4621
Refs #4616

🤖 Generated with [Claude Code](https://claude.com/claude-code)