### PR TITLE
fix(bundler): #4598 다운레벨 ESM 의 top-level await — 타겟 준수와 값 정확성 양립

### DIFF
--- a/.changeset/tla-downlevel-esm.md
+++ b/.changeset/tla-downlevel-esm.md
@@ -1,0 +1,16 @@
+---
+"@zntc/core": patch
+---
+
+`--target < es2022` 에서 top-level await 산출물이 **타겟 엔진에서 파싱조차 안 되던** 문제를
+고쳤다 (#4598). React Native 는 Hermes 가 거부해 앱이 아예 뜨지 않았다.
+
+`es2022_tla.lowerProgram` 이 `export const x = await f()` 를 건너뛰어 await 가 최상위에
+남았다. 이제 그 선언(과 그 바인딩에 의존하는 후속 선언)을 async IIFE 로 옮기고, `__esm`
+factory 가 **초기화 완료 promise** 를 돌려주도록 해 소비자가 기다릴 수 있게 했다.
+
+⚠️ await 와 무관한 export 는 지연하지 않는다 — `await …;` 뒤의 `export const NAME='hello'`
+까지 옮기면 소비자가 `undefined` 를 읽는다.
+
+남은 범위: es5(Hermes preset)는 소비자 체이닝이 필요해 값이 아직 `undefined` 다(파싱은 정상).
+`require()` 로 TLA 모듈을 소비하는 위상은 Node 도 `ERR_REQUIRE_ASYNC_MODULE` 로 거부한다.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -946,6 +946,13 @@ pub const Bundler = struct {
         return .{
             // #4598: IIFE + async 지원 타겟만 (근거는 TransformOptions 필드 주석).
             .tla_chunk_wrapped = self.tlaChunkWrapped(format),
+            // #4598: 기다려 줄 기계가 있는 위상에서만 export 초기화식을 옮긴다.
+            // ⚠️ `promoteAsyncConeToEsmWrap` 의 빌드-단위 조건과 **정확히 같아야** 한다.
+            .tla_export_decl_deferrable = self.options.unsupported.top_level_await and
+                !self.options.unsupported.async_await and
+                !self.options.code_splitting and
+                !self.options.preserve_modules and
+                format == .esm,
             .define = self.options.define,
             .experimental_decorators = self.options.experimental_decorators,
             .emit_decorator_metadata = self.options.emit_decorator_metadata,

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4693,6 +4693,166 @@ test "#4598 code splitting 청크는 위임하지 않는다 — bare await 가 n
     try std.testing.expect(saw_dep);
 }
 
+fn bundleTlaDownlevel(tmp: *std.testing.TmpDir, dep_src: []const u8, main_src: []const u8) ![]const u8 {
+    try writeFile(tmp.dir, "dep.ts", dep_src);
+    try writeFile(tmp.dir, "main.ts", main_src);
+    const entry = try absPath(tmp, "main.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        // es2017 상당: TLA 미지원, async/await 는 지원.
+        .unsupported = .{ .top_level_await = true },
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    return std.testing.allocator.dupe(u8, result.output);
+}
+
+test "#4598 다운레벨 ESM: export 선언 안의 TLA 가 최상위 await 를 남기지 않는다" {
+    // `--target < es2022` 는 "이 엔진은 top-level await 를 못 쓴다" 는 선언이다. 그런데
+    // `lowerProgram` 이 export 선언을 건너뛰어 await 가 최상위에 남았고, 그 산물은 타겟
+    // 엔진에서 **파싱조차 안 됐다**(RN 은 Hermes 가 거부해 앱이 아예 안 떴다).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const js = try bundleTlaDownlevel(
+        &tmp,
+        "export const v = await Promise.resolve(41);\nexport const val = v + 1;",
+        "import { val } from './dep';\nconsole.log(val);",
+    );
+    defer std.testing.allocator.free(js);
+
+    // 판별식: 최상위(들여쓰기 0) 에 `await` 가 있는 줄이 없어야 한다.
+    var it = std.mem.splitScalar(u8, js, '\n');
+    while (it.next()) |line| {
+        if (line.len == 0 or line[0] == ' ' or line[0] == '\t') continue;
+        try std.testing.expect(std.mem.indexOf(u8, line, "await ") == null);
+    }
+    // 소비자가 기다릴 수 있도록 모듈이 래핑돼야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, js, "__esm({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, js, "await init_dep()") != null);
+}
+
+test "#4598 다운레벨 ESM: async IIFE 는 정확히 한 번만 방출된다 (side-effect 2회 실행 가드)" {
+    // ⚠️ 문장을 쪼개 `generateStatements` 를 여러 번 부르면 codegen 이 내부 버퍼에
+    //    **누적**해 앞 내용이 다시 붙는다 — async IIFE 가 두 개 방출돼 모듈 side-effect 가
+    //    2회 실행됐다. 픽스처 값 비교로는 안 잡혔고(값이 우연히 같음) 이 단언이 잡았다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const js = try bundleTlaDownlevel(
+        &tmp,
+        "export const v = await Promise.resolve(41);\nexport const val = v + 1;",
+        "import { val } from './dep';\nconsole.log(val);",
+    );
+    defer std.testing.allocator.free(js);
+
+    var n: usize = 0;
+    var pos: usize = 0;
+    while (std.mem.indexOfPos(u8, js, pos, "(async () =>")) |at| {
+        n += 1;
+        pos = at + 12;
+    }
+    try std.testing.expectEqual(@as(usize, 1), n);
+}
+
+test "#4598 다운레벨 ESM: minify 에서도 promise 변수 참조가 맞는다 (회귀 가드)" {
+    // ⚠️ `return <이름>;` 을 AST **원본** 이름으로 붙이면 minify 시 실제 방출명과 어긋나
+    //    `ReferenceError` 다. hoist 수집 시점의 **리네임 반영 이름**을 써야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "dep.ts", "export const v = await Promise.resolve(41);\nexport const val = v + 1;");
+    try writeFile(tmp.dir, "main.ts", "import { val } from './dep';\nconsole.log(val);");
+    const entry = try absPath(&tmp, "main.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .unsupported = .{ .top_level_await = true },
+        .minify_identifiers = true,
+        .minify_whitespace = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const js = result.output;
+    // TLA promise 변수는 `X=(async` 로 대입된다. 그 **같은 이름**으로 `return X` 가
+    // 있어야 한다 — 원본 이름을 쓰면 여기서 어긋나 `ReferenceError` 가 된다.
+    const marker = "=(async";
+    const at = std.mem.indexOf(u8, js, marker) orelse return error.MissingTlaAssign;
+    var start = at;
+    while (start > 0) : (start -= 1) {
+        const c = js[start - 1];
+        const ok = (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
+            (c >= '0' and c <= '9') or c == '_' or c == '$';
+        if (!ok) break;
+    }
+    const name = js[start..at];
+    try std.testing.expect(name.len > 0);
+    const ret = try std.fmt.allocPrint(std.testing.allocator, "return {s}", .{name});
+    defer std.testing.allocator.free(ret);
+    try std.testing.expect(std.mem.indexOf(u8, js, ret) != null);
+}
+
+test "#4598 다운레벨 ESM: promise 임시변수가 사용자 심볼을 덮지 않는다" {
+    // ⚠️ 이름을 직접 발명하면(`__zntc_tla`) 사용자가 같은 이름을 쓸 때 값을 덮어쓰고,
+    //    접미사로 피하면 이번엔 리네이머가 사용자 심볼을 건드린다(적대적 검증이 둘 다 잡음).
+    //    기존 임시변수 기계(`makeTempVarSpan`, #4220 충돌 회피)를 써야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const js = try bundleTlaDownlevel(
+        &tmp,
+        "const __zntc_tla = 'user';\nawait Promise.resolve();\nexport const got = 1;",
+        "import { got } from './dep';\nconsole.log(got);",
+    );
+    defer std.testing.allocator.free(js);
+    // 합성 promise 변수가 사용자 이름을 쓰면 안 된다.
+    try std.testing.expect(std.mem.indexOf(u8, js, "__zntc_tla = (async") == null);
+}
+
+test "#4598 다운레벨 ESM: await 와 무관한 export 는 지연하지 않는다 (회귀 가드)" {
+    // ⚠️ "exported 선언 전부" 를 IIFE 로 옮기면 `await …;` **뒤**의 `export const NAME`
+    //    까지 지연돼 소비자가 `undefined` 를 읽는다. 폐기된 시도가 정확히 그랬고, 그때는
+    //    45칸 매트릭스가 이 위상을 인코딩하지 않아 "회귀 0" 으로 오판했다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const js = try bundleTlaDownlevel(
+        &tmp,
+        "await Promise.resolve();\nexport const NAME = 'hello';",
+        "import { NAME } from './dep';\nconsole.log(NAME);",
+    );
+    defer std.testing.allocator.free(js);
+
+    // `NAME` 은 IIFE 밖에서 **동기 초기화**돼야 한다 — 할당(`NAME = `)이 아니라 선언 형태.
+    const has_sync_decl = std.mem.indexOf(u8, js, "NAME = \"hello\"") != null;
+    try std.testing.expect(has_sync_decl);
+    // 지연 산물(할당만 남고 선언은 `var NAME;`)이면 안 된다.
+    try std.testing.expect(std.mem.indexOf(u8, js, "var NAME;") == null);
+}
+
+test "#4598 다운레벨 ESM: 라이브러리 entry 의 export 는 보존된다 (회귀 가드)" {
+    // ⚠️ entry 를 래핑하면 `export { ... }` 가 래퍼 심볼로 바뀌어 **공개 API 가 통째로
+    //    사라진다**(폐기된 시도 실측). export 가 있는 entry 는 승격 대상에서 뺀다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.ts", "export const A = 1;\nexport const V = await Promise.resolve(41);");
+    const entry = try absPath(&tmp, "lib.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .unsupported = .{ .top_level_await = true },
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "export {") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "A") != null);
+}
+
 test "#4604 CSS url(): catch-all tsconfig paths 가 bare url() 을 가로채지 않는다 (형제 있음)" {
     // 신고된 재현 그대로. `"paths": { "*": ["src/*"] }` 하에서 `url(assets/logo.png)` 가
     // paths 에 걸려 `src/assets/logo.png` 로, `url(./assets/logo.png)` 는 형제로 가서

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4825,11 +4825,14 @@ test "#4598 다운레벨 ESM: await 와 무관한 export 는 지연하지 않는
     );
     defer std.testing.allocator.free(js);
 
