### PR TITLE
fix(semantic): #4599 소문자로 시작하지 않는 bare JSX 태그의 참조가 안 잡히던 문제

### DIFF
--- a/.changeset/jsx-bare-tag-resolve.md
+++ b/.changeset/jsx-bare-tag-resolve.md
@@ -1,0 +1,12 @@
+---
+"@zntc/core": patch
+---
+
+`<_ns/>` 처럼 소문자로 시작하지 않는 bare JSX 태그의 참조가 안 잡혀 대상 import 가 통째로
+tree-shake 되던 문제를 고쳤다 (#4599 잔여분).
+
+analyzer 가 bare 태그를 `isUpper(name[0])` 일 때만 변수 참조로 resolve 해서, `_ns`/`$x` 처럼
+밑줄·달러로 시작하는 태그는 참조가 보이지 않았다. 선언 없는 `<_ns/>` 가 방출됐다.
+
+JSX 관례(babel·tsc·esbuild·rolldown 공통)에서 intrinsic 은 **소문자로 시작하는 태그뿐**이므로,
+판정을 "소문자로 시작하지 않음" 으로 바꿨다. `<div>` 같은 intrinsic 은 종전대로 문자열 태그다.

--- a/src/bundler/bundler_test/jsx.zig
+++ b/src/bundler/bundler_test/jsx.zig
@@ -1161,6 +1161,56 @@ test "JSX: preserve — 실체화된 namespace 변수는 컴포넌트로 해석�
     try std.testing.expect(std.mem.indexOf(u8, result.output, "Ns_ns") != null);
 }
 
+test "JSX: 소문자로 시작하지 않는 bare 태그는 변수 참조로 잡힌다 (#4599 잔여)" {
+    // `<_ns/>` 처럼 밑줄/달러로 시작하는 태그는 intrinsic 이 아니라 **식별자**다
+    // (babel·tsc·esbuild 공통 관례). analyzer 가 `isUpper` 로만 resolve 하면 이 참조가
+    // 안 잡혀 대상 import 가 통째로 tree-shake 되고, **선언 없는 `<_ns/>` 가 방출**된다.
+    // esbuild 실측: namespace 를 살려 `<Ns_exports />` 로 재작성한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app.tsx",
+        \\import * as _ns from './ns';
+        \\export function Raw() { return <_ns/>; }
+    );
+    try writeFile(tmp.dir, "ns.tsx",
+        \\export const Root = () => null;
+        \\export const Other = "NS_OTHER_MARKER";
+    );
+
+    const entry = try absPath(&tmp, "app.tsx");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .jsx_runtime = .preserve });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // 대상 모듈이 살아 있어야 한다 (tree-shake 되면 이 마커가 사라진다).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_OTHER_MARKER") != null);
+    // 실체화된 이름은 컴포넌트로 해석되도록 대문자 시작.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Ns_ns") != null);
+}
+
+test "JSX: 소문자 시작 태그는 intrinsic 으로 남는다 (#4599 범위 가드)" {
+    // 위 수정이 과하면(모든 bare 태그를 resolve) `<div>` 가 변수 참조가 돼
+    // 없는 심볼을 찾거나 동명 로컬에 잘못 묶인다. 이 대조군이 그걸 막는다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app.tsx",
+        \\export function A() { return <div>hi</div>; }
+    );
+
+    const entry = try absPath(&tmp, "app.tsx");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .jsx_runtime = .preserve });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "<div>hi</div>") != null);
+}
+
 // 대조군 — preserve 가 아니면 이름을 건드리지 않는다. 변수는 식별자 표현식으로만 쓰여
 // 대소문자가 무의미한데, 전역으로 바꾸면 기존 출력의 변수명이 통째로 흔들린다.
 // 이 테스트가 없으면 "항상 대문자화" 로 바꿔도 위 테스트가 통과해 범위 가드가 사라진다.

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1596,10 +1596,16 @@ pub const SemanticAnalyzer = struct {
                 self.resolveIdentifier(name, idx, flags);
             },
 
-            // JSX tag name이 대문자로 시작하면 컴포넌트 참조 (e.g. <Header />)
+            // 단독 JSX 태그가 **intrinsic 문자열이 아니면** 변수 참조다 (e.g. `<Header />`).
+            //
+            // ⚠️ 판정은 "대문자로 시작" 이 아니라 "**소문자로 시작하지 않음**" 이다 (#4599).
+            // JSX 관례(babel·tsc·esbuild 공통)에서 intrinsic 은 소문자로 시작하는 태그뿐이고,
+            // `_ns` / `$x` 처럼 밑줄·달러로 시작하는 태그는 식별자다. `isUpper` 로만 보면
+            // 그런 태그의 참조가 안 잡혀 대상 import 가 통째로 tree-shake 되고, 선언 없는
+            // `<_ns/>` 가 방출된다 (esbuild 는 살려서 `<Ns_exports />` 로 재작성).
             .jsx_identifier => {
                 const name = self.ast.getSourceText(node.span);
-                if (name.len > 0 and std.ascii.isUpper(name[0])) {
+                if (name.len > 0 and !std.ascii.isLower(name[0])) {
                     self.resolveIdentifier(name, idx, .{ .read = true });
                 }
             },


### PR DESCRIPTION
## 문제

```tsx
import * as _ns from './ns';
export function Raw() { return <_ns/>; }
```

`_ns` 참조가 잡히지 않아 `./ns` 의 export 가 전부 tree-shake 되고, **선언 없는 `<_ns/>` 가
방출**된다. 진단 0건 — downstream 변환 후 정의되지 않은 컴포넌트가 된다.

## 루트커즈

`analyzer.zig` 가 bare JSX 태그를 `std.ascii.isUpper(name[0])` 일 때만 변수 참조로 resolve 한다.
`_ns` / `$x` 처럼 밑줄·달러로 시작하는 태그가 이 게이트에 걸려 symbol-aware 경로에서 escape 가
보이지 않는다.

## 수정

JSX 관례에서 intrinsic 은 **소문자로 시작하는 태그뿐**이다. `isUpper` 는 그 관례를 좁게 근사한
것이라 `_`/`$` 시작 태그를 놓친다 → 판정을 "소문자로 시작하지 않음" 으로 바꿨다.

## 3사 실측 — 두 참조 번들러 모두 식별자로 본다

| 태그 | esbuild | rolldown | zntc (수정 후) |
|---|---|---|---|
| `<_ns/>` | namespace 살리고 `<Ns_exports />` 로 재작성 | `jsx(ns_exports, {})` + 대상 생존 | `<Ns_ns/>` + 대상 생존 |
| `<div>` | 문자열 태그 유지 | `jsx("div", …)` | 문자열 태그 유지 |

## 검증

- 재현 → 수정 확인 (`NS_OTHER_MARKER` 소실 → 생존).
- **양방향 A/B 비공허**:
  - `isUpper` 로 되돌림 → 새 테스트 실패
  - 모든 태그를 resolve(과함) → **기존 intrinsic 테스트** 실패
    (`JSX: bare lowercase tag <div/> is intrinsic, not a variable ref`)

  범위가 양쪽으로 고정된다 — 좁혀도 넓혀도 깨진다.
- 유닛 **6319 통과**, 통합 **4448 pass** (실패 2건은 main baseline 동일), `zig build napi` 통과.

Closes #4599

🤖 Generated with [Claude Code](https://claude.com/claude-code)