### PR TITLE
fix(bundler): #4598 splitting 청크 SyntaxError 회귀 + worker 가 부모 format 으로 판정하던 문제

### DIFF
--- a/.changeset/tla-worker-format-gate.md
+++ b/.changeset/tla-worker-format-gate.md
@@ -1,0 +1,15 @@
+---
+"@zntc/core": patch
+---
+
+worker 서브빌드의 top-level await 다운레벨이 **부모 번들의 format 에 따라 깨졌다 안 깨졌다**
+하던 문제를 고쳤다 (#4598 후속).
+
+worker 는 부모가 esm/cjs/umd 여도 자기 자신은 iife 로 방출된다. 그런데 #4598 의 위임 판정이
+부모 format 을 보고 있어, 부모가 iife 가 아니면 위임이 꺼진 채로 iife 청크가 방출됐다. 결과적으로
+같은 worker 파일이 `const val = v + 1;` 을 async 래퍼 밖에 남겨 `ReferenceError: v is not
+defined` 를 냈다. 이제 worker 는 자기 방출 format(`workerFormat()`)으로 판정한다.
+
+같은 원인의 두 번째 구멍도 함께 막았다. multi-format(`output: [...]`)은 **하나의 그래프를 여러
+format 으로** 방출하므로 "async factory 가 생긴다"는 위임의 전제가 성립하지 않는다. 방출 format
+이 하나로 확정되지 않으면 위임하지 않고 모듈 단위 래핑에 맡긴다.

--- a/.changeset/tla-worker-format-gate.md
+++ b/.changeset/tla-worker-format-gate.md
@@ -2,14 +2,14 @@
 "@zntc/core": patch
 ---
 
-worker 서브빌드의 top-level await 다운레벨이 **부모 번들의 format 에 따라 깨졌다 안 깨졌다**
-하던 문제를 고쳤다 (#4598 후속).
+#4598 TLA 위임의 구멍 두 개를 막았다.
 
-worker 는 부모가 esm/cjs/umd 여도 자기 자신은 iife 로 방출된다. 그런데 #4598 의 위임 판정이
-부모 format 을 보고 있어, 부모가 iife 가 아니면 위임이 꺼진 채로 iife 청크가 방출됐다. 결과적으로
-같은 worker 파일이 `const val = v + 1;` 을 async 래퍼 밖에 남겨 `ReferenceError: v is not
-defined` 를 냈다. 이제 worker 는 자기 방출 format(`workerFormat()`)으로 판정한다.
+**1) code splitting 청크가 파싱조차 안 되던 회귀.** splitting 의 IIFE 청크는 async factory 가
+아니라 `__zntc_register({"m.js": function(exports, module, require) {...}})` — plain function
+이다. 위임하면 `await` 가 그 안에 그대로 들어가 **청크 전체가 SyntaxError** 였다. splitting 은
+위임 대상에서 뺀다. 모듈 단위 래핑은 #4598 로 여전히 깨져 있지만 최소한 파싱은 된다.
 
-같은 원인의 두 번째 구멍도 함께 막았다. multi-format(`output: [...]`)은 **하나의 그래프를 여러
-format 으로** 방출하므로 "async factory 가 생긴다"는 위임의 전제가 성립하지 않는다. 방출 format
-이 하나로 확정되지 않으면 위임하지 않고 모듈 단위 래핑에 맡긴다.
+**2) worker 서브빌드가 부모 format 으로 판정하던 문제.** worker 는 부모가 esm/cjs/umd 여도
+자신은 iife 로 방출된다. 부모 format 으로 판정하면 같은 worker 파일이 부모에 따라 깨졌다 안
+깨졌다 했다 — `const val = v + 1;` 이 async 래퍼 밖에 남아 `ReferenceError: v is not defined`.
+이제 worker 는 자기 방출 format(`workerFormat()`)으로 판정한다.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -918,14 +918,29 @@ pub const Bundler = struct {
         if (self.owned_disk_cache) |*s| s.deinit();
     }
 