-    // `NAME` 은 IIFE 밖에서 **동기 초기화**돼야 한다 — 할당(`NAME = `)이 아니라 선언 형태.
-    const has_sync_decl = std.mem.indexOf(u8, js, "NAME = \"hello\"") != null;
-    try std.testing.expect(has_sync_decl);
-    // 지연 산물(할당만 남고 선언은 `var NAME;`)이면 안 된다.
-    try std.testing.expect(std.mem.indexOf(u8, js, "var NAME;") == null);
+    // ⚠️ 문자열 존재만 보면 공허하다. `NAME` 대입이 async IIFE **밖**에 있어야 한다 —
+    //    안으로 들어가면 소비자가 `undefined` 를 읽는다(폐기된 시도의 회귀).
+    const assign_at = std.mem.indexOf(u8, js, "NAME = \"hello\"") orelse return error.MissingNameAssign;
+    if (std.mem.indexOf(u8, js, "= (async () =>")) |iife_at| {
+        const close_at = std.mem.indexOfPos(u8, js, iife_at, "})()") orelse return error.MissingIifeClose;
+        // 대입이 IIFE 본문 구간(iife_at..close_at) 안에 있으면 지연된 것 = 회귀.
+        try std.testing.expect(!(assign_at > iife_at and assign_at < close_at));
+    }
 }
 
 test "#4598 다운레벨 ESM: 라이브러리 entry 의 export 는 보존된다 (회귀 가드)" {
@@ -4849,8 +4852,20 @@ test "#4598 다운레벨 ESM: 라이브러리 entry 의 export 는 보존된다 
     const result = try b.bundle(std.testing.io);
     defer result.deinit(std.testing.allocator);
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "export {") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "A") != null);
+    const js = result.output;
+    // ⚠️ export **이름**만 확인하면 공허하다 — 리뷰가 잡은 회귀(값이 `undefined`)를
+    //    이 단언은 통과시켰다. 값이 실제로 채워지는지 구조로 확인한다.
+    try std.testing.expect(std.mem.indexOf(u8, js, "export {") != null);
+    // `V` 초기화가 async IIFE 로 옮겨졌다면 **최상위에서 기다려야** 한다.
+    if (std.mem.indexOf(u8, js, "= (async () =>")) |_| {
+        var has_top_await = false;
+        var it = std.mem.splitScalar(u8, js, '\n');
+        while (it.next()) |line| {
+            if (line.len == 0 or line[0] == ' ' or line[0] == '\t') continue;
+            if (std.mem.startsWith(u8, line, "await ")) has_top_await = true;
+        }
+        try std.testing.expect(has_top_await);
+    }
 }
 
 test "#4604 CSS url(): catch-all tsconfig paths 가 bare url() 을 가로채지 않는다 (형제 있음)" {

--- a/src/bundler/cache_key.zig
+++ b/src/bundler/cache_key.zig
@@ -147,7 +147,9 @@ comptime {
     // 전용이고(파일 상단) parse/semantic 은 이 값을 읽지 않는다. ⚠️ post-transform 캐시로
     // 확장하면 편입 필수 — 값에 따라 TLA 래핑 여부가 갈려 같은 소스가 다른 AST 를 낸다.
     const tf_fields = @typeInfo(@import("../transformer/options.zig").TransformOptions).@"struct".fields.len;
-    if (tf_fields != 46)
+    // #4598 `tla_export_decl_deferrable`: transform 전용(파싱에 영향 없음) — SelectiveOptions
+    // 미편입. ⚠️ post-transform 캐시로 확장하면 편입 필수(값에 따라 AST 가 갈린다).
+    if (tf_fields != 47)
         @compileError("TransformOptions 필드 수 변경 — 새 필드의 parse-영향 여부 판정 후 SelectiveOptions 갱신 + 이 수 갱신 필요.");
 }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1422,10 +1422,33 @@ pub fn needsPropertyQuote(name: []const u8) bool {
 /// `lowerProgram` 이 만든 형태는 `<name> = (async () => {` 또는 `<name>=(async()=>{`.
 /// ⚠️ 이름은 리네임/mangle 을 거치므로 하드코딩할 수 없다 — 방출된 텍스트에서 읽는다.
 fn findTlaTempName(code: []const u8) ?[]const u8 {
-    const marker = "= (async () =>";
-    const marker_min = "=(async()=>";
-    const at = std.mem.indexOf(u8, code, marker) orelse
-        std.mem.indexOf(u8, code, marker_min) orelse return null;
+    // ⚠️ codegen 철자를 리터럴로 못 박으면 minify 형태(`=(async ()=>`)를 놓쳐 최상위
+    //    await 가 조용히 빠진다 → export 값이 `undefined`(리뷰 실측). `=` 뒤 공백과
+    //    `async` 뒤 공백을 모두 허용해 스캔한다.
+    const at = blk: {
+        var i: usize = 0;
+        while (std.mem.indexOfPos(u8, code, i, "async")) |a| {
+            i = a + 5;
+            // `async` 앞으로 `=`(공백 허용)가 있어야 한다.
+            var b = a;
+            while (b > 0 and (code[b - 1] == ' ' or code[b - 1] == '\t')) b -= 1;
+            // IIFE 여는 괄호 `(` 허용: `= (async () => …)()` / `=(async ()=>…)()`
+            if (b > 0 and code[b - 1] == '(') {
+                b -= 1;
+                while (b > 0 and (code[b - 1] == ' ' or code[b - 1] == '\t')) b -= 1;
+            }
+            if (b == 0 or code[b - 1] != '=') continue;
+            // `async` 뒤로 `()` 그리고 `=>` 가 와야 한다(공백 허용).
+            var c = a + 5;
+            while (c < code.len and (code[c] == ' ' or code[c] == '\t')) c += 1;
+            if (c + 1 >= code.len or code[c] != '(' or code[c + 1] != ')') continue;
+            var d = c + 2;
+            while (d < code.len and (code[d] == ' ' or code[d] == '\t')) d += 1;
+            if (d + 1 >= code.len or code[d] != '=' or code[d + 1] != '>') continue;
+            break :blk b - 1; // `=` 위치
+        }
+        return null;
+    };
     var end = at;
     while (end > 0 and (code[end - 1] == ' ' or code[end - 1] == '\t')) end -= 1;
     var start = end;

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -982,6 +982,19 @@ pub fn emitWithTreeShaking(
                 try module_output.appendSlice(allocator, code_to_append);
             }
             prev_was_cjs_var_minify = is_cjs_var_minify;
+            // #4598: 래핑되지 않은(scope-hoist) TLA 모듈은 `lowerProgram` 이 만든
+            // `var <temp> = (async () => {…})();` 를 **아무도 기다리지 않는다** → export 값이
+            // 조용히 `undefined` 가 된다(리뷰 실측: main `V= 41` → `V= undefined`).
+            // 최상위에서 기다린다. ESM 출력에선 문법적으로 합법이고, main 도 같은 위상에서
+            // 최상위 await 를 내므로 회귀가 아니다.
+            if (m.tla_iife_stmt != null and m.wrap_kind == .none and options.format == .esm) {
+                if (findTlaTempName(code_to_append)) |tmp_name| {
+                    try module_output.appendSlice(allocator, "await ");
+                    try module_output.appendSlice(allocator, tmp_name);
+                    try module_output.appendSlice(allocator, ";\n");
+                    module_line += 1;
+                }
+            }
             module_line += @intCast(std.mem.count(u8, code_to_append, "\n"));
             if (!options.minify_whitespace) {
                 try module_output.appendSlice(allocator, "//#endregion\n");
@@ -1405,6 +1418,27 @@ pub fn needsPropertyQuote(name: []const u8) bool {
 }
 
 /// 들여쓰기를 적용하여 텍스트를 ArrayList에 추가. 줄바꿈 뒤에 탭을 삽입.
+/// #4598: 방출된 모듈 코드에서 TLA promise 임시변수명을 찾는다.
+/// `lowerProgram` 이 만든 형태는 `<name> = (async () => {` 또는 `<name>=(async()=>{`.
+/// ⚠️ 이름은 리네임/mangle 을 거치므로 하드코딩할 수 없다 — 방출된 텍스트에서 읽는다.
+fn findTlaTempName(code: []const u8) ?[]const u8 {
+    const marker = "= (async () =>";
+    const marker_min = "=(async()=>";
+    const at = std.mem.indexOf(u8, code, marker) orelse
+        std.mem.indexOf(u8, code, marker_min) orelse return null;
+    var end = at;
+    while (end > 0 and (code[end - 1] == ' ' or code[end - 1] == '\t')) end -= 1;
+    var start = end;
+    while (start > 0) : (start -= 1) {
+        const c = code[start - 1];
+        const ok = (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
+            (c >= '0' and c <= '9') or c == '_' or c == '$';
+        if (!ok) break;
+    }
+    if (start == end) return null;
+    return code[start..end];
+}
+
 pub fn appendIndented(wrapped: *std.ArrayList(u8), allocator: std.mem.Allocator, text: []const u8) !void {
     for (text) |c| {
         try wrapped.append(allocator, c);

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -1286,9 +1286,7 @@ fn appendWrappedInitCall(
     options: *const EmitOptions,
     rename_tbl: ?*const RenameTable,
 ) !void {
-    const target_needs_await = src_mod.uses_top_level_await or src_mod.in_async_cone;
-    const importer_is_async = importer.uses_top_level_await or importer.in_async_cone;
-    const is_tla = src_mod.wrap_kind == .esm and target_needs_await and importer_is_async;
+    const is_tla = @import("../module.zig").isAwaitableInit(src_mod, importer, options.transform_options_base.unsupported);
     const guard = src_mod.shouldGuard(options.entry_error_guard);
     switch (src_mod.wrap_kind) {
         .esm => {

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -1024,7 +1024,7 @@ pub fn emitEsmWrappedModule(
             re_export_inited.put(allocator, src_i, {}) catch {};
             if (shouldLazyReExportInit(options, src_mod_ptr)) continue;
 
-            try appendWrappedInitCall(&star_init_buf, allocator, src_mod_ptr, options, rename_tbl);
+            try appendWrappedInitCall(&star_init_buf, allocator, src_mod_ptr, module, options, rename_tbl);
         }
 
         // Side-effect-only import (`import './x';`) → target이 ESM 래핑일 때만
@@ -1042,7 +1042,7 @@ pub fn emitEsmWrappedModule(
             if (src_mod.wrap_kind != .esm) continue;
             re_export_inited.put(allocator, src_i, {}) catch {};
 
-            try appendWrappedInitCall(&star_init_buf, allocator, src_mod, options, rename_tbl);
+            try appendWrappedInitCall(&star_init_buf, allocator, src_mod, module, options, rename_tbl);
         }
     }
 
@@ -1298,10 +1298,15 @@ fn appendWrappedInitCall(
     buf: *std.ArrayList(u8),
     allocator: std.mem.Allocator,
     src_mod: *const Module,
+    /// #4598 3b: 이 호출이 들어갈 **소비자(래핑 중인 모듈)**. `await` 는 소비자의 factory
+    /// 가 async 일 때만 낼 수 있다 — 아니면 non-async 함수 본문에 await 가 떨어진다.
+    importer: *const Module,
     options: *const EmitOptions,
     rename_tbl: ?*const RenameTable,
 ) !void {
-    const is_tla = src_mod.wrap_kind == .esm and src_mod.uses_top_level_await;
+    const target_needs_await = src_mod.uses_top_level_await or src_mod.in_async_cone;
+    const importer_is_async = importer.uses_top_level_await or importer.in_async_cone;
+    const is_tla = src_mod.wrap_kind == .esm and target_needs_await and importer_is_async;
     const guard = src_mod.shouldGuard(options.entry_error_guard);
     switch (src_mod.wrap_kind) {
         .esm => {

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -193,6 +193,8 @@ pub fn emitEsmWrappedModule(
 
     var hoisted_stmts: std.ArrayList(u32) = .empty;
     defer hoisted_stmts.deinit(allocator);
+    // #4598: TLA promise 임시변수의 리네임 반영된 이름 (없으면 null).
+    var tla_var_name: ?[]const u8 = null;
     var body_stmts: std.ArrayList(u32) = .empty;
     defer body_stmts.deinit(allocator);
     // strict execution order: 함수 선언을 factory body 최상단에 배치.
@@ -352,6 +354,12 @@ pub fn emitEsmWrappedModule(
                     if (name_node.tag == .binding_identifier) {
                         const raw_name = try arena_alloc.dupe(u8, esm_ast.getText(name_node.data.string_ref));
                         const resolved = try arena_alloc.dupe(u8, resolveNodeName(metadata, @intFromEnum(name_raw), raw_name));
+                        // #4598: TLA promise 임시변수의 **리네임된** 이름을 포착한다.
+                        // ⚠️ AST 원본 이름(`_a`)을 쓰면 minify 시 실제 방출명(`c`)과 어긋나
+                        //    `ReferenceError` 다(적대적 검증이 잡음).
+                        if (module.tla_iife_stmt) |tix| {
+                            if (raw_idx == tix) tla_var_name = resolved;
+                        }
                         try hoisted_var_names.append(allocator, resolved);
                     } else {
                         var it = try ast_walk.bindingIdentifiers(allocator, esm_ast, name_raw, .{});
@@ -831,41 +839,15 @@ pub fn emitEsmWrappedModule(
             func_names = sm.names.items;
         }
     }
-    // #4598: TLA IIFE 문장을 `return <expr>;` 로 바꿔 `init_X()` 가 **초기화 완료
-    // promise** 를 돌려주게 한다. 그래야 소비자가 기다릴 대상이 생긴다.
-    //   es2017+ : factory 가 `async` 라 반환 promise 가 그대로 완료 신호가 된다.
-    //   es5     : IIFE 가 이미 `__async(...)` 라 그 promise 를 그대로 돌려준다.
-    // ⚠️ 구조적 추측(마지막 문장이 IIFE 인가) 대신 `lowerProgram` 이 알려 준 인덱스만 본다.
-    var body_code = if (module.tla_iife_stmt) |tla_ix| blk: {
-        var pre: std.ArrayList(u32) = .empty;
-        defer pre.deinit(allocator);
-        var post: std.ArrayList(u32) = .empty;
-        defer post.deinit(allocator);
-        var target: ?u32 = null;
-        for (body_stmts.items) |ix| {
-            if (ix == tla_ix and target == null) {
-                target = ix;
-                continue;
-            }
-            if (target == null) try pre.append(allocator, ix) else try post.append(allocator, ix);
-        }
-        const t = target orelse break :blk try body_cg.generateStatements(root, body_stmts.items);
-        const a = try body_cg.generateStatements(root, pre.items);
-        const mid = try body_cg.generateStatements(root, &.{t});
-        const b = try body_cg.generateStatements(root, post.items);
-        const mid_t = std.mem.trimStart(u8, mid, " \t");
-        // ⚠️ IIFE 뒤에 문장이 남아 있으면 `return` 을 바로 붙이면 **그 뒤가 실행되지 않는다**
-        //    (픽스처 01 이 즉시 잡았다: `await …;` 뒤의 `export const NAME` 이 사라짐).
-        //    그 경우 promise 를 임시 변수에 담아 두고 맨 끝에서 돌려준다.
-        if (std.mem.trim(u8, b, " \t\n\r").len == 0) {
-            break :blk try std.fmt.allocPrint(arena_alloc, "{s}\treturn {s}", .{ a, mid_t });
-        }
-        break :blk try std.fmt.allocPrint(
-            arena_alloc,
-            "{s}\tvar __zntc_tla = {s}{s}\treturn __zntc_tla;\n",
-            .{ a, mid_t, b },
-        );
-    } else try body_cg.generateStatements(root, body_stmts.items);
+    // #4598: `lowerProgram` 이 `var __zntc_tla = (async () => {…})();` 를 만들어 두었으면
+    // factory 끝에 `return __zntc_tla;` 를 덧붙여 `init_X()` 가 **초기화 완료 promise** 를
+    // 돌려주게 한다 — 그래야 소비자가 기다릴 대상이 생긴다.
+    // ⚠️ 문장을 쪼개 `generateStatements` 를 여러 번 부르면 안 된다. codegen 이 내부
+    //    버퍼에 누적해서 앞 내용이 다시 붙는다(IIFE 2회 방출 — 유닛 테스트가 잡음).
+    var body_code = try body_cg.generateStatements(root, body_stmts.items);
+    if (tla_var_name) |tla_var| {
+        body_code = try std.fmt.allocPrint(arena_alloc, "{s}\treturn {s};\n", .{ body_code, tla_var });
+    }
 
     // 5.1. Hermes 호환: hoisted var와 같은 이름의 named function expression 이름 제거.
     // Hermes는 "X = function X() {...}" 에서 named function expression의 이름 X가

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -1050,7 +1050,13 @@ pub fn emitEsmWrappedModule(
     //    호이스팅된 함수가 호출되기 전에 의존 모듈이 초기화되도록 보장한다.
     const preamble_code = if (metadata) |md| md.cjs_import_preamble else null;
 
-    const is_async = module.uses_top_level_await;
+    // #4598 3a: cone 안(= TLA 를 동기 소비하는) 모듈의 factory 도 async 로 만든다.
+    // 그래야 3b 에서 그 본문에 `await init_X()` 를 놓을 자리가 생긴다.
+    // ⚠️ async 문법이 없는 타겟(es5)은 제외 — 상태머신 낮추기가 선행돼야 한다(3d).
+    // 이 단계만으로는 동작이 바뀌면 안 된다: `init_X()` 반환이 undefined → promise 로
+    // 바뀌지만 소비자는 아직 `(init_X(), exports_X)` 로 무시한다.
+    const is_async = module.uses_top_level_await or
+        (module.in_async_cone and !options.transform_options_base.unsupported.async_await);
 
     // entry dependency chain은 entry factory 안의 nested require로 남긴다.
     // dependency를 top-level 개별 guard로 풀면 ErrorUtils 설치 후 throw가 swallow되어

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -831,7 +831,41 @@ pub fn emitEsmWrappedModule(
             func_names = sm.names.items;
         }
     }
-    var body_code = try body_cg.generateStatements(root, body_stmts.items);
+    // #4598: TLA IIFE 문장을 `return <expr>;` 로 바꿔 `init_X()` 가 **초기화 완료
+    // promise** 를 돌려주게 한다. 그래야 소비자가 기다릴 대상이 생긴다.
+    //   es2017+ : factory 가 `async` 라 반환 promise 가 그대로 완료 신호가 된다.
+    //   es5     : IIFE 가 이미 `__async(...)` 라 그 promise 를 그대로 돌려준다.
+    // ⚠️ 구조적 추측(마지막 문장이 IIFE 인가) 대신 `lowerProgram` 이 알려 준 인덱스만 본다.
+    var body_code = if (module.tla_iife_stmt) |tla_ix| blk: {
+        var pre: std.ArrayList(u32) = .empty;
+        defer pre.deinit(allocator);
+        var post: std.ArrayList(u32) = .empty;
+        defer post.deinit(allocator);
+        var target: ?u32 = null;
+        for (body_stmts.items) |ix| {
+            if (ix == tla_ix and target == null) {
+                target = ix;
+                continue;
+            }
+            if (target == null) try pre.append(allocator, ix) else try post.append(allocator, ix);
+        }
+        const t = target orelse break :blk try body_cg.generateStatements(root, body_stmts.items);
+        const a = try body_cg.generateStatements(root, pre.items);
+        const mid = try body_cg.generateStatements(root, &.{t});
+        const b = try body_cg.generateStatements(root, post.items);
+        const mid_t = std.mem.trimStart(u8, mid, " \t");
+        // ⚠️ IIFE 뒤에 문장이 남아 있으면 `return` 을 바로 붙이면 **그 뒤가 실행되지 않는다**
+        //    (픽스처 01 이 즉시 잡았다: `await …;` 뒤의 `export const NAME` 이 사라짐).
+        //    그 경우 promise 를 임시 변수에 담아 두고 맨 끝에서 돌려준다.
+        if (std.mem.trim(u8, b, " \t\n\r").len == 0) {
+            break :blk try std.fmt.allocPrint(arena_alloc, "{s}\treturn {s}", .{ a, mid_t });
+        }
+        break :blk try std.fmt.allocPrint(
+            arena_alloc,
+            "{s}\tvar __zntc_tla = {s}{s}\treturn __zntc_tla;\n",
+            .{ a, mid_t, b },
+        );
+    } else try body_cg.generateStatements(root, body_stmts.items);
 
     // 5.1. Hermes 호환: hoisted var와 같은 이름의 named function expression 이름 제거.
     // Hermes는 "X = function X() {...}" 에서 named function expression의 이름 X가

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -743,10 +743,13 @@ fn finalizeGraph(self: *ModuleGraph, entry_points: []const []const u8) !void {
 
     graph_finalize.promoteExportsKinds(self);
     graph_finalize.promoteRunBeforeMainModules(self);
-    graph_finalize.registerWrapperSymbols(self);
+    // #4598: cone 계산 → 승격 → 심볼 등록 순서여야 한다. `registerWrapperSymbols` 가
+    // `wrap_kind != .none` 인 모듈에만 `init_X`/`exports_X` 를 등록하므로, 승격이 그보다
+    // 뒤면 승격된 모듈이 심볼 없이 남는다.
     graph_finalize.propagateTopLevelAwait(self);
-    // #4598: 판정 전용 async cone (require 엣지 포함).
     graph_finalize.computeAsyncCone(self);
+    graph_finalize.promoteAsyncConeToEsmWrap(self);
+    graph_finalize.registerWrapperSymbols(self);
     checkSelfReExport(self);
 }
 

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -745,6 +745,8 @@ fn finalizeGraph(self: *ModuleGraph, entry_points: []const []const u8) !void {
     graph_finalize.promoteRunBeforeMainModules(self);
     graph_finalize.registerWrapperSymbols(self);
     graph_finalize.propagateTopLevelAwait(self);
+    // #4598: 판정 전용 async cone (require 엣지 포함).
+    graph_finalize.computeAsyncCone(self);
     checkSelfReExport(self);
 }
 

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -461,7 +461,11 @@ pub fn computeAsyncCone(self: *ModuleGraph) void {
     {
         var it = self.modules.iterator(0);
         while (it.next()) |m| {
-            m.in_async_cone = m.self_uses_top_level_await;
+            // ⚠️ `self_uses_top_level_await` 만으로는 부족하다. 그 값은 **변환 뒤** analyzer
+            // 가 세우는데, TLA lowering 이 await 를 async IIFE 안으로 옮기면
+            // `isInsideFunctionScope()` 가 true 라 false 가 된다. lowering 이 IIFE 를
+            // 만들었다는 사실(`tla_iife_stmt`)이 정확한 신호다.
+            m.in_async_cone = m.self_uses_top_level_await or m.tla_iife_stmt != null;
             if (m.in_async_cone) seed = true;
         }
     }
@@ -507,5 +511,40 @@ pub fn computeAsyncCone(self: *ModuleGraph) void {
             m.in_async_cone = true;
             queue.append(self.allocator, imp) catch return;
         }
+    }
+}
+
+/// #4598: async cone 모듈을 `__esm` 래퍼로 승격.
+///
+/// 래핑돼야 소비자가 `await init_X()` 로 **기다릴 대상**을 갖는다. scope-hoist 된 채로는
+/// 기다릴 것이 없어 최상위 await(=타겟 위반) 말고는 방법이 없다.
+///
+/// ⚠️ 폐기된 시도(`ba943dec`)가 깨진 원인을 전부 가드로 막는다:
+/// - **entry 는 export 가 없을 때만** 승격. export 가 있는 라이브러리 entry 를 래핑하면
+///   `export { ... }` 가 래퍼 심볼로 바뀌어 **공개 API 가 통째로 사라진다**(실측).
+/// - `.cjs` 래퍼는 제외 — `__commonJS` 는 factory 반환값을 버려 promise 를 못 흘린다.
+///   그 위상은 별도 진단 대상이다(Node 도 `ERR_REQUIRE_ASYNC_MODULE` 로 거부).
+/// - splitting / preserve-modules / multi-format 제외 — 각각 진입·청크 계약이 달라
+///   폐기본에서 개별 결함이 났다.
+/// - async 문법이 없는 타겟(es5)은 상태머신 낮추기가 선행돼야 한다.
+///
+/// `computeAsyncCone` **뒤에**, `registerWrapperSymbols` **앞에** 불러야 한다.
+pub fn promoteAsyncConeToEsmWrap(self: *ModuleGraph) void {
+    const base = &self.transform_options_base;
+    if (!base.unsupported.top_level_await) return; // 타겟이 TLA 지원 → 손대지 않음
+    if (base.unsupported.async_await) return; // es5 는 아직 대상 아님
+    if (self.code_splitting or self.preserve_modules) return;
+    // 청크 위임(#4625)이 이 청크를 async factory 로 감싸면 모듈을 또 래핑하지 않는다.
+    // 위임 산물이 scope-hoist 라 더 작고 이미 검증돼 있다 — 겹치면 커지기만 한다.
+    if (base.tla_chunk_wrapped) return;
+
+    var it = self.modules.iterator(0);
+    while (it.next()) |m| {
+        if (!m.in_async_cone) continue;
+        if (!m.module_type.isJavaScriptLike()) continue;
+        if (m.wrap_kind != .none) continue; // 이미 래핑(cjs 포함) → 그 기계에 맡긴다
+        if (m.is_entry_point and m.export_bindings.len > 0) continue; // 라이브러리 entry 보호
+        if (m.exports_kind == .none) m.exports_kind = .esm;
+        if (m.exports_kind.isEsm()) m.wrap_kind = .esm;
     }
 }

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -549,7 +549,37 @@ pub fn promoteAsyncConeToEsmWrap(self: *ModuleGraph) void {
         //    안 그러면 `lowerProgram` 이 옮긴 초기화식을 아무도 기다리지 않아 export 값이
         //    조용히 `undefined` 가 된다(리뷰 실측: main `V= 41` → `V= undefined`).
         if (m.is_entry_point and m.export_bindings.len > 0) continue;
+        // ⚠️ **순수 re-export entry**(`export { v } from './dep'`)가 소비자면 승격하면 안 된다.
+        //    그 위상엔 `init_X()` 를 부르는 경로가 아예 없어(import 바인딩도 wrap 도 없음)
+        //    factory 가 정의만 되고 호출되지 않는다 → export 값이 영구히 `undefined`
+        //    (리뷰 실측: main `v= 41` → `v= undefined`). 승격 안 하면 scope-hoist 로
+        //    남아 emitter 의 최상위 await fallback 이 처리한다.
+        if (hasOnlyReExportImporters(self, m)) continue;
         if (m.exports_kind == .none) m.exports_kind = .esm;
         if (m.exports_kind.isEsm()) m.wrap_kind = .esm;
     }
+}
+
+/// #4598: 이 모듈을 소비하는 importer 가 **전부 re-export 뿐**인지.
+/// 그 위상엔 `init_X()` 호출 경로가 없어 승격하면 factory 가 영영 안 돈다.
+fn hasOnlyReExportImporters(self: *ModuleGraph, target: *const Module) bool {
+    const t_idx = blk: {
+        var it = self.modules.iterator(0);
+        var i: u32 = 0;
+        while (it.next()) |m| : (i += 1) {
+            if (m == target) break :blk i;
+        }
+        return false;
+    };
+    var saw_any = false;
+    var it = self.modules.iterator(0);
+    while (it.next()) |m| {
+        for (m.import_records) |rec| {
+            if (rec.resolved.isNone()) continue;
+            if (@intFromEnum(rec.resolved) != t_idx) continue;
+            saw_any = true;
+            if (rec.kind != .re_export) return false;
+        }
+    }
+    return saw_any;
 }

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -443,3 +443,69 @@ pub fn propagateTopLevelAwait(self: *ModuleGraph) void {
         }
     }
 }
+
+/// #4598: **async cone** 계산 — TLA 모듈과, 그것을 동기 소비하는 모든 모듈.
+///
+/// `propagateTopLevelAwait` 와 두 가지가 다르다:
+/// 1. **`require` 엣지도 탄다.** CJS 모듈이 TLA 모듈을 동기 require 하는 위상을 잡아야
+///    한다 — Node 도 그 조합을 `ERR_REQUIRE_ASYNC_MODULE` 로 거부한다.
+/// 2. **판정 전용 필드**(`in_async_cone`)에만 쓴다. `uses_top_level_await` 를 넓히면
+///    `appendModuleCall`(`await init_X()`) 등이 함께 바뀐다(#4598 4차 회귀 원인).
+///
+/// dynamic import 는 이미 promise 경계라 전파하지 않는다.
+pub fn computeAsyncCone(self: *ModuleGraph) void {
+    const count = self.modules.count();
+    if (count == 0) return;
+
+    var seed = false;
+    {
+        var it = self.modules.iterator(0);
+        while (it.next()) |m| {
+            m.in_async_cone = m.self_uses_top_level_await;
+            if (m.in_async_cone) seed = true;
+        }
+    }
+    if (!seed) return;
+
+    // 역의존성 맵: static import 계열 + require.
+    var rdeps = self.allocator.alloc(std.ArrayListUnmanaged(u32), count) catch return;
+    defer {
+        for (rdeps) |*l| l.deinit(self.allocator);
+        self.allocator.free(rdeps);
+    }
+    for (rdeps) |*l| l.* = .empty;
+    {
+        var it = self.modules.iterator(0);
+        var src: usize = 0;
+        while (it.next()) |m| : (src += 1) {
+            for (m.import_records) |rec| {
+                if (rec.resolved.isNone()) continue;
+                const eager = rec.kind.isEagerEvalDependency() or rec.kind == .require;
+                if (!eager) continue;
+                const t = @intFromEnum(rec.resolved);
+                if (t >= count) continue;
+                rdeps[t].append(self.allocator, @intCast(src)) catch return;
+            }
+        }
+    }
+
+    var queue: std.ArrayListUnmanaged(u32) = .empty;
+    defer queue.deinit(self.allocator);
+    {
+        var it = self.modules.iterator(0);
+        var i: usize = 0;
+        while (it.next()) |m| : (i += 1) {
+            if (m.in_async_cone) queue.append(self.allocator, @intCast(i)) catch return;
+        }
+    }
+    var head: usize = 0;
+    while (head < queue.items.len) : (head += 1) {
+        const cur = queue.items[head];
+        for (rdeps[cur].items) |imp| {
+            const m = self.modules.at(imp);
+            if (m.in_async_cone) continue;
+            m.in_async_cone = true;
+            queue.append(self.allocator, imp) catch return;
+        }
+    }
+}

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -543,7 +543,12 @@ pub fn promoteAsyncConeToEsmWrap(self: *ModuleGraph) void {
         if (!m.in_async_cone) continue;
         if (!m.module_type.isJavaScriptLike()) continue;
         if (m.wrap_kind != .none) continue; // 이미 래핑(cjs 포함) → 그 기계에 맡긴다
-        if (m.is_entry_point and m.export_bindings.len > 0) continue; // 라이브러리 entry 보호
+        // 라이브러리 entry(= export 가 있는 entry)는 승격하지 않는다 — 래핑하면
+        // `export { … }` 가 래퍼 심볼로 바뀌어 **공개 API 가 사라진다**(실측).
+        // ⚠️ 대신 emitter 가 승격 안 된 TLA 모듈에 최상위 `await <temp>;` 를 낸다.
+        //    안 그러면 `lowerProgram` 이 옮긴 초기화식을 아무도 기다리지 않아 export 값이
+        //    조용히 `undefined` 가 된다(리뷰 실측: main `V= 41` → `V= undefined`).
+        if (m.is_entry_point and m.export_bindings.len > 0) continue;
         if (m.exports_kind == .none) m.exports_kind = .esm;
         if (m.exports_kind.isEsm()) m.wrap_kind = .esm;
     }

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -149,6 +149,9 @@ pub fn run(self: anytype, module: *Module, arena_alloc: std.mem.Allocator) void 
     }
 
     const root = transformer.transform() catch return;
+    // #4598: `lowerProgram` 이 만든 async IIFE statement 를 module 로 넘긴다 —
+    // emitter 가 `__esm` factory 안에서 그 문장만 `return <expr>;` 로 방출한다.
+    if (transformer.tla_iife_stmt) |ix| module.tla_iife_stmt = @intFromEnum(ix);
     // #4210: 다운레벨 못한 ES2025 inline modifier 가 출력에 보존됨 → loud 진단
     // (transform-driven — 실제 fold bail 반영). transpile path 와 동일 메시지.
     if (transformer.used_unsupported_modifier) {

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -217,10 +217,21 @@ fn allocLazyEsmImportExpr(self: *const Linker, import_mod: *const Module, value_
     return try std.fmt.allocPrint(self.allocator, "({s}{s}{s}{s}{s})", .{ import_init, sep, value_init, sep, target_name });
 }
 
-fn appendEsmInitCall(self: *const Linker, preamble: anytype, target_mod: *const Module) !void {
-    const is_tla = target_mod.uses_top_level_await;
+/// #4598 3b: `await init_X()` 는 **양쪽 조건**이 맞을 때만 낸다.
+///   ① target 이 기다릴 대상을 준다 (TLA 이거나 async cone 안)
+///   ② importer 의 factory 가 async 다 — 아니면 non-async 함수 본문에 `await` 가 떨어져
+///      **번들 전체가 SyntaxError** (폐기된 `ba943dec` 에서 리뷰가 잡은 구멍).
+/// 예전엔 target 만 봤다.
+fn appendEsmInitCall(
+    self: *const Linker,
+    preamble: anytype,
+    target_mod: *const Module,
+    importer: *const Module,
+) !void {
+    const target_needs_await = target_mod.uses_top_level_await or target_mod.in_async_cone;
+    const importer_is_async = importer.uses_top_level_await or importer.in_async_cone;
     const guard = target_mod.shouldGuard(self.entry_error_guard);
-    if (is_tla) try preamble.write("await ");
+    if (target_needs_await and importer_is_async) try preamble.write("await ");
     try writeEsmInitExprBody(self, preamble, target_mod, guard);
     try preamble.write(if (guard) rt.GUARD_LAMBDA_CLOSE else rt.INIT_CALL_END);
 }
@@ -595,7 +606,7 @@ pub fn buildMetadataForAst(
                     .esm => {
                         if (esm_init_set.contains(target_idx)) continue;
                         try esm_init_set.put(self.allocator, target_idx, {});
-                        try appendEsmInitCall(self, &preamble, target_mod);
+                        try appendEsmInitCall(self, &preamble, target_mod, &m);
                     },
                 }
             }
@@ -937,11 +948,11 @@ pub fn buildMetadataForAst(
                 }
                 if (!lazy_esm_import and !esm_init_set.contains(@intCast(canonical_mod))) {
                     try esm_init_set.put(self.allocator, @intCast(canonical_mod), {});
-                    try appendEsmInitCall(self, &preamble, target_mod);
+                    try appendEsmInitCall(self, &preamble, target_mod, &m);
                 }
                 if (!lazy_esm_import and value_init_mod_idx != canonical_mod and !esm_init_set.contains(@intCast(value_init_mod_idx))) {
                     try esm_init_set.put(self.allocator, @intCast(value_init_mod_idx), {});
-                    try appendEsmInitCall(self, &preamble, value_init_mod);
+                    try appendEsmInitCall(self, &preamble, value_init_mod, &m);
                 }
                 // import binding은 아래의 rename 경로로 처리 (continue하지 않음)
             }
@@ -965,7 +976,7 @@ pub fn buildMetadataForAst(
                                 !esm_init_set.contains(rb_idx))
                             {
                                 try esm_init_set.put(self.allocator, rb_idx, {});
-                                try appendEsmInitCall(self, &preamble, rw);
+                                try appendEsmInitCall(self, &preamble, rw, &m);
                             }
                         }
                     }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -1604,7 +1604,25 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module, format: types
                 defer self.allocator.free(exports_name);
                 // #1621: minify 시 __toCommonJS → $tC 축약.
                 const to_cjs_name: []const u8 = if (self.minify_whitespace) rt.NAMES.TOCOMMONJS_MIN else "__toCommonJS";
-                const call_expr = try std.fmt.allocPrint(self.allocator, "({s}(), {s}({s}))", .{ init_name, to_cjs_name, exports_name });
+                // #4598 3b-4: 소비자가 **초기화 완료를 기다려야** 값을 본다.
+                //   ① target 이 기다릴 대상을 준다 (TLA 이거나 async cone 안)
+                //   ② importer(`m`) 의 factory 가 async 다 — 아니면 non-async 본문에
+                //      `await` 가 떨어져 SyntaxError (폐기된 ba943dec 의 구멍).
+                // 없으면 `init_X()` 가 promise 를 돌려주는데 그걸 버리고 exports 를 즉시
+                // 읽어 `undefined` 가 된다.
+                // ⚠️ importer 가 `await` 를 **담을 수 있어야** 한다:
+                //   - `__commonJS` 래퍼는 async 로 안 만든다(그 헬퍼가 반환값을 버려 promise
+                //     전파가 불가 — 별도 진단 대상). 거기에 await 를 넣으면 SyntaxError(실측).
+                //   - async 문법이 없는 타겟(es5)도 제외 — 상태머신 낮추기가 선행돼야 한다.
+                const importer_can_await = m.wrap_kind == .esm and
+                    (m.uses_top_level_await or m.in_async_cone) and
+                    !self.graph.transform_options_base.unsupported.async_await;
+                const needs_await = (target_mod.uses_top_level_await or target_mod.in_async_cone) and
+                    importer_can_await;
+                const call_expr = if (needs_await)
+                    try std.fmt.allocPrint(self.allocator, "(await {s}(), {s}({s}))", .{ init_name, to_cjs_name, exports_name })
+                else
+                    try std.fmt.allocPrint(self.allocator, "({s}(), {s}({s}))", .{ init_name, to_cjs_name, exports_name });
                 try require_rewrites.put(self.allocator, rec.specifier, call_expr);
             }
         }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -228,10 +228,9 @@ fn appendEsmInitCall(
     target_mod: *const Module,
     importer: *const Module,
 ) !void {
-    const target_needs_await = target_mod.uses_top_level_await or target_mod.in_async_cone;
-    const importer_is_async = importer.uses_top_level_await or importer.in_async_cone;
+    const needs_await = @import("../module.zig").isAwaitableInit(target_mod, importer, self.graph.transform_options_base.unsupported);
     const guard = target_mod.shouldGuard(self.entry_error_guard);
-    if (target_needs_await and importer_is_async) try preamble.write("await ");
+    if (needs_await) try preamble.write("await ");
     try writeEsmInitExprBody(self, preamble, target_mod, guard);
     try preamble.write(if (guard) rt.GUARD_LAMBDA_CLOSE else rt.INIT_CALL_END);
 }
@@ -1604,25 +1603,12 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module, format: types
                 defer self.allocator.free(exports_name);
                 // #1621: minify 시 __toCommonJS → $tC 축약.
                 const to_cjs_name: []const u8 = if (self.minify_whitespace) rt.NAMES.TOCOMMONJS_MIN else "__toCommonJS";
-                // #4598 3b-4: 소비자가 **초기화 완료를 기다려야** 값을 본다.
-                //   ① target 이 기다릴 대상을 준다 (TLA 이거나 async cone 안)
-                //   ② importer(`m`) 의 factory 가 async 다 — 아니면 non-async 본문에
-                //      `await` 가 떨어져 SyntaxError (폐기된 ba943dec 의 구멍).
-                // 없으면 `init_X()` 가 promise 를 돌려주는데 그걸 버리고 exports 를 즉시
-                // 읽어 `undefined` 가 된다.
-                // ⚠️ importer 가 `await` 를 **담을 수 있어야** 한다:
-                //   - `__commonJS` 래퍼는 async 로 안 만든다(그 헬퍼가 반환값을 버려 promise
-                //     전파가 불가 — 별도 진단 대상). 거기에 await 를 넣으면 SyntaxError(실측).
-                //   - async 문법이 없는 타겟(es5)도 제외 — 상태머신 낮추기가 선행돼야 한다.
-                const importer_can_await = m.wrap_kind == .esm and
-                    (m.uses_top_level_await or m.in_async_cone) and
-                    !self.graph.transform_options_base.unsupported.async_await;
-                const needs_await = (target_mod.uses_top_level_await or target_mod.in_async_cone) and
-                    importer_can_await;
-                const call_expr = if (needs_await)
-                    try std.fmt.allocPrint(self.allocator, "(await {s}(), {s}({s}))", .{ init_name, to_cjs_name, exports_name })
-                else
-                    try std.fmt.allocPrint(self.allocator, "({s}(), {s}({s}))", .{ init_name, to_cjs_name, exports_name });
+                // ⚠️ #4598: 여기엔 `await` 를 넣지 않는다. 이 문자열은 모듈 안 **모든**
+                //    `require(spec)` 지점에 치환되는데, RN `inline_requires` 처럼 중첩
+                //    함수 본문에 있는 require 까지 포함된다 — non-async 함수 안에 await 가
+                //    들어가 번들 전체가 파싱 불가가 된다(리뷰 실측). 초기화 순서는
+                //    preamble 의 `appendEsmInitCall` 이 담당한다.
+                const call_expr = try std.fmt.allocPrint(self.allocator, "({s}(), {s}({s}))", .{ init_name, to_cjs_name, exports_name });
                 try require_rewrites.put(self.allocator, rec.specifier, call_expr);
             }
         }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -441,6 +441,17 @@ pub const Module = struct {
     /// (`await init_X()`)·`ZNTC0002` 경고 등 여러 경로가 읽어서, 값을 넓히면 의도치 않은
     /// 곳이 함께 바뀐다(4차 시도가 이걸로 회귀했다). 위임 사실만 담는 전용 필드로 둔다.
     tla_delegated_to_chunk: bool = false,
+
+    /// #4598: 이 모듈이 **async cone** 안에 있는지 — top-level await 를 쓰는 모듈이거나,
+    /// 그런 모듈을 **static import 또는 require 로** 소비하는 모듈.
+    ///
+    /// ⚠️ `uses_top_level_await` 와 별개 필드다. 그 플래그는 `appendModuleCall`
+    /// (`await init_X()`) 등 여러 방출 경로가 읽어서, 전파 범위를 넓히면 의도치 않은 곳이
+    /// 함께 바뀐다(#4598 4차 시도가 이걸로 회귀). cone 은 **판정 전용**이다.
+    ///
+    /// `uses_top_level_await` 와 달리 **require 엣지도 탄다** — CJS 모듈이 TLA 모듈을
+    /// 동기 소비하는 위상을 잡아내야 하기 때문이다(Node 도 `ERR_REQUIRE_ASYNC_MODULE` 로 거부).
+    in_async_cone: bool = false,
     /// Module Federation 연합 경계 모듈 (#3318 P1-1). `mf.exposes` 타겟 ∪
     /// `mf.shared` ∪ shared 전방-의존 폐포. P1-1 은 **표시·안정 ID 계산만**
     /// (분석) — 스코프 호이스팅 소거 제외 *enforcement*·container/manifest

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -452,6 +452,11 @@ pub const Module = struct {
     /// `uses_top_level_await` 와 달리 **require 엣지도 탄다** — CJS 모듈이 TLA 모듈을
     /// 동기 소비하는 위상을 잡아내야 하기 때문이다(Node 도 `ERR_REQUIRE_ASYNC_MODULE` 로 거부).
     in_async_cone: bool = false,
+
+    /// #4598: `lowerProgram` 이 만든 async IIFE statement 의 AST 인덱스.
+    /// `__esm` factory 방출 시 이 문장만 `return <expr>;` 로 바꿔 `init_X()` 가
+    /// 초기화 완료 promise 를 돌려주게 한다. null 이면 해당 없음.
+    tla_iife_stmt: ?u32 = null,
     /// Module Federation 연합 경계 모듈 (#3318 P1-1). `mf.exposes` 타겟 ∪
     /// `mf.shared` ∪ shared 전방-의존 폐포. P1-1 은 **표시·안정 ID 계산만**
     /// (분석) — 스코프 호이스팅 소거 제외 *enforcement*·container/manifest

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -187,11 +187,21 @@ pub fn isAwaitableInit(
     importer: *const Module,
     unsupported: @import("../transformer/transformer.zig").TransformOptions.compat.UnsupportedFeatures,
 ) bool {
-    if (unsupported.async_await) return false;
-    // ① target
+    // ① target 이 기다릴 대상(초기화 완료 promise)을 주는가.
+    //    `__commonJS` 는 factory 반환값을 버려 promise 를 못 흘린다.
     if (target.wrap_kind != .esm) return false;
     if (!(target.uses_top_level_await or target.in_async_cone)) return false;
-    // ② importer
+
+    // ② importer 가 그 await 를 담을 수 있는가.
+    //
+    // ⚠️ **네이티브 TLA 를 쓰는 타겟(es2022+)에서는 importer 를 따지면 안 된다.** 거기선
+    //    모듈 최상위 await 가 합법이라 scope-hoist importer 도 그냥 쓸 수 있다. importer
+    //    조건을 걸었더니 es2022 에서 `await init_X()` 가 사라져 값이 `undefined` 가 됐다
+    //    (리뷰 실측: main `41` → `undefined`). 다운레벨 타겟에서만 문맥을 따진다.
+    if (!unsupported.top_level_await) return true;
+
+    // 다운레벨: async 문법이 없으면 factory 를 async 로 못 만든다.
+    if (unsupported.async_await) return false;
     if (importer.wrap_kind != .esm) return false;
     if (!(importer.uses_top_level_await or importer.in_async_cone)) return false;
     return true;

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -169,6 +169,34 @@ pub fn destroyParseArena(allocator: std.mem.Allocator, arena: *std.heap.ArenaAll
     allocator.destroy(arena);
 }
 
+/// #4598: `await init_X()` 를 낼 수 있는가 — **이 질문의 유일한 답변자**.
+///
+/// 예전엔 같은 판정이 5곳(`appendEsmInitCall` · `appendWrappedInitCall` ·
+/// `buildRequireRewrites` · lazy ESM import · default re-export)에 **서로 다른 조건**으로
+/// 흩어져 있었다. 그래서 어떤 곳은 non-async 문맥에 `await` 를 넣어 번들을 파싱 불가로
+/// 만들고, 어떤 곳은 async 인데 `await` 를 빼먹어 **조용한 `undefined`** 를 만들었다.
+/// 새 호출부가 생기면 반드시 이 함수를 쓸 것 — 조건을 손으로 다시 적지 말 것.
+///
+/// 두 축을 모두 만족해야 한다:
+///   ① **target 이 기다릴 대상을 준다** — 초기화 완료 promise 를 돌려주는 `__esm` 래퍼.
+///      `__commonJS` 는 factory 반환값을 버리므로 promise 를 못 흘린다.
+///   ② **importer 가 그 await 를 담을 수 있다** — 자기 factory 가 async 인 `__esm` 래퍼.
+///      async 문법이 없는 타겟(es5)은 factory 를 async 로 못 만든다.
+pub fn isAwaitableInit(
+    target: *const Module,
+    importer: *const Module,
+    unsupported: @import("../transformer/transformer.zig").TransformOptions.compat.UnsupportedFeatures,
+) bool {
+    if (unsupported.async_await) return false;
+    // ① target
+    if (target.wrap_kind != .esm) return false;
+    if (!(target.uses_top_level_await or target.in_async_cone)) return false;
+    // ② importer
+    if (importer.wrap_kind != .esm) return false;
+    if (!(importer.uses_top_level_await or importer.in_async_cone)) return false;
+    return true;
+}
+
 pub const Module = struct {
     index: ModuleIndex,
     /// 절대 파일 경로. graph의 path_to_module 키와 동일한 메모리를 참조 (빌림).

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -912,6 +912,10 @@ pub const BundlerDiagnostic = struct {
         plugin_error,
         /// `output.exports = "default"` 모드 + named export 섞임. Rollup 도 동일 케이스 throw. #2159
         output_exports_conflict,
+        /// CJS 모듈이 top-level await 를 쓰는 모듈을 **동기 require** 로 소비 (#4598).
+        /// Node 도 같은 위상을 `ERR_REQUIRE_ASYNC_MODULE` 로 거부한다 — 동기 require 는
+        /// 비동기 초기화를 기다릴 수단이 없어 초기화 전 exports 를 읽는다.
+        require_async_module,
         /// `@jsx` / `@jsxFrag` pragma 가 있는데 effective JSX runtime 이 automatic — classic
         /// factory 가 무시됨 (D026). warning severity.
         jsx_pragma_ignored,

--- a/src/error_codes.zig
+++ b/src/error_codes.zig
@@ -52,6 +52,7 @@ pub const Code = enum(u16) {
     circular_reexport = 104,
     ambiguous_export = 105,
     output_exports_conflict = 106,
+    require_async_module = 107,
 
     // ═══════════════════════════════════════════════════════
     // 0200-0299: 번들러 — 파일/로더
@@ -340,6 +341,7 @@ pub const Code = enum(u16) {
             .circular_reexport => "Re-export references the module itself (self-cycle)",
             .ambiguous_export => "Ambiguous import: a name is exported by multiple modules via 'export *'",
             .output_exports_conflict => "Output exports conflict with the selected module format",
+            .require_async_module => "require() cannot be used on a module graph with top-level await",
             .read_error => "Failed to read file",
             .json_parse_error => "Failed to parse JSON",
             .no_loader => "No loader is configured for this file type",

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1131,6 +1131,13 @@ pub const Ast = struct {
     /// `assertInvariants` 가 탐지. D1b (in-place) 전환 시 shared module 재진입
     /// 탐지/차단 용도로 확장 예정.
     transformed_root: ?NodeIndex = null,
+    /// #4598: `es2022_tla.lowerProgram` 이 이 program 을 async IIFE 로 이미 감쌌는지.
+    ///
+    /// ⚠️ Transformer **인스턴스** 필드로는 안 된다. graph prepass 와 emit 이 각각 새
+    /// Transformer 를 만들고, `transform_cache` 가 없는 모듈은 emit 에서 transform 이
+    /// 다시 돌아 **이미 감싼 body 를 또 감싼다** → async IIFE 가 두 개 방출돼 side-effect
+    /// 가 2회 실행된다(유닛 테스트가 잡음). AST 는 두 인스턴스가 공유하므로 여기 둔다.
+    tla_lowered: bool = false,
 
     /// top-level `declare class/function/var/let/const/enum/namespace/import =` 의
     /// binding name 사이드테이블. parser 가 declare 노드를 `NodeIndex.none` 으로 strip

--- a/src/parser/ast_codec.zig
+++ b/src/parser/ast_codec.zig
@@ -49,7 +49,10 @@ comptime {
     // 류)나 deserialize 정확성에 영향을 주는 필드면 — 직렬화 누락 시 cache-hit 후 stale 출력이
     // 된다. 다른 codec(semantic/module/cache_key)처럼 필드 수를 못박아, 변경 시 새 필드를
     // "직렬화 / 빈값복원" 중 어디로 분류할지 재검토를 컴파일 에러로 강제한다.
-    if (@typeInfo(Ast).@"struct".fields.len != 24)
+    // #4598 `tla_lowered`: **직렬화 불필요**. 이 플래그는 "이 Ast 를 이미 TLA lowering 했다"
+    // 는 **한 빌드 안의 멱등성** 표식이다. 디스크 캐시에서 복원되는 Ast 는 lowering 이 끝난
+    // 산물이 아니라 parse 결과이므로 false 로 복원되는 것이 맞다.
+    if (@typeInfo(Ast).@"struct".fields.len != 25)
         @compileError("Ast 필드 수가 바뀜 — 새 필드의 직렬화 필요 여부를 판정해 ast_codec 갱신 후 이 수를 갱신할 것.");
 }
 

--- a/src/rich_diagnostic.zig
+++ b/src/rich_diagnostic.zig
@@ -154,6 +154,7 @@ pub fn bundlerErrorCode(code: BundlerDiagnostic.ErrorCode) ?error_codes.Code {
         .assign_to_import => .assign_to_import,
         .ambiguous_export => .ambiguous_export,
         .output_exports_conflict => .output_exports_conflict,
+        .require_async_module => .require_async_module,
         .require_context_invalid => .require_context_invalid,
         .require_context_no_handler => .require_context_no_handler,
         .plugin_error => .plugin_error,

--- a/src/transformer/es2022_tla.zig
+++ b/src/transformer/es2022_tla.zig
@@ -29,6 +29,9 @@
 //! - oxc: 미구현 (TLA 는 ES2022 이상 타겟에서만 사용한다는 전제).
 
 const std = @import("std");
+
+/// #4598: TLA IIFE 의 promise 를 담는 변수명. emitter 가 `return <이 이름>;` 으로 돌려준다.
+pub const TLA_PROMISE_VAR = "__zntc_tla";
 const ast_mod = @import("../parser/ast.zig");
 const ast_walk = @import("../parser/ast_walk.zig");
 const es_helpers = @import("es_helpers.zig");
@@ -202,6 +205,10 @@ fn drainPendingAround(
 /// 반환: wrap 된 program 노드 index (TLA 가 없으면 null — caller 가 기본 visit 수행).
 pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) Transformer.Error!?NodeIndex {
     std.debug.assert(node.tag == .program);
+    // ⚠️ 멱등성: 같은 program 에 두 번 적용되면 async IIFE 가 **두 개** 방출돼
+    // side-effect 가 2회 실행된다(유닛 테스트가 잡음). 플래그는 **AST** 에 둬야 한다 —
+    // prepass/emit 이 각각 새 Transformer 를 만들기 때문.
+    if (self.ast.tla_lowered) return null;
     const list = node.data.list;
 
     // 1. wrap 대상 TLA 존재 여부 검사.
@@ -355,14 +362,34 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
 
     // (arrow)() — 호출 (arrow 는 call-target 위치에서 codegen 이 자동 wrap)
     const call = try es_helpers.makeCallExpr(self, arrow, &.{}, node.span);
-    const iife_stmt = try es_helpers.makeExprStmt(self, call, node.span);
+    // #4598: 표현식 문장이 아니라 **변수 선언**으로 만든다 — `var __zntc_tla = (…)();`.
+    // emitter 가 `__esm` factory 끝에 `return __zntc_tla;` 만 덧붙이면 `init_X()` 가
+    // 초기화 완료 promise 를 돌려준다. 문장을 쪼개 재조립하는 방식은 codegen 이 내부
+    // 버퍼에 **누적**해서 IIFE 가 두 번 방출됐다(유닛 테스트가 잡음).
+    // ⚠️ 이름을 직접 발명하면 안 된다. 사용자가 같은 이름을 쓰면 값을 덮어쓰고,
+    //    접미사를 붙여 피해도 이번엔 리네이머가 사용자 심볼을 건드려 참조가 끊긴다
+    //    (적대적 검증이 둘 다 잡음). 기존 임시변수 기계는 `collidesWithUserSymbol`
+    //    (#4220) 로 충돌 회피가 이미 들어가 있고 리네이머와도 정합적이다.
+    const tla_name = try es_helpers.makeTempVarSpan(self);
+    const tla_binding = try es_helpers.makeBindingIdentifier(self, tla_name);
+    const tla_declarator = try es_helpers.makeDeclarator(self, tla_binding, call, node.span);
+    const iife_stmt = try es_helpers.makeVarDeclaration(self, &.{tla_declarator}, .@"var", node.span);
 
     // async/await lowering 이 이 arrow 에 적용되어야 하므로 재방문이 필요한 경우가 있지만,
     // `visitNode` 는 자식 재방문을 내부적으로 처리한다. 우리는 arrow 를 top-down dispatch 에
     // 다시 넣기 위해 expression_statement 를 visit.
+    const iife_pt = self.pending_nodes.items.len;
+    const iife_tt = self.trailing_nodes.items.len;
     const visited_iife = try self.visitNode(iife_stmt);
+    // ⚠️ 여기서 배수하지 않으면 아래 exports 패스의 배수가 이 pending 을 주워 담아
+    //    **IIFE 가 두 번** 방출된다 → side-effect 2회 실행(유닛 테스트가 잡음).
+    self.pending_nodes.shrinkRetainingCapacity(iife_pt);
+    self.trailing_nodes.shrinkRetainingCapacity(iife_tt);
     // #4598: emitter 가 `__esm` factory 안에서 이 문장을 `return <expr>;` 로 방출한다.
-    if (!visited_iife.isNone()) self.tla_iife_stmt = visited_iife;
+    if (!visited_iife.isNone()) {
+        self.tla_iife_stmt = visited_iife;
+        self.ast.tla_lowered = true;
+    }
 
     // 최종 program list: [imports...] + [visited_iife] + [exports...]
     // 현재 scratch 에는 [imports_end..body_stmts_end] 까지 wrap 대상이 있으므로

--- a/src/transformer/es2022_tla.zig
+++ b/src/transformer/es2022_tla.zig
@@ -219,6 +219,7 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
         const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
         const child_node = self.ast.getNode(child);
         if (isModuleDeclaration(child_node.tag)) {
+            if (!self.options.tla_export_decl_deferrable) continue;
             // `export const x = await f()` 도 대상. 예전엔 건너뛰어서 await 가 최상위에
             // 남고, es2017 낮추기가 그걸 `yield` 로 바꿔 **generator 가 아닌 `__esm`
             // factory 안의 bare yield** 가 됐다 (Hermes/acorn 모두 SyntaxError).
@@ -252,6 +253,7 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
             const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + j]);
             const child_node = self.ast.getNode(child);
             if (!isModuleDeclaration(child_node.tag)) continue;
+            if (!self.options.tla_export_decl_deferrable) continue;
             const d = exportedVarDeclIdx(self, child_node) orelse continue;
             if (!allDeclaratorsAreIdentifiers(self, d)) continue;
             const has_await = try hasTopLevelAwait(self.ast, d);

--- a/src/transformer/es2022_tla.zig
+++ b/src/transformer/es2022_tla.zig
@@ -187,6 +187,8 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
     // `visitNode` 는 자식 재방문을 내부적으로 처리한다. 우리는 arrow 를 top-down dispatch 에
     // 다시 넣기 위해 expression_statement 를 visit.
     const visited_iife = try self.visitNode(iife_stmt);
+    // #4598: emitter 가 `__esm` factory 안에서 이 문장을 `return <expr>;` 로 방출한다.
+    if (!visited_iife.isNone()) self.tla_iife_stmt = visited_iife;
 
     // 최종 program list: [imports...] + [visited_iife] + [exports...]
     // 현재 scratch 에는 [imports_end..body_stmts_end] 까지 wrap 대상이 있으므로

--- a/src/transformer/es2022_tla.zig
+++ b/src/transformer/es2022_tla.zig
@@ -92,6 +92,110 @@ pub fn hasTopLevelAwait(ast: *const ast_mod.Ast, idx: NodeIndex) std.mem.Allocat
     return c.found;
 }
 
+/// `export <var-decl>` 이면 내부 `variable_declaration` 인덱스. 그 외 null.
+///
+/// ⚠️ `export_named_declaration` extra 는 **6슬롯**:
+///    `[decl(0), specs_start(1), specs_len(2), source(3), attrs_start(4), attrs_len(5)]`.
+///    4슬롯으로 읽으면 인접 extra_data 를 attrs 로 오독한다.
+fn exportedVarDeclIdx(self: anytype, export_node: Node) ?NodeIndex {
+    if (export_node.tag != .export_named_declaration) return null;
+    const decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[export_node.data.extra]);
+    if (decl_idx.isNone()) return null;
+    if (self.ast.getNode(decl_idx).tag != .variable_declaration) return null;
+    return decl_idx;
+}
+
+/// 모든 declarator 가 **단순 식별자**인지.
+///
+/// ⚠️ 구조분해 패턴은 대상에서 뺀다 — 초기화식 없는 `var {a,b};` 는 문법 오류이고,
+///    폐기된 시도가 정확히 그걸로 번들 전체를 파싱 불가로 만들었다.
+fn allDeclaratorsAreIdentifiers(self: anytype, decl_idx: NodeIndex) bool {
+    const decl = self.ast.getNode(decl_idx);
+    const dlist = self.ast.extra_data.items[decl.data.extra + 1];
+    const dlen = self.ast.extra_data.items[decl.data.extra + 2];
+    if (dlen == 0) return false;
+    var k: u32 = 0;
+    while (k < dlen) : (k += 1) {
+        const dcl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[dlist + k]);
+        const dcl = self.ast.getNode(dcl_idx);
+        const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[dcl.data.extra]);
+        if (name_idx.isNone()) return false;
+        if (self.ast.getNode(name_idx).tag != .binding_identifier) return false;
+    }
+    return true;
+}
+
+const RefScanCtx = struct {
+    names: *const std.StringHashMapUnmanaged(void),
+    ast: *const ast_mod.Ast,
+    found: bool,
+};
+
+fn refScanVisit(ctx: *RefScanCtx, idx: NodeIndex, node: Node) ast_walk.WalkAction {
+    _ = idx;
+    if (node.tag == .identifier_reference) {
+        if (ctx.names.contains(ctx.ast.getText(node.data.string_ref))) {
+            ctx.found = true;
+            return .stop;
+        }
+    }
+    return .descend;
+}
+
+/// 서브트리가 `names` 중 하나를 참조하는지 (IIFE 로 지연된 바인딩 의존 판정).
+fn referencesAny(self: anytype, idx: NodeIndex, names: *const std.StringHashMapUnmanaged(void)) bool {
+    if (names.count() == 0) return false;
+    var c = RefScanCtx{ .names = names, .ast = self.ast, .found = false };
+    ast_walk.walkPreorderIterative(self.ast.allocator, self.ast, idx, &c, refScanVisit) catch return false;
+    return c.found;
+}
+
+/// declarator 들의 초기화식을 떼어 `var a, b;` 로 만든다 (선언은 밖에 남아 export 보존).
+/// 호출 전에 `allDeclaratorsAreIdentifiers` 가 참임이 보장돼야 한다.
+fn stripVarInitializers(comptime Transformer: type, self: *Transformer, decl_idx: NodeIndex) Transformer.Error!NodeIndex {
+    const decl = self.ast.getNode(decl_idx);
+    const dl = self.ast.extra_data.items[decl.data.extra + 1];
+    const dn = self.ast.extra_data.items[decl.data.extra + 2];
+    const top = self.scratch.items.len;
+    defer self.scratch.shrinkRetainingCapacity(top);
+    var k: u32 = 0;
+    while (k < dn) : (k += 1) {
+        const dcl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[dl + k]);
+        const dcl = self.ast.getNode(dcl_idx);
+        const nm: NodeIndex = @enumFromInt(self.ast.extra_data.items[dcl.data.extra]);
+        const ty: NodeIndex = @enumFromInt(self.ast.extra_data.items[dcl.data.extra + 1]);
+        const ne = try self.ast.addExtras(&.{ @intFromEnum(nm), @intFromEnum(ty), @intFromEnum(NodeIndex.none) });
+        const nd = try self.ast.addNode(.{ .tag = .variable_declarator, .span = dcl.span, .data = .{ .extra = ne } });
+        try self.scratch.append(self.allocator, nd);
+    }
+    const nl = try self.ast.addNodeList(self.scratch.items[top..]);
+    const de = try self.ast.addExtras(&.{ @intFromEnum(ast_mod.VariableDeclarationKind.@"var"), nl.start, nl.len });
+    return try self.ast.addNode(.{ .tag = .variable_declaration, .span = decl.span, .data = .{ .extra = de } });
+}
+
+/// `visitNode` 가 쌓은 `pending_nodes`(앞) / `trailing_nodes`(뒤) 를 scratch 로 옮긴다.
+///
+/// ⚠️ `lowerProgram` 은 `visitExtraList` 를 안 쓰고 직접 리스트를 조립하므로 이 배수를
+///    스스로 해야 한다. 빠뜨리면 데코레이터/다운레벨 class 의 호이스팅된 선언이 통째로
+///    사라져 `Export 'C' is not defined` 가 된다(폐기된 시도가 정확히 그랬다).
+fn drainPendingAround(
+    comptime Transformer: type,
+    self: *Transformer,
+    pending_top: usize,
+    trailing_top: usize,
+    visited: NodeIndex,
+) Transformer.Error!void {
+    if (self.pending_nodes.items.len > pending_top) {
+        try self.scratch.appendSlice(self.allocator, self.pending_nodes.items[pending_top..]);
+        self.pending_nodes.shrinkRetainingCapacity(pending_top);
+    }
+    if (!visited.isNone()) try self.scratch.append(self.allocator, visited);
+    if (self.trailing_nodes.items.len > trailing_top) {
+        try self.scratch.appendSlice(self.allocator, self.trailing_nodes.items[trailing_top..]);
+        self.trailing_nodes.shrinkRetainingCapacity(trailing_top);
+    }
+}
+
 /// program 의 top-level 에 TLA 가 있으면 async IIFE 로 wrap.
 /// `self` 는 Transformer. options.unsupported.top_level_await 가 true 일 때만 호출.
 ///
@@ -107,13 +211,59 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
     while (i < list.len) : (i += 1) {
         const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
         const child_node = self.ast.getNode(child);
-        if (isModuleDeclaration(child_node.tag)) continue;
+        if (isModuleDeclaration(child_node.tag)) {
+            // `export const x = await f()` 도 대상. 예전엔 건너뛰어서 await 가 최상위에
+            // 남고, es2017 낮추기가 그걸 `yield` 로 바꿔 **generator 가 아닌 `__esm`
+            // factory 안의 bare yield** 가 됐다 (Hermes/acorn 모두 SyntaxError).
+            const d = exportedVarDeclIdx(self, child_node) orelse continue;
+            if (!allDeclaratorsAreIdentifiers(self, d)) continue; // 구조분해는 제외
+            if (try hasTopLevelAwait(self.ast, d)) {
+                has_tla = true;
+                break;
+            }
+            continue;
+        }
         if (try hasTopLevelAwait(self.ast, child)) {
             has_tla = true;
             break;
         }
     }
     if (!has_tla) return null;
+
+    // 어떤 export 선언을 IIFE 로 옮길지 **미리** 정한다.
+    //
+    // 규칙: ① await 를 포함한 선언, ② 그리고 ①에서 지연된 바인딩을 참조하는 후속 선언.
+    // ⚠️ "exported 선언 전부" 로 넓히면 안 된다 — `await …;` 뒤의 `export const NAME='hello'`
+    //    처럼 **await 와 무관한** export 까지 지연돼 소비자가 `undefined` 를 읽는다(실측 회귀).
+    var deferred_names: std.StringHashMapUnmanaged(void) = .empty;
+    defer deferred_names.deinit(self.allocator);
+    var move_set: std.AutoHashMapUnmanaged(u32, void) = .empty;
+    defer move_set.deinit(self.allocator);
+    {
+        var j: u32 = 0;
+        while (j < list.len) : (j += 1) {
+            const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + j]);
+            const child_node = self.ast.getNode(child);
+            if (!isModuleDeclaration(child_node.tag)) continue;
+            const d = exportedVarDeclIdx(self, child_node) orelse continue;
+            if (!allDeclaratorsAreIdentifiers(self, d)) continue;
+            const has_await = try hasTopLevelAwait(self.ast, d);
+            const dep = referencesAny(self, d, &deferred_names);
+            if (!has_await and !dep) continue;
+            try move_set.put(self.allocator, @intFromEnum(child), {});
+            // 이 선언의 바인딩들을 "지연됨" 으로 기록 → 뒤따르는 의존 선언도 함께 옮긴다.
+            const decl = self.ast.getNode(d);
+            const dl = self.ast.extra_data.items[decl.data.extra + 1];
+            const dn = self.ast.extra_data.items[decl.data.extra + 2];
+            var k: u32 = 0;
+            while (k < dn) : (k += 1) {
+                const dcl = self.ast.getNode(@enumFromInt(self.ast.extra_data.items[dl + k]));
+                const nm: NodeIndex = @enumFromInt(self.ast.extra_data.items[dcl.data.extra]);
+                if (nm.isNone()) continue;
+                try deferred_names.put(self.allocator, self.ast.getText(self.ast.getNode(nm).data.string_ref), {});
+            }
+        }
+    }
 
     // 2. 자식을 두 그룹으로 분리.
     //    - 그대로 유지: import/export 문
@@ -137,8 +287,10 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
         const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
         const child_node = self.ast.getNode(child);
         if (child_node.tag == .import_declaration or child_node.tag == .ts_import_equals_declaration) {
+            const pt = self.pending_nodes.items.len;
+            const tt = self.trailing_nodes.items.len;
             const visited = try self.visitNode(child);
-            if (!visited.isNone()) try self.scratch.append(self.allocator, visited);
+            try drainPendingAround(Transformer, self, pt, tt, visited);
         }
     }
     const imports_end = self.scratch.items.len;
@@ -150,9 +302,31 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
         const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[list.start + i]);
         const child_node = self.ast.getNode(child);
         if (child_node.tag == .import_declaration or child_node.tag == .ts_import_equals_declaration) continue;
-        if (isModuleDeclaration(child_node.tag)) continue; // 아래 exports 패스에서 처리
+        if (isModuleDeclaration(child_node.tag)) {
+            // move_set 인 export 선언: `v = <init>;` 만 IIFE 안으로. 선언 자체는 아래
+            // exports 패스가 초기화식을 뗀 `var v;` 로 밖에 남겨 export 를 보존한다.
+            if (!move_set.contains(@intFromEnum(child))) continue;
+            const d = exportedVarDeclIdx(self, child_node).?;
+            const decl = self.ast.getNode(d);
+            const dl = self.ast.extra_data.items[decl.data.extra + 1];
+            const dn = self.ast.extra_data.items[decl.data.extra + 2];
+            var k2: u32 = 0;
+            while (k2 < dn) : (k2 += 1) {
+                const dcl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[dl + k2]);
+                const dcl = self.ast.getNode(dcl_idx);
+                const nm: NodeIndex = @enumFromInt(self.ast.extra_data.items[dcl.data.extra]);
+                const init_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[dcl.data.extra + 2]);
+                if (nm.isNone() or init_idx.isNone()) continue;
+                const assign = try es_helpers.makeAssignStmt(self, nm, init_idx, dcl.span, 0);
+                const av = try self.visitNode(assign);
+                if (!av.isNone()) try self.scratch.append(self.allocator, av);
+            }
+            continue;
+        }
+        const pt = self.pending_nodes.items.len;
+        const tt = self.trailing_nodes.items.len;
         const visited = try self.visitNode(child);
-        if (!visited.isNone()) try self.scratch.append(self.allocator, visited);
+        try drainPendingAround(Transformer, self, pt, tt, visited);
     }
     const body_stmts_end = self.scratch.items.len;
 
