### PR TITLE
fix(transformer): #4598 TLA 래퍼가 export 스코프를 분리해 ReferenceError 를 내던 문제 (1단계)

### DIFF
--- a/.changeset/tla-export-scope.md
+++ b/.changeset/tla-export-scope.md
@@ -2,12 +2,15 @@
 "@zntc/core": patch
 ---
 
-top-level await + `--target < es2022` 에서 `export const/let/var` 가 스코프 분리로 깨지던 문제를
-고쳤다 (#4598 1단계).
+top-level await + `--target < es2022` 에서 export 가 스코프 분리로 깨지던 문제를 고쳤다 (#4598).
 
 TLA 래퍼가 최상위 문장을 `(async () => {…})()` 안으로 넣는데 export 선언은 밖에 남아,
-**선언은 안 / 사용은 밖** 으로 갈려 `ReferenceError` 가 났다. 이제 `var X;`(밖) +
-`X = init;`(래퍼 안, 원래 순서 유지) 로 분해한다 — ESM live binding 으로 밖에서도 보인다.
+**선언은 안 / 사용은 밖** 으로 갈려 `ReferenceError` 가 났다.
 
-⚠️ `export function` / `export class` / `export default` / `const X=…; export {X}` 는 아직
-같은 방식으로 깨진다 (#4598 에 후속 기록).
+- `export const/let/var X = init` → `var X;`(밖) + `X = init;`(래퍼 안, 원래 순서 유지)
+- `export function f(){}` → `var f;` + `f = function f(){…};`(본문 **맨 위** = 호이스팅 등가)
+- `export class C{}` → `var C;` + `C = class C{…};`(원위치 — 클래스는 원래 TDZ)
+
+⚠️ `export default` 와 `const X=…; export {X}` 는 아직 남았다 (#4598 후속).
+⚠️ 대입 전 접근 시 원본의 TDZ `ReferenceError` 가 `undefined` 접근으로 바뀐다 — 이미 에러인
+경로에서 에러 종류만 달라지는 것으로, ESM live binding 방식의 본질적 한계다.

--- a/.changeset/tla-export-scope.md
+++ b/.changeset/tla-export-scope.md
@@ -1,0 +1,13 @@
+---
+"@zntc/core": patch
+---
+
+top-level await + `--target < es2022` 에서 `export const/let/var` 가 스코프 분리로 깨지던 문제를
+고쳤다 (#4598 1단계).
+
+TLA 래퍼가 최상위 문장을 `(async () => {…})()` 안으로 넣는데 export 선언은 밖에 남아,
+**선언은 안 / 사용은 밖** 으로 갈려 `ReferenceError` 가 났다. 이제 `var X;`(밖) +
+`X = init;`(래퍼 안, 원래 순서 유지) 로 분해한다 — ESM live binding 으로 밖에서도 보인다.
+
+⚠️ `export function` / `export class` / `export default` / `const X=…; export {X}` 는 아직
+같은 방식으로 깨진다 (#4598 에 후속 기록).

--- a/.changeset/tla-export-scope.md
+++ b/.changeset/tla-export-scope.md
@@ -4,13 +4,15 @@
 
 top-level await + `--target < es2022` 에서 export 가 스코프 분리로 깨지던 문제를 고쳤다 (#4598).
 
-TLA 래퍼가 최상위 문장을 `(async () => {…})()` 안으로 넣는데 export 선언은 밖에 남아,
-**선언은 안 / 사용은 밖** 으로 갈려 `ReferenceError` 가 났다.
+TLA 래퍼가 최상위 문장을 `(async () => {…})()` 안으로 넣는데 export 는 밖에 남아,
+**선언은 안 / 사용은 밖** 으로 갈려 `ReferenceError` 가 났다. 이제 바인딩만 밖으로 올리고
+초기화는 래퍼 안에 남긴다 — ESM live binding.
 
-- `export const/let/var X = init` → `var X;`(밖) + `X = init;`(래퍼 안, 원래 순서 유지)
-- `export function f(){}` → `var f;` + `f = function f(){…};`(본문 **맨 위** = 호이스팅 등가)
-- `export class C{}` → `var C;` + `C = class C{…};`(원위치 — 클래스는 원래 TDZ)
+- `export const/let/var X = init` → `var X;`(밖) + `X = init;`(원위치)
+- `export function f(){}` → `f = function f(){…};`(본문 **맨 위** = 호이스팅 등가)
+- `export class C{}` → `C = class C{…};`(원위치 — 클래스는 원래 TDZ)
+- `export default expr` → `export { _t as default };` (live binding. `export default _t` 는 스냅샷)
+- `const X=…; export {X}` → 선언을 대입으로 전환 (const-bake 가 elide 하던 것도 해소)
 
-⚠️ `export default` 와 `const X=…; export {X}` 는 아직 남았다 (#4598 후속).
 ⚠️ 대입 전 접근 시 원본의 TDZ `ReferenceError` 가 `undefined` 접근으로 바뀐다 — 이미 에러인
 경로에서 에러 종류만 달라지는 것으로, ESM live binding 방식의 본질적 한계다.

--- a/src/transformer/es2022_tla.zig
+++ b/src/transformer/es2022_tla.zig
@@ -103,6 +103,70 @@ fn hasTopLevelAwait(ast: *const ast_mod.Ast, idx: NodeIndex) std.mem.Allocator.E
 ///
 /// 반환: 밖에 둘 `export var …;` 노드. 분해할 수 없으면(구조분해 바인딩 등) null —
 /// 호출자가 종전대로 pass-through 한다.
+/// `export function f(){}` / `export class C{}` 를 `export var f;`(밖) + `f = function f(){…};` 로
+/// 분해한다 (#4598 2단계).
+///
+/// ⚠️ **리네임하지 않는다.** 선언을 named function expression 대입으로 바꾸면 안쪽 바인딩이
+/// 사라져 섀도잉이 없어지고, 자기참조는 named FE 의 이름이 처리한다. 스코프 인식 리네임 패스
+/// 라는 큰 위험을 통째로 없앤다. (상호재귀·재대입·`f.name` 까지 원본과 등가임을 실측 확인)
+///
+/// ⚠️ 함수는 대입을 래퍼 본문 **맨 위**에 둔다 — 선언 호이스팅과 등가다(`typeof f` 가 선언
+/// 앞에서 `"function"`, 초기화 전 호출은 TDZ `ReferenceError` 로 원본과 일치). 클래스는 원래
+/// TDZ 라 원위치에 둔다.
+fn splitExportedFnOrClass(
+    comptime Transformer: type,
+    self: *Transformer,
+    export_node: Node,
+    hoisted: *std.ArrayListUnmanaged(NodeIndex),
+    assigns: *std.ArrayListUnmanaged(NodeIndex),
+) Transformer.Error!?NodeIndex {
+    const e = export_node.data.extra;
+    if (e + 3 >= self.ast.extra_data.items.len) return null;
+    const decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+    const specs_start = self.ast.extra_data.items[e + 1];
+    const specs_len = self.ast.extra_data.items[e + 2];
+    const source_raw = self.ast.extra_data.items[e + 3];
+    if (!@as(NodeIndex, @enumFromInt(source_raw)).isNone()) return null;
+    if (decl_idx.isNone()) return null;
+
+    const decl = self.ast.getNode(decl_idx);
+    const is_fn = decl.tag == .function_declaration;
+    const is_class = decl.tag == .class_declaration;
+    if (!is_fn and !is_class) return null;
+
+    // extras[0] = 이름. 익명(`export default function(){}`)은 여기 오지 않는다.
+    const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[decl.data.extra]);
+    if (name_idx.isNone()) return null;
+    const name_span = self.ast.getNode(name_idx).span;
+
+    // 선언 → 표현식: 같은 extras 를 공유하고 tag 만 바꾼다 (codegen 이 같은 emit 경로).
+    const visited_decl = try self.visitNode(decl_idx);
+    if (visited_decl.isNone()) return null;
+    const vd = self.ast.getNode(visited_decl);
+    const expr = try self.ast.addNode(.{
+        .tag = if (is_fn) .function_expression else .class_expression,
+        .span = vd.span,
+        .data = vd.data,
+    });
+
+    const target = try es_helpers.makeIdentifierRefFromSpan(self, name_span);
+    const assign = try es_helpers.makeAssignExpr(self, target, expr, decl.span, 0);
+    const stmt = try es_helpers.makeExprStmt(self, assign, decl.span);
+    if (is_fn) try hoisted.append(self.allocator, stmt) else try assigns.append(self.allocator, stmt);
+
+    const bare_binding = try es_helpers.makeBindingIdentifier(self, name_span);
+    const bare_dtor = try es_helpers.makeDeclarator(self, bare_binding, NodeIndex.none, decl.span);
+    const new_decl = try es_helpers.makeVarDeclaration(self, &.{bare_dtor}, .@"var", decl.span);
+    const new_extra = try self.ast.addExtras(&.{
+        @intFromEnum(new_decl), specs_start, specs_len, source_raw,
+    });
+    return try self.ast.addNode(.{
+        .tag = .export_named_declaration,
+        .span = export_node.span,
+        .data = .{ .extra = new_extra },
+    });
+}
+
 fn splitExportedVarDecl(
     comptime Transformer: type,
     self: *Transformer,
@@ -234,6 +298,9 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
     defer split_assign_off.deinit(self.allocator);
     var split_assigns: std.ArrayListUnmanaged(NodeIndex) = .empty;
     defer split_assigns.deinit(self.allocator);
+    // 함수 선언 대입은 래퍼 본문 **맨 위**로 (호이스팅 등가).
+    var hoisted_assigns: std.ArrayListUnmanaged(NodeIndex) = .empty;
+    defer hoisted_assigns.deinit(self.allocator);
     {
         var ei: u32 = 0;
         while (ei < list.len) : (ei += 1) {
@@ -241,7 +308,9 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
             const child_node = self.ast.getNode(child);
             if (child_node.tag != .export_named_declaration) continue;
             const before: u32 = @intCast(split_assigns.items.len);
-            const split = try splitExportedVarDecl(Transformer, self, child_node, &split_assigns) orelse continue;
+            const split = (try splitExportedVarDecl(Transformer, self, child_node, &split_assigns)) orelse
+                (try splitExportedFnOrClass(Transformer, self, child_node, &hoisted_assigns, &split_assigns)) orelse
+                continue;
             try split_src.append(self.allocator, child);
             try split_export.append(self.allocator, split);
             try split_assign_off.append(self.allocator, before);
@@ -251,6 +320,8 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
 
     // wrap target 수집 (visit 하여 기본 변환 적용)
     const body_stmts_top = self.scratch.items.len;
+    // 함수 대입을 먼저 — 선언 호이스팅과 등가가 되도록 본문 맨 위에 둔다.
+    for (hoisted_assigns.items) |h| try self.scratch.append(self.allocator, h);
     i = 0;
     while (i < list.len) : (i += 1) {
         const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);

--- a/src/transformer/es2022_tla.zig
+++ b/src/transformer/es2022_tla.zig
@@ -89,6 +89,93 @@ fn hasTopLevelAwait(ast: *const ast_mod.Ast, idx: NodeIndex) std.mem.Allocator.E
 /// `self` 는 Transformer. options.unsupported.top_level_await 가 true 일 때만 호출.
 ///
 /// 반환: wrap 된 program 노드 index (TLA 가 없으면 null — caller 가 기본 visit 수행).
+/// `export const X = init;` 을 **`export var X;`(래퍼 밖) + `X = init;`(래퍼 안)** 으로 분해한다 (#4598).
+///
+/// TLA 래퍼는 최상위 문장을 `(async () => {…})()` 안으로 넣는데, export 선언은 ESM 상 최상위에만
+/// 올 수 있어 밖에 남는다. 그러면 **선언은 안 / 사용은 밖** 으로 스코프가 갈려
+/// `ReferenceError` 가 난다 (#4598 재현). 바인딩만 밖으로 올리고 초기화는 원래 자리(래퍼 안)에
+/// 남기면, ESM live binding 으로 밖에서도 보인다 — rspack 이 export 를 getter 로 선등록하는 것의
+/// ESM 등가 형태다.
+///
+/// ⚠️ **참조 분석을 하지 않는다.** "이 export 가 래퍼 로컬을 참조하는가" 로 좁히려 했다가 계속
+/// 경계를 놓쳤다(`export default`·`export {X}`·중첩 블록). 전부 균일하게 분해하면 그 판정이
+/// 필요 없다.
+///
+/// 반환: 밖에 둘 `export var …;` 노드. 분해할 수 없으면(구조분해 바인딩 등) null —
+/// 호출자가 종전대로 pass-through 한다.
+fn splitExportedVarDecl(
+    comptime Transformer: type,
+    self: *Transformer,
+    export_node: Node,
+    assigns: *std.ArrayListUnmanaged(NodeIndex),
+) Transformer.Error!?NodeIndex {
+    const e = export_node.data.extra;
+    if (e + 3 >= self.ast.extra_data.items.len) return null;
+    const decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+    const specs_start = self.ast.extra_data.items[e + 1];
+    const specs_len = self.ast.extra_data.items[e + 2];
+    const source_raw = self.ast.extra_data.items[e + 3];
+    // `export { x } from '…'` 은 대상이 다른 모듈이라 분해 대상이 아니다.
+    if (!@as(NodeIndex, @enumFromInt(source_raw)).isNone()) return null;
+    if (decl_idx.isNone()) return null;
+
+    const decl_node = self.ast.getNode(decl_idx);
+    if (decl_node.tag != .variable_declaration) return null;
+
+    const ve = decl_node.data.extra;
+    if (ve + 2 >= self.ast.extra_data.items.len) return null;
+    const decls_start = self.ast.extra_data.items[ve + 1];
+    const decls_len = self.ast.extra_data.items[ve + 2];
+
+    const scratch_top = self.scratch.items.len;
+    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+    var di: u32 = 0;
+    while (di < decls_len) : (di += 1) {
+        const dtor_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[decls_start + di]);
+        const dtor = self.ast.getNode(dtor_idx);
+        if (dtor.tag != .variable_declarator) return null;
+        const de = dtor.data.extra;
+        if (de + 2 >= self.ast.extra_data.items.len) return null;
+        const binding_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[de]);
+        const init_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[de + 2]);
+        const binding = self.ast.getNode(binding_idx);
+        // 구조분해(`export const { a } = o`)는 바인딩이 단순 식별자가 아니라 분해 규칙이
+        // 달라진다 — 종전 동작을 유지하고 여기서 빠진다.
+        if (binding.tag != .binding_identifier) return null;
+
+        // 밖: `var X;` (init 제거)
+        const bare_binding = try es_helpers.makeBindingIdentifier(self, binding.span);
+        const bare_dtor = try es_helpers.makeDeclarator(self, bare_binding, NodeIndex.none, dtor.span);
+        try self.scratch.append(self.allocator, bare_dtor);
+
+        // 안: `X = init;` (init 이 없으면 대입도 없다 — `export let x;`)
+        if (!init_idx.isNone()) {
+            const target = try es_helpers.makeIdentifierRefFromSpan(self, binding.span);
+            const visited_init = try self.visitNode(init_idx);
+            if (visited_init.isNone()) return null;
+            const assign = try es_helpers.makeAssignExpr(self, target, visited_init, dtor.span, 0);
+            try assigns.append(self.allocator, try es_helpers.makeExprStmt(self, assign, dtor.span));
+        }
+    }
+
+    // `var` 로 강등한다 — 래퍼 안 대입이 TDZ 에 걸리지 않아야 한다.
+    const new_decl = try es_helpers.makeVarDeclaration(
+        self,
+        self.scratch.items[scratch_top..],
+        .@"var",
+        decl_node.span,
+    );
+    const new_extra = try self.ast.addExtras(&.{
+        @intFromEnum(new_decl), specs_start, specs_len, source_raw,
+    });
+    return try self.ast.addNode(.{
+        .tag = .export_named_declaration,
+        .span = export_node.span,
+        .data = .{ .extra = new_extra },
+    });
+}
+
 pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) Transformer.Error!?NodeIndex {
     std.debug.assert(node.tag == .program);
     const list = node.data.list;
@@ -136,6 +223,32 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
     }
     const imports_end = self.scratch.items.len;
 
+    // #4598: export 선언을 미리 분해해 둔다 — `export var X;`(밖) + `X = init;`(안).
+    // ⚠️ 대입문은 **원래 문장 순서 그대로** 래퍼 본문에 끼워 넣어야 한다. 끝에 몰아넣으면
+    // 그 export 를 앞에서 읽는 코드가 `undefined` 를 본다 (실측으로 잡음).
+    var split_src: std.ArrayListUnmanaged(NodeIndex) = .empty;
+    defer split_src.deinit(self.allocator);
+    var split_export: std.ArrayListUnmanaged(NodeIndex) = .empty;
+    defer split_export.deinit(self.allocator);
+    var split_assign_off: std.ArrayListUnmanaged(u32) = .empty;
+    defer split_assign_off.deinit(self.allocator);
+    var split_assigns: std.ArrayListUnmanaged(NodeIndex) = .empty;
+    defer split_assigns.deinit(self.allocator);
+    {
+        var ei: u32 = 0;
+        while (ei < list.len) : (ei += 1) {
+            const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + ei]);
+            const child_node = self.ast.getNode(child);
+            if (child_node.tag != .export_named_declaration) continue;
+            const before: u32 = @intCast(split_assigns.items.len);
+            const split = try splitExportedVarDecl(Transformer, self, child_node, &split_assigns) orelse continue;
+            try split_src.append(self.allocator, child);
+            try split_export.append(self.allocator, split);
+            try split_assign_off.append(self.allocator, before);
+        }
+        try split_assign_off.append(self.allocator, @intCast(split_assigns.items.len));
+    }
+
     // wrap target 수집 (visit 하여 기본 변환 적용)
     const body_stmts_top = self.scratch.items.len;
     i = 0;
@@ -143,7 +256,17 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
         const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
         const child_node = self.ast.getNode(child);
         if (child_node.tag == .import_declaration or child_node.tag == .ts_import_equals_declaration) continue;
-        if (isModuleDeclaration(child_node.tag)) continue; // 아래 exports 패스에서 처리
+        if (isModuleDeclaration(child_node.tag)) {
+            // 분해된 export 라면 **이 자리에** 대입문을 넣는다.
+            for (split_src.items, 0..) |sc, si| {
+                if (sc != child) continue;
+                const from = split_assign_off.items[si];
+                const to = split_assign_off.items[si + 1];
+                for (split_assigns.items[from..to]) |a| try self.scratch.append(self.allocator, a);
+                break;
+            }
+            continue;
+        }
         const visited = try self.visitNode(child);
         if (!visited.isNone()) try self.scratch.append(self.allocator, visited);
     }
@@ -194,6 +317,15 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
         const child_node = self.ast.getNode(child);
         if (child_node.tag == .import_declaration or child_node.tag == .ts_import_equals_declaration) continue;
         if (!isModuleDeclaration(child_node.tag)) continue;
+        // 분해된 export 는 원본 대신 `export var X;` 를 내보낸다 (초기화는 래퍼 안).
+        var replaced = false;
+        for (split_src.items, 0..) |sc, si| {
+            if (sc != child) continue;
+            try self.scratch.append(self.allocator, split_export.items[si]);
+            replaced = true;
+            break;
+        }
+        if (replaced) continue;
         const visited = try self.visitNode(child);
         if (!visited.isNone()) try self.scratch.append(self.allocator, visited);
     }

--- a/src/transformer/es2022_tla.zig
+++ b/src/transformer/es2022_tla.zig
@@ -113,6 +113,141 @@ fn hasTopLevelAwait(ast: *const ast_mod.Ast, idx: NodeIndex) std.mem.Allocator.E
 /// ⚠️ 함수는 대입을 래퍼 본문 **맨 위**에 둔다 — 선언 호이스팅과 등가다(`typeof f` 가 선언
 /// 앞에서 `"function"`, 초기화 전 호출은 TDZ `ReferenceError` 로 원본과 일치). 클래스는 원래
 /// TDZ 라 원위치에 둔다.
+/// `export default expr` 를 `var _t;`(밖) + `_t = expr;`(안) + `export { _t as default };`(밖)
+/// 으로 분해한다 (#4598).
+///
+/// ⚠️ `export default _t;` 로는 안 된다 — `export default <expr>` 는 평가 시점의 **값 스냅샷**을
+/// 내보내므로 래퍼가 대입하기 전의 `undefined` 가 고정된다. live binding 을 얻으려면
+/// `export { _t as default }` 형태여야 한다.
+/// specifier-only export(`const X = …; export { X };`)의 **선언 쪽**을 분해한다 (#4598).
+///
+/// export 절은 최상위(래퍼 밖)에 남는데 선언은 래퍼 안으로 들어가 바인딩이 끊긴다.
+/// 게다가 const-bake 가 래퍼 안에서 참조를 못 봐(export 절이 밖) 선언을 통째로 elide 한다 —
+/// 그러면 `export { X }` 가 존재하지 않는 이름을 가리킨다.
+///
+/// 여기서는 **선언 문장 자체**를 `X = init;` 로 바꾸고 `var X;` 를 밖으로 올린다.
+/// 반환: 래퍼 안에 넣을 대입문. 대상이 아니면 null.
+fn splitLocalDeclForExport(
+    comptime Transformer: type,
+    self: *Transformer,
+    decl_node: Node,
+    exported_names: []const Span,
+    extra_outer: *std.ArrayListUnmanaged(NodeIndex),
+    out_assigns: *std.ArrayListUnmanaged(NodeIndex),
+) Transformer.Error!bool {
+    if (decl_node.tag != .variable_declaration) return false;
+    const ve = decl_node.data.extra;
+    if (ve + 2 >= self.ast.extra_data.items.len) return false;
+    const decls_start = self.ast.extra_data.items[ve + 1];
+    const decls_len = self.ast.extra_data.items[ve + 2];
+    if (decls_len == 0) return false;
+
+    // 이 선언의 바인딩이 **전부** export 대상이어야 통째로 전환한다. 섞여 있으면
+    // 부분 전환이 되어 순서/의미가 복잡해지므로 건드리지 않는다.
+    var di: u32 = 0;
+    while (di < decls_len) : (di += 1) {
+        const dtor = self.ast.getNode(@enumFromInt(self.ast.extra_data.items[decls_start + di]));
+        if (dtor.tag != .variable_declarator) return false;
+        const binding = self.ast.getNode(@as(NodeIndex, @enumFromInt(self.ast.extra_data.items[dtor.data.extra])));
+        if (binding.tag != .binding_identifier) return false;
+        const name = self.ast.getText(binding.span);
+        var found = false;
+        for (exported_names) |en| {
+            if (std.mem.eql(u8, name, self.ast.getText(en))) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) return false;
+    }
+
+    const scratch_top = self.scratch.items.len;
+    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+    di = 0;
+    while (di < decls_len) : (di += 1) {
+        const dtor_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[decls_start + di]);
+        const dtor = self.ast.getNode(dtor_idx);
+        const de = dtor.data.extra;
+        const binding_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[de]);
+        const init_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[de + 2]);
+        const binding = self.ast.getNode(binding_idx);
+
+        const bare_binding = try es_helpers.makeBindingIdentifier(self, binding.span);
+        const bare_dtor = try es_helpers.makeDeclarator(self, bare_binding, NodeIndex.none, dtor.span);
+        try self.scratch.append(self.allocator, bare_dtor);
+
+        if (!init_idx.isNone()) {
+            const target = try es_helpers.makeIdentifierRefFromSpan(self, binding.span);
+            const visited_init = try self.visitNode(init_idx);
+            if (visited_init.isNone()) return false;
+            const assign = try es_helpers.makeAssignExpr(self, target, visited_init, dtor.span, 0);
+            try out_assigns.append(self.allocator, try es_helpers.makeExprStmt(self, assign, dtor.span));
+        }
+    }
+
+    const var_stmt = try es_helpers.makeVarDeclaration(
+        self,
+        self.scratch.items[scratch_top..],
+        .@"var",
+        decl_node.span,
+    );
+    try extra_outer.append(self.allocator, var_stmt);
+    return true;
+}
+
+fn splitExportDefault(
+    comptime Transformer: type,
+    self: *Transformer,
+    export_node: Node,
+    assigns: *std.ArrayListUnmanaged(NodeIndex),
+    extra_outer: *std.ArrayListUnmanaged(NodeIndex),
+) Transformer.Error!?NodeIndex {
+    const expr_idx = export_node.data.unary.operand;
+    if (expr_idx.isNone()) return null;
+    const expr_node = self.ast.getNode(expr_idx);
+    // 함수/클래스 선언형 default 는 이름 유무·호이스팅이 달라 별도 축이다 — 건드리지 않는다.
+    switch (expr_node.tag) {
+        .function_declaration, .class_declaration => return null,
+        else => {},
+    }
+
+    const visited = try self.visitNode(expr_idx);
+    if (visited.isNone()) return null;
+
+    const tmp_span = try es_helpers.makeTempVarSpan(self);
+
+    // 안: `_t = expr;`
+    const target = try es_helpers.makeIdentifierRefFromSpan(self, tmp_span);
+    const assign = try es_helpers.makeAssignExpr(self, target, visited, export_node.span, 0);
+    try assigns.append(self.allocator, try es_helpers.makeExprStmt(self, assign, export_node.span));
+
+    // 밖(앞): `var _t;`
+    const bare_binding = try es_helpers.makeBindingIdentifier(self, tmp_span);
+    const bare_dtor = try es_helpers.makeDeclarator(self, bare_binding, NodeIndex.none, export_node.span);
+    const var_stmt = try es_helpers.makeVarDeclaration(self, &.{bare_dtor}, .@"var", export_node.span);
+    try extra_outer.append(self.allocator, var_stmt);
+
+    // 밖(뒤): `export { _t as default };`
+    const local_ref = try es_helpers.makeIdentifierRefFromSpan(self, tmp_span);
+    const exported_ref = try es_helpers.makeIdentifierRef(self, "default");
+    const spec = try self.ast.addNode(.{
+        .tag = .export_specifier,
+        .span = export_node.span,
+        .data = .{ .binary = .{ .left = local_ref, .right = exported_ref, .flags = 0 } },
+    });
+    const spec_list = try self.ast.addNodeList(&.{spec});
+    const new_extra = try self.ast.addExtras(&.{
+        @intFromEnum(NodeIndex.none), spec_list.start, spec_list.len,
+        @intFromEnum(NodeIndex.none), 0,               0,
+    });
+    return try self.ast.addNode(.{
+        .tag = .export_named_declaration,
+        .span = export_node.span,
+        .data = .{ .extra = new_extra },
+    });
+}
+
 fn splitExportedFnOrClass(
     comptime Transformer: type,
     self: *Transformer,
@@ -121,11 +256,15 @@ fn splitExportedFnOrClass(
     assigns: *std.ArrayListUnmanaged(NodeIndex),
 ) Transformer.Error!?NodeIndex {
     const e = export_node.data.extra;
-    if (e + 3 >= self.ast.extra_data.items.len) return null;
+    if (e + 5 >= self.ast.extra_data.items.len) return null;
     const decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
     const specs_start = self.ast.extra_data.items[e + 1];
     const specs_len = self.ast.extra_data.items[e + 2];
     const source_raw = self.ast.extra_data.items[e + 3];
+    // ⚠️ `export_named_declaration` 은 **6슬롯**이다 (attrs_start/attrs_len 포함).
+    // 4슬롯만 쓰면 `readExportNamedExtras` 가 인접 extra_data 를 attrs 로 읽는다.
+    const attrs_start = self.ast.extra_data.items[e + 4];
+    const attrs_len = self.ast.extra_data.items[e + 5];
     if (!@as(NodeIndex, @enumFromInt(source_raw)).isNone()) return null;
     if (decl_idx.isNone()) return null;
 
@@ -158,7 +297,7 @@ fn splitExportedFnOrClass(
     const bare_dtor = try es_helpers.makeDeclarator(self, bare_binding, NodeIndex.none, decl.span);
     const new_decl = try es_helpers.makeVarDeclaration(self, &.{bare_dtor}, .@"var", decl.span);
     const new_extra = try self.ast.addExtras(&.{
-        @intFromEnum(new_decl), specs_start, specs_len, source_raw,
+        @intFromEnum(new_decl), specs_start, specs_len, source_raw, attrs_start, attrs_len,
     });
     return try self.ast.addNode(.{
         .tag = .export_named_declaration,
@@ -174,11 +313,15 @@ fn splitExportedVarDecl(
     assigns: *std.ArrayListUnmanaged(NodeIndex),
 ) Transformer.Error!?NodeIndex {
     const e = export_node.data.extra;
-    if (e + 3 >= self.ast.extra_data.items.len) return null;
+    if (e + 5 >= self.ast.extra_data.items.len) return null;
     const decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
     const specs_start = self.ast.extra_data.items[e + 1];
     const specs_len = self.ast.extra_data.items[e + 2];
     const source_raw = self.ast.extra_data.items[e + 3];
+    // ⚠️ `export_named_declaration` 은 **6슬롯**이다 (attrs_start/attrs_len 포함).
+    // 4슬롯만 쓰면 `readExportNamedExtras` 가 인접 extra_data 를 attrs 로 읽는다.
+    const attrs_start = self.ast.extra_data.items[e + 4];
+    const attrs_len = self.ast.extra_data.items[e + 5];
     // `export { x } from '…'` 은 대상이 다른 모듈이라 분해 대상이 아니다.
     if (!@as(NodeIndex, @enumFromInt(source_raw)).isNone()) return null;
     if (decl_idx.isNone()) return null;
@@ -231,7 +374,7 @@ fn splitExportedVarDecl(
         decl_node.span,
     );
     const new_extra = try self.ast.addExtras(&.{
-        @intFromEnum(new_decl), specs_start, specs_len, source_raw,
+        @intFromEnum(new_decl), specs_start, specs_len, source_raw, attrs_start, attrs_len,
     });
     return try self.ast.addNode(.{
         .tag = .export_named_declaration,
@@ -301,11 +444,22 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
     // 함수 선언 대입은 래퍼 본문 **맨 위**로 (호이스팅 등가).
     var hoisted_assigns: std.ArrayListUnmanaged(NodeIndex) = .empty;
     defer hoisted_assigns.deinit(self.allocator);
+    // `export default` 분해가 만드는 추가 최상위 문장(`var _t;`) — IIFE **앞**에 둔다.
+    var extra_outer: std.ArrayListUnmanaged(NodeIndex) = .empty;
+    defer extra_outer.deinit(self.allocator);
     {
         var ei: u32 = 0;
         while (ei < list.len) : (ei += 1) {
             const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + ei]);
             const child_node = self.ast.getNode(child);
+            if (child_node.tag == .export_default_declaration) {
+                const before_d: u32 = @intCast(split_assigns.items.len);
+                const sd = try splitExportDefault(Transformer, self, child_node, &split_assigns, &extra_outer) orelse continue;
+                try split_src.append(self.allocator, child);
+                try split_export.append(self.allocator, sd);
+                try split_assign_off.append(self.allocator, before_d);
+                continue;
+            }
             if (child_node.tag != .export_named_declaration) continue;
             const before: u32 = @intCast(split_assigns.items.len);
             const split = (try splitExportedVarDecl(Transformer, self, child_node, &split_assigns)) orelse
@@ -316,6 +470,36 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
             try split_assign_off.append(self.allocator, before);
         }
         try split_assign_off.append(self.allocator, @intCast(split_assigns.items.len));
+    }
+
+    // specifier-only export(`export { X };`)의 로컬 이름 수집 — 그 선언은 래퍼 안으로
+    // 들어가므로 바인딩을 밖으로 올려야 한다 (#4598).
+    var exported_locals: std.ArrayListUnmanaged(Span) = .empty;
+    defer exported_locals.deinit(self.allocator);
+    {
+        var ei: u32 = 0;
+        while (ei < list.len) : (ei += 1) {
+            const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + ei]);
+            const child_node = self.ast.getNode(child);
+            if (child_node.tag != .export_named_declaration) continue;
+            const e = child_node.data.extra;
+            if (e + 5 >= self.ast.extra_data.items.len) continue;
+            const decl_i: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+            const src_i: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 3]);
+            if (!decl_i.isNone() or !src_i.isNone()) continue; // 선언형/re-export 는 별도 경로
+            const ss = self.ast.extra_data.items[e + 1];
+            const sl = self.ast.extra_data.items[e + 2];
+            var si: u32 = 0;
+            while (si < sl) : (si += 1) {
+                const spec_i: NodeIndex = @enumFromInt(self.ast.extra_data.items[ss + si]);
+                if (spec_i.isNone()) continue;
+                const spec = self.ast.getNode(spec_i);
+                if (spec.tag != .export_specifier) continue;
+                const local_i = spec.data.binary.left;
+                if (local_i.isNone()) continue;
+                try exported_locals.append(self.allocator, self.ast.getNode(local_i).span);
+            }
+        }
     }
 
     // wrap target 수집 (visit 하여 기본 변환 적용)
@@ -337,6 +521,21 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
                 break;
             }
             continue;
+        }
+        if (exported_locals.items.len > 0) {
+            var local_assigns: std.ArrayListUnmanaged(NodeIndex) = .empty;
+            defer local_assigns.deinit(self.allocator);
+            if (try splitLocalDeclForExport(
+                Transformer,
+                self,
+                child_node,
+                exported_locals.items,
+                &extra_outer,
+                &local_assigns,
+            )) {
+                for (local_assigns.items) |a| try self.scratch.append(self.allocator, a);
+                continue;
+            }
         }
         const visited = try self.visitNode(child);
         if (!visited.isNone()) try self.scratch.append(self.allocator, visited);
