### PR TITLE
fix(bundler): #4598 IIFE 의 TLA 다운레벨을 청크 async factory 에 위임

### DIFF
--- a/.changeset/tla-chunk-async-factory.md
+++ b/.changeset/tla-chunk-async-factory.md
@@ -1,0 +1,13 @@
+---
+"@zntc/core": patch
+---
+
+IIFE 번들에서 top-level await + `--target < es2022` 가 `ReferenceError` 를 내던 문제를
+고쳤다 (#4598 부분).
+
+TLA 다운레벨을 모듈 단위 래핑 대신 **청크 레벨 async factory** 에 위임한다. 모듈 단위로 감싸면
+`export` 가 래퍼 밖에 남아 스코프가 갈리고, 같은 번들 소비자도 래퍼 밖 최상위에 놓여 값을 못
+본다(scope-hoisted 출력이라 live binding 이 없다).
+
+⚠️ **IIFE + async 지원 타겟에만** 적용한다. UMD/AMD/CJS 는 async factory 를 만들지 않고,
+es5 는 factory 가 generator 여야 하는데 `for await` 다운레벨과 충돌한다.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -924,6 +924,8 @@ pub const Bundler = struct {
     /// emit_runtime_helper_imports / borrow_source_ast) 만 caller 가 추가.
     fn buildTransformOptionsBase(self: *const Bundler) @import("../transformer/transformer.zig").TransformOptions {
         return .{
+            // #4598: IIFE + async 지원 타겟만 (근거는 TransformOptions 필드 주석).
+            .tla_chunk_wrapped = self.options.format == .iife and !self.options.unsupported.async_await,
             .define = self.options.define,
             .experimental_decorators = self.options.experimental_decorators,
             .emit_decorator_metadata = self.options.emit_decorator_metadata,

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4558,6 +4558,55 @@ test "#4616 --external-alias 가 cjs require 방출에도 적용된다" {
     try std.testing.expect(std.mem.indexOf(u8, js, "crypto-browserify") != null);
 }
 
+fn bundleTlaIife(tmp: *std.testing.TmpDir, unsup: @import("../../transformer/transformer.zig").TransformOptions.compat.UnsupportedFeatures) ![]const u8 {
+    try writeFile(tmp.dir, "src/tla.ts", "const items = [1];\nawait Promise.resolve();\nexport const OUT = { items };");
+    try writeFile(tmp.dir, "src/main.ts", "import { OUT } from './tla';\nconsole.log(JSON.stringify(OUT));");
+    const entry = try absPath(tmp, "src/main.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .iife,
+        .global_name = "App",
+        .unsupported = unsup,
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    return std.testing.allocator.dupe(u8, result.output);
+}
+
+test "#4598 IIFE: TLA 를 청크 async factory 에 위임한다" {
+    // 모듈 단위 래핑은 `export` 를 래퍼 밖에 남겨 스코프를 가르고, 같은 번들 소비자도 래퍼
+    // 밖 최상위에 놓여 값을 못 본다(scope-hoisted 라 live binding 이 없다). 청크 전체를
+    // 감싸면 선언·소비자가 한 스코프에 올바른 순서로 놓인다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const js = try bundleTlaIife(&tmp, .{ .top_level_await = true });
+    defer std.testing.allocator.free(js);
+
+    // factory 가 async — `var App = ` 바로 뒤를 본다(모듈 단위 산물과 구분).
+    const m = "var App = ";
+    const pos = std.mem.indexOf(u8, js, m).? + m.len;
+    try std.testing.expect(std.mem.startsWith(u8, js[pos..], "(async"));
+    // 모듈 단위 래핑 산물(`export` 밖 분리)이 없어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, js, "const OUT = { items }") != null);
+}
+
+test "#4598 IIFE: async 미지원 타겟은 위임하지 않는다 (회귀 가드)" {
+    // ⚠️ es5 는 factory 가 generator 여야 하는데 `for await` 다운레벨이 내부에 `await` 를
+    // 그대로 내보내 generator 안에서 SyntaxError 가 된다. 4차에서 실제로 회귀했다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const js = try bundleTlaIife(&tmp, .{ .top_level_await = true, .async_await = true });
+    defer std.testing.allocator.free(js);
+
+    const m = "var App = ";
+    const pos = std.mem.indexOf(u8, js, m).? + m.len;
+    try std.testing.expect(!std.mem.startsWith(u8, js[pos..], "(async"));
+    try std.testing.expect(!std.mem.startsWith(u8, js[pos..], "__async"));
+}
+
 test "#4604 CSS url(): catch-all tsconfig paths 가 bare url() 을 가로채지 않는다 (형제 있음)" {
     // 신고된 재현 그대로. `"paths": { "*": ["src/*"] }` 하에서 `url(assets/logo.png)` 가
     // paths 에 걸려 `src/assets/logo.png` 로, `url(./assets/logo.png)` 는 형제로 가서

--- a/src/bundler/cache_key.zig
+++ b/src/bundler/cache_key.zig
@@ -142,8 +142,12 @@ comptime {
     // SelectiveOptions ↔ TransformOptions 동기화 강제(정밀 전략 안전망). TransformOptions 에
     // 필드가 추가되면 컴파일 에러 → 그 필드가 parse/semantic(pre-pass) 결과에 영향을 주는지
     // 판정해서, 주면 SelectiveOptions 에 반영하고 이 수를 갱신할 것(누락=silent miscompile).
+    //
+    // 분류 (#4598): `tla_chunk_wrapped` 는 **transform-only**. 정밀 전략은 pre-transform 캐시
+    // 전용이고(파일 상단) parse/semantic 은 이 값을 읽지 않는다. ⚠️ post-transform 캐시로
+    // 확장하면 편입 필수 — 값에 따라 TLA 래핑 여부가 갈려 같은 소스가 다른 AST 를 낸다.
     const tf_fields = @typeInfo(@import("../transformer/options.zig").TransformOptions).@"struct".fields.len;
-    if (tf_fields != 45)
+    if (tf_fields != 46)
         @compileError("TransformOptions 필드 수 변경 — 새 필드의 parse-영향 여부 판정 후 SelectiveOptions 갱신 + 이 수 갱신 필요.");
 }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -451,13 +451,6 @@ pub fn emitWithTreeShaking(
         try output.append(allocator, '\n');
     }
 
-    // TLA 포함 여부: 래핑 포맷에서 async로 감싸야 하는지 결정
-    const has_tla = blk: {
-        for (sorted.items) |m| {
-            if (m.uses_top_level_await) break :blk true;
-        }
-        break :blk false;
-    };
     // IIFE 래퍼는 내부에 `this`/`arguments`/`new.target`을 노출하지 않으므로
     // arrow 전환이 시맨틱을 바꾸지 않는다. ES5 타겟처럼 arrow 미지원 환경에서만
     // 기존 `function` 형태를 유지 (#1580, esbuild 관행과 동일).
@@ -512,13 +505,29 @@ pub fn emitWithTreeShaking(
 
     // IIFE + externals 가 있으면 factory_fn 을 param 포함 형태로 조립 (#1824).
     // 예: `(function(React, ReactDom) {\n`. 그 외에는 정적 문자열 사용.
-    const factory_fn_static = if (has_tla)
+    // 네이티브 TLA 가 남아 있는 경우(es2022+) — factory 가 async 여야 문법이 성립한다.
+    const has_native_tla = blk: {
+        for (sorted.items) |m| {
+            if (m.uses_top_level_await) break :blk true;
+        }
+        break :blk false;
+    };
+    // #4598: 청크 async factory 는 **위임된 경우에만** 켠다. `has_tla` 만 보면 모듈 단위
+    // 래핑이 이미 처리한 경우(es5 등)까지 async 로 만들어 미지원 타겟에 `async` 가 나간다.
+    const tla_delegated = blk_d: {
+        for (sorted.items) |m| {
+            if (m.tla_delegated_to_chunk) break :blk_d true;
+        }
+        break :blk_d false;
+    };
+    const factory_async = has_native_tla or tla_delegated;
+    const factory_fn_static = if (factory_async)
         (if (use_arrow) "(async () => {\n" else "(async function() {\n")
     else
         (if (use_arrow) "(() => {\n" else "(function() {\n");
     const factory_fn_owned: ?[]const u8 = blk: {
         if (options.format != .iife or ext_param_names.len == 0) break :blk null;
-        const prefix = if (has_tla)
+        const prefix = if (factory_async)
             (if (use_arrow) "(async (" else "(async function(")
         else
             (if (use_arrow) "((" else "(function(");

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -137,6 +137,17 @@ pub fn run(self: anytype, module: *Module, arena_alloc: std.mem.Allocator) void 
     }
     transformer.line_offsets = module.line_offsets;
 
+    // #4598: 청크에 위임한 경우, **변환 전** AST 에서 TLA 유무를 확인해 전용 필드에 남긴다.
+    // 변환 뒤에 도는 analyzer 로는 알 수 없고(그 변환이 await 를 없앤다), 전역
+    // `uses_top_level_await` 를 넓히면 다른 경로가 함께 바뀐다(4차 회귀 원인).
+    if (opts.tla_chunk_wrapped and opts.unsupported.top_level_await) {
+        const es2022_tla_mod = @import("../../transformer/es2022_tla.zig");
+        if (ast_ptr.nodes.items.len > 0) {
+            const root_idx: @import("../../parser/ast.zig").NodeIndex = @enumFromInt(ast_ptr.nodes.items.len - 1);
+            module.tla_delegated_to_chunk = es2022_tla_mod.hasTopLevelAwait(ast_ptr, root_idx) catch false;
+        }
+    }
+
     const root = transformer.transform() catch return;
     // #4210: 다운레벨 못한 ES2025 inline modifier 가 출력에 보존됨 → loud 진단
     // (transform-driven — 실제 fold bail 반영). transpile path 와 동일 메시지.

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -435,6 +435,12 @@ pub const Module = struct {
     /// esbuild의 entryPointKind과 동일 — 정렬 순서나 exec_index와 무관하게
     /// 엔트리를 100% 정확히 식별한다.
     is_entry_point: bool = false,
+    /// 이 모듈의 top-level await 를 **청크 레벨 async factory 에 위임**했는지 (#4598).
+    ///
+    /// ⚠️ `uses_top_level_await` 를 재활용하면 안 된다. 그 플래그는 `appendModuleCall`
+    /// (`await init_X()`)·`ZNTC0002` 경고 등 여러 경로가 읽어서, 값을 넓히면 의도치 않은
+    /// 곳이 함께 바뀐다(4차 시도가 이걸로 회귀했다). 위임 사실만 담는 전용 필드로 둔다.
+    tla_delegated_to_chunk: bool = false,
     /// Module Federation 연합 경계 모듈 (#3318 P1-1). `mf.exposes` 타겟 ∪
     /// `mf.shared` ∪ shared 전방-의존 폐포. P1-1 은 **표시·안정 ID 계산만**
     /// (분석) — 스코프 호이스팅 소거 제외 *enforcement*·container/manifest

--- a/src/transformer/es2022_tla.zig
+++ b/src/transformer/es2022_tla.zig
@@ -68,6 +68,13 @@ fn topLevelAwaitVisit(ctx: *TopLevelAwaitCtx, idx: NodeIndex, node: Node) ast_wa
         .class_declaration,
         .class_expression,
         => return .skip_children,
+        // `for await (… of …)` 도 top-level await 다 — 다운레벨 시 내부에 `await` 를
+        // 남기므로 감지 대상이다. 놓치면 변환만 건너뛰고 청크 factory 는 async 가 아닌
+        // 상태가 돼 네이티브 await 가 누출된다 (#4598).
+        .for_await_of_statement => {
+            ctx.found = true;
+            return .stop;
+        },
         .await_expression => {
             ctx.found = true;
             return .stop;
@@ -76,7 +83,7 @@ fn topLevelAwaitVisit(ctx: *TopLevelAwaitCtx, idx: NodeIndex, node: Node) ast_wa
     }
 }
 
-fn hasTopLevelAwait(ast: *const ast_mod.Ast, idx: NodeIndex) std.mem.Allocator.Error!bool {
+pub fn hasTopLevelAwait(ast: *const ast_mod.Ast, idx: NodeIndex) std.mem.Allocator.Error!bool {
     // 반복 순회(#4123): top-level 깊은 좌결합 체인에서 재귀 시 스택 오버플로우. OOM 은
     // 호출자(lowerProgram=Error!)로 전파한다 — true/false 어느 기본값도 안전하지 않으므로
     // (false=미지원 타깃에 unwrapped await / true=불필요 IIFE wrap) 추측 대신 에러 전파.

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -60,6 +60,16 @@ pub const AutoLabelMode = enum {
 
 /// Transformer 설정.
 pub const TransformOptions = struct {
+    /// 청크 레벨 async factory 가 top-level await 를 대신 처리하는지 (#4598).
+    ///
+    /// IIFE + async 지원 타겟에서만 켠다. 그 조합에서는 모듈 단위 래핑이 해롭다 —
+    /// `export` 가 래퍼 밖에 남아 스코프가 갈리고, 같은 번들 소비자도 래퍼 밖 최상위에
+    /// 놓여 값을 못 본다(scope-hoisted 출력이라 live binding 이 없다).
+    ///
+    /// ⚠️ UMD/AMD/CJS 로 넓히면 안 된다 — async factory 를 만들지 않아 감쌀 것이 없어진다.
+    /// ⚠️ async 미지원 타겟(es5)도 안 된다 — factory 가 generator 여야 하는데 `for await`
+    /// 다운레벨이 내부에 `await` 를 그대로 내보내 generator 안에서 SyntaxError 가 된다.
+    tla_chunk_wrapped: bool = false,
     /// TS 타입 스트리핑 활성화 (기본: true)
     strip_types: bool = true,
     /// console.* 호출 제거 (--drop=console)

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -83,7 +83,7 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
             // 여기서 early-return 해 TLA+styled-components(css-prop) 동시 사용 시 추출된
             // module-level decl 이 hoist 되지 않고 소실됐다.
             const result = blk: {
-                if (self.options.unsupported.top_level_await) {
+                if (self.options.unsupported.top_level_await and !self.options.tla_chunk_wrapped) {
                     if (try es2022_tla.lowerProgram(Transformer, self, node)) |wrapped| break :blk wrapped;
                 }
                 break :blk try self.visitListNode(idx);


### PR DESCRIPTION
## 문제

`top-level await` + `--target < es2022` IIFE 번들이 `ReferenceError` 를 냈다.

## 루트커즈 — 플래그가 자기가 측정할 것을 없앤 변환 뒤에 기록된다

`transform_prepass.zig` 의 `SemanticAnalyzer` 가 `transformer.transform()` **뒤에** 돈다.
모듈 단위 TLA 래핑이 await 를 async IIFE 안으로 옮기면 `isInsideFunctionScope()` 가 true 가 되어
`uses_top_level_await` 가 서지 않는다. 그 결과 `emitter.zig` 의 **청크 레벨 async factory 가
정확히 다운레벨이 필요한 구간에서 꺼진다**(es2022+ 에서만 발화 — 거기선 필요가 없다).

계측: es2022 `self=true` / es2017·es5 `self=false`.

## 수정 — 위임 + 전용 필드

IIFE + async 지원 타겟에서는 모듈 단위 래핑을 건너뛰고 청크 factory 가 감싼다.
**선언·함수·클래스를 전혀 건드리지 않고** 모든 모듈이 한 스코프에 올바른 순서로 놓인다.

⚠️ 위임 사실은 **전용 필드**(`Module.tla_delegated_to_chunk`)에 담는다. `uses_top_level_await`
를 재활용하면 `appendModuleCall`(`await init_X()`)·`ZNTC0002` 경고 등 여러 경로가 함께 바뀐다.

⚠️ `for await` 도 감지 대상에 넣었다. 놓치면 변환만 건너뛰고 factory 는 async 가 아닌 상태가 돼
네이티브 await 가 누출된다.

## ⚠️ 범위를 넓히면 깨진다 (전부 실측)

| 넓힌 게이트 | 결과 |
|---|---|
| `format != .esm` | **umd es5 회귀** — UMD 는 async factory 를 안 만든다 |
| `format == .iife` (es5 포함) | **forawait es5 회귀** — `for await` 다운레벨의 내부 `await` 가 generator factory 안에서 SyntaxError |
| 전역 `uses_top_level_await` 확장 | 무관한 경로가 함께 바뀜 |

## 검증 — 20칸 전수 (포맷 4 × 타겟 3 + export 형태 4 × 타겟 2)

**main 대비 개선 2, 회귀 0** (18칸 동일):

| 칸 | main | 이 PR |
|---|---|---|
| `iife es2017` (같은 번들 소비자) | ❌ | **✅** |
| `repro es2017` (export 가 래퍼 로컬 참조) | ❌ | **✅** |

- **A/B 비공허**: 위임을 끄면 해당 테스트만 실패.
- **범위 가드**: async 미지원 타겟에서 factory 가 async/generator 가 **아님**을 단언.
- 유닛 **6320 통과**, 통합 **4448 pass**(실패 2건은 main baseline 동일), `zig build napi` 통과.

## 남은 범위 (#4598 유지)

UMD/AMD/CJS(async factory 없음) · ESM(최상위 `export` 를 async 안에 못 넣음) · es5 전반.
근본 해결은 rspack 식 **모듈 레지스트리 + getter** 가 필요하다 — 이슈에 지형을 기록해 뒀다.

Refs #4598

🤖 Generated with [Claude Code](https://claude.com/claude-code)