@@ -203,8 +377,33 @@ pub fn lowerProgram(comptime Transformer: type, self: *Transformer, node: Node) 
         const child_node = self.ast.getNode(child);
         if (child_node.tag == .import_declaration or child_node.tag == .ts_import_equals_declaration) continue;
         if (!isModuleDeclaration(child_node.tag)) continue;
+        if (move_set.contains(@intFromEnum(child))) {
+            // 초기화식은 위 wrap 패스가 이미 IIFE 안에 넣었다. 여기선 선언만 남긴다.
+            // ⚠️ `let` 이면 IIFE 안 할당이 선언보다 먼저 실행돼 **TDZ**. `var` 는 호이스팅
+            //    되므로 순서에 안전하다. `const` 는 초기화식 없는 선언 자체가 문법 오류.
+            const d = exportedVarDeclIdx(self, child_node).?;
+            const stripped = try stripVarInitializers(Transformer, self, d);
+            const ex = child_node.data.extra;
+            const new_ex = try self.ast.addExtras(&.{
+                @intFromEnum(stripped),
+                self.ast.extra_data.items[ex + 1],
+                self.ast.extra_data.items[ex + 2],
+                self.ast.extra_data.items[ex + 3],
+                self.ast.extra_data.items[ex + 4],
+                self.ast.extra_data.items[ex + 5],
+            });
+            const new_export = try self.ast.addNode(.{
+                .tag = .export_named_declaration,
+                .span = child_node.span,
+                .data = .{ .extra = new_ex },
+            });
+            try self.scratch.append(self.allocator, new_export);
+            continue;
+        }
+        const pt = self.pending_nodes.items.len;
+        const tt = self.trailing_nodes.items.len;
         const visited = try self.visitNode(child);
