### PR TITLE
fix(bundler): #4598 es5(RN) 의 TLA 소비자를 promise 체이닝으로 — Hermes 앱 부팅 복구

### DIFF
--- a/.changeset/tla-es5-then-chain.md
+++ b/.changeset/tla-es5-then-chain.md
@@ -1,0 +1,19 @@
+---
+"@zntc/core": patch
+---
+
+React Native(Hermes) 에서 top-level await 를 쓰는 의존성이 있으면 **앱이 아예 뜨지 않던**
+문제를 고쳤다 (#4598).
+
+es5 계열 타겟(Hermes preset 포함)에서는 `__esm` factory 를 async 로 만들 수 없다. 그래서
+직전 수정은 그 위상에서 lowering 을 껐는데, 그러면 `v = yield …` 가 generator 가 아닌
+factory 에 남아 Hermes 가 번들을 거부했다.
+
+이제 es5 에서도 lowering 을 하고, 소비자는 **promise 체이닝**으로 기다린다:
+
+```js
+"app.ts"() { return Promise.all([init_dep()]).then(function() { … }); }
+```
+
+`init_X()` 가 돌려주는 것은 이미 낮춰진 `__async(...)` promise 이므로 상태머신 없이
+순수 ES5 문법으로 성립한다. hermesc 통과 + 값 정확성 둘 다 확인했다.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -948,8 +948,10 @@ pub const Bundler = struct {
             .tla_chunk_wrapped = self.tlaChunkWrapped(format),
             // #4598: 기다려 줄 기계가 있는 위상에서만 export 초기화식을 옮긴다.
             // ⚠️ `promoteAsyncConeToEsmWrap` 의 빌드-단위 조건과 **정확히 같아야** 한다.
+            // ⚠️ `async_await` 조건을 걸면 안 된다 — es5(Hermes preset)에서 lowering 이
+            //    꺼져 `v = yield …` 가 generator 아닌 factory 에 남는다(RN 앱 로드 실패).
+            //    es5 는 소비자가 `.then` 체이닝으로 기다린다.
             .tla_export_decl_deferrable = self.options.unsupported.top_level_await and
-                !self.options.unsupported.async_await and
                 !self.options.code_splitting and
                 !self.options.preserve_modules and
                 format == .esm,

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -4711,6 +4711,41 @@ fn bundleTlaDownlevel(tmp: *std.testing.TmpDir, dep_src: []const u8, main_src: [
     return std.testing.allocator.dupe(u8, result.output);
 }
 
+test "#4598 es5(RN): TLA 소비자가 promise 체이닝으로 기다린다" {
+    // es5(Hermes preset)는 factory 를 async 로 못 만든다. 대신 `init_X()` 가 돌려주는
+    // 이미 낮춰진 `__async(...)` promise 를 `.then` 으로 기다린다 — 상태머신 불필요.
+    //
+    // ⚠️ 이 경로가 꺼지면 `v = yield …` 가 generator 아닌 factory 에 남아 **Hermes 가
+    //    번들을 거부**한다(RN 앱이 아예 안 뜸). 게이트에 `async_await` 조건을 걸었다가
+    //    실제로 그렇게 됐다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "dep.ts", "export const v = await Promise.resolve(41);\nexport const val = v + 1;");
+    try writeFile(tmp.dir, "main.ts", "import { val } from './dep';\nconsole.log(val);");
+    const entry = try absPath(&tmp, "main.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .esm,
+        .unsupported = @import("../../transformer/compat.zig").fromESTarget(.es5),
+    });
+    defer b.deinit();
+    const result = try b.bundle(std.testing.io);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const js = result.output;
+
+    // 소비자가 체이닝으로 기다려야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, js, "Promise.all([") != null);
+    try std.testing.expect(std.mem.indexOf(u8, js, "]).then(function()") != null);
+    // ⚠️ 판별식: `yield` 는 반드시 `__generator` 상태머신 **안**에만 있어야 한다.
+    //    generator 가 아닌 factory 안의 bare yield 가 Hermes 거부의 원인이었다.
+    if (std.mem.indexOf(u8, js, "yield ")) |y| {
+        const g = std.mem.indexOf(u8, js, "__generator(") orelse return error.MissingGenerator;
+        try std.testing.expect(g < y);
+    }
+}
+
 test "#4598 다운레벨 ESM: export 선언 안의 TLA 가 최상위 await 를 남기지 않는다" {
     // `--target < es2022` 는 "이 엔진은 top-level await 를 못 쓴다" 는 선언이다. 그런데
     // `lowerProgram` 이 export 선언을 건너뛰어 await 가 최상위에 남았고, 그 산물은 타겟

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -847,6 +847,35 @@ pub fn emitEsmWrappedModule(
     var body_code = try body_cg.generateStatements(root, body_stmts.items);
     if (tla_var_name) |tla_var| {
         body_code = try std.fmt.allocPrint(arena_alloc, "{s}\treturn {s};\n", .{ body_code, tla_var });
+    } else if (module.in_async_cone and options.transform_options_base.unsupported.async_await) {
+        // #4598 es5: factory 를 async 로 못 만드니 **promise 체이닝**으로 기다린다.
+        //   `"m.ts"() { return init_dep().then(function(){ …body… }); }`
+        // `init_X()` 는 memoize 돼 있어 body 안의 재호출은 비용이 없다. Hermes 는 Promise 를
+        // 제공하므로 상태머신 낮추기 없이 순수 ES5 문법으로 성립한다(PoC 확인).
+        if (linker) |l| {
+            var deps: std.ArrayList(u8) = .empty;
+            defer deps.deinit(allocator);
+            var n: usize = 0;
+            for (module.import_records) |rec| {
+                if (rec.resolved.isNone()) continue;
+                if (!rec.kind.isEagerEvalDependency() and rec.kind != .require) continue;
+                const dep = l.graph.getModule(rec.resolved) orelse continue;
+                if (dep.wrap_kind != .esm or !dep.in_async_cone) continue;
+                const nm = try dep.allocInitName(allocator, rename_tbl);
+                defer allocator.free(nm);
+                if (n > 0) try deps.appendSlice(allocator, ",");
+                try deps.appendSlice(allocator, nm);
+                try deps.appendSlice(allocator, "()");
+                n += 1;
+            }
+            if (n > 0) {
+                body_code = try std.fmt.allocPrint(
+                    arena_alloc,
+                    "\treturn Promise.all([{s}]).then(function() {{\n{s}\t}});\n",
+                    .{ deps.items, body_code },
+                );
+            }
+        }
     }
 
     // 5.1. Hermes 호환: hoisted var와 같은 이름의 named function expression 이름 제거.

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -532,7 +532,8 @@ pub fn computeAsyncCone(self: *ModuleGraph) void {
 pub fn promoteAsyncConeToEsmWrap(self: *ModuleGraph) void {
     const base = &self.transform_options_base;
     if (!base.unsupported.top_level_await) return; // 타겟이 TLA 지원 → 손대지 않음
-    if (base.unsupported.async_await) return; // es5 는 아직 대상 아님
+    // es5 도 대상이다 — factory 를 async 로 못 만들 뿐, `init_X()` 는 이미 낮춰진
+    // `__async(...)` promise 를 돌려주고 소비자는 `.then` 으로 기다릴 수 있다.
     if (self.code_splitting or self.preserve_modules) return;
     // 청크 위임(#4625)이 이 청크를 async factory 로 감싸면 모듈을 또 래핑하지 않는다.
     // 위임 산물이 scope-hoist 라 더 작고 이미 검증돼 있다 — 겹치면 커지기만 한다.


### PR DESCRIPTION
## Summary

React Native(Hermes) 에서 top-level await 를 쓰는 의존성이 하나라도 있으면 **앱이 아예 뜨지
않던** 문제를 고쳤다. `hermesc` FAIL → OK, 값도 `undefined` → 정상.

## Changes

### 문제 — 직전 PR(#4627)이 RN 을 제외했다

#4627 의 빌드 게이트가 `!unsupported.async_await` 를 요구했다. Hermes preset 은 async 를
미지원으로 두므로 **게이트가 꺼지고 lowering 이 건너뛰어져** `v = yield …` 가 generator 가
아닌 `__esm` factory 에 남았다 → hermesc 거부.

⚠️ #4627 본문의 "RN 앱이 뜹니다" 는 머지 시점엔 사실이 아니었다. 세션 중간엔 맞았지만
게이트를 넣으며 잃었고, 그 이후 RN 검증을 다시 하지 않았다.

### 수정 — es5 는 async 대신 promise 체이닝

es5 도 lowering 대상으로 되돌리고, factory 를 async 로 만들 수 없는 대신 **소비자가
체이닝으로 기다린다**:

```js
"app.ts"() { return Promise.all([init_dep()]).then(function() { …body… }); }
```

`init_X()` 가 돌려주는 건 이미 낮춰진 `__async(...)` promise 라 **상태머신 낮추기가
필요 없다** — 순수 ES5 문법으로 성립한다. `init_X` 는 memoize 돼 있어 body 안 재호출은
비용이 없다.

> Zig 초보자 설명: es2017+ 에서는 `__esm` factory 를 `async` 로 만들어 `await init_dep()`
> 를 쓴다. es5 엔 `async`/`await` 문법이 없으니 같은 순서를 `Promise.then` 콜백으로
> 표현한 것이다. 결과(초기화가 끝난 뒤 본문 실행)는 동일하다.

## Test Plan

- [x] `zig build test` — **6324 통과**(신규 1)
- [x] `zig build napi` 통과
- [x] 통합 4448 pass / 2 fail (main baseline 동일)
- [x] **RN 실앱 통합 30 pass / 0 fail** (`hermesc errors: 0`)

**A/B 양방향 확인** — 체이닝을 빼도, es5 게이트를 다시 막아도 새 테스트가 **정확히 그것만**
실패한다(컴파일 에러 아님).

**실측** (`--target=es5`)

| 케이스 | main | 이 PR |
|---|---|---|
| RN(hermesc) | **FAIL** (앱 안 뜸) | **OK** (7920 bytes) |
| RN 값 | — | `APP: undefined` → **`APP: 42`** |
| es5 2단 체인 | 크래시 | **`B: 2`** |
| es5 diamond | 크래시 | **`2 10`** |
| TLA 없는 es5 빌드 | `1` | `1` (무영향) |
| es5 + minify | — | **`B: 2`** |
| 결정성 | — | 2회 빌드 byte 동일 |

## Decision Impact

None

## 남은 범위 (#4598)

- **`require()` 소비자** — `__commonJS` 가 factory 반환값을 버려 promise 를 못 흘린다.
  Node 도 `ERR_REQUIRE_ASYNC_MODULE` 로 거부하는 위상이라 진단 대상.
- **`export default await` · 구조분해 export** — bare yield 가 남는다. **main 도 동일**한
  기존 버그.

Refs #4598

🤖 Generated with [Claude Code](https://claude.com/claude-code)