+    /// #4598: TLA 다운레벨을 청크 async factory 에 위임할지. **방출 format 이 인자**다 —
+    /// `self.options.format` 을 직접 보면 안 된다. worker 서브빌드는 부모가 esm/cjs 여도
+    /// 자기 자신은 `workerFormat()` (= 거의 항상 iife) 으로 방출하므로, 부모 format 으로
+    /// 판정하면 청크가 async factory 인데 모듈은 래핑된 채로 남는 불일치가 생긴다.
+    fn tlaChunkWrapped(self: *const Bundler, format: EmitOptions.Format) bool {
+        // multi-format 은 **하나의 그래프를 여러 format 으로** 방출한다. 위임은 "이 모듈의
+        // await 를 감싸 줄 async factory 가 실제로 생긴다" 는 약속이라 방출 format 이
+        // 하나로 확정될 때만 성립 — 확정 못 하면 위임하지 않고 모듈 단위 래핑에 맡긴다.
+        if (self.options.output.len > 1) return false;
+        return format == .iife and !self.options.unsupported.async_await;
+    }
+
     /// BundleOptions → TransformOptions base 변환 (#1961 PR 1f). graph 와 emitter
     /// 양쪽이 동일 base 를 시작점으로 transformer.init 호출 — drift hot spot 단일화.
     /// per-module override (react_refresh / plugins / jsx_transform / jsx_filename /
     /// emit_runtime_helper_imports / borrow_source_ast) 만 caller 가 추가.