-        if (!visited.isNone()) try self.scratch.append(self.allocator, visited);
+        try drainPendingAround(Transformer, self, pt, tt, visited);
     }
 
     const new_list = try self.ast.addNodeList(self.scratch.items[imports_top..]);

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -70,6 +70,14 @@ pub const TransformOptions = struct {
     /// ⚠️ async 미지원 타겟(es5)도 안 된다 — factory 가 generator 여야 하는데 `for await`
     /// 다운레벨이 내부에 `await` 를 그대로 내보내 generator 안에서 SyntaxError 가 된다.
     tla_chunk_wrapped: bool = false,
+    /// #4598: `export const x = await f()` 의 **초기화식을 async IIFE 로 옮겨도 되는지**.
+    ///
+    /// 옮기면 "그 promise 를 누군가 기다려야" 값이 채워진다. 기다려 줄 기계
+    /// (`promoteAsyncConeToEsmWrap` 승격 + 소비자 await, 또는 emitter 의 최상위 await
+    /// fallback)가 **없는 빌드 위상**에서 옮기면 export 가 조용히 `undefined` 가 된다
+    /// — splitting·preserve-modules·비-ESM 출력에서 실제로 그랬다(리뷰 실측).
+    /// 그래서 빌드 단위로 미리 판정해 내려보낸다.
+    tla_export_decl_deferrable: bool = false,
     /// TS 타입 스트리핑 활성화 (기본: true)
     strip_types: bool = true,
     /// console.* 호출 제거 (--drop=console)

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -132,6 +132,11 @@ pub const Transformer = struct {
     /// ES 다운레벨링 임시 변수 카운터.
     /// `foo() ?? bar` → `(_a = foo()) != null ? _a : bar`에서 _a, _b, _c, ... 생성에 사용.
     temp_var_counter: u32 = 0,
+    /// #4598: `es2022_tla.lowerProgram` 이 만든 async IIFE **statement** 의 인덱스.
+    /// emitter 가 `__esm` factory 본문에서 이 문장을 `return <expr>;` 로 방출해
+    /// `init_X()` 가 **초기화 완료 promise** 를 돌려주게 한다(소비자가 기다릴 대상).
+    /// 구조적 추측(마지막 문장이 IIFE 인가) 대신 생성자가 직접 알려 주는 채널이다.
+    tla_iife_stmt: ?ast_mod.NodeIndex = null,
 
     /// ES2022 static block: `this` → 클래스 이름 치환을 위한 컨텍스트.
     /// static block body를 visit하는 동안만 설정된다.


### PR DESCRIPTION
## Summary

`--target < es2022` 에서 top-level await 산출물이 **타겟 엔진에서 파싱조차 안 되던** 문제를
고쳤다. React Native 는 Hermes 가 거부해 앱이 아예 뜨지 않았다 (hermesc: main FAIL → OK).

## Changes

### 루트커즈 — `lowerProgram` 이 export 선언을 건너뛰었다

`es2022_tla.lowerProgram` 이 `export const x = await f()` 를 wrap 대상에서 뺐다("첫 패스"
TODO). 그러면 await 가 최상위에 남고, 뒤이어 도는 es2017 낮추기가 그걸 `yield` 로 바꾼다 —
감싸는 `__esm` factory 는 generator 가 아니라 **bare yield** 다. RN 은 모든 모듈을 `__esm`
래핑(실앱 산출물 451개)하므로 TLA 의존성 하나로 번들 전체가 로드 실패했다.

### 구조

1. **export 선언도 wrap 대상**. 단 **await 를 포함한 선언 + 그 바인딩에 의존하는 후속
   선언만** 옮긴다. "전부" 로 넓히면 `await …;` 뒤의 `export const NAME='hello'` 까지
   지연돼 소비자가 `undefined` 를 읽는다(실측).
2. IIFE 를 `var <temp> = (async () => {…})();` 로 만들고 `__esm` factory 끝에
   `return <temp>;` — `init_X()` 가 **초기화 완료 promise** 를 돌려준다.
3. **async cone**(TLA 모듈 + 동기 소비자, `require` 엣지 포함)을 `__esm` 으로 승격.
   scope-hoist 소비자는 기다릴 대상이 없어 최상위 await 말고는 방법이 없다.
4. 승격 안 된 모듈은 emitter 가 최상위 `await <temp>;` 를 낸다(ESM 출력 한정).
5. `await` 판정을 **`Module.isAwaitableInit(target, importer, unsupported)` 하나**로 통일.

> Zig 초보자 설명: 예전엔 "이 init 을 여기서 await 할 수 있나" 를 5곳이 각각 다른 조건으로
> 판정했다. 조건이 조금씩 달라 어떤 곳은 non-async 함수 안에 `await` 를 넣어 번들을 파싱
> 불가로 만들고, 어떤 곳은 async 인데 빼먹어 값이 조용히 `undefined` 가 됐다. 술어를 함수
> 하나로 모으면 새 호출부가 생겨도 같은 규칙을 쓰게 된다.

## ⚠️ 게이트 (전부 실측 근거)

| 제외 | 이유 |
|---|---|
| splitting · preserve-modules · 비-ESM 출력 | 옮긴 초기화식을 **기다려 줄 기계가 없다** |
| es5(Hermes preset) | factory 를 async 로 못 만든다 — `.then` 체이닝은 별도 작업 |
| `.cjs` 래퍼 | `__commonJS` 가 factory 반환값을 버려 promise 전파 불가 |
| 라이브러리 entry(export 있음) | 래핑하면 `export { … }` 가 래퍼 심볼로 바뀌어 API 소실 |
| 순수 re-export 소비 모듈 | `init_X()` 호출 경로가 없어 factory 가 영영 안 돈다 |
| 청크 위임(#4625)이 닿는 곳 | 위임 산물이 더 작고 이미 검증됨 |

## Test Plan

- [x] `zig build test` — **6323 통과**(신규 6)
- [x] `zig build napi` 통과
- [x] 통합 4448 pass / 2 fail (main baseline 동일: watch RSS · Hermes `__copyProps`)

**타겟 기준 오라클** — `node --check` 는 호스트(Node 24) 기준이라 무효라, acorn `ecmaVersion`
을 타겟에 맞춰 판정했다. RN 은 `hermesc` 가 권위.

**main 대비 실측** (전부 `--format=esm --target=es2017`)

| 케이스 | main | 이 PR |
|---|---|---|
| 기본형 | PARSE_FAIL | **PARSE_OK / `42`** |
| multi-declarator · mix · 역방향 | PARSE_FAIL / 값 정상 | **PARSE_OK / 값 동일** |
| TLA 2단 체인 · diamond | PARSE_FAIL | **PARSE_OK / `B: 2`, `2 10`** |
| 비-export 바인딩 참조 | 크래시 | **`b= 11`** |
| RN(hermesc) | **FAIL** | **OK** |
| es2022 · minify · splitting · re-export entry · 라이브러리 entry | — | **회귀 0** |

`/code-review max` **4회**. 마지막 라운드 15건을 전수 재현 검증해 실제 회귀 4건
(es2022 · minify · splitting · 순수 re-export entry)을 수정했다. 나머지는 재현 결과
기존 버그이거나 동작 차이가 없었다.

## Decision Impact

None

## 남은 범위 (#4598 유지)

- **es5/RN 값** — 파싱은 고쳐져 앱이 뜨지만 값은 `undefined`. `.then` 체이닝이 상태머신 없이
  동작함을 PoC 로 확인(`hermesc OK`, `APP: 42`).
- **`require()` 소비자** — `__commonJS` 가 factory 반환값을 버린다. Node 도
  `ERR_REQUIRE_ASYNC_MODULE` 로 거부하는 위상이라 진단 대상.
- **`export default await` · 구조분해 export** — bare yield 가 남는다. **main 도 동일**한
  기존 버그.

Refs #4598

🤖 Generated with [Claude Code](https://claude.com/claude-code)