@@ -379,6 +578,8 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
     // 현재 scratch 에는 [imports_end..body_stmts_end] 까지 wrap 대상이 있으므로
     // body_stmts_top 이후를 drop 하고 새 리스트를 구성.
     self.scratch.shrinkRetainingCapacity(imports_end);
+    // `var _t;` 는 IIFE **앞** — 래퍼 안 대입이 이 바인딩에 닿아야 한다.
+    for (extra_outer.items) |o| try self.scratch.append(self.allocator, o);
     if (!visited_iife.isNone()) try self.scratch.append(self.allocator, visited_iife);
 
     // exports pass-through

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -2328,6 +2328,45 @@ test "TLA: 분해된 대입은 원래 문장 순서를 지킨다 (#4598)" {
     try std.testing.expect(assign < use);
 }
 
+test "TLA: export function 은 named FE 대입 + 맨 위 배치로 호이스팅을 지킨다 (#4598)" {
+    // ⚠️ 리네임하지 않는다 — 선언을 named function expression 대입으로 바꾸면 안쪽 바인딩이
+    // 사라져 섀도잉이 없어지고 자기참조는 FE 이름이 처리한다. 대입을 본문 맨 위에 두면
+    // 선언 호이스팅과 등가다(`typeof f` 가 선언 앞에서 "function").
+    const source = "const items = [1]; await foo(); export function f() { return items; }";
+    var r = try parseAsModuleAndTransform(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .top_level_await = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    try std.testing.expect(std.mem.indexOf(u8, code, "var f") != null);
+    const assign = std.mem.indexOf(u8, code, "f = function f").?;
+    const await_pos = std.mem.indexOf(u8, code, "await foo()").?;
+    // 대입이 await 보다 앞 = 본문 맨 위 (호이스팅 등가)
+    try std.testing.expect(assign < await_pos);
+}
+
+test "TLA: export class 는 원위치 대입 (클래스는 원래 TDZ) (#4598)" {
+    const source = "const items = [1]; await foo(); export class C { m() { return items; } }";
+    var r = try parseAsModuleAndTransform(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .top_level_await = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    try std.testing.expect(std.mem.indexOf(u8, code, "var C") != null);
+    const assign = std.mem.indexOf(u8, code, "C = class").?;
+    const await_pos = std.mem.indexOf(u8, code, "await foo()").?;
+    // 함수와 달리 원위치 — await 뒤에 온다.
+    try std.testing.expect(assign > await_pos);
+}
+
 test "TLA: 구조분해 export 는 분해하지 않고 종전 동작 유지 (#4598 범위 가드)" {
     // 바인딩이 단순 식별자가 아니면 분해 규칙이 달라진다 — 건드리지 않는다.
     // 이 가드가 없으면 "전부 분해" 로 넓혀도 위 테스트들이 통과해 범위가 사라진다.

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -2367,6 +2367,43 @@ test "TLA: export class 는 원위치 대입 (클래스는 원래 TDZ) (#4598)" 
     try std.testing.expect(assign > await_pos);
 }
 
+test "TLA: export default 는 live binding 으로 분해된다 (#4598)" {
+    // ⚠️ `export default _t;` 로는 안 된다 — `export default <expr>` 는 평가 시점 **값 스냅샷**
+    // 이라 래퍼가 대입하기 전의 `undefined` 가 고정된다. `export { _t as default }` 여야 한다.
+    const source = "const items = [1]; await foo(); export default { items };";
+    var r = try parseAsModuleAndTransform(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .top_level_await = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    try std.testing.expect(std.mem.indexOf(u8, code, "as default") != null);
+    // 스냅샷 형태(`export default <ident>;`)가 남으면 안 된다.
+    try std.testing.expect(std.mem.indexOf(u8, code, "export default") == null);
+}
+
+test "TLA: specifier-only export 의 선언도 바인딩을 밖으로 올린다 (#4598)" {
+    // `const X = …; export { X };` 는 선언이 래퍼 안으로 들어가 export 절과 끊긴다.
+    // 게다가 const-bake 가 래퍼 안에서 참조를 못 봐(export 절이 밖) 선언을 통째로 elide 한다.
+    const source = "const items = [1]; await foo(); const OUT = { items }; export { OUT }; use(OUT);";
+    var r = try parseAsModuleAndTransform(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .top_level_await = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    try std.testing.expect(std.mem.indexOf(u8, code, "var OUT") != null);
+    const assign = std.mem.indexOf(u8, code, "OUT = {").?;
+    const await_pos = std.mem.indexOf(u8, code, "await foo()").?;
+    try std.testing.expect(assign > await_pos); // 원위치(래퍼 안)
+}
+
 test "TLA: 구조분해 export 는 분해하지 않고 종전 동작 유지 (#4598 범위 가드)" {
     // 바인딩이 단순 식별자가 아니면 분해 규칙이 달라진다 — 건드리지 않는다.
     // 이 가드가 없으면 "전부 분해" 로 넓혀도 위 테스트들이 통과해 범위가 사라진다.

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -2286,6 +2286,65 @@ fn parseAsModuleAndTransform(allocator: std.mem.Allocator, source: []const u8, o
     return .{ .ast = moved_ast, .root = root, .scanner = scanner_ptr, .parser = parser_ptr, .allocator = allocator };
 }
 
+test "TLA: export const 는 바인딩만 밖으로, 초기화는 래퍼 안에 남는다 (#4598)" {
+    // 예전엔 `export const OUT = {items}` 가 통째로 래퍼 **밖**으로 나가고 `items` 는 안에
+    // 남아 스코프가 갈렸다 → `ReferenceError: items is not defined`.
+    // 이제 `var OUT;`(밖) + `OUT = {items};`(안) 으로 분해한다 — ESM live binding.
+    const source = "const items = [1]; await foo(); export const OUT = { items };";
+    var r = try parseAsModuleAndTransform(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .top_level_await = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    // 선언과 초기화가 **같은 스코프**(래퍼 안)에 있어야 한다.
+    const wrap = std.mem.indexOf(u8, code, "async").?;
+    const items_decl = std.mem.indexOf(u8, code, "items = [1]").?;
+    const out_assign = std.mem.indexOf(u8, code, "OUT = {").?;
+    try std.testing.expect(items_decl > wrap);
+    try std.testing.expect(out_assign > wrap);
+    // 바인딩만 밖으로.
+    try std.testing.expect(std.mem.indexOf(u8, code, "var OUT") != null);
+}
+
+test "TLA: 분해된 대입은 원래 문장 순서를 지킨다 (#4598)" {
+    // ⚠️ 대입을 래퍼 끝에 몰아넣으면 그 export 를 앞에서 읽는 코드가 `undefined` 를 본다.
+    // 실측으로 잡은 함정 — 순서 가드가 없으면 재발한다.
+    const source = "await foo(); export const A = 1; use(A);";
+    var r = try parseAsModuleAndTransform(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .top_level_await = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    const assign = std.mem.indexOf(u8, code, "A = 1").?;
+    const use = std.mem.indexOf(u8, code, "use(A)").?;
+    try std.testing.expect(assign < use);
+}
+
+test "TLA: 구조분해 export 는 분해하지 않고 종전 동작 유지 (#4598 범위 가드)" {
+    // 바인딩이 단순 식별자가 아니면 분해 규칙이 달라진다 — 건드리지 않는다.
+    // 이 가드가 없으면 "전부 분해" 로 넓혀도 위 테스트들이 통과해 범위가 사라진다.
+    const source = "const o = {a:1}; await foo(); export const { a } = o;";
+    var r = try parseAsModuleAndTransform(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .top_level_await = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // 원형 유지 — `var { a }` 같은 분해 산물이 나오면 안 된다.
+    try std.testing.expect(std.mem.indexOf(u8, code, "export const {") != null or
+        std.mem.indexOf(u8, code, "export const{") != null);
+}
+
 test "TLA: es2022+ no-op (top_level_await supported)" {
     // TLA 가 지원되는 타겟에서는 await 가 그대로 유지된다.
     const source = "await foo();";


### PR DESCRIPTION
## 문제

`top-level await` + `--target < es2022` 번들이 **진단 없이 성공**하고 실행 불가 코드를 냈다.

```
$ zntc --bundle a.ts --format=esm --target=es2017 -o a.mjs   # exit 0, 진단 0건
$ node a.mjs
ReferenceError: items is not defined
```

## 루트커즈

TLA 래퍼가 최상위 문장을 `(async () => {…})()` 안으로 넣는데, `export` 선언은 ESM 상 최상위에만
올 수 있어 밖에 남는다 → **선언은 안 / 사용은 밖** 으로 스코프가 갈린다.

## 수정 — 바인딩만 밖으로

`export const X = init;` → `export var X;`(밖) + `X = init;`(래퍼 안, **원래 순서 유지**).
ESM live binding 으로 밖에서도 보인다. rspack 이 export 를 getter 로 선등록하는 것의 ESM 등가.

⚠️ **참조 분석을 하지 않는다.** "이 export 가 래퍼 로컬을 참조하는가" 로 좁히려다 계속 경계를
놓쳤다. 균일하게 분해하면 그 판정이 불필요하다.

⚠️ 대입을 래퍼 **끝에 몰아넣으면 안 된다** — 앞에서 읽는 코드가 `undefined` 를 본다. 1차 구현이
이 함정에 빠졌고 실행으로 잡았다. 순서 가드 테스트를 넣었다.

## 적대적 검증에서 뒤집힌 전제들

이슈 본문과 제 초기 계획이 여러 번 틀렸습니다. 전부 실측으로 확인:

| 주장 | 실측 |
|---|---|
| "정확한 다운레벨은 불가" (이슈 본문) | **거짓** — rspack 이 `__webpack_require__.a` 로 다운레벨, 실행 성공 |
| rolldown 방식(TLA 원형 유지)이 답 | **거짓** — RN 실물 `hermesc`(RN 0.83.1)가 네이티브 TLA 를 **파싱조차 못 함** |
| Hermes 가 async arrow 거부 | **거짓** — 구 `hermes-engine-cli 0.12.0` 만. ⚠️ 두 바이너리의 버전 문자열이 `LLVM 8.0.0svn` 로 **같은데 능력이 다름** |
| RN 은 async 래퍼로 부족, generator 필요 | **거짓** — es5 경로가 `__async`/`__generator` 로 이미 합성, Hermes 통과 |

즉 **래퍼 방식 자체는 옳았고, 깨진 건 export 스코프뿐**이었습니다.

⚠️ **검증 방법 함정**: Node 는 TLA 를 네이티브 지원하므로 **Node 실행만으로 판정하면 안 됩니다**
(`for await` 파손을 "정상" 으로 오판했습니다). Hermes 오라클은 RN fixture 의 `hermesc` + es5 빌드.

## 커버리지 (정직하게)

| 형태 | 상태 |
|---|---|
| export 없는 TLA | 종전대로 정상 |
| `export const/let/var` — **신고된 재현 케이스** | ✅ 수정 |
| 중첩 블록 안의 await | ✅ 수정 |
| `export function` / `class` / `default` / `const X=…; export {X}` | ❌ 미해결 |
| `for await...of` 가 래퍼를 안 탐 (별개 축) | ❌ 미해결 |

미해결분은 #4598 에 측정과 함께 남깁니다 — 같은 분해를 이름 선언 형태로 확장하면 됩니다.

## 검증

- 재현 → `R: {"items":[1]}` 정상, 순서도 원본 유지.
- **A/B 비공허**: 분해를 무력화하면 스코프 테스트 + 순서 테스트 2건 실패.
- **범위 가드**: 구조분해 export 는 분해하지 않는다(테스트) — 넓혀도 깨지게.
- 유닛 **6322 통과**, 통합 **4448 pass** (실패 2건은 main baseline 동일), `zig build napi` 통과.

Refs #4598

🤖 Generated with [Claude Code](https://claude.com/claude-code)