-    fn buildTransformOptionsBase(self: *const Bundler) @import("../transformer/transformer.zig").TransformOptions {
+    ///
+    /// `format` 은 **이 base 로 변환한 모듈이 실제로 방출될 format**. 대부분
+    /// `self.options.format` 이지만 worker 서브빌드는 다르다 (위 `tlaChunkWrapped` 주석).
+    fn buildTransformOptionsBase(self: *const Bundler, format: EmitOptions.Format) @import("../transformer/transformer.zig").TransformOptions {
         return .{
             // #4598: IIFE + async 지원 타겟만 (근거는 TransformOptions 필드 주석).
-            .tla_chunk_wrapped = self.options.format == .iife and !self.options.unsupported.async_await,
+            .tla_chunk_wrapped = self.tlaChunkWrapped(format),
             .define = self.options.define,
             .experimental_decorators = self.options.experimental_decorators,
             .emit_decorator_metadata = self.options.emit_decorator_metadata,
@@ -952,11 +967,14 @@ pub const Bundler = struct {
     /// BundleOptions → EmitOptions 변환. 3개 경로(단일/splitting/dev)에서 공용.
     /// transformer 옵션 mirror 필드는 모두 `transform_options_base` 에서 derived —
     /// `self.options` 와 `base` 양쪽이 single source 두 곳이 되는 drift 위험 제거 (#1961 후속).
-    fn makeEmitOptions(self: *const Bundler) EmitOptions {
-        const base = self.buildTransformOptionsBase();
+    /// `format` 은 이 EmitOptions 로 방출할 format. 호출 후 `emit_opts.format` 을 덮어쓰면
+    /// `transform_options_base` 의 #4598 게이트가 옛 format 으로 남아 어긋나므로 금지 —
+    /// 반드시 인자로 넘긴다.
+    fn makeEmitOptions(self: *const Bundler, format: EmitOptions.Format) EmitOptions {
+        const base = self.buildTransformOptionsBase(format);
         return .{
             .transform_options_base = base,
-            .format = self.options.format,
+            .format = format,
             // transformer-mirror 필드는 base 에서 derived (single source).
             .minify_whitespace = base.minify_whitespace,
             .minify_syntax = base.minify_syntax,
@@ -1081,7 +1099,8 @@ pub const Bundler = struct {
         worker_graph.code_splitting = self.options.code_splitting;
         worker_graph.preserve_modules = self.options.preserve_modules;
         worker_graph.minify_identifiers = self.options.minify_identifiers;
-        worker_graph.transform_options_base = self.buildTransformOptionsBase();
+        // #4598: worker 는 자기 자신의 방출 format(`workerFormat()`) 으로 판정해야 한다.
+        worker_graph.transform_options_base = self.buildTransformOptionsBase(self.workerFormat());
         defer worker_graph.deinit();
 
         const entry_path = try arena_alloc.dupe(u8, worker_path);
@@ -1105,8 +1124,7 @@ pub const Bundler = struct {
         defer worker_linker.deinit();
 
         // emit
-        var emit_opts = self.makeEmitOptions();
-        emit_opts.format = format;
+        var emit_opts = self.makeEmitOptions(format);
         const worker_result = try emitter.emitWithTreeShaking(
             io,
             arena_alloc,
@@ -1338,7 +1356,7 @@ pub const Bundler = struct {
         };
         if (disk_cache_ptr) |dc| {
             graph.disk_cache = dc;
-            const eo = self.makeEmitOptions();
+            const eo = self.makeEmitOptions(self.options.format);
             graph.disk_options_hash = @import("compiled_cache.zig").computeDiskOptionsHash(&eo);
             graph.disk_compiler_build_id = @import("../build_id.zig").current();
             // load hit 게이트: effective legal_comments 가 load-안전(inline/none)일 때만 load 활성.
@@ -1398,7 +1416,7 @@ pub const Bundler = struct {
         // PR-3a: dev lazy compilation — discovery 가 동적 import 경계 정지(seed 등록).
         graph.lazy_compilation = self.options.lazy_compilation;
         graph.lazy_force_parse = self.options.lazy_force_parse;
-        graph.transform_options_base = self.buildTransformOptionsBase();
+        graph.transform_options_base = self.buildTransformOptionsBase(self.options.format);
         // RFC #3933 Sub-PR-B.2: external_graph 면 deinit skip (caller 보존).
         defer if (!has_external_graph) graph.deinit();
 
@@ -1907,7 +1925,7 @@ pub const Bundler = struct {
         const dev_split = self.options.dev_mode and self.options.code_splitting and self.options.lazy_compilation;
         if (self.options.dev_mode and !dev_split) {
             // Dev mode: 프로덕션 파이프라인 재사용 (__commonJS/__esm 래핑 + HMR 런타임).
-            var dev_emit_opts = self.makeEmitOptions();
+            var dev_emit_opts = self.makeEmitOptions(self.options.format);
             dev_emit_opts.sourcemap.enable = true;
             dev_emit_opts.dev_mode = true;
             // 단일번들 dev 는 code_splitting=false 라 useDevModuleRegistry 가 lazy 와 무관히 true 지만,
@@ -2023,7 +2041,7 @@ pub const Bundler = struct {
                     try chunk_mod.computeCrossChunkGlobalNames(self.allocator, &chunk_graph, l);
             }
 
-            var emit_opts = self.makeEmitOptions();
+            var emit_opts = self.makeEmitOptions(self.options.format);
             emit_opts.preserve_modules = self.options.preserve_modules;
             emit_opts.preserve_modules_root = self.options.preserve_modules_root;
             emit_opts.worker_map_per_module = &worker_map_per_module;
@@ -2192,8 +2210,7 @@ pub const Bundler = struct {
                     });
                     l.resetEmitTransients();
                 }
-                var emit_opts = self.makeEmitOptions();
-                emit_opts.format = cfg.format;
+                var emit_opts = self.makeEmitOptions(cfg.format);
                 emit_opts.polyfills = polyfill_entries.items;
                 emit_opts.worker_map_per_module = &worker_map_per_module;
                 if (self.options.sourcemap.enable) emit_opts.sourcemap.enable = true;
@@ -2225,7 +2242,7 @@ pub const Bundler = struct {
             outputs_by_format = by;
         } else {
             // 단일 파일 경로 (tree shaking + 소스맵 지원)
-            var emit_opts = self.makeEmitOptions();
+            var emit_opts = self.makeEmitOptions(self.options.format);
             emit_opts.polyfills = polyfill_entries.items;
             emit_opts.worker_map_per_module = &worker_map_per_module;
             if (self.options.sourcemap.enable) emit_opts.sourcemap.enable = true;

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -918,15 +918,20 @@ pub const Bundler = struct {
         if (self.owned_disk_cache) |*s| s.deinit();
     }
 
-    /// #4598: TLA 다운레벨을 청크 async factory 에 위임할지. **방출 format 이 인자**다 —
-    /// `self.options.format` 을 직접 보면 안 된다. worker 서브빌드는 부모가 esm/cjs 여도
-    /// 자기 자신은 `workerFormat()` (= 거의 항상 iife) 으로 방출하므로, 부모 format 으로
-    /// 판정하면 청크가 async factory 인데 모듈은 래핑된 채로 남는 불일치가 생긴다.
+    /// #4598: TLA 다운레벨을 청크 async factory 에 위임할지. **모듈이 변환될 때 기준이 되는
+    /// format 이 인자**다 — `self.options.format` 을 직접 보면 안 된다. worker 서브빌드는
+    /// 부모가 esm/cjs 여도 자기 자신은 `workerFormat()` (= 거의 항상 iife) 으로 방출하므로,
+    /// 부모 format 으로 판정하면 청크가 async factory 인데 모듈은 래핑된 채로 남는다.
+    ///
+    /// 위임의 전제는 "이 모듈의 await 를 감싸 줄 **async factory 가 실제로 생긴다**" 이다.
+    /// 전제가 깨지는 위상은 아래처럼 명시적으로 뺀다 — 빼면 모듈 단위 래핑(여전히 #4598 로
+    /// 깨져 있음)으로 돌아가지만, 적어도 **파싱은 되는** 산물이 나온다.
     fn tlaChunkWrapped(self: *const Bundler, format: EmitOptions.Format) bool {
-        // multi-format 은 **하나의 그래프를 여러 format 으로** 방출한다. 위임은 "이 모듈의
-        // await 를 감싸 줄 async factory 가 실제로 생긴다" 는 약속이라 방출 format 이
-        // 하나로 확정될 때만 성립 — 확정 못 하면 위임하지 않고 모듈 단위 래핑에 맡긴다.
-        if (self.options.output.len > 1) return false;
+        // code splitting 의 IIFE 청크는 async factory 가 아니라
+        // `__zntc_register({"m.js": function(exports, module, require) {...}})` — plain
+        // function 이다. 위임하면 bare `await` 가 non-async function 안에 떨어져
+        // **청크 전체가 SyntaxError** 로 파싱조차 안 된다 (#4625 회귀).
+        if (self.options.code_splitting) return false;
         return format == .iife and !self.options.unsupported.async_await;
     }
 
@@ -967,9 +972,11 @@ pub const Bundler = struct {
     /// BundleOptions → EmitOptions 변환. 3개 경로(단일/splitting/dev)에서 공용.
     /// transformer 옵션 mirror 필드는 모두 `transform_options_base` 에서 derived —
     /// `self.options` 와 `base` 양쪽이 single source 두 곳이 되는 drift 위험 제거 (#1961 후속).
-    /// `format` 은 이 EmitOptions 로 방출할 format. 호출 후 `emit_opts.format` 을 덮어쓰면
-    /// `transform_options_base` 의 #4598 게이트가 옛 format 으로 남아 어긋나므로 금지 —
-    /// 반드시 인자로 넘긴다.
+    /// `format` 은 **모듈이 변환된 기준 format** (= 그래프의 `transform_options_base` 를
+    /// 만들 때 쓴 값). 보통 방출 format 과 같지만 multi-format 은 하나의 그래프를 여러
+    /// format 으로 방출하므로 다르다 — 그 경우 이 인자는 그래프 기준값을 그대로 넘기고
+    /// `emit_opts.format` 만 덮어쓴다. #4598 게이트가 그래프의 변환 결과를 따라가야 하기
+    /// 때문이다 (emit 만 다른 값으로 계산하면 변환된 모듈과 어긋난다).
     fn makeEmitOptions(self: *const Bundler, format: EmitOptions.Format) EmitOptions {
         const base = self.buildTransformOptionsBase(format);
         return .{
@@ -2210,7 +2217,10 @@ pub const Bundler = struct {
                     });
                     l.resetEmitTransients();
                 }
-                var emit_opts = self.makeEmitOptions(cfg.format);
+                // 그래프는 `self.options.format` 기준으로 **한 번** 변환됐다. 게이트는 그
+                // 변환을 따라가야 하므로 인자는 그래프 기준값, 방출 format 만 덮어쓴다.
+                var emit_opts = self.makeEmitOptions(self.options.format);
+                emit_opts.format = cfg.format;
                 emit_opts.polyfills = polyfill_entries.items;
                 emit_opts.worker_map_per_module = &worker_map_per_module;
                 if (self.options.sourcemap.enable) emit_opts.sourcemap.enable = true;

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4607,6 +4607,56 @@ test "#4598 IIFE: async 미지원 타겟은 위임하지 않는다 (회귀 가�
     try std.testing.expect(!std.mem.startsWith(u8, js[pos..], "__async"));
 }
 
+/// worker 서브빌드 산출물(별도 청크)의 본문을 돌려준다.
+fn bundleTlaWorker(tmp: *std.testing.TmpDir, parent_format: @import("../emitter.zig").EmitOptions.Format) ![]const u8 {
+    try writeFile(tmp.dir, "w.ts", "const v = await Promise.resolve(41);\nexport const val = v + 1;\nconsole.log(val);");
+    try writeFile(tmp.dir, "main.ts", "const w = new Worker(new URL('./w.ts', import.meta.url), { type: 'module' });\nconsole.log(w);");
+    const entry = try absPath(tmp, "main.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = parent_format,
+        .global_name = "App",
+        .unsupported = .{ .top_level_await = true },
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    const outs = result.asset_outputs orelse return error.ExpectedAssetOutput;
+    for (outs) |o| {
+        if (std.mem.indexOf(u8, o.path, "w-") != null) return std.testing.allocator.dupe(u8, o.contents);
+    }
+    return error.ExpectedWorkerChunk;
+}
+
+test "#4598 worker 서브빌드는 부모 format 이 아니라 자기 방출 format 으로 판정한다" {
+    // worker 는 부모가 esm/cjs 여도 자신은 `workerFormat()` = iife 로 방출된다. 게이트를
+    // 부모 format 으로 계산하면 부모가 esm 일 때만 위임이 꺼져, **같은 worker 파일이 부모
+    // format 에 따라 깨졌다 안 깨졌다** 했다 (`const val = v + 1` 이 async 래퍼 밖으로
+    // 밀려나 `v` 가 ReferenceError).
+    for ([_]@import("../emitter.zig").EmitOptions.Format{ .esm, .iife }) |pf| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const js = try bundleTlaWorker(&tmp, pf);
+        defer std.testing.allocator.free(js);
+
+        // ⚠️ "async 래퍼가 있다" 나 "선언이 래퍼보다 뒤에 온다" 로는 판별이 안 된다 —
+        // 깨진 산물에도 **모듈 단위** async 래퍼가 있고 선언은 그 뒤에 온다. 판별식은
+        // **청크 factory 자체가 async 인가**다.
+        const m = "var App = ";
+        const pos = std.mem.indexOf(u8, js, m).? + m.len;
+        try std.testing.expect(std.mem.startsWith(u8, js[pos..], "(async"));
+        // 선언·await 가 한 스코프에 남아야 한다.
+        try std.testing.expect(std.mem.indexOf(u8, js, "const v = await") != null);
+        try std.testing.expect(std.mem.indexOf(u8, js, "const val = v + 1") != null);
+        // 모듈 단위 래퍼가 **추가로** 있으면 안 된다 (factory 말고 두 번째 async 화살표).
+        const first = std.mem.indexOf(u8, js, "(async").?;
+        try std.testing.expect(std.mem.indexOfPos(u8, js, first + 6, "(async") == null);
+    }
+}
+
 test "#4604 CSS url(): catch-all tsconfig paths 가 bare url() 을 가로채지 않는다 (형제 있음)" {
     // 신고된 재현 그대로. `"paths": { "*": ["src/*"] }` 하에서 `url(assets/logo.png)` 가
     // paths 에 걸려 `src/assets/logo.png` 로, `url(./assets/logo.png)` 는 형제로 가서

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4646,15 +4646,51 @@ test "#4598 worker 서브빌드는 부모 format 이 아니라 자기 방출 for
         // 깨진 산물에도 **모듈 단위** async 래퍼가 있고 선언은 그 뒤에 온다. 판별식은
         // **청크 factory 자체가 async 인가**다.
         const m = "var App = ";
-        const pos = std.mem.indexOf(u8, js, m).? + m.len;
+        const pos = (std.mem.indexOf(u8, js, m) orelse return error.MissingIifeFactory) + m.len;
         try std.testing.expect(std.mem.startsWith(u8, js[pos..], "(async"));
         // 선언·await 가 한 스코프에 남아야 한다.
         try std.testing.expect(std.mem.indexOf(u8, js, "const v = await") != null);
         try std.testing.expect(std.mem.indexOf(u8, js, "const val = v + 1") != null);
         // 모듈 단위 래퍼가 **추가로** 있으면 안 된다 (factory 말고 두 번째 async 화살표).
-        const first = std.mem.indexOf(u8, js, "(async").?;
+        const first = std.mem.indexOf(u8, js, "(async") orelse return error.MissingAsyncFactory;
         try std.testing.expect(std.mem.indexOfPos(u8, js, first + 6, "(async") == null);
     }
+}
+
+test "#4598 code splitting 청크는 위임하지 않는다 — bare await 가 non-async function 에 떨어지면 SyntaxError" {
+    // splitting 의 IIFE 청크는 async factory 가 아니라
+    // `__zntc_register({"m.js": function(exports, module, require) {...}})` — plain function.
+    // 위임하면 `const v = await ...` 가 그 안에 그대로 들어가 **청크 전체가 파싱조차 안 된다**.
+    // 모듈 단위 래핑은 #4598 로 여전히 깨져 있지만(ReferenceError) 적어도 파싱은 된다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "dep.ts", "const v = await Promise.resolve(41);\nexport const val = v + 1;");
+    try writeFile(tmp.dir, "index.ts", "import { val } from './dep';\nconsole.log(val);\nimport('./dep').then((m) => console.log(m.val));");
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .iife,
+        .global_name = "App",
+        .code_splitting = true,
+        .unsupported = .{ .top_level_await = true },
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+    var saw_dep = false;
+    for (outs) |o| {
+        const aw = std.mem.indexOf(u8, o.contents, "await ") orelse continue;
+        saw_dep = true;
+        // `await` 보다 **앞에** async 래퍼가 있어야 한다 = await 가 async 문맥 안이다.
+        const wrap = std.mem.indexOf(u8, o.contents, "(async") orelse return error.BareAwaitInNonAsyncChunk;
+        try std.testing.expect(wrap < aw);
+    }
+    try std.testing.expect(saw_dep);
 }
 
 test "#4604 CSS url(): catch-all tsconfig paths 가 bare url() 을 가로채지 않는다 (형제 있음)" {

--- a/src/bundler/bundler_test/multi_format.zig
+++ b/src/bundler/bundler_test/multi_format.zig
@@ -220,3 +220,33 @@ test "multi-format: CSS import yields shared CSS output across formats" {
         return error.NoCssOutput;
     }
 }
+
+test "#4598 multi-format 은 TLA 위임을 끈다 (그래프 하나를 여러 format 으로 방출)" {
+    // 위임은 "이 모듈의 await 를 감싸 줄 청크 async factory 가 실제로 생긴다" 는 약속이다.
+    // multi-format 은 **같은 그래프**를 iife 로도 esm 으로도 방출하는데 esm 청크에는 그런
+    // factory 가 없다. format 이 하나로 확정되지 않으면 위임하지 않고 모듈 단위 래핑에 맡긴다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const v = await Promise.resolve(41);\nexport const val = v + 1;\nconsole.log(val);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .global_name = "App",
+        .format = .iife, // 단일이면 위임이 켜지는 조건
+        .unsupported = .{ .top_level_await = true },
+        .output = &.{ .{ .format = .iife }, .{ .format = .esm } },
+    });
+    defer b.deinit();
+
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    // iife 청크 factory 가 async 가 **아니어야** 한다 — 위임이 꺼졌다는 뜻.
+    const m = "var App = ";
+    const pos = std.mem.indexOf(u8, result.output, m).? + m.len;
+    try std.testing.expect(!std.mem.startsWith(u8, result.output[pos..], "(async"));
+}

--- a/src/bundler/bundler_test/multi_format.zig
+++ b/src/bundler/bundler_test/multi_format.zig
@@ -221,10 +221,14 @@ test "multi-format: CSS import yields shared CSS output across formats" {
     }
 }
 
-test "#4598 multi-format 은 TLA 위임을 끈다 (그래프 하나를 여러 format 으로 방출)" {
-    // 위임은 "이 모듈의 await 를 감싸 줄 청크 async factory 가 실제로 생긴다" 는 약속이다.
-    // multi-format 은 **같은 그래프**를 iife 로도 esm 으로도 방출하는데 esm 청크에는 그런
-    // factory 가 없다. format 이 하나로 확정되지 않으면 위임하지 않고 모듈 단위 래핑에 맡긴다.
+test "#4598 multi-format: iife 멤버는 위임을 유지한다 (esm 멤버는 미해결 잔여)" {
+    // ⚠️ 한때 "format 이 하나로 확정 안 되니 위임을 끄자" 로 가드를 넣었다가 **동작하던
+    // iife 멤버를 깨뜨렸다**. 위임을 끄면 모듈 단위 래핑으로 돌아가는데 그 래핑 자체가
+    // #4598 로 깨져 있어서(= `export const val` 이 async 래퍼 밖으로 밀려남) 두 멤버가
+    // 모두 죽는다. 끄는 쪽이 안전한 fallback 이 아니다.
+    //
+    // 지금 계약: 그래프는 `options.format` 기준으로 한 번 변환되고, 그 결정을 emit 이
+    // 그대로 따른다. iife 멤버는 정상 동작하고 esm 멤버는 #4598 잔여 범위로 남는다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "index.ts", "const v = await Promise.resolve(41);\nexport const val = v + 1;\nconsole.log(val);");
@@ -235,7 +239,7 @@ test "#4598 multi-format 은 TLA 위임을 끈다 (그래프 하나를 여러 fo
     var b = Bundler.init(std.testing.allocator, .{
         .entry_points = &.{entry},
         .global_name = "App",
-        .format = .iife, // 단일이면 위임이 켜지는 조건
+        .format = .iife,
         .unsupported = .{ .top_level_await = true },
         .output = &.{ .{ .format = .iife }, .{ .format = .esm } },
     });
@@ -245,8 +249,11 @@ test "#4598 multi-format 은 TLA 위임을 끈다 (그래프 하나를 여러 fo
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(!result.hasErrors());
 
-    // iife 청크 factory 가 async 가 **아니어야** 한다 — 위임이 꺼졌다는 뜻.
+    // iife 청크 factory 가 async 여야 한다 (= 위임 유지).
     const m = "var App = ";
-    const pos = std.mem.indexOf(u8, result.output, m).? + m.len;
-    try std.testing.expect(!std.mem.startsWith(u8, result.output[pos..], "(async"));
+    const pos = std.mem.indexOf(u8, result.output, m) orelse return error.MissingIifeFactory;
+    try std.testing.expect(std.mem.startsWith(u8, result.output[pos + m.len ..], "(async"));
+    // 선언이 갈리지 않고 한 스코프에 남아야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const v = await") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const val = v + 1") != null);
 }

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -241,6 +241,10 @@ pub fn hashEmitOptions(h: *InputHasher, options: *const EmitOptions) void {
     h.addBool(options.transform_options_base.verbatim_module_syntax);
     h.addBool(options.transform_options_base.keep_names);
     h.addU32(@bitCast(options.transform_options_base.unsupported));
+    // #4598 `tla_chunk_wrapped` 는 여기 따로 안 넣는다 — `format`·`code_splitting`·
+    // `unsupported` 로 **완전히 결정되는 파생값**이고 셋 다 이미 위에서 해싱된다.
+    // ⚠️ 게이트에 위 셋이 아닌 입력(예: `options.output.len`)을 추가하면 그 입력을
+    //    반드시 여기 함께 넣어야 한다. 안 그러면 두 빌드가 같은 키를 공유한다.
 
     // worker_map_per_module: HashMap iteration 순서 무관하게 결정적 hash. entry 별 sub-hash
     // 를 XOR aggregate. outer key (module 절대 경로) 가 entry 마다 unique 라 XOR 충돌 가능성


### PR DESCRIPTION
## Summary

#4598 TLA 위임의 구멍 두 개를 막았다. 하나는 **직전 PR #4625 가 넣은 회귀**(splitting 청크가
파싱조차 안 됨), 하나는 worker 서브빌드가 **자기 것이 아닌 format** 으로 판정하던 문제다.

## Changes

### 1) splitting 청크 SyntaxError — #4625 회귀

위임은 "이 모듈의 `await` 를 감싸 줄 **async factory 가 실제로 생긴다**" 는 약속이다.
그런데 code splitting 의 IIFE 청크는 async factory 가 아니라 plain function 이다:

```js
(function(g){ ... __zntc_register({"dep.js": function(exports, module, require) {
const v = await Promise.resolve(41);   // ← non-async function 안의 bare await
```

`SyntaxError: await is only valid in async functions` — **청크 전체가 파싱조차 안 된다**.
#4625 이전에는 모듈 단위 래핑이라 파싱은 되고 `ReferenceError` 였으니 명백한 악화다.
splitting 을 위임에서 뺐고, 산출 해시가 #4625 이전(`dep-a1f26a34.js`)과 **동일**함을 확인했다.

### 2) worker 서브빌드가 부모 format 으로 판정

worker 는 부모가 esm/cjs/umd 여도 자신은 `workerFormat()` = iife 로 방출된다. 게이트가
부모 format 을 보는 바람에 **같은 worker 파일이 부모에 따라 깨졌다 안 깨졌다** 했다:

```js
var App = (() => {                     // 부모=esm — factory 가 async 가 아님
  (async () => { const v = await Promise.resolve(41); })();
  const val = v + 1;                   // ← ReferenceError: v is not defined
```

`format` 을 명시 파라미터로 올려 각 호출 지점이 "어느 format 기준인지" 말하게 했다.

### 3) 철회 — multi-format 가드

첫 커밋에서 "format 이 하나로 확정 안 되면 위임을 끄자" 로 넣었다가 **동작하던 iife 멤버를
깨뜨렸다**. 끄면 모듈 단위 래핑으로 돌아가는데 그 래핑 자체가 #4598 로 깨져 있다 — 끄는 쪽이
안전한 fallback 이 아니다. 게다가 게이트가 부모의 `output.len` 을 보는 바람에 **항상 단일
format 만 방출하는 worker** 도 함께 위임을 잃었다. 걷어냈다.

> Zig 초보자 설명: `fn tlaChunkWrapped(self, format)` 처럼 판정에 쓸 값을 **인자로 받으면**,
> 호출부마다 "무엇을 기준으로 판정하는지" 를 코드가 강제로 밝히게 된다. `self.options` 를
> 함수 안에서 직접 읽으면 worker 처럼 기준이 다른 호출자가 조용히 틀린 값을 쓰게 된다.

## Test Plan

- [x] `zig build test` 통과 — **6317 전부 통과** (바이너리 직접 실행으로 확인)
- [x] `zig build napi` 통과
- [x] 통합 테스트 4448 pass / 2 fail (main baseline 과 동일: watch RSS · Hermes `__copyProps`)

**A/B 비공허 3건** — 각 가드를 수정 전 코드로 되돌리면 **정확히 해당 테스트만** 실패(컴파일 에러 아님):

| 되돌린 것 | 실패한 테스트 |
|---|---|
| splitting carve-out | `#4598 code splitting 청크는 위임하지 않는다` |
| multi-format 가드 부활 | `#4598 multi-format: iife 멤버는 위임을 유지한다` |
| worker 게이트 | `#4598 worker 서브빌드는 부모 format 이 아니라…` |

**실측 (main 바이너리 대조)**

- 단일 포맷 **45칸**(3 fixture × 5 format × 3 target) **전부 바이트 동일** — 기존 경로 무변경
- splitting: main **파싱 FAIL** → 이 PR **파싱 OK**(해시가 #4625 이전과 동일)
- worker 8칸 중 3칸 개선(부모 esm·cjs·umd × es2017): main `ReferenceError` → 이 PR `val=42`. **회귀 0**

## Decision Impact

None

## 남은 범위 (#4598 유지)

node+cjs worker · CJS/UMD/AMD · ESM · es5. 전부 "async factory 가 없다" 는 같은 뿌리다.

Refs #4598

🤖 Generated with [Claude Code](https://claude.com/claude-code)